### PR TITLE
[FIX] web: check if value exist

### DIFF
--- a/addons/web/static/src/js/views/calendar/calendar_renderer.js
+++ b/addons/web/static/src/js/views/calendar/calendar_renderer.js
@@ -102,18 +102,20 @@ var SidebarFilter = Widget.extend(FieldManagerMixin, {
         var self = this;
         event.stopPropagation();
         var value = event.data.changes[this.write_field].id;
-        this._rpc({
-                model: this.write_model,
-                method: 'create',
-                args: [{'user_id': session.uid,'partner_id': value,}],
-            })
-            .then(function () {
-                self.trigger_up('changeFilter', {
-                    'fieldName': self.fieldName,
-                    'value': value,
-                    'active': true,
+        if (value) {
+            this._rpc({
+                    model: this.write_model,
+                    method: 'create',
+                    args: [{'user_id': session.uid,'partner_id': value,}],
+                })
+                .then(function () {
+                    self.trigger_up('changeFilter', {
+                        'fieldName': self.fieldName,
+                        'value': value,
+                        'active': true,
+                    });
                 });
-            });
+        }
     },
     _onFilterActive: function (e) {
         var $input = $(e.currentTarget);


### PR DESCRIPTION
Check if partner_id value isn't undefined before create a write_model record from calendar's sidebar.

Description of the issue/feature this PR addresses:
Go to calendar, type a partner's name on the sidebar then clean the field.
Current behavior before PR:
Odoo server error ( creation/update: a mandatory field is not correctly set). Because partner_id is undefined.
Desired behavior after PR is merged:
Nothing special happens.

![out](https://user-images.githubusercontent.com/25034353/46953395-0bff1500-d08e-11e8-9b91-fe9eb7d3390b.gif)


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
