### PR TITLE
[FIX] web/database manager: fix MemoryError when restoring big databases

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -707,7 +707,9 @@ class Database(http.Controller):
     @http.route('/web/database/restore', type='http', auth="none", methods=['POST'], csrf=False)
     def restore(self, master_pwd, backup_file, name, copy=False):
         try:
-            data = base64.b64encode(backup_file.read())
+            data = ''
+            for chunk in iter(lambda: backup_file.read(8190), b''):
+                data += base64.b64encode(chunk)
             request.session.proxy("db").restore(master_pwd, name, data, copy)
             return http.local_redirect('/web/database/manager')
         except Exception, e:

--- a/openerp/service/db.py
+++ b/openerp/service/db.py
@@ -205,9 +205,13 @@ def dump_db(db_name, stream, backup_format='zip'):
             return stdout
 
 def exp_restore(db_name, data, copy=False):
+    def chunks(d, n=8192):
+        for i in range(0, len(d), n):
+            yield d[i:i+n]
     data_file = tempfile.NamedTemporaryFile(delete=False)
     try:
-        data_file.write(data.decode('base64'))
+        for chunk in chunks(data):
+            data_file.write(chunk.decode('base64'))
         data_file.close()
         restore_db(db_name, data_file.name, copy=copy)
     finally:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When using the database manager to restore a very big zip with filestore
archive, a MemoryError can be raised by Python in the 'binascii' module
when Odoo web client is trying to convert the uploaded file to base6

Current behavior before PR:
Database restoration fails.

Desired behavior after PR is merged:
Database restoration succeeds.
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

When using the database manager to restore a very big zip with filestore
archive, a MemoryError can be raised by Python in the 'binascii' module
when Odoo web client is trying to convert the uploaded file to base64.

This fix creates the base64 encoded data in chunks to avoid this issue.

The same fix is also used in the 'db' service when it received the base
64 encoded data and tries to convert it back to a file.

Closes issue 680195
