### PR TITLE
[FIX] mass_mailing: unsubscribe not working in multi lang

### DIFF
--- a/addons/mass_mailing/models/mail_mail.py
+++ b/addons/mass_mailing/models/mail_mail.py
@@ -97,9 +97,9 @@ class MailMail(models.Model):
             emails = tools.email_split(res.get('email_to')[0])
             email_to = emails and emails[0] or False
             unsubscribe_url = self._get_unsubscribe_url(email_to)
-            link_to_replace = base_url + '/unsubscribe_from_list'
+            regex_link_to_replace = re.escape(base_url) + '(/[a-z]{2}_[A-Z]{2})?' + '/unsubscribe_from_list'
             if link_to_replace in res['body']:
-                res['body'] = res['body'].replace(link_to_replace, unsubscribe_url if unsubscribe_url else '#')
+                res['body'] = re.sub(regex_link_to_replace, unsubscribe_url if unsubscribe_url else '#', res['body'])
         return res
 
     @api.multi


### PR DESCRIPTION
When installing the website with a lang  different than the one set
on the user, the button unsubscribe in the mass mailing snippets
didn't work because the unsubscribe link contains the code of the
language. The function send_get_email_dict in model mail.mail didn't
expect this behavior and so couldn't set the right unsubscribe link
in the mail.

opw:1850696
