### PR TITLE
Prevent direct changes to ir.actions.actions

### DIFF
--- a/odoo/addons/base/ir/ir_actions.py
+++ b/odoo/addons/base/ir/ir_actions.py
@@ -37,6 +37,21 @@ class IrActions(models.Model):
                                      ('report', 'Report')],
                                     required=True, default='action')
 
+    @api.model
+    def check_access_rights(self, operation, raise_exception=True):
+        if self._name != 'ir.actions.actions':
+            return super(IrActions, self).check_access_rights(operation, raise_exception=raise_exception)
+
+        assert operation in ('read', 'write', 'create', 'unlink'), 'Invalid access mode'
+
+        if operation == 'read':
+            return True
+
+        if raise_exception:
+            raise AccessError("Modifying server actions directly makes no sense")
+
+        return False
+
     def _compute_xml_id(self):
         res = self.get_external_id()
         for record in self:


### PR DESCRIPTION
* creating ir.actions.actions objects on their own makes no sense and will break other code as they'll find either an invalid type *or* a valid type which doesn't actually map into a record in the
  corresponding table
* while deleting ir.actions.actions records will also delete the related "child" record, it seems wholly unnecessary (just delete the child, the link works both ways)
* while altering the name of an ir.actions.actions is valid, this can be done through the child without the risk of altering the type to something incorrect (see first item)

First tried to do that via access rights, but the admin user ignores these entirely so...

Fixes #23057
