### PR TITLE
[IMP] Change probability accordingly when converting lead to opportunity

### DIFF
--- a/addons/crm/crm_lead.py
+++ b/addons/crm/crm_lead.py
@@ -682,7 +682,6 @@ class crm_lead(format_address, osv.osv):
             team_id = lead.team_id and lead.team_id.id or False
         val = {
             'planned_revenue': lead.planned_revenue,
-            'probability': lead.probability,
             'name': lead.name,
             'partner_id': customer and customer.id or False,
             'type': 'opportunity',


### PR DESCRIPTION
When converting a lead to an opportunity, the probability stays the same even if the stage is changed. 

Before reproducing, make sure the stage will change when converting into an opportunity, you shouldn't have a "new" stage that is made for both opportunity and leads. Have for example:

New : type = lead, probability = 10, Change probability automatically = True
New : type = Opportunity, probability = 20, Change probability automatically = True

Then, go to Sales > Sales > Leads, create a new lead. Click "Convert to Opportunity", then "Create Opportunity".

The probability stays the same even if the stage has changed. 
