### PR TITLE
Update help tooltip

### DIFF
--- a/addons/board/views/board_views.xml
+++ b/addons/board/views/board_views.xml
@@ -28,13 +28,15 @@
                   <p>
                     <b>Your personal dashboard is empty.</b>
                   </p><p>
-                    To add your first report into this dashboard, go to any
-                    menu, switch to list or graph view, and click <i>'Add to
-                    Dashboard'</i> in the extended search options.
+                  To add your first item to this dashboard, navigate to any 
+                  view and click <i>"Add to Dashboard"</i> in the extended 
+                   search options under <i>"Favorites"</i>.
                   </p><p>
-                    You can filter and group data before inserting into the
+                    You can filter and group data before inserting into the 
                     dashboard using the search options.
-                  </p>
+                  </p><p>
+                  Note that you may need to reload the page in your browser 
+                  for your changes to take effect.</p>
               </div>
             </field>
         </record> 


### PR DESCRIPTION
Update the help tooltip to inform the user that they must sometimes reload the browser page before items added to their dashboard become visible.

I've also indicated that view types other than graph and list can be added to a dashboard.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
