### PR TITLE
[IMP] Configurable maintenance and bus databases

### DIFF
--- a/addons/bus/models/bus.py
+++ b/addons/bus/models/bus.py
@@ -9,6 +9,7 @@ import time
 
 import openerp
 from openerp import api, fields, models
+import openerp.tools
 from openerp.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT
 
 _logger = logging.getLogger(__name__)
@@ -31,6 +32,7 @@ def hashable(key):
 class ImBus(models.Model):
 
     _name = 'bus.bus'
+    _bus_db = openerp.tools.config['bus_db']
 
     create_date = fields.Datetime('Create date')
     channel = fields.Char('Channel')
@@ -61,7 +63,7 @@ class ImBus(models.Model):
             # transaction is not commited yet, there will be nothing to fetch,
             # and the longpolling will return no notification.
             def notify():
-                with openerp.sql_db.db_connect('postgres').cursor() as cr:
+                with openerp.sql_db.db_connect(self._bus_db).cursor() as cr:
                     cr.execute("notify imbus, %s", (json_dump(list(channels)),))
             self._cr.after('commit', notify)
 
@@ -108,6 +110,7 @@ class ImBus(models.Model):
 class ImDispatch(object):
     def __init__(self):
         self.channels = {}
+        self._bus_db = openerp.tools.config['bus_db']
 
     def poll(self, dbname, channels, last, options=None, timeout=TIMEOUT):
         if options is None:
@@ -142,8 +145,8 @@ class ImDispatch(object):
 
     def loop(self):
         """ Dispatch postgres notifications to the relevant polling threads/greenlets """
-        _logger.info("Bus.loop listen imbus on db postgres")
-        with openerp.sql_db.db_connect('postgres').cursor() as cr:
+        _logger.info("Bus.loop listen imbus on db %s", self._bus_db)
+        with openerp.sql_db.db_connect(self._bus_db).cursor() as cr:
             conn = cr._cnx
             cr.execute("listen imbus")
             cr.commit();

--- a/openerp/service/db.py
+++ b/openerp/service/db.py
@@ -75,7 +75,7 @@ def _initialize_db(id, db_name, demo, lang, user_password, login='admin', countr
         _logger.exception('CREATE DATABASE failed:')
 
 def _create_empty_database(name):
-    db = openerp.sql_db.db_connect('postgres')
+    db = openerp.sql_db.db_connect(openerp.tools.config['maintenance_db'])
     with closing(db.cursor()) as cr:
         chosen_template = openerp.tools.config['db_template']
         cr.execute("SELECT datname FROM pg_database WHERE datname = %s",
@@ -96,7 +96,7 @@ def exp_create_database(db_name, demo, lang, user_password='admin', login='admin
 def exp_duplicate_database(db_original_name, db_name):
     _logger.info('Duplicate database `%s` to `%s`.', db_original_name, db_name)
     openerp.sql_db.close_db(db_original_name)
-    db = openerp.sql_db.db_connect('postgres')
+    db = openerp.sql_db.db_connect(openerp.tools.config['maintenance_db'])
     with closing(db.cursor()) as cr:
         cr.autocommit(True)     # avoid transaction block
         _drop_conn(cr, db_original_name)
@@ -135,7 +135,7 @@ def exp_drop(db_name):
     openerp.modules.registry.RegistryManager.delete(db_name)
     openerp.sql_db.close_db(db_name)
 
-    db = openerp.sql_db.db_connect('postgres')
+    db = openerp.sql_db.db_connect(openerp.tools.config['maintenance_db'])
     with closing(db.cursor()) as cr:
         cr.autocommit(True) # avoid transaction block
         _drop_conn(cr, db_name)
@@ -276,7 +276,7 @@ def exp_rename(old_name, new_name):
     openerp.modules.registry.RegistryManager.delete(old_name)
     openerp.sql_db.close_db(old_name)
 
-    db = openerp.sql_db.db_connect('postgres')
+    db = openerp.sql_db.db_connect(openerp.tools.config['maintenance_db'])
     with closing(db.cursor()) as cr:
         cr.autocommit(True)     # avoid transaction block
         _drop_conn(cr, old_name)
@@ -319,7 +319,7 @@ def list_dbs(force=False):
         raise openerp.exceptions.AccessDenied()
     chosen_template = openerp.tools.config['db_template']
     templates_list = tuple(set(['postgres', chosen_template]))
-    db = openerp.sql_db.db_connect('postgres')
+    db = openerp.sql_db.db_connect(openerp.tools.config['maintenance_db'])
     with closing(db.cursor()) as cr:
         try:
             db_user = openerp.tools.config["db_user"]

--- a/openerp/tools/config.py
+++ b/openerp/tools/config.py
@@ -87,7 +87,7 @@ class configmanager(object):
         self.config_file = fname
 
         self._LOGLEVELS = dict([
-            (getattr(loglevels, 'LOG_%s' % x), getattr(logging, x)) 
+            (getattr(loglevels, 'LOG_%s' % x), getattr(logging, x))
             for x in ('CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'NOTSET')
         ])
 
@@ -205,6 +205,10 @@ class configmanager(object):
                          help="specify the the maximum number of physical connections to posgresql")
         group.add_option("--db-template", dest="db_template", my_default="template1",
                          help="specify a custom database template to create a new database")
+        group.add_option("--maintenance-db", dest="maintenance_db", my_default="postgres",
+                         help="specify the maintenance database")
+        group.add_option("--bus-db", dest="bus_db", my_default="postgres",
+                         help="specify the database used for the longpolling bus")
         parser.add_option_group(group)
 
         group = optparse.OptionGroup(parser, "Internationalisation options",
@@ -386,7 +390,7 @@ class configmanager(object):
             'language', 'translate_out', 'translate_in', 'overwrite_existing_translations',
             'debug_mode', 'dev_mode', 'smtp_ssl', 'load_language',
             'stop_after_init', 'logrotate', 'without_demo', 'xmlrpc', 'syslog',
-            'list_db', 'proxy_mode',
+            'list_db', 'maintenance_db', 'bus_db', 'proxy_mode',
             'test_file', 'test_enable', 'test_commit', 'test_report_directory',
             'osv_memory_count_limit', 'osv_memory_age_limit', 'max_cron_threads', 'unaccent',
             'data_dir',


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
[See this issue](https://github.com/odoo/odoo/issues/12850)

**Current behavior before PR:**
Odoo won't start if its db_user does not have access to `postgres` database

**Desired behavior after PR is merged:**
The databases used for "maintenance" (db management) and bus operations can be configured, and by setting both one can start odoo even without access to the `postgres` database.
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

Odoo hardcodes 'postgres' as the database used for maintenance
operations (e.g. creating empty database, drop database, clone..)
and as the database used by the bus module for longpolling notifications

In some deployments, particularly if using a hosted postgres instances,
people don't have access to the postgres database.

This commit introduces two new config options: 'maintenance_db' and
'bus_db'; both of these default to 'postgres' so that nothing changes
unless users explicitly sets these values. By setting both, one can
install odoo even without any sort of access to the 'postgres' database.
