### PR TITLE
[FIX] purchase:  updated 'received qty' on purchase order

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -576,9 +576,8 @@ class PurchaseOrderLine(models.Model):
             total = 0.0
             for move in line.move_ids:
                 if move.state == 'done':
-                    if move.location_dest_id.usage == "supplier":
-                        if move.to_refund:
-                            total -= move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom)
+                    if move.location_dest_id.usage == "supplier" and move.to_refund:
+                        total -= move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom)
                     else:
                         total += move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom)
             line.qty_received = total


### PR DESCRIPTION

Description of the issue/feature this PR addresses:

opw- 1908249


Current behavior before PR:

currently when you create purchase order , related incoming shipment 
generated once you validate shipment , then related received qty field on purchase order line 
is not updated because of : https://github.com/odoo/odoo/commit/49c159a9060af25b49669d3b18079a95fac6229b#diff-f6e9b4b36d7d79d7ec315d8db6c935f9R545

as misplace else condition , if we have vender location as destination location on shipment 
then it will check for refund condition if we have refund then need to descrese quantity and do reverse increase qty if we donot refund but here there is missing  else condition 
what if we have supplier location and no refund then it will take 0.0 value .

and that is why received qty take total 0.0 value and not updated on po line.

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
