### PR TITLE
[11.0][web] the calendar events should use as background color of the color_index if it is a css color

### DIFF
--- a/addons/web/static/src/js/views/calendar/calendar_renderer.js
+++ b/addons/web/static/src/js/views/calendar/calendar_renderer.js
@@ -463,6 +463,13 @@ return AbstractRenderer.extend({
      */
     _renderEvents: function () {
         this.$calendar.fullCalendar('removeEvents');
+        for (var k in this.state.data) {
+            var key = this.state.data[k].color_index
+            // check if the key is a css color
+            if (typeof key === 'string' && key.match(/^((#[A-F0-9]{3})|(#[A-F0-9]{6})|((hsl|rgb)a?\(\s*(?:(\s*\d{1,3}%?\s*),?){3}(\s*,[0-9.]{1,4})?\))|)$/i)) {
+                this.state.data[k].color = this.state.data[k].color_index
+            }
+        }
         this.$calendar.fullCalendar('addEventSource', this.state.data);
     },
     /**


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fixes application of css colors to calendar events.

Current behavior before PR:
Currently, if you define a calendar view like:
calendar string="Meetings" color="color"
...
where color is an odoo field that contains a css color, it will apply that color to the calendar, but just in the section corresponding to groups:
![image](https://user-images.githubusercontent.com/7683926/39362712-b4a0291c-4a27-11e8-9a0b-d6822671150d.png)

But it does not apply that same background color to the events themselves, which is inconsistent.

Desired behavior after PR is merged:
Application of css colors is consistent in the calendar, both in the avatar and the event
![image](https://user-images.githubusercontent.com/7683926/39362765-e60d363e-4a27-11e8-9c53-8b855c1618f7.png)


@ged-odoo what do you think?

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
