### PR TITLE
[FIX] Account Payment: Wrong domain for journal_id field

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -368,8 +368,8 @@ class account_payment(models.Model):
         if self.partner_type:
             return {'domain': {'partner_id': [(self.partner_type, '=', True)]}}
 
-    @api.onchange('payment_type')
-    def _onchange_payment_type(self):
+    @api.onchange('payment_type', 'journal_id')
+    def _onchange_payment_type_journal(self):
         if not self.invoice_ids:
             # Set default partner type for the payment type
             if self.payment_type == 'inbound':


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Fix #23762

**Current behavior before PR:**

Wrong domain for journal_id field until changing the payment_type field

**Desired behavior after PR is merged:**

Domain works correctly.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
