### PR TITLE
[FIX] 11.0 stock: fix slow inventory valuation

### DIFF
--- a/addons/stock/models/stock_inventory.py
+++ b/addons/stock/models/stock_inventory.py
@@ -336,9 +336,6 @@ class InventoryLine(models.Model):
     company_id = fields.Many2one(
         'res.company', 'Company', related='inventory_id.company_id',
         index=True, readonly=True, store=True)
-    # TDE FIXME: necessary ? -> replace by location_id
-    state = fields.Selection(
-        'Status',  related='inventory_id.state', readonly=True)
     theoretical_qty = fields.Float(
         'Theoretical Quantity', compute='_compute_theoretical_qty',
         digits=dp.get_precision('Product Unit of Measure'), readonly=True, store=True)

--- a/addons/stock/models/stock_inventory.py
+++ b/addons/stock/models/stock_inventory.py
@@ -336,6 +336,9 @@ class InventoryLine(models.Model):
     company_id = fields.Many2one(
         'res.company', 'Company', related='inventory_id.company_id',
         index=True, readonly=True, store=True)
+    # TDE FIXME: necessary ? -> replace by location_id
+    state = fields.Selection(
+        'Status',  related='inventory_id.state', readonly=True)
     theoretical_qty = fields.Float(
         'Theoretical Quantity', compute='_compute_theoretical_qty',
         digits=dp.get_precision('Product Unit of Measure'), readonly=True, store=True)

--- a/addons/stock/views/stock_inventory_views.xml
+++ b/addons/stock/views/stock_inventory_views.xml
@@ -27,7 +27,6 @@
                 <field name="partner_id" groups="stock.group_tracking_owner"/>
                 <field name="theoretical_qty" readonly="1"/>
                 <field name="product_qty" string="Real Quantity"/>
-                <field name="state" invisible="1"/>
                 <field name="inventory_id" invisible="1"/>
                 <field name="inventory_location_id" invisible="1"/>
             </tree>
@@ -166,7 +165,6 @@
                                 <field name="partner_id" groups="stock.group_tracking_owner"/>
                                 <field name="theoretical_qty" readonly="1"/>
                                 <field name="product_qty" string="Real Quantity"/>
-                                <field name="state" invisible="True"/>
                             </tree>
                             <kanban class="o_kanban_mobile">
                                 <field name="product_id"  domain="[('type','=','product')]"/>
@@ -177,7 +175,6 @@
                                 <field name="partner_id"/>
                                 <field name="theoretical_qty" readonly="1"/>
                                 <field name="product_qty" string="Real Quantity"/>
-                                <field name="state" invisible="True"/>
 
                                 <templates>
                                     <t t-name="kanban-box">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When starting an inventory with more that 300 lines
every change in the lines takes ~5-6 seconds, which grows
with the amount of lines in inventory. This is due to this
relation that triggers a lot of unnecessary recalculations.

As this field is actually never used in code -> I think it should be dropped 
for the sake of performance

Current behavior before PR:

When large inventory is started (for "All products" for example) every change to the inventory 
lines take a lot of time, which increases exponentially with the amount of lines.

Desired behavior after PR is merged:

It should be hella fast


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
