### PR TITLE
[FIX] to prevent destroyed sessions, do not accept database names with

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1520,7 +1520,9 @@ def db_filter(dbs, httprequest=None):
         # use the value of --database as a comma seperated list of exposed databases.
         exposed_dbs = set(db.strip() for db in odoo.tools.config['db_name'].split(','))
         dbs = sorted(exposed_dbs.intersection(dbs))
-    return dbs
+    # do not accept dbs with null bytes in name (sessions with null bytes in db
+    # name cannot call any http interface (not even database selector))
+    return [db for db in dbs if "\x00" not in db]
 
 def db_monodb(httprequest=None):
     """


### PR DESCRIPTION
do not accept database names with null bytes anymore

Description of the issue/feature this PR addresses:
When sending a user a crafted link that has ?db=...%00...  in it, it is possible to destroy the users session in a way that a normal user is not able to recover it.0

Current behavior before PR:
Users on systems without a strict dbfilter that click a crafted link cannot login to Odoo anymore for abaout a week (or until they delete their cookies)

Desired behavior after PR is merged:
?db=... parameter values with null bytes in it are ignored.

<details><summary>Click to show output in servers log</summary>

```
2018-06-18 12:46:57,414 20011 INFO odoo test werkzeug: 127.0.0.1 - - [18/Jun/2018 12:46:57] "GET /web?db%3Dodoo%00test HTTP/1.0" 500 -
2018-06-18 12:46:57,427 20011 ERROR odoo test werkzeug: Error on request:
Traceback (most recent call last):
  File "/home/user/.virtualenvs/venv/lib/python3.6/site-packages/werkzeug/serving.py", line 205, in run_wsgi
    execute(self.server.app)
  File "/home/user/.virtualenvs/venv/lib/python3.6/site-packages/werkzeug/serving.py", line 193, in execute
    application_iter = app(environ, start_response)
  File "/home/user/odoo/odoo/service/wsgi_server.py", line 166, in application
    return application_unproxied(environ, start_response)
  File "/home/user/odoo/odoo/service/wsgi_server.py", line 154, in application_unproxied
    result = handler(environ, start_response)
  File "/home/user/odoo/odoo/http.py", line 1318, in __call__
    return self.dispatch(environ, start_response)
  File "/home/user/odoo/odoo/http.py", line 1292, in __call__
    return self.app(environ, start_wrapped)
  File "/home/user/.virtualenvs/venv/lib/python3.6/site-packages/werkzeug/wsgi.py", line 599, in __call__
    return self.app(environ, start_response)
  File "/home/user/odoo/odoo/http.py", line 1473, in dispatch
    odoo.registry(db).check_signaling()
  File "/home/user/odoo/odoo/__init__.py", line 76, in registry
    return modules.registry.Registry(database_name)
  File "/home/user/odoo/odoo/modules/registry.py", line 61, in __new__
    return cls.new(db_name)
  File "/home/user/odoo/odoo/modules/registry.py", line 73, in new
    registry.init(db_name)
  File "/home/user/odoo/odoo/modules/registry.py", line 145, in init
    with closing(self.cursor()) as cr:
  File "/home/user/odoo/odoo/modules/registry.py", line 484, in cursor
    return self._db.cursor()
  File "/home/user/odoo/odoo/sql_db.py", line 634, in cursor
    return Cursor(self.__pool, self.dbname, self.dsn, serialized=serialized)
  File "/home/user/odoo/odoo/sql_db.py", line 178, in __init__
    self._cnx = pool.borrow(dsn)
  File "/home/user/odoo/odoo/sql_db.py", line 517, in _locked
    return fun(self, *args, **kwargs)
  File "/home/user/odoo/odoo/sql_db.py", line 585, in borrow
    **connection_info)
  File "/home/user/.virtualenvs/venv/lib/python3.6/site-packages/psycopg2/__init__.py", line 130, in connect
    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
ValueError: embedded null character
```
</details>

Info @wt-io-it



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
