### PR TITLE
[IMP] api: enable function as argument on constrains & onchange decorators

### DIFF
--- a/odoo/api.py
+++ b/odoo/api.py
@@ -187,7 +187,12 @@ def onchange(*args):
             ``@onchange`` only supports simple field names, dotted names
             (fields of relational fields e.g. ``partner_id.tz``) are not
             supported and will be ignored
+
+        One may also pass a single function as argument. In that case, the
+        changing fields are given by calling the function with the field's model.
     """
+    if args and callable(args[0]):
+        args = args[0]
     return attrsetter('_onchange', args)
 
 

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -146,11 +146,15 @@ def constrains(*args):
         ``@constrains`` will be triggered only if the declared fields in the
         decorated method are included in the ``create`` or ``write`` call.
         It implies that fields not present in a view will not trigger a call
-        during a record creation. A override of ``create`` is necessary to make
+        during a record creation. An override of ``create`` is necessary to make
         sure a constraint will always be triggered (e.g. to test the absence of
         value).
 
+    One may also pass a single function as argument. In that case, the
+    constraints are given by calling the function with the field's model.
     """
+    if args and callable(args[0]):
+        args = args[0]
     return attrsetter('_constrains', args)
 
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -629,9 +629,13 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         cls = type(self)
         methods = defaultdict(list)
         for attr, func in getmembers(cls, is_onchange):
-            for name in func._onchange:
+            if callable(func._onchange):
+                func_onchange = list(func._onchange(self))
+            else:
+                func_onchange = func._onchange
+            for name in func_onchange:
                 if name not in cls._fields:
-                    _logger.warning("@onchange%r parameters must be field names", func._onchange)
+                    _logger.warning("method %s.%s: @onchange parameter %r must be a field name", cls._name, attr, name)
                 methods[name].append(func)
 
         # add onchange methods to implement "change_default" on fields

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -603,7 +603,11 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         cls = type(self)
         methods = []
         for attr, func in getmembers(cls, is_constraint):
-            for name in func._constrains:
+            if callable(func._constrains):
+                func_constrains = list(func._constrains(self))
+            else:
+                func_constrains = func._constrains
+            for name in func_constrains:
                 field = cls._fields.get(name)
                 if not field:
                     _logger.warning("method %s.%s: @constrains parameter %r is not a field name", cls._name, attr, name)
@@ -1110,7 +1114,11 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
     def _validate_fields(self, field_names):
         field_names = set(field_names)
         for check in self._constraint_methods:
-            if not field_names.isdisjoint(check._constrains):
+            if callable(check._constrains):
+                check_constrains = list(check._constrains(self))
+            else:
+                check_constrains = check._constrains
+            if not field_names.isdisjoint(check_constrains):
                 check(self)
 
     @api.model


### PR DESCRIPTION
**Description of the feature this PR addresses:**

This PR enable to pass a function as a single argument on `api.contrains` and `api.onchange` decorators. This function should return a tuple of field names (or an empty tuple).

**Current behavior before PR:**

The `api.contrains` and `api.onchange` decorators only admit field names.

**Desired behavior after PR is merged:**

The `api.contrains` and `api.onchange` decorators admit field names or a function that return field names.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr