### PR TITLE
[FIX] stock,mrp: wrong warning message when show_operations is active

### DIFF
--- a/addons/mrp/wizard/mrp_product_produce.py
+++ b/addons/mrp/wizard/mrp_product_produce.py
@@ -201,7 +201,7 @@ class MrpProductProduceLine(models.TransientModel):
         """
         res = {}
         if self.product_id.tracking == 'serial':
-            if float_compare(self.qty_done, 1.0, precision_rounding=self.move_id.product_id.uom_id.rounding) != 0:
+            if float_compare(self.qty_done, 1.0, precision_rounding=self.product_id.uom_id.rounding) != 0:
                 message = _('You can only process 1.0 %s for products with unique serial number.') % self.product_id.uom_id.name
                 res['warning'] = {'title': _('Warning'), 'message': message}
         return res

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -141,7 +141,7 @@ class StockMoveLine(models.Model):
         """
         res = {}
         if self.qty_done and self.product_id.tracking == 'serial':
-            if float_compare(self.qty_done, 1.0, precision_rounding=self.move_id.product_id.uom_id.rounding) != 0:
+            if float_compare(self.qty_done, 1.0, precision_rounding=self.product_id.uom_id.rounding) != 0:
                 message = _('You can only process 1.0 %s for products with unique serial number.') % self.product_id.uom_id.name
                 res['warning'] = {'title': _('Warning'), 'message': message}
         return res


### PR DESCRIPTION
When moving a product tracked by serial number, an erroneous warning
message shows when the show_operations flag is activated in the
operation type object. This is caused by non-existing move_id while
the picking is being created. The move_id is supposed to contain
the rounding precision but when the move_id is not present, rounding
is 0, resulting to wrong float_compare. A quick fix is to use the
product_id that is directly linked to the operation. The product_id
surely exists and contains the rounding precision.

OPW: 1905221
