### PR TITLE
[FIX] website: GOOGLE ANALYTICS button not displayed

### DIFF
--- a/addons/website/static/src/js/backend/dashboard.js
+++ b/addons/website/static/src/js/backend/dashboard.js
@@ -202,10 +202,13 @@ var Dashboard = Widget.extend(ControlPanelMixin, {
                 $analytics_components.find('.js_unauthorized_message').remove();
                 self.display_unauthorized_message($analytics_components, 'not_initialized');
             };
-            gapi.analytics.auth.authorize({
+            var authObj = gapi.analytics.auth.authorize({
                 container: $analytics_auth[0],
                 clientid: client_id
             });
+            if ('Gs' in authObj) {
+                authObj.Gs = null;
+            }
 
             $analytics_auth.appendTo($analytics_components);
 


### PR DESCRIPTION
Steps to reproduce the bug:

- Install website app and configure your google analytics data(Tracking Id and Client secret)
- Go on the website dashboard and the button Google analytics is displayed
- Go to an other app and come back to website dashboard

Bug:

The button GOOGLE ANALYTICS didn't appear.

opw:1902682
