### PR TITLE
[FIX] manufacturing: set product quantity in bom instead of search quantity

### DIFF
--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -16,7 +16,7 @@
                     <sheet>
                         <div class="oe_button_box" name="button_box">
                             <button name="%(action_report_mrp_bom)d" type="action"
-                                class="oe_stat_button" icon="fa-bars" string="Structure &amp; Cost" attrs="{'invisible': [('bom_line_ids', '=', [])]}"/>
+                                class="oe_stat_button" icon="fa-bars" string="Structure &amp; Cost" attrs="{'invisible': [('bom_line_ids', '=', [])]}" context="{'searchQty': product_qty}"/>
                             <button name="toggle_active" type="object"
                                     class="oe_stat_button" icon="fa-archive">
                                 <field name="active" widget="boolean_button"

--- a/addons/stock/static/src/js/stock_traceability_report_backend.js
+++ b/addons/stock/static/src/js/stock_traceability_report_backend.js
@@ -26,6 +26,7 @@ var stock_report_generic = AbstractAction.extend(ControlPanelMixin, {
         this.given_context.ttype = action.context.ttype || false;
         this.given_context.auto_unfold = action.context.auto_unfold || false;
         this.given_context.lot_name = action.context.lot_name || false;
+        this.given_context.searchQty = action.context.searchQty || 1.0;
         return this._super.apply(this, arguments);
     },
     willStart: function() {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- This commit is related to issue https://github.com/odoo/odoo/issues/27465

Current behavior before PR:
- before this commit, on click of the button **Structure & Cost** quantity was not updated because context was not given

Desired behavior after PR is merged:
- after this commit, quantity will be updated




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
