### PR TITLE
[FIX] payment_stripe: enable zip verification

### DIFF
--- a/addons/payment_stripe/static/src/js/stripe.js
+++ b/addons/payment_stripe/static/src/js/stripe.js
@@ -85,6 +85,7 @@ odoo.define('payment_stripe.stripe', function(require) {
                     description: $("input[name='invoice_num']").val(),
                     currency: currency,
                     amount: amount,
+                    zipCode: true,
                 });
         } else {
             var currency = $("input[name='currency']").val();
@@ -103,6 +104,7 @@ odoo.define('payment_stripe.stripe', function(require) {
                     description: $("input[name='invoice_num']").val(),
                     currency: currency,
                     amount: amount,
+                    zipCode: true,
                 });
             });
         }


### PR DESCRIPTION
Before this commit, the Stripe Checkout API was not set up to verify the ZIP code
which lead to some transaction denials.

Moreover, Stripe recommends to enable that check to avoid any disputes with the banks.

Hence, after this commit, the zip verification is enabled.

OPW 787008

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
