### PR TITLE
[FIX] landed cost move price unit calculation

### DIFF
--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -107,7 +107,7 @@ class LandedCost(models.Model):
                     'landed_cost_value': new_landed_cost_value,
                     'value': line.move_id.value + cost_to_add,
                     'remaining_value': line.move_id.remaining_value + cost_to_add,
-                    'price_unit': (line.move_id.value + new_landed_cost_value) / line.move_id.product_qty,
+                    'price_unit': (line.move_id.value + cost_to_add) / line.move_id.product_qty,
                 })
                 # `remaining_qty` is negative if the move is out and delivered proudcts that were not
                 # in stock.

--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -100,14 +100,14 @@ class LandedCost(models.Model):
             }
             for line in cost.valuation_adjustment_lines.filtered(lambda line: line.move_id):
                 # Prorate the value at what's still in stock
-                cost_to_add = (line.move_id.remaining_qty / line.move_id.product_qty) * line.additional_landed_cost
+                remaining_cost_to_add = (line.move_id.remaining_qty / line.move_id.product_qty) * line.additional_landed_cost
 
                 new_landed_cost_value = line.move_id.landed_cost_value + line.additional_landed_cost
                 line.move_id.write({
                     'landed_cost_value': new_landed_cost_value,
-                    'value': line.move_id.value + cost_to_add,
-                    'remaining_value': line.move_id.remaining_value + cost_to_add,
-                    'price_unit': (line.move_id.value + cost_to_add) / line.move_id.product_qty,
+                    'value': line.move_id.value + line.additional_landed_cost,
+                    'remaining_value': line.move_id.remaining_value + remaining_cost_to_add,
+                    'price_unit': (line.move_id.value + line.additional_landed_cost) / line.move_id.product_qty,
                 })
                 # `remaining_qty` is negative if the move is out and delivered proudcts that were not
                 # in stock.

--- a/doc/cla/corporate/osoul.md
+++ b/doc/cla/corporate/osoul.md
@@ -1,0 +1,15 @@
+Libya, 2018-05-20
+
+Osoul agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Osoul dev@osoul.ly https://github.com/osoul
+
+List of contributors:
+
+Osoul dev@osoul.ly https://github.com/osoul


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Incorrect price_unit calculation of stock moves when there multiple landed costs (not landed cost lines) for the shipment.

**Steps to reproduce:**

- Create purchase order for Product A, with 100 qty and $100 unit price
- Receive the shipment
- Create landed cost with one cost of $100, and validate it.
- The current stock move unit price is $101, value $10100, landed_cost_value $100
- Create a new landed cost with one cost of $200, and validate it
- Now the stock move unit price is $104, value $10300, landed_cost_value $300

**Desired behavior after PR is merged:**
Following the example above, the end state should be unit price is $103, value $10300, landed_cost_value $300

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr