### PR TITLE
[imp] base: Set html field value to '' instead of empty tags

### DIFF
--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -253,7 +253,11 @@ def html_sanitize(src, silent=True, sanitize_tags=True, sanitize_attributes=Fals
     if cleaned.startswith(u'<div>') and cleaned.endswith(u'</div>'):
         cleaned = cleaned[5:-6]
 
-    return cleaned
+    # this regex checks if the cleaned content is an empty tag tree
+    if len(re.sub(r"(<(\/)?(p|strong|h\d|br|b|font|\\n)[^>]*>)|(&nbsp;)", "", cleaned).strip()) == 0:
+        return ""
+    else:
+        return cleaned
 
 #----------------------------------------------------------
 # HTML/Text management


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

If html fields are left empty in configuration it could hapen it has empty tags in the database. If checked if these fields have content this test will return True. To avoid this the tags should be replaced by an empty string before writing to the database.

example of unwanted behavior: https://drive.google.com/file/d/1dO_Ur6n3Sgzem0KQ_dXEPRlQkTVaEim8/view

Desired behavior after PR is merged:

during sanitizing of html fields run a regex over the field to determine if it consists of anpty tags or only whitespaces. In this case return '' instead of the original field.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
