### PR TITLE
[FIX] *: raise UserError on non-ASCII e-mail address

### DIFF
--- a/addons/mail/models/mail_alias.py
+++ b/addons/mail/models/mail_alias.py
@@ -8,6 +8,7 @@ import unicodedata
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 from odoo.tools import ustr
+from odoo.tools.mail import verify_ascii_address
 from odoo.tools.safe_eval import safe_eval
 
 _logger = logging.getLogger(__name__)
@@ -116,6 +117,9 @@ class Alias(models.Model):
         if parent_model_name:
             model = self.env['ir.model']._get(parent_model_name)
             vals['alias_parent_model_id'] = model.id
+        if vals.get('alias_domain'):
+            # only check the domain, since the alias_name goes through _clean_and_make_unique
+            verify_ascii_address(vals['alias_domain'])
         return super(Alias, self).create(vals)
 
     @api.multi
@@ -123,6 +127,9 @@ class Alias(models.Model):
         """"give a unique alias name if given alias name is already assigned"""
         if vals.get('alias_name') and self.ids:
             vals['alias_name'] = self._clean_and_make_unique(vals.get('alias_name'), alias_ids=self.ids)
+        if vals.get('alias_domain'):
+            # only check the domain, since the alias_name goes through _clean_and_make_unique
+            verify_ascii_address(vals['alias_domain'])
         return super(Alias, self).write(vals)
 
     @api.multi

--- a/odoo/addons/base/res/res_partner.py
+++ b/odoo/addons/base/res/res_partner.py
@@ -516,6 +516,8 @@ class Partner(models.Model):
             if any(u.has_group('base.group_user') for u in partner.user_ids if u != self.env.user):
                 self.env['res.users'].check_access_rights('write')
             partner._fields_sync(vals)
+        if vals.get('email'):
+            tools.mail.verify_ascii_address(vals['email'])
         return result
 
     @api.model
@@ -532,6 +534,8 @@ class Partner(models.Model):
         partner = super(Partner, self).create(vals)
         partner._fields_sync(vals)
         partner._handle_first_contact_creation()
+        if vals.get('email'):
+            tools.mail.verify_ascii_address(vals['email'])
         return partner
 
     @api.multi

--- a/odoo/addons/base/res/res_users.py
+++ b/odoo/addons/base/res/res_users.py
@@ -333,6 +333,8 @@ class Users(models.Model):
         user.partner_id.active = user.active
         if user.partner_id.company_id:
             user.partner_id.write({'company_id': user.company_id.id})
+        if vals.get('login'):
+            tools.mail.verify_ascii_address(vals['login'])
         return user
 
     @api.multi
@@ -375,6 +377,9 @@ class Users(models.Model):
             db = self._cr.dbname
             for id in self.ids:
                 self.__uid_cache[db].pop(id, None)
+
+        if values.get('login'):
+            tools.mail.verify_ascii_address(values['login'])
 
         return res
 

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -17,6 +17,7 @@ from lxml import etree
 import odoo
 from odoo.loglevels import ustr
 from odoo.tools import pycompat, misc
+from odoo.exceptions import UserError
 
 _logger = logging.getLogger(__name__)
 
@@ -533,3 +534,16 @@ def decode_smtp_header(smtp_header):
 # was mail_thread.decode_header()
 def decode_message_header(message, header, separator=' '):
     return separator.join(decode_smtp_header(h) for h in message.get_all(header, []) if h)
+
+
+def verify_ascii_address(address):
+    """
+    Verifies that the provided e-mail address is US-ASCII.
+    """
+    try:
+        address.encode('ascii')
+    except UnicodeEncodeError:
+        raise UserError(
+            "non-ASCII e-mail addresses are not currently supported by Odoo, please try again "
+            "with an ASCII e-mail address or a punycode-encoded e-mail address."
+        )


### PR DESCRIPTION
Before this commit:

* Create/Modify a user/partner/mail_alias or any other model that
contains an e-mail field.

* In the e-mail field, input an internationalized e-mail, i.e. an e-mail
containing unicode characters.

* Try to send an e-mail to such partner/user/etc, either via an invoice,
quotation, whatever kind of notification system from Odoo.

Result:

* No traceback on the frontend, but the logs will show that there was
    an error (that was catched by mail, probably), the error happened
    when the stdlib email tried to format the address, since the stdlib
    **only** supports RFC2822 e-mails and explicitly converts addresses
    to ascii, which of course will fail for non-ASCII e-mail addresses.

* The user, unaware of this error, would think that the message was
    sent but alas, that is not the case, the e-mail won't be sent and
    the user won't know it.

After this commit:

* After this commit, any e-mail field will **only** accept ASCII e-mail
addresses or alternatively, punycode-encoded e-mail addresses provided
by the user.

Rationale:

Unfortunately, the python stdlib `email` doesn't support non-ASCII
e-mail addresses and what's worse, it doesn't support *all* formats of
punycode encoding and decoding, which means that accepting non-ASCII
e-mails and trying to convert them to punycode and vice-versa would be a
very bad idea since it might not work with all e-mails.

See issue #23527 for more details.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
