### PR TITLE
[FIX] point_of_sale, sale_stock, stock_account: POS Anglo-Saxon Accounting

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -226,8 +226,7 @@ class PosOrder(models.Model):
                 if product_key[0] == "product":
                     line = grouped_data[product_key][0]
                     product = Product.browse(line['product_id'])
-                    # In the SO part, the entries will be inverted by function compute_invoice_totals
-                    price_unit = - product._get_anglo_saxon_price_unit()
+                    price_unit = self._get_pos_anglo_saxon_price_unit(product, line['partner_id'], line['quantity'])
                     account_analytic = Analytic.browse(line.get('analytic_account_id'))
                     res = Product._anglo_saxon_sale_move_lines(
                         line['name'], product, product.uom_id, line['quantity'], price_unit,
@@ -385,6 +384,16 @@ class PosOrder(models.Model):
             move.sudo().write({'line_ids': all_lines})
             move.sudo().post()
         return True
+
+    def _get_pos_anglo_saxon_price_unit(self, product, partner_id, quantity):
+        # In the SO part, the entries will be inverted by function compute_invoice_totals
+        price_unit = - product._get_anglo_saxon_price_unit()
+        if product._get_invoice_policy() == "delivery":
+            moves = self.filtered(lambda o: o.partner_id.id == partner_id).mapped('picking_id.move_lines').filtered(lambda m: m.product_id.id == product.id)
+            moves.sorted(lambda x: x.date)
+            average_price_unit = product._compute_average_price(quantity, quantity, moves)
+            price_unit = average_price_unit or price_unit
+        return price_unit
 
     def _reconcile_payments(self):
         for order in self:

--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -195,6 +195,9 @@ class ProductProduct(models.Model):
         for product in self:
             product.price = prices.get(product.id, 0.0)
 
+    def _get_invoice_policy(self):
+        return False
+
     def _set_product_price(self):
         for product in self:
             if self._context.get('uom'):

--- a/addons/sale/models/product_product.py
+++ b/addons/sale/models/product_product.py
@@ -21,3 +21,6 @@ class ProductProduct(models.Model):
         return r
 
     sales_count = fields.Integer(compute='_sales_count', string='# Sales')
+
+    def _get_invoice_policy(self):
+        return self.invoice_policy

--- a/addons/sale_stock/models/account_invoice.py
+++ b/addons/sale_stock/models/account_invoice.py
@@ -38,21 +38,4 @@ class AccountInvoiceLine(models.Model):
         return price_unit
 
     def _compute_average_price(self, qty_done, quantity, moves):
-        average_price_unit = 0
-        qty_delivered = 0
-        invoiced_qty = 0
-        for move in moves:
-            if move.state != 'done':
-                continue
-            invoiced_qty += move.product_qty
-            if invoiced_qty <= qty_done:
-                continue
-            qty_to_consider = move.product_qty
-            if invoiced_qty - move.product_qty < qty_done:
-                qty_to_consider = invoiced_qty - qty_done
-            qty_to_consider = min(qty_to_consider, quantity - qty_delivered)
-            qty_delivered += qty_to_consider
-            average_price_unit = (average_price_unit * (qty_delivered - qty_to_consider) + move.price_unit * qty_to_consider) / qty_delivered
-            if qty_delivered == quantity:
-                break
-        return average_price_unit
+        return self.env['product.product']._compute_average_price(qty_done, quantity, moves)

--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -205,6 +205,26 @@ class ProductProduct(models.Model):
             return price
         return self.uom_id._compute_price(price, uom)
 
+    def _compute_average_price(self, qty_done, quantity, moves):
+        average_price_unit = 0
+        qty_delivered = 0
+        invoiced_qty = 0
+        for move in moves:
+            if move.state != 'done':
+                continue
+            invoiced_qty += move.product_qty
+            if invoiced_qty <= qty_done:
+                continue
+            qty_to_consider = move.product_qty
+            if invoiced_qty - move.product_qty < qty_done:
+                qty_to_consider = invoiced_qty - qty_done
+            qty_to_consider = min(qty_to_consider, quantity - qty_delivered)
+            qty_delivered += qty_to_consider
+            average_price_unit = (average_price_unit * (qty_delivered - qty_to_consider) + move.price_unit * qty_to_consider) / qty_delivered
+            if qty_delivered == quantity:
+                break
+        return average_price_unit
+
 
 class ProductCategory(models.Model):
     _inherit = 'product.category'


### PR DESCRIPTION
In average price, the stock move cost related to the picking of the POS Order
must be used to compute the price.

opw:1802727