### PR TITLE
[11.0] [BUG] Update calculation of tax_base_amount when tax is a child.

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -372,7 +372,7 @@ class AccountMoveLine(models.Model):
     def _compute_tax_base_amount(self):
         for move_line in self:
             if move_line.tax_line_id:
-                base_lines = move_line.move_id.line_ids.filtered(lambda line: move_line.tax_line_id in line.tax_ids)
+                base_lines = move_line.move_id.line_ids.filtered(lambda line: move_line.tax_line_id in line.tax_ids + line.tax_ids.mapped('children_tax_ids'))
                 move_line.tax_base_amount = abs(sum(base_lines.mapped('balance')))
             else:
                 move_line.tax_base_amount = 0


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Tax base amount is not calculated correctly on child tax. Create an invoice with tax line assigned on a tax that has children. The field tax_ids on the tax line has he value of the tax line from the invoice, meaning the parent tax. The lines created for the taxes contains in tax_line_id the children tax, so the calculation of tax_base_amount will be always 0 for child tax.

Current behavior before PR:
Tax_base_amount field is always 0.
Desired behavior after PR is merged:
Tax_base_amount field is sum of balance from parent tax lines.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
