### PR TITLE
[FIX] sale_stock: Wrong delivered qty compute.

### DIFF
--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -278,9 +278,8 @@ class SaleOrderLine(models.Model):
         super(SaleOrderLine, self)._get_delivered_qty()
         qty = 0.0
         for move in self.move_ids.filtered(lambda r: r.state == 'done' and not r.scrapped):
-            if move.location_dest_id.usage == "customer":
-                if not move.origin_returned_move_id:
-                    qty += move.product_uom._compute_quantity(move.product_uom_qty, self.product_uom)
+            if move.location_dest_id.usage == "customer" or (move.location_dest_id.usage == "customer" and move.to_refund):
+                qty += move.product_uom._compute_quantity(move.product_uom_qty, self.product_uom)
             elif move.location_dest_id.usage != "customer" and move.to_refund:
                 qty -= move.product_uom._compute_quantity(move.product_uom_qty, self.product_uom)
         return qty


### PR DESCRIPTION
Impacted Versions:
10.0, 11.0

Description of the issue/feature this PR addresses:
When you confirm a sale order with a stackable product a picking is created to deliver that product. If you reverse that picking with the to_refund flag in True and then confirm and reverse the picking 2 with the same flag the quantity_delivered is wrong computed.

Steps to reproduce:
- Create a stockable product, create a SO selling 1 unit.
- Confirm the SO, validate the Picking 1 => delivered qty is 1
- Return Picking 1 and validate Picking 2 => delivered qty is 0
- Return Picking 2 and validate Picking 3 => delivered qty is 0

Current behavior before PR:
The delivered quantity is wrong computed

Desired behavior after PR is merged:
The deelivered quantity must be 1

I have a video with the issue replicated on runbot
https://youtu.be/vSP_gSouSBo

Best Regards
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
