### PR TITLE
[FIX]hr_holidays: set correct days when creating new leave request

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -290,6 +290,7 @@ class HolidaysRequest(models.Model):
         tz = self.env.user.tz if self.env.user.tz and not self.request_unit_custom else 'UTC'  # custom -> already in UTC
         self.date_from = timezone(tz).localize(datetime.combine(self.request_date_from, hour_from)).astimezone(UTC).replace(tzinfo=None)
         self.date_to = timezone(tz).localize(datetime.combine(self.request_date_to, hour_to)).astimezone(UTC).replace(tzinfo=None)
+        self._onchange_leave_dates()
 
     @api.onchange('request_unit_half')
     def _onchange_request_unit_half(self):


### PR DESCRIPTION
- here, there is need to call '_onchange_leave_dates' method because this method computes number of days according to date_from and date_to fields which are set in method '_onchange_request_parameters'.
- so, call '_onchange_leave_dates' after setting date_from and date_to parameters.

Related to Issue: 1895291

Description of the issue/feature this PR addresses:
When trying to create leaves(from a calendar) the first time it shows the wrong duration but click on a half day and unclick, it shows 1 day. in duration.

Current behavior before PR:
When trying to create leaves(from a calendar) the first time it shows the wrong duration but click on a half day and unclick, it shows 1 day. in duration.

Desired behavior after PR is merged:
It shows the correct duration while creating leave request from a calendar.

Issue:
https://www.odoo.com/web#id=1895291&action=327&model=project.task&view_type=form&menu_id=4720

Pad:
https://pad.odoo.com/p/r.79862f847d6b2334a59838d759dd152d

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
