### PR TITLE
[IMP] purchase: send purchase report by email or print button

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -327,6 +327,11 @@ class PurchaseOrder(models.Model):
         return self.env.ref('purchase.report_purchase_quotation').report_action(self)
 
     @api.multi
+    def print_purchase(self):
+        self.write({'state': "purchase"})
+        return self.env.ref('purchase.action_report_purchase_order').report_action(self)
+
+    @api.multi
     def button_approve(self, force=False):
         self.write({'state': 'purchase', 'date_approve': fields.Date.context_today(self)})
         self._create_picking()

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -159,7 +159,8 @@
                     <button name="button_confirm" type="object" states="draft" string="Confirm Order" id="draft_confirm"/>
                     <button name="button_confirm" type="object" states="sent" string="Confirm Order" class="oe_highlight" id="bid_confirm"/>
                     <button name="button_approve" type="object" states='to approve' string="Approve Order" class="oe_highlight" groups="purchase.group_purchase_manager"/>
-                    <button name="action_rfq_send" states="purchase" string="Send PO by Email" type="object" context="{'send_rfq':False}"/>
+                    <button name="action_rfq_send" class="oe_highlight" states="purchase" string="Send PO by Email" type="object" context="{'send_rfq':False}"/>
+                    <button name="print_purchase" class="oe_highlight" string="Print PO" type="object" states="purchase" groups="base.group_user"/>
                     <button name="action_view_picking" string="Receive Products" class="oe_highlight" type="object" attrs="{'invisible': ['|', '|' , ('is_shipped', '=', True), ('state','not in', ('purchase','done')), ('picking_count', '=', 0)]}"/>
                     <button name="button_draft" states="cancel" string="Set to Draft" type="object" />
                     <button name="button_cancel" states="draft,to approve,sent,purchase" string="Cancel" type="object" />


### PR DESCRIPTION
Description of the issue/feature this PR addresses: https://github.com/odoo/odoo/issues/24266

Current behavior before PR: 
Only **"SEND PO BY EMAIL"** button was there

Desired behavior after PR is merged: 
**"SEND PO BY EMAIL"** and **"PRINT PO"** will be there. 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
