### PR TITLE
[FIX] Incorrect table alias used in joins

### DIFF
--- a/openerp/osv/expression.py
+++ b/openerp/osv/expression.py
@@ -549,9 +549,11 @@ class ExtendedLeaf(object):
     def get_join_conditions(self):
         conditions = []
         alias = self._models[0]._table
+        links = []
         for context in self.join_context:
             previous_alias = alias
-            alias += '__' + context[4]
+            links.append((context[1]._table, context[4]))
+            alias, _ = generate_table_alias(self._models[0]._table, links)
             conditions.append('"%s"."%s"="%s"."%s"' % (previous_alias, context[2], alias, context[3]))
         return conditions
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR contains the part of #1760 which has not been merged yet.

Current behavior before PR:

Suppose you have models with long names `long.a` and `long.b` where `long.b` inherits from `long.a` by `_inherits`. Then Odoo will generate the alias by joining the table names by two underscores. When the name exceeds the 64 character limit of PostgreSQL, Odoo will use a hash-based alias to stay within the limit. However, when preparing joins this alias is not used, which leads to broken SQL

``` sql
SELECT "verylongtable111".id FROM "verylongtable3333" as "verylongtable111__verylongtable2222222222222_id__veryl_7647c3a2","verylongtable2222222222222" as "verylongtable111__verylongtable2222222222222_id","verylongtable111" WHERE ("verylongtable111"."verylongtable2222222222222_id"="verylongtable111__verylongtable2222222222222_id"."id" AND "verylongtable111__verylongtable2222222222222_id"."verylongtable3333_id"="verylongtable111__verylongtable2222222222222_id__verylongtable3333_id"."id") AND ("verylongtable111__verylongtable2222222222222_id__veryl_7647c3a2"."some_field" = 5) ORDER BY "verylongtable111"."id"  
```

In this case `verylongtable111__verylongtable2222222222222_id__verylongtable3333_id` is unknown to PostgreSQL. The alias should be used instead.

Desired behavior after PR is merged:

The correct table alias is used in all circumstances.
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
