### PR TITLE
[IMP] base: show to be deleted documents in settings module

### DIFF
--- a/odoo/addons/base/res/res_config.py
+++ b/odoo/addons/base/res/res_config.py
@@ -412,10 +412,23 @@ class ResConfigSettings(models.TransientModel, ResConfigModuleInstallationMixin)
             [('name', '=', module_name.replace("module_", '')),
             ('state', 'in', ['to install', 'installed', 'to upgrade'])])
 
+        ModuleUninstall = self.env.get('base.module.uninstall')
         if modules and not field_value:
-            deps = modules.sudo().downstream_dependencies()
-            dep_names = (deps | modules).mapped('shortdesc')
+            deps = modules.sudo().downstream_dependencies(known_deps=modules)
+            dep_names = (deps.filtered('application') or deps).mapped('shortdesc')
             message = '\n'.join(dep_names)
+
+            additional_message = ""
+            uninstall = ModuleUninstall.create({"module_id": modules.id})
+            for model_id in uninstall.model_ids:
+                if model_id.count:
+                    additional_message += "%s -> %s records\n" % (model_id.name, model_id.count)
+
+            if additional_message:
+                additional_message = "\n\nIn effect, the following documents will be deleted:\n" + additional_message
+
+            message += additional_message
+
             return {
                 'warning': {
                     'title': _('Warning!'),


### PR DESCRIPTION
The uninstall wizard shows models that are tagged with
'is_mail_thread' resulting to limited list of models when user
tries to uninstall a module. Additionally, some modules do not
contain any models that are 'mail_thread', which means that the
uninstall wizard doesn't show any models that will be deleted,
however, after the uninstallation, models defined in the module
(except the inherited model) will be deleted.

This commit shows the 'extra' models that will be deleted when
there is no 'mail_thread' models to be deleted. Additionally,
the models that will be deleted is also shown in the warning
message when a module in settings is unchecked.

Task# 1888785
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
