### PR TITLE
[FIX] mail: Playing video not working on iOS

### DIFF
--- a/addons/mail/static/src/js/thread.js
+++ b/addons/mail/static/src/js/thread.js
@@ -330,7 +330,13 @@ var Thread = Widget.extend({
     _onAttachmentView: function (event) {
         event.stopPropagation();
         var activeAttachmentID = $(event.currentTarget).data('id');
-        if (activeAttachmentID) {
+        var check = true;
+        debugger;
+        this.is_video = _.findWhere(this.attachments, { id: activeAttachmentID });
+        if (this.is_video && this.is_video.mimetype.match("video") && $.browser.safari){
+            check = false;
+        }
+        if (activeAttachmentID && check) {
             var attachmentViewer = new DocumentViewer(this, this.attachments, activeAttachmentID);
             attachmentViewer.appendTo($('body'));
         }


### PR DESCRIPTION
Steps to reproduce the bug:

- Go to Odoo on Safari browser
- Go to CRM > Operations > Manufacturing orders
- Select a MO and log a note on it with a video attachment
- Try to watch the video

Bug: it's not possible to watch the video

HTTP servers hosting media files for iOS must support byte-range requests, which iOS
uses to perform random access in media playback. (Byte-range support is also
known as content-range or partial-range support.)

Odoo server doesn't support partial requests with accept-ranges

opw:1857873
