### PR TITLE
[11.0][FIX] base adapted for multicompany environment

### DIFF
--- a/odoo/addons/base/res/res_company.py
+++ b/odoo/addons/base/res/res_company.py
@@ -223,6 +223,7 @@ class Company(models.Model):
             'phone': vals.get('phone'),
             'website': vals.get('website'),
             'vat': vals.get('vat'),
+            'company_id': False,
         })
         vals['partner_id'] = partner.id
         self.clear_caches()

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3330,6 +3330,11 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         # create or update parent records
         for parent_model, parent_vals in tocreate.items():
             parent_id = parent_vals.pop('id')
+
+            # share the company_id to the parent_id if possible
+            if vals.get('company_id') and self.env[parent_model]._fields.get('company_id'):
+                parent_vals['company_id'] = vals.get('company_id')
+
             if not parent_id:
                 parent_id = self.env[parent_model].create(parent_vals).id
             else:


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
This PR fixes three bugs in `base` for a multicompany environment.

**Current behavior before PR:**
`res_company.py`: When creating a company from scratch, it creates a partner with the default company.
`res_partner.py`: When writing the company in a partner, it doesn't write the company in the partner children.
`models.py`: When creating a parent record for a record, it doesn't pass the company of the record.

**Desired behavior after PR is merged:**
`res_company.py`: When creating a company from scratch, it creates a partner without any company.
`res_partner.py`: When writing the company in a partner, it writes the company in the partner and all its children at the same time.
`models.py`: When creating a parent record for a record, it pass the company of the record if possible.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
