### PR TITLE
[FIX] models: in `recompute`, guard against recursive recomputations

### DIFF
--- a/openerp/addons/test_new_api/ir.model.access.csv
+++ b/openerp/addons/test_new_api/ir.model.access.csv
@@ -10,3 +10,5 @@ access_mixed,test_new_api_mixed,test_new_api.model_test_new_api_mixed,,1,1,1,1
 access_test_function_noinfiniterecursion,access_test_function_noinfiniterecursion,model_test_old_api_function_noinfiniterecursion,,1,1,1,1
 access_test_function_counter,access_test_function_counter,model_test_old_api_function_counter,,1,1,1,1
 access_domain_bool,access_domain_bool,model_domain_bool,,1,1,1,1
+access_effect,access_effect,model_test_new_api_effect,,1,1,1,1
+access_effect_line,access_effect_line,model_test_new_api_effect_line,,1,1,1,1

--- a/openerp/addons/test_new_api/models.py
+++ b/openerp/addons/test_new_api/models.py
@@ -273,3 +273,23 @@ class BoolModel(models.Model):
     bool_true = fields.Boolean('b1', default=True)
     bool_false = fields.Boolean('b2', default=False)
     bool_undefined = fields.Boolean('b3')
+
+
+class Effect(models.Model):
+    _name = 'test_new_api.effect'
+
+    lines = fields.One2many('test_new_api.effect.line', 'effect')
+    size = fields.Integer(compute='_compute_size', store=True)
+
+    @api.depends('lines')
+    def _compute_size(self):
+        for effect in self:
+            effect.size = len(effect.lines)
+            effect.lines.write({'size': effect.size})
+
+
+class EffectLine(models.Model):
+    _name = 'test_new_api.effect.line'
+
+    effect = fields.Many2one('test_new_api.effect')
+    size = fields.Integer()

--- a/openerp/addons/test_new_api/tests/test_new_fields.py
+++ b/openerp/addons/test_new_api/tests/test_new_fields.py
@@ -486,6 +486,15 @@ class TestNewFields(common.TransactionCase):
         message.important = True
         self.assertIn(message, discussion.important_messages)
 
+    def test_70_compute_effect(self):
+        """ test the behavior of a compute method with side effects """
+        effect = self.env['test_new_api.effect'].create({})
+        self.assertEqual(effect.size, 0)
+
+        # create a line; this computes the size and assign it on lines
+        self.env['test_new_api.effect.line'].create({'effect': effect.id})
+        self.assertEqual(effect.size, 1)
+
 
 class TestMagicFields(common.TransactionCase):
 

--- a/openerp/models.py
+++ b/openerp/models.py
@@ -5847,13 +5847,13 @@ class BaseModel(object):
             # determine the fields to recompute
             fs = self.env[field.model_name]._field_computed[field]
             ns = [f.name for f in fs if f.store]
-            # evaluate fields, and group record ids by update
-            updates = defaultdict(set)
-            for rec in recs.exists():
-                vals = rec._convert_to_write({n: rec[n] for n in ns})
-                updates[frozendict(vals)].add(rec.id)
-            # update records in batch when possible
             with recs.env.norecompute():
+                # evaluate fields, and group record ids by update
+                updates = defaultdict(set)
+                for rec in recs.exists():
+                    vals = rec._convert_to_write({n: rec[n] for n in ns})
+                    updates[frozendict(vals)].add(rec.id)
+                # update records in batch when possible
                 for vals, ids in updates.iteritems():
                     recs.browse(ids)._write(dict(vals))
             # mark computed fields as done


### PR DESCRIPTION
The issue occurs when a compute method explicitly writes on records other than
the ones to be computed.  The scenario goes as follows:
- some update invokes method `recompute`;
- the method `recompute` selects `f` to be recomputed on `recs`;
- the compute method of `f` explicitly writes on other records;
- the latter update invokes method `recompute`;
- the method `recompute` selects `f` to be recomputed on `recs`;
- ...

This leads to an infinite recursion, because the field `f` is marked as done on
`recs` after being computed and stored in database.  The fix simply avoids
recursive calls to `recompute` in compute methods; all the recomputations are
done by the outer call to `recompute`.
