### PR TITLE
[FIX] core: always load auth=none routes from `base` and `web` modules

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1306,7 +1306,8 @@ class Root(object):
     @lazy_property
     def nodb_routing_map(self):
         _logger.info("Generating nondb routing")
-        return routing_map([''] + odoo.conf.server_wide_modules, True)
+        server_wide_modules = {'base', 'web'} | set(odoo.conf.server_wide_modules)
+        return routing_map([''] + list(server_wide_modules), True)
 
     def __call__(self, environ, start_response):
         """ Handle a WSGI request


### PR DESCRIPTION
RPC routes added by 285ead28e31ca54e9629d5153d0d03d7b4951535 should
actually be loaded whatever the value of the `--load` parameter.

Oversight of 279d92869391ac9f860d2070a7b92693fffee687.

opw-1896092