### PR TITLE
[FIX] tools.profiler: fix total number of calls while using @profiler…

### DIFF
--- a/odoo/tools/profiler.py
+++ b/odoo/tools/profiler.py
@@ -156,9 +156,11 @@ def profile(method=None, whitelist=None, blacklist=(None,), files=None,
                     v['report'][call['lineno']]['nb_queries'] += next_call['queries'] - call.get('queries', 0)
                 v['report'][call['lineno']]['delay'] += next_call['time'] - call['time']
 
+            total_nb = 0
             queries = 0
             delay = 0
             for call in v['report'].values():
+                total_nb += call['nb'] if call.get('nb') else 0
                 queries += call['nb_queries']
                 delay += call['delay']
 
@@ -183,7 +185,7 @@ def profile(method=None, whitelist=None, blacklist=(None,), files=None,
                 log.append('\n')
 
             log.append("\nTotal:\n%-10s%-10d%-10s\n\n" % (
-                        str(data['nb']),
+                        str(total_nb),
                         queries,
                         str(round(delay*100000)/100)))
 


### PR DESCRIPTION
… decorator

Task(issue): https://www.odoo.com/web#id=1807622&view_type=form&model=project.task&action=327&menu_id=4720

Pad: https://pad.odoo.com/p/r.6b1e774e751037ca2c6b244868cf6849

Description of the issue/feature this PR addresses:
when we use @profiler decorator, the total number of calls shows the number of calls in the last line only.
https://drive.google.com/file/d/1Sw0ef8BXEGnCLEp7sgtbGs3yBgGyoGVV/view

Desired behavior after PR is merged:
it should show the sum of the total number of calls in all the lines.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
