### PR TITLE
[V10][REF] avoid useless duplicated call for function field that share the same inverse function

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3542,9 +3542,12 @@ class BaseModel(object):
                 # put the values of pure new-style fields into cache, and inverse them
                 for record in self:
                     record._cache.update(record._convert_to_cache(new_vals, update=True))
+                inverse_called = []
                 for key in new_vals:
-                    self._fields[key].determine_inverse(self)
-
+                    inverse = self._fields[key].inverse
+                    if inverse and not inverse in inverse_called:
+                        self._fields[key].determine_inverse(self)
+                        inverse_called.append(inverse)
         return True
 
     @api.multi

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3542,12 +3542,12 @@ class BaseModel(object):
                 # put the values of pure new-style fields into cache, and inverse them
                 for record in self:
                     record._cache.update(record._convert_to_cache(new_vals, update=True))
-                inverse_called = []
+                inverse_done = set()
                 for key in new_vals:
-                    inverse = self._fields[key].inverse
-                    if inverse and not inverse in inverse_called:
-                        self._fields[key].determine_inverse(self)
-                        inverse_called.append(inverse)
+                    field = self._fields[key]
+                    if field.inverse not in inverse_done:
+                        inverse_done.add(field.inverse)
+                        field.determine_inverse(self)
         return True
 
     @api.multi


### PR DESCRIPTION
Hi
Computing field already support the multi call for "compute function". Indeed if I have 3 fields I can use the same compute fonction and all the field will be computed at the same time.

With this patch I add the same behaviour for the inverse function. Indeed for now the inverse function can be the same but if you have 3 fields then the inverse function will be called 3 times. This is useless and make harder the debug and also can decrease the perf if the inverse function is complicated.

My path simply call only one time each inverse function

What do you think?
