### PR TITLE
[PATCH] sales_team: Wrong display on Sales Channels

### DIFF
--- a/addons/sales_team/views/sales_team_dashboard.xml
+++ b/addons/sales_team/views/sales_team_dashboard.xml
@@ -28,7 +28,7 @@
                                     <div class="col-xs-6 o_kanban_primary_left" name="to_replace_in_sale_crm">
                                         <button type="object" class="btn btn-primary" name="action_primary_channel_button"><field name="dashboard_button_name"/></button>
                                     </div>
-                                    <div class="col-xs-6 o_kanban_primary_right" style="padding-bottom:0;">
+                                    <div class="col-xs-8 o_kanban_primary_right" style="padding-bottom:0;">
                                         <t name="first_options"/>
                                         <t name="second_options"/>
                                         <t name="third_options"/>


### PR DESCRIPTION
When displaying more than 4 numbers in opportunities_amount, it could
overlap the frame.

opw:1871200