### PR TITLE
[FIX] sale_expense: ability to reinvoice an expense product more than…

### DIFF
--- a/addons/sale_expense/models/__init__.py
+++ b/addons/sale_expense/models/__init__.py
@@ -4,3 +4,4 @@
 from . import analytic
 from . import hr_expense
 from . import product_template
+from . import sale_order

--- a/addons/sale_expense/models/sale_order.py
+++ b/addons/sale_expense/models/sale_order.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models, _
+
+from odoo.exceptions import ValidationError
+from odoo.osv import expression
+from odoo.tools.safe_eval import safe_eval
+
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    ###########################################
+    ### Analytic : auto recompute delivered quantity
+    ###########################################
+
+    def _expense_compute_delivered_quantity_domain(self):
+        so_line_ids = self.filtered(lambda sol: sol.product_id.can_be_expensed).ids
+        domain = []
+        if so_line_ids:
+            domain = [('so_line', 'in', so_line_ids)]
+        return domain
+
+    @api.multi
+    def _analytic_compute_delivered_quantity_domain(self):
+        domain = super(SaleOrderLine, self)._analytic_compute_delivered_quantity_domain()
+        expense_domain = self._expense_compute_delivered_quantity_domain()
+        return expression.OR([domain, expense_domain])

--- a/addons/sale_expense/tests/test_sale_expense.py
+++ b/addons/sale_expense/tests/test_sale_expense.py
@@ -89,3 +89,90 @@ class TestSaleExpense(TestSale):
         inv_id = so.action_invoice_create()
         inv = self.env['account.invoice'].browse(inv_id)
         self.assertEqual(inv.amount_untaxed, 621.54 + (prod_exp_2.list_price * 100.0), 'Sale Expense: invoicing of expense is wrong')
+
+    def test_sale_same_expense_twice(self):
+        """ Test the behaviour of sales orders when managing expenses """
+        # force the pricelist to have the same currency as the company
+        self.env.ref('product.list0').currency_id = self.env.ref('base.main_company').currency_id
+
+        # create a so with a product invoiced on delivery
+        prod = self.env.ref('product.product_product_1')
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'partner_invoice_id': self.partner.id,
+            'partner_shipping_id': self.partner.id,
+            'order_line': [(0, 0, {'name': prod.name, 'product_id': prod.id, 'product_uom_qty': 2, 'product_uom': prod.uom_id.id, 'price_unit': prod.list_price})],
+            'pricelist_id': self.env.ref('product.list0').id,
+        })
+        so._compute_tax_id()
+        so.action_confirm()
+        so._create_analytic_account()  # normally created at so confirmation when you use the right products
+        init_price = so.amount_total
+
+        # create some expense and validate it (expense at cost)
+        prod_exp_1 = self.env.ref('hr_expense.car_travel')
+        company = self.env.ref('base.main_company')
+        journal = self.env['account.journal'].create({'name': 'Purchase Journal - Test', 'code': 'HRTPJ', 'type': 'purchase', 'company_id': company.id})
+        account_payable = self.env['account.account'].create({'code': 'X1111', 'name': 'HR Expense - Test Payable Account', 'user_type_id': self.env.ref('account.data_account_type_payable').id, 'reconcile': True})
+        employee = self.env['hr.employee'].create({'name': 'Test employee', 'user_id': self.user.id, 'address_home_id': self.user.partner_id.id})
+        self.user.partner_id.property_account_payable_id = account_payable.id
+        # Submit to Manager
+        sheet = self.env['hr.expense.sheet'].create({
+            'name': 'Expense for John Smith',
+            'employee_id': employee.id,
+            'journal_id': journal.id,
+        })
+        exp = self.env['hr.expense'].create({
+            'name': 'Car Travel',
+            'product_id': prod_exp_1.id,
+            'analytic_account_id': so.analytic_account_id.id,
+            'product_uom_id': self.env.ref('product.product_uom_km').id,
+            'unit_amount': 0.15,
+            'quantity': 100,
+            'employee_id': employee.id,
+            'sheet_id': sheet.id
+        })
+        # Approve
+        sheet.approve_expense_sheets()
+        # Create Expense Entries
+        sheet.action_sheet_move_create()
+        # expense should now be in sales order
+        self.assertIn(prod_exp_1, so.mapped('order_line.product_id'), 'Sale Expense: expense product should be in so')
+        sol = so.order_line.filtered(lambda sol: sol.product_id.id == prod_exp_1.id)
+        self.assertEqual((sol.price_unit, sol.qty_delivered), (prod_exp_1.list_price, 100.0), 'Sale Expense: error when invoicing an expense at cost')
+        self.assertEqual(so.amount_total, init_price, 'Sale Expense: price of so not updated after adding expense')
+
+        # create some expense with same product and validate it
+        init_price = so.amount_total
+        prod_exp_2 = self.env.ref('hr_expense.car_travel')
+        # Submit to Manager
+        sheet = self.env['hr.expense.sheet'].create({
+            'name': 'Expense for John Smith',
+            'employee_id': employee.id,
+            'journal_id': journal.id,
+        })
+        exp = self.env['hr.expense'].create({
+            'name': 'Car Travel',
+            'product_id': prod_exp_1.id,
+            'analytic_account_id': so.analytic_account_id.id,
+            'product_uom_id': self.env.ref('product.product_uom_km').id,
+            'unit_amount': 0.15,
+            'quantity': 200,
+            'employee_id': employee.id,
+            'sheet_id': sheet.id
+        })
+        # Approve
+        sheet.approve_expense_sheets()
+        # Create Expense Entries
+        sheet.action_sheet_move_create()
+        # expense should now be in sales order
+        self.assertIn(prod_exp_2, so.mapped('order_line.product_id'), 'Sale Expense: expense product should be in so')
+        sol = so.order_line.filtered(lambda sol: sol.product_id.id == prod_exp_2.id)
+        self.assertEqual((sol.price_unit, sol.qty_delivered), (prod_exp_2.list_price, 300.0), 'Sale Expense: error when invoicing an expense at cost')
+        self.assertEqual(so.amount_total, init_price, 'Sale Expense: price of so not updated after adding expense')
+        # self.assertTrue(so.invoice_status, 'no', 'Sale Expense: expenses should not impact the invoice_status of the so')
+
+        # both expenses should be invoiced
+        inv_id = so.action_invoice_create()
+        inv = self.env['account.invoice'].browse(inv_id)
+        self.assertEqual(inv.amount_untaxed, (prod_exp_1.list_price * 100.0) + (prod_exp_2.list_price * 200.0), 'Sale Expense: invoicing of expense is wrong')

--- a/addons/sale_timesheet/models/sale_order.py
+++ b/addons/sale_timesheet/models/sale_order.py
@@ -167,7 +167,10 @@ class SaleOrderLine(models.Model):
         # TODO JEM: avoid increment delivered for all AAL or just timesheet ?
         # see nim commit https://github.com/odoo/odoo/commit/21fbb9776a5fbd1838b189f1f7cf8c5d40663e14
         so_line_ids = self.filtered(lambda sol: sol.product_id.service_type != 'manual').ids
-        return ['&', ('so_line', 'in', so_line_ids), ('project_id', '!=', False)]
+        domain = []
+        if so_line_ids:
+            domain = ['&', ('so_line', 'in', so_line_ids), ('project_id', '!=', False)]
+        return domain
 
     @api.multi
     def _analytic_compute_delivered_quantity_domain(self):


### PR DESCRIPTION
… once on same so

Description of the issue/feature this PR addresses:
Ability to reinvoice an expense product more than ones on same SO

Current behavior before PR:
Only the first time an expense product was posted it was added to the so to reinvoice. A second time expensing the same product, the quantity delivered was not updated

Desired behavior after PR is merged:
One can expense the same product on a so multiple times

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
