### PR TITLE
[FIX] website_slides: Unpublished slides not visible

### DIFF
--- a/addons/website_slides/security/ir.model.access.csv
+++ b/addons/website_slides/security/ir.model.access.csv
@@ -1,6 +1,6 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_slide_slide_public,slide.slide.public,model_slide_slide,base.group_public,1,0,0,0
-access_slide_slide_portal,slide.slide.portal,model_slide_slide,base.group_portal,1,1,1,0
+access_slide_slide_portal,slide.slide.portal,model_slide_slide,base.group_portal,1,0,0,0
 access_slide_slide_user,slide.slide.user,model_slide_slide,base.group_user,1,1,1,1
 access_slide_tag_public,slide.tag.public,model_slide_tag,base.group_public,1,0,0,0
 access_slide_tag_portal,slide.tag.portal,model_slide_tag,base.group_portal,1,0,0,0

--- a/addons/website_slides/security/website_slides_security.xml
+++ b/addons/website_slides/security/website_slides_security.xml
@@ -17,7 +17,7 @@
         <record id="rule_slide_channel_public" model="ir.rule">
             <field name="name">Channel: public: published only</field>
             <field name="model_id" ref="model_slide_channel"/>
-            <field name="groups" eval="[(4, ref('base.group_public'))]"/>
+            <field name="groups" eval="[(4, ref('base.group_public')) ,(4, ref('base.group_portal'))]"/>
             <field name="domain_force">[('website_published', '=', True)]</field>
         </record>
 
@@ -36,7 +36,7 @@
         <record id="rule_slide_slide_public" model="ir.rule">
             <field name="name">Slide: public: published only</field>
             <field name="model_id" ref="model_slide_slide"/>
-            <field name="groups" eval="[(4, ref('base.group_public'))]"/>
+            <field name="groups" eval="[(4, ref('base.group_public')), (4, ref('base.group_portal'))]"/>
             <field name="domain_force">[('channel_id.website_published', '=', True), ('website_published', '=', True)]</field>
         </record>
     </data>


### PR DESCRIPTION
The unpublished slides are just visible for the group allowed by
the channel.

opw:708499
