### PR TITLE
[FIX] mail: Wrong company displayed in the footer

### DIFF
--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -374,11 +374,12 @@ class MailTemplate(models.Model):
         res_to_rec = dict.fromkeys(res_ids, None)
         for record in records:
             res_to_rec[record.id] = record
+        author = self._context.get('author', False)
         variables = {
             'format_date': lambda date, format=False, context=self._context: format_date(self.env, date, format),
             'format_tz': lambda dt, tz=False, format=False, context=self._context: format_tz(self.env, dt, tz, format),
             'format_amount': lambda amount, currency, context=self._context: format_amount(self.env, amount, currency),
-            'user': self.env.user,
+            'user': author or self.env.user,
             'ctx': self._context,  # context kw would clash with mako internals
         }
         for res_id, record in res_to_rec.iteritems():

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -78,6 +78,7 @@ class Partner(models.Model):
         company_name = company.name;
 
         return {
+            'author': user,
             'signature': signature,
             'website_url': website_url,
             'company': company,


### PR DESCRIPTION
Steps to reproduce the bug:

- Set a multi company environment with two company A and B
- Set user admin in company A
- Set user demo in company B
- Create a PO with user demo
- Send a RFQ

Bug:

The company of the admin user was displayed in the footer of the email.

The function _notify called on res.parter model is called in sudo by
the function _notify on mail.message model.

The function render_template on mail.template model uses the user defined
on self.env to render the template. So the user admin was always used.

opw:1835647
