### PR TITLE
[FIX] stock: pull rule on mto extra move

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -598,7 +598,7 @@ class StockMove(models.Model):
             moves_to_unlink._clean_merged()
             moves_to_unlink._action_cancel()
             moves_to_unlink.sudo().unlink()
-        return (self | self.env['stock.move'].concat(*moves_to_merge)) - moves_to_unlink
+        return (self | (merge_into or self.env['stock.move']) | self.env['stock.move'].concat(*moves_to_merge)) - moves_to_unlink
 
     def _get_relevant_state_among_moves(self):
         # We sort our moves by importance of state:
@@ -1031,6 +1031,7 @@ class StockMove(models.Model):
 
     def _prepare_extra_move_vals(self, qty):
         vals = {
+            'procure_method': 'make_to_stock',
             'origin_returned_move_id': self.origin_returned_move_id.id,
             'product_uom_qty': qty,
             'picking_id': self.picking_id.id,


### PR DESCRIPTION
Usecase to reproduce:
- Set a product with routes mto and buy
- Validate a SO with this product
- Validate the PO and the DO
- Go on the receipt and set a quantity done greater than ordered
- Validate the receipt

It will create a backorder with the extra quantity and the original
delivery order will not be validated.

It happens because the action_confirm will launch procurement rules
on the extra stock move. It will result by creating a new PO with the
extra quantity. Since the extra move will be linked a new purchase_line_id,
it will not be merged in the original move. The original move will not
be validated since it's not returned by _merge_move.

This commit fix _merge_move in order to returns both the extra_move and
the original move if they couldn't be merge. It also set extra_move as
make to stock.

opw-1886947

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
