### PR TITLE
[FIX] base: also consider test_file test mode for generating pdfs

### DIFF
--- a/odoo/addons/base/ir/ir_actions_report.py
+++ b/odoo/addons/base/ir/ir_actions_report.py
@@ -563,7 +563,7 @@ class IrActionsReport(models.Model):
     def render_qweb_pdf(self, res_ids=None, data=None):
         # In case of test environment without enough workers to perform calls to wkhtmltopdf,
         # fallback to render_html.
-        if tools.config['test_enable'] and not tools.config['test_report_directory']:
+        if (tools.config['test_enable'] or tools.config['test_file']) and not tools.config['test_report_directory']:
             return self.render_qweb_html(res_ids, data=data)
 
         # As the assets are generated during the same transaction as the rendering of the


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When running a single test file that renders a pdf (e.g.: addons/sale_management/tests/test_sale_ui.py) with --test-file, rendering the pdf fails because test_file was not recognized as test mode by the render method.

Current behavior before PR:
Rendering pdfs in test_file mode fails

Desired behavior after PR is merged:
Rendering pdfs in test_file mode works

Info @wt-io-it



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
