### PR TITLE
[REF] doc: install - Add locales configuration

### DIFF
--- a/doc/setup/install.rst
+++ b/doc/setup/install.rst
@@ -180,6 +180,11 @@ Or ``dpkg`` (handles less dependencies automatically):
 This will install Odoo as a service, create the necessary PostgreSQL_ user
 and automatically start the server.
 
+.. danger:: odoo uses databases encoding with UTF-8 then you need to install
+            and configure locales_ and set environment variables
+            LANG, LANGUAGE, LC_ALL, PYTHONIOENCODING
+            before installing postgresql and starting odoo service.
+
 .. danger:: to print PDF reports, you must install wkhtmltopdf_ yourself:
             the version of wkhtmltopdf_ available in debian repositories does
             not support headers and footers so it can not be installed
@@ -562,3 +567,4 @@ default db to serve on localhost:8069
 .. _Editions: https://www.odoo.com/pricing#pricing_table_features
 .. _nightly: https://nightly.odoo.com/10.0/nightly/
 .. _extra: https://nightly.odoo.com/extra/
+.. _locales: https://help.ubuntu.com/community/Locale


### PR DESCRIPTION
Fix the following errors:
  - `DataError: new encoding (UTF8) is incompatible with the encoding of the template database (SQL_ASCII) HINT: Use the same encoding as in the template database, or use template0 as template.`
    - https://www.odoo.com/es_ES/forum/ayuda-1/question/dataerror-new-encoding-utf8-is-incompatible-with-the-encoding-of-the-template-database-sql-ascii-52124

  - `/werkzeug/filesystem.py:63: BrokenFilesystemWarning: Detected a misconfigured UNIX filesystem: Will use UTF-8 as filesystem encoding instead of 'ANSI_X3.4-1968'`
    - https://stackoverflow.com/questions/34515331/werkzeug-raises-brokenfilesystemwarning