### PR TITLE
[FIX] Adjust the order of warehouse and transit location creation

### DIFF
--- a/addons/stock/models/res_company.py
+++ b/addons/stock/models/res_company.py
@@ -38,8 +38,8 @@ class Company(models.Model):
     def create(self, vals):
         company = super(Company, self).create(vals)
 
-        company.create_transit_location()
         # mutli-company rules prevents creating warehouse and sub-locations
         self.env['stock.warehouse'].check_access_rights('create')
         self.env['stock.warehouse'].sudo().create({'name': company.name, 'code': company.name[:5], 'company_id': company.id, 'partner_id': company.partner_id.id})
+        company.create_transit_location()
         return company


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The creation of transit location in the following method tries to map the warehouse and update the `property_stock_customer` and `property_stock_supplier` of the company's partner. However, the warehouse is not yet created, therefore this part of the code will never be executed.
https://github.com/odoo/odoo/blob/1686ef8c047efebb79cb962c8e730e0e2a63da69/addons/stock/models/res_company.py#L31-L35

Current behavior before PR:
When creating a new company (`res.company`), the `property_stock_customer` and `property_stock_supplier` of the company's partner (`res.partner`) will be set as Customer Location and Vendor Location.

Desired behavior after PR is merged:
Transit Location will be assigned to the company's partner (`res.partner`) after creation.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
