### PR TITLE
More grouping features

### DIFF
--- a/odoo/addons/test_read_group/models.py
+++ b/odoo/addons/test_read_group/models.py
@@ -9,6 +9,13 @@ class GroupOnDate(models.Model):
     value = fields.Integer("Value")
 
 
+class GroupOnDatetime(models.Model):
+    _name = 'test_read_group.on_datetime'
+
+    datetime = fields.Datetime("Datetime")
+    value = fields.Integer("Value")
+
+
 class BooleanAggregate(models.Model):
     _name = 'test_read_group.aggregate.boolean'
     _order = 'key DESC'

--- a/odoo/addons/test_read_group/tests/__init__.py
+++ b/odoo/addons/test_read_group/tests/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from . import test_group_number
 from . import test_group_only
 from . import test_empty
 from . import test_group_expand

--- a/odoo/addons/test_read_group/tests/__init__.py
+++ b/odoo/addons/test_read_group/tests/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from . import test_group_only
 from . import test_empty
 from . import test_group_expand
 from . import test_group_operator

--- a/odoo/addons/test_read_group/tests/test_group_number.py
+++ b/odoo/addons/test_read_group/tests/test_group_number.py
@@ -1,0 +1,29 @@
+from odoo.tests import common
+
+
+class TestDateNumber(common.TransactionCase):
+    """ Test grouping date:Nmonth and similar
+    """
+    def setUp(self):
+        super(TestDateNumber, self).setUp()
+        self.Model = self.env['test_read_group.on_date']
+
+    def test_group_month(self):
+        self.Model.create({'date': '2000-01-18', 'value': 1})
+        self.Model.create({'date': '2000-02-19', 'value': 20})
+        self.Model.create({'date': '2000-03-20', 'value': 300})
+
+
+        gb = self.Model.read_group([], ['date', 'value'], ['date:2month'], lazy=False)
+
+        self.assertSequenceEqual(sorted(gb, key=lambda r: r['date:2month'] or ''), [{
+            '__count': 2,
+            '__domain': ['&', ('date', '>=', '2000-01-01'), ('date', '<', '2000-03-01')],
+            'date:2month': 'January 2000',
+            'value': 21,
+        }, {
+            '__count': 1,
+            '__domain': ['&', ('date', '>=', '2000-03-01'), ('date', '<', '2000-05-01')],
+            'date:2month': 'March 2000',
+            'value': 300,
+        }])

--- a/odoo/addons/test_read_group/tests/test_group_only.py
+++ b/odoo/addons/test_read_group/tests/test_group_only.py
@@ -1,0 +1,30 @@
+from odoo.tests import common
+
+
+class TestDatetimeOnly(common.TransactionCase):
+    """ Test grouping date:only_INTERVAL1_..._INTERVALLAST
+    """
+    def setUp(self):
+        super(TestDatetimeOnly, self).setUp()
+        self.Model = self.env['test_read_group.on_datetime']
+
+    def test_only_hour(self):
+        self.Model.create({'datetime': '2000-12-18 12:01:02', 'value': 10})
+        self.Model.create({'datetime': '2000-12-18 13:01:02', 'value': 20})
+
+        self.Model.create({'datetime': '2000-12-19 12:01:02', 'value': 1})
+        self.Model.create({'datetime': '2000-12-19 13:01:02', 'value': 2})
+
+        gb = self.Model.read_group([], ['datetime', 'value'], ['datetime:only_hour'], lazy=False)
+
+        self.assertSequenceEqual(sorted(gb, key=lambda r: r['datetime:only_hour'] or ''), [{
+            '__count': 2,
+            '__domain': [('datetime', '=', '12:00:00')],
+            'datetime:only_hour': '12:00:00',
+            'value': 11,
+        }, {
+            '__count': 2,
+            '__domain': [('datetime', '=', '13:00:00')],
+            'datetime:only_hour': '13:00:00',
+            'value': 22,
+        }])

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1766,7 +1766,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
             'groupby': gb,
             'type': field_type,
             'normal_interval': bool(temporal and normal_interval),
-            'display_format': display_formats[gb_function] if temporal and normal_interval else None,
+            'display_format': display_formats[normal_interval[1]] if temporal and normal_interval else None,
             'interval': normal_interval[0] * time_intervals[normal_interval[1]] if temporal and normal_interval else None,
             'tz_convert': tz_convert,
             'qualified_field': qualified_field


### PR DESCRIPTION
**New type of grouping.** 

For example ``date:only_hour`` -- group by one of 24 value. Allows to analyze which hour of a day has most sales. Other examples:

                  * 'date:only_hour' -- group by every hour of a day (one of 24 values) 
                  * 'date:only_hour_15minute' -- group by every 15 min of a day (one of 24*4 values)
                  * 'date:only_dow' -- group by day of a week (one of 7 values)
                  * 'date:only_dow_hour' -- group by hour of each day of a week (one of 7*24 values)
                  * 'date:only_doy' -- group by day of a year (one of 365 values)

**More flexible usual grouping**

Allows to specify number in grouping, e.g. ``date:2month`` -- group by 2 monthes (Jan-Feb, Mar-Apr, etc.)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
