### PR TITLE
[FIX] account, account_tax: Wrong computation with python tax

### DIFF
--- a/addons/account_tax_python/models/account_tax.py
+++ b/addons/account_tax_python/models/account_tax.py
@@ -40,6 +40,8 @@ class AccountTaxPython(models.Model):
         taxes = self.filtered(lambda r: r.amount_type != 'code')
         company = self.env.user.company_id
         for tax in self.filtered(lambda r: r.amount_type == 'code'):
+            invoice = self.env.context.get('invoice', False)
+            partner = invoice and invoice.partner_shipping_id or partner
             localdict = {'price_unit': price_unit, 'quantity': quantity, 'product': product, 'partner': partner, 'company': company}
             safe_eval(tax.python_applicable, localdict, mode="exec", nocopy=True)
             if localdict.get('result', False):


### PR DESCRIPTION
Steps to reproduce the bug:

- Create a tax T with a computation with python code
- Set the following code:
result = partner.country_id.code == 'AR' and price_unit * 0.10
- Create two customers C1 from Argentina and C2 not from Argentina
- Create a SO with partner_invoice_id = C2 and partner_shipping_id = C1 and confirm it
    - The tax T is applied on the SO and the total amount is impacted
- Generate the invoice of the SO
    - The tax T is applied on the invoice BUT the total amount was not impacted

Because the partner used to compute the tax on the invoice was the partner_invoice_id instead of
the partner_shipping_id.

opw:1839091
