### PR TITLE
[FIX] mrp: fix consume quantity field in manufacturing order

### DIFF
--- a/addons/mrp/wizard/mrp_product_produce.py
+++ b/addons/mrp/wizard/mrp_product_produce.py
@@ -38,8 +38,7 @@ class MrpProductProduce(models.TransientModel):
             if 'produce_line_ids' in fields:
                 lines = []
                 for move in production.move_raw_ids.filtered(lambda x: (x.product_id.tracking != 'none') and x.state not in ('done', 'cancel') and x.bom_line_id):
-                    qty_to_consume = float_round(todo_quantity / move.bom_line_id.bom_id.product_qty * move.bom_line_id.product_qty,
-                                                 precision_rounding=move.product_uom.rounding, rounding_method="UP")
+                    qty_to_consume = float_round(todo_quantity * move.unit_factor, precision_rounding=move.product_uom.rounding)
                     for move_line in move.move_line_ids:
                         if float_compare(qty_to_consume, 0.0, precision_rounding=move.product_uom.rounding) <= 0:
                             break


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This commit is related to issue: https://github.com/odoo/odoo/issues/25894

Current behavior before PR:
Wrong value for field **To consume quantitys** in Produce lines when Produce sub-product on Manufacturing Orders.

Desired behavior after PR is merged:
Value correction of field **To consume quantitys** in Produce lines when Produce sub-product on Manufacturing Orders.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
