### PR TITLE
[FIX] base: escape comma and ampersand in the email address 'name' sequence

### DIFF
--- a/odoo/addons/base/ir/ir_mail_server.py
+++ b/odoo/addons/base/ir/ir_mail_server.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from email import encoders
 from email.charset import Charset
 from email.header import Header
@@ -21,13 +20,6 @@ from odoo.tools import ustr, pycompat
 
 _logger = logging.getLogger(__name__)
 _test_logger = logging.getLogger('odoo.tests')
-
-try:
-  from unidecode import unidecode
-except ImportError:
-  _logger.warning('The python module unidecode is not installed. names in email addresses will be altered significantly')
-  def unidecode(string):
-    return ''.join(list(filter(lambda c: ord(c) < 128, string)))
 
 
 class MailDeliveryException(except_orm):
@@ -123,7 +115,6 @@ def encode_rfc2822_address_header(header_text):
         # also Header.__str__ in Python 3 "Returns an approximation of the
         # Header as a string, using an unlimited line length.", the old one
         # was "A synonym for Header.encode()." so call encode() directly?
-        name = unidecode(name)
         name = Header(pycompat.to_text(name)).encode()
         return formataddr((name, email))
 


### PR DESCRIPTION
Create a user with a name containing non ASCII chars like "Frédéric, le Grand"
(notice the comma in the middle)

Since comma and & are addresses separators
This means that the name above will be interpreted by the mail library
as Addr1: name empty, address "Frédéric"
Addr2: name: "Le grand", address "<whatever@you.chose>"

Before this commit, this case came to be, passing non-ascii characters as email addresses,
which the mail library doesn't like

After this commit, we force the escaping of those characters

OPW 815202

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
