### PR TITLE
Add inheritance of 'format.address.mixin' into company, bank model so that we can localize address layout easily

### DIFF
--- a/odoo/addons/base/res/res_bank.py
+++ b/odoo/addons/base/res/res_bank.py
@@ -17,6 +17,7 @@ def sanitize_account_number(acc_number):
 
 class Bank(models.Model):
     _description = 'Bank'
+    _inherit = ['format.address.mixin']
     _name = 'res.bank'
     _order = 'name'
 
@@ -31,6 +32,15 @@ class Bank(models.Model):
     phone = fields.Char()
     active = fields.Boolean(default=True)
     bic = fields.Char('Bank Identifier Code', index=True, help="Sometimes called BIC or Swift.")
+
+    @api.model
+    def _fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
+        if (not view_id) and (view_type == 'form'):
+            view_id = self.env.ref('base.view_res_bank_form').id
+        res = super(Bank, self)._fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
+        if view_type == 'form':
+            res['arch'] = self._fields_view_get_address(res['arch'])
+        return res
 
     @api.multi
     @api.depends('name', 'bic')

--- a/odoo/addons/base/res/res_company.py
+++ b/odoo/addons/base/res/res_company.py
@@ -11,6 +11,7 @@ from odoo.exceptions import ValidationError, UserError
 class Company(models.Model):
     _name = "res.company"
     _description = 'Companies'
+    _inherit = ['format.address.mixin']
     _order = 'sequence, name'
 
     @api.multi
@@ -119,6 +120,15 @@ class Company(models.Model):
     def _inverse_country(self):
         for company in self:
             company.partner_id.country_id = company.country_id
+
+    @api.model
+    def _fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
+        if (not view_id) and (view_type == 'form'):
+            view_id = self.env.ref('base.view_company_form').id
+        res = super(Company, self)._fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
+        if view_type == 'form':
+            res['arch'] = self._fields_view_get_address(res['arch'])
+        return res
 
     @api.depends('partner_id', 'partner_id.image')
     def _compute_logo_web(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

* We must replace all of the address fields by view inheritance to localize address layout.

Desired behavior after PR is merged:

* Use `address_view_id` of partner model to layout address fields of company, bank form view if available.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
