### PR TITLE
[IMP] web/all: move the active/unarchive in the action button

### DIFF
--- a/addons/account/views/account_view.xml
+++ b/addons/account/views/account_view.xml
@@ -269,11 +269,7 @@
             <field name="arch" type="xml">
                 <form string="Account Journal">
                     <sheet>
-                        <div class="oe_button_box" name="button_box">
-                            <button class="oe_stat_button" type="object" name="toggle_active" icon="fa-archive">
-                                <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                            </button>
-                        </div>
+                        <div class="oe_button_box" name="button_box"></div>
                         <div class="oe_title">
                             <label for="name" class="oe_edit_only"/>
                             <h1><field name="name" class="oe_inline"/></h1>
@@ -487,11 +483,7 @@
             <field name="arch" type="xml">
                 <form string="Tags">
                     <sheet>
-                        <div class="oe_button_box" name="button_box">
-                            <button class="oe_stat_button" type="object" name="toggle_active" icon="fa-archive">
-                                <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                            </button>
-                        </div>
+                        <div class="oe_button_box" name="button_box"></div>
                         <group>
                             <field name="name"/>
                         </group>
@@ -1072,11 +1064,7 @@
             <field name="arch" type="xml">
                 <form string="Account Tax">
                     <sheet>
-                    <div class="oe_button_box" name="button_box">
-                        <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive">
-                            <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                        </button>
-                    </div>
+                    <div class="oe_button_box" name="button_box"></div>
                     <group>
                         <group>
                             <field name="name"/>
@@ -1722,12 +1710,7 @@
             <field name="arch" type="xml">
                 <form string="Payment Terms">
                     <sheet>
-                        <div class="oe_button_box" name="button_box">
-                            <button class="oe_stat_button" type="object" name="toggle_active" icon="fa-archive">
-                                <field name="active" widget="boolean_button"
-                                options='{"terminology": "archive"}'/>
-                            </button>
-                        </div>
+                        <div class="oe_button_box" name="button_box"></div>
                         <group>
                             <group>
                                 <field name="name"/>
@@ -1952,7 +1935,6 @@
                                 </group>
                                 <group>
                                     <field name="tag_ids" domain="[('applicability', '!=', 'accounts')]" widget="many2many_tags" context="{'default_applicability': 'taxes'}"/>
-                                    <field name="active" groups="base.group_no_one"/>
                                     <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
                                     <field name="tax_exigibility" widget="radio" attrs="{'invisible':[('amount_type','=', 'group')]}"/>
                                     <field name="cash_basis_account" attrs="{'invisible': [('tax_exigibility', '=', 'on_invoice')], 'required': [('tax_exigibility', '=', 'on_payment')]}"/>

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -7,12 +7,7 @@
             <field name="arch" type="xml">
                 <form string="Fiscal Position">
                     <sheet>
-                        <div class="oe_button_box" name="button_box">
-                            <button class="oe_stat_button" type="object" name="toggle_active" icon="fa-archive">
-                                <field name="active" widget="boolean_button"
-                                options='{"terminology": "archive"}'/>
-                            </button>
-                        </div>
+                        <div class="oe_button_box" name="button_box"></div>
                     <group>
                         <group>
                             <field name="name"/>
@@ -164,12 +159,12 @@
             <field name="priority" eval="22"/>
             <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]"/>
             <field name="arch" type="xml">
-                <button name="toggle_active" position="before">
+                <div name="button_box" position="inside">
                     <button class="oe_stat_button" type="action" name="%(account.action_open_partner_analytic_accounts)d"
                         icon="fa-book" groups="analytic.group_analytic_accounting">
                         <field string="Analytic Accounts" name="contracts_count" widget="statinfo"/>
                     </button>
-                </button>
+                </div>
             </field>
         </record>
 

--- a/addons/account_test/views/accounting_assert_test_views.xml
+++ b/addons/account_test/views/accounting_assert_test_views.xml
@@ -24,9 +24,6 @@
                                 <field name="name"/>
                                 <field name="sequence"/>
                             </group>
-                            <group>
-                                <field name="active"/>
-                            </group>
                         </group>
                         <notebook>
                             <page string="Description">

--- a/addons/analytic/views/analytic_account_views.xml
+++ b/addons/analytic/views/analytic_account_views.xml
@@ -16,11 +16,7 @@
             <field name="arch" type="xml">
                 <form string="Analytic Tags">
                     <sheet>
-                        <div class="oe_button_box" name="button_box">
-                            <button class="oe_stat_button" type="object" name="toggle_active" icon="fa-archive">
-                                <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                            </button>
-                        </div>
+                        <div class="oe_button_box" name="button_box"></div>
                         <group>
                             <field name="name"/>
                             <field name="active_analytic_distribution" groups="analytic.group_analytic_accounting"/>
@@ -147,10 +143,6 @@
                         <div class="oe_button_box" name="button_box">
                             <button class="oe_stat_button" type="action" name="%(account_analytic_line_action)d"
                             icon="fa-usd"  string="Cost/Revenue" widget="statinfo"/>
-                            <button class="oe_stat_button" type="object" name="toggle_active" icon="fa-archive">
-                                <field name="active" widget="boolean_button"
-                                options='{"terminology": "archive"}'/>
-                            </button>
                         </div>
                         <div class="oe_title">
                             <label for="name" class="oe_edit_only"/>

--- a/addons/base_automation/views/base_automation_view.xml
+++ b/addons/base_automation/views/base_automation_view.xml
@@ -15,13 +15,6 @@
                         attrs="{'invisible':[('binding_model_id','=',False)]}"
                         help="Remove the contextual action related to this server action"/>
                 </xpath>
-                <div class="oe_title" position="before">
-                    <div class="oe_button_box" name="button_box">
-                        <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive">
-                            <field name="active" widget="boolean_button"/>
-                        </button>
-                    </div>
-                </div>
                 <xpath expr="//group[@name='action_wrapper']" position="inside">
                     <group>
                         <field name="trigger"/>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -47,11 +47,7 @@
                             help="Convert to Opportunity" class="oe_highlight" attrs="{'invisible': [('type', '=', 'opportunity')]}"/>
                 </header>
                 <sheet>
-                    <div class="oe_button_box" name="button_box">
-                        <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive">
-                            <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                        </button>
-                    </div>
+                    <div class="oe_button_box" name="button_box"></div>
                     <div class="label label-success pull-right" attrs="{'invisible': [('probability', '&lt;', 100)]}">Won</div>
                     <div class="oe_title">
                         <label for="name" class="oe_edit_only" string="Lead"/>
@@ -442,6 +438,7 @@
             <field name="priority">20</field>
             <field name="arch" type="xml">
                 <form string="Opportunities" class="o_opportunity_form">
+                    <field name="active" invisible="1"/>
                     <header>
                         <button name="action_set_won" string="Mark Won"
                                 type="object" class="oe_highlight"
@@ -465,10 +462,6 @@
                                     <span class="o_stat_text" attrs="{'invisible': [('meeting_count', '&lt;', 2)]}"> Meetings</span>
                                     <span class="o_stat_text" attrs="{'invisible': [('meeting_count', '&gt;', 1)]}"> Meeting</span>
                                 </div>
-                            </button>
-                            <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive"
-                                    attrs="{'invisible': [('active', '=', True), ('probability', '&lt;', 100)]}">
-                                <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
                             </button>
                         </div>
                         <div class="label label-danger pull-right" attrs="{'invisible': ['|', ('probability', '&gt;', 0), ('active', '=', True)]}">Lost</div>
@@ -728,7 +721,6 @@
                 <form string="Channel">
                     <group>
                         <field name="name"/>
-                        <field name="active"/>
                     </group>
                 </form>
             </field>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -336,8 +336,8 @@
                                     <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
                                         <t t-if="widget.editable"><li><a type="edit">Edit</a></li></t>
                                         <t t-if="widget.deletable"><li><a type="delete">Delete</a></li></t>
-                                        <li t-if="! record.active.value"><a name="action_set_active" type="object">Restore</a></li>
-                                        <li t-if="record.active.value"><a name="action_set_unactive" type="object">Archive</a></li>
+                                        <li t-if="! record.active.raw_value"><a name="action_set_active" type="object">Restore</a></li>
+                                        <li t-if="record.active.raw_value"><a name="action_set_unactive" type="object">Archive</a></li>
                                         <li><ul class="oe_kanban_colorpicker" data-field="color"/></li>
                                     </ul>
                                 </div>

--- a/addons/crm/views/res_partner_views.xml
+++ b/addons/crm/views/res_partner_views.xml
@@ -98,7 +98,7 @@
             <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
             <field name="arch" type="xml">
                 <data>
-                    <button name="toggle_active" position="before">
+                    <div name="button_box" position="inside">
                         <button class="oe_stat_button o_res_partner_tip_opp" type="action"
                             attrs="{'invisible': [('customer', '=', False)]}"
                             name="%(crm.crm_lead_opportunities)d"
@@ -112,7 +112,7 @@
                             context="{'partner_id': active_id, 'partner_name': name}">
                             <field string="Meetings" name="meeting_count" widget="statinfo"/>
                         </button>
-                    </button>
+                    </div>
                 </data>
             </field>
         </record>

--- a/addons/crm_project/views/crm_lead_views.xml
+++ b/addons/crm_project/views/crm_lead_views.xml
@@ -7,7 +7,7 @@
         <field name="model">crm.lead</field>
         <field name="inherit_id" ref="crm.crm_case_form_view_leads" />
         <field name="arch" type="xml">
-            <xpath expr="//button[@name='toggle_active']" position="before">
+            <xpath expr="//div[@name='button_box']" position="inside">
                     <button class="oe_stat_button" type="action" name="%(crm_lead_convert2task_action)d" icon="fa-bug" help="Convert to Task">
                         <div class="o_field_widget o_stat_info">
                             <span class="o_stat_text">Convert To</span>

--- a/addons/delivery/views/delivery_view.xml
+++ b/addons/delivery/views/delivery_view.xml
@@ -56,9 +56,6 @@
                                     "hover_false": "Switch to production environment"
                                 }}'/>
                             </button>
-                            <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive">
-                                <field name="active" widget="boolean_button" options='{"terminology": "active"}'/>
-                            </button>
                             <button name="toggle_debug" type="object" class="oe_stat_button" icon="fa-code" groups="base.group_no_one" attrs="{'invisible': ['|', ('delivery_type', '=', 'fixed'), ('delivery_type', '=', 'base_on_rule')]}">
                                 <field name="debug_logging" widget="boolean_button" options='{"terminology": {
                                     "string_true": "Debug requests",

--- a/addons/document/static/src/js/document.js
+++ b/addons/document/static/src/js/document.js
@@ -42,12 +42,23 @@ Sidebar.include({
     //--------------------------------------------------------------------------
     // Public
     //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    redraw: function () {
+        this._super.apply(this, arguments);
+        this.$('.o_sidebar_add_attachment .o_form_binary_form')
+            .change(this._onAddAttachment.bind(this));
+        this.$('.o_sidebar_delete_attachment')
+            .click(this._onDeleteAttachment.bind(this));
+    },
     /**
      * @override
      */
     updateEnv: function (env) {
         this.env = env;
-        this._updateAttachments().then(this._redraw.bind(this));
+        this._updateAttachments().then(this.redraw.bind(this));
     },
 
     //--------------------------------------------------------------------------
@@ -83,17 +94,6 @@ Sidebar.include({
             a.write_date_string = field_utils.format.datetime(a.write_date, 'write_date', self.env.context.params);
         });
         this.items.files = attachments;
-    },
-    /**
-     * @private
-     * @override
-     */
-    _redraw: function () {
-        this._super.apply(this, arguments);
-        this.$('.o_sidebar_add_attachment .o_form_binary_form')
-            .change(this._onAddAttachment.bind(this));
-        this.$('.o_sidebar_delete_attachment')
-            .click(this._onDeleteAttachment.bind(this));
     },
     /**
      * Update the attachments to be displayed in the attachment section
@@ -152,6 +152,7 @@ Sidebar.include({
      * @param  {Event} event
      */
     _onDeleteAttachment: function (event) {
+        debugger
         event.preventDefault();
         var self = this;
         var $event = $(event.currentTarget);
@@ -163,7 +164,7 @@ Sidebar.include({
                     args: [parseInt($event.attr('data-id'), 10)],
                 })
                 .then(self._updateAttachments.bind(self))
-                .then(self._redraw.bind(self));
+                .then(self.redraw.bind(self));
             }
         };
         Dialog.confirm(this, _t("Do you really want to delete this attachment ?"), options);
@@ -181,7 +182,7 @@ Sidebar.include({
         if (uploadErrors.length) {
             this.do_warn(_t('Uploading Error'), uploadErrors[0].error);
         }
-        this._updateAttachments().then(this._redraw.bind(this));
+        this._updateAttachments().then(this.redraw.bind(this));
         framework.unblockUI();
     }
 });

--- a/addons/event/views/event_views.xml
+++ b/addons/event/views/event_views.xml
@@ -194,13 +194,6 @@
                                     help="Register with this event">
                                 <field name="seats_expected" widget="statinfo" string="Attendees"/>
                             </button>
-                            <button name="toggle_active"
-                                    type="object"
-                                    class="oe_stat_button"
-                                    icon="fa-archive">
-                                <field name="active" widget="boolean_button"
-                                    options='{"terminology": "archive"}'/>
-                            </button>
                         </div>
                         <div class="oe_title">
                             <label for="name" class="oe_edit_only"/>

--- a/addons/fetchmail/views/fetchmail_views.xml
+++ b/addons/fetchmail/views/fetchmail_views.xml
@@ -61,7 +61,6 @@
                                 <field name="priority"/>
                                 <field name="attach"/>
                                 <field name="original"/>
-                                <field name="active"/>
                             </group>
                         </page>
                     </notebook>

--- a/addons/fleet/views/fleet_vehicle_cost_views.xml
+++ b/addons/fleet/views/fleet_vehicle_cost_views.xml
@@ -178,11 +178,7 @@
                     <field name="state" widget="statusbar" />
                 </header>
                 <sheet>
-                    <div class="oe_button_box" name="button_box">
-                        <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive">
-                            <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                        </button>
-                    </div>
+                    <div class="oe_button_box" name="button_box"></div>
                     <group col="2">
                         <group string="Contract details">
                             <field name="vehicle_id"/>

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -51,9 +51,6 @@
                             help="show the odometer logs for this vehicle" >
                             <field name="odometer_count" widget="statinfo" string="Odometer"/>
                         </button>
-                        <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive">
-                            <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                        </button>
                     </div>
                     <field name="image_medium" widget='image' class="oe_avatar"/>
                     <div class="oe_title">

--- a/addons/google_drive/views/google_drive_views.xml
+++ b/addons/google_drive/views/google_drive_views.xml
@@ -21,7 +21,6 @@
                     <field name="model" invisible="1" />
                     <group>
                         <field name="name" />
-                        <field name="active" />
                         <field name="model_id"/>
                         <label for='filter_id' />
                         <div>

--- a/addons/hr/views/hr_views.xml
+++ b/addons/hr/views/hr_views.xml
@@ -37,13 +37,7 @@
             <field name="arch" type="xml">
                 <form string="Employee">
                     <sheet>
-                        <div class="oe_button_box" name="button_box">
-                            <button name="toggle_active" type="object" groups="hr.group_hr_user"
-                                    class="oe_stat_button" icon="fa-archive">
-                                <field name="active" widget="boolean_button"
-                                    options='{"terminology": "archive"}'/>
-                            </button>
-                        </div>
+                        <div class="oe_button_box" name="button_box"></div>
                         <div id="o_employee_container"><div id="o_employee_main">
                         <field name="image" widget='image' class="oe_avatar" options='{"preview_image":"image_medium"}'/>
                         <div class="oe_title">
@@ -485,11 +479,7 @@
             <field name="arch" type="xml">
                 <form string="department">
                     <sheet>
-                        <div class="oe_button_box" name="button_box">
-                            <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive">
-                                <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                            </button>
-                        </div>
+                        <div class="oe_button_box" name="button_box"></div>
                         <group col="4">
                             <field name="name"/>
                             <field name="manager_id"/>

--- a/addons/hr_attendance/views/hr_employee_view.xml
+++ b/addons/hr_attendance/views/hr_employee_view.xml
@@ -7,7 +7,7 @@
         <field name="priority">10</field>
         <field name="groups_id" eval="[(4,ref('hr_attendance.group_hr_attendance_user'))]"/>
         <field name="arch" type="xml">
-            <xpath expr="//button[@name='toggle_active']" position="before">
+            <xpath expr="//div[@name='button_box']" position="inside">
                 <field name="attendance_state" invisible="1"/>
                 <button name="%(hr_attendance_action_employee)d"
                     class="oe_stat_button"

--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -19,7 +19,7 @@
             <field name="inherit_id" ref="hr.view_employee_form"/>
             <field name="arch" type="xml">
                 <data>
-                    <xpath expr="//button[@name='toggle_active']" position="before">
+                    <xpath expr="//div[@name='button_box']" position="inside">
                         <button name="%(act_hr_employee_2_hr_contract)d"
                             class="oe_stat_button"
                             icon="fa-book"

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -264,13 +264,7 @@
                     <sheet>
                         <field name='product_variant_count' invisible='1'/>
                         <field name="id" invisible="True"/>
-                        <div class="oe_button_box" name="button_box">
-                            <button name="toggle_active" type="object"
-                                    class="oe_stat_button" icon="fa-archive">
-                                <field name="active" widget="boolean_button"
-                                    options='{"terminology": "archive"}'/>
-                            </button>
-                        </div>
+                        <div class="oe_button_box" name="button_box"></div>
                         <field name="image_medium" widget="image" class="oe_avatar"/>
                         <div class="oe_title">
                             <label class="oe_edit_only" for="name" string="Product Name"/>

--- a/addons/hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays/views/hr_leave_type_views.xml
@@ -19,12 +19,7 @@
         <field name="arch" type="xml">
             <form string="Leave Type">
                 <sheet>
-                    <div class="oe_button_box" name="button_box">
-                        <button class="oe_stat_button" type="object" name="toggle_active" icon="fa-archive">
-                            <field name="active" widget="boolean_button"
-                            options='{"terminology": "archive"}'/>
-                        </button>
-                    </div>
+                    <div class="oe_button_box" name="button_box"></div>
                     <group>
                         <group name="description" string="Description">
                             <field name="name"/>

--- a/addons/hr_holidays/views/hr_views.xml
+++ b/addons/hr_holidays/views/hr_views.xml
@@ -184,7 +184,7 @@
                     </div>
                 </group>
             </xpath>
-            <button name="toggle_active" position="before">
+            <div name="button_box" position="inside">
                 <field name="show_leaves" invisible="1"/>
                 <button name="%(act_hr_employee_holiday_request)d"
                         type="action"
@@ -195,7 +195,7 @@
                         help="Remaining leaves">
                     <field string="Leaves Left" name="leaves_count" widget="statinfo"/>
                 </button>
-            </button>
+            </div>
         </field>
     </record>
 

--- a/addons/hr_payroll/views/hr_employee_views.xml
+++ b/addons/hr_payroll/views/hr_employee_views.xml
@@ -7,7 +7,7 @@
         <field name="model">hr.employee</field>
         <field name="inherit_id" ref="hr.view_employee_form"/>
         <field name="arch" type="xml">
-                <button name="toggle_active" position="before">
+                <div name="button_box" position="inside">
                     <button name="%(act_hr_employee_payslip_list)d"
                         class="oe_stat_button"
                         icon="fa-money"
@@ -15,7 +15,7 @@
                         groups="hr_payroll.group_hr_payroll_user">
                         <field name="payslip_count" widget="statinfo" string="Payslips"/>
                     </button>
-                </button>
+                </div>
         </field>
     </record>
 </odoo>

--- a/addons/hr_payroll/views/hr_salary_rule_views.xml
+++ b/addons/hr_payroll/views/hr_salary_rule_views.xml
@@ -336,7 +336,6 @@
                 <group col="4">
                    <field name="code"/>
                    <field name="sequence" />
-                   <field name="active"/>
                    <field name="appears_on_payslip"/>
                    <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
                 </group>

--- a/addons/hr_recruitment/views/hr_recruitment_views.xml
+++ b/addons/hr_recruitment/views/hr_recruitment_views.xml
@@ -67,6 +67,7 @@
         <field name="model">hr.applicant</field>
         <field name="arch" type="xml">
           <form string="Jobs - Recruitment Form">
+            <field name="active" invisible="1"/>
             <header>
                 <button string="Create Employee" name="create_employee_from_applicant" type="object"
                         class="oe_highlight" attrs="{'invisible': ['|',('emp_id', '!=', False),('active', '=', False)]}"/>
@@ -94,12 +95,6 @@
                         type="object"
                         attrs="{'invisible': [('emp_id', '=', False)]}">
                         <field name="employee_name" widget="statinfo" string="Employee"/>
-                    </button>
-                    <button name="toggle_active" type="object"
-                            class="oe_stat_button" icon="fa-archive"
-                            attrs="{'invisible': [('active', '=', True)]}">
-                        <field name="active" widget="boolean_button"
-                            options='{"terminology": "archive"}'/>
                     </button>
                 </div>
                 <div class="oe_title">

--- a/addons/hr_timesheet/views/hr_views.xml
+++ b/addons/hr_timesheet/views/hr_views.xml
@@ -23,7 +23,7 @@
                 <group string="Timesheets" name="timesheet" invisible="1" groups="hr_timesheet.group_timesheet_manager">
                 </group>
             </xpath>
-            <xpath expr="//button[@name='toggle_active']" position="before">
+            <xpath expr="//div[@name='button_box']" position="inside">
                 <button class="oe_stat_button" type="action" name="%(timesheet_action_from_employee)d" icon="fa-calendar">
                     <div class="o_stat_info">
                         <span class="o_stat_text">Timesheets</span>

--- a/addons/hr_timesheet/views/project_views.xml
+++ b/addons/hr_timesheet/views/project_views.xml
@@ -39,9 +39,9 @@
             <field name="inherit_id" ref="project.edit_project"/>
             <field name="priority">24</field>
             <field name="arch" type="xml">
-                <button name="toggle_active" position="before">
+                <div name="button_box" position="inside">
                     <button class="oe_stat_button" name="%(act_hr_timesheet_line_by_project)d" type="action" icon="fa-calendar" string="Timesheets" attrs="{'invisible': [('allow_timesheets', '=', False)]}" groups="hr_timesheet.group_hr_timesheet_user"/>
-                </button>
+                </div>
                 <xpath expr="//div[@name='options_active']" position="inside">
                     <div>
                         <field name="allow_timesheets" class="oe_inline" string="Allow timesheets"/>

--- a/addons/lunch/views/lunch_views.xml
+++ b/addons/lunch/views/lunch_views.xml
@@ -584,13 +584,7 @@
                     <header>
                     </header>
                     <sheet>
-                        <div class="oe_button_box" name="button_box">
-                            <button name="toggle_active" type="object"
-                                class="oe_stat_button" icon="fa-archive">
-                                <field name="active" widget="boolean_button"
-                                    options='{"terminology": "archive"}'/>
-                            </button>
-                        </div>
+                        <div class="oe_button_box" name="button_box"></div>
                         <group>
                             <group>
                                 <field name='name'/>
@@ -660,13 +654,7 @@
             <field name="model">lunch.alert</field>
             <field name="arch" type="xml">
                 <form>
-                    <div class="oe_button_box" name="button_box">
-                        <button name="toggle_active" type="object"
-                            class="oe_stat_button" icon="fa-archive">
-                            <field name="active" widget="boolean_button"
-                                options='{"terminology": "archive"}'/>
-                        </button>
-                    </div>
+                    <div class="oe_button_box" name="button_box"></div>
                     <group>
                         <group string="Schedule Date">
                             <field name="alert_type"/>

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -6,11 +6,7 @@
         <field name="arch" type="xml">
             <form string="Activities">
                 <sheet>
-                    <div class="oe_button_box" name="button_box">
-                        <button class="oe_stat_button" type="object" name="toggle_active" icon="fa-archive">
-                            <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                        </button>
-                    </div>
+                    <div class="oe_button_box" name="button_box"></div>
                     <div class="oe_title">
                         <label for="name" class="oe_edit_only"/>
                         <h1><field name="name"/></h1>

--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -337,9 +337,6 @@
                             icon="fa-ticket">
                             <field string="Maintenance" name="maintenance_count" widget="statinfo"/>
                         </button>
-                        <button class="oe_stat_button" type="object" name="toggle_active" icon="fa-archive">
-                            <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                        </button>
                     </div>
                     <div class="oe_title">
                         <label for="name" class="oe_edit_only"/>
@@ -752,11 +749,7 @@
         <field name="arch" type="xml">
             <form string="Maintenance Team">
                 <sheet>
-                <div class="oe_button_box" name="button_box">
-                    <button class="oe_stat_button" type="object" name="toggle_active" icon="fa-archive">
-                        <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                    </button>
-                </div>
+                <div class="oe_button_box" name="button_box"></div>
                 <div class="oe_title">
                     <label for="name" class="oe_edit_only" string="Team Name"/>
                     <h1>

--- a/addons/mass_mailing/views/mass_mailing_views.xml
+++ b/addons/mass_mailing/views/mass_mailing_views.xml
@@ -244,11 +244,6 @@
                                     type="action" icon="fa-user" class="oe_stat_button">
                                 <field name="contact_nbr" string="Recipients" widget="statinfo"/>
                             </button>
-                            <button name="toggle_active" type="object"
-                                    class="oe_stat_button" icon="fa-archive">
-                                <field name="active" widget="boolean_button"
-                                    options='{"terminology": "archive"}'/>
-                            </button>
                         </div>
                         <div class="oe_title">
                             <label for="name" class="oe_edit_only"/>
@@ -482,11 +477,6 @@
                                 context="{'search_default_filter_bounced': True}"
                                 type="action" class="oe_stat_button">
                                 <field name="bounced_ratio" string="Bounced" widget="percentpie"/>
-                            </button>
-                            <button name="toggle_active" type="object"
-                                    class="oe_stat_button" icon="fa-archive">
-                                <field name="active" widget="boolean_button"
-                                    options='{"terminology": "archive"}'/>
                             </button>
                         </div>
 

--- a/addons/membership/views/product_views.xml
+++ b/addons/membership/views/product_views.xml
@@ -85,7 +85,6 @@
                             <field name="company_id"
                                 groups="base.group_multi_company"
                                 options="{'no_create': True}"/>
-                            <field name="active"/>
                         </group>
                         <group>
                             <label for="membership_date_from" string="Membership Duration"/>

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -8,13 +8,7 @@
             <field name="arch" type="xml">
                 <form string="Bill of Material">
                     <sheet>
-                        <div class="oe_button_box" name="button_box">
-                            <button name="toggle_active" type="object"
-                                    class="oe_stat_button" icon="fa-archive">
-                                <field name="active" widget="boolean_button"
-                                    options='{"terminology": "archive"}'/>
-                            </button>
-                        </div>
+                        <div class="oe_button_box" name="button_box"></div>
                     <group>
                         <group>
                             <field name="product_tmpl_id" context="{'default_type': 'product'}"/>

--- a/addons/mrp/views/mrp_routing_views.xml
+++ b/addons/mrp/views/mrp_routing_views.xml
@@ -70,10 +70,6 @@
                                     <span class="o_stat_text">Time<br/> Analysis</span>
                                 </div>
                             </button>
-                            <button class="oe_stat_button" name="toggle_active" type="object" icon="fa-archive">
-                                <field name="active" widget="boolean_button"
-                                    options='{"terminology": "archive"}'/>
-                            </button>
                         </div>
                         <div class="oe_title">
                             <h1>

--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -317,10 +317,6 @@
                                     <span class="o_stat_text">Performance</span>
                                 </div>
                             </button>
-                            <button class="oe_stat_button" name="toggle_active" type="object" icon="fa-archive">
-                                <field name="active" widget="boolean_button"
-                                    options='{"terminology": "archive"}'/>
-                            </button>
                         </div>
                         <group>
                             <group>

--- a/addons/mrp/views/product_views.xml
+++ b/addons/mrp/views/product_views.xml
@@ -44,7 +44,7 @@
             <field name="inherit_id" ref="product.product_template_only_form_view"/>
             <field name="groups_id" eval="[(4, ref('mrp.group_mrp_user'))]"/>
             <field name="arch" type="xml">
-                <button name="toggle_active" position="before">
+                <div name="button_box" position="inside">
                     <button class="oe_stat_button" name="%(template_open_bom)d" type="action"
                         attrs="{'invisible':[('type', 'not in', ['product', 'consu'])]}" icon="fa-flask">
                         <field string="Bill of Materials" name="bom_count" widget="statinfo" />
@@ -57,7 +57,7 @@
                         attrs="{'invisible':[('type', 'not in', ['product', 'consu'])]}" icon="fa-list-alt">
                         <field string="Manufacturing" name="mo_count" widget="statinfo" />
                     </button>
-                </button>
+                </div>
             </field>
         </record>
 
@@ -67,7 +67,7 @@
             <field name="inherit_id" ref="product.product_normal_form_view"/>
             <field name="groups_id" eval="[(4, ref('mrp.group_mrp_user'))]"/>
             <field name="arch" type="xml">
-                <button name="toggle_active" position="before">
+                <div name="button_box" position="inside">
                     <button class="oe_stat_button" name="action_view_bom" type="object"
                         attrs="{'invisible':[('type', 'not in', ['product', 'consu'])]}" icon="fa-flask">
                         <field string="Bill of Materials" name="bom_count" widget="statinfo" />
@@ -80,7 +80,7 @@
                         attrs="{'invisible':[('type', 'not in', ['product', 'consu'])]}" icon="fa-list-alt">
                         <field string="Manufacturing" name="mo_count" widget="statinfo" />
                     </button>
-                </button>
+                </div>
             </field>
         </record>
     </data>

--- a/addons/payment/views/payment_views.xml
+++ b/addons/payment/views/payment_views.xml
@@ -392,7 +392,6 @@
                             <field name='partner_id' />
                         </group>
                         <group>
-                            <field name="active"/>
                             <field name='acquirer_id'/>
                             <field name='acquirer_ref'/>
                         </group>

--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -32,11 +32,7 @@
                 <sheet>
                     <field name="currency_id" invisible="1"/>
                     <field name="is_installed_account_accountant" invisible="1"/>
-                    <div class="oe_button_box" name="button_box">
-                        <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive">
-                            <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                        </button>
-                    </div>
+                    <div class="oe_button_box" name="button_box"></div>
                     <div class="oe_title" id="title">
                         <label for="name" class="oe_edit_only"/>
                         <h1><field name="name"/></h1>

--- a/addons/product/views/product_pricelist_views.xml
+++ b/addons/product/views/product_pricelist_views.xml
@@ -134,13 +134,7 @@
             <field name="arch" type="xml">
                 <form string="Products Price List">
                     <sheet>
-                        <div class="oe_button_box" name="button_box">
-                            <button name="toggle_active" type="object"
-                                    class="oe_stat_button" icon="fa-archive" groups="sales_team.group_sale_manager">
-                                <field name="active" widget="boolean_button"
-                                    options='{"terminology": "archive"}'/>
-                            </button>
-                        </div>
+                        <div class="oe_button_box" name="button_box"></div>
                         <div class="oe_title">
                             <h1><field name="name" placeholder="e.g. USD Retailers"/></h1>
                         </div>

--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -33,14 +33,14 @@
                 <field name="barcode" attrs="{'invisible': [('product_variant_count', '>', 1)]}"/>
             </field>
 
-            <button name="toggle_active" position="before">
+            <div name="button_box" position="inside">
                 <button name="%(product.product_variant_action)d" type="action"
                     icon="fa-sitemap" class="oe_stat_button"
                     attrs="{'invisible': [('product_variant_count', '&lt;=', 1)]}"
                     groups="product.group_product_variant">
                     <field string="Variants" name="product_variant_count" widget="statinfo" />
                 </button>
-            </button>
+            </div>
 
             <xpath expr="//page[@name='general_information']" position="after">
                 <page name="variants" string="Variants" groups="product.group_product_variant">

--- a/addons/product/views/product_uom_views.xml
+++ b/addons/product/views/product_uom_views.xml
@@ -38,7 +38,6 @@
                         </p>
                     </group>
                     <group>
-                        <field name="active"/>
                         <field name="rounding" digits="[42, 5]"/>
                     </group>
                 </group>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -17,13 +17,7 @@
                 <sheet>
                     <field name='product_variant_count' invisible='1'/>
                     <field name="id" invisible="True"/>
-                    <div class="oe_button_box" name="button_box">
-                        <button name="toggle_active" type="object"
-                                class="oe_stat_button" icon="fa-archive">
-                            <field name="active" widget="boolean_button"
-                                options='{"terminology": "archive"}'/>
-                        </button>
-                    </div>
+                    <div class="oe_button_box" name="button_box"></div>
                     <field name="image_medium" widget="image" class="oe_avatar"/>
                     <div class="oe_title">
                         <label class="oe_edit_only" for="name" string="Product Name"/>
@@ -222,7 +216,6 @@
                                 <field name="default_code"/>
                             </group>
                             <group>
-                                <field name="active"/>
                                 <field name="type" invisible="1"/>
                             </group>
                         </group>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -103,6 +103,7 @@
                 <form string="Project">
                 <sheet string="Project">
                     <field name="analytic_account_id" invisible="1" required="0"/>
+                    <field name="active" invisible="1"/>
                     <div class="oe_button_box" name="button_box" groups="base.group_user">
                         <button  class="oe_stat_button" name="attachment_tree_view" type="object" icon="fa-files-o">
                             <field string="Documents" name="doc_count" widget="statinfo"/>
@@ -113,12 +114,6 @@
                         </button>
                         <button name="action_view_all_rating" type="object" attrs="{'invisible': ['|', '|', ('rating_status', '=', 'no'), ('percentage_satisfaction_task', '=', -1)]}" class="oe_stat_button oe_percent" icon="fa-smile-o" groups="project.group_project_rating">
                             <field string="% On tasks" name="percentage_satisfaction_task" widget="statinfo"/>
-                        </button>
-                        <button name="toggle_active" type="object"
-                                confirm="(Un)archiving a project automatically (un)archives its tasks and issues. Do you want to proceed?"
-                                class="oe_stat_button" icon="fa-archive">
-                            <field name="active" widget="boolean_button"
-                                options='{"terminology": "archive"}'/>
                         </button>
                     </div>
                     <div class="oe_title">
@@ -414,6 +409,7 @@
             <field eval="2" name="priority"/>
             <field name="arch" type="xml">
                 <form string="Task" class="o_form_project_tasks">
+                    <field name="active" invisible="1"/>
                     <header>
                         <button name="action_assign_to_me" string="Assign to Me" type="object" class="oe_highlight"
                             attrs="{'invisible' : [('user_id', '!=', False)]}"/>
@@ -431,11 +427,6 @@
                         </button>
                         <button name="%(rating_rating_action_task)d" type="action" attrs="{'invisible': [('rating_count', '=', 0)]}" class="oe_stat_button" icon="fa-smile-o" groups="project.group_project_rating">
                             <field name="rating_count" string="Rating" widget="statinfo"/>
-                        </button>
-                        <button name="toggle_active" type="object" groups="base.group_user"
-                                class="oe_stat_button" icon="fa-archive">
-                            <field name="active" widget="boolean_button"
-                                options='{"terminology": "archive"}'/>
                         </button>
                     </div>
                     <field name="kanban_state" widget="state_selection"/>
@@ -677,7 +668,7 @@
             <field name="inherit_id" ref="analytic.view_account_analytic_account_form"/>
             <field eval="18" name="priority"/>
             <field name="arch" type="xml">
-                <xpath expr="//button[@name='toggle_active']" position="before">
+                <xpath expr="//div[@name='button_box']" position="inside">
                     <button class="oe_stat_button" type="object" name="projects_action"
                         icon="fa-puzzle-piece" attrs="{'invisible': [('project_count', '=', 0)]}">
                         <field string="Projects" name="project_count" widget="statinfo"/>

--- a/addons/project/views/res_partner_views.xml
+++ b/addons/project/views/res_partner_views.xml
@@ -9,13 +9,13 @@
             <field name="priority" eval="50"/>
             <field name="groups_id" eval="[(4, ref('project.group_project_user'))]"/>
             <field name="arch" type="xml">
-                <button name="toggle_active" position="before">
+                <div name="button_box" position="inside">
                     <button class="oe_stat_button" type="action" name="%(project_task_action_from_partner)d"
                         context="{'search_default_partner_id': active_id, 'default_partner_id': active_id}" attrs="{'invisible': [('task_count', '=', 0)]}"
                         icon="fa-tasks">
                         <field  string="Tasks" name="task_count" widget="statinfo"/>
                     </button>
-                </button>
+                </div>
             </field>
        </record>
 

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -594,12 +594,12 @@
             <field name="inherit_id" ref="product.product_template_only_form_view"/>
             <field name="groups_id" eval="[(4, ref('purchase.group_purchase_user'))]"/>
             <field name="arch" type="xml">
-                <button name="toggle_active" position="before">
+                <div name="button_box" position="inside">
                    <button class="oe_stat_button" name="%(purchase.action_purchase_line_product_tree)d"
                        type="action" icon="fa-shopping-cart" attrs="{'invisible': [('purchase_ok', '=', False)]}">
                        <field string="Purchases" name="purchase_count" widget="statinfo"/>
                    </button>
-                </button>
+                </div>
             </field>
         </record>
 

--- a/addons/purchase/views/res_partner_views.xml
+++ b/addons/purchase/views/res_partner_views.xml
@@ -73,12 +73,12 @@
             <field name="priority" eval="20"/>
             <field name="groups_id" eval="[(4, ref('purchase.group_purchase_user'))]"/>
             <field name="arch" type="xml">
-                <button name="toggle_active" position="before">
+                <div name="button_box" position="inside">
                     <button class="oe_stat_button" name="%(purchase.act_res_partner_2_purchase_order)d" type="action"
                         attrs="{'invisible': [('supplier', '=', False)]}" icon="fa-shopping-cart">
                         <field string="Purchases" name="purchase_order_count" widget="statinfo"/>
                     </button>
-                </button>
+                </div>
                 <page name="internal_notes" position="inside">
                     <group colspan="2" col="2" groups="purchase.group_warning_purchase">
                         <separator string="Warning on the Purchase Order" colspan="4"/>
@@ -97,12 +97,12 @@
             <field name="priority" eval="20"/>
             <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]"/>
             <field name="arch" type="xml">
-                <button name="toggle_active" position="before">
+                <div name="button_box" position="inside">
                     <button class="oe_stat_button" name="%(purchase.act_res_partner_2_supplier_invoices)d" type="action"
                         attrs="{'invisible': [('supplier', '=', False)]}" icon="fa-pencil-square-o" help="Vendor Bills">
                         <field string="Vendor Bills" name="supplier_invoice_count" widget="statinfo"/>
                     </button>
-                </button>
+                </div>
             </field>
         </record>
 </odoo>

--- a/addons/resource/views/resource_views.xml
+++ b/addons/resource/views/resource_views.xml
@@ -33,7 +33,6 @@
                     <field name="name"/>
                     <field name="user_id" attrs="{'required':[('resource_type','=','user')], 'readonly':[('resource_type','=','material')]}"/>
                     <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
-                    <field name="active"/>
                    </group>
                    <group>
                     <field name="resource_type" />

--- a/addons/sale/views/res_partner_views.xml
+++ b/addons/sale/views/res_partner_views.xml
@@ -40,13 +40,13 @@
             <field name="priority" eval="20"/>
             <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
             <field name="arch" type="xml">
-                <button name="toggle_active" position="before">
+                <div name="button_box" position="inside">
                     <button class="oe_stat_button" type="action" name="%(sale.act_res_partner_2_sale_order)d" 
                         attrs="{'invisible': [('customer', '=', False)]}"
                         icon="fa-usd">
                         <field string="Sales" name="sale_order_count" widget="statinfo"/>
                     </button>     
-                </button>
+                </div>
                 <page name="internal_notes" position="inside">
                     <group colspan="2" col="2" groups="sale.group_warning_sale">
                         <separator string="Warning on the Sales Order" colspan="4" />

--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -641,12 +641,12 @@
             <field name="inherit_id" ref="product.product_normal_form_view"/>
             <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
             <field name="arch" type="xml">
-                <button name="toggle_active" position="before">
+                <div name="button_box" position="inside">
                     <button class="oe_stat_button" name="%(action_product_sale_list)d"
                         type="action" icon="fa-usd">
                         <field string="Sales" name="sales_count" widget="statinfo" />
                     </button>
-                </button>
+                </div>
                 <group name="description" position="after">
                     <group string="Warning when Selling this Product" groups="sale.group_warning_sale">
                         <field name="sale_line_warn" nolabel="1"/>
@@ -663,12 +663,12 @@
             <field name="inherit_id" ref="product.product_template_only_form_view"/>
             <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
             <field name="arch" type="xml">
-                <button name="toggle_active" position="before">
+                <div name="button_box" position="inside">
                     <button class="oe_stat_button" name="action_view_sales"
                         type="object" icon="fa-usd" attrs="{'invisible': [('sale_ok', '=', False)]}">
                         <field string="Sales" name="sales_count" widget="statinfo" />
                     </button>
-                </button>
+                </div>
                 <group name="description" position="after">
                     <group string="Warning when Selling this Product" groups="sale.group_warning_sale">
                         <field name="sale_line_warn" nolabel="1"/>

--- a/addons/sale_crm/views/crm_lead_views.xml
+++ b/addons/sale_crm/views/crm_lead_views.xml
@@ -15,7 +15,7 @@
                                   'default_medium_id': medium_id,
                                   'default_source_id': source_id}"/>
                 </xpath>
-                <button name="toggle_active" position="before">
+                <div name="button_box" position="inside">
                     <button class="oe_stat_button" type="action"
                             name="%(sale_action_quotations)d" icon="fa-pencil-square-o"
                             context="{'default_partner_id': partner_id, 'search_default_draft': 1}">
@@ -32,7 +32,7 @@
                             <span class="o_stat_text"> Orders</span>
                         </div>
                     </button>
-                </button>
+                </div>
             </field>
         </record>
 

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -22,7 +22,7 @@
             <field name="groups_id" eval="[(4, ref('base.group_user'))]"/>
             <field name="inherit_id" ref="project.view_task_form2"/>
             <field name="arch" type="xml">
-                <xpath expr="//button[@name='toggle_active']" position="before">
+                <xpath expr="//div[@name='button_box']" position="inside">
                     <button type="object" name="action_view_so"
                             class="oe_stat_button" icon="fa-dollar"
                             attrs="{'invisible': [('sale_line_id', '=', False)]}"

--- a/addons/sales_team/views/crm_team_views.xml
+++ b/addons/sales_team/views/crm_team_views.xml
@@ -46,11 +46,7 @@
             <field name="arch" type="xml">
                 <form string="Sales Channel">
                     <sheet>
-                      <div class="oe_button_box" name="button_box">
-                            <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive">
-                                <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                            </button>
-                        </div>
+                        <div class="oe_button_box" name="button_box"></div>
                         <div class="oe_title">
                             <label for="name" class="oe_edit_only" string="Sales Channel"/>
                             <h1>

--- a/addons/stock/views/procurement_views.xml
+++ b/addons/stock/views/procurement_views.xml
@@ -59,11 +59,7 @@
             <field eval="10" name="priority"/>
             <field name="arch" type="xml">
                 <form string="Procurement Rule">
-                    <div class="oe_button_box" name="button_box">
-                        <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive">
-                            <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                        </button>
-                    </div>
+                    <div class="oe_button_box" name="button_box"></div>
                     <div class="oe_title">
                         <label for="name" class="oe_edit_only"/>
                         <h1><field name="name" placeholder="e.g. Buy"/></h1>

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -170,7 +170,7 @@
                             name="%(action_view_change_product_quantity)d"
                             attrs="{'invisible': [('type', '!=', 'product')]}"/>
                     </header>
-                    <button name="toggle_active" position="before">
+                    <div name="button_box" position="inside">
                         <button class="oe_stat_button"
                                name="%(product_open_quants)d"
                                icon="fa-building-o"
@@ -223,7 +223,7 @@
                             name="action_open_product_lot"
                             attrs="{'invisible': [('tracking', '=', 'none')]}"
                             class="oe_stat_button" icon="fa-bars" groups="stock.group_production_lot"/>
-                    </button>
+                    </div>
                 </data>
             </field>
         </record>
@@ -238,7 +238,7 @@
                     <header position="inside" >
                         <button name="%(action_view_change_product_quantity)d" string="Update Qty On Hand" type="action" attrs="{'invisible': [('type', '!=', 'product')]}"/>
                     </header>
-                    <button name="toggle_active" position="before">
+                    <div name="button_box" position="inside">
                         <button type="object"
                             name="action_open_quants"
                             attrs="{'invisible':[('type', '!=', 'product')]}"
@@ -292,7 +292,7 @@
                             name="action_open_product_lot"
                             attrs="{'invisible': [('tracking', '=', 'none')]}"
                             class="oe_stat_button" icon="fa-bars" groups="stock.group_production_lot"/>
-                    </button>
+                    </div>
 
                     <!-- change attrs of fields added in view_template_property_form
                     to restrict the display for templates -->

--- a/addons/stock/views/stock_incoterms_views.xml
+++ b/addons/stock/views/stock_incoterms_views.xml
@@ -19,11 +19,7 @@
             <field name="arch" type="xml">
                 <form string="Incoterms">
                     <sheet>
-                        <div class="oe_button_box" name="button_box">
-                            <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive">
-                                <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                            </button>
-                        </div>
+                        <div class="oe_button_box" name="button_box"></div>
                         <group>
                             <field name="name"/>
                             <field name="code"/>

--- a/addons/stock/views/stock_location_views.xml
+++ b/addons/stock/views/stock_location_views.xml
@@ -22,9 +22,6 @@
                             icon="fa-filter" name="%(act_product_location_open)d" type="action"
                             context="{'location_id': active_id}"
                             />
-                   <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive">
-                        <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                    </button>
                 </div>
                 <label for="name" class="oe_edit_only"/>
                 <h1><field name="name"/></h1>
@@ -171,11 +168,7 @@
             <field name="model">stock.location.path</field>
             <field name="arch" type="xml">
                 <form string="Location Paths">
-                    <div class="oe_button_box" name="button_box">
-                        <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive" groups="stock.group_adv_location">
-                            <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                        </button>
-                    </div>
+                    <div class="oe_button_box" name="button_box"></div>
                     <div class="oe_title">
                         <label for="name" class="oe_edit_only"/>
                         <h1><field name="name"/></h1>
@@ -231,11 +224,7 @@
             <field name="arch" type="xml">
                 <form string="Route">
                     <sheet>
-                        <div class="oe_button_box" name="button_box">
-                            <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive" groups="stock.group_adv_location">
-                                <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                            </button>
-                        </div>
+                        <div class="oe_button_box" name="button_box"></div>
                         <div class="oe_title">
                             <label for="name" class="oe_edit_only"/>
                             <h1><field name="name"/></h1>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -31,11 +31,7 @@
             <field name="arch" type="xml">
                 <form string="Operation Types">
                     <sheet>
-                        <div class="oe_button_box" name="button_box">
-                            <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive">
-                                <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                            </button>
-                        </div>
+                        <div class="oe_button_box" name="button_box"></div>
                         <group>
                             <group>
                                 <field name="name"/>

--- a/addons/stock/views/stock_warehouse_views.xml
+++ b/addons/stock/views/stock_warehouse_views.xml
@@ -13,9 +13,6 @@
                                     icon="fa-refresh"
                                     class="oe_stat_button"
                                     type="object"/>
-                            <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive">
-                                <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                            </button>
                         </div>
                         <label for="name" class="oe_edit_only"/>
                         <h1><field name="name"/></h1>
@@ -194,11 +191,7 @@
             <field name="arch" type="xml">
                 <form string="Reordering Rules">
                     <sheet>
-                        <div class="oe_button_box" name="button_box">
-                            <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive">
-                                <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                            </button>
-                        </div>
+                        <div class="oe_button_box" name="button_box"></div>
                         <group>
                             <group>
                                 <field name="name" />

--- a/addons/stock_landed_costs/views/stock_landed_cost_views.xml
+++ b/addons/stock_landed_costs/views/stock_landed_cost_views.xml
@@ -189,11 +189,7 @@
             <field name="arch" type="xml">
                 <form string="Landed Costs">
                     <sheet>
-                        <div class="oe_button_box" name="button_box">
-                            <button name="toggle_active" type="object" groups="base.group_user" class="oe_stat_button" icon="fa-archive">
-                                <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                            </button>
-                        </div>
+                        <div class="oe_button_box" name="button_box"></div>
                         <field name="image_medium" widget="image" class="oe_avatar"/>
                         <div class="oe_title">
                             <div class="oe_edit_only">

--- a/addons/survey/views/survey_views.xml
+++ b/addons/survey/views/survey_views.xml
@@ -170,9 +170,6 @@
                                 icon="fa-pencil-square-o">
                                 <field string="Answers" name="tot_comp_survey" widget="statinfo"/>
                             </button>
-                            <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive" attrs="{'invisible': [('is_closed', '=', False)]}">
-                                <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                            </button>
                         </div>
                         <div class="oe_title" style="width: 100%;">
                             <label for="title" class="oe_edit_only"/>

--- a/addons/utm/views/utm.xml
+++ b/addons/utm/views/utm.xml
@@ -54,7 +54,6 @@
                 <form string="Channel">
                     <group>
                         <field name="name"/>
-                        <field name="active"/>
                     </group>
                 </form>
             </field>

--- a/addons/web/static/src/js/chrome/sidebar.js
+++ b/addons/web/static/src/js/chrome/sidebar.js
@@ -47,7 +47,25 @@ var Sidebar = Widget.extend({
     start: function () {
         this._super.apply(this, arguments);
         this.$el.addClass('btn-group');
-        this._redraw();
+        this.redraw();
+    },
+    /**
+     * Method that renders the sidebar when there is a data update
+     *
+     * @private
+     */
+    redraw: function () {
+        this.$el.html(QWeb.render('Sidebar', {widget: this}));
+
+        // Hides Sidebar sections when item list is empty
+        this.$('.o_dropdown').each(function () {
+            if (!$(this).find('li').length) {
+                $(this).hide();
+            }
+        });
+        this.$("[title]").tooltip({
+            delay: { show: 500, hide: 0}
+        });
     },
 
     //--------------------------------------------------------------------------
@@ -61,7 +79,7 @@ var Sidebar = Widget.extend({
      */
     updateEnv: function (env) {
         this.env = env;
-        this._redraw();
+        this.redraw();
     },
 
     //--------------------------------------------------------------------------
@@ -166,24 +184,6 @@ var Sidebar = Widget.extend({
                     });
                 });
             }
-        });
-    },
-    /**
-     * Method that renders the sidebar when there is a data update
-     *
-     * @private
-     */
-    _redraw: function () {
-        this.$el.html(QWeb.render('Sidebar', {widget: this}));
-
-        // Hides Sidebar sections when item list is empty
-        this.$('.o_dropdown').each(function () {
-            if (!$(this).find('li').length) {
-                $(this).hide();
-            }
-        });
-        this.$("[title]").tooltip({
-            delay: { show: 500, hide: 0}
         });
     },
 

--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -717,6 +717,9 @@ var BasicModel = AbstractModel.extend({
             });
         }
 
+        if (options.fieldNames !== undefined) {
+            element.fieldNames = options.fieldNames;
+        }
         if (options.context !== undefined) {
             element.context = options.context;
         }

--- a/addons/web/static/src/js/views/form/form_view.js
+++ b/addons/web/static/src/js/views/form/form_view.js
@@ -41,6 +41,10 @@ var FormView = BasicView.extend({
         this.controllerParams.mode = mode;
 
         this.rendererParams.mode = mode;
+
+        if ('active' in this.loadParams.fields && !('active' in this.loadParams.fieldsInfo.form)) {
+            this.loadParams.fieldsInfo.form.active = {};
+        }
     },
 
     //--------------------------------------------------------------------------

--- a/addons/web/static/src/js/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/js/views/kanban/kanban_controller.js
@@ -10,6 +10,7 @@ odoo.define('web.KanbanController', function (require) {
 var BasicController = require('web.BasicController');
 var Context = require('web.Context');
 var core = require('web.core');
+var Domain = require('web.Domain');
 var view_dialogs = require('web.view_dialogs');
 
 var _t = core._t;
@@ -210,7 +211,16 @@ var KanbanController = BasicController.extend({
                 self.model.reload(record.id).then(function (db_id) {
                     var data = self.model.get(db_id);
                     var kanban_record = event.target;
-                    kanban_record.update(data);
+                    var domain = parent ? parent.domain : group.domain;
+                    if ('active' in data.data && _.pluck(domain, 0).indexOf('active') === -1) {
+                        domain = [['active', '=', true]].concat(domain);
+                    }
+                    var visible = new Domain(domain).compute(data.evalContext);
+                    if (visible) {
+                        kanban_record.update(data);
+                    } else {
+                        kanban_record.destroy();
+                    }
                 });
             },
         });

--- a/addons/web/static/src/js/views/list/list_controller.js
+++ b/addons/web/static/src/js/views/list/list_controller.js
@@ -138,7 +138,7 @@ var ListController = BasicController.extend({
                     callback: this._onToggleArchiveState.bind(this, true)
                 });
                 other.push({
-                    label: _t("Unarchive"),
+                    label: _t("Restore"),
                     callback: this._onToggleArchiveState.bind(this, false)
                 });
             }
@@ -462,7 +462,7 @@ var ListController = BasicController.extend({
         event.data.callback(env);
     },
     /**
-     * Called when clicking on 'Archive' or 'Unarchive' in the sidebar.
+     * Called when clicking on 'Archive' or 'Restore' in the sidebar.
      *
      * @private
      * @param {boolean} archive

--- a/addons/web/static/tests/views/form_tests.js
+++ b/addons/web/static/tests/views/form_tests.js
@@ -1672,7 +1672,7 @@ QUnit.module('Views', {
                         '<field name="foo"/>' +
                 '</form>',
             res_id: 1,
-            viewOptions: {sidebar: true},
+            viewOptions: {hasSidebar: true},
             mockRPC: function (route, args) {
                 if (args.method === 'toggle_active') {
                     assert.ok(args.args[0] === 1, "should call 'toggle_active' action");
@@ -1700,7 +1700,7 @@ QUnit.module('Views', {
                         '<field name="foo"/>' +
                 '</form>',
             res_id: 1,
-            viewOptions: {sidebar: true},
+            viewOptions: {hasSidebar: true},
             mockRPC: function (route, args) {
                 if (args.method === 'search_read' && args.model === 'ir.attachment') {
                     return $.when([]);

--- a/addons/web/static/tests/views/kanban_tests.js
+++ b/addons/web/static/tests/views/kanban_tests.js
@@ -2547,6 +2547,42 @@ QUnit.module('Views', {
         kanban.destroy();
     });
 
+    QUnit.test('button executes action and check domain', function (assert) {
+        assert.expect(2);
+
+        var data = this.data;
+        data.partner.fields.active = {string: "Active", type: "boolean", default: true};
+        for (var k in this.data.partner.records) {
+            data.partner.records[k].active = true;
+        }
+
+        var kanban = createView({
+            View: KanbanView,
+            model: "partner",
+            data: data,
+            arch:
+                '<kanban>' +
+                    '<templates><div t-name="kanban-box">' +
+                        '<field name="foo"/>' +
+                        '<field name="active"/>' +
+                        '<button type="object" name="a1" />' +
+                        '<button type="object" name="toggle_active" />' +
+                    '</div></templates>' +
+                '</kanban>',
+        });
+
+        testUtils.intercept(kanban, 'execute_action', function (event) {
+            data.partner.records[0].active = false;
+            event.data.on_closed();
+        });
+
+        assert.strictEqual(kanban.$('.o_kanban_record:contains(yop)').length, 1, "should display 'yop' record");
+        kanban.$('.o_kanban_record:contains(yop) button[data-name="toggle_active"]').click();
+        assert.strictEqual(kanban.$('.o_kanban_record:contains(yop)').length, 0, "should remove 'yop' record from the view");
+
+        kanban.destroy();
+    });
+
     QUnit.test('rendering date and datetime', function (assert) {
         assert.expect(2);
 

--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -76,7 +76,6 @@
                             </group>
                             <group>
                                 <field name="website_id"/>
-                                <field name="active"/>
                                 <field name="sequence"/>
                             </group>
                         </group>

--- a/addons/website_blog/views/website_blog_views.xml
+++ b/addons/website_blog/views/website_blog_views.xml
@@ -23,11 +23,7 @@
             <field name="arch" type="xml">
                 <form string="Blog">
                     <sheet>
-                        <div class="oe_button_box" name="button_box">
-                            <button name="toggle_active" type="object" confirm="(Un)archiving a blog automatically (un)archives its posts. Do you want to proceed?" class="oe_stat_button" icon="fa-archive">
-                                <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                            </button>
-                        </div>
+                        <div class="oe_button_box" name="button_box"></div>
                         <group>
                             <field name="name"/>
                             <field name="subtitle"/>
@@ -68,9 +64,6 @@
                             <button class="oe_stat_button" name="website_publish_button"
                                 type="object" icon="fa-globe">
                                 <field name="website_published" widget="website_button"/>
-                            </button>
-                            <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive">
-                                <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
                             </button>
                         </div>
                         <group>

--- a/addons/website_crm_partner_assign/views/res_partner_views.xml
+++ b/addons/website_crm_partner_assign/views/res_partner_views.xml
@@ -70,7 +70,6 @@
                     <group>
                         <field name="partner_weight"/>
                         <field name="sequence"/>
-                        <field name="active"/>
                     </group>
                 </sheet>
             </form>

--- a/addons/website_customer/views/res_partner_views.xml
+++ b/addons/website_customer/views/res_partner_views.xml
@@ -22,7 +22,6 @@
                         <field name="name"/>
                         <field name="classname"/>
                         <field name="website_published"/>
-                        <field name="active"/>
                     </group>
                 </form>
             </field>

--- a/addons/website_event/views/event_views.xml
+++ b/addons/website_event/views/event_views.xml
@@ -30,7 +30,7 @@
         <field name="model">event.event</field>
         <field name="inherit_id" ref="event.view_event_form"/>
         <field name="arch" type="xml">
-            <button name="toggle_active" position="before">
+            <div name="button_box" position="inside">
                 <field name="website_url" invisible="1"/>
                 <button name="website_publish_button"
                         type="object"
@@ -38,7 +38,7 @@
                         icon="fa-globe">
                     <field name="website_published" widget="website_button"/>
                 </button>
-            </button>
+            </div>
             <label for="is_online" position="after">
                 <field name="website_menu"/>
                 <label for="website_menu" string="Website Menu"/>

--- a/addons/website_event_track/views/event_track_views.xml
+++ b/addons/website_event_track/views/event_track_views.xml
@@ -118,9 +118,6 @@
                                 type="object" icon="fa-globe">
                                 <field name="website_published" widget="website_button"/>
                             </button>
-                            <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive">
-                                <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                            </button>
                         </div>
                         <field name="kanban_state" widget="state_selection"/>
                         <div class="oe_title">

--- a/addons/website_forum/views/forum.xml
+++ b/addons/website_forum/views/forum.xml
@@ -27,11 +27,7 @@
             <field name="arch" type="xml">
                 <form string="Forum">
                     <sheet>
-                        <div class="oe_button_box" name="button_box">
-                            <button name="toggle_active" type="object" confirm="(Un)archiving a forum automatically (un)archives its posts. Do you want to proceed?" class="oe_stat_button" icon="fa-archive">
-                                <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                            </button>
-                        </div>
+                        <div class="oe_button_box" name="button_box"></div>
                         <label for="name" class="oe_edit_only"/>
                         <h1>
                             <field name="name"/>
@@ -146,11 +142,7 @@
             <field name="arch" type="xml">
                 <form string="Forum Post">
                     <sheet>
-                        <div class="oe_button_box" name="button_box">
-                            <button name="toggle_active" type="object" confirm="(Un)archiving a post automatically (un)archives its answers. Do you want to proceed?" class="oe_stat_button" icon="fa-archive">
-                                <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                            </button>
-                        </div>
+                        <div class="oe_button_box" name="button_box"></div>
                         <label for="name" class="oe_edit_only"/>
                         <h1>
                             <field name="name" placeholder="Name"/>

--- a/addons/website_forum/views/res_users.xml
+++ b/addons/website_forum/views/res_users.xml
@@ -11,12 +11,12 @@
                 <field name="signature" position="after">
                     <field name="karma" string="Forum Karma"/>
                 </field>
-                <button name="toggle_active" position="before">
+                <div name="button_box" position="inside">
                     <button class="oe_stat_button" name="open_website_url"
                         type="object" icon="fa-globe">
                         <field name="website_published" widget="website_button"/>
                     </button>
-                </button>
+                </div>
             </field>
         </record>
 

--- a/addons/website_hr/views/hr_employee_views.xml
+++ b/addons/website_hr/views/hr_employee_views.xml
@@ -6,12 +6,12 @@
         <field name="model">hr.employee</field>
         <field name="inherit_id" ref="hr.view_employee_form"/>
         <field name="arch" type="xml">
-            <button name="toggle_active" position="before">
+            <div name="button_box" position="inside">
                 <button class="oe_stat_button" name="website_publish_button"
                     type="object" icon="fa-globe" groups="hr.group_hr_user">
                     <field name="website_published" widget="website_button"/>
                 </button>
-            </button>
+            </div>
             <xpath expr="//page[@name='public']/group" position="inside">
                 <group>
                     <field name="public_info"/>

--- a/addons/website_partner/views/res_partner_views.xml
+++ b/addons/website_partner/views/res_partner_views.xml
@@ -7,12 +7,12 @@
         <field eval="18" name="priority"/>
         <field name="arch" type="xml">
             <data>
-                <button name="toggle_active" position="before">
+                <div name="button_box" position="inside">
                     <button class="oe_stat_button" name="website_publish_button"
                         type="object" icon="fa-globe">
                         <field name="website_published" widget="website_button"/>
                     </button>
-                </button>
+                </div>
             </data>
         </field>
     </record>

--- a/addons/website_quote/views/sale_quote_views.xml
+++ b/addons/website_quote/views/sale_quote_views.xml
@@ -17,9 +17,6 @@
                 <form string="Sale Quotation Template">
                     <sheet>
                         <div class="oe_button_box" name="button_box">
-                            <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive">
-                                <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                            </button>
                             <button string="Edit Template" type="object" name="open_template" class="oe_stat_button" icon="fa-pencil"/>
                         </div>
                         <div class="oe_title">

--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -82,12 +82,12 @@
                     <field name="website_style_ids" widget="many2many_tags" groups="base.group_no_one"/>
                 </group>
             </group>
-            <button name="toggle_active" position="before">
+            <div name="button_box" position="inside">
                 <button class="oe_stat_button" name="website_publish_button"
                     type="object" icon="fa-globe" attrs="{'invisible': [('sale_ok','=',False)]}">
                     <field name="website_published" widget="website_button"/>
                 </button>
-            </button>
+            </div>
             <xpath expr="//notebook[last()]" position="inside">
                 <page string="Images" groups="website_sale.group_website_multi_image">
                     <field name="product_image_ids" mode="kanban" context="{'default_name': name, 'default_product_tmpl_id': active_id}">

--- a/addons/website_sale_delivery/views/website_sale_delivery_views.xml
+++ b/addons/website_sale_delivery/views/website_sale_delivery_views.xml
@@ -11,7 +11,7 @@
                     <field name="website_description"  placeholder="Description displayed on the eCommerce and on online quotations."/>
                 </page>
             </xpath>
-            <xpath expr="//button[@name='toggle_active']" position='before'>
+            <xpath expr="//div[@name='button_box']" position='inside'>
                 <button class="oe_stat_button" name="website_publish_button" type="object" icon="fa-globe">
                     <field name="website_published" widget="website_button"/>
                 </button>

--- a/addons/website_sale_digital/views/website_sale_digital_view.xml
+++ b/addons/website_sale_digital/views/website_sale_digital_view.xml
@@ -5,11 +5,11 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_only_form_view" />
         <field name="arch" type="xml">
-            <button name="toggle_active" position="before">
+            <div name="button_box" position="inside">
                 <button class="oe_stat_button" name="action_open_attachments" type="object" icon="fa-file">
                     <field string="Portal Files" name="attachment_count" widget="statinfo" />
                 </button>
-            </button>
+            </div>
         </field>
     </record>
 
@@ -18,11 +18,11 @@
         <field name="model">product.product</field>
         <field name="inherit_id" ref="product.product_normal_form_view"/>
         <field name="arch" type="xml">
-             <button name="toggle_active" position="before">
+             <div name="button_box" position="inside">
                 <button class="oe_stat_button" name="action_open_attachments" type="object" icon="fa-file">
                     <field string="Portal Files" name="attachment_count" widget="statinfo" />
                 </button>
-            </button>
+            </div>
         </field>
     </record>
 </odoo>

--- a/addons/website_slides/views/website_slides_backend.xml
+++ b/addons/website_slides/views/website_slides_backend.xml
@@ -49,9 +49,6 @@
                                     type="object" icon="fa-globe">
                                 <field name="website_published" widget="website_button"/>
                             </button>
-                            <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive">
-                                <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
-                            </button>
                         </div>
                         <field name="image" widget="image" class="oe_avatar" options='{"preview_image": "image_thumb"}' readonly="1"/>
                         <div class="oe_title">
@@ -218,9 +215,6 @@
                             <button class="oe_stat_button" name="website_publish_button"
                                     type="object" icon="fa-globe">
                                 <field name="website_published" widget="website_button"/>
-                            </button>
-                            <button name="toggle_active" type="object" confirm="(Un)archiving a channel automatically (un)archives its slides. Do you want to proceed?" class="oe_stat_button" icon="fa-archive">
-                                <field name="active" widget="boolean_button" options='{"terminology": "archive"}'/>
                             </button>
                         </div>
                         <div class="oe_title">

--- a/odoo/addons/base/views/ir_cron_views.xml
+++ b/odoo/addons/base/views/ir_cron_views.xml
@@ -7,13 +7,6 @@
             <field name="mode">primary</field>
             <field name="inherit_id" ref="base.view_server_action_form"/>
             <field name="arch" type="xml">
-                <div class="oe_title" position="before">
-                    <div class="oe_button_box" name="button_box">
-                        <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive">
-                            <field name="active" widget="boolean_button"/>
-                        </button>
-                    </div>
-                </div>
                 <xpath expr="//button[@name='create_action']" position="replace">
                     <button name="method_direct_trigger" type="object" string="Run Manually" class="oe_highlight"/>
                 </xpath>

--- a/odoo/addons/base/views/ir_filters_views.xml
+++ b/odoo/addons/base/views/ir_filters_views.xml
@@ -12,7 +12,6 @@
                         <field name="model_id"/>
                         <field name="is_default"/>
                         <field name="action_id"/>
-                        <field name="active"/>
                     </group>
                     <group>
                         <field name="domain" widget="domain" options="{'model': 'model_id'}"/>

--- a/odoo/addons/base/views/ir_model_views.xml
+++ b/odoo/addons/base/views/ir_model_views.xml
@@ -550,7 +550,6 @@
                         <field name="name"/>
                         <field name="model_id"/>
                         <field name="group_id"/>
-                        <field name="active"/>
                     </group>
                     <group string="Access" col="4">
                         <field name="perm_read"/>

--- a/odoo/addons/base/views/ir_rule_views.xml
+++ b/odoo/addons/base/views/ir_rule_views.xml
@@ -6,11 +6,7 @@
             <field name="arch" type="xml">
                 <form string="Record rules">
                   <sheet>
-                    <div class="oe_button_box" name="button_box">
-                        <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-archive">
-                            <field name="active" widget="boolean_button"/>
-                        </button>
-                    </div>
+                    <div class="oe_button_box" name="button_box"></div>
                     <group>
                         <group string="General">
                             <field name="name"/>

--- a/odoo/addons/base/views/ir_sequence_views.xml
+++ b/odoo/addons/base/views/ir_sequence_views.xml
@@ -13,7 +13,6 @@
                       </group>
                       <group>
                         <field name="code"/>
-                        <field name="active"/>
                         <field name="company_id" groups="base.group_multi_company"/>
                       </group>
                     </group>

--- a/odoo/addons/base/views/ir_ui_view_views.xml
+++ b/odoo/addons/base/views/ir_ui_view_views.xml
@@ -12,7 +12,6 @@
                             <field name="type"/>
                             <field name="model"/>
                             <field name="priority"/>
-                            <field name="active"/>
                         </group>
                         <group groups="base.group_no_one">
                             <field name="field_parent"/>

--- a/odoo/addons/base/views/res_bank_views.xml
+++ b/odoo/addons/base/views/res_bank_views.xml
@@ -26,7 +26,6 @@
                         <group string="Communication">
                             <field name="phone"/>
                             <field name="email" widget="email"/>
-                            <field name="active"/>
                         </group>
                     </group>
                 </form>

--- a/odoo/addons/base/views/res_currency_views.xml
+++ b/odoo/addons/base/views/res_currency_views.xml
@@ -119,14 +119,10 @@
             <field name="arch" type="xml">
                 <form string="Currency">
                     <sheet>
+                        <field name="active" invisible="1"/>
                         <div class="oe_button_box" name="button_box">
                             <button class="oe_stat_button" string="Rates" type="action" name="%(act_view_currency_rates)d"
                                 icon="fa-money" widget="statinfo" attrs="{'invisible': [('active', '=', False)]}"/>
-                            <button name="toggle_active" type="object"
-                                    class="oe_stat_button" icon="fa-archive">
-                                <field name="active" widget="boolean_button"
-                                    options='{"terminology": "active"}'/>
-                            </button>
                         </div>
                         <group>
                             <group>

--- a/odoo/addons/base/views/res_lang_views.xml
+++ b/odoo/addons/base/views/res_lang_views.xml
@@ -24,11 +24,6 @@
             <field name="arch" type="xml">
                 <form string="Languages">
                     <sheet>
-                        <div class="oe_button_box" name="button_box">
-                            <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-check">
-                                <field name="active" widget="boolean_button" options='{"terminology": "active"}'/>
-                            </button>
-                        </div>
                         <div class="oe_title">
                             <label for="name" class="oe_edit_only"/>
                             <h1><field name="name"/></h1>

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -195,13 +195,7 @@
             <field name="arch" type="xml">
                 <form string="Partners">
                 <sheet>
-                    <div class="oe_button_box" name="button_box">
-                        <button name="toggle_active" type="object"
-                                class="oe_stat_button" icon="fa-archive">
-                            <field name="active" widget="boolean_button"
-                                options='{"terminology": "archive"}'/>
-                        </button>
-                    </div>
+                    <div class="oe_button_box" name="button_box"></div>
                     <field name="image" widget='image' class="oe_avatar" options='{"preview_image": "image_medium", "size": [90, 90]}'/>
                     <div class="oe_title">
                         <field name="is_company" invisible="1"/>
@@ -625,7 +619,6 @@
                 <form string="Contact Tag">
                     <group col="4">
                         <field name="name"/>
-                        <field name="active"/>
                         <field name="parent_id"/>
                     </group>
                 </form>
@@ -664,7 +657,6 @@
                     <group col="4">
                         <field name="name"/>
                         <field name="full_name"/>
-                        <field name="active"/>
                     </group>
                 </form>
             </field>

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -162,11 +162,7 @@
                     </header>
                     <sheet>
                         <field name="id" invisible="1"/>
-                        <div class="oe_button_box" name="button_box">
-                            <button name="toggle_active" type="object" class="oe_stat_button" icon="fa-check">
-                                <field name="active" widget="boolean_button" options='{"terminology": "active"}'/>
-                            </button>
-                        </div>
+                        <div class="oe_button_box" name="button_box"></div>
                         <field name="image" widget='image' class="oe_avatar" options='{"preview_image": "image_medium"}'/>
                         <div class="oe_title">
                             <label for="name" class="oe_edit_only"/>


### PR DESCRIPTION
In an onborading, poeple click on "Archive" -> they don't find the task
anymore. Remove "Active" button from the stat bar and move it in the
"Action" (only in form). The label is "Archive". When it is Archived,
the button become "Restore"

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
