### PR TITLE
[FIX] account: Impossible to make a partial credit note

### DIFF
--- a/addons/account/models/account_invoice.py
+++ b/addons/account/models/account_invoice.py
@@ -89,7 +89,7 @@ class AccountInvoice(models.Model):
     def _compute_residual(self):
         residual = 0.0
         residual_company_signed = 0.0
-        sign = self.type in ['in_refund', 'out_refund'] and -1 or 1
+        sign = self.type in ['in_invoice', 'out_refund'] and -1 or 1
         for line in self.sudo().move_id.line_ids:
             if line.account_id.internal_type in ('receivable', 'payable'):
                 residual_company_signed += line.amount_residual

--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -416,7 +416,7 @@ class account_payment(models.Model):
             total_residual_company_signed = sum(invoice.residual_company_signed for invoice in self.invoice_ids)
             total_payment_company_signed = self.currency_id.with_context(date=self.payment_date).compute(self.amount, self.company_id.currency_id)
             if self.invoice_ids[0].type in ['in_invoice', 'out_refund']:
-                amount_wo = total_payment_company_signed - total_residual_company_signed
+                amount_wo = total_payment_company_signed + total_residual_company_signed
             else:
                 amount_wo = total_residual_company_signed - total_payment_company_signed
             # Align the sign of the secondary currency writeoff amount with the sign of the writeoff

--- a/addons/account/tests/test_payment.py
+++ b/addons/account/tests/test_payment.py
@@ -181,3 +181,30 @@ class TestPayment(AccountingTestCase):
             {'account_id': self.account_usd.id, 'debit': 0.0, 'credit': 38.21, 'amount_currency': -58.42, 'currency_id': self.currency_usd_id},
             {'account_id': self.partner_axelor.property_account_payable_id.id, 'debit': 38.21, 'credit': 0.0, 'amount_currency': 50, 'currency_id': self.currency_chf_id},
         ])
+
+    def test_payment_and_writeoff_out_refund(self):
+        # Use case:
+        # Company is in EUR, create a credit note for 100 EUR and register payment of 90.
+        # Mark invoice as fully paid with a write_off
+        # Check that all the aml are correctly created.
+        invoice = self.create_invoice(amount=100, type='out_refund', currency_id=self.currency_eur_id)
+        # register payment on invoice
+        payment = self.payment_model.create({'payment_type': 'outbound',
+            'payment_method_id': self.env.ref('account.account_payment_method_manual_in').id,
+            'partner_type': 'customer',
+            'partner_id': self.partner_agrolait.id,
+            'amount': 90,
+            'payment_date': time.strftime('%Y') + '-07-15',
+            'payment_difference_handling': 'reconcile',
+            'writeoff_account_id': self.account_payable.id,
+            'journal_id': self.bank_journal_euro.id,
+            'invoice_ids': [(4, invoice.id, None)]
+            })
+        payment.post()
+        self.check_journal_items(payment.move_line_ids, [
+            {'account_id': self.account_eur.id, 'debit': 0.0, 'credit': 90.0, 'amount_currency': 0.0, 'currency_id': False},
+            {'account_id': self.account_payable.id, 'debit': 0.0, 'credit': 10.0, 'amount_currency': 0.0, 'currency_id': False},
+            {'account_id': self.account_receivable.id, 'debit': 100.0, 'credit': 0.0, 'amount_currency': 0.0, 'currency_id': False},
+        ])
+        self.assertEqual(invoice.state, 'paid')
+


### PR DESCRIPTION
Steps to reproduce the bug:

- Create a credit note for an amount of 100$
- Validate it and register a payment
- Let's pay an amount of 90$ and mark this credit note as fully paid

Bug:

An error message was raised saying: Wrong credit or debit value in accounting entry !

The field residual_company_signed must be positive for out_invoice and in_refund and
negative for in_invoice and out_refund. In this way, the correct writeoff amount
can be computed in function _create_payment_entry.

opw:1893570
