### PR TITLE
[REM][project] Remove the constraint that forbid to set a parent task…

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -545,12 +545,6 @@ class Task(models.Model):
         for task in self:
             task.subtask_count = self.search_count([('id', 'child_of', task.id), ('id', '!=', task.id)])
 
-    @api.constrains('parent_id')
-    def _check_subtask_project(self):
-        for task in self:
-            if task.parent_id.project_id and task.project_id != task.parent_id.project_id.subtask_project_id:
-                raise UserError(_("You can't define a parent task if its project is not correctly configured. The sub-task's project of the parent task's project should be this task's project"))
-
     # Override view according to the company definition
     @api.model
     def fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):


### PR DESCRIPTION
… when the current task is not in the right project. Since sometimes we need to fix that kind of data and sub task are not always in the 'right' project, this constraint is not very helpful and this constraint can be by passed anyway : Go back to the right project, set the parent task you want and change the project again.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
