### PR TITLE
Ldap filter: add multiple %s feature

### DIFF
--- a/addons/auth_ldap/models/res_company_ldap.py
+++ b/addons/auth_ldap/models/res_company_ldap.py
@@ -4,6 +4,7 @@
 import ldap
 import logging
 from ldap.filter import filter_format
+import re
 
 from odoo import api, fields, models, tools
 from odoo.tools.pycompat import to_native
@@ -96,7 +97,9 @@ class CompanyLDAP(models.Model):
 
         entry = False
         try:
-            filter = filter_format(conf['ldap_filter'], (login,))
+            pattern = r"[^%](%s)"
+            match_count = re.findall(pattern, conf['ldap_filter']).__len__()
+            filter = filter_format(conf['ldap_filter'], (login,) * match_count)
         except TypeError:
             _logger.warning('Could not format LDAP filter. Your filter should contain one \'%s\'.')
             return False

--- a/doc/cla/corporate/rydlab.md
+++ b/doc/cla/corporate/rydlab.md
@@ -1,0 +1,15 @@
+Russia, 2018-06-27
+
+Rydlab agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Rydlab OOO company@rydlab.ru https://github.com/rydlab
+
+List of contributors:
+
+Alexandr Shitov a.shitov@rydlab.ru https://github.com/ashitov


### PR DESCRIPTION
Description of the issue/feature this PR addresses: LDAP filter now can handle more than 1 %s, to use multiple fields to query user. For example: (|(mail=%s)(login=%s))

Current behavior before PR: Now ODOO process only 1 %s in ldap filter.

Desired behavior after PR is merged: ODOO process multiple %s in ldap filter 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
