### PR TITLE
[IMP] stock: Improvement stock picking

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -924,10 +924,10 @@ class StockMove(models.Model):
                         continue
                     # Reserve new quants and create move lines accordingly.
                     forced_package_id = move.package_level_id.package_id or None
-                    available_quantity = self.env['stock.quant']._get_available_quantity(move.product_id, move.location_id, package_id=forced_package_id)
+                    available_quantity = self.env['stock.quant']._get_available_quantity(move.product_id, move.location_id, package_id=forced_package_id, owner_id=move.restrict_partner_id)
                     if available_quantity <= 0:
                         continue
-                    taken_quantity = move._update_reserved_quantity(need, available_quantity, move.location_id, package_id=forced_package_id, strict=False)
+                    taken_quantity = move._update_reserved_quantity(need, available_quantity, move.location_id, package_id=forced_package_id, owner_id=move.restrict_partner_id, strict=False)
                     if float_is_zero(taken_quantity, precision_rounding=move.product_id.uom_id.rounding):
                         continue
                     if need == taken_quantity:

--- a/addons/stock/tests/__init__.py
+++ b/addons/stock/tests/__init__.py
@@ -14,6 +14,7 @@ from . import test_packing
 from . import test_packing_neg
 from . import test_proc_rule
 from . import test_wise_operator
+from . import test_picking_owner
 
 # TODO enable this test: error on runbot to create asset and open the iframe
 # from . import test_ui

--- a/addons/stock/tests/test_picking_owner.py
+++ b/addons/stock/tests/test_picking_owner.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.addons.stock.tests.common import TestStockCommon
+from odoo.exceptions import UserError
+from odoo.tests import Form
+
+class TestPickingOwner(TestStockCommon):
+
+    def setUp(self):
+        super(TestPickingOwner, self).setUp()
+        self.picking_out = self.env.ref('stock.picking_type_out')
+        self.stock_location = self.env.ref('stock.stock_location_stock')
+
+    def create_picking(self, picking_type, location_dest):
+        """ Create picking based on picking type """
+        picking_form = Form(self.env['stock.picking'])
+        picking_form.partner_id = self.env.ref('base.res_partner_3')
+        picking_form.picking_type_id = picking_type
+        with picking_form.move_lines.new() as move:
+            move.product_id = self.productA
+            move.product_uom_qty = 5.0
+            move.location_id = self.stock_location
+            move.location_dest_id = location_dest
+        picking_form.owner_id = self.env.ref('base.res_partner_1')
+        picking = picking_form.save()
+        return picking
+
+    def test_picking_owner_asign(self):
+        # ------------------------------------------
+        # Receive shipment with owner.
+        # -----------------------------------------
+
+        # Create Incoming shipment and confirm it.
+        incoming_picking = self.create_picking(self.env.ref('stock.picking_type_in'), self.stock_location)
+        incoming_picking.action_confirm()
+        # Assign Owner to shipment.
+        incoming_picking._assign_owner()
+        # Transfer Incoming shipment.
+        wizard = incoming_picking.button_validate()
+        immediate_transfer = self.env[wizard['res_model']].browse(wizard['res_id'])
+        immediate_transfer.process()
+
+        # ------------------------------------------------
+        # Deliver shipment with owner.
+        # --------------------------------------
+
+        # Create Outgoing shipment and confirm it.
+        outgoing_picking = self.create_picking(self.picking_out, self.env.ref('stock.stock_location_suppliers'))
+        outgoing_picking.action_confirm()
+        # Assign owner on Outgoing shipment
+        outgoing_picking.action_assign()
+        # Outgoing shipment owner change
+        outgoing_picking.write({'owner_id': self.env.ref('base.res_partner_2').id})
+        # System should raise warning to user that he need to unresearve picking first
+        # then they can change owner.
+        with self.assertRaises(UserError):
+            outgoing_picking.onchange_picking_owner()
+        # Outgoing shipment unreserve product
+        outgoing_picking.do_unreserve()
+        # Reassign owner on Outgoing shipment
+        outgoing_picking.write({'owner_id': self.env.ref('base.res_partner_1').id})
+        outgoing_picking.action_assign()
+        # check the owner stock move owner and Outgoing shipment
+        self.assertEqual(outgoing_picking.mapped('move_lines').restrict_partner_id.id, outgoing_picking.owner_id.id, "same owner product can be sell.")
+        # Transfer Outgoing shipment.
+        wizard = outgoing_picking.button_validate()
+        immediate_transfer = self.env[wizard['res_model']].browse(wizard['res_id'])
+        immediate_transfer.process()

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -258,10 +258,7 @@
                             <field name="date_done" string="Effective Date" attrs="{'invisible': [('state', '!=', 'done')]}"/>
                             <field name="origin" placeholder="e.g. PO0032"/>
                             <field name="owner_id" groups="stock.group_tracking_owner"/>
-                            <div groups="stock.group_tracking_owner" colspan="2" col="2">
-                                <button name="action_assign_owner" string="Assign Owner" type="object" attrs="{'invisible': ['|',('move_line_exist', '=', False),('state', 'not in', ('draft','assigned','confirmed'))]}"
-                                    class="oe_link"/>
-                            </div>
+                            <field name="move_lines" invisible="1"/>
                         </group>
                     </group>
                     <notebook>


### PR DESCRIPTION
Pad:https://pad.odoo.com/p/r.4c34a2bc384852c6212b22be168c2bbe
Task:https://www.odoo.com/web#id=1860575&action=333&active_id=131&model=project.task&view_type=form&menu_id=4720 

-Remove the "assign owner" button on the picking
 -Picking should be automatically assign the owner on all the lines of the pickings

TASK:1860575

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
