### PR TITLE
Change column type of serialized fields + make __leaf_to_sql inheritable

### DIFF
--- a/addons/base_sparse_field/models/fields.py
+++ b/addons/base_sparse_field/models/fields.py
@@ -79,7 +79,7 @@ class Serialized(fields.Field):
     _slots = {
         'prefetch': False,              # not prefetched by default
     }
-    column_type = ('text', 'text')
+    column_type = ('jsonb', 'jsonb')
 
     def convert_to_column(self, value, record, values=None):
         return json.dumps(value)

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -277,7 +277,7 @@ def distribute_not(domain):
     Because we don't use SQL semantic for processing a 'left not in right'
     query (i.e. our 'not in' is not simply translated to a SQL 'not in'),
     it means that a '! left in right' can not be simply processed
-    by __leaf_to_sql by first emitting code for 'left in right' then wrapping
+    by _leaf_to_sql by first emitting code for 'left in right' then wrapping
     the result with 'not (...)', as it would result in a 'not in' at the SQL
     level.
 
@@ -1063,7 +1063,7 @@ class expression(object):
                             right and isinstance(right, (tuple, list)) and all(isinstance(item, pycompat.string_types) for item in right):
                         push(create_substitution_leaf(leaf, _get_expression(comodel, left, right, operator), model))
                     else:
-                        # right == [] or right == False and all other cases are handled by __leaf_to_sql()
+                        # right == [] or right == False and all other cases are handled by _leaf_to_sql()
                         push_result(leaf)
 
             # -------------------------------------------------
@@ -1151,7 +1151,7 @@ class expression(object):
             joins |= set(leaf.get_join_conditions())
         self.joins = list(joins)
 
-    def __leaf_to_sql(self, eleaf):
+    def _leaf_to_sql(self, eleaf):
         model = eleaf.model
         leaf = eleaf.leaf
         left, operator, right = leaf
@@ -1236,7 +1236,7 @@ class expression(object):
                 params = []
             else:
                 # '=?' behaves like '=' in other cases
-                query, params = self.__leaf_to_sql(
+                query, params = self._leaf_to_sql(
                     create_substitution_leaf(eleaf, (left, '=', right), model))
 
         else:
@@ -1268,7 +1268,7 @@ class expression(object):
         # Process the domain from right to left, using a stack, to generate a SQL expression.
         for leaf in reversed(self.result):
             if leaf.is_leaf(internal=True):
-                q, ps = self.__leaf_to_sql(leaf)
+                q, ps = self._leaf_to_sql(leaf)
                 stack.append(q)
                 params.extend(reversed(ps))
             elif leaf.leaf == NOT_OPERATOR:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

I think the introduction of sparse field is really great and important.

Indeed, for one of my customer, we have some models with more than 400 fields, filled only sometimes.
It is really, really bad for the performance, but the sparse field resolve it.
The only problem, is that, for now, sparse field work like compute field and can't be search in a classic view.

I think it would considerably improve the sparse field usability and it is totally feasible wit jsonb column in postgresql for example.

So, this PR aims to change 2 things in order to make possible the existence of a module implementing the search feature on sparse fields.

1) rename expression.__leaf_to_sql in order to override it easily
I guess it is not risky at all as it is used only in one file and should not be override (as it has a double underscore)
Anyway, I propose to do this in master in anycase, so be sure not to have any regression on stable branches.

2) Make the serialized fields a jsonb column instead of text, that is which make the search possible on the field.
I think this is a change reasonable in master branch.

After this 2 changes, it becomes possible to make a module implementing the search feature on sparse fields, see : 
https://github.com/florian-dacosta/sparse-field/tree/sparse-field-search/base_sparse_field_search

Of course, I am open to a better solution if any about this, but I really think that if we can search on sparse field, it will help a lot of different use cases...
Thanks

Current behavior before PR:
Not possible to implement search feature for sparse field

Desired behavior after PR is merged:
possible to create a module implementing search feature for sparse field


@rco-odoo 
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
