### PR TITLE
[FIX] fleet: specified the right view_type for vehicle contracts

### DIFF
--- a/addons/fleet/models/fleet_vehicle_cost.py
+++ b/addons/fleet/models/fleet_vehicle_cost.py
@@ -200,7 +200,7 @@ class FleetVehicleLogContract(models.Model):
             'name': _("Renew Contract"),
             'view_mode': 'form',
             'view_id': self.env.ref('fleet.fleet_vehicle_log_contract_view_form').id,
-            'view_type': 'tree,form',
+            'view_type': 'form',
             'res_model': 'fleet.vehicle.log.contract',
             'type': 'ir.actions.act_window',
             'domain': '[]',


### PR DESCRIPTION
This commit is related to the issue: https://github.com/odoo/odoo/issues/26834

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
