### PR TITLE
[FIX] api: Fixing a bug with context extraction from RPC calls

### DIFF
--- a/doc/cla/individual/crwr45.md
+++ b/doc/cla/individual/crwr45.md
@@ -1,0 +1,11 @@
+United Kingdom, 2018-02-01
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Charlie Wheeler-Robinson crwr@pigotts.org.uk https://github.com/crwr45

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -292,7 +292,7 @@ def split_context(method, args, kwargs):
         Return a triple ``context, args, kwargs``.
     """
     pos = len(getargspec(method).args) - 1
-    if pos < len(args):
+    if len(args) > 0 and pos < len(args):
         return args[pos], args[:pos], kwargs
     else:
         return kwargs.pop('context', None), args, kwargs


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When split_context is called with an empty list for 'args' it crashes
trying to access position -1 in that empty list. This was encountered
using odoorpc to call stock.picking.action_confirm().

Current behavior before PR:
2018-01-23 13:09:39,487 16294 ERROR odoo odoo.http: tuple index out of range
Traceback (most recent call last):
[...snip...]
  File "/home/odoo/odoo/odoo/api.py", line 680, in call_kw_multi
    context, args, kwargs = split_context(method, args, kwargs)
  File "/home/odoo/odoo/odoo/api.py", line 298, in split_context
    return args[pos], args[:pos], kwargs

Desired behavior after PR is merged:
This fix simply skips using args if it is empty and extracts the
context from kwargs.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
