### PR TITLE
[FIX] account_asset: Access error with shared product with deferred revenue

### DIFF
--- a/addons/account_asset/account_asset_invoice.py
+++ b/addons/account_asset/account_asset_invoice.py
@@ -110,13 +110,12 @@ class AccountInvoiceLine(models.Model):
 class ProductTemplate(models.Model):
     _inherit = 'product.template'
     asset_category_id = fields.Many2one('account.asset.category', string='Asset Type', ondelete="restrict")
-    deferred_revenue_category_id = fields.Many2one('account.asset.category', string='Deferred Revenue Type', ondelete="restrict")
+    deferred_revenue_category_id = fields.Many2one('account.asset.category', string='Deferred Revenue Type', ondelete="restrict", company_dependent=True)
 
     @api.onchange('deferred_revenue_category_id')
     def onchange_deferred_revenue(self):
         if self.deferred_revenue_category_id:
             self.property_account_income_id = self.deferred_revenue_category_id.account_asset_id
-            self.company_id = self.deferred_revenue_category_id.company_id
 
     @api.onchange('asset_category_id')
     def onchange_asset(self):


### PR DESCRIPTION
Steps to reproduce the bug:
-Let's consider a multicompany environment with company A and B
-Let's consider a shared product P for A and B
-P has a deferred revenue type D set on it
-D is defined in A
-Let's consider a user U in company B
-U creates a SO with P and try to generate the invoice

Bug:

A access error was raised because U is not allowed to see D and
D is needed to genrate the invoice.

Fine tuning of this commit: ec7f88c334e10c81de4c05e62a06f4b6b2c19ae3

opw:1825944
