### PR TITLE
[FIX] base,stock: better dealing with settings access rights

### DIFF
--- a/addons/account/models/__init__.py
+++ b/addons/account/models/__init__.py
@@ -14,3 +14,4 @@ from . import company
 from . import res_config_settings
 from . import web_planner
 from . import account_cash_rounding
+from . import res_users

--- a/addons/account/models/res_users.py
+++ b/addons/account/models/res_users.py
@@ -1,0 +1,12 @@
+from odoo import models, _, api
+
+
+class Users(models.Model):
+    _inherit = 'res.users'
+
+    @api.constrains('groups_id')
+    def _group_needed_for_settings(self, msg_list=[]):
+        group_needed = self.env.ref('account.group_account_manager')
+        if group_needed.id not in self.groups_id.ids:
+            msg_list.append(_('This user must have the group "%s" for the module Invoicing/Accouting') % group_needed.name)
+        super(Users, self)._group_needed_for_settings(msg_list)

--- a/addons/stock/models/__init__.py
+++ b/addons/stock/models/__init__.py
@@ -20,3 +20,4 @@ from . import stock_warehouse
 from . import stock_scrap
 from . import web_planner
 from . import product
+from . import res_users

--- a/addons/stock/models/res_partner.py
+++ b/addons/stock/models/res_partner.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import fields, models, _, api
 from odoo.addons.base.res.res_partner import WARNING_MESSAGE, WARNING_HELP
 
 
@@ -17,3 +17,14 @@ class Partner(models.Model):
     picking_warn = fields.Selection(WARNING_MESSAGE, 'Stock Picking', help=WARNING_HELP, default='no-message', required=True)
     # TDE FIXME: expand this message / help
     picking_warn_msg = fields.Text('Message for Stock Picking')
+
+
+class User(models.Model):
+    _inherit = 'res.users'
+
+    @api.constrains('groups_id')
+    def _group_needed_for_settings(self, msg_list=[]):
+        group_needed = self.env.ref('stock.group_stock_manager')
+        if group_needed.id not in self.groups_id.ids:
+            msg_list.append(_('This user must have the group "%s" for the module Inventory') % group_needed.name)
+        super(User, self)._group_needed_for_settings(msg_list)

--- a/addons/stock/models/res_partner.py
+++ b/addons/stock/models/res_partner.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, _, api
+from odoo import fields, models
 from odoo.addons.base.res.res_partner import WARNING_MESSAGE, WARNING_HELP
 
 
@@ -17,14 +17,3 @@ class Partner(models.Model):
     picking_warn = fields.Selection(WARNING_MESSAGE, 'Stock Picking', help=WARNING_HELP, default='no-message', required=True)
     # TDE FIXME: expand this message / help
     picking_warn_msg = fields.Text('Message for Stock Picking')
-
-
-class User(models.Model):
-    _inherit = 'res.users'
-
-    @api.constrains('groups_id')
-    def _group_needed_for_settings(self, msg_list=[]):
-        group_needed = self.env.ref('stock.group_stock_manager')
-        if group_needed.id not in self.groups_id.ids:
-            msg_list.append(_('This user must have the group "%s" for the module Inventory') % group_needed.name)
-        super(User, self)._group_needed_for_settings(msg_list)

--- a/addons/stock/models/res_users.py
+++ b/addons/stock/models/res_users.py
@@ -1,0 +1,12 @@
+from odoo import models, _, api
+
+
+class Users(models.Model):
+    _inherit = 'res.users'
+
+    @api.constrains('groups_id')
+    def _group_needed_for_settings(self, msg_list=[]):
+        group_needed = self.env.ref('stock.group_stock_manager')
+        if group_needed.id not in self.groups_id.ids:
+            msg_list.append(_('This user must have the group "%s" for the module Inventory') % group_needed.name)
+        super(Users, self)._group_needed_for_settings(msg_list)

--- a/addons/website/models/__init__.py
+++ b/addons/website/models/__init__.py
@@ -12,3 +12,4 @@ from . import res_partner
 from . import web_planner
 from . import res_config_settings
 from . import ir_model_fields
+from . import res_users

--- a/addons/website/models/res_users.py
+++ b/addons/website/models/res_users.py
@@ -1,0 +1,12 @@
+from odoo import models, _, api
+
+
+class Users(models.Model):
+    _inherit = 'res.users'
+
+    @api.constrains('groups_id')
+    def _group_needed_for_settings(self, msg_list=[]):
+        group_needed = self.env.ref('website.group_website_designer')
+        if group_needed.id not in self.groups_id.ids:
+            msg_list.append(_('This user must have the group "%s" for the module Website') % group_needed.name)
+        super(Users, self)._group_needed_for_settings(msg_list)

--- a/odoo/addons/base/res/res_users.py
+++ b/odoo/addons/base/res/res_users.py
@@ -212,6 +212,17 @@ class Users(models.Model):
     companies_count = fields.Integer(compute='_compute_companies_count', string="Number of Companies", default=_companies_count)
     tz_offset = fields.Char(compute='_compute_tz_offset', string='Timezone offset', invisible=True)
 
+    # To Do in master:
+    # Remove this and all overrides
+    # Make the res.config.settings deal better with groups
+    @api.constrains('groups_id')
+    def _group_needed_for_settings(self, msg_list=[]):
+        # Method meant to be overriden in each module that has access rights issues in Settings
+        # the override should check the presence of the settings group necessary for the module
+        # and call super(['your message'])
+        if msg_list and self.has_group('base.group_system'):
+            raise ValidationError('\n'.join(msg_list))
+
     @api.model
     def _get_company(self):
         return self.env.user.company_id


### PR DESCRIPTION
In Odoo v11 all the res.config.settings of all installed modules are loaded in the view

Imagine that you want a "second" admin:
- create users and assign groups
- but you don't want that second admin Dashboard or settings to be polluted by modules he won't use anyway
- then you make this user a simple user or nothing for some modules

The problem is when accessing settings, some fields won't be readable
or writable (because the user doesn't have the right group)
yielding an access right error

This commit aims at forcing any "admin" to be manager of all modules, circumventing the above stated error

Understood that the res.config.settings model should be better engineerd in the first place,
this commit is only a workaround, begging for a change in master

As a side note: multicompany also breaks the settings, and should yield another commit

OPW 801210

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
