### PR TITLE
[FIX] purchase: reference code in vendor pricelist

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -769,7 +769,7 @@ class PurchaseOrderLine(models.Model):
             lang=self.partner_id.lang,
             partner_id=self.partner_id.id,
         )
-        self.name = product_lang.display_name
+        self.name = product_lang.name_get()[0][1]
         if product_lang.description_purchase:
             self.name += '\n' + product_lang.description_purchase
 


### PR DESCRIPTION
Steps to reproduce the bug:

- Create two vendor contacts Pere and Fils
- Fils is a sub contact of Pere
- Create two vendor pricelist for product A, Ppere and Pfils
- Ppere with code reference pere
- Pfils with code reference fils
- Create RFQ with Fils as vendor and sell A

Bug: The code reference used in the description of the line is pere instead of fils

Technical reason:

In function onchange_product_id, the description was set with display_name on model product.product
The function display_name called the function name_get on product.product and this function returned a list with [(id, [fils] A ), (id, [pere] A)](two references one for partner_id and the other one for commercial_partner_id). The function _compute_display_name in the orm made a dict()
on this list. This is why the reference code pere was chosen.

Now with the fix, the first reference code is chosen. This fix has been inspired by function
product_id_change on sale.order.line

PS: Now the reference code of the vendor is taken, it means that if no code is set on the vendor's pricelist no reference code will be set. Before the fix it took the reference code of the commercial_partner_id So it is changes the behavior.

opw:1858466
