### PR TITLE
[FIX] Don't truncate many2many_tags names.

### DIFF
--- a/addons/web/static/src/less/fields.less
+++ b/addons/web/static/src/less/fields.less
@@ -116,7 +116,7 @@
 
             > .o_badge_text {
                 .o-text-overflow(inline-block);
-                max-width: 200px;
+                max-width: 100%;
             }
 
             > .o_colorpicker > ul {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When using many2many_tags widget, many2many_tags_email widget, the names of the records linked are truncated to 200px. 
Current behavior before PR:
The names should not be truncated. The same behaviour is already in list_view.less.
Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
