### PR TITLE
[SUPPORT] pos_fast_reconcile: unofficial perfs improvements

### DIFF
--- a/addons/pos_fast_reconcile/__init__.py
+++ b/addons/pos_fast_reconcile/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/addons/pos_fast_reconcile/__manifest__.py
+++ b/addons/pos_fast_reconcile/__manifest__.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
+# FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+{
+    'name': 'Point of Sale - Fast Reconcile',
+    'version': '1.1',
+    'category': 'Point Of Sale',
+    'author': 'Odoo Support',
+    'sequence': 20,
+    'summary': 'Performance patch for the Point of Sale',
+    'description': """
+Performance Patch for v11.0
+===========================
+
+For POS Sessions over several hundreds orders, the closing can take an extremely
+long time, mainly for 2 reasons:
+
+- The reconciliation is O(n²), which means that reconciling the move lines of
+  the payments with the move lines of the session gets longer fast
+- The creation of move lines for each payment takes a long time
+
+For the `master` branch, we are currently developping a batch create mechanism
+in the ORM that should allow for the creation of a big amount of move lines
+without intermediary recomputes (among other things).
+
+The reconciliation algorithm has already been merged in master and is now
+O(n log(n)), which should improve performance for these cases significantly.
+
+This being a stable branch, we do not have the luxury of merging this. Instead,
+Odoo Support provides this 'fix module' for those that are interested.
+
+In a nutshell:
+
+- Hardcoded fast creation of move lines for payments
+    Note that this bit could potentially be incompatible with custom modules that
+    modify the schema for the account_move_line table
+- Fast Reconcile Algorithm
+    Only applied to the reconciliation of the POS Sessions move lines and *not*
+    applied to the rest of the accounting mechanisms.
+
+Note that this module is provided outside of the standard Odoo code and is not
+covered by any warranty. See the disclaimer in the manifest of this module
+for more information.
+    """,
+    'depends': ['point_of_sale'],
+    'installable': True,
+    'website': 'https://www.odoo.com/help',
+}

--- a/addons/pos_fast_reconcile/models/__init__.py
+++ b/addons/pos_fast_reconcile/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_bank_statement
+from . import pos_order

--- a/addons/pos_fast_reconcile/models/account_bank_statement.py
+++ b/addons/pos_fast_reconcile/models/account_bank_statement.py
@@ -1,0 +1,75 @@
+from psycopg2.extensions import AsIs
+import logging
+
+from odoo import models
+
+_logger = logging.getLogger(__name__)
+
+
+class AccountBankStatementLine(models.Model):
+    _inherit = 'account.bank.statement.line'
+
+    def fast_counterpart_creation(self):
+        company_currency = self.journal_id.company_id.currency_id
+        statement_currency = self.journal_id.currency_id or company_currency
+        partner_id = self.partner_id.id or None
+        st_line_currency = self.currency_id or statement_currency
+        for st_line in self:
+            # If we are in multi-currency use standard process
+            if st_line_currency.id != company_currency.id:
+                vals = {
+                    'name': st_line.name,
+                    'debit': st_line.amount < 0 and -st_line.amount or 0.0,
+                    'credit': st_line.amount > 0 and st_line.amount or 0.0,
+                    'account_id': st_line.account_id.id,
+                }
+                return st_line.process_reconciliation(new_aml_dicts=[vals])
+            move_vals = self._prepare_reconciliation_move(st_line.statement_id.name)
+            move = self.env['account.move'].create(move_vals)
+            debit = st_line.amount < 0 and -st_line.amount or 0.0
+            credit = st_line.amount > 0 and st_line.amount or 0.0
+            debit_cash_basis = 0 if move.journal_id.type in ('sale', 'purchase') else debit
+            credit_cash_basis = 0 if move.journal_id.type in ('sale', 'purchase') else credit
+            aml_dict = {
+                'name': st_line.name,
+                'debit': debit,
+                'credit': credit,
+                'balance': debit - credit,
+                'account_id': st_line.account_id.id,
+                'move_id': move.id,
+                'partner_id': partner_id,
+                'statement_id': st_line.statement_id.id,
+                'statement_line_id': st_line.id,
+                'reconciled': False,
+                'amount_residual': debit - credit if st_line.account_id.reconcile else 0,
+                'amount_residual_currency': 0,
+                'debit_cash_basis': debit_cash_basis,
+                'credit_cash_basis': credit_cash_basis,
+                'balance_cash_basis': debit_cash_basis - credit_cash_basis,
+                'company_currency_id': move.company_id.currency_id.id,
+                'ref': move.ref,
+                'journal_id': move.journal_id.id,
+                'date': move.date,
+                'date_maturity': move.date,
+                'company_id': st_line.account_id.company_id.id,
+                'user_type_id': st_line.account_id.user_type_id.id,
+            }
+            columns = aml_dict.keys()
+            values = [aml_dict[column] for column in columns]
+            self.env.cr.execute('''INSERT INTO account_move_line(%s) VALUES %s''', (AsIs(','.join(columns)), tuple(values)))
+            # Create conterpart
+            account = credit > 0 and self.statement_id.journal_id.default_credit_account_id or self.statement_id.journal_id.default_debit_account_id
+            aml_dict['debit'] = credit
+            aml_dict['credit'] = debit
+            aml_dict['balance'] = credit - debit
+            aml_dict['account_id'] = account.id
+            aml_dict['amount_residual'] = debit - credit if account.reconcile else 0,
+            aml_dict['debit_cash_basis'] = credit_cash_basis,
+            aml_dict['credit_cash_basis'] = debit_cash_basis,
+            aml_dict['balance_cash_basis'] = credit_cash_basis - debit_cash_basis,
+            columns = aml_dict.keys()
+            values = [aml_dict[column] for column in columns]
+            self.env.cr.execute('''INSERT INTO account_move_line(%s) VALUES %s''', (AsIs(','.join(columns)), tuple(values)))
+            move.post()
+            # record the move name on the statement line to be able to retrieve it in case of unreconciliation
+            st_line.write({'move_name': move.name})

--- a/addons/pos_fast_reconcile/models/pos_order.py
+++ b/addons/pos_fast_reconcile/models/pos_order.py
@@ -1,0 +1,96 @@
+import logging
+
+from odoo import models, _
+from odoo.exceptions import UserError, except_orm
+from odoo.tools import float_is_zero
+
+
+_logger = logging.getLogger(__name__)
+
+
+class PosOrder(models.Model):
+    _inherit = "pos.order"
+
+    def _fast_reconcile(self, amls):
+        debit_amls = amls.filtered(lambda aml: aml.debit > 0 and not aml.reconciled)
+        credit_amls = amls.filtered(lambda aml: aml.credit > 0 and not aml.reconciled)
+        company_ids = set([a.company_id.id for a in amls])
+        if len(company_ids) > 1:
+            raise UserError(_('To reconcile the entries company should be the same for all entries!'))
+        all_accounts = [a.account_id for a in amls]
+        if len(set(all_accounts)) > 1:
+            raise UserError(_('Entries are not of the same account!'))
+        if not (all_accounts[0].reconcile or all_accounts[0].internal_type == 'liquidity'):
+            raise UserError(_('The account %s (%s) is not marked as reconciliable !') % (all_accounts[0].name, all_accounts[0].code))
+        company_id = debit_amls and debit_amls[0].company_id
+        company_currency_id = company_id.currency_id
+        # Ensure that this is a full reconciliation
+        sum_debit = sum([a.debit for a in debit_amls])
+        sum_credit = sum([a.credit for a in credit_amls])
+        # If reconciliation is not total or that all moves don't have same currency, skip, it won't be reconciled at all
+        # So user will have to do it himself
+        if not float_is_zero(sum_debit - sum_credit, precision_rounding=company_currency_id.rounding):
+            return
+        if len(set([a.currency_id for a in amls])) > 1:
+            return
+        currency_id = debit_amls and debit_amls[0].currency_id
+        if currency_id.id:
+            currency_id = currency_id.id
+        else:
+            currency_id = None
+
+        full_reconcile = self.env['account.full.reconcile'].create({})
+        while True:
+            if not debit_amls.ids or not credit_amls.ids:
+                break
+            debit = debit_amls[0]
+            credit = credit_amls[0]
+            amount = min(debit.amount_residual, credit.amount_residual)
+            amount_currency = min(debit.amount_currency, credit.amount_currency)
+
+            vals = (debit.id, credit.id, amount, amount_currency, currency_id, company_id.id, full_reconcile.id)
+
+            if float_is_zero(debit.amount_residual - amount, precision_rounding=company_currency_id.rounding):
+                debit_amls = debit_amls[1:]
+            else:
+                debit_amls[0].amount_residual -= amount
+                debit_amls[0].amount_residual_currency -= amount_currency
+            if float_is_zero(credit.amount_residual - amount, precision_rounding=company_currency_id.rounding):
+                credit_amls = credit_amls[1:]
+            else:
+                credit_amls[0].amount_residual -= amount
+                credit_amls[0].amount_residual_currency -= amount_currency
+            # Create partial reconcile
+            self.env.cr.execute('''INSERT INTO account_partial_reconcile
+                    (debit_move_id, credit_move_id, amount, amount_currency, currency_id, company_id, full_reconcile_id) VALUES (%s, %s, %s, %s, %s, %s, %s)''', vals)
+
+        # update account_move_line
+        self.env.cr.execute('UPDATE account_move_line SET reconciled=%s, amount_residual=0, amount_residual_currency=0, full_reconcile_id=%s WHERE id IN %s', (True, full_reconcile.id, tuple(amls.ids)))
+
+    def _reconcile_payments(self):
+        reconcile_by_partner = {}
+        invoices = self.env['account.invoice']
+        for order in self:
+            aml = order.statement_ids.mapped('journal_entry_ids') | order.account_move.line_ids | order.invoice_id.move_id.line_ids
+            if order.invoice_id:
+                invoices += order.invoice_id
+            aml = aml.filtered(lambda r: not r.reconciled and r.account_id.internal_type == 'receivable' and r.partner_id == order.partner_id.commercial_partner_id)
+            partner = len(aml) > 1 and aml[0].partner_id and aml[0].partner_id.id or False
+            if reconcile_by_partner.get(partner):
+                reconcile_by_partner[partner] = reconcile_by_partner[partner] | aml
+            else:
+                reconcile_by_partner[partner] = aml
+        try:
+            for k, v in reconcile_by_partner.items():
+                self._fast_reconcile(v)
+            # Validate invoice
+            self.invalidate_cache()
+            for inv in invoices:
+                inv._compute_residual()
+                inv._compute_payments()
+            _logger.info(_('POS Session AML fast-reconciled using new algorithm'))
+        except except_orm:
+            raise
+        except:
+            _logger.warning(_('Error when trying to fast-reconcile POS Session move lines; falling back to standard code'))
+            return super(PosOrder, self)._reconcile_payments()


### PR DESCRIPTION
For POS Sessions over several hundreds orders, the closing can take an extremely
long time, mainly for 2 reasons:
- The reconciliation is O(n²), which means that reconciling the move lines of
  the payments with the move lines of the session gets longer fast
- The creation of move lines for each payment takes a long time

For the `master` branch, we are currently developping a batch create mechanism
in the ORM that should allow for the creation of a big amount of move lines
without intermediary recomputes (among other things).

The reconciliation algorithm has already been merged in master and is now
O(n log(n)), which should improve performance for these cases significantly.

This being a stable branch, we do not have the luxury of merging this. Instead,
Odoo Support provides this 'fix module' for those that are interested.

In a nutshell:
- Hardcoded fast creation of move lines for payments
    Note that this bit could potentially be incompatible with custom modules that
    modify the schema for the account_move_line table
- Fast Reconcile Algorithm
    Only applied to the reconciliation of the POS Sessions move lines and *not*
    applied to the rest of the accounting mechanisms.

Note that this module is provided outside of the standard Odoo code and is not
covered by any warranty. See the disclaimer in the manifest of this module
for more information.

courstesy of dbo-odoo and csn-odoo

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
