### PR TITLE
[PATCH] website_sale: Billing address in Authorize.net transaction

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -160,14 +160,14 @@ class Website(models.Model):
         self.ensure_one()
         affiliate_id = request.session.get('affiliate_id')
         salesperson_id = affiliate_id if self.env['res.users'].sudo().browse(affiliate_id).exists() else request.website.salesperson_id.id
-        addr = partner.address_get(['delivery', 'invoice'])
+        addr = partner.address_get(['delivery'])
         default_user_id = partner.parent_id.user_id.id or partner.user_id.id
         values = {
             'partner_id': partner.id,
             'pricelist_id': pricelist.id,
             'payment_term_id': self.sale_get_payment_term(partner),
             'team_id': self.salesteam_id.id,
-            'partner_invoice_id': addr['invoice'],
+            'partner_invoice_id': partner.id,
             'partner_shipping_id': addr['delivery'],
             'user_id': salesperson_id or self.salesperson_id.id or default_user_id,
         }
@@ -252,6 +252,7 @@ class Website(models.Model):
                 # change the partner, and trigger the onchange
                 sale_order.write({'partner_id': partner.id})
                 sale_order.onchange_partner_id()
+                sale_order.write({'partner_invoice_id': partner.id})
                 sale_order.onchange_partner_shipping_id() # fiscal position
                 sale_order['payment_term_id'] = self.sale_get_payment_term(partner)
 


### PR DESCRIPTION
Let's consider the partner P1 with the address A1 and its invoice partner P2
with the address A2.

When creating a transaction in the shop for P1 with billing address = A1:

- if option Payment Flow =  Redirection to the acquirer website
   => the billing address of the transaction is A1

- if if option Payment Flow = Payment from Odoo
   => the billing address of the transaction was A2

Now with this patch, the billing address is A1 in each case.

opw:1867188
