### PR TITLE
[IMP] base_import: Allow user to import translated terms

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -199,10 +199,8 @@ class Import(models.TransientModel):
                 'required': bool(field.get('required')),
                 'fields': [],
                 'type': field['type'],
+                'translate': bool(field.get('translate')),
             }
-
-            if field.get('translate'):
-                field_value['translate'] = True
 
             if field['type'] in ('many2many', 'many2one'):
                 field_value['fields'] = [

--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -201,6 +201,9 @@ class Import(models.TransientModel):
                 'type': field['type'],
             }
 
+            if field.get('translate'):
+                field_value['translate'] = True
+
             if field['type'] in ('many2many', 'many2one'):
                 field_value['fields'] = [
                     dict(field_value, name='id', string=_("External ID"), type='id'),
@@ -588,6 +591,7 @@ class Import(models.TransientModel):
 
             return {
                 'fields': fields,
+                'installed_langs': {lang[0]: lang[1].split('/')[0].strip() for lang in self.env['res.lang'].get_installed()},
                 'matches': matches or False,
                 'headers': headers or False,
                 'headers_type': header_types or False,

--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -197,9 +197,9 @@ class Import(models.TransientModel):
                 'string': field['string'],
                 # Y U NO ALWAYS HAS REQUIRED
                 'required': bool(field.get('required')),
+                'translate': bool(field.get('translate')),
                 'fields': [],
                 'type': field['type'],
-                'translate': bool(field.get('translate')),
             }
 
             if field['type'] in ('many2many', 'many2one'):

--- a/addons/base_import/models/test_models.py
+++ b/addons/base_import/models/test_models.py
@@ -41,6 +41,12 @@ class CharStillreadonly(models.Model):
 
     value = fields.Char(readonly=True, states={'draft': [('readonly', True)]})
 
+class CharTrandlated(models.Model):
+    _name = name('char.translated')
+    _description = 'Tests : Base Import Model, Character translated'
+
+    value = fields.Char(translate=True)
+
 # TODO: complex field (m2m, o2m, m2o)
 class M2o(models.Model):
     _name = name('m2o')

--- a/addons/base_import/security/ir.model.access.csv
+++ b/addons/base_import/security/ir.model.access.csv
@@ -5,6 +5,7 @@ access_base_import_tests_models_char_readonly,base.import.tests.models.char.read
 access_base_import_tests_models_char_states,base.import.tests.models.char.states,model_base_import_tests_models_char_states,base.group_user,1,1,1,1
 access_base_import_tests_models_char_noreadonly,base.import.tests.models.char.noreadonly,model_base_import_tests_models_char_noreadonly,base.group_user,1,1,1,1
 access_base_import_tests_models_char_stillreadonly,base.import.tests.models.char.stillreadonly,model_base_import_tests_models_char_stillreadonly,base.group_user,1,1,1,1
+access_base_import_tests_models_char_translated,base.import.tests.models.char.translated,model_base_import_tests_models_char_translated,base.group_user,1,1,1,1
 access_base_import_tests_models_m2o,base.import.tests.models.m2o,model_base_import_tests_models_m2o,base.group_user,1,1,1,1
 access_base_import_tests_models_m2o_related,base.import.tests.models.m2o.related,model_base_import_tests_models_m2o_related,base.group_user,1,1,1,1
 access_base_import_tests_models_m2o_required,base.import.tests.models.m2o.required,model_base_import_tests_models_m2o_required,base.group_user,1,1,1,1

--- a/addons/base_import/static/src/js/import_action.js
+++ b/addons/base_import/static/src/js/import_action.js
@@ -434,7 +434,7 @@ var DataImport = AbstractAction.extend({
 
             var $columnHeader = self.$('.oe_import_grid-header .oe_import_grid-cell:eq(' + k + ') .o_import_header_name');
             var $translateNode = $(QWeb.render('ImportView.translate')).insertAfter($columnHeader);
-            bind = function (data) {
+            bind_translation_icon = function (data) {
                 $translateNode.toggleClass('d-none', !data.translate)
                     .attr('data-field', data.id)
                     .attr('data-lang', '')
@@ -460,7 +460,7 @@ var DataImport = AbstractAction.extend({
                 width: 'resolve',
                 dropdownCssClass: 'oe_import_selector'
             }).on('change', function (e) {
-                bind(item_finder(e.currentTarget.value));
+                bind_translation_icon(item_finder(e.currentTarget.value));
             });
         });
     },

--- a/addons/base_import/static/src/js/import_action.js
+++ b/addons/base_import/static/src/js/import_action.js
@@ -434,7 +434,7 @@ var DataImport = AbstractAction.extend({
 
             var $columnHeader = self.$('.oe_import_grid-header .oe_import_grid-cell:eq(' + k + ') .o_import_header_name');
             var $translateNode = $(QWeb.render('ImportView.translate')).insertAfter($columnHeader);
-            bind_translation_icon = function (data) {
+            var bindTranslationIcon = function (data) {
                 $translateNode.toggleClass('d-none', !data.translate)
                     .attr('data-field', data.id)
                     .attr('data-lang', '')
@@ -454,13 +454,14 @@ var DataImport = AbstractAction.extend({
 
                     var data = item_finder(default_value);
                     bind(data);
+                    bindTranslationIcon(data);
                     callback(data);
                 },
                 placeholder: _t('Don\'t import'),
                 width: 'resolve',
                 dropdownCssClass: 'oe_import_selector'
             }).on('change', function (e) {
-                bind_translation_icon(item_finder(e.currentTarget.value));
+                bindTranslationIcon(item_finder(e.currentTarget.value));
             });
         });
     },

--- a/addons/base_import/static/src/js/import_action.js
+++ b/addons/base_import/static/src/js/import_action.js
@@ -470,7 +470,7 @@ var DataImport = AbstractAction.extend({
     //--------------------------------------------------------------------------
 
     /**
-     * Open dialog to select language to import translate term
+     * Open dialog to select language to import translation terms
      *
      * @private
      * @param {Event} ev

--- a/addons/base_import/static/src/xml/base_import.xml
+++ b/addons/base_import/static/src/xml/base_import.xml
@@ -180,4 +180,16 @@
             <t t-call="ImportView.import_button"/>
         </t>
     </t>
+    <span t-name="ImportView.translate" class="o_import_translate d-none">
+        <a class="o_import_translate_icon ml4" href="#" title="Choose the translation to import from this column."><i class="fa fa-globe"></i></a>
+        <div><i class="o_import_translate_text text-muted"></i></div>
+    </span>
+    <div t-name="ImportView.TranslateDialog">
+        <select class="custom-select">
+            <option></option>
+            <option t-foreach="installed_langs" t-as="lang" t-att-value="lang" t-att-selected="selected_lang == lang ? '1' : None">
+                <t t-esc="installed_langs[lang]"/>
+            </option>
+        </select>
+    </div>
 </templates>

--- a/addons/base_import/tests/test_base_import.py
+++ b/addons/base_import/tests/test_base_import.py
@@ -281,7 +281,7 @@ class TestPreview(TransactionCase):
             ['qux', '5', '6'],
         ])
         # Ensure we only have the response fields we expect
-        self.assertItemsEqual(list(result), ['matches', 'headers', 'fields', 'preview', 'headers_type', 'options', 'advanced_mode', 'debug'])
+        self.assertItemsEqual(list(result), ['matches', 'headers', 'fields', 'preview', 'headers_type', 'options', 'advanced_mode', 'debug', 'installed_langs'])
 
     @unittest.skipUnless(can_import('xlrd'), "XLRD module not available")
     def test_xls_success(self):
@@ -311,7 +311,7 @@ class TestPreview(TransactionCase):
             ['qux', '5', '6'],
         ])
         # Ensure we only have the response fields we expect
-        self.assertItemsEqual(list(result), ['matches', 'headers', 'fields', 'preview', 'headers_type', 'options', 'advanced_mode', 'debug'])
+        self.assertItemsEqual(list(result), ['matches', 'headers', 'fields', 'preview', 'headers_type', 'options', 'advanced_mode', 'debug', 'installed_langs'])
 
     @unittest.skipUnless(can_import('xlrd.xlsx'), "XLRD/XLSX not available")
     def test_xlsx_success(self):
@@ -341,7 +341,7 @@ class TestPreview(TransactionCase):
             ['qux', '5', '6'],
         ])
         # Ensure we only have the response fields we expect
-        self.assertItemsEqual(list(result), ['matches', 'headers', 'fields', 'preview', 'headers_type', 'options', 'advanced_mode', 'debug'])
+        self.assertItemsEqual(list(result), ['matches', 'headers', 'fields', 'preview', 'headers_type', 'options', 'advanced_mode', 'debug', 'installed_langs'])
 
     @unittest.skipUnless(can_import('odf'), "ODFPY not available")
     def test_ods_success(self):
@@ -371,7 +371,7 @@ class TestPreview(TransactionCase):
             ['aux', '5', '6'],
         ])
         # Ensure we only have the response fields we expect
-        self.assertItemsEqual(list(result), ['matches', 'headers', 'fields', 'preview', 'headers_type', 'options', 'advanced_mode', 'debug'])
+        self.assertItemsEqual(list(result), ['matches', 'headers', 'fields', 'preview', 'headers_type', 'options', 'advanced_mode', 'debug', 'installed_langs'])
 
 
 class test_convert_import_data(TransactionCase):

--- a/addons/base_import/tests/test_base_import.py
+++ b/addons/base_import/tests/test_base_import.py
@@ -275,9 +275,9 @@ class TestPreview(TransactionCase):
         # Order depends on iteration order of fields_get
         self.assertItemsEqual(result['fields'], [
             ID_FIELD,
-            {'id': 'name', 'name': 'name', 'string': 'Name', 'required': False, 'fields': [], 'type': 'char'},
-            {'id': 'somevalue', 'name': 'somevalue', 'string': 'Some Value', 'required': True, 'fields': [], 'type': 'integer'},
-            {'id': 'othervalue', 'name': 'othervalue', 'string': 'Other Variable', 'required': False, 'fields': [], 'type': 'integer'},
+            {'id': 'name', 'name': 'name', 'string': 'Name', 'required': False, 'translate': False, 'fields': [], 'type': 'char'},
+            {'id': 'somevalue', 'name': 'somevalue', 'string': 'Some Value', 'required': True, 'translate': False, 'fields': [], 'type': 'integer'},
+            {'id': 'othervalue', 'name': 'othervalue', 'string': 'Other Variable', 'required': False, 'translate': False, 'fields': [], 'type': 'integer'},
         ])
         self.assertEqual(result['preview'], [
             ['foo', '1', '2'],
@@ -305,9 +305,9 @@ class TestPreview(TransactionCase):
         self.assertEqual(result['headers'], ['name', 'Some Value', 'Counter'])
         self.assertItemsEqual(result['fields'], [
             ID_FIELD,
-            {'id': 'name', 'name': 'name', 'string': 'Name', 'required': False, 'fields': [], 'type': 'char'},
-            {'id': 'somevalue', 'name': 'somevalue', 'string': 'Some Value', 'required': True, 'fields': [], 'type': 'integer'},
-            {'id': 'othervalue', 'name': 'othervalue', 'string': 'Other Variable', 'required': False, 'fields': [], 'type': 'integer'},
+            {'id': 'name', 'name': 'name', 'string': 'Name', 'required': False, 'translate': False, 'fields': [], 'type': 'char'},
+            {'id': 'somevalue', 'name': 'somevalue', 'string': 'Some Value', 'required': True, 'translate': False, 'fields': [], 'type': 'integer'},
+            {'id': 'othervalue', 'name': 'othervalue', 'string': 'Other Variable', 'required': False, 'translate': False, 'fields': [], 'type': 'integer'},
         ])
         self.assertEqual(result['preview'], [
             ['foo', '1', '2'],
@@ -335,9 +335,9 @@ class TestPreview(TransactionCase):
         self.assertEqual(result['headers'], ['name', 'Some Value', 'Counter'])
         self.assertItemsEqual(result['fields'], [
             ID_FIELD,
-            {'id': 'name', 'name': 'name', 'string': 'Name', 'required': False, 'fields': [], 'type': 'char'},
-            {'id': 'somevalue', 'name': 'somevalue', 'string': 'Some Value', 'required': True, 'fields': [], 'type': 'integer'},
-            {'id': 'othervalue', 'name': 'othervalue', 'string': 'Other Variable', 'required': False, 'fields': [], 'type': 'integer'},
+            {'id': 'name', 'name': 'name', 'string': 'Name', 'required': False, 'translate': False, 'fields': [], 'type': 'char'},
+            {'id': 'somevalue', 'name': 'somevalue', 'string': 'Some Value', 'required': True, 'translate': False, 'fields': [], 'type': 'integer'},
+            {'id': 'othervalue', 'name': 'othervalue', 'string': 'Other Variable', 'required': False, 'translate': False, 'fields': [], 'type': 'integer'},
         ])
         self.assertEqual(result['preview'], [
             ['foo', '1', '2'],
@@ -365,9 +365,9 @@ class TestPreview(TransactionCase):
         self.assertEqual(result['headers'], ['name', 'Some Value', 'Counter'])
         self.assertItemsEqual(result['fields'], [
             ID_FIELD,
-            {'id': 'name', 'name': 'name', 'string': 'Name', 'required': False, 'fields': [], 'type': 'char'},
-            {'id': 'somevalue', 'name': 'somevalue', 'string': 'Some Value', 'required': True, 'fields': [], 'type': 'integer'},
-            {'id': 'othervalue', 'name': 'othervalue', 'string': 'Other Variable', 'required': False, 'fields': [], 'type': 'integer'},
+            {'id': 'name', 'name': 'name', 'string': 'Name', 'required': False, 'translate': False, 'fields': [], 'type': 'char'},
+            {'id': 'somevalue', 'name': 'somevalue', 'string': 'Some Value', 'required': True, 'translate': False, 'fields': [], 'type': 'integer'},
+            {'id': 'othervalue', 'name': 'othervalue', 'string': 'Other Variable', 'required': False, 'translate': False, 'fields': [], 'type': 'integer'},
         ])
         self.assertEqual(result['preview'], [
             ['foo', '1', '2'],

--- a/addons/base_import/tests/test_base_import.py
+++ b/addons/base_import/tests/test_base_import.py
@@ -19,10 +19,10 @@ ID_FIELD = {
 }
 
 
-def make_field(name='value', string='Value', required=False, fields=[], field_type='id'):
+def make_field(name='value', string='Value', required=False, translate=False, fields=[], field_type='id'):
     return [
         ID_FIELD,
-        {'id': name, 'name': name, 'string': string, 'required': required, 'fields': fields, 'type': field_type},
+        {'id': name, 'name': name, 'string': string, 'required': required, 'translate': translate,'fields': fields, 'type': field_type},
     ]
 
 
@@ -69,12 +69,16 @@ class TestBasicFields(BaseImportCase):
         always... filtered out"""
         self.assertEqualFields(self.get_fields('char.stillreadonly'), [ID_FIELD])
 
+    def test_translated(self):
+        """ Required fields should be flagged (so they can be fill-required) """
+        self.assertEqualFields(self.get_fields('char.translated'), make_field(translate=True, field_type='char'))
+
     def test_m2o(self):
         """ M2O fields should allow import of themselves (name_get),
         their id and their xid"""
         self.assertEqualFields(self.get_fields('m2o'), make_field(field_type='many2one', fields=[
-            {'id': 'value', 'name': 'id', 'string': 'External ID', 'required': False, 'fields': [], 'type': 'id'},
-            {'id': 'value', 'name': '.id', 'string': 'Database ID', 'required': False, 'fields': [], 'type': 'id'},
+            {'id': 'value', 'name': 'id', 'string': 'External ID', 'required': False, 'translate': False, 'fields': [], 'type': 'id'},
+            {'id': 'value', 'name': '.id', 'string': 'Database ID', 'required': False, 'translate': False, 'fields': [], 'type': 'id'},
         ]))
 
     def test_m2o_required(self):
@@ -83,8 +87,8 @@ class TestBasicFields(BaseImportCase):
         is id-based)
         """
         self.assertEqualFields(self.get_fields('m2o.required'), make_field(field_type='many2one', required=True, fields=[
-            {'id': 'value', 'name': 'id', 'string': 'External ID', 'required': True, 'fields': [], 'type': 'id'},
-            {'id': 'value', 'name': '.id', 'string': 'Database ID', 'required': True, 'fields': [], 'type': 'id'},
+            {'id': 'value', 'name': 'id', 'string': 'External ID', 'required': True, 'translate': False, 'fields': [], 'type': 'id'},
+            {'id': 'value', 'name': '.id', 'string': 'Database ID', 'required': True, 'translate': False, 'fields': [], 'type': 'id'},
         ]))
 
 
@@ -97,11 +101,11 @@ class TestO2M(BaseImportCase):
         self.assertEqualFields(self.get_fields('o2m'), make_field(field_type='one2many', fields=[
             ID_FIELD,
             # FIXME: should reverse field be ignored?
-            {'id': 'parent_id', 'name': 'parent_id', 'string': 'Parent', 'type': 'many2one', 'required': False, 'fields': [
-                {'id': 'parent_id', 'name': 'id', 'string': 'External ID', 'required': False, 'fields': [], 'type': 'id'},
-                {'id': 'parent_id', 'name': '.id', 'string': 'Database ID', 'required': False, 'fields': [], 'type': 'id'},
+            {'id': 'parent_id', 'name': 'parent_id', 'string': 'Parent', 'type': 'many2one', 'required': False, 'translate': False, 'fields': [
+                {'id': 'parent_id', 'name': 'id', 'string': 'External ID', 'required': False, 'translate': False, 'fields': [], 'type': 'id'},
+                {'id': 'parent_id', 'name': '.id', 'string': 'Database ID', 'required': False, 'translate': False, 'fields': [], 'type': 'id'},
             ]},
-            {'id': 'value', 'name': 'value', 'string': 'Value', 'required': False, 'fields': [], 'type': 'integer'},
+            {'id': 'value', 'name': 'value', 'string': 'Value', 'required': False, 'translate': False, 'fields': [], 'type': 'integer'},
         ]))
 
 

--- a/odoo/addons/base/models/ir_fields.py
+++ b/odoo/addons/base/models/ir_fields.py
@@ -77,7 +77,8 @@ class IrFieldsConverter(models.AbstractModel):
                     converted[field] = False
                     continue
                 try:
-                    converted[field], ws = converters[field](value)
+                    field_name = field.split(':')[0]
+                    converted[field], ws = converters[field_name](value)
                     for w in ws:
                         if isinstance(w, str):
                             # wrap warning string in an ImportWarning for

--- a/odoo/addons/base/models/ir_fields.py
+++ b/odoo/addons/base/models/ir_fields.py
@@ -77,6 +77,7 @@ class IrFieldsConverter(models.AbstractModel):
                     converted[field] = False
                     continue
                 try:
+                    # may have field_name:language_code, we support importing of translation, so split with colon
                     field_name = field.split(':')[0]
                     converted[field], ws = converters[field_name](value)
                     for w in ws:

--- a/odoo/addons/test_impex/ir.model.access.csv
+++ b/odoo/addons/test_impex/ir.model.access.csv
@@ -5,6 +5,7 @@ access_export_float,access_export_float,model_export_float,,1,1,1,1
 access_export_decimal,access_export_decimal,model_export_decimal,,1,1,1,1
 access_export_string_bounded,access_export_string_bounded,model_export_string_bounded,,1,1,1,1
 access_export_string_required,access_export_string_required,model_export_string_required,,1,1,1,1
+access_export_string_translate,access_export_string_translate,model_export_string_translate,,1,1,1,1
 access_export_string,access_export_string,model_export_string,,1,1,1,1
 access_export_date,access_export_date,model_export_date,,1,1,1,1
 access_export_datetime,access_export_datetime,model_export_datetime,,1,1,1,1

--- a/odoo/addons/test_impex/models.py
+++ b/odoo/addons/test_impex/models.py
@@ -21,6 +21,7 @@ MODELS = [
     ('decimal', fields.Float(digits=(16, 3))),
     ('string.bounded', fields.Char(size=16)),
     ('string.required', fields.Char(size=None, required=True)),
+    ('string.translate', fields.Char(translate=True)),
     ('string', fields.Char(size=None)),
     ('date', fields.Date()),
     ('datetime', fields.Datetime()),

--- a/odoo/addons/test_impex/tests/test_load.py
+++ b/odoo/addons/test_impex/tests/test_load.py
@@ -399,6 +399,26 @@ class test_required_string_field(ImporterCase):
         self.assertIs(result['ids'], False)
 
 
+class test_translate_string_field(ImporterCase):
+    model_name = 'export.string.translate'
+
+    def test_imported(self):
+        result = self.import_(['value', 'value:fr_BE'], [
+            ['chhagan', 'lagan'],
+            ['magan', 'bhagan']
+        ])
+        self.assertEqual(len(result['ids']), 2)
+        self.assertFalse(result['messages'])
+
+    def test_without_source(self):
+        result = self.import_(['value:fr_BE'], [
+            ['shaktimaan'],
+            ['gangadhar']
+        ])
+        self.assertFalse(result['ids'])
+        self.assertEqual(len(result['messages']), 2)
+
+
 class test_text(ImporterCase):
     model_name = 'export.text'
 

--- a/odoo/addons/test_impex/tests/test_load.py
+++ b/odoo/addons/test_impex/tests/test_load.py
@@ -410,6 +410,12 @@ class test_translate_string_field(ImporterCase):
         self.assertEqual(len(result['ids']), 2)
         self.assertFalse(result['messages'])
 
+    def test_imported_translation(self):
+        result = self.import_(['value', 'value:fr_BE'], [
+            ['shaktiman', 'gangadhar'],
+        ])
+        self.assertEqual(['gangadhar'], values(self.read(context={'lang': 'fr_BE'})))
+
     def test_without_source(self):
         result = self.import_(['value:fr_BE'], [
             ['shaktimaan'],

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3421,7 +3421,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                     val = vals[name]
                     Translations._set_ids(tname, 'model', splitted_name[1], self.ids, val)
                 else:
-                    raise MissingError(_('Missing source value for the field %s') % splitted_name[0])
+                    raise UserError(_('Missing source value for the field %s') % splitted_name[0])
 
         # mark fields to recompute; do this before setting other fields, because
         # the latter can require the value of computed fields, e.g., a one2many
@@ -3712,7 +3712,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                     val = data['stored'][name]
                     Translations._set_ids(tname, 'model', splitted_name[1], record.ids, val)
                 else:
-                    raise MissingError(_('Missing source value for the field %s') % splitted_name[0])
+                    raise UserError(_('Missing source value for the field %s') % splitted_name[0])
 
         return records
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3166,6 +3166,11 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
             will set the field ``foo`` to ``1`` and the field ``bar`` to
             ``"Qux"`` if those are valid (otherwise it will trigger an error).
 
+            field key may have field_name:language_code, this will add translation entry
+            in ir.translation with given value for that field, for that source field is needed::
+
+                [{'bar': "Qux", 'bar:fr_BE': "Qux in FR", ...}, ...]
+
         :raise AccessError: * if user has no write rights on the requested object
                             * if user tries to bypass access rules for write on the requested object
         :raise ValidateError: if user tries to enter invalid value for a field that is not in selection
@@ -3461,6 +3466,11 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
             For backward compatibility, ``vals_list`` may be a dictionary.
             It is treated as a singleton list ``[vals]``, and a single record
             is returned.
+
+            field key may have field_name:language_code, this will add translation entry
+            in ir.translation with given value for that field, for that source field is needed::
+
+                [{'field_name': field_value, 'field_name': field_value_translated, ...}, ...]
 
             see :meth:`~.write` for details
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -966,16 +966,16 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         # m2o fields can't be on multiple lines so exclude them from the
         # is_relational field rows filter, but special-case it later on to
         # be handled with relational fields (as it can have subfields)
-        is_relational = lambda field: fields[field].relational
+        is_relational = lambda field: fields.get(field) and fields[field].relational
         get_o2m_values = itemgetter_tuple([
             index
             for index, fnames in enumerate(fields_)
-            if fields[fnames[0]].type == 'one2many'
+            if fields.get(fnames[0]) and fields[fnames[0]].type == 'one2many'
         ])
         get_nono2m_values = itemgetter_tuple([
             index
             for index, fnames in enumerate(fields_)
-            if fields[fnames[0]].type != 'one2many'
+            if fields.get(fnames[0]) and fields[fnames[0]].type != 'one2many'
         ])
         # Checks if the provided row has any non-empty one2many fields
         def only_o2m_values(row):
@@ -3252,6 +3252,8 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         inverse_fields = []
         protected_fields = []
         for key, val in vals.items():
+            field_name = key
+            key = key.split(':')[0]
             if key in bad_names:
                 continue
             field = self._fields.get(key)
@@ -3259,11 +3261,11 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                 unknown_names.append(key)
                 continue
             if field.store:
-                store_vals[key] = val
+                store_vals[field_name] = val
             if field.inherited:
-                inherited_vals[field.related_field.model_name][key] = val
+                inherited_vals[field.related_field.model_name][field_name] = val
             elif field.inverse:
-                inverse_vals[key] = val
+                inverse_vals[field_name] = val
                 inverse_fields.append(field)
                 protected_fields.extend(self._field_computed.get(field, [field]))
 
@@ -3340,11 +3342,16 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         columns = []                    # list of (column_name, format, value)
         updated = []                    # list of updated or translated columns
         other_fields = []               # list of non-column fields
+        translated_term_fields = []     # list of translated term fields
         single_lang = len(self.env['res.lang'].get_installed()) <= 1
         has_translation = self.env.lang and self.env.lang != 'en_US'
 
         for name, val in vals.items():
-            field = self._fields[name]
+            splitted_name = name.split(':')
+            field = self._fields[splitted_name[0]]
+            if len(splitted_name) > 1 and field.translate is True:
+                translated_term_fields.append(name)
+                continue
             assert field.store
 
             if field.deprecated:
@@ -3382,12 +3389,13 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                 if cr.rowcount != len(sub_ids):
                     raise MissingError(_('One of the records you are trying to modify has already been deleted (Document type: %s).') % self._description)
 
+            Translations = self.env['ir.translation']
             for name in updated:
                 field = self._fields[name]
                 if callable(field.translate):
                     # The source value of a field has been modified,
                     # synchronize translated terms when possible.
-                    self.env['ir.translation']._sync_terms_translations(field, self)
+                    Translations._sync_terms_translations(field, self)
 
                 elif has_translation and field.translate:
                     # The translated value of a field has been modified.
@@ -3398,8 +3406,17 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                         self.with_context(lang=None).write({name: src_trans})
                     tname = "%s,%s" % (self._name, name)
                     val = field.convert_to_column(vals[name], self, vals)
-                    self.env['ir.translation']._set_ids(
+                    Translations._set_ids(
                         tname, 'model', self.env.lang, self.ids, val, src_trans)
+
+            for name in translated_term_fields:
+                splitted_name = name.split(':')
+                if splitted_name[0] in vals:
+                    tname = '%s,%s' % (self._name, splitted_name[0])
+                    val = vals[name]
+                    Translations._set_ids(tname, 'model', splitted_name[1], self.ids, val)
+                else:
+                    raise MissingError(_('Missing source value for the field %s') % splitted_name[0])
 
         # mark fields to recompute; do this before setting other fields, because
         # the latter can require the value of computed fields, e.g., a one2many
@@ -3481,6 +3498,8 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
             data['inherited'] = inherited = defaultdict(dict)
             data['protected'] = protected = set()
             for key, val in vals.items():
+                field_name = key
+                key = key.split(':')[0]
                 if key in bad_names:
                     continue
                 field = self._fields.get(key)
@@ -3488,11 +3507,11 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                     unknown_names.add(key)
                     continue
                 if field.store:
-                    stored[key] = val
+                    stored[field_name] = val
                 if field.inherited:
-                    inherited[field.related_field.model_name][key] = val
+                    inherited[field.related_field.model_name][field_name] = val
                 elif field.inverse:
-                    inversed[key] = val
+                    inversed[field_name] = val
                     inversed_fields.add(field)
                     protected.update(self._field_computed.get(field, [field]))
 
@@ -3589,6 +3608,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         ids = []                        # ids of created records
         other_fields = set()            # non-column fields
         translated_fields = set()       # translated fields
+        translated_term_fields = set()  # translated terms fields
 
         # column names, formats and values (for common fields)
         columns0 = [('id', "nextval(%s)", self._sequence)]
@@ -3603,6 +3623,11 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
             stored = data['stored']
             columns = [column for column in columns0 if column[0] not in stored]
             for name, val in sorted(stored.items()):
+                splitted_name = name.split(':')
+                field = self._fields[splitted_name[0]]
+                if len(splitted_name) > 1 and field.translate is True:
+                    translated_term_fields.add(name)
+                    continue
                 field = self._fields[name]
                 assert field.store
 
@@ -3658,8 +3683,8 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         records.check_access_rule('create')
 
         # add translations
+        Translations = self.env['ir.translation']
         if self.env.lang and self.env.lang != 'en_US':
-            Translations = self.env['ir.translation']
             for field in translated_fields:
                 tname = "%s,%s" % (field.model_name, field.name)
                 for data in data_list:
@@ -3667,6 +3692,17 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                         record = data['record']
                         val = data['stored'][field.name]
                         Translations._set_ids(tname, 'model', self.env.lang, record.ids, val, val)
+
+        for name in translated_term_fields:
+            splitted_name = name.split(':')
+            for data in data_list:
+                if splitted_name[0] in data['stored'] and name in data['stored']:
+                    tname = '%s,%s' % (self._name, splitted_name[0])
+                    record = data['record']
+                    val = data['stored'][name]
+                    Translations._set_ids(tname, 'model', splitted_name[1], record.ids, val)
+                else:
+                    raise MissingError(_('Missing source value for the field %s') % splitted_name[0])
 
         return records
 
@@ -5143,6 +5179,8 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         invalids = []
         triggers = defaultdict(set)
         for fname in fnames:
+            if len(fname.split(':')) > 1:
+                continue
             mfield = self._fields[fname]
             # invalidate mfield on self, and its inverses fields
             invalids.append((mfield, self._ids))


### PR DESCRIPTION
* base: Using load method allow to import translated terms. consider field having colon ':' as translated terms field, after colon language locale code for which terms will import.
like: name:fr_BE

Description of the issue/feature this PR addresses:
* Task: https://www.odoo.com/web#id=1850632&action=327&model=project.task&view_type=form&menu_id=4720
* Pad: https://pad.odoo.com/p/r.2e784bfced6ae5695163a2233f61ad58

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
