### PR TITLE
[FIX] account, account_payment: the residual on the invoice should be…

### DIFF
--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -213,6 +213,12 @@
                              <span t-field="invoice.amount_total" t-options='{"widget": "monetary", "display_currency": invoice.currency_id}'/>
                         </td>
                     </tr>
+                    <tr class="border-black">
+                        <td><strong>Amount Due</strong></td>
+                        <td class="text-right">
+                             <span t-field="invoice.residual" t-options='{"widget": "monetary", "display_currency": invoice.currency_id}'/>
+                        </td>
+                    </tr>
                 </table>
             </div>
         </div>

--- a/addons/account_payment/models/payment.py
+++ b/addons/account_payment/models/payment.py
@@ -130,7 +130,7 @@ class PaymentTransaction(models.Model):
             values.update(render_values)
         return self.acquirer_id.with_context(submit_class='btn btn-primary', submit_txt=submit_txt or _('Pay Now')).sudo().render(
             self.reference,
-            invoice.amount_total,
+            invoice.residual,
             invoice.currency_id.id,
             values=values,
         )
@@ -155,7 +155,7 @@ class PaymentTransaction(models.Model):
             tx_values = {
                 'acquirer_id': acquirer.id,
                 'type': tx_type,
-                'amount': invoice.amount_total,
+                'amount': invoice.residual,
                 'currency_id': invoice.currency_id.id,
                 'partner_id': invoice.partner_id.id,
                 'partner_country_id': invoice.partner_id.country_id.id,


### PR DESCRIPTION
… the amount paid

Make an invoice for a portal user and pay a part of it

Make the portal user go onto that invoice.

Before this commit, the "form" view of the invoice on the portal did not mention the amount due
and
the amount that was taken into accont was the total making it impossible to pay a partially paid
invoice on the portal

After this commit, the invoice view on the portal displays the amount due
Also, the amount due is the one that will be paid when clicking on pay

OPW 1839954

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
