### PR TITLE
[FIX] account, sale: Wrong partner on SO tax computation

### DIFF
--- a/addons/sale/models/account_invoice.py
+++ b/addons/sale/models/account_invoice.py
@@ -26,6 +26,9 @@ class AccountInvoice(models.Model):
         states={'draft': [('readonly', False)]},
         help="Delivery address for current invoice.")
 
+    def _get_partner_shipping_id(self):
+        return self.partner_shipping_id
+
     @api.onchange('partner_shipping_id')
     def _onchange_partner_shipping_id(self):
         """


### PR DESCRIPTION
Since this commit: bbc361d38904d756a3c9226904fec4a6d8e4ccd6

This is always the partner_shipping_id which is used to compute the taxes on a SO
So to have the same behavior on a invoice, we apply the same logic.

Steps to reproduce the bug before the fix:

- Create a tax T with a computation with python code
- Set the following code:
result = partner.country_id.code == 'AR' and price_unit * 0.10
- Create two customers C1 from Argentina and C2 not from Argentina
- Create a SO with partner_invoice_id = C2 and partner_shipping_id = C1 and confirm it
    - The tax T is applied on the SO and the total amount is impacted
- Generate the invoice of the SO
    - The tax T is applied on the invoice BUT the total amount was not impacted

opw:1839091
