### PR TITLE
[FIX] stock: Duplicate Detailed Operations

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -629,6 +629,7 @@ class Picking(models.Model):
             #                                    'picking_id': pick.id
             #                                    }) # Might change first element
             # # Link existing moves or add moves when no one is related
+            pick.move_line_ids.filtered(lambda x: x.qty_done == 0 and not x.lot_id).unlink()
             for ops in pick.move_line_ids.filtered(lambda x: not x.move_id):
                 # Search move with this product
                 moves = pick.move_lines.filtered(lambda x: x.product_id == ops.product_id) 


### PR DESCRIPTION
Steps to reproduce the bug:

- Create a stockable product P tracked by serial number with route BUY
- Create PO with 5 P and validate the PO
- On the picking, just set one serial number and create a backorder
- Go on the backorder

Bug:

8 lines were created:
    - 4 lines with one reserved quantity
    - 4 lines with no reserved quantity

Now only 4 lines with one reserved quantity are created.

opw:1847714
