### PR TITLE
[IMP] web, auth_signup: Login case insensitive and strip leading/trai…

### DIFF
--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -101,6 +101,8 @@ class AuthSignupHome(Home):
         """ Shared helper returning the rendering context for signup and reset password """
         qcontext = request.params.copy()
         qcontext.update(self.get_auth_signup_config())
+        if qcontext.get('login', False):
+            qcontext.update({'login': qcontext['login'].lower().strip()})
         if not qcontext.get('token') and request.session.get('auth_signup_token'):
             qcontext['token'] = request.session.get('auth_signup_token')
         if qcontext.get('token'):

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -465,6 +465,8 @@ class Home(http.Controller):
     def web_login(self, redirect=None, **kw):
         ensure_db()
         request.params['login_success'] = False
+        if request.params.get('login', False):
+            request.params['login'] = request.params['login'].lower().strip()
         if request.httprequest.method == 'GET' and redirect and request.session.uid:
             return http.redirect_with_hash(redirect)
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
I am running a SaaS platform and get many tickets with login problems.
It's always because users sign up with capital letters or mistakenly add a leading/trailing blank space.

**This is one easy solution but maybe you have a better one?**

Current behavior before PR:
Leading/Trailing spaces are not removed
Login is case sensitive

Desired behavior after PR is merged:
Login is case insensitive
Leading/Trailing spaces are removed

One question remains: How can this be included in migrations if e.g for existing DB's the following user names in Odoo will be regarded as same login:
"User1"
"user1"
"User1 "
" User1 "

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr