### PR TITLE
[FIX] account: faster payment registering on large numbers of invoices

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -797,7 +797,7 @@ class AccountMoveLine(models.Model):
         elif self._context.get('skip_full_reconcile_check') == 'amount_currency_only':
             field = 'amount_residual_currency'
         #target the pair of move in self that are the oldest
-        sorted_moves = sorted(self, key=lambda a: a.date)
+        sorted_moves = sorted(self.with_context(prefetch_fields=False), key=lambda a: a.date)
         debit = credit = False
         for aml in sorted_moves:
             if credit and debit:


### PR DESCRIPTION
Registering a payment on a large number of invoices is somewhat slow (>1 min for 100 invoices, > 40 minutes for 800 invoices on my machine).

Speeds up registering a payment on ~100 invoices by a factor of ~4, on ~800 invoices it speeds up performance by a factor of ~8.

@qdp-odoo I guess that the exchange rate entry commit is not safe for a stable release, since things outside Odoo using `auto_reconcile_lines` will require an additional call to `compute_full_after_batch_reconcile`. Perhaps you can think of a better way to do it? Otherwise I can write a wrapper function that calls `auto_reconcile_lines` followed by `compute_full_after_batch_reconcile` and then merge in master instead.