### PR TITLE
[FIX] purchase: Cancelling PO using dropshipping

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -330,6 +330,9 @@ class PurchaseOrder(models.Model):
 
     @api.multi
     def button_draft(self):
+        for order in self:
+            procurements = order.order_line.mapped('procurement_ids')
+            procurements.filtered(lambda r: r.state == 'cancel' and r.rule_id.propagate).write({'state': 'confirmed'})
         self.write({'state': 'draft'})
         return {}
 


### PR DESCRIPTION
Steps to reproduce the bug:

- Create a SO and one line with dropshipping
- Confirm the SO and a PO is created
- Cancel the PO
- Set back the PO to draft and  confirm it
- Validate the delivery

Bug:

The delivred quantity on the SO line was not updated.

opw:1888888
