### PR TITLE
[FIX] sale_mrp: price unit of kit

### DIFF
--- a/addons/sale_mrp/sale_mrp.py
+++ b/addons/sale_mrp/sale_mrp.py
@@ -62,7 +62,7 @@ class SaleOrderLine(models.Model):
 
     @api.multi
     def _get_bom_component_qty(self, bom):
-        product_uom_qty_bom = self.env['product.uom']._compute_qty_obj(self.product_uom, self.product_uom_qty, bom.product_uom)
+        product_uom_qty_bom = self.env['product.uom']._compute_qty_obj(self.product_uom, 1, bom.product_uom)
         bom_exploded = self.env['mrp.bom']._bom_explode(bom, self.product_id, product_uom_qty_bom)[0]
         components = {}
         for bom_line in bom_exploded:
@@ -138,7 +138,7 @@ class AccountInvoiceLine(models.Model):
                         prod_moves = [m for m in moves if m.product_id.id == product_id]
                         prod_qty_done = factor * qty_done
                         prod_quantity = factor * quantity
-                        average_price_unit += self._compute_average_price(prod_qty_done, prod_quantity, prod_moves)
+                        average_price_unit += factor * self._compute_average_price(prod_qty_done, prod_quantity, prod_moves)
                     price_unit = average_price_unit or price_unit
                     price_unit = self.product_id.uom_id._compute_price(self.product_id.uom_id.id, price_unit, to_uom_id=self.uom_id.id)
         return price_unit

--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -22,6 +22,7 @@ class TestSaleMrpFlow(common.TransactionCase):
         self.Inventory = self.env['stock.inventory']
         self.InventoryLine = self.env['stock.inventory.line']
         self.ProductProduce = self.env['mrp.product.produce']
+        self.ProductCategory = self.env['product.category']
 
         self.partner_agrolite = self.env.ref('base.res_partner_2')
         self.categ_unit = self.env.ref('product.product_uom_categ_unit')
@@ -383,3 +384,102 @@ class TestSaleMrpFlow(common.TransactionCase):
         del_qty = sum(sol.qty_delivered for sol in self.so.order_line)
         self.assertEqual(del_qty, 5.0, 'Sale MRP: delivered quantity should be 5.0 after complete delivery of a kit')
         self.assertEqual(self.so.invoice_status, 'to invoice', 'Sale MRP: so invoice_status should be "to invoice" after complete delivery of a kit')
+
+    def test_02_sale_mrp_anglo_saxon(self):
+        """Test the price unit of a kit"""
+        # This test will check that the correct journal entries are created when a stockable product in real time valuation
+        # and in real cost method is sold in a company using anglo-saxon.
+        # For this test, let's consider a product category called Test category in real-time valuation and real price costing method
+        # Let's  also consider a finished product with a bom with two components: component1(cost = 20) and component2(cost = 10)
+        # These products are in the Test category
+        # The bom consists of 2 component1 and 1 component2
+        # The invoice policy of the finished product is based on delivered quantities
+        self.uom_unit = self.ProductUom.create({
+            'name': 'Test-Unit',
+            'category_id': self.categ_unit.id,
+            'factor': 1,
+            'uom_type': 'reference',
+            'rounding': 1.0})
+        self.company = self.env.ref('base.main_company')
+        self.company.anglo_saxon_accounting = True
+        self.partner = self.env.ref('base.res_partner_1')
+        self.category = self.env.ref('product.product_category_1').copy({'name': 'Test category','property_valuation': 'real_time', 'property_cost_method': 'real'})
+        account_type = self.env['account.account.type'].create({'name': 'RCV type', 'type': 'receivable'})
+        self.account_receiv = self.env['account.account'].create({'name': 'Receivable', 'code': 'RCV00' , 'user_type_id': account_type.id, 'reconcile': True})
+        account_expense = self.env['account.account'].create({'name': 'Expense', 'code': 'EXP00' , 'user_type_id': account_type.id, 'reconcile': True})
+        account_output = self.env['account.account'].create({'name': 'Output', 'code': 'OUT00' , 'user_type_id': account_type.id, 'reconcile': True})
+        self.partner.property_account_receivable_id = self.account_receiv
+        self.category.property_account_income_categ_id = self.account_receiv
+        self.category.property_account_expense_categ_id = account_expense
+        self.category.property_stock_account_input_categ_id = self.account_receiv
+        self.category.property_stock_account_output_categ_id = account_output
+        self.category.property_stock_valuation_account_id = self.account_receiv
+        self.category.property_stock_journal = self.env['account.journal'].create({'name': 'Stock journal', 'type': 'sale', 'code': 'STK00'})
+        self.finished_product = self.Product.create({
+                'name': 'Finished product',
+                'type': 'product',
+                'uom_id': self.uom_unit.id,
+                'invoice_policy': 'delivery',
+                'categ_id': self.category.id})
+        self.component1 = self.Product.create({
+                'name': 'Component 1',
+                'type': 'product',
+                'uom_id': self.uom_unit.id,
+                'categ_id': self.category.id,
+                'standard_price': 20})
+        self.component2 = self.Product.create({
+                'name': 'Component 2',
+                'type': 'product',
+                'uom_id': self.uom_unit.id,
+                'categ_id': self.category.id,
+                'standard_price': 10})
+        self.bom = self.MrpBom.create({
+                'product_tmpl_id': self.finished_product.product_tmpl_id.id,
+                'product_qty': 1.0,
+                'type': 'phantom',
+                'product_efficiency': 1.0,
+                'product_uom': self.uom_unit.id})
+        self.MrpBomLine.create({
+                'product_id': self.component1.id,
+                'product_qty': 2.0,
+                'bom_id': self.bom.id,
+                'product_uom': self.uom_unit.id})
+        self.MrpBomLine.create({
+                'product_id': self.component2.id,
+                'product_qty': 1.0,
+                'bom_id': self.bom.id,
+                'product_uom': self.uom_unit.id})
+
+        # Create a SO for a specific partner for three units of the finished product
+        so_vals = {
+            'partner_id': self.partner.id,
+            'partner_invoice_id': self.partner.id,
+            'partner_shipping_id': self.partner.id,
+            'order_line': [(0, 0, {'name': self.finished_product.name, 'product_id': self.finished_product.id, 'product_uom_qty': 3, 'product_uom': self.finished_product.uom_id.id, 'price_unit': self.finished_product.list_price})],
+            'pricelist_id': self.env.ref('product.list0').id,
+            'company_id': self.company.id,
+        }
+        self.so = self.SaleOrder.create(so_vals)
+        # Validate the SO
+        self.so.action_confirm()
+        # Deliver the three finished products
+        pick = self.so.picking_ids
+        # To check the products on the picking
+        self.assertEqual(pick.move_lines.mapped('product_id'), self.component1 | self.component2)
+        pick.force_assign()
+        wiz_act = pick.do_new_transfer()
+        wiz = self.env[wiz_act['res_model']].browse(wiz_act['res_id'])
+        wiz.process()
+        pick.do_new_transfer()
+        # Create the invoice
+        self.so.action_invoice_create()
+        self.invoice = self.so.invoice_ids
+        # Changed the invoiced quantity of the finished product to 2
+        self.invoice.invoice_line_ids.write({'quantity': 2.0})
+        self.invoice.signal_workflow('invoice_open')
+        aml = self.invoice.move_id.line_ids
+        aml_expense = aml.filtered(lambda l: l.account_id.id == account_expense.id)
+        aml_output = aml.filtered(lambda l: l.account_id.id == account_output.id)
+        # Check that the cost of Good Sold entries are equal to 2* (2 * 20 + 1 * 10) = 100
+        self.assertEqual(aml_expense.debit, 100, "Cost of Good Sold entry missing or mismatching")
+        self.assertEqual(aml_output.credit, 100, "Cost of Good Sold entry missing or mismatching")


### PR DESCRIPTION
- Create the following products in FIFO costing method and real-time
  valuation:
  Prod Final (F); Invoiced on Delivered Quantity
  Prod Comp1 (C1); Cost = 20
  Prod Comp2 (C2); Cost = 10
- Create the BOM Kit for F:
  2 Unit(s) of C1
  1 Unit(s) of C2
- Create a SO for 3 Unit(s) of F
- Validate SO and picking
- Create the invoice and validate

The price unit taken into account for F in the anglo-saxon accounting
entry is:
20 + 10 = 30
=> entry in Stock Output Account is 3 * 30 = 90

while it should be:
(2 * 20) + (1 * 10) = 50
=> entry in Stock Output Account is 3 * 50 = 150

This should finally fix issues corrected with:
9a7ed7c: price unit multiplied by the qty sold (*)
f1fdb97: price unit taking into account only 1 unit of each
component

(*) In the use case solved, the price unit was:
(6 * 20) + (3 * 10) = 150
=> entry in Stock Output Account is 3 * 150 = 450

Closes #27039

opw:1886216
