### PR TITLE
[FIX] base: Not possible to delete a paper format

### DIFF
--- a/odoo/addons/base/views/report_paperformat_views.xml
+++ b/odoo/addons/base/views/report_paperformat_views.xml
@@ -6,7 +6,7 @@
             <field name="name">paper_format_view_tree</field>
             <field name="model">report.paperformat</field>
             <field name="arch" type="xml">
-                <tree string="Paper format configuration">
+                <tree string="Paper format configuration" delete="true">
                     <field name="name" />
                 </tree>
             </field>


### PR DESCRIPTION
As in 11.0, it is possible to delete a paper format.

opw:1896778
