### PR TITLE
[RFC][POC] new XMLRPC endpoint

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -37,6 +37,7 @@ help:
 	@echo "  changes    to make an overview of all changed/added/deprecated items"
 	@echo "  linkcheck  to check all external links for integrity"
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
+	@echo "  extractor  to extract embedded snippets into codefiles"
 
 clean:
 	-rm -rf $(BUILDDIR)/*
@@ -157,3 +158,8 @@ pseudoxml:
 	$(SPHINXBUILD) -b pseudoxml $(ALLSPHINXOPTS) $(BUILDDIR)/pseudoxml
 	@echo
 	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."
+
+extractor:
+	$(SPHINXBUILD) -b extractor $(ALLSPHINXOPTS) $(BUILDDIR)/extractor
+	@echo
+	@echo "Extraction finished. The extracted files are in $(BUILDDIR)/extractor."

--- a/doc/_extensions/code_extractor.py
+++ b/doc/_extensions/code_extractor.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+import codecs
+import collections
+import itertools
+import os
+import os.path
+import stat
+import re
+
+import cStringIO
+import textwrap
+
+from docutils import nodes
+from docutils.parsers.rst import directives
+from pygments.lexers import get_lexer_by_name
+from sphinx.builders import Builder
+from sphinx.directives.code import CodeBlock
+from sphinx.util.nodes import set_source_info
+
+def setup(app):
+    app.add_directive('snippet', SnippetDirective)
+    app.add_builder(ExtractorBuilder)
+
+
+class SnippetDirective(CodeBlock):
+    """
+    * hide: whether the snippet should be hidden in non-extracted output 
+            (e.g. html). It is always extracted
+    * indent: snippets are always dedented during extraction. Can be either a
+              number of spaces to indent by, or a string to indent with (e.g. 
+              a line comment)
+    """
+    option_spec = {
+        'indent': directives.unchanged,
+        'hide': directives.flag,
+        # CodeBlock options
+        'linenos': directives.flag,
+        'lineno-start': int,
+        'emphasize-lines': directives.unchanged_required,
+        'class': directives.class_option,
+        'name': directives.unchanged,
+    }
+
+    def run(self):
+        if 'hide' in self.options:
+            code = '\n'.join(self.content)
+            node = nodes.comment(
+                code, code,
+                language=self.arguments[0],
+                snippet=True,
+                indent=self.options.get('indent', ''),
+            )
+            set_source_info(self, node)
+            return [node]
+
+        [node] = super(SnippetDirective, self).run()
+        if isinstance(node, nodes.system_message):
+            return [node]
+        # ensure this was not a captioned block (not handling that currently)
+        assert isinstance(node, nodes.literal_block), "snippets should not be captioned"
+        node['snippet'] = True
+        node['indent'] = self.options.get('indent', '')
+        return [node]
+
+ext_pattern = re.compile(r'\*\.\w+')
+class ExtractorBuilder(Builder):
+    name = 'extractor'
+
+    def write(self, build_docnames, updated_docnames, method='update'):
+        if build_docnames is None:
+            build_docnames = sorted(self.env.all_docs)
+
+        self.info('extracting...')
+        for docname in build_docnames:
+            # no need to resolve the doctree
+            doctree = self.env.get_doctree(docname)
+            self.extract(docname, doctree)
+
+    def condition(self, node):
+        return (
+            isinstance(node, (nodes.literal_block, nodes.comment))
+            and node.get('snippet')
+        )
+
+    def extract(self, docname, doctree):
+        bylang = collections.defaultdict(list)
+        for node in doctree.traverse(self.condition):
+            bylang[node['language']].append(node)
+
+        for lang, ns in bylang.iteritems():
+            filenames = get_lexer_by_name(lang).filenames
+            # try to find the first extension glob (*.xyz) in the filename patterns list
+            extglob = next(itertools.ifilter(ext_pattern.match, filenames), None)
+            if extglob is None:
+                print "No extension found for language %s" % lang
+            # remove leading * to keep only the actual extension
+            ext = extglob[1:]
+            outpath = os.path.join(self.outdir, docname + ext)
+            with codecs.open(outpath, 'w', encoding='utf-8') as f:
+                for node in ns:
+                    lines = cStringIO.StringIO(textwrap.dedent(node.astext()))
+                    indent = node['indent']
+                    # if indent is a number, convert to n-wide space string
+                    if indent.isdigit():
+                        indent = ' ' * int(indent)
+                    if indent:
+                        lines = (
+                            indent + line
+                            for line in lines
+                        )
+
+                    f.writelines(lines)
+                    f.write('\n\n')
+
+
+    def get_target_uri(self, docname, typ=None):
+        return ''
+
+    def get_outdated_docs(self):
+        return self.env.found_docs

--- a/doc/_extensions/odoo_ext/switcher.py
+++ b/doc/_extensions/odoo_ext/switcher.py
@@ -23,7 +23,8 @@ class SwitcherDirective(Directive):
             else:
                 assert child['names'], ("A switcher case must be either a "\
                                         "code block or a compound with a name")
-                titles.append(' '.join(child['names']))
+                [name] = child['names']
+                titles.append(get_lexer_by_name(name).name)
         tabs = nodes.bullet_list('', *[
             nodes.list_item('', nodes.Text(title))
             for title in titles

--- a/doc/api_integration.rst
+++ b/doc/api_integration.rst
@@ -26,67 +26,55 @@ easily available over XML-RPC_ and accessible from a variety of languages.
 Connection
 ==========
 
-.. kinda gross because it duplicates existing bits
+.. snippet:: python
+    :hide:
 
-.. only:: html
+    import xmlrpclib
 
-    .. rst-class:: setupcode hidden
+.. snippet:: ruby
+    :hide:
 
-        .. code-block:: python
+    require 'xmlrpc/client'
 
-            import xmlrpclib
-            info = xmlrpclib.ServerProxy('https://demo.odoo.com/start').start()
-            url, db, username, password = \
-                info['host'], info['database'], info['user'], info['password']
-            common = xmlrpclib.ServerProxy('{}/xmlrpc/2/common'.format(url))
-            uid = common.authenticate(db, username, password, {})
-            models = xmlrpclib.ServerProxy('{}/xmlrpc/2/object'.format(url))
+.. snippet:: php
+    :hide:
 
-        .. code-block:: ruby
+    <?php
+    /*
+    run instructions:
+    * install Composer (http://getcomposer.org) or just download the latest
+      non-snapshot composer.phar (https://getcomposer.org/download/) next to
+      this script
+    * run "composer require darkaonline/ripcord" (or "php composer.phar require darkaonline/ripcord")
+    * run the script ("php api_integration.php")
+    */
+    require __DIR__ . '/vendor/autoload.php';
+    use Ripcord\Ripcord as ripcord;
 
-            require "xmlrpc/client"
-            info = XMLRPC::Client.new2('https://demo.odoo.com/start').call('start')
-            url, db, username, password = \
-                info['host'], info['database'], info['user'], info['password']
-            common = XMLRPC::Client.new2("#{url}/xmlrpc/2/common")
-            uid = common.call('authenticate', db, username, password, {})
-            models = XMLRPC::Client.new2("#{url}/xmlrpc/2/object").proxy
+.. snippet:: java
+    :hide:
 
-        .. code-block:: php
+    /*
+    run instructions:
+    * download/install sbt (http://www.scala-sbt.org)
+    * next to this file, create a file "build.sbt" with the following content:
+    name := "API Integration Examples"
+    version := "0.1"
+    resolvers += "Central" at "http://central.maven.org/maven2/"
+    libraryDependencies += "org.apache.xmlrpc" % "xmlrpc-client" % "3.1.3"
+    * run "sbt run" in this file's directory
+    */
+    import java.net.URL;
+    import java.util.*;
+    import org.apache.xmlrpc.client.XmlRpcClient;
+    import org.apache.xmlrpc.client.XmlRpcClientConfigImpl;
+    import static java.util.Arrays.asList;
+    import static java.util.Collections.*;
 
-            require_once('ripcord.php');
-            $info = ripcord::client('https://demo.odoo.com/start')->start();
-            list($url, $db, $username, $password) =
-              array($info['host'], $info['database'], $info['user'], $info['password']);
-            $common = ripcord::client("$url/xmlrpc/2/common");
-            $uid = $common->authenticate($db, $username, $password, array());
-            $models = ripcord::client("$url/xmlrpc/2/object");
-
-        .. code-block:: java
-
-            final XmlRpcClient client = new XmlRpcClient();
-            final XmlRpcClientConfigImpl start_config = new XmlRpcClientConfigImpl();
-            start_config.setServerURL(new URL("https://demo.odoo.com/start"));
-            final Map<String, String> info = (Map<String, String>)client.execute(
-                start_config, "start", emptyList());
-
-            final String url = info.get("host"),
-                          db = info.get("database"),
-                    username = info.get("user"),
-                    password = info.get("password");
-
-            final XmlRpcClientConfigImpl common_config = new XmlRpcClientConfigImpl();
-            common_config.setServerURL(new URL(String.format("%s/xmlrpc/2/common", url)));
-
-            int uid = (int)client.execute(
-                common_config, "authenticate", Arrays.asList(
-                    db, username, password, emptyMap()));
-
-            final XmlRpcClient models = new XmlRpcClient() {{
-                setConfig(new XmlRpcClientConfigImpl() {{
-                    setServerURL(new URL(String.format("%s/xmlrpc/2/object", url)));
-                }});
-            }};
+    class api_integration {
+        public static void main(String[] args)
+            throws org.apache.xmlrpc.XmlRpcException,
+                   java.net.MalformedURLException {
 
 Configuration
 -------------
@@ -118,28 +106,32 @@ parameters
 
 .. switcher::
 
-    .. code-block:: python
+    .. snippet:: python
+        :indent: #
 
         url = <insert server URL>
         db = <insert database name>
         username = 'admin'
         password = <insert password for your admin user (default: admin)>
 
-    .. code-block:: ruby
+    .. snippet:: ruby
+        :indent: #
 
         url = <insert server URL>
         db = <insert database name>
         username = "admin"
         password = <insert password for your admin user (default: admin)>
 
-    .. code-block:: php
+    .. snippet:: php
+        :indent: //
 
         $url = <insert server URL>;
         $db = <insert database name>;
         $username = "admin";
         $password = <insert password for your admin user (default: admin)>;
 
-    .. code-block:: java
+    .. snippet:: java
+        :indent: //
 
         final String url = <insert server URL>,
                       db = <insert database name>,
@@ -156,25 +148,22 @@ database:
 
 .. switcher::
 
-    .. code-block:: python
+    .. snippet:: python
 
-        import xmlrpclib
         info = xmlrpclib.ServerProxy('https://demo.odoo.com/start').start()
         url, db, username, password = \
             info['host'], info['database'], info['user'], info['password']
 
-    .. code-block:: ruby
+    .. snippet:: ruby
 
-        require "xmlrpc/client"
         info = XMLRPC::Client.new2('https://demo.odoo.com/start').call('start')
         url, db, username, password = \
             info['host'], info['database'], info['user'], info['password']
 
     .. case:: PHP
 
-        .. code-block:: php
+        .. snippet:: php
 
-            require_once('ripcord.php');
             $info = ripcord::client('https://demo.odoo.com/start')->start();
             list($url, $db, $username, $password) =
               array($info['host'], $info['database'], $info['user'], $info['password']);
@@ -194,19 +183,19 @@ database:
 
     .. case:: Java
 
-        .. code-block:: java
+        .. snippet:: java
 
             final XmlRpcClient client = new XmlRpcClient();
 
             final XmlRpcClientConfigImpl start_config = new XmlRpcClientConfigImpl();
             start_config.setServerURL(new URL("https://demo.odoo.com/start"));
-            final Map<String, String> info = (Map<String, String>)client.execute(
+            final Map<?, ?> info = (Map)client.execute(
                 start_config, "start", emptyList());
 
-            final String url = info.get("host"),
-                          db = info.get("database"),
-                    username = info.get("user"),
-                    password = info.get("password");
+            final String url = (String)info.get("host"),
+                          db = (String)info.get("database"),
+                    username = (String)info.get("user"),
+                    password = (String)info.get("password");
 
         .. note::
 
@@ -234,22 +223,22 @@ the login.
 
 .. switcher::
 
-    .. code-block:: python
+    .. snippet:: python
 
         common = xmlrpclib.ServerProxy('{}/xmlrpc/2/common'.format(url))
         common.version()
 
-    .. code-block:: ruby
+    .. snippet:: ruby
 
         common = XMLRPC::Client.new2("#{url}/xmlrpc/2/common")
         common.call('version')
 
-    .. code-block:: php
+    .. snippet:: php
 
         $common = ripcord::client("$url/xmlrpc/2/common");
         $common->version();
 
-    .. code-block:: java
+    .. snippet:: java
 
         final XmlRpcClientConfigImpl common_config = new XmlRpcClientConfigImpl();
         common_config.setServerURL(
@@ -271,19 +260,19 @@ the login.
 
 .. switcher::
 
-    .. code-block:: python
+    .. snippet:: python
 
         uid = common.authenticate(db, username, password, {})
 
-    .. code-block:: ruby
+    .. snippet:: ruby
 
         uid = common.call('authenticate', db, username, password, {})
 
-    .. code-block:: php
+    .. snippet:: php
 
         $uid = $common->authenticate($db, $username, $password, array());
 
-    .. code-block:: java
+    .. snippet:: java
 
         int uid = (int)client.execute(
             common_config, "authenticate", asList(
@@ -316,28 +305,28 @@ Each call to ``execute_kw`` takes the following parameters:
 
     .. switcher::
 
-        .. code-block:: python
+        .. snippet:: python
 
             models = xmlrpclib.ServerProxy('{}/xmlrpc/2/object'.format(url))
             models.execute_kw(db, uid, password,
                 'res.partner', 'check_access_rights',
                 ['read'], {'raise_exception': False})
 
-        .. code-block:: ruby
+        .. snippet:: ruby
 
             models = XMLRPC::Client.new2("#{url}/xmlrpc/2/object").proxy
             models.execute_kw(db, uid, password,
                 'res.partner', 'check_access_rights',
                 ['read'], {raise_exception: false})
 
-        .. code-block:: php
+        .. snippet:: php
 
             $models = ripcord::client("$url/xmlrpc/2/object");
             $models->execute_kw($db, $uid, $password,
                 'res.partner', 'check_access_rights',
                 array('read'), array('raise_exception' => false));
 
-        .. code-block:: java
+        .. snippet:: java
 
             final XmlRpcClient models = new XmlRpcClient() {{
                 setConfig(new XmlRpcClientConfigImpl() {{
@@ -348,7 +337,7 @@ Each call to ``execute_kw`` takes the following parameters:
                 db, uid, password,
                 "res.partner", "check_access_rights",
                 asList("read"),
-                new HashMap() {{ put("raise_exception", false); }}
+                new HashMap<String, Object>() {{ put("raise_exception", false); }}
             ));
 
     .. code-block:: json
@@ -371,26 +360,26 @@ companies for instance:
 
     .. switcher::
 
-        .. code-block:: python
+        .. snippet:: python
 
             models.execute_kw(db, uid, password,
                 'res.partner', 'search',
                 [[['is_company', '=', True], ['customer', '=', True]]])
 
-        .. code-block:: ruby
+        .. snippet:: ruby
 
             models.execute_kw(db, uid, password,
                 'res.partner', 'search',
                 [[['is_company', '=', true], ['customer', '=', true]]])
 
-        .. code-block:: php
+        .. snippet:: php
 
             $models->execute_kw($db, $uid, $password,
                 'res.partner', 'search', array(
                     array(array('is_company', '=', true),
                           array('customer', '=', true))));
 
-        .. code-block:: java
+        .. snippet:: java
 
             asList((Object[])models.execute("execute_kw", asList(
                 db, uid, password,
@@ -415,21 +404,21 @@ available to only retrieve a subset of all matched records.
 
     .. switcher::
     
-        .. code-block:: python
+        .. snippet:: python
     
             models.execute_kw(db, uid, password,
                 'res.partner', 'search',
                 [[['is_company', '=', True], ['customer', '=', True]]],
                 {'offset': 10, 'limit': 5})
     
-        .. code-block:: ruby
+        .. snippet:: ruby
     
             models.execute_kw(db, uid, password,
                 'res.partner', 'search',
                 [[['is_company', '=', true], ['customer', '=', true]]],
                 {offset: 10, limit: 5})
     
-        .. code-block:: php
+        .. snippet:: php
     
             $models->execute_kw($db, $uid, $password,
                 'res.partner', 'search',
@@ -437,7 +426,7 @@ available to only retrieve a subset of all matched records.
                             array('customer', '=', true))),
                 array('offset'=>10, 'limit'=>5));
     
-        .. code-block:: java
+        .. snippet:: java
     
             asList((Object[])models.execute("execute_kw", asList(
                 db, uid, password,
@@ -445,7 +434,7 @@ available to only retrieve a subset of all matched records.
                 asList(asList(
                     asList("is_company", "=", true),
                     asList("customer", "=", true))),
-                new HashMap() {{ put("offset", 10); put("limit", 5); }}
+                new HashMap<String, Object>() {{ put("offset", 10); put("limit", 5); }}
             )));
     
     .. code-block:: json
@@ -465,34 +454,34 @@ only the number of records matching the query. It takes the same
 
     .. switcher::
     
-        .. code-block:: python
+        .. snippet:: python
     
             models.execute_kw(db, uid, password,
                 'res.partner', 'search_count',
                 [[['is_company', '=', True], ['customer', '=', True]]])
     
-        .. code-block:: ruby
+        .. snippet:: ruby
     
             models.execute_kw(db, uid, password,
                 'res.partner', 'search_count',
                 [[['is_company', '=', true], ['customer', '=', true]]])
     
-        .. code-block:: php
+        .. snippet:: php
     
             $models->execute_kw($db, $uid, $password,
                 'res.partner', 'search_count',
                 array(array(array('is_company', '=', true),
                             array('customer', '=', true))));
     
-        .. code-block:: java
+        .. snippet:: java
     
-            (Integer)models.execute("execute_kw", asList(
+            Integer.class.cast(models.execute("execute_kw", asList(
                 db, uid, password,
                 "res.partner", "search_count",
                 asList(asList(
                     asList("is_company", "=", true),
                     asList("customer", "=", true)))
-            ));
+            )));
     
     .. code-block:: json
     
@@ -517,7 +506,7 @@ which tends to be a huge amount.
     
     .. switcher::
     
-        .. code-block:: python
+        .. snippet:: python
     
             ids = models.execute_kw(db, uid, password,
                 'res.partner', 'search',
@@ -528,7 +517,7 @@ which tends to be a huge amount.
             # count the number of fields fetched by default
             len(record)
     
-        .. code-block:: ruby
+        .. snippet:: ruby
     
             ids = models.execute_kw(db, uid, password,
                 'res.partner', 'search',
@@ -539,7 +528,7 @@ which tends to be a huge amount.
             # count the number of fields fetched by default
             record.length
     
-        .. code-block:: php
+        .. snippet:: php
     
             $ids = $models->execute_kw($db, $uid, $password,
                 'res.partner', 'search',
@@ -551,7 +540,7 @@ which tends to be a huge amount.
             // count the number of fields fetched by default
             count($records[0]);
     
-        .. code-block:: java
+        .. snippet:: java
     
             final List ids = asList((Object[])models.execute(
                 "execute_kw", asList(
@@ -560,7 +549,7 @@ which tends to be a huge amount.
                     asList(asList(
                         asList("is_company", "=", true),
                         asList("customer", "=", true))),
-                    new HashMap() {{ put("limit", 1); }})));
+                    new HashMap<String, Object>() {{ put("limit", 1); }})));
             final Map record = (Map)((Object[])models.execute(
                 "execute_kw", asList(
                     db, uid, password,
@@ -581,32 +570,32 @@ Conversedly, picking only three fields deemed interesting.
 
     .. switcher::
 
-        .. code-block:: python
+        .. snippet:: python
 
             models.execute_kw(db, uid, password,
                 'res.partner', 'read',
                 [ids], {'fields': ['name', 'country_id', 'comment']})
 
-        .. code-block:: ruby
+        .. snippet:: ruby
 
             models.execute_kw(db, uid, password,
                 'res.partner', 'read',
                 [ids], {fields: %w(name country_id comment)})
 
-        .. code-block:: php
+        .. snippet:: php
 
             $models->execute_kw($db, $uid, $password,
                 'res.partner', 'read',
                 array($ids),
                 array('fields'=>array('name', 'country_id', 'comment')));
 
-        .. code-block:: java
+        .. snippet:: java
 
             asList((Object[])models.execute("execute_kw", asList(
                 db, uid, password,
                 "res.partner", "read",
                 asList(ids),
-                new HashMap() {{
+                new HashMap<String, Object>() {{
                     put("fields", asList("name", "country_id", "comment"));
                 }}
             )));
@@ -633,31 +622,31 @@ updating a record):
 
     .. switcher::
 
-        .. code-block:: python
+        .. snippet:: python
 
             models.execute_kw(
                 db, uid, password, 'res.partner', 'fields_get',
                 [], {'attributes': ['string', 'help', 'type']})
 
-        .. code-block:: ruby
+        .. snippet:: ruby
 
             models.execute_kw(
                 db, uid, password, 'res.partner', 'fields_get',
                 [], {attributes: %w(string help type)})
 
-        .. code-block:: php
+        .. snippet:: php
 
             $models->execute_kw($db, $uid, $password,
                 'res.partner', 'fields_get',
                 array(), array('attributes' => array('string', 'help', 'type')));
 
-        .. code-block:: java
+        .. snippet:: java
 
-            (Map<String, Map<String, Object>>)models.execute("execute_kw", asList(
+            final Map<?, ?> m = (Map)models.execute("execute_kw", asList(
                 db, uid, password,
                 "res.partner", "fields_get",
                 emptyList(),
-                new HashMap() {{
+                new HashMap<String, Object>() {{
                     put("attributes", asList("string", "help", "type"));
                 }}
             ));
@@ -718,21 +707,21 @@ if that list is not provided it will fetch all fields of matched records):
 
     .. switcher::
 
-        .. code-block:: python
+        .. snippet:: python
 
             models.execute_kw(db, uid, password,
                 'res.partner', 'search_read',
                 [[['is_company', '=', True], ['customer', '=', True]]],
                 {'fields': ['name', 'country_id', 'comment'], 'limit': 5})
 
-        .. code-block:: ruby
+        .. snippet:: ruby
 
             models.execute_kw(db, uid, password,
                 'res.partner', 'search_read',
                 [[['is_company', '=', true], ['customer', '=', true]]],
                 {fields: %w(name country_id comment), limit: 5})
 
-        .. code-block:: php
+        .. snippet:: php
 
             $models->execute_kw($db, $uid, $password,
                 'res.partner', 'search_read',
@@ -740,7 +729,7 @@ if that list is not provided it will fetch all fields of matched records):
                             array('customer', '=', true))),
                 array('fields'=>array('name', 'country_id', 'comment'), 'limit'=>5));
 
-        .. code-block:: java
+        .. snippet:: java
 
             asList((Object[])models.execute("execute_kw", asList(
                 db, uid, password,
@@ -748,7 +737,7 @@ if that list is not provided it will fetch all fields of matched records):
                 asList(asList(
                     asList("is_company", "=", true),
                     asList("customer", "=", true))),
-                new HashMap() {{
+                new HashMap<String, Object>() {{
                     put("fields", asList("name", "country_id", "comment"));
                     put("limit", 5);
                 }}
@@ -804,30 +793,30 @@ set through the mapping argument, the default value will be used.
 
     .. switcher::
 
-        .. code-block:: python
+        .. snippet:: python
 
             id = models.execute_kw(db, uid, password, 'res.partner', 'create', [{
                 'name': "New Partner",
             }])
 
-        .. code-block:: ruby
+        .. snippet:: ruby
 
             id = models.execute_kw(db, uid, password, 'res.partner', 'create', [{
                 name: "New Partner",
             }])
 
-        .. code-block:: php
+        .. snippet:: php
 
             $id = $models->execute_kw($db, $uid, $password,
                 'res.partner', 'create',
                 array(array('name'=>"New Partner")));
 
-        .. code-block:: java
+        .. snippet:: java
 
             final Integer id = (Integer)models.execute("execute_kw", asList(
                 db, uid, password,
                 "res.partner", "create",
-                asList(new HashMap() {{ put("name", "New Partner"); }})
+                asList(new HashMap<String, Object>() {{ put("name", "New Partner"); }})
             ));
 
     .. code-block:: json
@@ -862,7 +851,7 @@ a record).
 
     .. switcher::
 
-        .. code-block:: python
+        .. snippet:: python
 
             models.execute_kw(db, uid, password, 'res.partner', 'write', [[id], {
                 'name': "Newer partner"
@@ -870,7 +859,7 @@ a record).
             # get record name after having changed it
             models.execute_kw(db, uid, password, 'res.partner', 'name_get', [[id]])
 
-        .. code-block:: ruby
+        .. snippet:: ruby
 
             models.execute_kw(db, uid, password, 'res.partner', 'write', [[id], {
                 name: "Newer partner"
@@ -878,7 +867,7 @@ a record).
             # get record name after having changed it
             models.execute_kw(db, uid, password, 'res.partner', 'name_get', [[id]])
 
-        .. code-block:: php
+        .. snippet:: php
 
             $models->execute_kw($db, $uid, $password, 'res.partner', 'write',
                 array(array($id), array('name'=>"Newer partner")));
@@ -886,14 +875,14 @@ a record).
             $models->execute_kw($db, $uid, $password,
                 'res.partner', 'name_get', array(array($id)));
 
-        .. code-block:: java
+        .. snippet:: java
 
             models.execute("execute_kw", asList(
                 db, uid, password,
                 "res.partner", "write",
                 asList(
                     asList(id),
-                    new HashMap() {{ put("name", "Newer Partner"); }}
+                    new HashMap<String, Object>() {{ put("name", "Newer Partner"); }}
                 )
             ));
             // get record name after having changed it
@@ -917,21 +906,21 @@ Records can be deleted in bulk by providing their ids to
 
     .. switcher::
 
-        .. code-block:: python
+        .. snippet:: python
 
             models.execute_kw(db, uid, password, 'res.partner', 'unlink', [[id]])
             # check if the deleted record is still in the database
             models.execute_kw(db, uid, password,
                 'res.partner', 'search', [[['id', '=', id]]])
 
-        .. code-block:: ruby
+        .. snippet:: ruby
 
             models.execute_kw(db, uid, password, 'res.partner', 'unlink', [[id]])
             # check if the deleted record is still in the database
             models.execute_kw(db, uid, password,
                 'res.partner', 'search', [[['id', '=', id]]])
 
-        .. code-block:: php
+        .. snippet:: php
 
             $models->execute_kw($db, $uid, $password,
                 'res.partner', 'unlink',
@@ -941,7 +930,7 @@ Records can be deleted in bulk by providing their ids to
                 'res.partner', 'search',
                 array(array(array('id', '=', $id))));
 
-        .. code-block:: java
+        .. snippet:: java
 
             models.execute("execute_kw", asList(
                 db, uid, password,
@@ -1018,7 +1007,7 @@ Provides information about Odoo models via its various fields
 
     .. switcher::
 
-        .. code-block:: python
+        .. snippet:: python
 
             models.execute_kw(db, uid, password, 'ir.model', 'create', [{
                 'name': "Custom Model",
@@ -1029,7 +1018,7 @@ Provides information about Odoo models via its various fields
                 db, uid, password, 'x_custom_model', 'fields_get',
                 [], {'attributes': ['string', 'help', 'type']})
 
-        .. code-block:: php
+        .. snippet:: php
 
             $models->execute_kw(
                 $db, $uid, $password,
@@ -1046,7 +1035,7 @@ Provides information about Odoo models via its various fields
                 array('attributes' => array('string', 'help', 'type'))
             );
 
-        .. code-block:: ruby
+        .. snippet:: ruby
 
             models.execute_kw(
                 db, uid, password,
@@ -1059,7 +1048,7 @@ Provides information about Odoo models via its various fields
                 db, uid, password, 'x_custom_model', 'fields_get',
                 [], {attributes: %w(string help type)})
 
-        .. code-block:: java
+        .. snippet:: java
 
             models.execute(
                 "execute_kw", asList(
@@ -1159,7 +1148,7 @@ activated as actual fields on the model.
 
     .. switcher::
 
-        .. code-block:: python
+        .. snippet:: python
 
             id = models.execute_kw(db, uid, password, 'ir.model', 'create', [{
                 'name': "Custom Model",
@@ -1182,7 +1171,7 @@ activated as actual fields on the model.
                 }])
             models.execute_kw(db, uid, password, 'x_custom', 'read', [[record_id]])
 
-        .. code-block:: php
+        .. snippet:: php
 
             $id = $models->execute_kw(
                 $db, $uid, $password,
@@ -1213,7 +1202,7 @@ activated as actual fields on the model.
                 'x_custom', 'read',
                 array(array($record_id)));
 
-        .. code-block:: ruby
+        .. snippet:: ruby
 
             id = models.execute_kw(
                 db, uid, password,
@@ -1240,9 +1229,9 @@ activated as actual fields on the model.
                 db, uid, password,
                 'x_custom', 'read', [[record_id]])
 
-        .. code-block:: java
+        .. snippet:: java
 
-            final Integer id = (Integer)models.execute(
+            final Integer model_id = (Integer)models.execute(
                 "execute_kw", asList(
                     db, uid, password,
                     "ir.model", "create",
@@ -1257,7 +1246,7 @@ activated as actual fields on the model.
                     db, uid, password,
                     "ir.model.fields", "create",
                     asList(new HashMap<String, Object>() {{
-                        put("model_id", id);
+                        put("model_id", model_id);
                         put("name", "x_name");
                         put("ttype", "char");
                         put("state", "manual");
@@ -1273,7 +1262,7 @@ activated as actual fields on the model.
                     }})
             ));
 
-            client.execute(
+            models.execute(
                 "execute_kw", asList(
                     db, uid, password,
                     "x_custom", "read",
@@ -1294,6 +1283,44 @@ activated as actual fields on the model.
                 "display_name": "test record"
             }
         ]
+
+.. custom models cleanup
+
+.. snippet:: python
+    :hide:
+
+    custom_ids = models.execute_kw(db, uid, password, 'ir.model', 'search', [[('model', 'ilike', 'x_custom')]])
+    models.execute_kw(db, uid, password, 'ir.model', 'unlink', [custom_ids])
+
+.. snippet:: ruby
+    :hide:
+
+    custom_ids = models.execute_kw(db, uid, password, 'ir.model', 'search', [[['model', 'ilike', 'x_custom']]])
+    models.execute_kw(db, uid, password, 'ir.model', 'unlink', [custom_ids])
+
+.. snippet:: php
+    :hide:
+
+    $custom_ids = $models->execute_kw($db, $uid, $password, 'ir.model', 'search', array(array(array('model', 'ilike', 'x_custom'))));
+    $models->execute_kw($db, $uid, $password, 'ir.model', 'unlink', array($custom_ids));
+
+.. snippet:: java
+    :hide:
+
+    final Object custom_ids = models.execute(
+        "execute_kw", asList(
+            db, uid, password,
+            "ir.model", "search",
+            asList(asList(
+                asList("model", "ilike", "x_custom")
+            ))
+        )
+    );
+    models.execute("execute_kw", asList(
+        db, uid, password,
+        "ir.model", "unlink",
+        asList(custom_ids)
+    ));
 
 Report printing
 ---------------
@@ -1379,6 +1406,12 @@ Reports can be printed over RPC with the following information:
 
         the report is sent as PDF binary data encoded in base64_, it must be
         decoded and may need to be saved to disk before use
+
+.. snippet:: java
+    :hide:
+
+        }
+    }
 
 .. _PostgreSQL: http://www.postgresql.org
 .. _XML-RPC: http://en.wikipedia.org/wiki/XML-RPC

--- a/doc/api_integration.rst
+++ b/doc/api_integration.rst
@@ -158,7 +158,7 @@ database.
 
             $info = ripcord::client('https://demo.odoo.com/start')->start();
             list($url, $database, $username, $password) =
-              array($info['host'], $info['database'], $info['user'], $info['password']);
+              [$info['host'], $info['database'], $info['user'], $info['password']];
 
         .. note::
 
@@ -281,7 +281,7 @@ to be initialized with authentication.
         $db = Ripcord::client(
             "${url['scheme']}://$username:$password@${url['host']}:$port/RPC2?db=$database"
         );
-        $db->res->users->context_get(0);
+        $db->res->users->context_get([]);
 
     .. snippet:: java
 
@@ -341,13 +341,13 @@ model on which you can keep calling methods.
 
             partners = db.proxy('res.partner')
             partners.check_access_rights(
-                    [], ['read'], {raise_exception: false})
+                [], ['read'], {raise_exception: false})
 
         .. snippet:: php
 
             $partners = $db->res->partner;
             $partners->check_access_rights(
-                0, array('read'), array('raise_exception' => false));
+                [], ['read'], ['raise_exception' => false]);
 
         .. snippet:: java
 
@@ -389,10 +389,9 @@ companies for instance:
 
         .. snippet:: php
 
-            $partners->search(0, array(
-                array(array('is_company', '=', true),
-                      array('customer', '=', true))
-            ));
+            $partners->search([], [
+                [['is_company', '=', true], ['customer', '=', true]]
+            ]);
 
         .. snippet:: java
 
@@ -432,10 +431,9 @@ available to only retrieve a subset of all matched records.
     
         .. snippet:: php
     
-            $partners->search(0, array(
-                array(array('is_company', '=', true),
-                      array('customer', '=', true))
-            ), array('offset'=>10, 'limit'=>5));
+            $partners->search([], [
+                [['is_company', '=', true], ['customer', '=', true]]
+            ], ['offset'=>10, 'limit'=>5]);
     
         .. snippet:: java
     
@@ -481,10 +479,9 @@ only the number of records matching the query. It takes the same
     
         .. snippet:: php
     
-            $partners->search_count(0, array(
-                array(array('is_company', '=', true),
-                      array('customer', '=', true))
-            ));
+            $partners->search_count([], [
+                [['is_company', '=', true], ['customer', '=', true]]
+            ]);
     
         .. snippet:: java
     
@@ -538,10 +535,9 @@ which tends to be a huge amount.
     
         .. snippet:: php
     
-            $ids = $partners->search(0, array(
-                array(array('is_company', '=', true),
-                      array('customer', '=', true))
-            ), array('limit'=>1));
+            $ids = $partners->search([], [
+                [['is_company', '=', true], ['customer', '=', true]]
+            ], ['limit'=>1]);
             $records = $partners->read($ids);
             // count the number of fields fetched by default
             count($records[0]);
@@ -580,7 +576,7 @@ Conversedly, picking only three fields deemed interesting.
 
         .. snippet:: php
 
-            $partners->read($ids, array('fields'=>array('name', 'country_id', 'comment')));
+            $partners->read($ids, ['fields'=>['name', 'country_id', 'comment']]);
 
         .. snippet:: java
 
@@ -624,8 +620,7 @@ updating a record):
 
         .. snippet:: php
 
-            $partners->fields_get(
-                0, array('attributes' => array('string', 'help', 'type')));
+            $partners->fields_get([], ['attributes' => ['string', 'help', 'type']]);
 
         .. snippet:: java
 
@@ -707,10 +702,9 @@ if that list is not provided it will fetch all fields of matched records):
 
         .. snippet:: php
 
-            $partners->search_read(0, array(
-                array(array('is_company', '=', true),
-                      array('customer', '=', true))
-            ), array('fields'=>array('name', 'country_id', 'comment'), 'limit'=>5));
+            $partners->search_read([], [
+                [['is_company', '=', true], ['customer', '=', true]]
+            ], ['fields'=>['name', 'country_id', 'comment'], 'limit'=>5]);
 
         .. snippet:: java
 
@@ -789,8 +783,9 @@ set through the mapping argument, the default value will be used.
 
         .. snippet:: php
 
-            $newids = $partners->create(
-                0, array(array('name'=>"New Partner")));
+            $newids = $partners->create([], [[
+                'name'=>"New Partner"
+            ]]);
 
         .. snippet:: java
 
@@ -849,7 +844,9 @@ a record).
 
         .. snippet:: php
 
-            $partners->write($newids, array(array('name'=>"Newer partner")));
+            $partners->write($newids, [[
+                'name'=>"Newer partner"
+            ]]);
             // get record name after having changed it
             $partners->name_get($newids);
 
@@ -896,9 +893,7 @@ Records can be deleted in bulk by providing their ids to
 
             $partners->unlink($newids);
             // check if the deleted record is still in the database
-            $partners->search(0, array(
-                array(array('id', 'in', $newids))
-            ));
+            $partners->search(0, [[['id', 'in', $newids]]]);
 
         .. snippet:: java
 
@@ -986,14 +981,14 @@ Provides information about Odoo models via its various fields
 
         .. snippet:: php
 
-            $db->ir->model->create(0, array(array(
+            $db->ir->model->create([], [[
                 'name' => "Custom Model",
                 'model' => 'x_custom_model',
                 'state' => 'manual'
-            )));
-            $db->x_custom_model->fields_get(0, array(
-                'attributes' => array('string', 'help', 'type')
-            ));
+            ]]);
+            $db->x_custom_model->fields_get([], [
+                'attributes' => ['string', 'help', 'type']
+            ]);
 
         .. snippet:: ruby
 
@@ -1123,21 +1118,21 @@ activated as actual fields on the model.
 
         .. snippet:: php
 
-            $ids = $db->ir->model->create(0, array(array(
+            $ids = $db->ir->model->create([], [[
                 'name' => "Custom Model",
                 'model' => 'x_custom',
                 'state' => 'manual'
-            )));
-            $db->ir->model->fields->create(0, array(array(
+            ]]);
+            $db->ir->model->fields->create([], [[
                 'model_id' => $ids[0],
                 'name' => 'x_name',
                 'ttype' => 'char',
                 'state' => 'manual',
                 'required' => true
-            )));
-            $record_ids = $db->x_custom->create(0, array(array(
+            ]]);
+            $record_ids = $db->x_custom->create([], [[
                 'x_name' => "test record"
-            )));
+            ]]);
             $db->x_custom->read($record_ids);
 
         .. snippet:: ruby
@@ -1224,9 +1219,9 @@ activated as actual fields on the model.
 .. snippet:: php
     :hide:
 
-    $custom_ids = $db->ir->model->search(0, array(
-        array(array('model', 'ilike', 'x_custom'))
-    ));
+    $custom_ids = $db->ir->model->search([], [
+        [['model', 'ilike', 'x_custom']]
+    ]);
     $db->ir->model->unlink($custom_ids);
 
 .. snippet:: java

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -29,6 +29,7 @@ extensions = [
     'odoo_ext',
     'html_domain',
     'exercise_admonition',
+    'code_extractor',
     'patchqueue'
 ]
 

--- a/odoo/addons/rpc2/__init__.py
+++ b/odoo/addons/rpc2/__init__.py
@@ -34,7 +34,7 @@ class Rpc2(http.Controller):
             marshaller = lambda result:(
                 "<?xml version='1.0'?>\n"
                 "<methodResponse>%s</methodResponse>\n" %
-                    XMLRPCMarshaller('utf-8', allow_none=True).dumps((result,))
+                    XMLRPCMarshaller('utf-8').dumps((result,))
             )
             try:
                 params, method = xmlrpclib.loads(req.stream.read())
@@ -52,6 +52,7 @@ class Rpc2(http.Controller):
         elif req.mimetype == 'application/json':
             request = {}
             try:
+                # FIXME: reject parsing null for coherence?
                 request = json.load(req.stream)
                 assert 'id' in request, "Notification requests are not supported"
                 result = self.dispatch(
@@ -72,6 +73,7 @@ class Rpc2(http.Controller):
                         'data': http.serialize_exception(e)
                     }
                 }
+            # FIXME: reject marshalling None for coherence
             response = JSONMarshaller().encode(resp)
         else:
             return werkzeug.exceptions.UnsupportedMediaType(

--- a/odoo/addons/rpc2/__init__.py
+++ b/odoo/addons/rpc2/__init__.py
@@ -1,0 +1,256 @@
+# -*- coding: utf-8 -*-
+import base64
+import collections
+import json
+import logging
+import threading
+import types
+from datetime import datetime
+try:
+    from xmlrpc import client as xmlrpclib
+except ImportError:
+    import xmlrpclib
+
+import werkzeug.exceptions
+import werkzeug.wrappers
+from lxml import etree
+from lxml.builder import E
+
+from odoo import http, models, service, registry
+from odoo.service import security
+
+from . import global_, database, model
+from . import models
+
+logger = logging.getLogger(__name__)
+
+
+class Rpc2(http.Controller):
+    @http.route('/RPC2/', auth='none', methods=['POST'], csrf=False)
+    def rpc2(self, db=None):
+        req = http.request.httprequest
+
+        if req.mimetype == 'text/xml':
+            marshaller = lambda result:(
+                "<?xml version='1.0'?>\n"
+                "<methodResponse>%s</methodResponse>\n" %
+                    XMLRPCMarshaller('utf-8', allow_none=True).dumps((result,))
+            )
+            try:
+                params, method = xmlrpclib.loads(req.stream.read())
+                result = self.dispatch(db, method, params)
+                response = marshaller(result)
+            except NameError as e:
+                response = marshaller(xmlrpclib.Fault(
+                    faultCode=xmlrpclib.METHOD_NOT_FOUND,
+                    faultString=str(e)
+                ))
+            except xmlrpclib.Fault as f:
+                response = marshaller(f)
+            except Exception as e:
+                response = service.wsgi_server.xmlrpc_convert_exception_int(e)
+        elif req.mimetype == 'application/json':
+            request = {}
+            try:
+                request = json.load(req.stream)
+                assert 'id' in request, "Notification requests are not supported"
+                result = self.dispatch(
+                    db, request['method'], request.get('params', []))
+                resp = {
+                    'jsonrpc': '2.0',
+                    'id': request['id'],
+                    'result': result
+                }
+            except Exception as e:
+                resp = {
+                    'jsonrpc': '2.0',
+                    'id': request.get('id'),
+                    'error': {
+                        # TODO: use XML-RPC fault codes from wsgi_server?
+                        'code': 200,
+                        'message': str(e),
+                        'data': http.serialize_exception(e)
+                    }
+                }
+            response = JSONMarshaller().encode(resp)
+        else:
+            return werkzeug.exceptions.UnsupportedMediaType(
+                "%s mime type not supported by /RPC2, request may be either "
+                "XML-RPC as text/xml or JSON-RPC 2.0 as application/json"
+                % req.mimetype)
+
+        return werkzeug.wrappers.Response(response, mimetype=req.mimetype)
+
+    def dispatch(self, db, method, params):
+        path = method.split('.')
+        if not db:
+            if len(path) != 1:
+                raise NameError("{} is not a valid global method".format(method))
+            [func] = path
+            return global_.dispatch(func, *params)
+
+        uid = None
+        auth = http.request.httprequest.authorization
+        if auth and auth.type == 'basic':
+            uid = security.login(db, auth.username, auth.password)
+
+        if not uid:
+            r = werkzeug.wrappers.Response(status=401)
+            r.www_authenticate.set_basic("Odoo-RPC")
+            raise werkzeug.exceptions.Unauthorized(response=r)
+
+        threading.current_thread().uid = uid
+        threading.current_thread().dbname = db
+
+
+        r = registry(db).check_signaling()
+        try:
+            if len(path) == 1:
+                return database.dispatch(r, uid, path[0], *params)
+            else:
+                model_name, func = method.rsplit('.', 1)
+                return model.dispatch(r, uid, model_name, func, *params)
+        finally:
+            r.signal_changes()
+
+class Dispatcher(object):
+    """ Dispatches values to instance methods based on value types
+
+    >>> class A(object):
+    ...     dispatcher = Dispatcher()
+    ...     @dispatcher.register(int)
+    ...     def _int(self, value):
+    ...         return "int {}".format(value)
+    ...     @dispatcher.register(float)
+    ...     def _float(self, value):
+    ...         return "float {}".format(value)
+    >>> a = A()
+    >>> a.dispatcher(1)
+    'int 1'
+    >>> a.dispatcher(1.)
+    'float 1.0'
+    """
+    def __init__(self):
+        self.types = []
+        self.default = None
+
+    def register(self, types):
+        def decorator(fn):
+            self.types.append((types, fn))
+            return fn
+        return decorator
+    def register_default(self, default):
+        self.default = default
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+        return Proxy(self, instance)
+    def __call__(self): pass
+
+class XMLRPCMarshaller(object):
+    serialize = Dispatcher()
+    def __init__(self, encoding='utf-8', allow_none=False):
+        self.encoding = encoding
+        self.allow_none = allow_none
+        self.memo = set()
+    def dumps(self, values):
+        if isinstance(values, xmlrpclib.Fault):
+            tree = E.fault(self.serialize({
+                'faultCode': values.faultCode,
+                'faultString': values.faultString,
+            }))
+        else:
+            tree = E.params()
+            tree.extend(E.param(self.serialize(value)) for value in values)
+        return etree.tostring(tree, encoding=self.encoding, xml_declaration=False)
+
+    @serialize.register(models.BaseModel)
+    def dump_model(self, value):
+        return self.serialize(value.ids)
+
+    @serialize.register(types.NoneType)
+    def dump_none(self, value):
+        if self.allow_none:
+            return E.nil()
+        raise TypeError("cannot marshal None unless allow_none is enabled")
+
+    @serialize.register(bool)
+    def dump_bool(self, value):
+        return E.value(E.boolean("1" if value else "0"))
+
+    @serialize.register((int, long))
+    def dump_int(self, value):
+        if value > xmlrpclib.MAXINT or value < xmlrpclib.MININT:
+            raise OverflowError("int exceeds XML-RPC limits")
+        return E.value(E.int(str(value)))
+
+    @serialize.register(float)
+    def dump_float(self, value):
+        return E.value(E.double(repr(value)))
+
+    # fixme: string_types?
+    @serialize.register(basestring)
+    def dump_str(self, value):
+        return E.value(E.string(value))
+
+    @serialize.register(collections.Mapping)
+    def dump_mapping(self, value):
+        m = id(value)
+        if m in self.memo:
+            raise TypeError("cannot marshal recursive dictionaries")
+        self.memo.add(m)
+        struct = E.struct()
+        struct.extend(
+            # coerce all keys to string (same as JSON)
+            E.member(E.name(unicode(k)), self.serialize(v))
+            for k, v in value.iteritems()
+        )
+        self.memo.remove(m)
+        return E.value(struct)
+
+    @serialize.register(collections.Iterable)
+    def dump_iterable(self, value):
+        m = id(value)
+        if m in self.memo:
+            raise TypeError("cannot marshal recursive sequences")
+        self.memo.add(m)
+        data = E.data()
+        data.extend(self.serialize(v) for v in value)
+        self.memo.remove(m)
+        return E.value(E.array(data))
+
+    @serialize.register(datetime)
+    def dump_datetime(self, value):
+        d = etree.Element('datetime.iso8601')
+        d.text = value.replace(microsecond=0).isoformat()
+        return E.value(d)
+
+    # FIXME: bytes in p3 but not in p2?
+    @serialize.register(xmlrpclib.Binary)
+    def dump_binary(self, value):
+        return E.value(E.base64(base64.encodestring(value.data)))
+
+    @serialize.register_default
+    def fallback(self, value):
+        return self.serialize(vars(value))
+
+class JSONMarshaller(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, models.BaseModel):
+            return o.ids
+        if isinstance(o, collections.Mapping):
+            return dict(o)
+        if isinstance(o, collections.Iterable):
+            return list(o)
+        return super(JSONMarshaller, self).default(o)
+
+class Proxy(object):
+    def __init__(self, dispatcher, instance):
+        self.dispatcher = dispatcher
+        self.instance = instance
+    def __call__(self, item):
+        for types, fn in self.dispatcher.types:
+            if isinstance(item, types):
+                return fn(self.instance, item)
+        return self.dispatcher.default(self.instance, item)

--- a/odoo/addons/rpc2/__manifest__.py
+++ b/odoo/addons/rpc2/__manifest__.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+{
+    'name': "RPC2",
+    'description': """
+Replacement XML-RPC layer
+=========================
+
+* Aims to call into the new API instead of the old one, preparing the ultimate
+  deprecation and removal of old-style calls
+  - pass ids and context as explicit parameters so a correct `Environment` and
+    "record" can be created before calling the requested method
+  - serialize recordset at the XML-RPC boundary instead of... elsewhere?
+* Aims to better use XML-RPC and better integrate with what XML-RPC libraries
+  support
+  - /RPC2/ path (used in examples, default path in Ruby stdlib)
+  - HTTP Basic Auth instead of own scheme, directly integrated in most
+    libraries
+  - fully dotted path instead of multiple endpoints, some libraries (e.g.
+    Python stdlib) can use proxy chains transparently
+""",
+
+    'category': 'Uncategorized',
+    'version': '0.1',
+    'depends': ['base'],
+    'auto_install': True,
+}

--- a/odoo/addons/rpc2/database.py
+++ b/odoo/addons/rpc2/database.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+def dispatch(registry, uid, func, *args):
+    raise NameError("No function %s in database %s" % (func, registry.db_name))

--- a/odoo/addons/rpc2/global_.py
+++ b/odoo/addons/rpc2/global_.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+from odoo.http import request
+from odoo.service import common, db
+
+def dispatch(func, *args):
+    if func not in funcs:
+        raise NameError("No global function %s" % func)
+
+    fn = funcs[func]
+    if getattr(fn, '__noadmin__', False):
+       pass
+    else:
+        db.check_super(request.httprequest.authorization.password)
+    return fn(*args)
+
+funcs = {}
+def register(fn):
+    funcs[fn.__name__] = fn
+    return fn
+def noadmin(fn):
+    fn.__noadmin__ = True
+    return fn
+
+@register
+@noadmin
+def version():
+    return common.exp_version()
+
+@register
+def create(dbname, demo, lang, user_password='admin'):
+    return db.exp_create_database(
+        dbname, demo, lang, user_password=user_password)
+
+@register
+def drop(dbname):
+    return db.exp_drop(dbname)
+
+@register
+def dump(dbname, format):
+    return db.exp_dump(dbname, format)
+
+@register
+def restore(dbname, data, copy=False):
+    return db.exp_restore(dbname, data, copy)
+
+@register
+def rename(old, new):
+    return db.exp_rename(old, new)
+
+@register
+def change_admin_password(new):
+    return db.exp_change_admin_password(new)
+
+@register
+def migrate_databases(databases):
+    return db.exp_migrate_databases(databases)
+
+@register
+def duplicate(source, destination):
+    return db.exp_duplicate_database(source, destination)
+
+@register
+@noadmin
+def exists(dbname):
+    return db.exp_db_exist(dbname)
+
+@register
+@noadmin
+def list(document=False):
+    return db.exp_list(document)
+
+@register
+@noadmin
+def list_languages():
+    return db.exp_list_lang()

--- a/odoo/addons/rpc2/model.py
+++ b/odoo/addons/rpc2/model.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+import itertools
+
+import odoo.api
+import odoo.exceptions
+
+def dispatch(registry, uid, model, method, *args):
+    ids, context, args, kwargs = extract_call_info(method, args)
+
+    with registry.cursor() as cr:
+        env = odoo.api.Environment(cr, uid, context or {})
+        records = env[model].browse(ids)
+        return getattr(records, method)(*args, **kwargs)
+
+
+def extract_call_info(method, args):
+    if method.startswith('_'):
+        raise odoo.exceptions.AccessError(
+            "%s is a private method and can not be called over RPC" % method)
+    subject, args, kwargs = itertools.islice(
+        itertools.chain(args, [None, None, None]),
+        0, 3)
+    ids = []
+    context = {}
+    # comes straight from xmlrpclib.loads, so should only be list or dict
+    if type(subject) is list:
+        ids = subject
+    elif type(subject) is dict:
+        ids = subject.get('records')
+        context = subject.get('context')
+    elif subject:
+        # other truthy subjects are errors
+        raise ValueError("Unknown RPC subject %s, expected falsy value, list or dict" % subject)
+
+    # optional args, kwargs
+    if type(args) is dict:
+        kwargs = args
+        args = None
+    if args is None: args = []
+    if kwargs is None: kwargs = {}
+
+    return ids, context, args, kwargs

--- a/odoo/addons/rpc2/models/__init__.py
+++ b/odoo/addons/rpc2/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import system

--- a/odoo/addons/rpc2/models/system.py
+++ b/odoo/addons/rpc2/models/system.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+
+import itertools
+import xmlrpclib
+
+from odoo import models, exceptions, service
+
+from ..model import dispatch, extract_call_info
+
+
+class RpcSystem(models.AbstractModel):
+    _name = 'system'
+
+    def multicall(self, callspecs):
+        """
+        Performs multiple *independent* method calls within a single RPC call.
+
+        The "parent" context (context of the multicall) is merged into the
+        context of each call's subject, if any.
+
+        Callspecs are of the form ``{'methodName': string, 'params': [subject[, args][, kwargs]]}``.
+
+        The result is an array of either call results wrapped in a
+        single-element array or RPC error specs.
+        """
+        results = []
+        for callspec in callspecs:
+            model, method = callspec['methodName'].rsplit('.', 1)
+            # dispatch creates a new cursor and automatically
+            # commits/rollbacks internally, so calls are properly sequential
+            # and independent
+            try:
+                result = dispatch(self.env.registry, self.env.uid, model, method, *callspec['params'])
+            except NameError, e:
+                results.append({
+                    'faultCode': xmlrpclib.METHOD_NOT_FOUND,
+                    'faultString': str(e),
+                })
+            except xmlrpclib.Fault, f:
+                results.append({
+                    'faultCode': f.faultCode,
+                    'faultString': f.faultString,
+                })
+            except Exception, e:
+                xmlrpcified = service.wsgi_server.xmlrpc_convert_exception_int(e)
+                results.append({
+                    'faultCode': xmlrpcified.faultCode,
+                    'faultString': xmlrpcified.faultString,
+                })
+            else:
+                results.append([result])
+        return results
+
+    def sequence(self, firstCall, pipeline):
+        """ Applies a sequence of method calls to a base subject.
+
+        If one step of the pipeline returns a recordset, the next step will
+        apply to that, otherwise the previous step's recordset will be reused.
+
+        pipeline callspecs are of the form::
+
+            {'methodName': string, 'params': [[args][, kwargs]]}
+
+        where ``method`` is a dotless actual method name rather than fully
+        decorated with the model name.
+
+        The first call is of the same form as ``multicall``'s callspec, and
+        its methodName must similarly be fully decorated.
+
+        The result is the final return value of the entire pipeline.
+        """
+        model, method = firstCall['methodName'].rsplit('.', 1)
+        ids, context, args, kwargs = extract_call_info(method, firstCall['params'])
+
+        results = getattr(
+            self.env(context=context)[model].browse(ids),
+            method
+        )(*args, **kwargs)
+
+        for spec in pipeline:
+            if not isinstance(results, models.BaseModel):
+                raise exceptions.AccessError("Can only perform RPC calls on recordsets")
+            method = spec['methodName']
+            if method.startswith('_'):
+                raise exceptions.AccessError(
+                    "%s is a private method and can not be called over RPC" % method)
+
+            args, kwargs = itertools.islice(
+                itertools.chain(spec['params'], [None, None]),
+                0, 2
+            )
+            if type(args) is dict:
+                kwargs = args
+                args = None
+            if args is None: args = []
+            if kwargs is None: kwargs = {}
+
+            results = getattr(results, method)(*args, **kwargs)
+            # FIXME: check for uid change?
+
+        return results

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1365,9 +1365,19 @@ class Root(object):
             httprequest.session.context["lang"] = lang
 
     def get_request(self, httprequest):
-        # deduce type of request
         if httprequest.args.get('jsonp'):
             return JsonRequest(httprequest)
+
+        try:
+            func, _ = self.nodb_routing_map.bind_to_environ(httprequest.environ).match()
+        except werkzeug.exceptions.HTTPException as e:
+            pass
+        else:
+            # can dispatch JSON requests to HTTP handler
+            if func.routing['type'] == 'http':
+                return HttpRequest(httprequest)
+
+        # deduce type of request
         if httprequest.mimetype in ("application/json", "application/json-rpc"):
             return JsonRequest(httprequest)
         else:


### PR DESCRIPTION
The current XMLRPC endpoints (`/xmlrpc/` and `/xmlrpc/2/`) use the old calling conventions (CC). They can't be converted to the new CC as there is not enough information at their level to do so (knowledge of whether/where ids and contexts are). This means new-CC methods _must_ currently be decorated with `@model` or `@multi` to be exposed over RPC, or calling them raises a TypeError (number of parameters does not match). The old CC can't be deprecated/removed until an RPC endpoint using the new CC is available.

At the same time, while working on the webservice doc I found out Odoo's xmlrpc layer is pretty idiosyncratic and doesn't really take advantage of xmlrpc and the facilities provided by xmlrpc libraries. The endpoint switch caused by the new CC is the occasion to explore/improve that part as well.

# Problems of the existing endpoint / system
1. does RPC over RPC (implements its own Odoo RPC over XML-RPC) so can't take advantage of library conveniences when they exist
2. only works with dicts and lists, not recordset or other types of mappings and sequences
3. doesn't allow None/nil/null, will break clients if support is enabled, this is an issue because json-rpc serialises `None` by default so devs lose the habit of returning a dummy placeholder as it works fine from the web client
4. non-standard authentication

# Calling Conventions (improves on 1 and 2)

```python
a_call(subject[, args:list][, kwargs:dict])
```

Splits the ids (if any) and context (if any) from positional and keyword arguments in order to better match the "new API" calling conventions (where these informations are respectively part of the recordset and environment not the method call). In the RPC layer, these two items are part of the `subject` positional argument which can be:
- falsy, in which case the method is called on an empty recordset with a context-less environment
- a list, which is assumed to be a list of record ids used for the subject recordset
- a mapping which may provide the keys `records` and `context`. The `records` key is browsed (or ignored if missing/empty) and the `context` key is used to seed the Environment (or ignored if missing)

This scheme seems to provide the best flexibility and terseness, as well as a measure of extensibility by allowing / using more keys from the `subject` mapping in the future.

Like `execute_kw`, calls then take a `args` list and a `kwargs` dict, both are optional rather than just the kwargs: a method can be called with only args, only kwargs, both or neither.

# Custom XMLRPC serializer (improves on 2)

New CC methods can return recordsets, which the new RPC endpoint has to automatically convert somehow, the easiest was to serialise recordsets as lists of ids (that's coherent with the old/new API decorators, and means e.g. `search` returns the same thing).

Customizing `xmlrpclib.Marshaller` didn't work because it dispatches by strict type equality, so it wasn't possible to hook into it to serialise arbitrary recordsets (they get types created on-the-fly). A new marshaller was reimplemented on top of lxml instead. It provides the following features not provided by `xmlrpclib.Marshaller`:

- serialises recordsets to lists of ids, uses `BaseModel.ids` (ignores NewId)
- converts all mapping keys to strings (same as `json.dumps`) instead of raising an error (see #12667 and probably others I didn't find)
- can serialise arbitrary mappings (e.g. Counter, defaultdict) not just `dict`
- can serialise arbitrary iterables, not just `list` and `tuple`

# Allow None/nil/null (fixes 3)

Of the 4 libraries we have examples for, 3 either enable the feature by default or via a simple flag. The last one (Apache XML-RPC) can be coerced into supporting it using ~15 lines of code which is downright terse as far as the combination of Java and dynamically typed RPC goes.

This allows more natural returns from methods (aka don't return anything instead of the artificial unconditional `return True` and `return False` peppered through the codebase) and is in line with JSON-RPC.

# Endpoint (avoids conflict with existing)

Uses `/RPC2`:
- does not conflict with existing endpoints
- used for the examples in [the XML-RPC specification](http://xmlrpc.scripting.com/spec.html)
- a number of documents call it the conventional XML-RPC path
- at least [one stdlib defaults to /RPC2](http://www.ruby-doc.org/stdlib-2.1.5/libdoc/xmlrpc/rdoc/XMLRPC/Client.html#method-c-new) when no `path` is provided

# Authentication (fixes 4, also improves on 1)

All xmlrpc libraries surveyed provide built-in support for [Basic Authentication](http://en.wikipedia.org/wiki/Basic_access_authentication). The new endpoint thus replaces the custom authentication by BA
- no less (or more) secure than the existing scheme: relies on underlying transport being HTTPS for security
- avoids an extraneous auth step to resolve a uid (although that means if the "current user"'s uid is needed it has to be resolved separately)
- no need to keep uid/password around, they're embedded in the xmlrpc proxy object
- easy to integrate (Basic sends "cleartext" username and password, they're just base64-encoded)

# Leverage XML-RPC conventions (improves on 1)

XML-RPC `methodName` is conventionally a dotted path (e.g. `system.listMethods`), which some libraries (`ripcord`, `xmlrpclib`) can map onto the language's own dereferencing/attribute access. This maps nicely to Odoo's models: the last segment of the `methodName` is the method itself, the rest is the model name. This means `read` for `account.account` can be called as:

``` python
a_db.account.account.read(…)
```

Ruby's stdlib XMLRPC::Client has no separation between dereferencing and method call, but it's still possible to proxy to a model then call a number of methods on it e.g.

``` ruby
partner = a_db.proxy('res.partner')
partner.read(...)
partner.write(...)
```

Because authentication depends on the db (or lack thereof), the database name is part of the endpoint URL (query parameter)
- Global methods (e.g. create/drop database) are done on a DB-less endpoint
- DB-specific methods (none currently but maybe printing reports? Sending workflow signals?) are function calls on DB'd endpoint (straight `methodName` without dots)
- method calls on models are calls on DB'd endpoint with at least one dot in `methodName`
# Code comparison
## setup

``` python
common = xmlrpclib.ServerProxy('https://{}/xmlrpc/2/common'.format(domain))
uid = common.authenticate(db, username, password, {})
models = xmlrpclib.ServerProxy('https://{}/xmlrpc/2/object'.format(domain))
partners = lambda *args: models.execute_kw(db, uid, password, 'res.partner', *args)
partners('read', …)
```
becomes
``` python
db = xmlrpclib.ServerProxy('https://{}:{}@{}/RPC2/{}'.format(username, password, domain, db))
partners = db.res.partner
partners.read(…)
```
or in Ruby
```ruby
common = XMLRPC::Client.new(host, "/xmlrpc/2/common", 8069)
uid = common.authenticate(db, username, password, {})
models = XMLRPC::Client.new(host, "/xmlrpc/2/object", 8069)
partners = lambda {|*args| models.execute_kw(db, uid, password, 'res.partner', *args) }
partners.call('read', …)
```
becomes
```ruby
db = XMLRPC::Client.new(host, '/RPC2/' + db, 8069, nil, nil, username, password)
partners = db.proxy('res.partner')
partners.read(…)
```
## simple method call

``` python
models.execute_kw(db, uid, password, 'res.partner', 'check_access_rights', ['read'], {'raise_exception': False})
```

becomes

``` python
partners.check_access_rights((), ['read'], {'raise_exception': False})
```
## search

``` python
models.execute_kw(db, uid, password, 'res.partner', 'search', [[['is_company', '=', True], ['customer', '=', True]]])
```

becomes

``` python
partners.search((), [[['is_company', '=', True], ['customer', '=', True]]])
```
## read

``` python
models.execute_kw(db, uid, password, 'res.partner', 'read', [ids])
```

becomes

``` python
partners.read(ids)
```

# JSON-RPC ISO

The endpoint also supports JSON-RPC2 with the same signature, using basic auth. The dispatching is performed based on the request's mime type.

Nota: maybe the XML-RPC serialiser should reject datetimes and binaries? These are not types JSON understands...

# Possible additions/reflexions
- [standard extension `system.multicall`](https://web.archive.org/web/20060624230303/http://www.xmlrpc.com/discuss/msgReader$1208?mode=topic), allows performing multiple independent calls over a single RPC requests, has somewhat built-in support on all reviewed RPC libraries (Python's stdlib, Ruby's stdlib, PHP's Ripcord and Java's Apache XML-RPC)
- similar but non-standard extensions `system.cascade` and `system.sequence`, the first would allow a sequence of ~independent calls to the same subject, the latter would instead be a call chain, where call 2 would be performed on the result of call 1 e.g.

      cascade(subject, action_confirm, read)

  would call "action_confirm()" then "read()" on the subject but

      sequence(subject, mapped('partner_ids'), read)

  would get the subject's associated partners then read those.

/cc @odony @rco-odoo 