### PR TITLE
[IMP] Introducing zoom level for wkhtmltopdf in paper formats

### DIFF
--- a/doc/cla/individual/danger89.md
+++ b/doc/cla/individual/danger89.md
@@ -8,4 +8,4 @@ declaration.
 
 Signed,
 
-Melroy van den Berg webmaster1989@gmail.com https://github.com/danger89
+Melroy van den Berg melroy@melroy.org https://github.com/danger89

--- a/doc/reference/reports.rst
+++ b/doc/reference/reports.rst
@@ -243,6 +243,8 @@ following attributes:
     format if you define the page dimensions.
 ``dpi``
     output DPI; 90 by default
+``zoom``
+    Zoom level output; 1.0 by default
 ``margin_top``, ``margin_bottom``, ``margin_left``, ``margin_right``
     margin sizes in mm
 ``page_height``, ``page_width``
@@ -270,6 +272,7 @@ Example::
         <field name="header_line" eval="False"/>
         <field name="header_spacing">3</field>
         <field name="dpi">80</field>
+        <field name="zoom">1.0</field>
     </record>
 
 .. _reference/reports/custom_reports:

--- a/odoo/addons/base/base_data.xml
+++ b/odoo/addons/base/base_data.xml
@@ -97,6 +97,7 @@ Administrator</span>]]></field>
             <field name="header_line" eval="False" />
             <field name="header_spacing">35</field>
             <field name="dpi">90</field>
+            <field name="zoom">1.0</field>
         </record>
 
         <record id="paperformat_us" model="report.paperformat">
@@ -113,6 +114,7 @@ Administrator</span>]]></field>
             <field name="header_line" eval="False" />
             <field name="header_spacing">35</field>
             <field name="dpi">90</field>
+            <field name="zoom">1.0</field>
         </record>
 
         <record id="paperformat_batch_deposit" model="report.paperformat">
@@ -129,6 +131,7 @@ Administrator</span>]]></field>
             <field name="header_line" eval="False" />
             <field name="header_spacing">0</field>
             <field name="dpi">90</field>
+            <field name="zoom">1.0</field>
         </record>
 
     </data>

--- a/odoo/addons/base/ir/ir_actions_report.py
+++ b/odoo/addons/base/ir/ir_actions_report.py
@@ -243,6 +243,11 @@ class IrActionsReport(models.Model):
                 else:
                     command_args.extend(['--dpi', str(paperformat_id.dpi)])
 
+            if specific_paperformat_args and specific_paperformat_args.get('data-report-zoom'):
+                command_args.extend(['--zoom', str(specific_paperformat_args['data-report-zoom'])])
+            elif paperformat_id.zoom:
+                command_args.extend(['--zoom', str(paperformat_id.zoom)])
+
             if specific_paperformat_args and specific_paperformat_args.get('data-report-header-spacing'):
                 command_args.extend(['--header-spacing', str(specific_paperformat_args['data-report-header-spacing'])])
             elif paperformat_id.header_spacing:

--- a/odoo/addons/base/res/report_paperformat.py
+++ b/odoo/addons/base/res/report_paperformat.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
@@ -60,6 +59,7 @@ class report_paperformat(models.Model):
     header_line = fields.Boolean('Display a header line', default=False)
     header_spacing = fields.Integer('Header spacing', default=35)
     dpi = fields.Integer('Output DPI', required=True, default=90)
+    zoom = fields.Float('Output Zoom Level', default=1.0)
     report_ids = fields.One2many('ir.actions.report', 'paperformat_id', 'Associated reports', help="Explicitly associated reports")
 
     @api.constrains('format')

--- a/odoo/addons/base/res/report_paperformat_views.xml
+++ b/odoo/addons/base/res/report_paperformat_views.xml
@@ -29,6 +29,7 @@
                         <field name="header_line" />
                         <field name="header_spacing" />
                         <field name="dpi" />
+                        <field name="zoom" />
                         <field name="report_ids" widget="many2many_tags" options="{'not_delete': True}"/>
                     </group>
                 </form>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: wkhtmltopdf has several issues in the past and in the current future, which caused a lot of frustration. Due to misbehavior of wkhtmltopdf `--dpi` parameter. However, wkhtmltopdf also support a zoom parameter which can also be used to fine tune your documents. This PR will add support for this zoom feature in wkhtmltopdf. And therefor makes it easier to manipulate (PDF) reports in Odoo.

See related issues:
 - https://github.com/odoo/odoo/wiki/Wkhtmltopdf
 - https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2156
 - https://github.com/wkhtmltopdf/wkhtmltopdf/issues/3741
 - https://github.com/wkhtmltopdf/wkhtmltopdf/issues/3651
 - And more...

Changes are *test & verified within Runbot*, and it seems to work fine!

Testing: You can test your changes yourself, by changing the current paper format settings. And increasing /decreasing the zoom field. Try to export a pdf (eg invoice), and compare the pdf file with an original (1.0 zoom factor). 

Current behavior before PR: Unable to use the `--zoom` parameter from wkhtmltopdf in Odoo. [Read more](https://wkhtmltopdf.org/usage/wkhtmltopdf.txt).

Desired behavior after PR is merged: You can set *besides the already* DPI setting also set the zoom factor (default `1.0` float number), the same default value wkhtmltopdf uses. The zoom factor can be set in the paper format section, below the DPI setting.

*Question to the developers:* I'm adding a new field to the paper format model, do I need to write some upgrader? Or will Odoo take case of this automatically?

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr