### PR TITLE
[FIX] Allow for static from address and DMARC conformity

### DIFF
--- a/odoo/addons/base/ir/ir_mail_server.py
+++ b/odoo/addons/base/ir/ir_mail_server.py
@@ -484,9 +484,7 @@ class IrMailServer(models.Model):
             'author': address[0],
             'company': self.env.user.company_id.name,
         }
-        return '%s <%s>' % (
-            rewritten_name, self._get_default_bounce_address(),
-        )
+        return formataddr((rewritten_name, self._get_default_bounce_address()))
 
     @api.model
     def _get_rewrite_from_whitelist(self):

--- a/odoo/addons/base/ir/ir_mail_server_view.xml
+++ b/odoo/addons/base/ir/ir_mail_server_view.xml
@@ -15,9 +15,6 @@
                         <field name="smtp_port"/>
                         <field name="smtp_debug" groups="base.group_no_one"/>
                      </group>
-                     <group col="4" name="group_advanced" string="Advanced Settings">
-                         <field name="smtp_from" />
-                     </group>
                      <group string="Security and Authentication" colspan="4">
                         <field name="smtp_encryption"/>
                         <field name="smtp_user"/>

--- a/odoo/addons/base/ir/ir_mail_server_view.xml
+++ b/odoo/addons/base/ir/ir_mail_server_view.xml
@@ -17,8 +17,6 @@
                      </group>
                      <group col="4" name="group_advanced" string="Advanced Settings">
                          <field name="smtp_from" />
-                         <field name="smtp_from_only_dmarc"
-                                attrs="{'invisible': [('smtp_from', '=', False)]}" />
                      </group>
                      <group string="Security and Authentication" colspan="4">
                         <field name="smtp_encryption"/>

--- a/odoo/addons/base/ir/ir_mail_server_view.xml
+++ b/odoo/addons/base/ir/ir_mail_server_view.xml
@@ -15,6 +15,11 @@
                         <field name="smtp_port"/>
                         <field name="smtp_debug" groups="base.group_no_one"/>
                      </group>
+                     <group col="4" name="group_advanced" string="Advanced Settings">
+                         <field name="smtp_from" />
+                         <field name="smtp_from_only_dmarc"
+                                attrs="{'invisible': [('smtp_from', '=', False)]}" />
+                     </group>
                      <group string="Security and Authentication" colspan="4">
                         <field name="smtp_encryption"/>
                         <field name="smtp_user"/>

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ ebaysdk==2.1.4
 feedparser==5.2.1
 gevent==1.1.2
 greenlet==0.4.10
+gs.dmarc==2.1.9
 jcconv==0.2.3
 Jinja2==2.8
 lxml==3.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ ebaysdk==2.1.4
 feedparser==5.2.1
 gevent==1.1.2
 greenlet==0.4.10
-gs.dmarc==2.1.9
 jcconv==0.2.3
 Jinja2==2.8
 lxml==3.5.0


### PR DESCRIPTION
* Add the ability for an SMTP server to send from a static outbound from address, instead of repackaging as the sender
* Add an option to only perform FROM header rewrite when the sender's DMARC policy requires it
* Fixes #3347

----

**Description of the issue/feature this PR addresses:**

Properly handle DMARC policies

**Current behavior before PR:**

Ref #3347

**Desired behavior after PR is merged:**

From header respects SMTP server settings, and DMARC policy is queried for optional replacement - also respecting SMTP server settings.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

cc @odony, @gdgellatly, @mvaled 
