### PR TITLE
[IMP] web_editor: add unique to uploaded images

### DIFF
--- a/addons/web_editor/static/src/js/widgets/widgets.js
+++ b/addons/web_editor/static/src/js/widgets/widgets.js
@@ -286,7 +286,7 @@ var ImageDialog = Widget.extend({
             $form.find('.well > span').remove();
             $form.find('.well > div').show();
             _.each(attachments, function (record) {
-                record.src = record.url || '/web/image/' + record.id;
+                record.src = record.url || _.str.sprintf('/web/image/%s-%s/%s', record.id, record.checksum.slice(0, 8), encodeURI(record.name));
                 record.is_document = !(/gif|jpe|jpg|png/.test(record.mimetype));
             });
             if (error || !attachments.length) {
@@ -347,7 +347,7 @@ var ImageDialog = Widget.extend({
             return (r.url || r.id);
         });
         _.each(this.records, function (record) {
-            record.src = record.url || _.str.sprintf('/web/image/%s/%s', record.id, encodeURI(record.name)); // Name is added for SEO purposes
+            record.src = record.url || _.str.sprintf('/web/image/%s-%s/%s', record.id, record.checksum.slice(0, 8), encodeURI(record.name)); // Name is added for SEO purposes
             record.is_document = !(/gif|jpe|jpg|png/.test(record.mimetype));
         });
         this.display_attachments();


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Before this commit all images uploaded with web_editor were missing unique tag which caused no image caching (Cache-Control: max-age=0).
This improvement is required for websites where content is mostly added with web_editor: blog posts, product's description etc.

Current behavior before PR: Uploaded images have no unique param in src attribute.

Desired behavior after PR is merged: Uploaded images have unique param in src attribute which is first 8 letters of image's checksum.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
