### PR TITLE
[IMP] base: show documents to be deleted in settings uninstall

### DIFF
--- a/odoo/addons/base/module/wizard/base_module_uninstall.py
+++ b/odoo/addons/base/module/wizard/base_module_uninstall.py
@@ -32,7 +32,13 @@ class BaseModuleUninstall(models.TransientModel):
 
     @api.depends('module_ids')
     def _compute_model_ids(self):
-        ir_models = self._get_models()
+        if self._context.get('is_module_in_settings'):
+            # get only the models related to the module
+            domain = [('model', '=', 'ir.model'), ('module', '=', self.module_id.name)]
+            data = self.env['ir.model.data'].search_read(domain, ['res_id'])
+            ir_models = self.env['ir.model'].browse([item['res_id'] for item in data])
+        else:
+            ir_models = self._get_models()
         ir_models_xids = ir_models._get_external_ids()
         for wizard in self:
             if wizard.module_id:


### PR DESCRIPTION
On the settings page, there are fields called module_{something}
that when deactivated, module {something} will be uninstalled
which can result to deletion of records.

This will add information to the warning message when the checkbox
is unchecked. The information include the names of the documents
that will be deleted and the corresponding number of records.

Task# 1888785

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
