### PR TITLE
list -> iterable builtins

### DIFF
--- a/addons/account/models/account.py
+++ b/addons/account/models/account.py
@@ -383,7 +383,7 @@ class AccountJournal(models.Model):
             account_code_prefix = company.bank_account_code_prefix or ''
         else:
             account_code_prefix = company.cash_account_code_prefix or company.bank_account_code_prefix or ''
-        for num in pycompat.range(1, 100):
+        for num in range(1, 100):
             new_code = str(account_code_prefix.ljust(code_digits - 1, '0')) + str(num)
             rec = self.env['account.account'].search([('code', '=', new_code), ('company_id', '=', company.id)], limit=1)
             if not rec:
@@ -412,7 +412,7 @@ class AccountJournal(models.Model):
             if not vals.get('code'):
                 journal_code_base = (vals['type'] == 'cash' and 'CSH' or 'BNK')
                 journals = self.env['account.journal'].search([('code', 'like', journal_code_base + '%'), ('company_id', '=', company_id)])
-                for num in pycompat.range(1, 100):
+                for num in range(1, 100):
                     # journal_code has a maximal size of 5, hence we can enforce the boundary num < 100
                     journal_code = journal_code_base + str(num)
                     if journal_code not in journals.mapped('code'):

--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -808,7 +808,7 @@ class AccountBankStatementLine(models.Model):
                 whose value is the same as described in process_reconciliation except that ids are used instead of recordsets.
         """
         AccountMoveLine = self.env['account.move.line']
-        for st_line, datum in zip(self, data):
+        for st_line, datum in pycompat.izip(self, data):
             payment_aml_rec = AccountMoveLine.browse(datum.get('payment_aml_ids', []))
             for aml_dict in datum.get('counterpart_aml_dicts', []):
                 aml_dict['move_line'] = AccountMoveLine.browse(aml_dict['counterpart_aml_id'])
@@ -879,7 +879,7 @@ class AccountBankStatementLine(models.Model):
         for aml_dict in (counterpart_aml_dicts + new_aml_dicts):
             if aml_dict.get('tax_ids') and isinstance(aml_dict['tax_ids'][0], pycompat.integer_types):
                 # Transform the value in the format required for One2many and Many2many fields
-                aml_dict['tax_ids'] = map(lambda id: (4, id, None), aml_dict['tax_ids'])
+                aml_dict['tax_ids'] = [(4, id, None) for id in aml_dict['tax_ids']]
 
         # Fully reconciled moves are just linked to the bank statement
         total = self.amount

--- a/addons/account/models/account_invoice.py
+++ b/addons/account/models/account_invoice.py
@@ -71,7 +71,7 @@ class AccountInvoice(models.Model):
         inv_types = inv_type if isinstance(inv_type, list) else [inv_type]
         company_id = self._context.get('company_id', self.env.user.company_id.id)
         domain = [
-            ('type', 'in', filter(None, map(TYPE2JOURNAL.get, inv_types))),
+            ('type', 'in', [TYPE2JOURNAL[ty] for ty in inv_types if ty in TYPE2JOURNAL]),
             ('company_id', '=', company_id),
         ]
         return self.env['account.journal'].search(domain, limit=1)
@@ -192,11 +192,11 @@ class AccountInvoice(models.Model):
     @api.one
     @api.depends('move_id.line_ids.amount_residual')
     def _compute_payments(self):
-        payment_lines = []
+        payment_lines = set()
         for line in self.move_id.line_ids:
-            payment_lines.extend(filter(None, [rp.credit_move_id.id for rp in line.matched_credit_ids]))
-            payment_lines.extend(filter(None, [rp.debit_move_id.id for rp in line.matched_debit_ids]))
-        self.payment_move_line_ids = self.env['account.move.line'].browse(list(set(payment_lines)))
+            payment_lines.update(line.mapped('matched_credit_ids.credit_move_id.id'))
+            payment_lines.update(line.mapped('matched_debit_ids.debit_move_id.id'))
+        self.payment_move_line_ids = self.env['account.move.line'].browse(list(payment_lines))
 
     name = fields.Char(string='Reference/Description', index=True,
         readonly=True, states={'draft': [('readonly', False)]}, copy=False, help='The name that will be used on account move lines')
@@ -335,7 +335,7 @@ class AccountInvoice(models.Model):
             '_onchange_partner_id': ['account_id', 'payment_term_id', 'fiscal_position_id', 'partner_bank_id'],
             '_onchange_journal_id': ['currency_id'],
         }
-        for onchange_method, changed_fields in onchanges.items():
+        for onchange_method, changed_fields in pycompat.items(onchanges):
             if any(f not in vals for f in changed_fields):
                 invoice = self.new(vals)
                 getattr(invoice, onchange_method)()
@@ -456,7 +456,7 @@ class AccountInvoice(models.Model):
             tax_grouped = invoice.get_taxes_values()
 
             # Create new tax lines
-            for tax in tax_grouped.values():
+            for tax in pycompat.values(tax_grouped):
                 account_invoice_tax.create(tax)
 
         # dummy write on self to trigger recomputations
@@ -475,7 +475,7 @@ class AccountInvoice(models.Model):
     def _onchange_invoice_line_ids(self):
         taxes_grouped = self.get_taxes_values()
         tax_lines = self.tax_line_ids.browse([])
-        for tax in taxes_grouped.values():
+        for tax in pycompat.values(taxes_grouped):
             tax_lines += tax_lines.new(tax)
         self.tax_line_ids = tax_lines
         return
@@ -820,7 +820,7 @@ class AccountInvoice(models.Model):
                 else:
                     line2[tmp] = l
             line = []
-            for key, val in line2.items():
+            for key, val in pycompat.items(line2):
                 line.append((0, 0, val))
         return line
 
@@ -1017,7 +1017,7 @@ class AccountInvoice(models.Model):
         result = []
         for line in lines:
             values = {}
-            for name, field in line._fields.iteritems():
+            for name, field in pycompat.items(line._fields):
                 if name in MAGIC_COLUMNS:
                     continue
                 elif field.type == 'many2one':
@@ -1155,8 +1155,8 @@ class AccountInvoice(models.Model):
         for line in self.tax_line_ids:
             res.setdefault(line.tax_id.tax_group_id, 0.0)
             res[line.tax_id.tax_group_id] += line.amount
-        res = sorted(res.items(), key=lambda l: l[0].sequence)
-        res = map(lambda l: (l[0].name, l[1]), res)
+        res = sorted(pycompat.items(res), key=lambda l: l[0].sequence)
+        res = [(l[0].name, l[1]) for l in res]
         return res
 
 

--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -166,7 +166,7 @@ class account_journal(models.Model):
                         """, (tuple(self.ids),))
             number_to_reconcile = self.env.cr.fetchone()[0]
             # optimization to read sum of balance from account_move_line
-            account_ids = tuple(filter(None, [self.default_debit_account_id.id, self.default_credit_account_id.id]))
+            account_ids = tuple(ac for ac in [self.default_debit_account_id.id, self.default_credit_account_id.id] if ac)
             if account_ids:
                 amount_field = 'balance' if not self.currency_id else 'amount_currency'
                 query = """SELECT sum(%s) FROM account_move_line WHERE account_id in %%s;""" % (amount_field,)

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1696,7 +1696,7 @@ class AccountPartialReconcile(models.Model):
                         total_amount_currency += aml.company_id.currency_id.with_context(date=aml.date).compute(aml.balance, partial_rec.currency_id)
                 for x in aml.matched_debit_ids | aml.matched_credit_ids:
                     partial_rec_set[x] = None
-        partial_rec_ids = [x.id for x in partial_rec_set.keys()]
+        partial_rec_ids = [x.id for x in partial_rec_set]
         aml_ids = aml_set.ids
         #then, if the total debit and credit are equal, or the total amount in currency is 0, the reconciliation is full
         digits_rounding_precision = aml_set[0].company_id.currency_id.rounding

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -5,6 +5,9 @@ from odoo import api, fields, models, _
 from odoo import SUPERUSER_ID
 
 import logging
+
+from odoo.tools import pycompat
+
 _logger = logging.getLogger(__name__)
 
 def migrate_set_tags_and_taxes_updatable(cr, registry, module):
@@ -322,7 +325,7 @@ class AccountChartTemplate(models.Model):
 
         # writing account values after creation of accounts
         company.transfer_account_id = account_template_ref[transfer_account_id.id]
-        for key, value in generated_tax_res['account_dict'].items():
+        for key, value in pycompat.items(generated_tax_res['account_dict']):
             if value['refund_account_id'] or value['account_id'] or value['cash_basis_account']:
                 AccountTaxObj.browse(key).write({
                     'refund_account_id': account_ref.get(value['refund_account_id'], False),

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -4,7 +4,7 @@ from operator import itemgetter
 import time
 
 from odoo import api, fields, models, _
-from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
+from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT, pycompat
 from odoo.exceptions import ValidationError
 from odoo.addons.base.res.res_partner import WARNING_MESSAGE, WARNING_HELP
 
@@ -72,7 +72,7 @@ class AccountFiscalPosition(models.Model):
         ref_dict = {}
         for line in self.account_ids:
             ref_dict[line.account_src_id] = line.account_dest_id
-        for key, acc in accounts.items():
+        for key, acc in list(pycompat.items(accounts)):
             if acc in ref_dict:
                 accounts[key] = ref_dict[acc]
         return accounts
@@ -245,7 +245,7 @@ class ResPartner(models.Model):
         res = self._cr.fetchall()
         if not res:
             return [('id', '=', '0')]
-        return [('id', 'in', map(itemgetter(0), res))]
+        return [('id', 'in', [r[0] for r in res])]
 
     @api.model
     def _credit_search(self, operator, operand):
@@ -292,7 +292,7 @@ class ResPartner(models.Model):
                 """ % where_clause
         self.env.cr.execute(query, where_clause_params)
         price_totals = self.env.cr.dictfetchall()
-        for partner, child_ids in all_partners_and_children.items():
+        for partner, child_ids in pycompat.items(all_partners_and_children):
             partner.total_invoiced = sum(price['total'] for price in price_totals if price['partner_id'] in child_ids)
 
     @api.multi

--- a/addons/account/report/account_balance.py
+++ b/addons/account/report/account_balance.py
@@ -44,7 +44,7 @@ class ReportTrialBalance(models.AbstractModel):
             currency = account.currency_id and account.currency_id or account.company_id.currency_id
             res['code'] = account.code
             res['name'] = account.name
-            if account.id in account_result.keys():
+            if account.id in account_result:
                 res['debit'] = account_result[account.id].get('debit')
                 res['credit'] = account_result[account.id].get('credit')
                 res['balance'] = account_result[account.id].get('balance')

--- a/addons/account/report/account_general_ledger.py
+++ b/addons/account/report/account_general_ledger.py
@@ -27,7 +27,7 @@ class ReportGeneralLedger(models.AbstractModel):
         """
         cr = self.env.cr
         MoveLine = self.env['account.move.line']
-        move_lines = dict(map(lambda x: (x, []), accounts.ids))
+        move_lines = {x: [] for x in accounts.ids}
 
         # Prepare initial sql query and Get the initial move lines
         if init_balance:

--- a/addons/account/report/account_journal.py
+++ b/addons/account/report/account_journal.py
@@ -24,7 +24,7 @@ class ReportJournal(models.AbstractModel):
             query += 'am.name'
         query += ', "account_move_line".move_id, acc.code'
         self.env.cr.execute(query, tuple(params))
-        ids = map(lambda x: x[0], self.env.cr.fetchall())
+        ids = (x[0] for x in self.env.cr.fetchall())
         return self.env['account.move.line'].browse(ids)
 
     def _sum_debit(self, data, journal_id):

--- a/addons/account/report/account_overdue_report.py
+++ b/addons/account/report/account_overdue_report.py
@@ -8,7 +8,7 @@ class ReportOverdue(models.AbstractModel):
     _name = 'report.account.report_overdue'
 
     def _get_account_move_lines(self, partner_ids):
-        res = dict(map(lambda x:(x,[]), partner_ids))
+        res = {x: [] for x in partner_ids}
         self.env.cr.execute("SELECT m.name AS move_id, l.date, l.name, l.ref, l.date_maturity, l.partner_id, l.blocked, l.amount_currency, l.currency_id, "
             "CASE WHEN at.type = 'receivable' "
                 "THEN SUM(l.debit) "

--- a/addons/account/tests/test_reconciliation.py
+++ b/addons/account/tests/test_reconciliation.py
@@ -2,6 +2,9 @@ from odoo.addons.account.tests.account_test_classes import AccountingTestCase
 import time
 import unittest
 
+from odoo.tools import pycompat
+
+
 class TestReconciliation(AccountingTestCase):
 
     """Tests for reconciliation (account.tax)
@@ -336,8 +339,8 @@ class TestReconciliation(AccountingTestCase):
         self.assertTrue(exchange_loss_line, 'There should be one move line of 0.01 EUR in credit')
         # The journal items of the reconciliation should have their debit and credit total equal
         # Besides, the total debit and total credit should be 60.61 EUR (2.00 USD)
-        self.assertEquals(sum([res['debit'] for res in result.values()]), 60.61)
-        self.assertEquals(sum([res['credit'] for res in result.values()]), 60.61)
+        self.assertEquals(sum(res['debit'] for res in pycompat.values(result)), 60.61)
+        self.assertEquals(sum(res['credit'] for res in pycompat.items(result)), 60.61)
         counterpart_exchange_loss_line = None
         for line in exchange_loss_line.move_id.line_id:
             if line.account_id.id == self.account_fx_expense_id:

--- a/addons/account_asset/models/account_asset.py
+++ b/addons/account_asset/models/account_asset.py
@@ -7,7 +7,7 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools import DEFAULT_SERVER_DATE_FORMAT as DF
+from odoo.tools import DEFAULT_SERVER_DATE_FORMAT as DF, pycompat
 from odoo.tools import float_compare, float_is_zero
 
 
@@ -374,7 +374,7 @@ class AccountAssetAsset(models.Model):
         vals = self.onchange_category_id_values(self.category_id.id)
         # We cannot use 'write' on an object that doesn't exist yet
         if vals:
-            for k, v in vals['value'].iteritems():
+            for k, v in pycompat.items(vals['value']):
                 setattr(self, k, v)
 
     def onchange_category_id_values(self, category_id):
@@ -583,7 +583,7 @@ class AccountAssetDepreciationLine(models.Model):
             message = ''
             if message_description:
                 message = '<span>%s</span>' % message_description
-            for name, values in tracked_values.iteritems():
+            for name, values in pycompat.items(tracked_values):
                 message += '<div> &nbsp; &nbsp; &bull; <b>%s</b>: ' % name
                 message += '%s</div>' % values
             return message

--- a/addons/account_asset/wizard/asset_depreciation_confirmation_wizard.py
+++ b/addons/account_asset/wizard/asset_depreciation_confirmation_wizard.py
@@ -22,6 +22,6 @@ class AssetDepreciationConfirmationWizard(models.TransientModel):
             'view_mode': 'tree,form',
             'res_model': 'account.move',
             'view_id': False,
-            'domain': "[('id','in',[" + ','.join(map(str, created_move_ids)) + "])]",
+            'domain': "[('id','in',[" + ','.join(str(id) for id in created_move_ids) + "])]",
             'type': 'ir.actions.act_window',
         }

--- a/addons/account_test/report/report_account_test.py
+++ b/addons/account_test/report/report_account_test.py
@@ -31,8 +31,8 @@ class ReportAssertAccount(models.AbstractModel):
             :rtype: [(key, value)]
             """
             if cols is None:
-                cols = item.keys()
-            return [(col, item.get(col)) for col in cols if col in item.keys()]
+                cols = list(item)
+            return [(col, item.get(col)) for col in cols if col in item]
 
         localdict = {
             'cr': self.env.cr,

--- a/addons/account_voucher/models/account_voucher.py
+++ b/addons/account_voucher/models/account_voucher.py
@@ -5,6 +5,7 @@
 from odoo import fields, models, api, _
 import odoo.addons.decimal_precision as dp
 from odoo.exceptions import UserError
+from odoo.tools import pycompat
 
 
 class AccountVoucher(models.Model):
@@ -357,7 +358,7 @@ class AccountVoucherLine(models.Model):
             self.company_id.id,
             self.voucher_id.currency_id.id,
             self.voucher_id.voucher_type)
-        for fname, fvalue in onchange_res['value'].iteritems():
+        for fname, fvalue in pycompat.items(onchange_res['value']):
             setattr(self, fname, fvalue)
 
     def _get_account(self, product, fpos, type):

--- a/addons/anonymization/models/anonymization.py
+++ b/addons/anonymization/models/anonymization.py
@@ -76,7 +76,7 @@ class IrModelFieldsAnonymization(models.Model):
     @api.multi
     def write(self, vals):
         # check field state: all should be clear before we can modify a field:
-        if not len(vals.keys()) == 1 and vals.get('state') == 'clear':
+        if not len(vals) == 1 and vals.get('state') == 'clear':
             self._check_write()
         if vals.get('field_name') and vals.get('model_name'):
             vals['model_id'], vals['field_id'] = self._get_model_and_field_ids(vals)

--- a/addons/anonymization/wizard/anonymize_wizard.py
+++ b/addons/anonymization/wizard/anonymize_wizard.py
@@ -270,7 +270,7 @@ class IrModelFieldsAnonymizeWizard(models.TransientModel):
         data = pickle.loads(base64.decodestring(self.file_import))
 
         fixes = self.env['ir.model.fields.anonymization.migration.fix'].search_read([
-            ('target_version', '=', '.'.join(map(str, version_info[:2])))
+            ('target_version', '=', '.'.join(str(v) for v in version_info[:2]))
         ], ['model_name', 'field_name', 'query', 'query_type', 'sequence'])
         fixes = group(fixes, ('model_name', 'field_name'))
 

--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -7,6 +7,7 @@ from odoo import http, _
 from odoo.addons.auth_signup.models.res_users import SignupError
 from odoo.addons.web.controllers.main import ensure_db, Home
 from odoo.http import request
+from odoo.tools import pycompat
 
 _logger = logging.getLogger(__name__)
 
@@ -86,7 +87,7 @@ class AuthSignupHome(Home):
             try:
                 # retrieve the user info (name, login or email) corresponding to a signup token
                 token_infos = request.env['res.partner'].sudo().signup_retrieve_info(qcontext.get('token'))
-                for k, v in token_infos.items():
+                for k, v in pycompat.items(token_infos):
                     qcontext.setdefault(k, v)
             except:
                 qcontext['error'] = _("Invalid signup token")
@@ -96,7 +97,7 @@ class AuthSignupHome(Home):
     def do_signup(self, qcontext):
         """ Shared helper that creates a res.partner out of a token """
         values = { key: qcontext.get(key) for key in ('login', 'name', 'password') }
-        assert values.values(), "The form was not properly filled in."
+        assert values, "The form was not properly filled in."
         assert values.get('password') == qcontext.get('confirm_password'), "Passwords do not match; please retype them."
         supported_langs = [lang['code'] for lang in request.env['res.lang'].sudo().search_read([], ['code'])]
         if request.lang in supported_langs:

--- a/addons/auth_signup/models/res_partner.py
+++ b/addons/auth_signup/models/res_partner.py
@@ -17,7 +17,7 @@ class SignupError(Exception):
 def random_token():
     # the token has an entropy of about 120 bits (6 bits/char * 20 chars)
     chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
-    return ''.join(random.SystemRandom().choice(chars) for _ in pycompat.range(20))
+    return ''.join(random.SystemRandom().choice(chars) for _ in range(20))
 
 def now(**kwargs):
     dt = datetime.now() + timedelta(**kwargs)

--- a/addons/base_address_extended/models/base_address_extended.py
+++ b/addons/base_address_extended/models/base_address_extended.py
@@ -5,7 +5,7 @@ import re
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-
+from odoo.tools import pycompat
 
 STREET_FIELDS = ('street_name', 'street_number', 'street_number2')
 
@@ -135,7 +135,7 @@ class Partner(models.Model):
                 vals[field_name] = street_raw
             # assign the values to the fields
             # /!\ Note that a write(vals) would cause a recursion since it would bypass the cache
-            for k, v in vals.items():
+            for k, v in pycompat.items(vals):
                 partner[k] = v
 
 

--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -12,6 +12,7 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, SUPERUSER_ID
 from odoo.modules.registry import Registry
+from odoo.tools import pycompat
 from odoo.tools.safe_eval import safe_eval
 
 _logger = logging.getLogger(__name__)
@@ -263,7 +264,7 @@ class BaseAutomation(models.Model):
                 if res:
                     if 'value' in res:
                         res['value'].pop('id', None)
-                        self.update({key: val for key, val in res['value'].iteritems() if key in self._fields})
+                        self.update({key: val for key, val in pycompat.items(res['value']) if key in self._fields})
                     if 'domain' in res:
                         result.setdefault('domain', {}).update(res['domain'])
                     if 'warning' in res:

--- a/addons/base_gengo/wizard/base_gengo_translations.py
+++ b/addons/base_gengo/wizard/base_gengo_translations.py
@@ -8,6 +8,7 @@ import uuid
 
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import UserError, ValidationError
+from odoo.tools import pycompat
 
 _logger = logging.getLogger(__name__)
 
@@ -193,7 +194,7 @@ class BaseGengoTranslations(models.TransientModel):
         term_ids.write(vals)
         jobs = response.get('jobs', [])
         if jobs:
-            for t_id, job in jobs.items():
+            for t_id, job in pycompat.items(jobs):
                 self._update_terms_job(job)
 
         return

--- a/addons/base_geolocalize/models/res_partner.py
+++ b/addons/base_geolocalize/models/res_partner.py
@@ -31,10 +31,10 @@ def geo_query_address(street=None, zip=None, city=None, state=None, country=None
         # put country qualifier in front, otherwise GMap gives wrong results,
         # e.g. 'Congo, Democratic Republic of the' => 'Democratic Republic of the Congo'
         country = '{1} {0}'.format(*country.split(',', 1))
-    return tools.ustr(', '.join(filter(None, [street,
-                                              ("%s %s" % (zip or '', city or '')).strip(),
-                                              state,
-                                              country])))
+    return tools.ustr(', '.join(
+        field for field in [street, ("%s %s" % (zip or '', city or '')).strip(), state, country]
+        if field
+    ))
 
 
 class ResPartner(models.Model):

--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -15,7 +15,7 @@ from odoo import api, fields, models
 from odoo.tools.translate import _
 from odoo.tools.mimetypes import guess_mimetype
 from odoo.tools.misc import ustr
-from odoo.tools import DEFAULT_SERVER_DATE_FORMAT, DEFAULT_SERVER_DATETIME_FORMAT
+from odoo.tools import DEFAULT_SERVER_DATE_FORMAT, DEFAULT_SERVER_DATETIME_FORMAT, pycompat
 
 try:
     from cStringIO import StringIO
@@ -49,7 +49,7 @@ FILE_TYPE_DICT = {
 }
 EXTENSIONS = {
     '.' + ext: handler
-    for mime, (ext, handler, req) in FILE_TYPE_DICT.iteritems()
+    for mime, (ext, handler, req) in pycompat.items(FILE_TYPE_DICT)
 }
 
 
@@ -121,7 +121,7 @@ class Import(models.TransientModel):
         }]
         model_fields = Model.fields_get()
         blacklist = models.MAGIC_COLUMNS + [Model.CONCURRENCY_CHECK_FIELD]
-        for name, field in model_fields.iteritems():
+        for name, field in pycompat.items(model_fields):
             if name in blacklist:
                 continue
             # an empty string means the field is deprecated, @deprecated must
@@ -134,7 +134,7 @@ class Import(models.TransientModel):
                     continue
                 # states = {state: [(attr, value), (attr2, value2)], state2:...}
                 if not any(attr == 'readonly' and value is False
-                           for attr, value in itertools.chain.from_iterable(states.itervalues())):
+                           for attr, value in itertools.chain.from_iterable(pycompat.values(states))):
                     continue
             field_value = {
                 'id': name,
@@ -208,7 +208,7 @@ class Import(models.TransientModel):
     def _read_xls_book(self, book):
         sheet = book.sheet_by_index(0)
         # emulate Sheet.get_rows for pre-0.9.4
-        for row in itertools.imap(sheet.row, range(sheet.nrows)):
+        for row in pycompat.imap(sheet.row, range(sheet.nrows)):
             values = []
             for cell in row:
                 if cell.ctype is xlrd.XL_CELL_NUMBER:
@@ -543,13 +543,13 @@ class Import(models.TransientModel):
         else:
             mapper = operator.itemgetter(*indices)
         # Get only list of actually imported fields
-        import_fields = filter(None, fields)
+        import_fields = [f for f in fields if f]
 
         rows_to_import = self._read_file(options)
         if options.get('headers'):
             rows_to_import = itertools.islice(rows_to_import, 1, None)
         data = [
-            list(row) for row in itertools.imap(mapper, rows_to_import)
+            list(row) for row in pycompat.imap(mapper, rows_to_import)
             # don't try inserting completely empty rows (e.g. from
             # filtering out o2m fields)
             if any(row)
@@ -566,7 +566,7 @@ class Import(models.TransientModel):
             value = value[1:-1]
             negative = True
         float_regex = re.compile(r'([-]?[0-9.,]+)')
-        split_value = filter(None, float_regex.split(value))
+        split_value = [g for g in float_regex.split(value) if g]
         if len(split_value) > 2:
             # This is probably not a float
             return False
@@ -603,7 +603,7 @@ class Import(models.TransientModel):
     def _parse_import_data(self, data, import_fields, options):
         # Get fields of type date/datetime
         all_fields = self.env[self.res_model].fields_get()
-        for name, field in all_fields.iteritems():
+        for name, field in pycompat.items(all_fields):
             if field['type'] in ('date', 'datetime') and name in import_fields:
                 # Parse date
                 index = import_fields.index(name)

--- a/addons/base_import/models/odf_ods_reader.py
+++ b/addons/base_import/models/odf_ods_reader.py
@@ -19,6 +19,8 @@ from odf import opendocument
 from odf.table import Table, TableRow, TableCell
 from odf.text import P
 
+from odoo.tools import pycompat
+
 
 class ODSReader(object):
 
@@ -95,4 +97,4 @@ class ODSReader(object):
         return self.SHEETS[name]
 
     def getFirstSheet(self):
-        return next(iter(self.SHEETS.itervalues()))
+        return next(iter(pycompat.values(self.SHEETS)))

--- a/addons/base_import/tests/test_base_import.py
+++ b/addons/base_import/tests/test_base_import.py
@@ -9,7 +9,6 @@ from odoo.tests.common import TransactionCase, can_import
 from odoo.modules.module import get_module_resource
 from odoo.tools import mute_logger
 
-
 ID_FIELD = {
     'id': 'id',
     'name': 'id',
@@ -260,7 +259,7 @@ class TestPreview(TransactionCase):
             ['qux', '5', '6'],
         ])
         # Ensure we only have the response fields we expect
-        self.assertItemsEqual(result.keys(), ['matches', 'headers', 'fields', 'preview', 'headers_type', 'options', 'advanced_mode', 'debug'])
+        self.assertItemsEqual(list(result), ['matches', 'headers', 'fields', 'preview', 'headers_type', 'options', 'advanced_mode', 'debug'])
 
     @unittest.skipUnless(can_import('xlrd'), "XLRD module not available")
     def test_xls_success(self):
@@ -290,7 +289,7 @@ class TestPreview(TransactionCase):
             ['qux', '5', '6'],
         ])
         # Ensure we only have the response fields we expect
-        self.assertItemsEqual(result.keys(), ['matches', 'headers', 'fields', 'preview', 'headers_type', 'options', 'advanced_mode', 'debug'])
+        self.assertItemsEqual(list(result), ['matches', 'headers', 'fields', 'preview', 'headers_type', 'options', 'advanced_mode', 'debug'])
 
     @unittest.skipUnless(can_import('xlrd.xlsx'), "XLRD/XLSX not available")
     def test_xlsx_success(self):
@@ -320,7 +319,7 @@ class TestPreview(TransactionCase):
             ['qux', '5', '6'],
         ])
         # Ensure we only have the response fields we expect
-        self.assertItemsEqual(result.keys(), ['matches', 'headers', 'fields', 'preview', 'headers_type', 'options','advanced_mode', 'debug'])
+        self.assertItemsEqual(list(result), ['matches', 'headers', 'fields', 'preview', 'headers_type', 'options','advanced_mode', 'debug'])
 
     @unittest.skipUnless(can_import('odf'), "ODFPY not available")
     def test_ods_success(self):
@@ -350,7 +349,7 @@ class TestPreview(TransactionCase):
             ['aux', '5', '6'],
         ])
         # Ensure we only have the response fields we expect
-        self.assertItemsEqual(result.keys(), ['matches', 'headers', 'fields', 'preview', 'headers_type', 'options', 'advanced_mode', 'debug'])
+        self.assertItemsEqual(list(result), ['matches', 'headers', 'fields', 'preview', 'headers_type', 'options', 'advanced_mode', 'debug'])
 
 
 class test_convert_import_data(TransactionCase):

--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -8,7 +8,7 @@ from os.path import join as opj
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.modules import load_information_from_description_file
-from odoo.tools import convert_file, exception_to_unicode
+from odoo.tools import convert_file, exception_to_unicode, pycompat
 from odoo.tools.osutil import tempdir
 
 _logger = logging.getLogger(__name__)
@@ -113,6 +113,6 @@ class IrModule(models.Model):
                         _logger.exception('Error while importing module')
                         errors[mod_name] = exception_to_unicode(e)
         r = ["Successfully imported module '%s'" % mod for mod in success]
-        for mod, error in errors.items():
+        for mod, error in pycompat.items(errors):
             r.append("Error while importing module '%s': %r" % (mod, error))
         return '\n'.join(r), module_names

--- a/addons/base_import_module/models/ir_ui_view.py
+++ b/addons/base_import_module/models/ir_ui_view.py
@@ -23,6 +23,6 @@ class IrUiView(models.Model):
            GROUP BY coalesce(v.inherit_id, v.id)
         """, [model])
 
-        ids = map(itemgetter(0), self._cr.fetchall())
+        ids = (row[0] for row in self._cr.fetchall())
         views = self.with_context(load_all_views=True).browse(ids)
         return views._check_xml() and result

--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -154,7 +154,7 @@ class ResPartner(models.Model):
         match = self.__check_vat_ch_re2.match(vat)
         if match:
             # For new TVA numbers, do a mod11 check
-            num = filter(lambda s: s.isdigit(), match.group(1))        # get the digits only
+            num = [s for s in match.group(1) if s.isdigit()]        # get the digits only
             factor = (5, 4, 3, 2, 7, 6, 5, 4)
             csum = sum([int(num[i]) * factor[i] for i in range(8)])
             check = (11 - (csum % 11)) % 11

--- a/addons/calendar/models/calendar.py
+++ b/addons/calendar/models/calendar.py
@@ -34,7 +34,7 @@ def calendar_id2real_id(calendar_id=None, with_date=False):
         :return: real event id
     """
     if calendar_id and isinstance(calendar_id, (basestring)):
-        res = filter(None, calendar_id.split('-'))
+        res = [bit for bit in calendar_id.split('-') if bit]
         if len(res) == 2:
             real_id = res[0]
             if with_date:
@@ -127,7 +127,7 @@ class Attendee(models.Model):
     def create(self, values):
         if not values.get("email") and values.get("common_name"):
             common_nameval = values.get("common_name").split(':')
-            email = filter(lambda x: x.__contains__('@'), common_nameval)  # TODO JEM : should be refactored
+            email = [x for x in common_nameval if '@' in x] # TODO JEM : should be refactored
             values['email'] = email and email[0] or ''
             values['common_name'] = values.get("common_name")
         return super(Attendee, self).create(values)
@@ -354,7 +354,7 @@ class AlarmManager(models.AbstractModel):
 
         all_meetings = self.get_next_potential_limit_alarm('email', seconds=cron_interval)
 
-        for meeting in self.env['calendar.event'].browse(all_meetings.keys()):
+        for meeting in self.env['calendar.event'].browse(all_meetings):
             max_delta = all_meetings[meeting.id]['max_duration']
 
             if meeting.recurrency:
@@ -468,7 +468,7 @@ class Alarm(models.Model):
     name = fields.Char('Name', required=True)
     type = fields.Selection([('notification', 'Notification'), ('email', 'Email')], 'Type', required=True, default='email')
     duration = fields.Integer('Remind Before', required=True, default=1)
-    interval = fields.Selection(list(_interval_selection.iteritems()), 'Unit', required=True, default='hours')
+    interval = fields.Selection(list(pycompat.items(_interval_selection)), 'Unit', required=True, default='hours')
     duration_minutes = fields.Integer('Duration in minutes', compute='_compute_duration_minutes', store=True, help="Duration in minutes")
 
     @api.onchange('duration', 'interval')
@@ -541,7 +541,7 @@ class Meeting(models.Model):
         """ Get recurrent start and stop dates based on Rule string"""
         start_dates = self._get_recurrent_date_by_event(date_field='start')
         stop_dates = self._get_recurrent_date_by_event(date_field='stop')
-        return zip(start_dates, stop_dates)
+        return list(pycompat.izip(start_dates, stop_dates))
 
     @api.multi
     def _get_recurrent_date_by_event(self, date_field='start'):
@@ -550,7 +550,7 @@ class Meeting(models.Model):
         date_field: the field containing the reference date information for recurrency computation
         """
         self.ensure_one()
-        if date_field in self._fields.keys() and self._fields[date_field].type in ('date', 'datetime'):
+        if date_field in self._fields and self._fields[date_field].type in ('date', 'datetime'):
             reference_date = self[date_field]
         else:
             reference_date = self.start
@@ -1157,7 +1157,7 @@ class Meeting(models.Model):
         data['final_date'] = rule._until and rule._until.strftime(DEFAULT_SERVER_DATETIME_FORMAT)
         #repeat weekly
         if rule._byweekday:
-            for i in pycompat.range(0, 7):
+            for i in range(0, 7):
                 if i in rule._byweekday:
                     data[day_list[i]] = True
             data['rrule_type'] = 'weekly'
@@ -1286,7 +1286,7 @@ class Meeting(models.Model):
     @api.multi
     def _get_message_unread(self):
         id_map = {x: calendar_id2real_id(x) for x in self.ids}
-        real = self.browse(set(id_map.values()))
+        real = self.browse(set(pycompat.values(id_map)))
         super(Meeting, real)._get_message_unread()
         for event in self:
             if event.id == id_map[event.id]:
@@ -1298,7 +1298,7 @@ class Meeting(models.Model):
     @api.multi
     def _get_message_needaction(self):
         id_map = {x: calendar_id2real_id(x) for x in self.ids}
-        real = self.browse(set(id_map.values()))
+        real = self.browse(set(pycompat.values(id_map)))
         super(Meeting, real)._get_message_needaction()
         for event in self:
             if event.id == id_map[event.id]:
@@ -1339,7 +1339,7 @@ class Meeting(models.Model):
 
     @api.multi
     def get_metadata(self):
-        real = self.browse(set({x: calendar_id2real_id(x) for x in self.ids}.values()))
+        real = self.browse({calendar_id2real_id(x) for x in self.ids})
         return super(Meeting, real).get_metadata()
 
     @api.model
@@ -1460,7 +1460,7 @@ class Meeting(models.Model):
             if fields and (f not in fields):
                 fields2.append(f)
 
-        select = map(lambda x: (x, calendar_id2real_id(x)), self.ids)
+        select = [(x, calendar_id2real_id(x)) for x in self.ids]
         real_events = self.browse([real_id for calendar_id, real_id in select])
         real_data = super(Meeting, real_events).read(fields=fields2, load=load)
         real_data = dict((d['id'], d) for d in real_data)
@@ -1493,7 +1493,7 @@ class Meeting(models.Model):
                 if user_id == self.env.user.id or partner_id in r.get("partner_ids", []):
                     continue
             if r['privacy'] == 'private':
-                for f in r.keys():
+                for f in r:
                     recurrent_fields = self._get_recurrent_fields()
                     public_fields = list(set(recurrent_fields + ['id', 'allday', 'start', 'stop', 'display_start', 'display_stop', 'duration', 'user_id', 'state', 'interval', 'count', 'recurrent_id_date', 'rrule']))
                     if f not in public_fields:

--- a/addons/calendar/models/mail_message.py
+++ b/addons/calendar/models/mail_message.py
@@ -19,13 +19,13 @@ class Message(models.Model):
                 if isinstance(args[index][2], basestring):
                     args[index] = (args[index][0], args[index][1], get_real_ids(args[index][2]))
                 elif isinstance(args[index][2], list):
-                    args[index] = (args[index][0], args[index][1], map(lambda x: get_real_ids(x), args[index][2]))
+                    args[index] = (args[index][0], args[index][1], [get_real_ids(x) for x in args[index][2]])
         return super(Message, self).search(args, offset=offset, limit=limit, order=order, count=count)
 
     @api.model
     def _find_allowed_model_wise(self, doc_model, doc_dict):
         if doc_model == 'calendar.event':
             order = self._context.get('order', self._order)
-            for virtual_id in self.env[doc_model].browse(doc_dict.keys()).get_recurrent_ids([], order=order):
+            for virtual_id in self.env[doc_model].browse(doc_dict).get_recurrent_ids([], order=order):
                 doc_dict.setdefault(virtual_id, doc_dict[get_real_ids(virtual_id)])
         return super(Message, self)._find_allowed_model_wise(doc_model, doc_dict)

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -433,9 +433,6 @@ class Lead(models.Model):
             res = _get_first_not_null(attr, opportunities)
             return res.id if res else False
 
-        def _concat_all(attr, opportunities):
-            return '\n\n'.join(filter(None, (opp[attr] for opp in opportunities)))
-
         # process the fields' values
         data = {}
         for field_name in fields:
@@ -447,7 +444,7 @@ class Lead(models.Model):
             elif field.type == 'many2one':
                 data[field_name] = _get_first_not_null_id(field_name, self)  # take the first not null
             elif field.type == 'text':
-                data[field_name] = _concat_all(field_name, self)  # contact field of all opportunities
+                data[field_name] = '\n\n'.join(it for it in self.mapped(field_name) if it)
             else:
                 data[field_name] = _get_first_not_null(field_name, self)
 

--- a/addons/crm/wizard/base_partner_merge.py
+++ b/addons/crm/wizard/base_partner_merge.py
@@ -17,8 +17,7 @@ from .validate_email import validate_email
 from odoo import api, fields, models
 from odoo import SUPERUSER_ID, _
 from odoo.exceptions import ValidationError, UserError
-from odoo.tools import mute_logger
-
+from odoo.tools import mute_logger, pycompat
 
 _logger = logging.getLogger('base.partner.merge')
 
@@ -269,7 +268,7 @@ class MergePartnerAutomatic(models.TransientModel):
                 return item
         # get all fields that are not computed or x2many
         values = dict()
-        for column, field in model_fields.iteritems():
+        for column, field in pycompat.items(model_fields):
             if field.type not in ('many2many', 'one2many') and field.compute is None:
                 for item in itertools.chain(src_partners, [dst_partner]):
                     if item[column]:
@@ -407,7 +406,7 @@ class MergePartnerAutomatic(models.TransientModel):
         """
         return any(
             self.env[model].search_count([(field, 'in', aggr_ids)])
-            for model, field in models.iteritems()
+            for model, field in pycompat.items(models)
         )
 
     @api.model

--- a/addons/event/models/event.py
+++ b/addons/event/models/event.py
@@ -5,6 +5,7 @@ import pytz
 from odoo import _, api, fields, models
 from odoo.addons.mail.models.mail_template import format_tz
 from odoo.exceptions import AccessError, UserError, ValidationError
+from odoo.tools import pycompat
 from odoo.tools.translate import html_translate
 
 from dateutil.relativedelta import relativedelta
@@ -393,7 +394,7 @@ class EventRegistration(models.Model):
             'partner_id': partner_id.id,
             'event_id': event_id and event_id.id or False,
         }
-        data.update({key: registration[key] for key in registration.keys() if key in self._fields})
+        data.update({key: value for key, value in pycompat.items(registration) if key in self._fields})
         return data
 
     @api.one

--- a/addons/event/models/event_mail.py
+++ b/addons/event/models/event_mail.py
@@ -98,10 +98,10 @@ class EventMailScheduler(models.Model):
     def execute(self):
         if self.interval_type == 'after_sub':
             # update registration lines
-            lines = []
-            reg_ids = [mail_reg.registration_id for mail_reg in self.mail_registration_ids]
-            for registration in filter(lambda item: item not in reg_ids, self.event_id.registration_ids):
-                lines.append((0, 0, {'registration_id': registration.id}))
+            lines = [
+                (0, 0, {'registration_id': registration.id})
+                for registration in (self.event_id.registration_ids - self.mapped('mail_registration_ids.registration_id'))
+            ]
             if lines:
                 self.write({'mail_registration_ids': lines})
             # execute scheduler on registrations

--- a/addons/fleet/models/fleet_vehicle_cost.py
+++ b/addons/fleet/models/fleet_vehicle_cost.py
@@ -6,6 +6,8 @@ from odoo.exceptions import UserError
 
 from dateutil.relativedelta import relativedelta
 
+from odoo.tools import pycompat
+
 
 class FleetVehicleCost(models.Model):
     _name = 'fleet.vehicle.cost'
@@ -262,7 +264,7 @@ class FleetVehicleLogContract(models.Model):
                 res[contract.vehicle_id.id] = 1
 
         Vehicle = self.env['fleet.vehicle']
-        for vehicle, value in res.items():
+        for vehicle, value in pycompat.items(res):
             Vehicle.browse(vehicle).message_post(body=_('%s contract(s) need(s) to be renewed and/or closed!') % value)
         return contracts.write({'state': 'toclose'})
 

--- a/addons/gamification/models/goal.py
+++ b/addons/gamification/models/goal.py
@@ -260,7 +260,7 @@ class Goal(models.Model):
         for goal in self:
             goals_by_definition.setdefault(goal.definition_id, []).append(goal)
 
-        for definition, goals in goals_by_definition.items():
+        for definition, goals in pycompat.items(goals_by_definition):
             goals_to_write = {}
             if definition.computation_mode == 'manually':
                 for goal in goals:
@@ -305,9 +305,9 @@ class Goal(models.Model):
                         subqueries.setdefault((start_date, end_date), {}).update({goal.id:safe_eval(definition.batch_user_expression, {'user': goal.user_id})})
 
                     # the global query should be split by time periods (especially for recurrent goals)
-                    for (start_date, end_date), query_goals in subqueries.items():
+                    for (start_date, end_date), query_goals in pycompat.items(subqueries):
                         subquery_domain = list(general_domain)
-                        subquery_domain.append((field_name, 'in', list(set(query_goals.values()))))
+                        subquery_domain.append((field_name, 'in', list(set(pycompat.values(query_goals)))))
                         if start_date:
                             subquery_domain.append((field_date_name, '>=', start_date))
                         if end_date:
@@ -351,7 +351,7 @@ class Goal(models.Model):
 
                         goals_to_write.update(goal._get_write_values(new_value))
 
-            for goal, values in goals_to_write.iteritems():
+            for goal, values in pycompat.items(goals_to_write):
                 if not values:
                     continue
                 goal.write(values)

--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -20,7 +20,7 @@ class Meeting(models.Model):
     @api.multi
     def write(self, values):
         sync_fields = set(self.get_fields_need_update_google())
-        if (set(values.keys()) and sync_fields) and 'oe_update_date' not in values.keys() and 'NewMeeting' not in self._context:
+        if (set(values) and sync_fields) and 'oe_update_date' not in values and 'NewMeeting' not in self._context:
             values['oe_update_date'] = fields.Datetime.now()
         return super(Meeting, self).write(values)
 

--- a/addons/google_calendar/models/google_calendar.py
+++ b/addons/google_calendar/models/google_calendar.py
@@ -10,7 +10,7 @@ import pytz
 import urllib2
 
 from odoo import api, fields, models, tools, _
-from odoo.tools import exception_to_unicode
+from odoo.tools import exception_to_unicode, pycompat
 
 _logger = logging.getLogger(__name__)
 
@@ -23,15 +23,15 @@ class Meta(type):
     """ This Meta class allow to define class as a structure, and so instancied variable
         in __init__ to avoid to have side effect alike 'static' variable """
     def __new__(typ, name, parents, attrs):
-        methods = dict((k, v) for k, v in attrs.iteritems()
-                       if callable(v))
-        attrs = dict((k, v) for k, v in attrs.iteritems()
-                     if not callable(v))
+        methods = {k: v for k, v in pycompat.items(attrs)
+                       if callable(v)}
+        attrs = {k: v for k, v in pycompat.items(attrs)
+                     if not callable(v)}
 
         def init(self, **kw):
-            for key, val in attrs.iteritems():
+            for key, val in pycompat.items(attrs):
                 setattr(self, key, val)
-            for key, val in kw.iteritems():
+            for key, val in pycompat.items(kw):
                 assert key in attrs
                 setattr(self, key, val)
 
@@ -40,9 +40,7 @@ class Meta(type):
         return type.__new__(typ, name, parents, methods)
 
 
-class Struct(object):
-    __metaclass__ = Meta
-
+Struct = Meta('Struct', (object,), {})
 
 class OdooEvent(Struct):
     event = False
@@ -161,7 +159,7 @@ class SyncOperation(object):
     def __init__(self, src, info, **kw):
         self.src = src
         self.info = info
-        for key, val in kw.items():
+        for key, val in pycompat.items(kw):
             setattr(self, key, val)
 
     def __str__(self):
@@ -689,7 +687,7 @@ class GoogleCalendar(models.AbstractModel):
 
             my_google_attendees = CalendarAttendee.with_context(context_novirtual).search([
                 ('partner_id', '=', my_partner_id),
-                ('google_internal_event_id', 'in', all_event_from_google.keys())
+                ('google_internal_event_id', 'in', pycompat.keys(all_event_from_google))
             ])
             my_google_att_ids = my_google_attendees.ids
 
@@ -753,7 +751,7 @@ class GoogleCalendar(models.AbstractModel):
             ev_to_sync.OE.status = event.active
             ev_to_sync.OE.synchro = att.oe_synchro_date
 
-        for event in all_event_from_google.values():
+        for event in pycompat.values(all_event_from_google):
             event_id = event.get('id')
             base_event_id = event_id.rsplit('_', 1)[0]
 
@@ -788,7 +786,7 @@ class GoogleCalendar(models.AbstractModel):
         #      DO ACTION     #
         ######################
         for base_event in event_to_synchronize:
-            event_to_synchronize[base_event] = sorted(event_to_synchronize[base_event].iteritems(), key=operator.itemgetter(0))
+            event_to_synchronize[base_event] = sorted(pycompat.items(event_to_synchronize[base_event]), key=operator.itemgetter(0))
             for current_event in event_to_synchronize[base_event]:
                 self.env.cr.commit()
                 event = current_event[1]  # event is an Sync Event !

--- a/addons/hr/models/hr.py
+++ b/addons/hr/models/hr.py
@@ -7,7 +7,7 @@ from odoo import api, fields, models
 from odoo import tools, _
 from odoo.exceptions import ValidationError
 from odoo.modules.module import get_module_resource
-
+from odoo.tools import pycompat
 
 _logger = logging.getLogger(__name__)
 
@@ -250,7 +250,7 @@ class Employee(models.Model):
         if auto_follow_fields is None:
             auto_follow_fields = ['user_id']
         user_field_lst = []
-        for name, field in self._fields.items():
+        for name, field in pycompat.items(self._fields):
             if name in auto_follow_fields and name in updated_fields and field.comodel_name == 'res.users':
                 user_field_lst.append(name)
         return user_field_lst

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -5,7 +5,7 @@ import re
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-from odoo.tools import email_split, float_is_zero
+from odoo.tools import email_split, float_is_zero, pycompat
 
 import odoo.addons.decimal_precision as dp
 
@@ -237,12 +237,12 @@ class HrExpense(models.Model):
                     })
 
             #convert eml into an osv-valid format
-            lines = map(lambda x: (0, 0, expense._prepare_move_line(x)), move_lines)
+            lines = [(0, 0, expense._prepare_move_line(x)) for x in move_lines]
             move.with_context(dont_create_taxes=True).write({'line_ids': lines})
             expense.sheet_id.write({'account_move_id': move.id})
             if expense.payment_mode == 'company_account':
                 expense.sheet_id.paid_expense_sheets()
-        for move in move_group_by_sheet.values():
+        for move in pycompat.values(move_group_by_sheet):
             move.post()
         return True
 

--- a/addons/hr_holidays/models/hr_holidays.py
+++ b/addons/hr_holidays/models/hr_holidays.py
@@ -142,7 +142,7 @@ class HolidaysType(models.Model):
         if not count and not order and self._context.get('employee_id'):
             leaves = self.browse(leave_ids)
             sort_key = lambda l: (not l.limit, l.virtual_remaining_leaves)
-            return map(int, leaves.sorted(key=sort_key, reverse=True))
+            return leaves.sorted(key=sort_key, reverse=True).ids
         return leave_ids
 
 

--- a/addons/hr_payroll/models/hr_payslip.py
+++ b/addons/hr_payroll/models/hr_payslip.py
@@ -11,6 +11,7 @@ import babel
 from odoo import api, fields, models, tools, _
 from odoo.addons import decimal_precision as dp
 from odoo.exceptions import UserError, ValidationError
+from odoo.tools import pycompat
 
 
 class HrPayslip(models.Model):
@@ -203,7 +204,8 @@ class HrPayslip(models.Model):
                 'contract_id': contract.id,
             }
 
-            res += [attendances] + leaves.values()
+            res.append(attendances)
+            res.extend(pycompat.values(leaves))
         return res
 
     @api.model
@@ -367,7 +369,7 @@ class HrPayslip(models.Model):
                     #blacklist this rule and its children
                     blacklist += [id for id, seq in rule._recursive_search_of_rules()]
 
-        return [value for code, value in result_dict.items()]
+        return [value for code, value in pycompat.items(result_dict)]
 
     # YTI TODO To rename. This method is not really an onchange, as it is not in any view
     # employee_id and contract_id could be browse records
@@ -378,9 +380,9 @@ class HrPayslip(models.Model):
             'value': {
                 'line_ids': [],
                 #delete old input lines
-                'input_line_ids': map(lambda x: (2, x,), self.input_line_ids.ids),
+                'input_line_ids': [(2, x,) for x in self.input_line_ids.ids],
                 #delete old worked days lines
-                'worked_days_line_ids': map(lambda x: (2, x,), self.worked_days_line_ids.ids),
+                'worked_days_line_ids': [(2, x,) for x in self.worked_days_line_ids.ids],
                 #'details_by_salary_head':[], TODO put me back
                 'name': '',
                 'contract_id': False,

--- a/addons/hr_payroll/report/report_payslip_details.py
+++ b/addons/hr_payroll/report/report_payslip_details.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, models
+from odoo.tools import pycompat
 
 
 class PayslipDetailsReport(models.AbstractModel):
@@ -37,9 +38,9 @@ class PayslipDetailsReport(models.AbstractModel):
                 result.setdefault(x[2], {})
                 result[x[2]].setdefault(x[1], [])
                 result[x[2]][x[1]].append(x[0])
-            for payslip_id, lines_dict in result.iteritems():
+            for payslip_id, lines_dict in pycompat.items(result):
                 res.setdefault(payslip_id, [])
-                for rule_categ_id, line_ids in lines_dict.iteritems():
+                for rule_categ_id, line_ids in pycompat.items(lines_dict):
                     rule_categories = RuleCateg.browse(rule_categ_id)
                     lines = PayslipLine.browse(line_ids)
                     level = 0
@@ -69,9 +70,9 @@ class PayslipDetailsReport(models.AbstractModel):
             result.setdefault(line.slip_id.id, {})
             result[line.slip_id.id].setdefault(line.register_id, line)
             result[line.slip_id.id][line.register_id] |= line
-        for payslip_id, lines_dict in result.iteritems():
+        for payslip_id, lines_dict in pycompat.items(result):
             res.setdefault(payslip_id, [])
-            for register, lines in lines_dict.iteritems():
+            for register, lines in pycompat.items(lines_dict):
                 res[payslip_id].append({
                     'register_name': register.name,
                     'total': sum(lines.mapped('total')),

--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -4,6 +4,7 @@
 from datetime import datetime
 
 from odoo import api, fields, models, tools, SUPERUSER_ID
+from odoo.tools import pycompat
 from odoo.tools.translate import _
 from odoo.exceptions import UserError
 
@@ -248,7 +249,7 @@ class Applicant(models.Model):
             self = self.with_context(default_department_id=vals.get('department_id'))
         if vals.get('job_id') or self._context.get('default_job_id'):
             job_id = vals.get('job_id') or self._context.get('default_job_id')
-            for key, value in self._onchange_job_id_internal(job_id)['value'].iteritems():
+            for key, value in pycompat.items(self._onchange_job_id_internal(job_id)['value']):
                 if key not in vals:
                     vals[key] = value
         if vals.get('user_id'):

--- a/addons/hw_blackbox_be/controllers/main.py
+++ b/addons/hw_blackbox_be/controllers/main.py
@@ -80,7 +80,7 @@ class Blackbox(Thread):
 
     def _wrap_low_level_message_around(self, high_level_message):
         bcc = self._lrc(high_level_message)
-        high_level_message_bytes = map(ord, high_level_message)
+        high_level_message_bytes = (ord(b) for b in high_level_message)
 
         low_level_message = bytearray()
         low_level_message.append(0x02)

--- a/addons/hw_escpos/escpos/escpos.py
+++ b/addons/hw_escpos/escpos/escpos.py
@@ -168,7 +168,7 @@ class StyleStack:
     def to_escpos(self):
         """ converts the current style to an escpos command string """
         cmd = ''
-        ordered_cmds = sorted(self.cmds.keys(), key=lambda x: self.cmds[x]['_order'])
+        ordered_cmds = sorted(self.cmds, key=lambda x: self.cmds[x]['_order'])
         for style in ordered_cmds:
             cmd += self.cmds[style][self.get(style)]
         return cmd
@@ -788,7 +788,7 @@ class Escpos:
                     if encoding in remaining:
                         del remaining[encoding]
                     if len(remaining) >= 1:
-                        encoding = remaining.items()[0][0]
+                        (encoding, _) = remaining.popitem()
                     else:
                         encoding = 'cp437'
                         encoded  = '\xb1'    # could not encode, output error character

--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -6,6 +6,7 @@ import re
 from datetime import datetime, timedelta
 
 from odoo import api, fields, models, modules, tools
+from odoo.tools import pycompat
 
 
 class ImLivechatChannel(models.Model):
@@ -95,7 +96,7 @@ class ImLivechatChannel(models.Model):
         for record in self:
             dt = fields.Datetime.to_string(datetime.utcnow() - timedelta(days=7))
             repartition = record.channel_ids.rating_get_grades([('create_date', '>=', dt)])
-            total = sum(repartition.values())
+            total = sum(pycompat.values(repartition))
             if total > 0:
                 happy = repartition['great']
                 record.rating_percentage_satisfaction = ((happy*100) / total) if happy > 0 else 0

--- a/addons/im_livechat/models/mail_channel.py
+++ b/addons/im_livechat/models/mail_channel.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
+from odoo.tools import pycompat
 
 
 class ChannelPartner(models.Model):
@@ -77,7 +78,7 @@ class MailChannel(models.Model):
                 last_msg = self.env['mail.message'].search([("channel_ids", "in", [channel.id])], limit=1)
                 if last_msg:
                     channel_infos_dict[channel.id]['last_message_date'] = last_msg.date
-        return channel_infos_dict.values()
+        return list(pycompat.values(channel_infos_dict))
 
     @api.model
     def channel_fetch_slot(self):

--- a/addons/l10n_in_hr_payroll/report/report_hr_yearly_salary_detail.py
+++ b/addons/l10n_in_hr_payroll/report/report_hr_yearly_salary_detail.py
@@ -4,6 +4,7 @@
 from datetime import date
 
 from odoo import api, models
+from odoo.tools import pycompat
 
 
 class EmployeesYearlySalaryReport(models.AbstractModel):
@@ -97,7 +98,7 @@ class EmployeesYearlySalaryReport(models.AbstractModel):
 
     def salary_list(self, salaries):
         cat_salary_all = []
-        for category_name, amount in salaries.items():
+        for category_name, amount in pycompat.items(salaries):
             cat_salary = []
             total = 0.0
             cat_salary.append(category_name)

--- a/addons/l10n_lu/scripts/tax2csv.py
+++ b/addons/l10n_lu/scripts/tax2csv.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 import csv
 
 import xlrd
-
+from odoo.tools import pycompat
 
 def _e(s):
     if type(s) is unicode:
@@ -32,33 +32,33 @@ class LuxTaxGenerator:
         self.suffix = self.sheet_info.cell_value(4, 2)
 
     def iter_tax_codes(self):
-        keys = map(lambda c: c.value, self.sheet_tax_codes.row(0))
+        keys = [c.value for c in self.sheet_tax_codes.row(0)]
         yield keys
         for i in range(1, self.sheet_tax_codes.nrows):
-            row = map(lambda c: c.value, self.sheet_tax_codes.row(i))
-            d =  OrderedDict(zip(keys, row))
+            row = (c.value for c in self.sheet_tax_codes.row(i))
+            d = OrderedDict(pycompat.izip(keys, row))
             d['sign'] = int(d['sign'])
             d['sequence'] = int(d['sequence'])
             yield d
 
     def iter_taxes(self):
-        keys = map(lambda c: c.value, self.sheet_taxes.row(0))
+        keys = [c.value for c in self.sheet_taxes.row(0)]
         yield keys
         for i in range(1, self.sheet_taxes.nrows):
-            row = map(lambda c: c.value, self.sheet_taxes.row(i))
-            yield OrderedDict(zip(keys, row))
+            row = (c.value for c in self.sheet_taxes.row(i))
+            yield OrderedDict(pycompat.izip(keys, row))
 
     def iter_fiscal_pos_map(self):
-        keys = map(lambda c: c.value, self.sheet_fiscal_pos_map.row(0))
+        keys = [c.value for c in self.sheet_fiscal_pos_map.row(0)]
         yield keys
         for i in range(1, self.sheet_fiscal_pos_map.nrows):
-            row = map(lambda c: c.value, self.sheet_fiscal_pos_map.row(i))
-            yield OrderedDict(zip(keys, row))
+            row = (c.value for c in self.sheet_fiscal_pos_map.row(i))
+            yield OrderedDict(pycompat.izip(keys, row))
 
     def tax_codes_to_csv(self):
         writer = csv.writer(open('account.tax.code.template-%s.csv' %
                                  self.suffix, 'wb'))
-        tax_codes_iterator = self.iter_tax_codes()
+        tax_codes_iterator = self.iter_tax_codes
         keys = next(tax_codes_iterator)
         writer.writerow(keys)
 
@@ -69,7 +69,7 @@ class LuxTaxGenerator:
             if tax_code in tax_codes:
                 raise RuntimeError('duplicate tax code %s' % tax_code)
             tax_codes[tax_code] = row['id']
-            writer.writerow(map(_e, row.values()))
+            writer.writerow(pycompat.imap(_e, pycompat.values(row)))
 
         # read taxes and add leaf tax codes
         new_tax_codes = {}  # id: parent_code
@@ -168,7 +168,7 @@ class LuxTaxGenerator:
                 cur_seq = seq + 1000
             else:
                 cur_seq = seq
-            writer.writerow(map(_e, row.values()[3:]) + [cur_seq])
+            writer.writerow(list(pycompat.imap(_e, list(pycompat.values(row))[3:])) + [cur_seq])
 
     def fiscal_pos_map_to_csv(self):
         writer = csv.writer(open('account.fiscal.'
@@ -178,7 +178,7 @@ class LuxTaxGenerator:
         keys = next(fiscal_pos_map_iterator)
         writer.writerow(keys)
         for row in fiscal_pos_map_iterator:
-            writer.writerow(map(_e, row.values()))
+            writer.writerow(pycompat.imap(_e, pycompat.values(row)))
 
 
 if __name__ == '__main__':

--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -13,7 +13,7 @@ from urlparse import urlparse
 from werkzeug import url_encode, unescape
 
 from odoo import models, fields, api, _
-from odoo.tools import ustr
+from odoo.tools import ustr, pycompat
 
 URL_REGEX = r'(\bhref=[\'"](?!mailto:)([^\'"]+)[\'"])'
 
@@ -165,7 +165,7 @@ class link_tracker(models.Model):
             create_vals['url'] = VALIDATE_URL(vals['url'])
 
         search_domain = []
-        for fname, value in create_vals.iteritems():
+        for fname, value in pycompat.items(create_vals):
             search_domain.append((fname, '=', value))
 
         result = self.search(search_domain, limit=1)

--- a/addons/lunch/models/lunch.py
+++ b/addons/lunch/models/lunch.py
@@ -10,6 +10,8 @@ from odoo import api, fields, models, _
 from odoo.exceptions import AccessError, ValidationError
 import odoo.addons.decimal_precision as dp
 
+from odoo.tools import pycompat
+
 
 class LunchOrder(models.Model):
     """
@@ -24,10 +26,10 @@ class LunchOrder(models.Model):
         prev_order = self.env['lunch.order.line'].search([('user_id', '=', self.env.uid), ('product_id.active', '!=', False)], limit=20, order='id desc')
         # If we return return prev_order.ids, we will have duplicates (identical orders).
         # Therefore, this following part removes duplicates based on product_id and note.
-        return {
+        return list(pycompat.values({
             (order.product_id, order.note): order.id
             for order in prev_order
-        }.values()
+        }))
 
     user_id = fields.Many2one('res.users', 'User', readonly=True,
                               states={'new': [('readonly', False)]},
@@ -86,10 +88,10 @@ class LunchOrder(models.Model):
         prev_order = self.env['lunch.order.line'].search([('user_id', '=', self.env.uid), ('product_id.active', '!=', False)], limit=20, order='date desc, id desc')
         # If we use prev_order.ids, we will have duplicates (identical orders).
         # Therefore, this following part removes duplicates based on product_id and note.
-        self.previous_order_ids = {
+        self.previous_order_ids = list(pycompat.values({
             (order.product_id, order.note): order.id
             for order in prev_order
-        }.values()
+        }))
 
         if self.previous_order_ids:
             lunch_data = []

--- a/addons/mail/models/html2text.py
+++ b/addons/mail/models/html2text.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 """html2text: Turn HTML into equivalent Markdown-structured text."""
+from odoo.tools import pycompat
+
 __version__ = "2.36"
 __author__ = "Aaron Swartz (me@aaronsw.com)"
 __copyright__ = "(C) 2004-2008 Aaron Swartz. GNU GPL 3."
@@ -8,7 +10,6 @@ __contributors__ = ["Martin 'Joey' Schulze", "Ricardo Reyes", "Kevin Jay North"]
 # TODO:
 #   Support decoded entities with unifiable.
 
-if not hasattr(__builtins__, 'True'): True, False = 1, 0
 import re, sys, urllib, htmlentitydefs, codecs
 import sgmllib
 import urlparse
@@ -52,7 +53,7 @@ unifiable = {'rsquo':"'", 'lsquo':"'", 'rdquo':'"', 'ldquo':'"',
 
 unifiable_n = {}
 
-for k in unifiable.keys():
+for k in unifiable:
     unifiable_n[name2cp(k)] = unifiable[k]
 
 def charref(name):
@@ -61,13 +62,13 @@ def charref(name):
     else:
         c = int(name)
 
-    if not UNICODE_SNOB and c in unifiable_n.keys():
+    if not UNICODE_SNOB and c in unifiable_n:
         return unifiable_n[c]
     else:
         return unichr(c)
 
 def entityref(c):
-    if not UNICODE_SNOB and c in unifiable.keys():
+    if not UNICODE_SNOB and c in unifiable:
         return unifiable[c]
     else:
         try: name2cp(c)
@@ -400,7 +401,7 @@ class _html2text(sgmllib.SGMLParser):
                 self.a = newa
 
             if self.abbr_list and force == "end":
-                for abbr, definition in self.abbr_list.items():
+                for abbr, definition in pycompat.items(self.abbr_list):
                     self.out("  *[" + abbr + "]: " + definition + "\n")
 
             self.p_p = 0

--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -9,7 +9,7 @@ import uuid
 from odoo import _, api, fields, models, modules, tools
 from odoo.exceptions import UserError
 from odoo.osv import expression
-from odoo.tools import ormcache
+from odoo.tools import ormcache, pycompat
 from odoo.tools.safe_eval import safe_eval
 
 
@@ -614,12 +614,12 @@ class Channel(models.Model):
             GROUP BY mail_channel_id
             """, (tuple(self.ids),))
         channels_preview = dict((r['message_id'], r) for r in self._cr.dictfetchall())
-        last_messages = self.env['mail.message'].browse(channels_preview.keys()).message_format()
+        last_messages = self.env['mail.message'].browse(channels_preview).message_format()
         for message in last_messages:
             channel = channels_preview[message['id']]
             del(channel['message_id'])
             channel['last_message'] = message
-        return channels_preview.values()
+        return list(pycompat.values(channels_preview))
 
     #------------------------------------------------------
     # Commands

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -13,6 +13,7 @@ from email.utils import formataddr
 from odoo import _, api, fields, models
 from odoo import tools
 from odoo.addons.base.ir.ir_mail_server import MailDeliveryException
+from odoo.tools import pycompat
 from odoo.tools.safe_eval import safe_eval
 
 _logger = logging.getLogger(__name__)
@@ -206,7 +207,7 @@ class MailMail(models.Model):
             groups[mail.mail_server_id.id].append(mail.id)
         sys_params = self.env['ir.config_parameter'].sudo()
         batch_size = int(sys_params.get_param('mail.session.batch.size', 1000))
-        for server_id, record_ids in groups.iteritems():
+        for server_id, record_ids in pycompat.items(groups):
             for mail_batch in tools.split_every(batch_size, record_ids):
                 yield server_id, mail_batch
 

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -4,6 +4,7 @@
 import logging
 import threading
 
+from odoo.tools import pycompat
 from odoo.tools.misc import split_every
 
 from odoo import _, api, fields, models, registry, SUPERUSER_ID
@@ -174,7 +175,7 @@ class Partner(models.Model):
 
         emails = self.env['mail.mail']
         recipients_nbr, recipients_max = 0, 50
-        for email_type, recipient_template_values in recipients.iteritems():
+        for email_type, recipient_template_values in pycompat.items(recipients):
             if recipient_template_values['followers']:
                 # generate notification email content
                 template_fol_values = dict(base_template_ctx, **recipient_template_values)  # fixme: set button_unfollow to none

--- a/addons/mail/tests/test_mail_followers.py
+++ b/addons/mail/tests/test_mail_followers.py
@@ -29,14 +29,15 @@ class TestMailFollowers(TestMail):
         self.assertFalse(specific)
         self.assertEqual(len(generic), 2)
 
-        self.assertEqual(set([generic[0][2]['res_model_id'], generic[1][2]['res_model_id']]),
-                         set([mail_channel_model_id]))
-        self.assertEqual(set(filter(None, [generic[0][2].get('channel_id'), generic[1][2].get('channel_id')])),
-                         set([test_channel.id]))
-        self.assertEqual(set(filter(None, [generic[0][2].get('partner_id'), generic[1][2].get('partner_id')])),
-                         set([self.user_employee.partner_id.id]))
-        self.assertEqual(set(generic[0][2]['subtype_ids'][0][2] + generic[1][2]['subtype_ids'][0][2]),
-                         set([self.mt_mg_nodef.id, self.mt_al_nodef.id]))
+        items = [it[2] for it in generic]
+        self.assertEqual({item['res_model_id'] for item in items},
+                         {mail_channel_model_id})
+        self.assertEqual({item['channel_id'] for item in items if item.get('channel_id')},
+                         {test_channel.id})
+        self.assertEqual({item['partner_id'] for item in items if item.get('partner_id')},
+                         {self.user_employee.partner_id.id})
+        self.assertEqual(set(items[0]['subtype_ids'][0][2] + items[1]['subtype_ids'][0][2]),
+                         {self.mt_mg_nodef.id, self.mt_al_nodef.id})
 
     def test_m2o_command_update_selective(self):
         test_channel = self.env['mail.channel'].create({'name': 'Test'})
@@ -55,7 +56,7 @@ class TestMailFollowers(TestMail):
         self.assertEqual(generic[0][2]['channel_id'], test_channel.id)
         self.assertEqual(set(generic[0][2]['subtype_ids'][0][2]), set(self.default_group_subtypes.ids))
 
-        self.assertEqual(specific.keys(), [self.test_public.id])
+        self.assertEqual(list(specific), [self.test_public.id])
         self.assertEqual(specific[self.test_public.id][0][2]['res_model_id'], mail_channel_model_id)
         self.assertEqual(specific[self.test_public.id][0][2]['partner_id'], self.user_employee.partner_id.id)
         self.assertEqual(set(specific[self.test_public.id][0][2]['subtype_ids'][0][2]), set([self.mt_mg_nodef.id]))

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -93,7 +93,7 @@ class MailComposer(models.TransientModel):
             result['res_id'] = self.env.user.partner_id.id
 
         if fields is not None:
-            [result.pop(field, None) for field in result.keys() if field not in fields]
+            [result.pop(field, None) for field in list(result) if field not in fields]
         return result
 
     @api.model
@@ -140,7 +140,7 @@ class MailComposer(models.TransientModel):
             for mid, rmod, rid in self._cr.fetchall():
                 message_values[mid] = {'model': rmod, 'res_id': rid}
             # remove from the set to check the ids that mail_compose_message accepts
-            author_ids = [mid for mid, message in message_values.iteritems()
+            author_ids = [mid for mid, message in pycompat.items(message_values)
                           if message.get('model') and not message.get('res_id')]
             self = self.browse(list(set(self.ids) - set(author_ids)))  # not sure slef = ...
 
@@ -248,7 +248,7 @@ class MailComposer(models.TransientModel):
             for res_ids in sliced_res_ids:
                 batch_mails = Mail
                 all_mail_values = wizard.get_mail_values(res_ids)
-                for res_id, mail_values in all_mail_values.iteritems():
+                for res_id, mail_values in pycompat.items(all_mail_values):
                     if wizard.composition_mode == 'mass_mail':
                         batch_mails |= Mail.create(mail_values)
                     else:
@@ -338,7 +338,7 @@ class MailComposer(models.TransientModel):
     def onchange_template_id_wrapper(self):
         self.ensure_one()
         values = self.onchange_template_id(self.template_id.id, self.composition_mode, self.model, self.res_id)['value']
-        for fname, value in values.iteritems():
+        for fname, value in pycompat.items(values):
             setattr(self, fname, value)
 
     @api.multi

--- a/addons/marketing_campaign/models/marketing_campaign.py
+++ b/addons/marketing_campaign/models/marketing_campaign.py
@@ -9,6 +9,7 @@ import re
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError, ValidationError
+from odoo.tools import pycompat
 from odoo.tools.safe_eval import safe_eval
 
 import odoo.addons.decimal_precision as dp
@@ -466,10 +467,10 @@ class MarketingCampaignWorkitem(models.Model):
         matching_workitems = []
         for id, res_id, model in res:
             workitem_map.setdefault(model, {}).setdefault(res_id, set()).add(id)
-        for model, id_map in workitem_map.iteritems():
+        for model, id_map in pycompat.items(workitem_map):
             Model = self.env[model]
             condition_name[0] = Model._rec_name
-            condition = [('id', 'in', id_map.keys()), condition_name]
+            condition = [('id', 'in', list(id_map)), condition_name]
             for record in Model.search(condition):
                 matching_workitems.extend(id_map[record.id])
         return [('id', 'in', list(set(matching_workitems)))]

--- a/addons/mass_mailing/models/mass_mailing.py
+++ b/addons/mass_mailing/models/mass_mailing.py
@@ -258,9 +258,9 @@ class MassMailingCampaign(models.Model):
             # Update standard results with default results
             result = []
             for state_value, state_name in states:
-                res = filter(lambda x: x['stage_id'] == (state_value, state_name), read_group_res)
+                res = [x for x in read_group_res if x['stage_id'] == (state_value, state_name)]
                 if not res:
-                    res = filter(lambda x: x['stage_id'] == state_value, read_group_all_states)
+                    res = [x for x in read_group_all_states if x['stage_id'] == state_value]
                 res[0]['stage_id'] = [state_value, state_name]
                 result.append(res[0])
             return result
@@ -456,7 +456,7 @@ class MassMailing(models.Model):
     def _onchange_model_and_list(self):
         if self.mailing_model == 'mail.mass_mailing.list':
             if self.contact_list_ids:
-                self.mailing_domain = "[('list_ids', 'in', [%s]), ('opt_out', '=', False)]" % (','.join(map(str,self.contact_list_ids.ids)),)
+                self.mailing_domain = "[('list_ids', 'in', [%s]), ('opt_out', '=', False)]" % (','.join(str(id) for id in self.contact_list_ids.ids),)
             else:
                 self.mailing_domain = "[(0, '=', 1)]"
         elif 'opt_out' in self.env[self.mailing_model]._fields and not self.mailing_domain:
@@ -497,9 +497,9 @@ class MassMailing(models.Model):
             # Update standard results with default results
             result = []
             for state_value, state_name in states:
-                res = filter(lambda x: x['state'] == state_value, read_group_res)
+                res = [x for x in read_group_res if x['state'] == state_value]
                 if not res:
-                    res = filter(lambda x: x['state'] == state_value, read_group_all_states)
+                    res = [x for x in read_group_all_states if x['state'] == state_value]
                 res[0]['state'] = [state_value, state_name]
                 result.append(res[0])
             return result

--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -5,6 +5,7 @@ from dateutil import relativedelta
 import datetime
 
 from odoo import api, exceptions, fields, models, _
+from odoo.tools import pycompat
 
 
 class MrpWorkcenter(models.Model):
@@ -73,7 +74,7 @@ class MrpWorkcenter(models.Model):
             if res_group['state'] in ('pending', 'ready', 'progress'):
                 result_duration_expected[res_group['workcenter_id'][0]] += res_group['duration_expected']
         for workcenter in self:
-            workcenter.workorder_count = sum(count for state, count in result[workcenter.id].items() if state not in ('done', 'cancel'))
+            workcenter.workorder_count = sum(count for state, count in pycompat.items(result[workcenter.id]) if state not in ('done', 'cancel'))
             workcenter.workorder_pending_count = result[workcenter.id].get('pending', 0)
             workcenter.workcenter_load = result_duration_expected[workcenter.id]
             workcenter.workorder_ready_count = result[workcenter.id].get('ready', 0)

--- a/addons/mrp/models/stock_picking.py
+++ b/addons/mrp/models/stock_picking.py
@@ -25,7 +25,7 @@ class StockPickingType(models.Model):
             data = self.env['mrp.production'].read_group(domains[field] +
                 [('state', 'not in', ('done', 'cancel')), ('picking_type_id', 'in', self.ids)],
                 ['picking_type_id'], ['picking_type_id'])
-            count = dict(map(lambda x: (x['picking_type_id'] and x['picking_type_id'][0], x['picking_type_id_count']), data))
+            count = {x['picking_type_id'] and x['picking_type_id'][0]: x['picking_type_id_count'] for x in data}
             for record in mrp_picking_types:
                 record[field] = count.get(record.id, 0)
 

--- a/addons/mrp/wizard/mrp_product_produce.py
+++ b/addons/mrp/wizard/mrp_product_produce.py
@@ -59,7 +59,7 @@ class MrpProductProduce(models.TransientModel):
             res['product_qty'] = quantity
             res['product_id'] = production.product_id.id
             res['product_uom_id'] = production.product_uom_id.id
-            res['consume_line_ids'] = map(lambda x: (0,0,x), lines) + map(lambda x:(4, x), existing_lines)
+            res['consume_line_ids'] = [(0,0,x) for x in lines] + [(4, x) for x in existing_lines]
         return res
 
     serial = fields.Boolean('Requires Serial')

--- a/addons/mrp_repair/wizard/mrp_repair_make_invoice.py
+++ b/addons/mrp_repair/wizard/mrp_repair_make_invoice.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
+from odoo.tools import pycompat
 
 
 class MakeInvoice(models.TransientModel):
@@ -24,7 +25,7 @@ class MakeInvoice(models.TransientModel):
             # but that second call will not do anything, since the repairs are already invoiced.
             repairs.action_repair_invoice_create()
         return {
-            'domain': [('id', 'in', new_invoice.values())],
+            'domain': [('id', 'in', list(pycompat.values(new_invoice)))],
             'name': 'Invoices',
             'view_type': 'form',
             'view_mode': 'tree,form',

--- a/addons/pad/models/pad.py
+++ b/addons/pad/models/pad.py
@@ -9,7 +9,7 @@ import urllib2
 
 from odoo import api, models, _
 from odoo.exceptions import UserError
-from odoo.tools import html2plaintext
+from odoo.tools import html2plaintext, pycompat
 
 from ..py_etherpad import EtherpadLiteClient
 
@@ -102,7 +102,7 @@ class PadCommon(models.AbstractModel):
 
         # In case the pad is created programmatically, the content is not filled in yet since it is
         # normally initialized by the JS layer
-        for k, field in self._fields.iteritems():
+        for k, field in pycompat.items(self._fields):
             if hasattr(field, 'pad_content_field') and k not in vals:
                 ctx = {
                     'model': self._name,
@@ -115,7 +115,7 @@ class PadCommon(models.AbstractModel):
 
     # Set the pad content in vals
     def _set_pad_value(self, vals):
-        for k, v in vals.items():
+        for k, v in list(pycompat.items(vals)):
             field = self._fields[k]
             if hasattr(field, 'pad_content_field'):
                 vals[field.pad_content_field] = self.pad_get_content(v)
@@ -125,7 +125,7 @@ class PadCommon(models.AbstractModel):
         self.ensure_one()
         if not default:
             default = {}
-        for k, field in self._fields.iteritems():
+        for k, field in pycompat.items(self._fields):
             if hasattr(field, 'pad_content_field'):
                 pad = self.pad_generate_url()
                 default[k] = pad.get('url')

--- a/addons/payment/models/payment_acquirer.py
+++ b/addons/payment/models/payment_acquirer.py
@@ -4,7 +4,7 @@ import hmac
 import logging
 
 from odoo import api, exceptions, fields, models, _
-from odoo.tools import consteq, float_round, image_resize_images, ustr
+from odoo.tools import consteq, float_round, image_resize_images, ustr, pycompat
 from odoo.addons.base.module import module
 from odoo.exceptions import ValidationError
 
@@ -155,7 +155,7 @@ class PaymentAcquirer(models.Model):
         """ If the field has 'required_if_provider="<provider>"' attribute, then it
         required if record.provider is <provider>. """
         for acquirer in self:
-            if any(getattr(f, 'required_if_provider', None) == acquirer.provider and not acquirer[k] for k, f in self._fields.items()):
+            if any(getattr(f, 'required_if_provider', None) == acquirer.provider and not acquirer[k] for k, f in pycompat.items(self._fields)):
                 return False
         return True
 
@@ -686,7 +686,7 @@ class PaymentToken(models.Model):
             if hasattr(self, custom_method_name):
                 values.update(getattr(self, custom_method_name)(values))
                 # remove all non-model fields used by (provider)_create method to avoid warning
-                fields_wl = set(self._fields.keys()) & set(values.keys())
+                fields_wl = set(self._fields) & set(values)
                 values = {field: values[field] for field in fields_wl}
         return super(PaymentToken, self).create(values)
 

--- a/addons/payment_authorize/models/authorize_request.py
+++ b/addons/payment_authorize/models/authorize_request.py
@@ -62,7 +62,7 @@ class AuthorizeAPI():
         response = urlopen(request).read()
         response = strip_ns(response, XMLNS)
         if response.find('messages/resultCode').text == 'Error':
-            messages = map(lambda m: m.text, response.findall('messages/message/text'))
+            messages = [m.text for m in response.findall('messages/message/text')]
             raise ValidationError('Authorize.net Error Message(s):\n %s' % '\n'.join(messages))
         return response
 

--- a/addons/payment_authorize/tests/test_authorize.py
+++ b/addons/payment_authorize/tests/test_authorize.py
@@ -11,7 +11,7 @@ import odoo
 from odoo.addons.payment.models.payment_acquirer import ValidationError
 from odoo.addons.payment.tests.common import PaymentAcquirerCommon
 from odoo.addons.payment_authorize.controllers.main import AuthorizeController
-from odoo.tools import mute_logger
+from odoo.tools import mute_logger, pycompat
 
 
 @odoo.tests.common.at_install(True)
@@ -91,7 +91,7 @@ class AuthorizeForm(AuthorizeCommon):
         tree = objectify.fromstring(res)
         self.assertEqual(tree.get('action'), 'https://test.authorize.net/gateway/transact.dll', 'Authorize: wrong form POST url')
         for el in tree.iterfind('input'):
-            values = el.values()
+            values = list(pycompat.values(el.attrib))
             if values[1] in ['submit', 'x_fp_hash', 'return_url', 'x_state', 'x_ship_to_state']:
                 continue
             self.assertEqual(

--- a/addons/payment_buckaroo/controllers/main.py
+++ b/addons/payment_buckaroo/controllers/main.py
@@ -6,6 +6,7 @@ import werkzeug
 
 from odoo import http
 from odoo.http import request
+from odoo.tools import pycompat
 
 _logger = logging.getLogger(__name__)
 
@@ -26,6 +27,6 @@ class BuckarooController(http.Controller):
         """ Buckaroo."""
         _logger.info('Buckaroo: entering form_feedback with post data %s', pprint.pformat(post))  # debug
         request.env['payment.transaction'].sudo().form_feedback(post, 'buckaroo')
-        post = dict((key.upper(), value) for key, value in post.items())
+        post = {key.upper(): value for key, value in pycompat.items(post)}
         return_url = post.get('ADD_RETURNDATA') or '/'
         return werkzeug.utils.redirect(return_url)

--- a/addons/payment_buckaroo/models/payment.py
+++ b/addons/payment_buckaroo/models/payment.py
@@ -7,6 +7,8 @@ import urlparse
 from odoo import api, fields, models, _
 from odoo.addons.payment.models.payment_acquirer import ValidationError
 from odoo.addons.payment_buckaroo.controllers.main import BuckarooController
+
+from odoo.tools import pycompat
 from odoo.tools.float_utils import float_compare
 
 _logger = logging.getLogger(__name__)
@@ -19,7 +21,7 @@ def normalize_keys_upper(data):
     convert everything to upper case to be able to easily detected the presence
     of a parameter by checking the uppercase key only
     """
-    return dict((key.upper(), val) for key, val in data.items())
+    return {key.upper(): val for key, val in pycompat.items(data)}
 
 
 class AcquirerBuckaroo(models.Model):
@@ -65,13 +67,13 @@ class AcquirerBuckaroo(models.Model):
         values = dict(values or {})
 
         if inout == 'out':
-            for key in values.keys():
+            for key in list(values):
                 # case insensitive keys
                 if key.upper() == 'BRQ_SIGNATURE':
                     del values[key]
                     break
 
-            items = sorted(values.items(), key=lambda pair: pair[0].lower())
+            items = sorted(pycompat.items(values), key=lambda pair: pair[0].lower())
             sign = ''.join('%s=%s' % (k, urllib.unquote_plus(v)) for k, v in items)
         else:
             sign = ''.join('%s=%s' % (k, get_value(k)) for k in keys)

--- a/addons/payment_ogone/models/payment.py
+++ b/addons/payment_ogone/models/payment.py
@@ -143,7 +143,7 @@ class PaymentAcquirerOgone(models.Model):
                 ]
                 return key.upper() in keys
 
-        items = sorted((k.upper(), v) for k, v in values.items())
+        items = sorted((k.upper(), v) for k, v in pycompat.items(values))
         sign = ''.join('%s=%s%s' % (k, v, key) for k, v in items if v and filter_key(k))
         sign = sign.encode("utf-8")
         shasign = sha1(sign).hexdigest()

--- a/addons/payment_paypal/controllers/main.py
+++ b/addons/payment_paypal/controllers/main.py
@@ -37,7 +37,7 @@ class PaypalController(http.Controller):
             :return: tuple containing the STATUS str and the key/value pairs
                      parsed as a dict
         """
-        lines = filter(None, response.split('\n'))
+        lines = [line for line in response.split('\n') if line]
         status = lines.pop(0)
 
         pdt_post = {}

--- a/addons/point_of_sale/report/pos_invoice.py
+++ b/addons/point_of_sale/report/pos_invoice.py
@@ -20,7 +20,7 @@ class PosInvoiceReport(models.AbstractModel):
         not_invoiced_orders_ids = list(set(docids) - set(invoiced_posorders_ids))
         if not_invoiced_orders_ids:
             not_invoiced_posorders = PosOrder.browse(not_invoiced_orders_ids)
-            not_invoiced_orders_names = list(map(lambda a: a.name, not_invoiced_posorders))
+            not_invoiced_orders_names = [a.name for a in not_invoiced_posorders]
             raise UserError(_('No link to an invoice for %s.') % ', '.join(not_invoiced_orders_names))
 
         return self.env['ir.actions.report'].sudo().render_template('account.report_invoice', {'docs': self.env['account.invoice'].sudo().browse(ids_to_print)})

--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -8,6 +8,8 @@ from odoo.exceptions import UserError, ValidationError
 
 import odoo.addons.decimal_precision as dp
 
+from odoo.tools import pycompat
+
 
 class Pricelist(models.Model):
     _name = "product.pricelist"
@@ -19,7 +21,7 @@ class Pricelist(models.Model):
 
     def _get_default_item_ids(self):
         ProductPricelistItem = self.env['product.pricelist.item']
-        vals = ProductPricelistItem.default_get(ProductPricelistItem._fields.keys())
+        vals = ProductPricelistItem.default_get(list(ProductPricelistItem._fields))
         vals.update(compute_price='formula')
         return [[0, False, vals]]
 
@@ -88,7 +90,7 @@ class Pricelist(models.Model):
         results = {}
         for pricelist in pricelists:
             subres = pricelist._compute_price_rule(products_qty_partner, date=date, uom_id=uom_id)
-            for product_id, price in subres.items():
+            for product_id, price in pycompat.items(subres):
                 results.setdefault(product_id, {})
                 results[product_id][pricelist.id] = price
         return results
@@ -126,7 +128,7 @@ class Pricelist(models.Model):
             while categ:
                 categ_ids[categ.id] = True
                 categ = categ.parent_id
-        categ_ids = categ_ids.keys()
+        categ_ids = list(categ_ids)
 
         is_product_template = products[0]._name == "product.template"
         if is_product_template:
@@ -251,7 +253,14 @@ class Pricelist(models.Model):
         """ For a given pricelist, return price for products
         Returns: dict{product_id: product price}, in the given pricelist """
         self.ensure_one()
-        return dict((product_id, res_tuple[0]) for product_id, res_tuple in self._compute_price_rule(zip(products, quantities, partners), date=date, uom_id=uom_id).iteritems())
+        return {
+            product_id: res_tuple[0]
+            for product_id, res_tuple in pycompat.items(self._compute_price_rule(
+                list(pycompat.izip(products, quantities, partners)),
+                date=date,
+                uom_id=uom_id
+            ))
+        }
 
     def get_product_price(self, product, quantity, partner, date=False, uom_id=False):
         """ For a given pricelist, return price for a given product """
@@ -272,7 +281,7 @@ class Pricelist(models.Model):
     @api.multi
     def price_get(self, prod_id, qty, partner=None):
         """ Multi pricelist, mono product - returns price per pricelist """
-        return dict((key, price[0]) for key, price in self.price_rule_get(prod_id, qty, partner=partner).items())
+        return {key: price[0] for key, price in pycompat.items(self.price_rule_get(prod_id, qty, partner=partner))}
 
     @api.multi
     def price_rule_get_multi(self, products_by_qty_by_partner):
@@ -288,7 +297,8 @@ class Pricelist(models.Model):
     @api.model
     def _price_get_multi(self, pricelist, products_by_qty_by_partner):
         """ Mono pricelist, multi product - return price per product """
-        return pricelist.get_products_price(zip(**products_by_qty_by_partner))
+        return pricelist.get_products_price(
+            list(pycompat.izip(**products_by_qty_by_partner)))
 
     def _get_partner_pricelist(self, partner_id, company_id=None):
         """ Retrieve the applicable pricelist for a given partner in a given company.

--- a/addons/product/report/product_pricelist.py
+++ b/addons/product/report/product_pricelist.py
@@ -27,7 +27,7 @@ class report_product_pricelist(models.AbstractModel):
         }
 
     def _get_quantity(self, data):
-        return sorted([data['form'][key] for key in data['form'].keys() if key.startswith('qty') and data['form'][key]])
+        return sorted([data['form'][key] for key in data['form'] if key.startswith('qty') and data['form'][key]])
 
     def _get_categories(self, pricelist, products, quantities):
         categ_data = []

--- a/addons/product_expiry/models/production_lot.py
+++ b/addons/product_expiry/models/production_lot.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import datetime
 from odoo import api, fields, models
+from odoo.tools import pycompat
 
 
 class StockProductionLot(models.Model):
@@ -31,10 +32,10 @@ class StockProductionLot(models.Model):
             'removal_date': 'removal_time',
             'alert_date': 'alert_time'
         }
-        res = dict.fromkeys(mapped_fields.keys(), False)
+        res = dict.fromkeys(mapped_fields, False)
         product = self.env['product.product'].browse(product_id) or self.product_id
         if product:
-            for field in mapped_fields.keys():
+            for field in mapped_fields:
                 duration = getattr(product, mapped_fields[field])
                 if duration:
                     date = datetime.datetime.now() + datetime.timedelta(days=duration)
@@ -45,7 +46,7 @@ class StockProductionLot(models.Model):
     @api.model
     def create(self, vals):
         dates = self._get_dates(vals.get('product_id'))
-        for d in dates.keys():
+        for d in dates:
             if not vals.get(d):
                 vals[d] = dates[d]
         return super(StockProductionLot, self).create(vals)
@@ -53,5 +54,5 @@ class StockProductionLot(models.Model):
     @api.onchange('product_id')
     def _onchange_product(self):
         dates_dict = self._get_dates()
-        for field, value in dates_dict.items():
+        for field, value in pycompat.items(dates_dict):
             setattr(self, field, value)

--- a/addons/product_margin/models/product_product.py
+++ b/addons/product_margin/models/product_product.py
@@ -4,6 +4,8 @@
 import time
 
 from odoo import api, fields, models
+from odoo.tools import pycompat
+
 
 class ProductProduct(models.Model):
     _inherit = "product.product"
@@ -67,8 +69,8 @@ class ProductProduct(models.Model):
                         prod_re[prod.id] = re_ind
                 re_ind += 1
             res_val = tot_products._compute_product_margin_fields_values(field_names=[x for x in fields if fields in fields_list])
-            for key in res_val.keys():
-                for l in res_val[key].keys():
+            for key in res_val:
+                for l in res_val[key]:
                     re = res[prod_re[key]]
                     if re.get(l):
                         re[l] += res_val[key][l]
@@ -137,6 +139,6 @@ class ProductProduct(models.Model):
             res[val.id]['expected_margin'] = res[val.id]['sale_expected'] - res[val.id]['normal_cost']
             res[val.id]['total_margin_rate'] = res[val.id]['turnover'] and res[val.id]['total_margin'] * 100 / res[val.id]['turnover'] or 0.0
             res[val.id]['expected_margin_rate'] = res[val.id]['sale_expected'] and res[val.id]['expected_margin'] * 100 / res[val.id]['sale_expected'] or 0.0
-            for k, v in res[val.id].items():
+            for k, v in pycompat.items(res[val.id]):
                 setattr(val, k, v)
         return res

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -614,7 +614,7 @@ class Task(models.Model):
         email_list = tools.email_split((msg.get('to') or '') + ',' + (msg.get('cc') or ''))
         # check left-part is not already an alias
         aliases = self.mapped('project_id.alias_name')
-        return filter(lambda x: x.split('@')[0] not in aliases, email_list)
+        return [x for x in email_list if x.split('@')[0] not in aliases]
 
     @api.model
     def message_new(self, msg, custom_values=None):
@@ -630,7 +630,7 @@ class Task(models.Model):
 
         task = super(Task, self).message_new(msg, custom_values=defaults)
         email_list = task.email_split(msg)
-        partner_ids = filter(None, task._find_partner_from_emails(email_list, force_create=False))
+        partner_ids = [p for p in task._find_partner_from_emails(email_list, force_create=False) if p]
         task.message_subscribe(partner_ids)
         return task
 
@@ -655,7 +655,7 @@ class Task(models.Model):
                         pass
 
         email_list = self.email_split(msg)
-        partner_ids = filter(None, self._find_partner_from_emails(email_list, force_create=False))
+        partner_ids = [p for p in self._find_partner_from_emails(email_list, force_create=False) if p]
         self.message_subscribe(partner_ids)
         return super(Task, self).message_update(msg, update_vals=update_vals)
 
@@ -677,7 +677,7 @@ class Task(models.Model):
             except Exception:
                 pass
         if self.project_id:
-            current_objects = filter(None, headers.get('X-Odoo-Objects', '').split(','))
+            current_objects = [h for h in headers.get('X-Odoo-Objects', '').split(',') if h]
             current_objects.insert(0, 'project.project-%s, ' % self.project_id.id)
             headers['X-Odoo-Objects'] = ','.join(current_objects)
         if self.tag_ids:

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -455,7 +455,7 @@ class PurchaseOrder(models.Model):
         pick_ids = sum([order.picking_ids.ids for order in self], [])
         #choose the view_mode accordingly
         if len(pick_ids) > 1:
-            result['domain'] = "[('id','in',[" + ','.join(map(str, pick_ids)) + "])]"
+            result['domain'] = "[('id','in',[" + ','.join(str(id) for id in pick_ids) + "])]"
         elif len(pick_ids) == 1:
             res = self.env.ref('stock.view_picking_form', False)
             result['views'] = [(res and res.id or False, 'form')]

--- a/addons/rating/models/rating.py
+++ b/addons/rating/models/rating.py
@@ -6,6 +6,7 @@ import uuid
 from odoo import api, fields, models, tools, _
 
 from odoo.modules.module import get_resource_path
+from odoo.tools import pycompat
 
 
 class Rating(models.Model):
@@ -214,7 +215,7 @@ class RatingMixin(models.AbstractModel):
         values.update((d['rating'], d['rating_count']) for d in data)
         # add other stats
         if add_stats:
-            rating_number = sum(values.values())
+            rating_number = sum(pycompat.values(values))
             result = {
                 'repartition': values,
                 'avg': sum(float(key * values[key]) for key in values) / rating_number if rating_number > 0 else 0,

--- a/addons/rating_project/models/project.py
+++ b/addons/rating_project/models/project.py
@@ -4,6 +4,7 @@
 from datetime import timedelta
 
 from odoo import api, fields, models
+from odoo.tools import pycompat
 from odoo.tools.safe_eval import safe_eval
 
 
@@ -73,13 +74,13 @@ class Project(models.Model):
         domain = [('create_date', '>=', fields.Datetime.to_string(fields.datetime.now() - timedelta(days=30)))]
         for project in self:
             activity = project.tasks.rating_get_grades(domain)
-            project.percentage_satisfaction_project = activity['great'] * 100 / sum(activity.values()) if sum(activity.values()) else -1
+            project.percentage_satisfaction_project = activity['great'] * 100 / sum(pycompat.values(activity)) if sum(pycompat.values(activity)) else -1
 
     @api.one
     @api.depends('tasks.rating_ids.rating')
     def _compute_percentage_satisfaction_task(self):
         activity = self.tasks.rating_get_grades()
-        self.percentage_satisfaction_task = activity['great'] * 100 / sum(activity.values()) if sum(activity.values()) else -1
+        self.percentage_satisfaction_task = activity['great'] * 100 / sum(pycompat.values(activity)) if sum(pycompat.values(activity)) else -1
 
     percentage_satisfaction_task = fields.Integer(
         compute='_compute_percentage_satisfaction_task', string="Happy % on Task", store=True, default=-1)

--- a/addons/rating_project_issue/models/project_issue.py
+++ b/addons/rating_project_issue/models/project_issue.py
@@ -4,6 +4,7 @@
 from datetime import timedelta
 
 from odoo import api, fields, models
+from odoo.tools import pycompat
 from odoo.tools.safe_eval import safe_eval
 
 
@@ -56,11 +57,11 @@ class Project(models.Model):
             if project.use_tasks:
                 activity_task = project.tasks.rating_get_grades(domain)
                 activity_great = activity_task['great']
-                activity_sum = sum(activity_task.values())
+                activity_sum = sum(pycompat.values(activity_task))
             if project.use_issues:
                 activity_issue = self.env['project.issue'].search([('project_id', '=', project.id)]).rating_get_grades(domain)
                 activity_great += activity_issue['great']
-                activity_sum += sum(activity_issue.values())
+                activity_sum += sum(pycompat.values(activity_issue))
             project.percentage_satisfaction_project = activity_great * 100 / activity_sum if activity_sum else -1
 
     @api.one
@@ -68,7 +69,7 @@ class Project(models.Model):
     def _compute_percentage_satisfaction_issue(self):
         project_issue = self.env['project.issue'].search([('project_id', '=', self.id)])
         activity = project_issue.rating_get_grades()
-        self.percentage_satisfaction_issue = activity['great'] * 100 / sum(activity.values()) if sum(activity.values()) else -1
+        self.percentage_satisfaction_issue = activity['great'] * 100 / sum(pycompat.values(activity)) if sum(pycompat.values(activity)) else -1
 
     percentage_satisfaction_issue = fields.Integer(compute='_compute_percentage_satisfaction_issue', string="Happy % on Issue", store=True, default=-1)
 

--- a/addons/resource/models/resource.py
+++ b/addons/resource/models/resource.py
@@ -247,7 +247,7 @@ class ResourceCalendar(models.Model):
         """ Return the list of weekdays that contain at least one working
         interval. """
         self.ensure_one()
-        return list(set(map(int, (self.attendance_ids.mapped('dayofweek')))))
+        return list({int(d) for d in self.attendance_ids.mapped('dayofweek')})
 
     @api.multi
     def _get_next_work_day(self, day_date):

--- a/addons/resource/models/resource_mixin.py
+++ b/addons/resource/models/resource_mixin.py
@@ -92,4 +92,4 @@ class ResourceMixin(models.AbstractModel):
         attendances = calendar._get_day_attendances(day_date, False, False)
         if not attendances:
             return 0
-        return sum(map(lambda i: float(i.hour_to) - float(i.hour_from), attendances))
+        return sum(float(i.hour_to) - float(i.hour_from) for i in attendances)

--- a/addons/sale/models/account_invoice.py
+++ b/addons/sale/models/account_invoice.py
@@ -3,6 +3,7 @@
 
 from itertools import groupby
 from odoo import api, fields, models, _
+from odoo.tools import pycompat
 
 
 class AccountInvoice(models.Model):
@@ -57,7 +58,7 @@ class AccountInvoice(models.Model):
         result = super(AccountInvoice, self)._refund_cleanup_lines(lines)
         if self.env.context.get('mode') == 'modify':
             for i, line in enumerate(lines):
-                for name, field in line._fields.iteritems():
+                for name, field in pycompat.items(line._fields):
                     if name == 'sale_line_ids':
                         result[i][2][name] = [(6, 0, line[name].ids)]
                         line[name] = False

--- a/addons/sale/models/res_partner.py
+++ b/addons/sale/models/res_partner.py
@@ -21,7 +21,7 @@ class ResPartner(models.Model):
         mapped_data = dict([(m['partner_id'][0], m['partner_id_count']) for m in sale_data])
         for partner in self:
             # let's obtain the partner id and all its child ids from the read up there
-            partner_ids = filter(lambda r: r['id'] == partner.id, partner_child_ids)[0]
-            partner_ids = [partner_ids.get('id')] + partner_ids.get('child_ids')
+            item = next(p for p in partner_child_ids if p['id'] == partner.id)
+            partner_ids = [partner.id] + item.get('child_ids')
             # then we can sum for all the partner's child
             partner.sale_order_count = sum(mapped_data.get(child, 0) for child in partner_ids)

--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-from odoo.tools import float_is_zero, float_compare, DEFAULT_SERVER_DATETIME_FORMAT
+from odoo.tools import float_is_zero, float_compare, DEFAULT_SERVER_DATETIME_FORMAT, pycompat
 from odoo.tools.misc import formatLang
 
 import odoo.addons.decimal_precision as dp
@@ -362,7 +362,7 @@ class SaleOrder(models.Model):
         if not invoices:
             raise UserError(_('There is no invoicable line.'))
 
-        for invoice in invoices.values():
+        for invoice in pycompat.values(invoices):
             if not invoice.invoice_line_ids:
                 raise UserError(_('There is no invoicable line.'))
             # If invoice is negative, do a refund invoice instead
@@ -379,7 +379,7 @@ class SaleOrder(models.Model):
             invoice.message_post_with_view('mail.message_origin_link',
                 values={'self': invoice, 'origin': references[invoice]},
                 subtype_id=self.env.ref('mail.mt_note').id)
-        return [inv.id for inv in invoices.values()]
+        return [inv.id for inv in pycompat.values(invoices)]
 
     @api.multi
     def action_draft(self):
@@ -517,8 +517,8 @@ class SaleOrder(models.Model):
                 if tax.include_base_amount:
                     base_tax += tax.compute_all(line.price_reduce + base_tax, quantity=1, product=line.product_id,
                                                 partner=self.partner_shipping_id)['taxes'][0]['amount']
-        res = sorted(res.items(), key=lambda l: l[0].sequence)
-        res = map(lambda l: (l[0].name, l[1]), res)
+        res = sorted(pycompat.items(res), key=lambda l: l[0].sequence)
+        res = [(l[0].name, l[1]) for l in res]
         return res
 
 

--- a/addons/sale/models/sale_analytic.py
+++ b/addons/sale/models/sale_analytic.py
@@ -3,6 +3,8 @@
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
+from odoo.tools import pycompat
+
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
@@ -46,7 +48,7 @@ class SaleOrderLine(models.Model):
                 qty = d['unit_amount']
             lines[line] += qty
 
-        for line, qty in lines.items():
+        for line, qty in pycompat.items(lines):
             line.qty_delivered = qty
         return True
 

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.exceptions import UserError, AccessError
+from odoo.tools import pycompat
 
 from .test_sale_common import TestSale
 
@@ -17,10 +18,10 @@ class TestSaleOrder(TestSale):
             'partner_id': self.partner.id,
             'partner_invoice_id': self.partner.id,
             'partner_shipping_id': self.partner.id,
-            'order_line': [(0, 0, {'name': p.name, 'product_id': p.id, 'product_uom_qty': 2, 'product_uom': p.uom_id.id, 'price_unit': p.list_price}) for (_, p) in self.products.iteritems()],
+            'order_line': [(0, 0, {'name': p.name, 'product_id': p.id, 'product_uom_qty': 2, 'product_uom': p.uom_id.id, 'price_unit': p.list_price}) for (_, p) in pycompat.items(self.products)],
             'pricelist_id': self.env.ref('product.list0').id,
         })
-        self.assertEqual(so.amount_total, sum([2 * p.list_price for (k, p) in self.products.iteritems()]), 'Sale: total amount is wrong')
+        self.assertEqual(so.amount_total, sum([2 * p.list_price for (k, p) in pycompat.items(self.products)]), 'Sale: total amount is wrong')
 
         # send quotation
         so.force_quotation_send()
@@ -35,7 +36,7 @@ class TestSaleOrder(TestSale):
         inv_id = so.action_invoice_create()
         inv = inv_obj.browse(inv_id)
         self.assertEqual(len(inv.invoice_line_ids), 2, 'Sale: invoice is missing lines')
-        self.assertEqual(inv.amount_total, sum([2 * p.list_price if p.invoice_policy == 'order' else 0 for (k, p) in self.products.iteritems()]), 'Sale: invoice total amount is wrong')
+        self.assertEqual(inv.amount_total, sum([2 * p.list_price if p.invoice_policy == 'order' else 0 for (k, p) in pycompat.items(self.products)]), 'Sale: invoice total amount is wrong')
         self.assertTrue(so.invoice_status == 'no', 'Sale: SO status after invoicing should be "nothing to invoice"')
         self.assertTrue(len(so.invoice_ids) == 1, 'Sale: invoice is missing')
 
@@ -46,7 +47,7 @@ class TestSaleOrder(TestSale):
         inv_id = so.action_invoice_create()
         inv = inv_obj.browse(inv_id)
         self.assertEqual(len(inv.invoice_line_ids), 2, 'Sale: second invoice is missing lines')
-        self.assertEqual(inv.amount_total, sum([2 * p.list_price if p.invoice_policy == 'delivery' else 0 for (k, p) in self.products.iteritems()]), 'Sale: second invoice total amount is wrong')
+        self.assertEqual(inv.amount_total, sum([2 * p.list_price if p.invoice_policy == 'delivery' else 0 for (k, p) in pycompat.items(self.products)]), 'Sale: second invoice total amount is wrong')
         self.assertTrue(so.invoice_status == 'invoiced', 'Sale: SO status after invoicing everything should be "invoiced"')
         self.assertTrue(len(so.invoice_ids) == 2, 'Sale: invoice is missing')
         # go over the sold quantity
@@ -71,7 +72,7 @@ class TestSaleOrder(TestSale):
             'partner_id': self.partner.id,
             'partner_invoice_id': self.partner.id,
             'partner_shipping_id': self.partner.id,
-            'order_line': [(0, 0, {'name': p.name, 'product_id': p.id, 'product_uom_qty': 2, 'product_uom': p.uom_id.id, 'price_unit': p.list_price}) for (_, p) in self.products.iteritems()],
+            'order_line': [(0, 0, {'name': p.name, 'product_id': p.id, 'product_uom_qty': 2, 'product_uom': p.uom_id.id, 'price_unit': p.list_price}) for (_, p) in pycompat.items(self.products)],
             'pricelist_id': self.env.ref('product.list0').id,
         })
 

--- a/addons/sale_expense/tests/test_sale_expense.py
+++ b/addons/sale_expense/tests/test_sale_expense.py
@@ -47,7 +47,7 @@ class TestSaleExpense(TestSale):
         # Create Expense Entries
         sheet.action_sheet_move_create()
         # expense should now be in sales order
-        self.assertTrue(prod_exp_1 in map(lambda so: so.product_id, so.order_line), 'Sale Expense: expense product should be in so')
+        self.assertIn(prod_exp_1, so.mapped('order_line.product_id'), 'Sale Expense: expense product should be in so')
         sol = so.order_line.filtered(lambda sol: sol.product_id.id == prod_exp_1.id)
         self.assertEqual((sol.price_unit, sol.qty_delivered), (621.54, 1.0), 'Sale Expense: error when invoicing an expense at cost')
         self.assertEqual(so.amount_total, init_price, 'Sale Expense: price of so not updated after adding expense')
@@ -76,7 +76,7 @@ class TestSaleExpense(TestSale):
         # Create Expense Entries
         sheet.action_sheet_move_create()
         # expense should now be in sales order
-        self.assertTrue(prod_exp_2 in map(lambda so: so.product_id, so.order_line), 'Sale Expense: expense product should be in so')
+        self.assertIn(prod_exp_2, so.mapped('order_line.product_id'), 'Sale Expense: expense product should be in so')
         sol = so.order_line.filtered(lambda sol: sol.product_id.id == prod_exp_2.id)
         self.assertEqual((sol.price_unit, sol.qty_delivered), (prod_exp_2.list_price, 100.0), 'Sale Expense: error when invoicing an expense at cost')
         self.assertEqual(so.amount_total, init_price, 'Sale Expense: price of so not updated after adding expense')

--- a/addons/sale_mrp/models/procurement.py
+++ b/addons/sale_mrp/models/procurement.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, models
+from odoo.tools import pycompat
 
 
 class ProcurementOrder(models.Model):
@@ -11,7 +12,7 @@ class ProcurementOrder(models.Model):
     def make_mo(self):
         """ override method to set link in production created from sale order."""
         res = super(ProcurementOrder, self).make_mo()
-        for procurement_id, production_id in res.items():
+        for procurement_id, production_id in pycompat.items(res):
             if production_id:
                 production = self.env['mrp.production'].browse(production_id)
                 move = production._get_parent_move(production.move_finished_ids[0])

--- a/addons/sale_mrp/sale_mrp.py
+++ b/addons/sale_mrp/sale_mrp.py
@@ -68,7 +68,7 @@ class AccountInvoiceLine(models.Model):
                 if bom.type == 'phantom':
                     average_price_unit = 0
                     components = s_line._get_bom_component_qty(bom)
-                    for product_id in components.keys():
+                    for product_id in components:
                         factor = components[product_id]['qty']
                         prod_moves = [m for m in moves if m.product_id.id == product_id]
                         prod_qty_done = factor * qty_done

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -3,6 +3,7 @@
 
 from odoo.addons.sale.tests.test_sale_common import TestSale
 from odoo.exceptions import UserError
+from odoo.tools import pycompat
 
 
 class TestSaleStock(TestSale):
@@ -16,7 +17,7 @@ class TestSaleStock(TestSale):
             'partner_id': self.partner.id,
             'partner_invoice_id': self.partner.id,
             'partner_shipping_id': self.partner.id,
-            'order_line': [(0, 0, {'name': p.name, 'product_id': p.id, 'product_uom_qty': 2, 'product_uom': p.uom_id.id, 'price_unit': p.list_price}) for (_, p) in self.products.iteritems()],
+            'order_line': [(0, 0, {'name': p.name, 'product_id': p.id, 'product_uom_qty': 2, 'product_uom': p.uom_id.id, 'price_unit': p.list_price}) for (_, p) in pycompat.items(self.products)],
             'pricelist_id': self.env.ref('product.list0').id,
             'picking_policy': 'direct',
         })
@@ -73,7 +74,7 @@ class TestSaleStock(TestSale):
             'partner_id': self.partner.id,
             'partner_invoice_id': self.partner.id,
             'partner_shipping_id': self.partner.id,
-            'order_line': [(0, 0, {'name': p.name, 'product_id': p.id, 'product_uom_qty': 2, 'product_uom': p.uom_id.id, 'price_unit': p.list_price}) for (_, p) in self.products.iteritems()],
+            'order_line': [(0, 0, {'name': p.name, 'product_id': p.id, 'product_uom_qty': 2, 'product_uom': p.uom_id.id, 'price_unit': p.list_price}) for (_, p) in pycompat.items(self.products)],
             'pricelist_id': self.env.ref('product.list0').id,
             'picking_policy': 'direct',
         })

--- a/addons/stock/models/procurement.py
+++ b/addons/stock/models/procurement.py
@@ -9,7 +9,8 @@ from psycopg2 import OperationalError
 
 from odoo import api, fields, models, registry, _
 from odoo.osv import expression
-from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT, float_compare, float_round
+from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT, float_compare, \
+    float_round, pycompat
 
 import logging
 
@@ -307,7 +308,7 @@ class ProcurementOrder(models.Model):
                 location_data[key]['orderpoints'] += orderpoint
                 location_data[key]['groups'] = self._procurement_from_orderpoint_get_groups([orderpoint.id])
 
-            for location_id, location_data in location_data.iteritems():
+            for location_id, location_data in pycompat.items(location_data):
                 location_orderpoints = location_data['orderpoints']
                 product_context = dict(self._context, location=location_orderpoints[0].location_id.id)
                 substract_quantity = location_orderpoints.subtract_procurements_from_orderpoints()

--- a/addons/stock/models/stock_inventory.py
+++ b/addons/stock/models/stock_inventory.py
@@ -4,7 +4,7 @@
 from odoo import api, fields, models, _
 from odoo.addons import decimal_precision as dp
 from odoo.exceptions import UserError
-from odoo.tools import float_utils
+from odoo.tools import float_utils, pycompat
 
 
 class Inventory(models.Model):
@@ -251,7 +251,7 @@ class Inventory(models.Model):
 
         for product_data in self.env.cr.dictfetchall():
             # replace the None the dictionary by False, because falsy values are tested later on
-            for void_field in [item[0] for item in product_data.items() if item[1] is None]:
+            for void_field in [item[0] for item in pycompat.items(product_data) if item[1] is None]:
                 product_data[void_field] = False
             product_data['theoretical_qty'] = product_data['product_qty']
             if product_data['product_id']:

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from odoo import api, fields, models
 from odoo.tools.float_utils import float_compare, float_round
 from odoo.tools.translate import _
-from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
+from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT, pycompat
 from odoo.exceptions import UserError
 
 import logging
@@ -611,7 +611,7 @@ class QuantPackage(models.Model):
 
     @api.multi
     def name_get(self):
-        return self._compute_complete_name().items()
+        return list(pycompat.items(self._compute_complete_name()))
 
     def _compute_complete_name(self):
         """ Forms complete name of location from parent location to child location. """

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -8,7 +8,7 @@ from dateutil import relativedelta
 from odoo import api, fields, models, _
 from odoo.addons import decimal_precision as dp
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools import DEFAULT_SERVER_DATE_FORMAT
+from odoo.tools import DEFAULT_SERVER_DATE_FORMAT, pycompat
 
 import logging
 
@@ -99,7 +99,7 @@ class Warehouse(models.Model):
             'wh_output_stock_loc_id': {'name': _('Output'), 'active': delivery_steps != 'ship_only', 'usage': 'internal'},
             'wh_pack_stock_loc_id': {'name': _('Packing Zone'), 'active': delivery_steps == 'pick_pack_ship', 'usage': 'internal'},
         }
-        for field_name, values in sub_locations.iteritems():
+        for field_name, values in pycompat.items(sub_locations):
             values['location_id'] = vals['view_location_id']
             if vals.get('company_id'):
                 values['company_id'] = vals.get('company_id')
@@ -240,10 +240,10 @@ class Warehouse(models.Model):
             },
         }
         data = self._get_picking_type_values(self.reception_steps, self.delivery_steps, self.wh_pack_stock_loc_id)
-        for field_name, values in data.iteritems():
+        for field_name, values in pycompat.items(data):
             data[field_name].update(create_data[field_name])
 
-        for picking_type, values in data.iteritems():
+        for picking_type, values in pycompat.items(data):
             sequence = IrSequenceSudo.create(sequence_data[picking_type])
             values.update(warehouse_id=self.id, color=color, sequence_id=sequence.id)
             warehouse_data[picking_type] = PickingType.create(values).id
@@ -511,7 +511,8 @@ class Warehouse(models.Model):
                 'auto': 'manual',
                 'picking_type_id': routing.picking_type.id,
                 'warehouse_id': self.id}
-            route_push_values.update((values or {}).items() + (push_values or {}).items())
+            route_push_values.update(values or {})
+            route_push_values.update(push_values or {})
             push_rules_list.append(route_push_values)
             route_pull_values = {
                 'name': self._format_rulename(routing.from_loc, routing.dest_loc, name_suffix),
@@ -521,7 +522,8 @@ class Warehouse(models.Model):
                 'picking_type_id': routing.picking_type.id,
                 'procure_method': first_rule is True and 'make_to_stock' or 'make_to_order',
                 'warehouse_id': self.id}
-            route_pull_values.update((values or {}).items() + (pull_values or {}).items())
+            route_pull_values.update(values or {})
+            route_pull_values.update(pull_values or {})
             pull_rules_list.append(route_pull_values)
             first_rule = False
         return push_rules_list, pull_rules_list
@@ -594,7 +596,7 @@ class Warehouse(models.Model):
     @api.one
     def _update_picking_type(self):
         picking_type_values = self._get_picking_type_values(self.reception_steps, self.delivery_steps, self.wh_pack_stock_loc_id)
-        for field_name, values in picking_type_values.iteritems():
+        for field_name, values in pycompat.items(picking_type_values):
             getattr(self, field_name).write(values)
 
     @api.multi

--- a/addons/stock/wizard/make_procurement.py
+++ b/addons/stock/wizard/make_procurement.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
+from odoo.tools import pycompat
 
 
 class MakeProcurement(models.TransientModel):
@@ -50,7 +51,7 @@ class MakeProcurement(models.TransientModel):
     @api.onchange('product_id')
     def onchange_product_id(self):
         if self.product_id:
-            for key, value in self.onchange_product_id_dict(self.product_id.id).iteritems():
+            for key, value in pycompat.items(self.onchange_product_id_dict(self.product_id.id)):
                 setattr(self, key, value)
 
     @api.model

--- a/addons/stock_account/models/stock.py
+++ b/addons/stock_account/models/stock.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-from odoo.tools import float_compare, float_round
+from odoo.tools import float_compare, float_round, pycompat
 
 import logging
 _logger = logging.getLogger(__name__)
@@ -127,7 +127,7 @@ class StockQuant(models.Model):
             quant_cost_qty[quant.cost] += quant.qty
 
         AccountMove = self.env['account.move']
-        for cost, qty in quant_cost_qty.iteritems():
+        for cost, qty in pycompat.items(quant_cost_qty):
             move_lines = move._prepare_account_move_line(qty, cost, credit_account_id, debit_account_id)
             if move_lines:
                 date = self._context.get('force_period_date', fields.Date.context_today(self))

--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -7,6 +7,7 @@ from odoo import api, fields, models, tools, _
 from odoo.addons import decimal_precision as dp
 from odoo.addons.stock_landed_costs.models import product
 from odoo.exceptions import UserError
+from odoo.tools import pycompat
 
 
 class LandedCost(models.Model):
@@ -122,7 +123,7 @@ class LandedCost(models.Model):
                     quant_dict[quant] = quant.cost + diff
                 if quant_correct:
                     quant_dict[quant_correct] = quant_correct.cost + diff_correct
-                for quant, value in quant_dict.items():
+                for quant, value in pycompat.items(quant_dict):
                     quant.sudo().write({'cost': value})
                 qty_out = 0
                 for quant in line.move_id.quant_ids:
@@ -147,7 +148,7 @@ class LandedCost(models.Model):
             for val_line in landed_cost.valuation_adjustment_lines:
                 val_to_cost_lines[val_line.cost_line_id] += val_line.additional_landed_cost
             if any(tools.float_compare(cost_line.price_unit, val_amount, precision_digits=prec_digits) != 0
-                   for cost_line, val_amount in val_to_cost_lines.iteritems()):
+                   for cost_line, val_amount in pycompat.items(val_to_cost_lines)):
                 return False
         return True
 
@@ -229,7 +230,7 @@ class LandedCost(models.Model):
                         else:
                             towrite_dict[valuation.id] += value
         if towrite_dict:
-            for key, value in towrite_dict.items():
+            for key, value in pycompat.items(towrite_dict):
                 AdjustementLines.browse(key).write({'additional_landed_cost': value})
         return True
 

--- a/addons/survey/models/survey.py
+++ b/addons/survey/models/survey.py
@@ -14,6 +14,8 @@ from odoo.exceptions import UserError, ValidationError
 
 from odoo.addons.website.models.website import slug
 
+from odoo.tools import pycompat
+
 email_validator = re.compile(r"[^@]+@[^@]+\.[^@]+")
 _logger = logging.getLogger(__name__)
 
@@ -23,8 +25,7 @@ def dict_keys_startswith(dictionary, string):
         .. note::
             This function uses dictionary comprehensions (Python >= 2.7)
     """
-    matched_keys = [key for key in dictionary.keys() if key.startswith(string)]
-    return dict((k, dictionary[k]) for k in matched_keys)
+    return {k: v for k, v in pycompat.items(dictionary) if k.startswith(string)}
 
 
 class SurveyStage(models.Model):
@@ -151,7 +152,7 @@ class Survey(models.Model):
         if page_id == 0:
             return (pages[0][1], 0, len(pages) == 1)
 
-        current_page_index = pages.index((filter(lambda p: p[1].id == page_id, pages))[0])
+        current_page_index = pages.index(next(p for p in pages if p[1].id == page_id))
 
         # All the pages have been displayed
         if current_page_index == len(pages) - 1 and not go_back:
@@ -238,7 +239,7 @@ class Survey(models.Model):
                     answers[input_line.value_suggested.id]['count'] += 1
                 if input_line.answer_type == 'text' and (not(current_filters) or input_line.user_input_id.id in current_filters):
                     comments.append(input_line)
-            result_summary = {'answers': answers.values(), 'comments': comments}
+            result_summary = {'answers': list(pycompat.values(answers)), 'comments': comments}
 
         # Calculate and return statistics for matrix
         if question.type == 'matrix':
@@ -248,7 +249,7 @@ class Survey(models.Model):
             comments = []
             [rows.update({label.id: label.value}) for label in question.labels_ids_2]
             [answers.update({label.id: label.value}) for label in question.labels_ids]
-            for cell in product(rows.keys(), answers.keys()):
+            for cell in product(rows, answers):
                 res[cell] = 0
             for input_line in question.user_input_line_ids:
                 if input_line.answer_type == 'suggestion' and (not(current_filters) or input_line.user_input_id.id in current_filters) and input_line.value_suggested_row:
@@ -638,7 +639,7 @@ class SurveyQuestion(models.Model):
             if self.comments_allowed:
                 comment_answer = answer_candidates.pop(("%s_%s" % (answer_tag, 'comment')), '').strip()
             # Preventing answers with blank value
-            if all([True if not answer.strip() else False for answer in answer_candidates.values()]) and answer_candidates:
+            if all(not answer.strip() for answer in pycompat.values(answer_candidates)) and answer_candidates:
                 errors.update({answer_tag: self.constr_error_msg})
             # There is no answer neither comments (if comments count as answer)
             if not answer_candidates and self.comment_count_as_answer and (not comment_flag or not comment_answer):
@@ -660,7 +661,7 @@ class SurveyQuestion(models.Model):
             if self.matrix_subtype == 'simple':
                 answer_number = len(answer_candidates)
             elif self.matrix_subtype == 'multiple':
-                answer_number = len(set([sk.rsplit('_', 1)[0] for sk in answer_candidates.keys()]))
+                answer_number = len({sk.rsplit('_', 1)[0] for sk in answer_candidates})
             else:
                 raise RuntimeError("Invalid matrix subtype")
             # Validate that each line has been answered

--- a/addons/survey/tests/test_survey.py
+++ b/addons/survey/tests/test_survey.py
@@ -12,6 +12,8 @@ from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
 from odoo.addons.website.models.website import slug
 
+from odoo.tools import pycompat
+
 
 class TestSurvey(TransactionCase):
 
@@ -176,7 +178,7 @@ class TestSurvey(TransactionCase):
 
         base_url = self.env['ir.config_parameter'].get_param('web.base.url')
         urltypes = {'public': 'start', 'print': 'print', 'result': 'results'}
-        for urltype, urltxt in urltypes.iteritems():
+        for urltype, urltxt in pycompat.items(urltypes):
             survey_url = getattr(self.survey1, urltype + '_url')
             survey_url_relative = getattr(self.survey1.with_context({'relative_url': True}), urltype + '_url')
             self.assertTrue(validate_url(survey_url))
@@ -208,7 +210,7 @@ class TestSurvey(TransactionCase):
         answers = [input_portal.user_input_line_ids[0], input_public.user_input_line_ids[0]]
         expected_values = {'answer_type': 'free_text', 'value_free_text': "Test Answer"}
         for answer in answers:
-            for field, value in expected_values.iteritems():
+            for field, value in pycompat.items(expected_values):
                 self.assertEqual(getattr(answer, field), value, msg="Unable to answer the survey. Expected behaviour of %s is not proper." % (field))
 
     def test_10_survey_result_simple_multiple_choice(self):
@@ -244,7 +246,7 @@ class TestSurvey(TransactionCase):
 
     def test_12_survey_result_numeric_box(self):
         question = self.env['survey.question'].sudo(self.survey_manager).create({'page_id': self.page1.id, 'question': 'Q0', 'type': 'numerical_box'})
-        num = map(float, random.sample(range(1, 100), 3))
+        num = [float(n) for n in random.sample(range(1, 100), 3)]
         nsum = sum(num)
         for i in range(3):
             self.env['survey.user_input'].sudo(self.user_public).create({'survey_id': self.survey1.id, 'user_input_line_ids': [(0, 0, {
@@ -253,7 +255,7 @@ class TestSurvey(TransactionCase):
             'average': round((nsum / len(num)), 2), 'max': round(max(num), 2),
             'min': round(min(num), 2), 'sum': nsum, 'most_common': Counter(num).most_common(5)}
         result = self.env['survey.survey'].prepare_result(question)
-        for key in exresult.keys():
+        for key in exresult:
             self.assertEqual(result[key], exresult[key], msg="Statistics of numeric box type questions are different from expectations")
 
     def test_13_survey_actions(self):
@@ -264,7 +266,7 @@ class TestSurvey(TransactionCase):
             'print': {'method': 'print', 'token': '/test', 'text': 'Print'},
             'result': {'method': 'result', 'token': '', 'text': 'Results of the'},
             'test': {'method': 'public', 'token': '/phantom', 'text': 'Results of the'}}
-        for action, val in actions.iteritems():
+        for action, val in pycompat.items(actions):
             result = getattr(self.survey1.with_context({'survey_token': val['token'][1:]}), 'action_' + action + '_survey')()
             url = getattr(self.survey1.with_context({'relative_url': True}), val['method'] + '_url') + val['token']
             self.assertEqual(result['url'], url)

--- a/addons/web/tests/test_serving_base.py
+++ b/addons/web/tests/test_serving_base.py
@@ -15,7 +15,7 @@ def sample(population):
 
 class TestModulesLoading(unittest.TestCase):
     def setUp(self):
-        self.mods = map(str, range(1000))
+        self.mods = [str(i) for i in range(1000)]
 
     def test_topological_sort(self):
         random.shuffle(self.mods)

--- a/addons/web_diagram/controllers/main.py
+++ b/addons/web_diagram/controllers/main.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import odoo.http as http
+from odoo.tools import pycompat
 
 from odoo.tools.safe_eval import safe_eval
 
@@ -43,7 +44,12 @@ class DiagramView(http.Controller):
         isolate_nodes = {}
         for blnk_node in graphs['blank_nodes']:
             isolate_nodes[blnk_node['id']] = blnk_node
-        y = map(lambda t: t['y'], filter(lambda x: x['y'] if x['x'] == 20 else None, nodes.values()))
+        y = [
+            t['y']
+            for t in pycompat.values(nodes)
+            if t['x'] == 20
+            if t['y']
+        ]
         y_max = (y and max(y)) or 120
 
         connectors = {}
@@ -93,11 +99,11 @@ class DiagramView(http.Controller):
                 color='white',
                 options={}
             )
-            for color, expr in bgcolors.items():
+            for color, expr in pycompat.items(bgcolors):
                 if safe_eval(expr, act):
                     n['color'] = color
 
-            for shape, expr in shapes.items():
+            for shape, expr in pycompat.items(shapes):
                 if safe_eval(expr, act):
                     n['shape'] = shape
 

--- a/addons/web_editor/models/ir_qweb.py
+++ b/addons/web_editor/models/ir_qweb.py
@@ -26,7 +26,7 @@ from PIL import Image as I
 import odoo.modules
 
 from odoo import api, models, fields
-from odoo.tools import ustr
+from odoo.tools import ustr, pycompat
 from odoo.tools import html_escape as escape
 from odoo.addons.base.ir import ir_qweb
 
@@ -283,7 +283,7 @@ class Image(models.AbstractModel):
             "hose again."
 
         aclasses = ['img', 'img-responsive'] + options.get('class', '').split()
-        classes = ' '.join(itertools.imap(escape, aclasses))
+        classes = ' '.join(pycompat.imap(escape, aclasses))
 
         max_size = None
         if options.get('resize'):

--- a/addons/web_editor/models/ir_ui_view.py
+++ b/addons/web_editor/models/ir_ui_view.py
@@ -84,8 +84,8 @@ class IrUiView(models.Model):
     @api.model
     def to_field_ref(self, el):
         # filter out meta-information inserted in the document
-        attributes = dict((k, v) for k, v in el.items()
-                          if not k.startswith('data-oe-'))
+        attributes = {k: v for k, v in pycompat.items(el.attrib)
+                           if not k.startswith('data-oe-')}
         attributes['t-field'] = el.get('data-oe-expression')
 
         out = html.html_parser.makeelement(el.tag, attrib=attributes)

--- a/addons/web_tour/models/ir_ui_menu.py
+++ b/addons/web_tour/models/ir_ui_menu.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, tools
+from odoo.tools import pycompat
 
 
 class IrUiMenu(models.Model):
@@ -31,7 +32,7 @@ class IrUiMenu(models.Model):
                     if subtree:
                         return subtree
 
-        for menu_id, menu_xmlid in xmlids.iteritems():
+        for menu_id, menu_xmlid in pycompat.items(xmlids):
             _find_subtree(menu_root, menu_id)['xmlid'] = menu_xmlid
 
         return menu_root

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -21,6 +21,8 @@ from odoo.exceptions import AccessError
 from odoo.addons.website.models.website import slug
 from odoo.addons.web.controllers.main import WebClient, Binary, Home
 
+from odoo.tools import pycompat
+
 logger = logging.getLogger(__name__)
 
 # Completely arbitrary limits
@@ -37,11 +39,11 @@ class QueryURL(object):
 
     def __call__(self, path=None, path_args=None, **kw):
         path = path or self.path
-        for key, value in self.args.items():
+        for key, value in pycompat.items(self.args):
             kw.setdefault(key, value)
         path_args = set(path_args or []).union(self.path_args)
         paths, fragments = [], []
-        for key, value in kw.items():
+        for key, value in pycompat.items(kw):
             if value and key in path_args:
                 if isinstance(value, browse_record):
                     paths.append((key, slug(value)))
@@ -193,7 +195,7 @@ class Website(Home):
                 })
             else:
                 # TODO: in master/saas-15, move current_website_id in template directly
-                pages_with_website = map(lambda p: "%d-%d" % (current_website.id, p), range(1, pages + 1))
+                pages_with_website = ["%d-%d" % (current_website.id, p) for p in range(1, pages + 1)]
 
                 # Sitemaps must be split in several smaller files with a sitemap index
                 content = View.render_template('website.sitemap_index_xml', {

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -14,7 +14,7 @@ import odoo
 from odoo import api, models
 from odoo import SUPERUSER_ID
 from odoo.http import request
-from odoo.tools import config
+from odoo.tools import config, pycompat
 from odoo.exceptions import QWebException
 from odoo.tools.safe_eval import safe_eval
 
@@ -241,7 +241,7 @@ class Http(models.AbstractModel):
     def _postprocess_args(cls, arguments, rule):
         super(Http, cls)._postprocess_args(arguments, rule)
 
-        for key, val in arguments.items():
+        for key, val in pycompat.items(arguments):
             # Replace uid placeholder by the current request.uid
             if isinstance(val, models.BaseModel) and isinstance(val._uid, RequestUID):
                 arguments[key] = val.sudo(request.uid)

--- a/addons/website/models/ir_qweb.py
+++ b/addons/website/models/ir_qweb.py
@@ -5,6 +5,7 @@ import ast
 
 from odoo import models
 from odoo.http import request
+from odoo.tools import pycompat
 
 
 class QWeb(models.AbstractModel):
@@ -65,7 +66,7 @@ class QWeb(models.AbstractModel):
             else:
                 return item
 
-        return map(process, items)
+        return [process(it) for it in items]
 
     def _compile_static_attributes(self, el, options):
         items = super(QWeb, self)._compile_static_attributes(el, options)
@@ -81,7 +82,7 @@ class QWeb(models.AbstractModel):
         atts = super(QWeb, self)._get_dynamic_att(tagName, atts, options, values)
         if options.get('rendering_bundle'):
             return atts
-        for name, value in atts.iteritems():
+        for name, value in pycompat.items(atts):
             atts[name] = self._website_build_attribute(tagName, name, value, options, values)
         return atts
 

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -367,7 +367,7 @@ class Website(models.Model):
 
         def get_url_localized(router, lang):
             arguments = dict(request.endpoint_arguments)
-            for key, val in arguments.items():
+            for key, val in list(pycompat.items(arguments)):
                 if isinstance(val, models.BaseModel):
                     arguments[key] = val.with_context(lang=lang)
             return router.build(request.endpoint, arguments)
@@ -486,7 +486,7 @@ class Website(models.Model):
                 'num': pmax
             },
             "pages": [
-                {'url': get_url(page), 'num': page} for page in pycompat.range(pmin, pmax+1)
+                {'url': get_url(page), 'num': page} for page in range(pmin, pmax+1)
             ]
         }
 
@@ -499,7 +499,7 @@ class Website(models.Model):
         endpoint = rule.endpoint
         methods = endpoint.routing.get('methods') or ['GET']
 
-        converters = rule._converters.values()
+        converters = list(pycompat.values(rule._converters))
         if not ('GET' in methods
             and endpoint.routing['type'] == 'http'
             and endpoint.routing['auth'] in ('none', 'public')
@@ -542,9 +542,10 @@ class Website(models.Model):
             if query_string and not converters and (query_string not in rule.build([{}], append_unknown=False)[1]):
                 continue
             values = [{}]
-            convitems = converters.items()
             # converters with a domain are processed after the other ones
-            convitems.sort(key=lambda x: hasattr(x[1], 'domain') and (x[1].domain != '[]'))
+            convitems = sorted(
+                pycompat.items(converters),
+                key=lambda x: hasattr(x[1], 'domain') and (x[1].domain != '[]'))
             for (i, (name, converter)) in enumerate(convitems):
                 newval = []
                 for val in values:
@@ -559,7 +560,7 @@ class Website(models.Model):
             for value in values:
                 domain_part, url = rule.build(value, append_unknown=False)
                 page = {'loc': url}
-                for key, val in value.items():
+                for key, val in pycompat.items(value):
                     if key.startswith('__'):
                         page[key[2:]] = val
                 if url in ('/sitemap.xml',):

--- a/addons/website/tests/test_converter.py
+++ b/addons/website/tests/test_converter.py
@@ -4,6 +4,8 @@
 import unittest
 from odoo.addons.website.models.website import slugify, unslug
 
+from odoo.tools import pycompat
+
 
 class TestUnslug(unittest.TestCase):
 
@@ -23,7 +25,7 @@ class TestUnslug(unittest.TestCase):
             'foo1': (None, None),
         }
 
-        for slug, expected in tests.iteritems():
+        for slug, expected in pycompat.items(tests):
             self.assertEqual(unslug(slug), expected)
 
 

--- a/addons/website/tests/test_crawl.py
+++ b/addons/website/tests/test_crawl.py
@@ -40,7 +40,7 @@ class Crawler(odoo.tests.HttpCase):
         _logger.info("%s %s", msg, url)
         r = self.url_open(url)
         code = r.getcode()
-        self.assertIn(code, pycompat.range(200, 300), "%s Fetching %s returned error response (%d)" % (msg, url, code))
+        self.assertIn(code, range(200, 300), "%s Fetching %s returned error response (%d)" % (msg, url, code))
 
         if r.info().gettype() == 'text/html':
             doc = lxml.html.fromstring(r.read())

--- a/addons/website/tests/test_views.py
+++ b/addons/website/tests/test_views.py
@@ -8,10 +8,11 @@ from lxml import etree as ET, html
 from lxml.html import builder as h
 
 from odoo.tests import common
+from odoo.tools import pycompat
 
 
 def attrs(**kwargs):
-    return dict(('data-oe-%s' % key, str(value)) for key, value in kwargs.iteritems())
+    return {'data-oe-%s' % key: str(value) for key, value in pycompat.items(kwargs)}
 
 
 class TestViewSaving(common.TransactionCase):

--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -104,7 +104,7 @@ class WebsiteBlog(http.Controller):
         # build the domain for blog post to display
         domain = []
         # retrocompatibility to accept tag as slug
-        active_tag_ids = tag and map(int, [unslug(t)[1] for t in tag.split(',')]) or []
+        active_tag_ids = tag and [int(unslug(t)[1]) for t in tag.split(',')] or []
         if active_tag_ids:
             domain += [('tag_ids', 'in', active_tag_ids)]
         if blog:
@@ -149,7 +149,7 @@ class WebsiteBlog(http.Controller):
             else:
                 tag_ids.append(current_tag)
             tag_ids = request.env['blog.tag'].browse(tag_ids).exists()
-            return ','.join(map(slug, tag_ids))
+            return ','.join(slug(tag) for tag in tag_ids)
         values = {
             'blog': blog,
             'blogs': blogs,

--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -4,6 +4,8 @@
 from datetime import datetime
 import random
 
+import itertools
+
 from odoo import api, models, fields, _
 from odoo.addons.website.models.website import slug
 from odoo.tools.translate import html_translate
@@ -165,7 +167,10 @@ class BlogPost(models.Model):
                 blog_post.teaser = blog_post.teaser_manual
             else:
                 content = html2plaintext(blog_post.content).replace('\n', ' ')
-                blog_post.teaser = ' '.join(filter(None, content.split(' '))[:50]) + '...'
+                blog_post.teaser = ' '.join(itertools.islice(
+                    (c for c in content.split(' ') if c),
+                    50
+                )) + '...'
 
     @api.multi
     def _set_teaser(self):

--- a/addons/website_crm_partner_assign/controllers/main.py
+++ b/addons/website_crm_partner_assign/controllers/main.py
@@ -12,6 +12,8 @@ from odoo import http
 from odoo.http import request
 from odoo.addons.website.models.website import slug, unslug
 from odoo.addons.website_partner.controllers.main import WebsitePartnerPage
+
+from odoo.tools import pycompat
 from odoo.tools.translate import _
 
 from odoo.addons.website_portal.controllers.main import website_account
@@ -149,7 +151,7 @@ class WebsiteAccount(website_account):
             'pager': pager,
             'searchbar_sortings': searchbar_sortings,
             'sortby': sortby,
-            'searchbar_filters': OrderedDict(sorted(searchbar_filters.items())),
+            'searchbar_filters': OrderedDict(sorted(pycompat.items(searchbar_filters))),
             'filterby': filterby,
         })
         return request.render("website_crm_partner_assign.portal_my_opportunities", values)
@@ -274,7 +276,7 @@ class WebsiteCrmPartnerAssign(WebsitePartnerPage):
             offset=pager['offset'], limit=self._references_per_page)
         partners = partner_ids.sudo()
 
-        google_map_partner_ids = ','.join(map(str, [p.id for p in partners]))
+        google_map_partner_ids = ','.join(str(p.id) for p in partners)
         google_maps_api_key = request.env['ir.config_parameter'].sudo().get_param('google_maps_api_key')
 
         values = {

--- a/addons/website_crm_partner_assign/models/crm_lead.py
+++ b/addons/website_crm_partner_assign/models/crm_lead.py
@@ -5,6 +5,7 @@ import random
 
 from odoo.addons.base_geolocalize.models.res_partner import geo_find, geo_query_address
 from odoo import api, fields, models, _
+from odoo.tools import pycompat
 
 
 class CrmLead(models.Model):
@@ -44,7 +45,7 @@ class CrmLead(models.Model):
                 if lead.partner_assigned_id and lead.partner_assigned_id.user_id != lead.user_id:
                     salesmans_leads.setdefault(lead.partner_assigned_id.user_id.id, []).append(lead.id)
 
-        for salesman_id, leads_ids in salesmans_leads.items():
+        for salesman_id, leads_ids in pycompat.items(salesmans_leads):
             leads = self.browse(leads_ids)
             leads.write({'user_id': salesman_id})
             for lead in leads:
@@ -218,7 +219,7 @@ class CrmLead(models.Model):
             if tag_spam and tag_spam not in self.tag_ids:
                 values['tag_ids'] = [(4, tag_spam.id, False)]
         if partner_ids:
-            values['partner_declined_ids'] = map(lambda p: (4, p, 0), partner_ids.ids)
+            values['partner_declined_ids'] = [(4, p, 0) for p in partner_ids.ids]
         self.sudo().write(values)
 
     @api.multi

--- a/addons/website_crm_partner_assign/wizard/crm_forward_to_partner.py
+++ b/addons/website_crm_partner_assign/wizard/crm_forward_to_partner.py
@@ -3,6 +3,7 @@
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
+from odoo.tools import pycompat
 
 
 class CrmLeadForwardToPartner(models.TransientModel):
@@ -85,7 +86,7 @@ class CrmLeadForwardToPartner(models.TransientModel):
                 else:
                     partners_leads[partner.id] = {'partner': partner, 'leads': [lead_details]}
 
-        for partner_id, partner_leads in partners_leads.items():
+        for partner_id, partner_leads in pycompat.items(partners_leads):
             in_portal = False
             if portal_group:
                 for contact in (partner.child_ids or partner).filtered(lambda contact: contact.user_ids):

--- a/addons/website_customer/controllers/main.py
+++ b/addons/website_customer/controllers/main.py
@@ -77,7 +77,7 @@ class WebsiteCustomer(http.Controller):
         )
 
         partners = Partner.sudo().search(domain, offset=pager['offset'], limit=self._references_per_page)
-        google_map_partner_ids = ','.join(map(str, partners.ids))
+        google_map_partner_ids = ','.join(str(it) for it in partners.ids)
         google_maps_api_key = request.env['ir.config_parameter'].sudo().get_param('google_maps_api_key')
 
         tags = Tag.search([('website_published', '=', True), ('partner_ids', 'in', partners.ids)], order='classname, name ASC')

--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -9,6 +9,7 @@ from dateutil.relativedelta import relativedelta
 from odoo import fields, http, _
 from odoo.addons.website.models.website import slug
 from odoo.http import request
+from odoo.tools import pycompat
 
 
 class WebsiteEventController(http.Controller):
@@ -79,7 +80,7 @@ class WebsiteEventController(http.Controller):
 
         def dom_without(without):
             domain = [('state', "in", ['draft', 'confirm', 'done'])]
-            for key, search in domain_search.items():
+            for key, search in pycompat.items(domain_search):
                 if key != without:
                     domain += search
             return domain
@@ -232,16 +233,16 @@ class WebsiteEventController(http.Controller):
         ''' Process data posted from the attendee details form. '''
         registrations = {}
         global_values = {}
-        for key, value in details.iteritems():
+        for key, value in pycompat.items(details):
             counter, field_name = key.split('-', 1)
             if counter == '0':
                 global_values[field_name] = value
             else:
                 registrations.setdefault(counter, dict())[field_name] = value
-        for key, value in global_values.iteritems():
-            for registration in registrations.values():
+        for key, value in pycompat.items(global_values):
+            for registration in pycompat.values(registrations):
                 registration[key] = value
-        return registrations.values()
+        return list(pycompat.values(registrations))
 
     @http.route(['/event/<model("event.event"):event>/registration/confirm'], type='http', auth="public", methods=['POST'], website=True)
     def registration_confirm(self, event, **post):

--- a/addons/website_event_questions/controllers/main.py
+++ b/addons/website_event_questions/controllers/main.py
@@ -3,6 +3,8 @@
 
 from odoo.addons.website_event.controllers.main import WebsiteEventController
 
+from odoo.tools import pycompat
+
 
 class WebsiteEvent(WebsiteEventController):
 
@@ -11,7 +13,7 @@ class WebsiteEvent(WebsiteEventController):
         registrations = super(WebsiteEvent, self)._process_registration_details(details)
         for registration in registrations:
             answer_ids = []
-            for key, value in registration.iteritems():
+            for key, value in pycompat.items(registration):
                 if key.startswith('answer_ids-'):
                     answer_ids.append([4, int(value)])
             registration['answer_ids'] = answer_ids

--- a/addons/website_event_sale/controllers/main.py
+++ b/addons/website_event_sale/controllers/main.py
@@ -4,6 +4,7 @@
 from odoo import http, _
 from odoo.addons.website_event.controllers.main import WebsiteEventController
 from odoo.http import request
+from odoo.tools import pycompat
 
 
 class WebsiteEventSaleController(WebsiteEventController):
@@ -20,14 +21,14 @@ class WebsiteEventSaleController(WebsiteEventController):
 
     def _process_tickets_details(self, data):
         ticket_post = {}
-        for key, value in data.iteritems():
+        for key, value in pycompat.items(data):
             if not key.startswith('nb_register') or '-' not in key:
                 continue
             items = key.split('-')
             if len(items) < 2:
                 continue
             ticket_post[int(items[1])] = int(value)
-        tickets = request.env['event.event.ticket'].browse(ticket_post.keys())
+        tickets = request.env['event.event.ticket'].browse(tuple(ticket_post))
         return [{'id': ticket.id, 'name': ticket.name, 'quantity': ticket_post[ticket.id], 'price': ticket.price} for ticket in tickets if ticket_post[ticket.id]]
 
     @http.route(['/event/<model("event.event"):event>/registration/confirm'], type='http', auth="public", methods=['POST'], website=True)

--- a/addons/website_event_track/controllers/main.py
+++ b/addons/website_event_track/controllers/main.py
@@ -8,7 +8,7 @@ import pytz
 
 from odoo import fields, http
 from odoo.http import request
-from odoo.tools import html_escape as escape, html2plaintext
+from odoo.tools import html_escape as escape, html2plaintext, pycompat
 
 
 class WebsiteEventTrackController(http.Controller):
@@ -47,7 +47,7 @@ class WebsiteEventTrackController(http.Controller):
             if forcetr or (start_date>dates[-1][0]) or not location:
                 formatted_time = self._get_locale_time(start_date, lang_code)
                 dates.append((start_date, {}, bool(location), formatted_time))
-                for loc in locations.keys():
+                for loc in list(locations):
                     if locations[loc] and (locations[loc][-1][2] > start_date):
                         locations[loc][-1][3] += 1
                     elif not locations[loc] or locations[loc][-1][2] <= start_date:
@@ -75,7 +75,7 @@ class WebsiteEventTrackController(http.Controller):
 
         days = {}
         tracks_by_days = {}
-        for day, tracks in days_tracks.iteritems():
+        for day, tracks in pycompat.items(days_tracks):
             tracks_by_days[day] = tracks
             days[day] = self._prepare_calendar(event, tracks)
 

--- a/addons/website_form/controllers/main.py
+++ b/addons/website_form/controllers/main.py
@@ -10,7 +10,7 @@ from psycopg2 import IntegrityError
 
 from odoo import http
 from odoo.http import request
-from odoo.tools import DEFAULT_SERVER_DATE_FORMAT, DEFAULT_SERVER_DATETIME_FORMAT
+from odoo.tools import DEFAULT_SERVER_DATE_FORMAT, DEFAULT_SERVER_DATETIME_FORMAT, pycompat
 from odoo.tools.translate import _
 from odoo.exceptions import ValidationError
 from odoo.addons.base.ir.ir_qweb.fields import nl2br
@@ -118,7 +118,7 @@ class WebsiteForm(http.Controller):
         error_fields = []
 
 
-        for field_name, field_value in values.items():
+        for field_name, field_value in pycompat.items(values):
             # If the value of the field if a file
             if hasattr(field_value, 'filename'):
                 # Undo file upload field name indexing
@@ -164,7 +164,7 @@ class WebsiteForm(http.Controller):
         if hasattr(dest_model, "website_form_input_filter"):
             data['record'] = dest_model.website_form_input_filter(request, data['record'])
 
-        missing_required_fields = [label for label, field in authorized_fields.iteritems() if field['required'] and not label in data['record']]
+        missing_required_fields = [label for label, field in pycompat.items(authorized_fields) if field['required'] and not label in data['record']]
         if any(error_fields):
             raise ValidationError(error_fields + missing_required_fields)
 

--- a/addons/website_form/models/models.py
+++ b/addons/website_form/models/models.py
@@ -5,6 +5,7 @@ import itertools
 
 from odoo import models, fields, api
 from odoo.http import request
+from odoo.tools import pycompat
 
 
 class website_form_config(models.Model):
@@ -47,7 +48,7 @@ class website_form_model(models.Model):
             ])
         }
         return {
-            k: v for k, v in self.get_authorized_fields(self.model).iteritems()
+            k: v for k, v in pycompat.items(self.get_authorized_fields(self.model))
             if k not in excluded
         }
 
@@ -57,17 +58,17 @@ class website_form_model(models.Model):
         model = self.env[model_name]
         fields_get = model.fields_get()
 
-        for key, val in model._inherits.iteritems():
+        for key, val in pycompat.items(model._inherits):
             fields_get.pop(val, None)
 
         # Unrequire fields with default values
-        default_values = model.default_get(fields_get.keys())
+        default_values = model.default_get(list(fields_get))
         for field in [f for f in fields_get if f in default_values]:
             fields_get[field]['required'] = False
 
         # Remove readonly and magic fields
         MAGIC_FIELDS = models.MAGIC_COLUMNS + [model.CONCURRENCY_CHECK_FIELD]
-        for field in fields_get.keys():
+        for field in list(fields_get):
             if fields_get[field]['readonly'] or field in MAGIC_FIELDS:
                 del fields_get[field]
 

--- a/addons/website_forum/controllers/main.py
+++ b/addons/website_forum/controllers/main.py
@@ -656,8 +656,8 @@ class WebsiteForum(http.Controller):
         posts = {}
         for act in activities:
             posts[act.res_id] = True
-        posts_ids = Post.search([('id', 'in', posts.keys())])
-        posts = dict(map(lambda x: (x.id, (x.parent_id or x, x.parent_id and x or False)), posts_ids))
+        posts_ids = Post.search([('id', 'in', list(posts))])
+        posts = {x.id: (x.parent_id or x, x.parent_id and x or False) for x in posts_ids}
 
         # TDE CLEANME MASTER: couldn't it be rewritten using a 'menu' key instead of one key for each menu ?
         if user == request.env.user:

--- a/addons/website_gengo/controllers/main.py
+++ b/addons/website_gengo/controllers/main.py
@@ -44,7 +44,7 @@ class WebsiteGengo(http.Controller):
             if not translation_ids:
                 translations = IrTranslation.search_read([('lang', '=', lang), ('src', '=', initial_content)], fields=['id'])
                 if translations:
-                    translation_ids = map(lambda t_id: t_id['id'], translations)
+                    translation_ids = [t_id['id'] for t_id in translations]
 
             vals = {
                 'gengo_comment': term['gengo_comment'],

--- a/addons/website_hr_recruitment/controllers/main.py
+++ b/addons/website_hr_recruitment/controllers/main.py
@@ -50,7 +50,7 @@ class WebsiteHrRecruitment(http.Controller):
 
         if department:
             jobs = (j for j in jobs if j.department_id and j.department_id.id == department.id)
-        if office_id and office_id in map(lambda x: x.id, offices):
+        if office_id and office_id in [x.id for x in offices]:
             jobs = (j for j in jobs if j.address_id and j.address_id.id == office_id)
         else:
             office_id = False

--- a/addons/website_livechat/controllers/main.py
+++ b/addons/website_livechat/controllers/main.py
@@ -3,6 +3,7 @@
 
 from odoo import http
 from odoo.http import request
+from odoo.tools import pycompat
 
 
 class WebsiteLivechat(http.Controller):
@@ -26,7 +27,7 @@ class WebsiteLivechat(http.Controller):
         # compute percentage
         percentage = dict.fromkeys(['great', 'okay', 'bad'], 0)
         for grade in repartition:
-            percentage[grade] = repartition[grade] * 100 / sum(repartition.values()) if sum(repartition.values()) else 0
+            percentage[grade] = repartition[grade] * 100 / sum(pycompat.values(repartition)) if sum(pycompat.values(repartition)) else 0
 
         # the value dict to render the template
         values = {

--- a/addons/website_membership/controllers/main.py
+++ b/addons/website_membership/controllers/main.py
@@ -75,7 +75,7 @@ class WebsiteMembership(http.Controller):
                     'country_id_count': 0,
                     'country_id': (country_id, current_country["name"])
                 })
-                countries = filter(lambda d:d['country_id'], countries)
+                countries = [d for d in countries if d['country_id']]
                 countries.sort(key=lambda d: d['country_id'][1])
 
         countries.insert(0, {
@@ -133,7 +133,7 @@ class WebsiteMembership(http.Controller):
                 google_map_partner_ids += free_partner_ids[:2000-len(google_map_partner_ids)]
                 count_members += len(free_partner_ids)
 
-        google_map_partner_ids = ",".join(map(str, google_map_partner_ids))
+        google_map_partner_ids = ",".join(str(it) for it in google_map_partner_ids)
         google_maps_api_key = request.env['ir.config_parameter'].sudo().get_param('google_maps_api_key')
 
         partners = {p.id: p for p in Partner.sudo().browse(list(page_partner_ids))}

--- a/addons/website_portal/controllers/main.py
+++ b/addons/website_portal/controllers/main.py
@@ -4,6 +4,7 @@
 from odoo import http
 from odoo.http import request
 from odoo import tools
+from odoo.tools import pycompat
 from odoo.tools.translate import _
 
 from odoo.fields import Date
@@ -130,10 +131,10 @@ class website_account(http.Controller):
                 error["vat"] = 'error'
 
         # error message for empty required fields
-        if [err for err in error.values() if err == 'missing']:
+        if [err for err in pycompat.values(error) if err == 'missing']:
             error_message.append(_('Some required fields are empty.'))
 
-        unknown = [k for k in data.iterkeys() if k not in self.MANDATORY_BILLING_FIELDS + self.OPTIONAL_BILLING_FIELDS]
+        unknown = [k for k in data if k not in self.MANDATORY_BILLING_FIELDS + self.OPTIONAL_BILLING_FIELDS]
         if unknown:
             error['common'] = 'Unknown field'
             error_message.append("Unknown field '%s'" % ','.join(unknown))

--- a/addons/website_portal_purchase/controllers/website_portal.py
+++ b/addons/website_portal_purchase/controllers/website_portal.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 from odoo import http
 from odoo.exceptions import AccessError
 from odoo.http import request
+from odoo.tools import pycompat
 from odoo.tools.translate import _
 
 from odoo.addons.website_portal.controllers.main import website_account, get_records_pager
@@ -88,7 +89,7 @@ class WebsitePortal(website_account):
             'archive_groups': archive_groups,
             'searchbar_sortings': searchbar_sortings,
             'sortby': sortby,
-            'searchbar_filters': OrderedDict(sorted(searchbar_filters.items())),
+            'searchbar_filters': OrderedDict(sorted(pycompat.items(searchbar_filters))),
             'filterby': filterby,
             'default_url': '/my/purchase',
         })

--- a/addons/website_project/controllers/main.py
+++ b/addons/website_project/controllers/main.py
@@ -8,6 +8,7 @@ from odoo.http import request
 
 from odoo.addons.website_portal.controllers.main import website_account, get_records_pager
 from odoo.osv.expression import OR
+from odoo.tools import pycompat
 
 
 class WebsiteAccount(website_account):
@@ -154,7 +155,7 @@ class WebsiteAccount(website_account):
             'searchbar_sortings': searchbar_sortings,
             'searchbar_inputs': searchbar_inputs,
             'sortby': sortby,
-            'searchbar_filters': OrderedDict(sorted(searchbar_filters.items())),
+            'searchbar_filters': OrderedDict(sorted(pycompat.items(searchbar_filters))),
             'filterby': filterby,
         })
         return request.render("website_project.my_tasks", values)

--- a/addons/website_project_issue/controllers/main.py
+++ b/addons/website_project_issue/controllers/main.py
@@ -7,6 +7,7 @@ from odoo import http, _
 from odoo.addons.website_portal.controllers.main import website_account, get_records_pager
 from odoo.http import request
 from odoo.osv.expression import OR
+from odoo.tools import pycompat
 
 
 class WebsiteAccount(website_account):
@@ -104,7 +105,7 @@ class WebsiteAccount(website_account):
             'searchbar_sortings': searchbar_sortings,
             'searchbar_inputs': searchbar_inputs,
             'sortby': sortby,
-            'searchbar_filters': OrderedDict(sorted(searchbar_filters.items())),
+            'searchbar_filters': OrderedDict(sorted(pycompat.items(searchbar_filters))),
             'filterby': filterby,
             'search_in': search_in,
             'search': search,

--- a/addons/website_quote/controllers/main.py
+++ b/addons/website_quote/controllers/main.py
@@ -50,7 +50,7 @@ class sale_quote(http.Controller):
         values = {
             'quotation': order_sudo,
             'message': message and int(message) or False,
-            'option': bool(filter(lambda x: not x.line_id, order_sudo.options)),
+            'option': any(not x.line_id for x in order_sudo.options),
             'order_valid': (not order_sudo.validity_date) or (now <= order_sudo.validity_date),
             'days_valid': days,
             'action': request.env.ref('sale.action_quotations').id,

--- a/addons/website_sale/models/product.py
+++ b/addons/website_sale/models/product.py
@@ -2,6 +2,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import api, fields, models, tools, _
 import odoo.addons.decimal_precision as dp
+
+from odoo.tools import pycompat
 from odoo.tools.translate import html_translate
 
 
@@ -197,7 +199,7 @@ class Product(models.Model):
 
         ret = self.env.user.has_group('sale.group_show_price_subtotal') and 'total_excluded' or 'total_included'
 
-        for p, p2 in zip(self, self2):
+        for p, p2 in pycompat.izip(self, self2):
             taxes = partner.property_account_position_id.map_tax(p.taxes_id)
             p.website_price = taxes.compute_all(p2.price, pricelist.currency_id, quantity=qty, product=p2, partner=partner)[ret]
             p.website_public_price = taxes.compute_all(p2.lst_price, quantity=qty, product=p2, partner=partner)[ret]

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -6,6 +6,7 @@ import random
 from odoo import api, models, fields, tools, _
 from odoo.http import request
 from odoo.exceptions import UserError, ValidationError
+from odoo.tools import pycompat
 
 _logger = logging.getLogger(__name__)
 
@@ -95,7 +96,7 @@ class SaleOrder(models.Model):
 
         # add untracked attributes in the name
         untracked_attributes = []
-        for k, v in attributes.items():
+        for k, v in pycompat.items(attributes):
             # attribute should be like 'attribute-48-1' where 48 is the product_id, 1 is the attribute_id and v is the attribute value
             attribute_value = self.env['product.attribute.value'].sudo().browse(int(v))
             if attribute_value and not attribute_value.attribute_id.create_variant:

--- a/addons/website_sale/tests/test_website_sale_pricelist.py
+++ b/addons/website_sale/tests/test_website_sale_pricelist.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from mock import patch
 from odoo.tests.common import TransactionCase
+from odoo.tools import pycompat
 
 
 class TestWebsitePriceList(TransactionCase):
@@ -60,7 +61,7 @@ class TestWebsitePriceList(TransactionCase):
             'CA': ['Canada'],
             'US': ['USD', 'EUR', 'Benelux', 'Canada']
         }
-        for country, result in country_list.items():
+        for country, result in pycompat.items(country_list):
             pls = self.get_pl(show, current_pl, country)
             self.assertEquals(len(set(pls.mapped('name')) & set(result)), len(pls), 'Test failed for %s (%s %s vs %s %s)'
                               % (country, len(pls), pls.mapped('name'), len(result), result))
@@ -77,7 +78,7 @@ class TestWebsitePriceList(TransactionCase):
             'CA': ['Canada']
         }
 
-        for country, result in country_list.items():
+        for country, result in pycompat.items(country_list):
             pls = self.get_pl(show, current_pl, country)
             self.assertEquals(len(set(pls.mapped('name')) & set(result)), len(pls), 'Test failed for %s (%s %s vs %s %s)'
                               % (country, len(pls), pls.mapped('name'), len(result), result))
@@ -98,7 +99,7 @@ class TestWebsitePriceList(TransactionCase):
             'CA': False
         }
 
-        for country, result in country_list.items():
+        for country, result in pycompat.items(country_list):
             self.args['country'] = country
             # mock patch method could not pass env context
             available = self.website.is_pricelist_available(christmas_pl)
@@ -119,7 +120,7 @@ class TestWebsitePriceList(TransactionCase):
             'CA': ['EUR', 'Canada'],
             'US': ['USD', 'EUR', 'Benelux', 'Canada']
         }
-        for country, result in country_list.items():
+        for country, result in pycompat.items(country_list):
             pls = self.get_pl(show, current_pl, country)
             self.assertEquals(len(set(pls.mapped('name')) & set(result)), len(pls), 'Test failed for %s (%s %s vs %s %s)'
                               % (country, len(pls), pls.mapped('name'), len(result), result))

--- a/addons/website_sale_digital/controllers/main.py
+++ b/addons/website_sale_digital/controllers/main.py
@@ -17,8 +17,8 @@ class WebsiteSaleDigitalConfirmation(WebsiteSale):
     def payment_confirmation(self, **post):
         response = super(WebsiteSaleDigitalConfirmation, self).payment_confirmation(**post)
         order_lines = response.qcontext['order'].order_line
-        digital_content = map(lambda x: x.product_id.type == 'digital', order_lines)
-        response.qcontext.update(digital=any(digital_content))
+        digital_content = any(x.product_id.type == 'digital' for x in order_lines)
+        response.qcontext.update(digital=digital_content)
         return response
 
 
@@ -85,8 +85,7 @@ class WebsiteSaleDigital(website_account):
 
         # Also check for attachments in the product templates
         elif res_model == 'product.template':
-            P = request.env['product.product']
-            template_ids = map(lambda x: P.browse(x).product_tmpl_id.id, purchased_products)
+            template_ids = request.env['product.product'].browse(purchased_products).mapped('product_tmpl_id').ids
             if res_id not in template_ids:
                 return redirect(self.orders_page)
 

--- a/addons/website_sale_digital/models/account_invoice.py
+++ b/addons/website_sale_digital/models/account_invoice.py
@@ -25,4 +25,4 @@ class AccountInvoiceLine(models.Model):
 
         # I only want product_ids, but search_read insists in giving me a list of
         # (product_id: <id>, name: <product code> <template_name> <attributes>)
-        return map(lambda x: x['product_id'][0], purchases)
+        return purchases.mapped('product_id').ids

--- a/addons/website_sale_options/controllers/main.py
+++ b/addons/website_sale_options/controllers/main.py
@@ -5,12 +5,15 @@ from odoo import http
 from odoo.http import request
 from odoo.addons.website_sale.controllers.main import WebsiteSale
 
+from odoo.tools import pycompat
+
+
 class WebsiteSaleOptions(WebsiteSale):
 
     @http.route(['/shop/product/<model("product.template"):product>'], type='http', auth="public", website=True)
     def product(self, product, category='', search='', **kwargs):
         r = super(WebsiteSaleOptions, self).product(product, category, search, **kwargs)
-        r.qcontext['optional_product_ids'] = map(lambda p: p.with_context({'active_id': p.id}), product.optional_product_ids)
+        r.qcontext['optional_product_ids'] = [p.with_context({'active_id': p.id}) for p in product.optional_product_ids]
         return r
 
     @http.route(['/shop/cart/update_option'], type='http', auth="public", methods=['POST'], website=True, multilang=False)
@@ -23,7 +26,7 @@ class WebsiteSaleOptions(WebsiteSale):
 
         option_ids = product.optional_product_ids.mapped('product_variant_ids').ids
         optional_product_ids = []
-        for k, v in kw.items():
+        for k, v in pycompat.items(kw):
             if "optional-product-" in k and int(kw.get(k.replace("product", "add"))) and int(v) in option_ids:
                 optional_product_ids.append(int(v))
 

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -263,10 +263,10 @@ class WebsiteSlides(http.Controller):
                 'caption': slide.name,
                 'url': slide.website_url
             }
-        vals = map(slide_mapped_dict, slide.get_related_slides(slides_to_suggest))
+        vals = [slide_mapped_dict(s) for s in slide.get_related_slides(slides_to_suggest)]
         add_more_slide = slides_to_suggest - len(vals)
         if max(add_more_slide, 0):
-            vals += map(slide_mapped_dict, slide.get_most_viewed_slides(add_more_slide))
+            vals.extend(slide_mapped_dict(s) for s in slide.get_most_viewed_slides(add_more_slide))
         return vals
 
     # --------------------------------------------------

--- a/addons/website_slides/models/slides.py
+++ b/addons/website_slides/models/slides.py
@@ -12,7 +12,7 @@ import re
 import urllib2
 
 from odoo import api, fields, models, SUPERUSER_ID, _
-from odoo.tools import image
+from odoo.tools import image, pycompat
 from odoo.tools.translate import html_translate
 from odoo.exceptions import Warning
 from odoo.addons.website.models.website import slug
@@ -323,7 +323,7 @@ class Slide(models.Model):
             values = res['values']
             if not values.get('document_id'):
                 raise Warning(_('Please enter valid Youtube or Google Doc URL'))
-            for key, value in values.iteritems():
+            for key, value in pycompat.items(values):
                 setattr(self, key, value)
 
     # website
@@ -386,7 +386,7 @@ class Slide(models.Model):
             values['date_published'] = datetime.datetime.now()
         if values.get('url'):
             doc_data = self._parse_document_url(values['url']).get('values', dict())
-            for key, value in doc_data.iteritems():
+            for key, value in pycompat.items(doc_data):
                 values.setdefault(key, value)
         # Do not publish slide if user has not publisher rights
         if not self.user_has_groups('website.group_website_publisher'):
@@ -400,7 +400,7 @@ class Slide(models.Model):
     def write(self, values):
         if values.get('url'):
             doc_data = self._parse_document_url(values['url']).get('values', dict())
-            for key, value in doc_data.iteritems():
+            for key, value in pycompat.items(doc_data):
                 values.setdefault(key, value)
         if values.get('channel_id'):
             custom_channels = self.env['slide.channel'].search([('custom_slide_id', '=', self.id), ('id', '!=', values.get('channel_id'))])

--- a/doc/_extensions/odoo_ext/translator.py
+++ b/doc/_extensions/odoo_ext/translator.py
@@ -71,9 +71,9 @@ class BootstrapTranslator(nodes.NodeVisitor, object):
         tagname = unicode(tagname).lower()
 
         # extract generic attributes
-        attrs = {name.lower(): value for name, value in attributes.iteritems()}
+        attrs = {name.lower(): value for name, value in attributes.items()}
         attrs.update(
-            (name, value) for name, value in node.attributes.iteritems()
+            (name, value) for name, value in node.attributes.items()
             if name.startswith('data-')
         )
 
@@ -97,7 +97,7 @@ class BootstrapTranslator(nodes.NodeVisitor, object):
             prefix=u''.join(prefix),
             tag=tagname,
             attrs=u' '.join(u'{}="{}"'.format(name, self.attval(value))
-                            for name,  value in attrs.iteritems()),
+                            for name,  value in attrs.items()),
             postfix=u''.join(postfix),
         )
     # only "space characters" SPACE, CHARACTER TABULATION, LINE FEED,

--- a/doc/python3.rst
+++ b/doc/python3.rst
@@ -172,6 +172,37 @@ statement to the following cross-language forms::
     exec(source, globals)
     exec(source, globals, locals)
 
+List/iteration builtins and methods
+-----------------------------------
+
+In Python 3, a number of builtins and methods formerly returning *lists* were
+converted to return *iterators* or *views*, with the corresponding redundant
+methods or functions having been *removed entirely*:
+
+* In Python 3, ``map``, ``filter`` and ``zip`` return iterators,
+  ``itertools.imap``, ``itertools.ifilter`` and ``itertools.izip`` have been
+  removed.
+
+  .. important::
+
+      When possible, use comprehensions (list, generator, ...) rather than
+      ``map`` or ``filter``, otherwise use the cross-version ``pycompat``
+      versions (``pycompat.imap``, ``pycompat.ifilter`` and
+      ``pycompat.izip``). The ``pycompat`` versions all return *iterators* and
+      may need to be wrapped in a ``list()`` call to yield a list.
+
+* In Python 3, ``dict.keys``, ``dict.values`` and ``dict.items`` return
+  *views* rather than lists, and the ``iter*`` and ``view*`` methods have
+  been removed.
+
+  .. important::
+
+      Prefer using :func:`odoo.tools.pycompat.keys`,
+      :func:`odoo.tools.pycompat.values` and :func:`odoo.tools.pycompat.items`
+      return cross-version iterators. When needing actual lists (e.g. to
+      modify a dictionary during iteration), wrap one of the calls above in a
+      ``list()``.
+
 builtins
 --------
 
@@ -258,21 +289,12 @@ code by replacing it with some other method altogether.
 ``xrange``
 ##########
 
-In Python 3, ``range()`` behaves the same as Python 3's ``xrange``. For
-cross-versions code you can:
+In Python 3, ``range()`` behaves the same as Python 3's ``xrange``.
 
-* just use ``range()`` everywhere and ignore the allocation cost of a list in
-  Python 2 (often not an issue)
-* conditionally alias ``xrange`` to ``range`` in Python 3 and use that
-* use a combination of ``itertools.count`` and ``takewhile`` for a
-  cross-compatible lazy increasing sequence of numbers
-
-.. warning::
-
-    In the *rare* cases where you need conditional code (code which applies
-    for one version of python and not the other), use ``sys.version_info``
-    e.g. ``sys.version_info() >= (3,)`` for Python3+ code or
-    ``sys.version_info() < (3,)`` for Python 2 code.
+For cross-version code, you can just use ``range()`` everywhere: while this
+will incur a slight allocation cost on Python 2, Python 3's ``range`` supports
+the entire Sequence protocol and thus behaves very much like a regular
+list or tuple.
 
 Removed/renamed methods
 -----------------------

--- a/odoo/addons/base/ir/ir_attachment.py
+++ b/odoo/addons/base/ir/ir_attachment.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 
 from odoo import api, fields, models, tools, SUPERUSER_ID, _
 from odoo.exceptions import AccessError
-from odoo.tools import config, human_size, ustr, html_escape
+from odoo.tools import config, human_size, ustr, html_escape, pycompat
 from odoo.tools.mimetypes import guess_mimetype
 
 _logger = logging.getLogger(__name__)
@@ -167,7 +167,7 @@ class IrAttachment(models.Model):
 
         # remove garbage files, and clean up checklist
         removed = 0
-        for fname, filepath in checklist.iteritems():
+        for fname, filepath in pycompat.items(checklist):
             if fname not in whitelist:
                 try:
                     os.unlink(self._full_path(fname))
@@ -318,7 +318,7 @@ class IrAttachment(models.Model):
             model_ids[values['res_model']].add(values['res_id'])
 
         # check access rights on the records
-        for res_model, res_ids in model_ids.iteritems():
+        for res_model, res_ids in pycompat.items(model_ids):
             # ignore attachments that are not attached to a resource anymore
             # when checking access rights (resource was deleted but attachment
             # was not)
@@ -374,12 +374,12 @@ class IrAttachment(models.Model):
 
         # To avoid multiple queries for each attachment found, checks are
         # performed in batch as much as possible.
-        for res_model, targets in model_attachments.iteritems():
+        for res_model, targets in pycompat.items(model_attachments):
             if res_model not in self.env:
                 continue
             if not self.env[res_model].check_access_rights('read', False):
                 # remove all corresponding attachment ids
-                ids.difference_update(itertools.chain(*targets.itervalues()))
+                ids.difference_update(itertools.chain(*pycompat.values(targets)))
                 continue
             # filter ids according to what access rules permit
             target_ids = list(targets)

--- a/odoo/addons/base/ir/ir_config_parameter.py
+++ b/odoo/addons/base/ir/ir_config_parameter.py
@@ -8,7 +8,7 @@ import uuid
 import logging
 
 from odoo import api, fields, models
-from odoo.tools import config, ormcache, mute_logger
+from odoo.tools import config, ormcache, mute_logger, pycompat
 
 _logger = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ class IrConfigParameter(models.Model):
         Initializes the parameters listed in _default_parameters.
         It overrides existing parameters if force is ``True``.
         """
-        for key, func in _default_parameters.iteritems():
+        for key, func in pycompat.items(_default_parameters):
             # force=True skips search and always performs the 'if' body (because ids=False)
             params = self.sudo().search([('key', '=', key)])
             if force or not params:

--- a/odoo/addons/base/ir/ir_http.py
+++ b/odoo/addons/base/ir/ir_http.py
@@ -21,6 +21,7 @@ import odoo
 from odoo import api, http, models, tools, SUPERUSER_ID
 from odoo.exceptions import AccessDenied, AccessError
 from odoo.http import request, STATIC_CACHE, content_disposition
+from odoo.tools import pycompat
 from odoo.tools.mimetypes import guess_mimetype
 from odoo.modules.module import get_resource_path, get_module_path
 
@@ -54,7 +55,7 @@ class ModelsConverter(werkzeug.routing.BaseConverter):
 
     def to_python(self, value):
         env = api.Environment(request.cr, UID_PLACEHOLDER, request.context)
-        return env[self.model].browse(map(int, value.split(',')))
+        return env[self.model].browse(int(v) for v in value.split(','))
 
     def to_url(self, value):
         return ",".join(value.ids)
@@ -202,7 +203,7 @@ class IrHttp(models.AbstractModel):
     @classmethod
     def _postprocess_args(cls, arguments, rule):
         """ post process arg to set uid on browse records """
-        for name, arg in arguments.items():
+        for name, arg in list(pycompat.items(arguments)):
             if isinstance(arg, models.BaseModel) and arg._uid is UID_PLACEHOLDER:
                 arguments[name] = arg.sudo(request.uid)
                 if not arg.exists():

--- a/odoo/addons/base/ir/ir_qweb/ir_qweb.py
+++ b/odoo/addons/base/ir/ir_qweb/ir_qweb.py
@@ -75,7 +75,7 @@ class IrQWeb(models.AbstractModel, QWeb):
     # apply ormcache_context decorator unless in dev mode...
     @tools.conditional(
         'xml' not in tools.config['dev_mode'],
-        tools.ormcache('id_or_xml_id', 'tuple(map(options.get, self._get_template_cache_keys()))'),
+        tools.ormcache('id_or_xml_id', 'tuple(options.get(k) for k in self._get_template_cache_keys())'),
     )
     def compile(self, id_or_xml_id, options):
         return super(IrQWeb, self).compile(id_or_xml_id, options=options)
@@ -173,7 +173,7 @@ class IrQWeb(models.AbstractModel, QWeb):
         if field_options and 'monetary' in field_options:
             try:
                 options = "{'widget': 'monetary'"
-                for k, v in json.loads(field_options).iteritems():
+                for k, v in pycompat.items(json.loads(field_options)):
                     if k in ('display_currency', 'from_currency'):
                         options = "%s, '%s': %s" % (options, k, v)
                     else:
@@ -238,12 +238,12 @@ class IrQWeb(models.AbstractModel, QWeb):
                         atype = 'text/less'
                     if atype not in ('text/less', 'text/sass'):
                         atype = 'text/css'
-                    path = filter(None, href.split('/'))
+                    path = [segment for segment in href.split('/') if segment]
                     filename = get_resource_path(*path) if path else None
                     files.append({'atype': atype, 'url': href, 'filename': filename, 'content': el.text, 'media': media})
                 elif el.tag == 'script':
                     atype = 'text/javascript'
-                    path = filter(None, src.split('/'))
+                    path = [segment for segment in src.split('/') if segment]
                     filename = get_resource_path(*path) if path else None
                     files.append({'atype': atype, 'url': src, 'filename': filename, 'content': el.text, 'media': media})
                 else:

--- a/odoo/addons/base/ir/ir_qweb/qweb.py
+++ b/odoo/addons/base/ir/ir_qweb/qweb.py
@@ -6,14 +6,15 @@ import traceback
 
 from collections import OrderedDict, Sized, Mapping, defaultdict
 from functools import reduce
-from itertools import chain, izip, tee, count
+from itertools import tee, count
 from textwrap import dedent
 
+import itertools
 from lxml import etree, html
 import werkzeug
 from werkzeug.utils import escape as _escape
 
-from odoo.tools import pycompat
+from odoo.tools import pycompat, freehash
 
 try:
     import builtins
@@ -82,7 +83,7 @@ class Contextifier(ast.NodeTransformer):
         return ast.copy_location(ast.Lambda(
             args=ast.arguments(
                 args=args.args,
-                defaults=map(self.visit, args.defaults),
+                defaults=[self.visit(default) for default in args.defaults],
                 vararg=args.vararg,
                 kwarg=args.kwarg,
             ),
@@ -109,7 +110,7 @@ class Contextifier(ast.NodeTransformer):
         for field, value in ast.iter_fields(node):
             # map transformation of comprehensions
             if isinstance(value, list):
-                setattr(newnode, field, map(transformer.visit, value))
+                setattr(newnode, field, [transformer.visit(v) for v in value])
             else: # set transformation of key/value/expr fields
                 setattr(newnode, field, transformer.visit(value))
         return newnode
@@ -168,14 +169,14 @@ def foreach_iterator(base_ctx, enum, name):
     if not enum:
         return
     if isinstance(enum, int):
-        enum = pycompat.range(enum)
+        enum = range(enum)
     size = None
     if isinstance(enum, Sized):
         ctx["%s_size" % name] = size = len(enum)
     if isinstance(enum, Mapping):
-        enum = enum.iteritems()
+        enum = pycompat.items(enum)
     else:
-        enum = izip(*tee(enum))
+        enum = pycompat.izip(*tee(enum))
     value_key = '%s_value' % name
     index_key = '%s_index' % name
     first_key = '%s_first' % name
@@ -201,7 +202,7 @@ def foreach_iterator(base_ctx, enum, name):
         yield ctx
     # copy changed items back into source context (?)
     # FIXME: maybe values could provide a ChainMap-style clone?
-    for k in base_ctx.keys():
+    for k in list(base_ctx):
         base_ctx[k] = ctx[k]
 
 _FORMAT_REGEX = re.compile(
@@ -226,7 +227,7 @@ class frozendict(dict):
     def update(self, *args, **kwargs):
         raise NotImplementedError("'update' not supported on frozendict")
     def __hash__(self):
-        return hash(frozenset((key, freehash(val)) for key, val in self.iteritems()))
+        return hash(frozenset((key, freehash(val)) for key, val in pycompat.items(self)))
 
 
 ####################################
@@ -510,6 +511,7 @@ class QWeb(object):
         """
         return ast.parse(dedent("""
             from collections import OrderedDict
+            from odoo.tools import pycompat
             from odoo.addons.base.ir.ir_qweb.qweb import escape, unicodifier, foreach_iterator
             """))
 
@@ -665,7 +667,7 @@ class QWeb(object):
 
         # all directives have been compiled, there should be none left
         if any(att.startswith('t-') for att in el.attrib):
-            raise "Unknown directive on %s" % ("', '".join(directives), etree.tostring(el))
+            raise NameError("Unknown directive on %s" % etree.tostring(el))
         return []
 
     def _values_var(self, varname, ctx):
@@ -726,7 +728,7 @@ class QWeb(object):
             attrib = {}
             # If `el` introduced new namespaces, write them as attribute by using the
             # `attrib` dict.
-            for ns_prefix, ns_definition in set(el.nsmap.items()) - set(options['nsmap'].items()):
+            for ns_prefix, ns_definition in set(pycompat.items(el.nsmap)) - set(pycompat.items(options['nsmap'])):
                 if ns_prefix is None:
                     attrib['xmlns'] = ns_definition
                 else:
@@ -735,8 +737,9 @@ class QWeb(object):
             # Etree will also remove the ns prefixes indirection in the attributes. As we only have
             # the namespace definition, we'll use an nsmap where the keys are the definitions and
             # the values the prefixes in order to get back the right prefix and restore it.
-            nsprefixmap = {v: k for k, v in options['nsmap'].items() + el.nsmap.items()}
-            for key, value in el.attrib.items():
+            ns = itertools.chain(pycompat.items(options['nsmap']), pycompat.items(el.nsmap))
+            nsprefixmap = {v: k for k, v in ns}
+            for key, value in pycompat.items(el.attrib):
                 attrib_qname = etree.QName(key)
                 if attrib_qname.namespace:
                     attrib['%s:%s' % (nsprefixmap[attrib_qname.namespace], attrib_qname.localname)] = value
@@ -754,7 +757,7 @@ class QWeb(object):
 
         if unqualified_el_tag == 't':
             return content
-        tag = u'<%s%s' % (el_tag, u''.join([u' %s="%s"' % (name, escape(unicodifier(value))) for name, value in attrib.iteritems()]))
+        tag = u'<%s%s' % (el_tag, u''.join([u' %s="%s"' % (name, escape(unicodifier(value))) for name, value in pycompat.items(attrib)]))
         if unqualified_el_tag in self._void_elements:
             return [self._append(ast.Str(tag + '/>'))] + content
         else:
@@ -766,10 +769,10 @@ class QWeb(object):
         # Etree will also remove the ns prefixes indirection in the attributes. As we only have
         # the namespace definition, we'll use an nsmap where the keys are the definitions and
         # the values the prefixes in order to get back the right prefix and restore it.
-        nsprefixmap = {v: k for k, v in options['nsmap'].items() + el.nsmap.items()}
+        nsprefixmap = {v: k for k, v in itertools.chain(pycompat.items(options['nsmap']), pycompat.items(el.nsmap))}
 
         nodes = []
-        for key, value in el.attrib.iteritems():
+        for key, value in pycompat.items(el.attrib):
             if not key.startswith('t-'):
                 attrib_qname = etree.QName(key)
                 if attrib_qname.namespace:
@@ -784,7 +787,7 @@ class QWeb(object):
         We do not support namespaced dynamic attributes.
         """
         nodes = []
-        for name, value in el.attrib.iteritems():
+        for name, value in pycompat.items(el.attrib):
             if name.startswith('t-attf-'):
                 nodes.append((name[7:], self._compile_format(value)))
             elif name.startswith('t-att-'):
@@ -810,7 +813,7 @@ class QWeb(object):
     def _compile_all_attributes(self, el, options, attr_already_created=False):
         """ Compile the attributes of the given elements into a list of AST nodes. """
         body = []
-        if any(name.startswith('t-att') or not name.startswith('t-') for name, value in el.attrib.iteritems()):
+        if any(name.startswith('t-att') or not name.startswith('t-') for name, value in pycompat.items(el.attrib)):
             if not attr_already_created:
                 attr_already_created = True
                 body.append(
@@ -851,7 +854,7 @@ class QWeb(object):
                     )))
 
         if attr_already_created:
-            # for name, value in t_attrs.iteritems():
+            # for name, value in pycompat.items(t_attrs):
             #     if value or isinstance(value, basestring)):
             #         append(u' ')
             #         append(name)
@@ -862,11 +865,11 @@ class QWeb(object):
                 target=ast.Tuple(elts=[ast.Name(id='name', ctx=ast.Store()), ast.Name(id='value', ctx=ast.Store())], ctx=ast.Store()),
                 iter=ast.Call(
                     func=ast.Attribute(
-                        value=ast.Name(id='t_attrs', ctx=ast.Load()),
-                        attr='iteritems',
+                        value=ast.Name(id='pycompat', ctx=ast.Load()),
+                        attr='items',
                         ctx=ast.Load()
                         ),
-                    args=[], keywords=[],
+                    args=[ast.Name(id='t_attrs', ctx=ast.Load())], keywords=[],
                     starargs=None, kwargs=None
                 ),
                 body=[ast.If(
@@ -923,7 +926,7 @@ class QWeb(object):
 
             # If `el` introduced new namespaces, write them as attribute by using the
             # `extra_attrib` dict.
-            for ns_prefix, ns_definition in set(el.nsmap.items()) - set(options['nsmap'].items()):
+            for ns_prefix, ns_definition in set(pycompat.items(el.nsmap)) - set(pycompat.items(options['nsmap'])):
                 if ns_prefix is None:
                     extra_attrib['xmlns'] = ns_definition
                 else:
@@ -932,7 +935,7 @@ class QWeb(object):
         if unqualified_el_tag == 't':
             return content
 
-        body = [self._append(ast.Str(u'<%s%s' % (el_tag, u''.join([u' %s="%s"' % (name, escape(unicodifier(value))) for name, value in extra_attrib.iteritems()]))))]
+        body = [self._append(ast.Str(u'<%s%s' % (el_tag, u''.join([u' %s="%s"' % (name, escape(unicodifier(value))) for name, value in pycompat.items(extra_attrib)]))))]
         body.extend(self._compile_all_attributes(el, options, attr_already_created))
         if unqualified_el_tag in self._void_elements:
             body.append(self._append(ast.Str(u'/>')))
@@ -1054,7 +1057,7 @@ class QWeb(object):
     def _compile_directive_if(self, el, options):
         orelse = []
         next_el = el.getnext()
-        if next_el is not None and {'t-else', 't-elif'} & set(next_el.attrib.keys()):
+        if next_el is not None and {'t-else', 't-elif'} & set(next_el.attrib):
             if el.tail and not el.tail.isspace():
                 raise ValueError("Unexpected non-whitespace characters between t-if and t-else directives")
             el.tail = None
@@ -1437,7 +1440,7 @@ class QWeb(object):
                 # make the nsmap an ast dict
                 keys = []
                 values = []
-                for key, value in options['nsmap'].items():
+                for key, value in pycompat.items(options['nsmap']):
                     if isinstance(key, basestring):
                         keys.append(ast.Str(s=key))
                     elif key is None:

--- a/odoo/addons/base/ir/ir_sequence.py
+++ b/odoo/addons/base/ir/ir_sequence.py
@@ -6,6 +6,7 @@ import pytz
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
+from odoo.tools import pycompat
 
 _logger = logging.getLogger(__name__)
 
@@ -178,7 +179,7 @@ class IrSequence(models.Model):
                 'weekday': '%w', 'h24': '%H', 'h12': '%I', 'min': '%M', 'sec': '%S'
             }
             res = {}
-            for key, format in sequences.iteritems():
+            for key, format in pycompat.items(sequences):
                 res[key] = effective_date.strftime(format)
                 res['range_' + key] = range_date.strftime(format)
                 res['current_' + key] = now.strftime(format)

--- a/odoo/addons/base/ir/ir_translation.py
+++ b/odoo/addons/base/ir/ir_translation.py
@@ -128,7 +128,7 @@ class IrTranslationImport(object):
         env = api.Environment(cr, SUPERUSER_ID, {})
         src_relevant_fields = []
         for model in env:
-            for field_name, field in env[model]._fields.items():
+            for field_name, field in pycompat.items(env[model]._fields):
                 if hasattr(field, 'translate') and callable(field.translate):
                     src_relevant_fields.append("%s,%s" % (model, field_name))
 
@@ -530,7 +530,7 @@ class IrTranslation(models.Model):
 
         # check for read/write access on translated field records
         fmode = 'read' if mode == 'read' else 'write'
-        for mname, ids in model_ids.iteritems():
+        for mname, ids in pycompat.items(model_ids):
             records = self.env[mname].browse(ids)
             records.check_access_rights(fmode)
             records.check_field_access_rights(fmode, model_fields[mname])
@@ -640,7 +640,7 @@ class IrTranslation(models.Model):
             return ['&', ('res_id', '=', rec.id), ('name', '=', name)]
 
         # insert missing translations, and extend domain for related fields
-        for name, fld in record._fields.items():
+        for name, fld in pycompat.items(record._fields):
             if not fld.translate:
                 continue
 

--- a/odoo/addons/base/ir/ir_values.py
+++ b/odoo/addons/base/ir/ir_values.py
@@ -5,7 +5,7 @@ from ast import literal_eval
 
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import AccessError, MissingError, ValidationError
-from odoo.tools import pickle
+from odoo.tools import pickle, pycompat
 
 import logging
 _logger = logging.getLogger(__name__)
@@ -315,7 +315,7 @@ class IrValues(models.Model):
         for row in self._cr.dictfetchall():
             value = pickle.loads(row['value'].encode('utf-8'))
             defaults.setdefault(row['name'], (row['id'], row['name'], value))
-        return defaults.values()
+        return list(pycompat.values(defaults))
 
     # use ormcache: this is called a lot by BaseModel.default_get()!
     @api.model
@@ -426,4 +426,4 @@ class IrValues(models.Model):
                 results[name] = (id, name, action_def)
             except (AccessError, MissingError):
                 continue
-        return sorted(results.values())
+        return sorted(pycompat.values(results))

--- a/odoo/addons/base/module/report/ir_module_reference_print.py
+++ b/odoo/addons/base/module/report/ir_module_reference_print.py
@@ -2,6 +2,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, models
+from odoo.tools import pycompat
+
 
 class IrModelReferenceReport(models.AbstractModel):
     _name = 'report.base.report_irmodulereference'
@@ -21,7 +23,7 @@ class IrModelReferenceReport(models.AbstractModel):
         if data:
             res_ids = data.mapped('res_id')
             fnames = self.env['ir.model.fields'].browse(res_ids).mapped('name')
-            return sorted(self.env[model].fields_get(fnames).iteritems())
+            return sorted(pycompat.items(self.env[model].fields_get(fnames)))
         return []
 
     @api.model

--- a/odoo/addons/base/res/ir_property.py
+++ b/odoo/addons/base/res/ir_property.py
@@ -217,7 +217,7 @@ class Property(models.Model):
                 prop.write({'value': value})
 
         # create new properties for records that do not have one yet
-        for ref, id in refs.iteritems():
+        for ref, id in pycompat.items(refs):
             value = clean(values[id])
             if value != default_value:
                 self.create({
@@ -248,13 +248,13 @@ class Property(models.Model):
             elif operator in ('!=', '<=', '<', '>', '>='):
                 value = makeref(value)
             elif operator in ('in', 'not in'):
-                value = map(makeref, value)
+                value = [makeref(v) for v in value]
             elif operator in ('=like', '=ilike', 'like', 'not like', 'ilike', 'not ilike'):
                 # most probably inefficient... but correct
                 target = self.env[comodel]
                 target_names = target.name_search(value, operator=operator, limit=None)
-                target_ids = map(itemgetter(0), target_names)
-                operator, value = 'in', map(makeref, target_ids)
+                target_ids = [n[0] for n in target_names]
+                operator, value = 'in', [makeref(v) for v in target_ids]
         elif field.type in ('integer', 'float'):
             # No record is created in ir.property if the field's type is float or integer with a value
             # equal to 0. Then to match with the records that are linked to a property field equal to 0,

--- a/odoo/addons/base/res/res_company.py
+++ b/odoo/addons/base/res/res_company.py
@@ -6,6 +6,7 @@ import re
 
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import ValidationError
+from odoo.tools import pycompat
 
 
 class Company(models.Model):
@@ -146,7 +147,7 @@ class Company(models.Model):
         if self.country_id:
             res['domain']['state_id'] = [('country_id', '=', self.country_id.id)]
         values = self.on_change_country(self.country_id.id)['value']
-        for fname, value in values.iteritems():
+        for fname, value in pycompat.items(values):
             setattr(self, fname, value)
         return res
 

--- a/odoo/addons/base/res/res_lang.py
+++ b/odoo/addons/base/res/res_lang.py
@@ -8,6 +8,7 @@ import re
 from operator import itemgetter
 
 from odoo import api, fields, models, tools, _
+from odoo.tools import pycompat
 from odoo.tools.safe_eval import safe_eval
 from odoo.exceptions import UserError, ValidationError
 
@@ -22,7 +23,7 @@ class Lang(models.Model):
     _description = "Languages"
     _order = "active desc,name"
 
-    _disallowed_datetime_patterns = tools.DATETIME_FORMATS_MAP.keys()
+    _disallowed_datetime_patterns = list(tools.DATETIME_FORMATS_MAP)
     _disallowed_datetime_patterns.remove('%y') # this one is in fact allowed, just not good practice
 
     name = fields.Char(required=True)
@@ -125,7 +126,7 @@ class Lang(models.Model):
             # For some locales, nl_langinfo returns a D_FMT/T_FMT that contains
             # unsupported '%-' patterns, e.g. for cs_CZ
             format = format.replace('%-', '%')
-            for pattern, replacement in tools.DATETIME_FORMATS_MAP.iteritems():
+            for pattern, replacement in pycompat.items(tools.DATETIME_FORMATS_MAP):
                 format = format.replace(pattern, replacement)
             return str(format)
 
@@ -318,5 +319,5 @@ def intersperse(string, counts, separator=''):
     left, rest, right = intersperse_pat.match(string).groups()
     def reverse(s): return s[::-1]
     splits = split(reverse(rest), counts)
-    res = separator.join(map(reverse, reverse(splits)))
+    res = separator.join(reverse(s) for s in reverse(splits))
     return left + res + right, len(splits) > 0 and len(splits) -1 or 0

--- a/odoo/addons/base/res/res_partner.py
+++ b/odoo/addons/base/res/res_partner.py
@@ -680,7 +680,7 @@ class Partner(models.Model):
                 query += ' limit %s'
                 where_clause_params.append(limit)
             self.env.cr.execute(query, where_clause_params)
-            partner_ids = map(lambda x: x[0], self.env.cr.fetchall())
+            partner_ids = [row[0] for row in self.env.cr.fetchall()]
 
             if partner_ids:
                 return self.browse(partner_ids).name_get()

--- a/odoo/addons/base/tests/test_api.py
+++ b/odoo/addons/base/tests/test_api.py
@@ -79,11 +79,11 @@ class TestAPI(common.TransactionCase):
         domain = [('name', 'ilike', 'j')]
         partners = self.env['res.partner'].search(domain)
         self.assertTrue(partners)
-        ids = map(int, partners)
+        ids = partners.ids
 
         # modify those partners, and check that partners has not changed
         partners.write({'active': False})
-        self.assertEqual(ids, map(int, partners))
+        self.assertEqual(ids, partners.ids)
 
         # redo the search, and check that the result is now empty
         partners2 = self.env['res.partner'].search(domain)
@@ -98,7 +98,7 @@ class TestAPI(common.TransactionCase):
         self.assertIsRecordset(user.groups_id, 'res.groups')
 
         partners = self.env['res.partner'].search([])
-        for name, field in partners._fields.iteritems():
+        for name, field in pycompat.items(partners._fields):
             if field.type == 'many2one':
                 for p in partners:
                     self.assertIsRecord(p[name], field.comodel_name)
@@ -296,7 +296,7 @@ class TestAPI(common.TransactionCase):
         self.assertItemsEqual(partners.ids, country_id_cache)
 
         # partners' countries are ready for prefetching
-        country_ids = set(cid for cids in country_id_cache.itervalues() for cid in cids)
+        country_ids = set(cid for cids in pycompat.values(country_id_cache) for cid in cids)
         self.assertTrue(len(country_ids) > 1)
         self.assertItemsEqual(country_ids, partners._prefetch['res.country'])
 

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -5,7 +5,7 @@ import psycopg2
 
 from odoo.models import BaseModel
 from odoo.tests.common import TransactionCase
-from odoo.tools import mute_logger
+from odoo.tools import mute_logger, pycompat
 import odoo.osv.expression as expression
 
 
@@ -85,10 +85,10 @@ class TestExpression(TransactionCase):
             'b ab': [cids['B'], cids['AB']],
         }
         pids = {}
-        for name, cat_ids in partners_config.iteritems():
+        for name, cat_ids in pycompat.items(partners_config):
             pids[name] = partners.create({'name': name, 'category_id': [(6, 0, cat_ids)]}).id
 
-        base_domain = [('id', 'in', pids.values())]
+        base_domain = [('id', 'in', list(pycompat.values(pids)))]
 
         def test(op, value, expected):
             found_ids = partners.search(base_domain + [('category_id', op, value)]).ids

--- a/odoo/addons/base/tests/test_float.py
+++ b/odoo/addons/base/tests/test_float.py
@@ -98,10 +98,10 @@ class TestFloatPrecision(TransactionCase):
         precisions = [2, 2, 2, 2, 2, 2, 3, 4]
         # Note: max precision for double floats is 53 bits of precision or
         # 17 significant decimal digits
-        for magnitude in pycompat.range(7):
-            for frac, exp, prec in zip(fractions, expecteds, precisions):
+        for magnitude in range(7):
+            for frac, exp, prec in pycompat.izip(fractions, expecteds, precisions):
                 for sign in [-1,1]:
-                    for x in pycompat.range(0, 10000, 97):
+                    for x in range(0, 10000, 97):
                         n = x * 10 ** magnitude
                         f = sign * (n + frac)
                         f_exp = ('-' if f != 0 and sign == -1 else '') + str(n) + exp

--- a/odoo/addons/base/tests/test_ir_filters.py
+++ b/odoo/addons/base/tests/test_ir_filters.py
@@ -4,11 +4,12 @@
 from odoo import exceptions
 from odoo.tests.common import TransactionCase, ADMIN_USER_ID
 
-def noid(d):
+def noid(seq):
     """ Removes values that are not relevant for the test comparisons """
-    d.pop('id', None)
-    d.pop('action_id', None)
-    return d
+    for d in seq:
+        d.pop('id', None)
+        d.pop('action_id', None)
+    return seq
 
 
 class FiltersCase(TransactionCase):
@@ -34,7 +35,7 @@ class TestGetFilters(FiltersCase):
 
         filters = self.env['ir.filters'].sudo(self.USER_ID).get_filters('ir.filters')
 
-        self.assertItemsEqual(map(noid, filters), [
+        self.assertItemsEqual(noid(filters), [
             dict(name='a', is_default=False, user_id=self.USER_NG, domain='[]', context='{}', sort='[]'),
             dict(name='b', is_default=False, user_id=self.USER_NG, domain='[]', context='{}', sort='[]'),
             dict(name='c', is_default=False, user_id=self.USER_NG, domain='[]', context='{}', sort='[]'),
@@ -52,7 +53,7 @@ class TestGetFilters(FiltersCase):
 
         filters = self.env['ir.filters'].sudo(self.USER_ID).get_filters('ir.filters')
 
-        self.assertItemsEqual(map(noid, filters), [
+        self.assertItemsEqual(noid(filters), [
             dict(name='a', is_default=False, user_id=False, domain='[]', context='{}', sort='[]'),
             dict(name='b', is_default=False, user_id=False, domain='[]', context='{}', sort='[]'),
             dict(name='c', is_default=False, user_id=False, domain='[]', context='{}', sort='[]'),
@@ -69,7 +70,7 @@ class TestGetFilters(FiltersCase):
 
         filters = self.env['ir.filters'].sudo(self.USER_ID).get_filters('ir.filters')
 
-        self.assertItemsEqual(map(noid, filters), [
+        self.assertItemsEqual(noid(filters), [
             dict(name='a', is_default=False, user_id=False, domain='[]', context='{}', sort='[]'),
             dict(name='c', is_default=False, user_id=self.USER_NG, domain='[]', context='{}', sort='[]'),
         ])
@@ -95,7 +96,7 @@ class TestOwnDefaults(FiltersCase):
         })
         filters = Filters.get_filters('ir.filters')
 
-        self.assertItemsEqual(map(noid, filters), [
+        self.assertItemsEqual(noid(filters), [
             dict(name='a', user_id=self.USER_NG, is_default=True,
                  domain='[]', context='{}', sort='[]')
         ])
@@ -120,7 +121,7 @@ class TestOwnDefaults(FiltersCase):
         })
         filters = Filters.get_filters('ir.filters')
 
-        self.assertItemsEqual(map(noid, filters), [
+        self.assertItemsEqual(noid(filters), [
             dict(name='a', user_id=self.USER_NG, is_default=False, domain='[]', context='{}', sort='[]'),
             dict(name='b', user_id=self.USER_NG, is_default=False, domain='[]', context='{}', sort='[]'),
             dict(name='c', user_id=self.USER_NG, is_default=True, domain='[]', context='{}', sort='[]'),
@@ -146,7 +147,7 @@ class TestOwnDefaults(FiltersCase):
         })
         filters = Filters.get_filters('ir.filters')
 
-        self.assertItemsEqual(map(noid, filters), [
+        self.assertItemsEqual(noid(filters), [
             dict(name='a', user_id=self.USER_NG, is_default=False, domain='[]', context='{}', sort='[]'),
             dict(name='b', user_id=self.USER_NG, is_default=False, domain='[]', context='{}', sort='[]'),
             dict(name='c', user_id=self.USER_NG, is_default=True, domain='[]', context='{}', sort='[]'),
@@ -172,7 +173,7 @@ class TestOwnDefaults(FiltersCase):
         })
         filters = Filters.get_filters('ir.filters')
 
-        self.assertItemsEqual(map(noid, filters), [
+        self.assertItemsEqual(noid(filters), [
             dict(name='a', user_id=self.USER_NG, is_default=True, domain='[]', context='{}', sort='[]'),
             dict(name='b', user_id=self.USER_NG, is_default=False, domain='[]', context='{}', sort='[]'),
         ])
@@ -204,7 +205,7 @@ class TestGlobalDefaults(FiltersCase):
         })
         filters = Filters.get_filters('ir.filters')
 
-        self.assertItemsEqual(map(noid, filters), [
+        self.assertItemsEqual(noid(filters), [
             dict(name='a', user_id=False, is_default=False, domain='[]', context='{}', sort='[]'),
             dict(name='b', user_id=False, is_default=False, domain='[]', context='{}', sort='[]'),
             dict(name='c', user_id=False, is_default=True, domain='[]', context='{}', sort='[]'),
@@ -271,7 +272,7 @@ class TestGlobalDefaults(FiltersCase):
         })
         filters = Filters.get_filters('ir.filters')
 
-        self.assertItemsEqual(map(noid, filters), [
+        self.assertItemsEqual(noid(filters), [
             dict(name='a', user_id=False, is_default=False, domain='[]', context='{}', sort='[]'),
             dict(name='b', user_id=False, is_default=True, domain='[]', context=context_value, sort='[]'),
         ])

--- a/odoo/addons/base/tests/test_orm.py
+++ b/odoo/addons/base/tests/test_orm.py
@@ -141,7 +141,7 @@ class TestORM(TransactionCase):
         partner_ids_by_year = defaultdict(list)
 
         partners = self.env['res.partner']
-        for name, date in partners_data.items():
+        for name, date in pycompat.items(partners_data):
             p = partners.create(dict(name=name, date=date))
             partner_ids.append(p.id)
             partner_ids_by_day[date].append(p.id)
@@ -297,7 +297,7 @@ class TestO2MSerialization(TransactionCase):
     def test_CREATE_commands(self):
         " returns the VALUES dict as-is "
         values = [{'foo': 'bar'}, {'foo': 'baz'}, {'foo': 'baq'}]
-        results = self.env['res.partner'].resolve_2many_commands('child_ids', map(CREATE, values))
+        results = self.env['res.partner'].resolve_2many_commands('child_ids', [CREATE(v) for v in values])
         self.assertEqual(results, values)
 
     def test_LINK_TO_command(self):
@@ -307,7 +307,7 @@ class TestO2MSerialization(TransactionCase):
             self.env['res.partner'].create({'name': 'bar'}).id,
             self.env['res.partner'].create({'name': 'baz'}).id,
         ]
-        commands = map(LINK_TO, ids)
+        commands = [LINK_TO(v) for v in ids]
 
         results = self.env['res.partner'].resolve_2many_commands('child_ids', commands, ['name'])
         self.assertItemsEqual(results, [
@@ -356,7 +356,7 @@ class TestO2MSerialization(TransactionCase):
             self.env['res.partner'].create({'name': 'bar'}).id,
             self.env['res.partner'].create({'name': 'baz'}).id,
         ]
-        commands = map(DELETE, ids)
+        commands = [DELETE(v) for v in ids]
 
         results = self.env['res.partner'].resolve_2many_commands('child_ids', commands, ['name'])
         self.assertEqual(results, [])

--- a/odoo/addons/base/tests/test_qweb.py
+++ b/odoo/addons/base/tests/test_qweb.py
@@ -13,6 +13,7 @@ from itertools import chain
 from odoo.modules import get_module_resource
 from odoo.tests.common import TransactionCase
 from odoo.addons.base.ir.ir_qweb import QWebException
+from odoo.tools import pycompat
 
 
 def dedent_and_strip(string):
@@ -411,7 +412,7 @@ class TestQWebNS(TransactionCase):
             'cac': 'urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2',
             'cbc': 'urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2'
         }
-        self.assertSetEqual(set(expected_ns.items()) - set(result_etree.nsmap.items()), set())
+        self.assertSetEqual(set(pycompat.items(expected_ns)) - set(pycompat.items(result_etree.nsmap)), set())
 
         # check that the t-call did its work
         cac_lines = result_etree.findall('.//cac:line', namespaces={'cac': 'urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2'})

--- a/odoo/addons/base/tests/test_search.py
+++ b/odoo/addons/base/tests/test_search.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests.common import TransactionCase
+from odoo.tools import pycompat
 
 
 class test_search(TransactionCase):
@@ -107,7 +108,7 @@ class test_search(TransactionCase):
             user_ids[u] = Users.create({'name': u, 'login': u}).id
             cron_ids[u] = Cron.create({'name': u, 'model_id': self.env.ref('base.model_res_partner').id, 'user_id': user_ids[u]}).id
 
-        ids = Cron.search([('id', 'in', cron_ids.values())], order='user_id').ids
+        ids = Cron.search([('id', 'in', list(pycompat.values(cron_ids)))], order='user_id').ids
         expected_ids = [cron_ids[l] for l in 'ABC']
         self.assertEqual(ids, expected_ids)
 
@@ -127,7 +128,7 @@ class test_search(TransactionCase):
         create('F', parent_id=cat_ids['D'])
 
         expected_ids = [cat_ids[x] for x in 'ADEFBC']
-        found_ids = Cats.search([('id', 'in', cat_ids.values())]).ids
+        found_ids = Cats.search([('id', 'in', list(pycompat.values(cat_ids)))]).ids
         self.assertEqual(found_ids, expected_ids)
 
     def test_13_m2o_order_loop_multi(self):

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -638,7 +638,7 @@ class TestViews(ViewCase):
         kw.setdefault('mode', 'extension' if kw.get('inherit_id') else 'primary')
         kw.setdefault('active', True)
 
-        keys = sorted(kw.keys())
+        keys = sorted(kw)
         fields = ','.join('"%s"' % (k.replace('"', r'\"'),) for k in keys)
         params = ','.join('%%(%s)s' % (k,) for k in keys)
 

--- a/odoo/addons/test_impex/tests/test_export.py
+++ b/odoo/addons/test_impex/tests/test_export.py
@@ -4,6 +4,7 @@
 import itertools
 
 from odoo.tests import common
+from odoo.tools import pycompat
 
 
 class CreatorCase(common.TransactionCase):
@@ -494,9 +495,9 @@ class test_o2m_multiple(CreatorCase):
         """
         fields = ['const', 'child1/value', 'child2/value']
         child1 = [(0, False, {'value': v, 'str': 'record%.02d' % index})
-                  for index, v in zip(itertools.count(), [4, 42, 36, 4, 13])]
+                  for index, v in pycompat.izip(itertools.count(), [4, 42, 36, 4, 13])]
         child2 = [(0, False, {'value': v, 'str': 'record%.02d' % index})
-                  for index, v in zip(itertools.count(10), [8, 12, 8, 55, 33, 13])]
+                  for index, v in pycompat.izip(itertools.count(10), [8, 12, 8, 55, 33, 13])]
 
         self.assertEqual(
             self.export(child1=child1, child2=False, fields=fields),

--- a/odoo/addons/test_limits/models.py
+++ b/odoo/addons/test_limits/models.py
@@ -5,7 +5,6 @@ import time
 import sys
 
 from odoo import models, api
-from odoo.tools import pycompat
 
 class m(models.Model):
     """ This model exposes a few methods that will consume between 'almost no
@@ -39,7 +38,7 @@ class m(models.Model):
         t0 = time.clock()
         t1 = time.clock()
         while t1 - t0 < seconds:
-            for i in pycompat.range(10000000):
+            for i in range(10000000):
                 x = i * i
             t1 = time.clock()
         return True

--- a/odoo/addons/test_new_api/models.py
+++ b/odoo/addons/test_new_api/models.py
@@ -5,6 +5,7 @@ import datetime
 
 from odoo import models, fields, api, _
 from odoo.exceptions import AccessError, ValidationError
+from odoo.tools import pycompat
 
 
 class Category(models.Model):
@@ -45,7 +46,7 @@ class Category(models.Model):
             categories.append(category[0])
         categories.append(self)
         # assign parents following sequence
-        for parent, child in zip(categories, categories[1:]):
+        for parent, child in pycompat.izip(categories, categories[1:]):
             if parent and child:
                 child.parent = parent
         # assign name of last category, and reassign display_name (to normalize it)

--- a/odoo/addons/test_new_api/tests/test_one2many.py
+++ b/odoo/addons/test_new_api/tests/test_one2many.py
@@ -45,7 +45,7 @@ class One2manyCase(TransactionCase):
         # Check the lines first
         self.assertItemsEqual(
             self.multi.lines.mapped('name'),
-            map(str, range(10)))
+            [str(i) for i in range(10)])
         # Modify the first line and drop the last one
         self.multi.lines[0].name = "hello"
         self.multi.lines = self.multi.lines[:-1]

--- a/odoo/addons/test_pylint/tests/test_pylint.py
+++ b/odoo/addons/test_pylint/tests/test_pylint.py
@@ -30,22 +30,33 @@ class TestPyLint(TransactionCase):
         'relative-import',
         'deprecated-module',
         'import-star-module-level',
-        # 'bad-python3-import', # TODO: more stuff used in report
+
+        'bad-builtin',
+
+        'dict-iter-method',
+        'dict-view-method',
 
         'long-suffix',
-        'apply-builtin',
-        'cmp-builtin',
-        'coerce-builtin',
-        'execfile-builtin',
-        'input-builtin',
-        'intern-builtin',
-        'long-builtin',
-        'raw_input-builtin',
-        'reload-builtin',
-        'xrange-builtin',
+    ]
+
+    BAD_FUNCTIONS = [
+        'apply',
+        'cmp',
+        'coerce',
+        'execfile',
+        'input',
+        'intern',
+        'long',
+        'raw_input',
+        'reload',
+        'xrange',
+        'long',
+        'map',
+        'filter',
+        'zip',
         # TODO: enable once report has been removed
-        # 'file-builtin',
-        # 'reduce-builtin',
+        # 'file',
+        # 'reduce',
     ]
 
     def _skip_test(self, reason):
@@ -69,6 +80,8 @@ class TestPyLint(TransactionCase):
             '--enable=%s' % ','.join(self.ENABLED_CODES),
             '--reports=n',
             "--msg-template='{msg} ({msg_id}) at {path}:{line}'",
+            '--load-plugins=pylint.extensions.bad_builtin',
+            '--bad-functions=%s' % ','.join(self.BAD_FUNCTIONS),
         ]
 
         try:

--- a/odoo/cli/command.py
+++ b/odoo/cli/command.py
@@ -28,7 +28,7 @@ class Help(Command):
     """Display the list of available commands"""
     def run(self, args):
         print("Available commands:\n")
-        names = commands.keys()
+        names = list(commands)
         padding = max([len(k) for k in names]) + 2
         for k in sorted(names):
             name = k.ljust(padding, ' ')

--- a/odoo/modules/db.py
+++ b/odoo/modules/db.py
@@ -99,7 +99,7 @@ def create_categories(cr, categories):
     category = []
     while categories:
         category.append(categories[0])
-        xml_id = 'module_category_' + ('_'.join(map(lambda x: x.lower(), category))).replace('&', 'and').replace(' ', '_')
+        xml_id = 'module_category_' + ('_'.join(x.lower() for x in category)).replace('&', 'and').replace(' ', '_')
         # search via xml_id (because some categories are renamed)
         cr.execute("SELECT res_id FROM ir_model_data WHERE name=%s AND module=%s AND model=%s",
                    (xml_id, "base", "ir.module.category"))

--- a/odoo/modules/graph.py
+++ b/odoo/modules/graph.py
@@ -8,7 +8,7 @@ import logging
 
 import odoo
 import odoo.tools as tools
-
+from odoo.tools import pycompat
 
 _logger = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ class Graph(dict):
             return
         # update the graph with values from the database (if exist)
         ## First, we set the default values for each package in graph
-        additional_data = dict((key, {'id': 0, 'state': 'uninstalled', 'dbdemo': False, 'installed_version': None}) for key in self.keys())
+        additional_data = {key: {'id': 0, 'state': 'uninstalled', 'dbdemo': False, 'installed_version': None} for key in pycompat.keys(self)}
         ## Then we get the values from the database
         cr.execute('SELECT name, id, state, demo AS dbdemo, latest_version AS installed_version'
                    '  FROM ir_module_module'
@@ -46,8 +46,8 @@ class Graph(dict):
         ## and we update the default values with values from the database
         additional_data.update((x['name'], x) for x in cr.dictfetchall())
 
-        for package in self.values():
-            for k, v in additional_data[package.name].items():
+        for package in pycompat.values(self):
+            for k, v in pycompat.items(additional_data[package.name]):
                 setattr(package, k, v)
 
     def add_module(self, cr, module, force=None):
@@ -94,7 +94,7 @@ class Graph(dict):
         self.update_from_db(cr)
 
         for package in later:
-            unmet_deps = filter(lambda p: p not in self, dependencies[package])
+            unmet_deps = [p for p in dependencies[package] if p not in self]
             _logger.error('module %s: Unmet dependencies: %s', package, ', '.join(unmet_deps))
 
         return len(self) - len_graph
@@ -102,9 +102,9 @@ class Graph(dict):
 
     def __iter__(self):
         level = 0
-        done = set(self.keys())
+        done = set(pycompat.keys(self))
         while done:
-            level_modules = sorted((name, module) for name, module in self.items() if module.depth==level)
+            level_modules = sorted((name, module) for name, module in pycompat.items(self) if module.depth==level)
             for name, module in level_modules:
                 done.remove(name)
                 yield module
@@ -164,7 +164,10 @@ class Node(object):
                 setattr(child, name, value + 1)
 
     def __iter__(self):
-        return itertools.chain(iter(self.children), *map(iter, self.children))
+        return itertools.chain(
+            self.children,
+            itertools.chain.from_iterable(self.children)
+        )
 
     def __str__(self):
         return self._pprint()

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -20,6 +20,7 @@ import odoo.tools as tools
 
 from odoo import api, SUPERUSER_ID
 from odoo.modules.module import adapt_version, initialize_sys_path, load_openerp_module
+from odoo.tools import pycompat
 
 _logger = logging.getLogger(__name__)
 _test_logger = logging.getLogger('odoo.tests')
@@ -295,15 +296,15 @@ def load_modules(db, force_demo=False, status=None, update_module=False):
                 _logger.info('updating modules list')
                 Module.update_list()
 
-            _check_module_names(cr, itertools.chain(tools.config['init'].keys(), tools.config['update'].keys()))
+            _check_module_names(cr, itertools.chain(tools.config['init'], tools.config['update']))
 
-            module_names = [k for k, v in tools.config['init'].items() if v]
+            module_names = [k for k, v in pycompat.items(tools.config['init']) if v]
             if module_names:
                 modules = Module.search([('state', '=', 'uninstalled'), ('name', 'in', module_names)])
                 if modules:
                     modules.button_install()
 
-            module_names = [k for k, v in tools.config['update'].items() if v]
+            module_names = [k for k, v in pycompat.items(tools.config['update']) if v]
             if module_names:
                 modules = Module.search([('state', '=', 'installed'), ('name', 'in', module_names)])
                 if modules:
@@ -391,7 +392,7 @@ def load_modules(db, force_demo=False, status=None, update_module=False):
                         getattr(py_module, uninstall_hook)(cr, registry)
 
                 Module = env['ir.module.module']
-                Module.browse(modules_to_remove.values()).module_uninstall()
+                Module.browse(pycompat.values(modules_to_remove)).module_uninstall()
                 # Recursive reload, should only happen once, because there should be no
                 # modules to remove next time
                 cr.commit()
@@ -414,7 +415,7 @@ def load_modules(db, force_demo=False, status=None, update_module=False):
             _logger.info('Modules loaded.')
 
         # STEP 8: call _register_hook on every model
-        for model in env.values():
+        for model in pycompat.values(env):
             model._register_hook()
 
         # STEP 9: save installed/updated modules for post-install tests

--- a/odoo/modules/migration.py
+++ b/odoo/modules/migration.py
@@ -13,6 +13,7 @@ from os.path import join as opj
 from odoo.modules.module import get_resource_path
 import odoo.release as release
 import odoo.tools as tools
+from odoo.tools import pycompat
 from odoo.tools.parse_version import parse_version
 
 
@@ -87,13 +88,12 @@ class MigrationManager(object):
             return "%s.%s" % (release.major_version, version)
 
         def _get_migration_versions(pkg):
-            versions = list(set(
+            versions = sorted({
                 ver
-                for lv in self.migrations[pkg.name].values()
-                for ver, lf in lv.items()
+                for lv in pycompat.values(self.migrations[pkg.name])
+                for ver, lf in pycompat.items(lv)
                 if lf
-            ))
-            versions.sort(key=lambda k: parse_version(convert_version(k)))
+            }, key=lambda k: parse_version(convert_version(k)))
             return versions
 
         def _get_migration_files(pkg, version, stage):
@@ -107,7 +107,7 @@ class MigrationManager(object):
                 'maintenance': opj('base', 'maintenance', 'migrations', pkg.name),
             }
 
-            for x in mapping.keys():
+            for x in mapping:
                 if version in m.get(x):
                     for f in m[x][version]:
                         if not f.startswith(stage + '-'):

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -1018,7 +1018,7 @@ class expression(object):
                             subop = 'not inselect' if operator in NEGATIVE_TERM_OPERATORS else 'inselect'
                             subquery = 'SELECT "%s" FROM "%s" WHERE "%s" IN %%s' % (rel_id1, rel_table, rel_id2)
                             # avoid flattening of argument in to_sql()
-                            subquery = cr.mogrify(subquery, [tuple(filter(None, res_ids))])
+                            subquery = cr.mogrify(subquery, [tuple(it for it in res_ids if it)])
                             push(create_substitution_leaf(leaf, ('id', subop, (subquery, [])), internal=True))
 
                     if call_null_m2m:
@@ -1200,7 +1200,7 @@ class expression(object):
                     else:
                         field = model._fields[left]
                         instr = ','.join([field.column_format] * len(params))
-                        params = map(partial(field.convert_to_column, record=model), params)
+                        params = [field.convert_to_column(p, record=model) for p in params]
                     query = '(%s."%s" %s (%s))' % (table_alias, left, operator, instr)
                 else:
                     # The case for (left, 'in', []) or (left, 'not in', []).

--- a/odoo/osv/orm.py
+++ b/odoo/osv/orm.py
@@ -1,6 +1,7 @@
 import json
 from lxml import etree
 
+from odoo.tools import pycompat
 from ..exceptions import except_orm
 from ..models import (
     MetaModel,
@@ -35,12 +36,12 @@ def transfer_field_to_modifiers(field, modifiers):
     for attr in ('invisible', 'readonly', 'required'):
         state_exceptions[attr] = []
         default_values[attr] = bool(field.get(attr))
-    for state, modifs in (field.get("states",{})).items():
+    for state, modifs in pycompat.items(field.get("states",{})):
         for modif in modifs:
             if default_values[modif[0]] != modif[1]:
                 state_exceptions[modif[0]].append(state)
 
-    for attr, default_value in default_values.items():
+    for attr, default_value in pycompat.items(default_values):
         if state_exceptions[attr]:
             modifiers[attr] = [("state", "not in" if default_value else "in", state_exceptions[attr])]
         else:

--- a/odoo/release.py
+++ b/odoo/release.py
@@ -13,8 +13,8 @@ RELEASE_LEVELS_DISPLAY = {ALPHA: ALPHA,
 #  (6,1,0,'beta',0) < (6,1,0,'candidate',1) < (6,1,0,'candidate',2)
 #  (6,1,0,'candidate',2) < (6,1,0,'final',0) < (6,1,2,'final',0)
 version_info = (11, 0, 0, ALPHA, 1, '')
-version = '.'.join(map(str, version_info[:2])) + RELEASE_LEVELS_DISPLAY[version_info[3]] + str(version_info[4] or '') + version_info[5]
-series = serie = major_version = '.'.join(map(str, version_info[:2]))
+version = '.'.join(str(s) for s in version_info[:2]) + RELEASE_LEVELS_DISPLAY[version_info[3]] + str(version_info[4] or '') + version_info[5]
+series = serie = major_version = '.'.join(str(s) for s in version_info[:2])
 
 product_name = 'Odoo'
 description = 'Odoo Server'

--- a/odoo/service/db.py
+++ b/odoo/service/db.py
@@ -351,7 +351,7 @@ def list_db_incompatible(databases):
         :return: A list of databases that are incompatible
     """
     incompatible_databases = []
-    server_version = '.'.join(map(str, version_info[:2]))
+    server_version = '.'.join(str(v) for v in version_info[:2])
     for database_name in databases:
         with closing(db_connect(database_name).cursor()) as cr:
             if odoo.tools.table_exists(cr, 'ir_module_module'):

--- a/odoo/service/model.py
+++ b/odoo/service/model.py
@@ -137,7 +137,7 @@ def check(f):
                 time.sleep(wait_time)
             except IntegrityError as inst:
                 registry = odoo.registry(dbname)
-                for key in registry._sql_error.keys():
+                for key in pycompat.keys(registry._sql_error):
                     if key in inst[0]:
                         raise ValidationError(tr(registry._sql_error[key], 'sql_constraint') or inst[0])
                 if inst.pgcode in (errorcodes.NOT_NULL_VIOLATION, errorcodes.FOREIGN_KEY_VIOLATION, errorcodes.RESTRICT_VIOLATION):

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -47,7 +47,7 @@ def undecimalize(symb, cr):
         return None
     return float(symb)
 
-for name, typeoid in types_mapping.items():
+for name, typeoid in pycompat.items(types_mapping):
     psycopg2.extensions.register_type(psycopg2.extensions.new_type(typeoid, name, lambda x, cr: x))
 psycopg2.extensions.register_type(psycopg2.extensions.new_type((700, 701, 1700,), 'float', undecimalize))
 
@@ -190,9 +190,9 @@ class Cursor(object):
         row = self._obj.fetchone()
         return row and self.__build_dict(row)
     def dictfetchmany(self, size):
-        return map(self.__build_dict, self._obj.fetchmany(size))
+        return [self.__build_dict(row) for row in self._obj.fetchmany(size)]
     def dictfetchall(self):
-        return map(self.__build_dict, self._obj.fetchall())
+        return [self.__build_dict(row) for row in self._obj.fetchall()]
 
     def __del__(self):
         if not self._closed and not self._cnx.closed:
@@ -260,7 +260,7 @@ class Cursor(object):
             sqllogs = {'from': self.sql_from_log, 'into': self.sql_into_log}
             sum = 0
             if sqllogs[type]:
-                sqllogitems = sqllogs[type].items()
+                sqllogitems = pycompat.items(sqllogs[type])
                 _logger.debug("SQL LOG %s:", type)
                 for r in sorted(sqllogitems, key=lambda k: k[1]):
                     delay = timedelta(microseconds=r[1][1])
@@ -473,7 +473,7 @@ class LazyCursor(object):
         if cr is None:
             from odoo import registry
             cr = self._cursor = registry(self.dbname).cursor()
-            for _ in pycompat.range(self._depth):
+            for _ in range(self._depth):
                 cr.__enter__()
         return getattr(cr, name)
 

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -135,7 +135,7 @@ class BaseCase(unittest.TestCase):
 
     def shortDescription(self):
         doc = self._testMethodDoc
-        return doc and ' '.join(filter(None, map(str.strip, doc.splitlines()))) or None
+        return doc and ' '.join(l.strip() for l in doc.splitlines() if not l.isspace()) or None
 
 
 class TransactionCase(BaseCase):

--- a/odoo/tools/amount_to_text_en.py
+++ b/odoo/tools/amount_to_text_en.py
@@ -71,7 +71,7 @@ def amount_to_text(number, currency):
     cents_number = int(list[1])
     cents_name = (cents_number > 1) and 'Cents' or 'Cent'
 
-    return ' '.join(filter(None, [start_word, units_name, (start_word or units_name) and (end_word or cents_name) and 'and', end_word, cents_name]))
+    return ' '.join(w for w in [start_word, units_name, (start_word or units_name) and (end_word or cents_name) and 'and', end_word, cents_name] if w)
 
 
 #-------------------------------------------------------------

--- a/odoo/tools/appdirs.py
+++ b/odoo/tools/appdirs.py
@@ -15,7 +15,7 @@ from __future__ import print_function
 # - XDG spec for Un*x: http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
 
 __version_info__ = (1, 3, 0)
-__version__ = '.'.join(map(str, __version_info__))
+__version__ = '.'.join(str(v) for v in __version_info__)
 
 
 import sys

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -13,7 +13,8 @@ import odoo.conf
 import odoo.loglevels as loglevels
 import logging
 import odoo.release as release
-from . import appdirs
+from . import appdirs, pycompat
+
 
 class MyOption (optparse.Option, object):
     """ optparse Option with two additional attributes.
@@ -55,7 +56,7 @@ def _deduplicate_loggers(loggers):
     # there are no duplicates within the output sequence
     return (
         '{}:{}'.format(logger, level)
-        for logger, level in dict(it.split(':') for it in loggers).iteritems()
+        for logger, level in pycompat.items(dict(it.split(':') for it in loggers))
     )
 
 
@@ -453,10 +454,10 @@ class configmanager(object):
         self.options['demo'] = (dict(self.options['init'])
                                 if not self.options['without_demo'] else {})
         self.options['update'] = opt.update and dict.fromkeys(opt.update.split(','), 1) or {}
-        self.options['translate_modules'] = opt.translate_modules and map(lambda m: m.strip(), opt.translate_modules.split(',')) or ['all']
+        self.options['translate_modules'] = opt.translate_modules and [m.strip() for m in opt.translate_modules.split(',')] or ['all']
         self.options['translate_modules'].sort()
 
-        dev_split = opt.dev_mode and  map(str.strip, opt.dev_mode.split(',')) or []
+        dev_split = opt.dev_mode and  [s.strip() for s in opt.dev_mode.split(',')] or []
         self.options['dev_mode'] = 'all' in dev_split and dev_split + ['pdb', 'reload', 'qweb', 'werkzeug', 'xml'] or dev_split
 
         if opt.pg_path:
@@ -527,9 +528,9 @@ class configmanager(object):
 
     def save(self):
         p = ConfigParser.ConfigParser()
-        loglevelnames = dict(zip(self._LOGLEVELS.values(), self._LOGLEVELS.keys()))
+        loglevelnames = dict(pycompat.izip(pycompat.values(self._LOGLEVELS), pycompat.keys(self._LOGLEVELS)))
         p.add_section('options')
-        for opt in sorted(self.options.keys()):
+        for opt in sorted(pycompat.keys(self.options)):
             if opt in ('version', 'language', 'translate_out', 'translate_in', 'overwrite_existing_translations', 'init', 'update'):
                 continue
             if opt in self.blacklist_for_save:
@@ -541,9 +542,9 @@ class configmanager(object):
             else:
                 p.set('options', opt, self.options[opt])
 
-        for sec in sorted(self.misc.keys()):
+        for sec in sorted(pycompat.keys(self.misc)):
             p.add_section(sec)
-            for opt in sorted(self.misc[sec].keys()):
+            for opt in sorted(pycompat.keys(self.misc[sec])):
                 p.set(sec,opt,self.misc[sec][opt])
 
         # try to create the directories and write the file

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -98,7 +98,7 @@ def _eval_xml(self, node, env):
             q = safe_eval(f_search, idref2)
             ids = env[f_model].search(q).ids
             if f_use != 'id':
-                ids = map(lambda x: x[f_use], env[f_model].browse(ids).read([f_use]))
+                ids = [x[f_use] for x in env[f_model].browse(ids).read([f_use])]
             _fields = env[f_model]._fields
             if (f_name in _fields) and _fields[f_name].type == 'many2many':
                 return ids
@@ -659,7 +659,7 @@ form: module.record_id""" % (xml_id,)
                 _fields = self.env[rec_model]._fields
                 # if the current field is many2many
                 if (f_name in _fields) and _fields[f_name].type == 'many2many':
-                    f_val = [(6, 0, map(lambda x: x[f_use], s))]
+                    f_val = [(6, 0, [x[f_use] for x in s])]
                 elif len(s):
                     # otherwise (we are probably in a many2one field),
                     # take the first element of the search
@@ -707,7 +707,7 @@ form: module.record_id""" % (xml_id,)
             'model': 'ir.ui.view',
         }
         for att in ['forcecreate', 'context']:
-            if att in el.keys():
+            if att in el.attrib:
                 record_attrs[att] = el.attrib.pop(att)
 
         Field = builder.E.field
@@ -733,7 +733,7 @@ form: module.record_id""" % (xml_id,)
             record.append(Field(name='customize_show', eval=el.get('customize_show')))
         groups = el.attrib.pop('groups', None)
         if groups:
-            grp_lst = map(lambda x: "ref('%s')" % x, groups.split(','))
+            grp_lst = [("ref('%s')" % x) for x in groups.split(',')]
             record.append(Field(name="groups_id", eval="[(6, 0, ["+', '.join(grp_lst)+"])]"))
         if el.attrib.pop('page', None) == 'True':
             record.append(Field(name="page", eval="True"))
@@ -854,7 +854,7 @@ def convert_csv_import(cr, module, fname, csvcontent, idref=None, mode='init',
         if not (line and any(line)):
             continue
         try:
-            datas.append(map(ustr, line))
+            datas.append([ustr(v) for v in line])
         except Exception:
             _logger.error("Cannot import the line: %s", line)
 

--- a/odoo/tools/float_utils.py
+++ b/odoo/tools/float_utils.py
@@ -217,10 +217,10 @@ if __name__ == "__main__":
     fractions = [.0, .015, .01499, .675, .67499, .4555, .4555, .45555]
     expecteds = ['.00', '.02', '.01', '.68', '.67', '.46', '.456', '.4556']
     precisions = [2, 2, 2, 2, 2, 2, 3, 4]
-    for magnitude in pycompat.range(7):
-        for frac, exp, prec in zip(fractions, expecteds, precisions):
+    for magnitude in range(7):
+        for frac, exp, prec in pycompat.izip(fractions, expecteds, precisions):
             for sign in [-1,1]:
-                for x in pycompat.range(0, 10000, 97):
+                for x in range(0, 10000, 97):
                     n = x * 10**magnitude
                     f = sign * (n + frac)
                     f_exp = ('-' if f != 0 and sign == -1 else '') + str(n) + exp

--- a/odoo/tools/func.py
+++ b/odoo/tools/func.py
@@ -33,7 +33,7 @@ class lazy_property(object):
         """ Reset all lazy properties on the instance `obj`. """
         cls = type(obj)
         obj_dict = vars(obj)
-        for name in obj_dict.keys():
+        for name in list(obj_dict):
             if isinstance(getattr(cls, name, None), lazy_property):
                 obj_dict.pop(name)
 

--- a/odoo/tools/graph.py
+++ b/odoo/tools/graph.py
@@ -5,6 +5,9 @@
 import operator
 import math
 
+from odoo.tools import pycompat
+
+
 class graph(object):
     def __init__(self, nodes, transitions, no_ancester=None):
         """Initialize graph's object
@@ -256,7 +259,7 @@ class graph(object):
         """The ranks are normalized by setting the least rank to zero.
         """
 
-        least_rank = min(map(lambda x: x['x'], self.result.values()))
+        least_rank = min(x['x'] for x in pycompat.values(self.result.values))
 
         if least_rank!=0:
             for node in self.result:
@@ -380,7 +383,7 @@ class graph(object):
         """Finds actual-order of the nodes with respect to maximum number of nodes in a rank in component
         """
         mid_pos = 0.0
-        max_level = max(map(lambda x: len(x), self.levels.values()))
+        max_level = max(len(x) for x in pycompat.values(self.levels.values))
 
         for level in self.levels:
             if level:
@@ -471,7 +474,7 @@ class graph(object):
         """
 
         if self.Is_Cyclic:
-            max_level = max(map(lambda x: len(x), self.levels.values()))
+            max_level = max(len(x) for x in pycompat.values(self.levels.values))
 
             if max_level%2:
                 self.result[self.start]['y'] = (max_level+1)/2 + self.max_order + (self.max_order and 1)
@@ -483,7 +486,7 @@ class graph(object):
         else:
             self.result[self.start]['y'] = 0
             self.tree_order(self.start, 0)
-            min_order = math.fabs(min(map(lambda x: x['y'], self.result.values())))
+            min_order = math.fabs(min(x['y'] for x in pycompat.values(self.result.values)))
 
             index = self.start_nodes.index(self.start)
             same = False
@@ -537,7 +540,7 @@ class graph(object):
                     self.result[start]['y'] = base + factor
                     factor += 1
 
-            self.max_order = max(map(lambda x: x['y'], self.result.values()))
+            self.max_order = max(x['y'] for x in pycompat.values(self.result.values))
 
     def find_starts(self):
         """Finds other start nodes of the graph in the case when graph is disconneted
@@ -626,7 +629,7 @@ class graph(object):
         self.make_chain()
         self.preprocess_order()
         self.order = {}
-        max_rank = max(map(lambda x: x, self.levels.keys()))
+        max_rank = max(x for x in self.levels)
 
         for i in range(max_rank+1):
             self.order[i] = 0
@@ -657,7 +660,7 @@ class graph(object):
 
                 for node in self.no_ancester:
                     for sec_node in self.transitions.get(node, []):
-                        if sec_node in self.partial_order.keys():
+                        if sec_node in pycompat.keys(self.partial_order):
                             self.transitions[self.start_nodes[0]].append(node)
                             break
 
@@ -743,7 +746,7 @@ if __name__=='__main__':
     for node in nodes:
         node_res[node] = result[node]
 
-    for name,node in node_res.items():
+    for name,node in pycompat.items(node_res):
 
         draw.arc( (int(node['y']-radius), int(node['x']-radius),int(node['y']+radius), int(node['x']+radius) ), 0, 360, (128,128,128))
         draw.text( (int(node['y']),  int(node['x'])), str(name),  (128,128,128))

--- a/odoo/tools/lru.py
+++ b/odoo/tools/lru.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # taken from http://code.activestate.com/recipes/252524-length-limited-o1-lru-cache-implementation/
 import threading
+
+from odoo.tools import pycompat
 from .func import synchronized
 
 __all__ = ['LRU']
@@ -92,6 +94,7 @@ class LRU(object):
     def __len__(self):
         return len(self.d)
 
+    # FIXME: should this have a P2 and a P3 version or something?
     @synchronized()
     def iteritems(self):
         cur = self.first
@@ -106,12 +109,12 @@ class LRU(object):
 
     @synchronized()
     def itervalues(self):
-        for i,j in self.iteritems():
+        for i,j in pycompat.items(self):
             yield j
 
     @synchronized()
     def keys(self):
-        return self.d.keys()
+        return list(pycompat.keys(self.d))
 
     @synchronized()
     def pop(self,key):

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -16,6 +16,7 @@ from lxml import etree
 
 import odoo
 from odoo.loglevels import ustr
+from odoo.tools import pycompat
 
 _logger = logging.getLogger(__name__)
 
@@ -84,7 +85,7 @@ class _Cleaner(clean.Cleaner):
             new_node.text = text
             new_node.tail = tail
             if attrs:
-                for key, val in attrs.iteritems():
+                for key, val in pycompat.items(attrs):
                     new_node.set(key, val)
             return new_node
 
@@ -153,7 +154,7 @@ class _Cleaner(clean.Cleaner):
                 if style[0].lower() in self._style_whitelist:
                     valid_styles[style[0].lower()] = style[1]
             if valid_styles:
-                el.attrib['style'] = '; '.join('%s: %s' % (key, val) for (key, val) in valid_styles.iteritems())
+                el.attrib['style'] = '; '.join('%s: %s' % (key, val) for (key, val) in pycompat.items(valid_styles))
             else:
                 del el.attrib['style']
 
@@ -530,4 +531,4 @@ def decode_smtp_header(smtp_header):
 
 # was mail_thread.decode_header()
 def decode_message_header(message, header, separator=' '):
-    return separator.join(map(decode_smtp_header, filter(None, message.get_all(header, []))))
+    return separator.join(decode_smtp_header(h) for h in message.get_all(header, []) if h)

--- a/odoo/tools/mimetypes.py
+++ b/odoo/tools/mimetypes.py
@@ -10,6 +10,8 @@ import logging
 import re
 import zipfile
 
+from odoo.tools import pycompat
+
 __all__ = ['guess_mimetype']
 
 _logger = logging.getLogger(__name__)
@@ -33,7 +35,7 @@ def _check_ooxml(data):
 
         # then there is a directory whose name denotes the type of the file:
         # word, pt (powerpoint) or xl (excel)
-        for dirname, mime in _ooxml_dirs.iteritems():
+        for dirname, mime in pycompat.items(_ooxml_dirs):
             if any(entry.startswith(dirname) for entry in filenames):
                 return mime
 

--- a/odoo/tools/osutil.py
+++ b/odoo/tools/osutil.py
@@ -39,7 +39,7 @@ def walksymlinks(top, topdown=True, onerror=None):
         if topdown:
             yield dirpath, dirnames, filenames
 
-        symlinks = filter(lambda dirname: os.path.islink(os.path.join(dirpath, dirname)), dirnames)
+        symlinks = (dirname for dirname in dirnames if os.path.islink(os.path.join(dirpath, dirname)))
         for s in symlinks:
             for x in walksymlinks(os.path.join(dirpath, s), topdown, onerror):
                 yield x

--- a/odoo/tools/parse_version.py
+++ b/odoo/tools/parse_version.py
@@ -7,6 +7,8 @@
 from __future__ import print_function
 import re
 
+from odoo.tools import pycompat
+
 component_re = re.compile(r'(\d+ | [a-z]+ | \.| -)', re.VERBOSE)
 replace = {'pre':'c', 'preview':'c','-':'final-','_':'final-','rc':'c','dev':'@','saas':'','~':''}.get
 
@@ -72,7 +74,7 @@ if __name__ == '__main__':
                 if verbose:
                     print(v, pv)
 
-            for a, b in zip(pvs, pvs[1:]):
+            for a, b in pycompat.izip(pvs, pvs[1:]):
                 assert a < b, '%s < %s == %s' % (a, b, a < b)
         
         chk(('0', '4.2', '4.2.3.4', '5.0.0-alpha', '5.0.0-rc1', '5.0.0-rc1.1', '5.0.0_rc2', '5.0.0_rc3', '5.0.0'), False)

--- a/odoo/tools/pycompat.py
+++ b/odoo/tools/pycompat.py
@@ -6,10 +6,12 @@ import sys
 PY2 = sys.version_info[0] == 2
 
 if PY2:
-    # pylint: disable=long-builtin,xrange-builtin
+    # pylint: disable=long-builtin,dict-iter-method
     integer_types = (int, long)
 
-    range = xrange
+    keys = lambda d: iter(d.iterkeys())
+    values = lambda d: iter(d.itervalues())
+    items = lambda d: iter(d.iteritems())
 
     # noinspection PyUnresolvedReferences
     from itertools import imap, izip, ifilter
@@ -19,9 +21,12 @@ if PY2:
         del cls.__next__
         return cls
 else:
+    # pylint: disable=bad-functions
     integer_types = (int,)
 
-    range = range
+    keys = lambda d: iter(d.keys())
+    values = lambda d: iter(d.values())
+    items = lambda d: iter(d.items())
 
     imap = map
     izip = zip

--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -23,7 +23,6 @@ from types import CodeType
 import logging
 import werkzeug
 
-from odoo.tools import pycompat
 from .misc import ustr
 
 import odoo
@@ -251,7 +250,7 @@ _BUILTINS = {
     'divmod': divmod,
     'isinstance': isinstance,
     'range': range,
-    'xrange': pycompat.range,
+    'xrange': range,
     'zip': zip,
     'Exception': Exception,
 }

--- a/odoo/tools/test_reports.py
+++ b/odoo/tools/test_reports.py
@@ -174,7 +174,7 @@ def try_report_action(cr, uid, action_id, active_model=None, active_ids=None,
                 view_data.update(wiz_data)
             _logger.debug("View data is: %r", view_data)
 
-            for fk, field in view_res.get('fields',{}).items():
+            for fk, field in pycompat.items(view_res.get('fields',{})):
                 # Default fields returns list of int, while at create()
                 # we need to send a [(6,0,[int,..])]
                 if field['type'] in ('one2many', 'many2many') \

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -255,7 +255,7 @@ def translate_xml_node(node, callback, method, parser=None):
         append_content(result, translate_content(todo) if todo_has_text else todo)
 
         # translate the required attributes
-        for name, value in result.items():
+        for name, value in pycompat.items(result.attrib):
             if name in TRANSLATED_ATTRS:
                 result.set(name, translate_text(value) or value)
 
@@ -660,7 +660,7 @@ def trans_export(lang, modules, buffer, format, cr):
                 row.setdefault('tnrs', []).append((type, name, res_id))
                 row.setdefault('comments', set()).update(comments)
 
-            for src, row in sorted(grouped_rows.items()):
+            for src, row in sorted(pycompat.items(grouped_rows)):
                 if not lang:
                     # translation template, so no translation value
                     row['translation'] = ''
@@ -674,7 +674,7 @@ def trans_export(lang, modules, buffer, format, cr):
                 module = row[0]
                 rows_by_module.setdefault(module, []).append(row)
             tmpdir = tempfile.mkdtemp()
-            for mod, modrows in rows_by_module.items():
+            for mod, modrows in pycompat.items(rows_by_module):
                 tmpmoddir = join(tmpdir, mod, 'i18n')
                 os.makedirs(tmpmoddir)
                 pofilename = (lang if lang else mod) + ".po" + ('t' if not lang else '')
@@ -1073,7 +1073,7 @@ def trans_load_data(cr, fileobj, fileformat, lang, lang_name=None, verbose=True,
             dic = dict.fromkeys(('type', 'name', 'res_id', 'src', 'value',
                                  'comments', 'imd_model', 'imd_name', 'module'))
             dic['lang'] = lang
-            dic.update(zip(fields, row))
+            dic.update(pycompat.izip(fields, row))
 
             # discard the target from the POT targets.
             src = dic['src']
@@ -1111,7 +1111,7 @@ def trans_load_data(cr, fileobj, fileformat, lang, lang_name=None, verbose=True,
         # Then process the entries implied by the POT file (which is more
         # correct w.r.t. the targets) if some of them remain.
         pot_rows = []
-        for src, target in pot_targets.iteritems():
+        for src, target in pycompat.items(pot_targets):
             if target.value:
                 for type, name, res_id in target.targets:
                     pot_rows.append((type, name, res_id, src, target.value, target.comments))

--- a/odoo/tools/yaml_tag.py
+++ b/odoo/tools/yaml_tag.py
@@ -1,6 +1,9 @@
 import yaml
 import logging
 
+from . import pycompat
+
+
 class YamlTag(object):
     """
     Superclass for constructors of custom tags defined in yaml file.
@@ -13,7 +16,7 @@ class YamlTag(object):
     def __getattr__(self, attr):
         return None
     def __repr__(self):
-        return "<%s %s>" % (self.__class__.__name__, sorted(self.__dict__.items()))
+        return "<%s %s>" % (self.__class__.__name__, sorted(pycompat.items(self.__dict__)))
 
 class Assert(YamlTag):
     def __init__(self, model, id=None, severity=logging.WARNING, string="NONAME", **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,9 @@ def py2exe_datafiles():
     import babel
     data_files['babel/localedata'] = glob(join(dirname(babel.__file__), 'localedata', '*'))
     others = ['global.dat', 'numbers.py', 'support.py', 'plural.py']
-    data_files['babel'] = map(lambda f: join(dirname(babel.__file__), f), others)
+    data_files['babel'] = [join(dirname(babel.__file__), f) for f in others]
     others = ['frontend.py', 'mofile.py']
-    data_files['babel/messages'] = map(lambda f: join(dirname(babel.__file__), 'messages', f), others)
+    data_files['babel/messages'] = [join(dirname(babel.__file__), 'messages', f) for f in others]
 
     import pytz
     tzdir = dirname(pytz.__file__)
@@ -51,7 +51,7 @@ def py2exe_datafiles():
                                 for f in filenames
                                 if not f.endswith(('.py', '.pyc', '.pyo'))]
 
-    return data_files.items()
+    return list(data_files.items())
 
 
 def py2exe_options():
@@ -128,7 +128,7 @@ setup(
     url=url,
     author=author,
     author_email=author_email,
-    classifiers=filter(None, classifiers.split('\n')),
+    classifiers=[c for c in classifiers.split('\n') if c],
     license=license,
     scripts=['setup/odoo'],
     packages=find_packages(),

--- a/setup/setup_dev.py
+++ b/setup/setup_dev.py
@@ -153,7 +153,7 @@ def main():
     elif len(sys.argv) == 2 and sys.argv[1] in cmds:
         cmds[sys.argv[1]]()
     else:
-        sys.exit('Unknow command. Command available: %r' % (cmds.keys(),))
+        sys.exit('Unknow command. Command available: %r' % (list(cmds,))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
In Python 3:
* `itertools.imap`, `itertools.ifilter`, `itertools.izip`, `dict.iterkeys`, `dict.itervalues` and `dict.iteritems` have been removed entirely
* the formerly eager (list-returning) map, filter, zip, dict.keys, dict.values and dict.items now returns lazy iterators (or view objects)

While this is not problematic when just iterating, there are numerous cases where the results are expected/used as lists which would break in P3.

=> convert all code using these functions to semantics-matching cross-version helpers (so that the behaviour is the same between P2 and P3), and ban the builtins via pylint to avoid them cropping back up.

Removed the `range` shim following discussion on `xrange` conversion commit as P3's `range` is a fairly complete Sequence object (though not a list) and `range` seems to more or less never be used for anything other than iteration, so the risk of incompatibility looks very remote.

issue #8530
