### PR TITLE
[FIX] manufacturing: bom structure and cost report

### DIFF
--- a/addons/mrp/report/mrp_report_bom_structure.py
+++ b/addons/mrp/report/mrp_report_bom_structure.py
@@ -14,13 +14,13 @@ class ReportBomStructure(models.AbstractModel):
         docs = []
         for bom_id in docids:
             bom = self.env['mrp.bom'].browse(bom_id)
-            variant = data and data.get('variant')
+            variant = data and data.get('variant') and int(data.get('variant'))
             candidates = variant and self.env['product.product'].browse(variant) or bom.product_tmpl_id.product_variant_ids
             for product_variant_id in candidates:
                 if data and data.get('childs'):
                     doc = self._get_pdf_line(bom_id, product_id=product_variant_id, qty=float(data.get('quantity')), child_bom_ids=json.loads(data.get('childs')))
                 else:
-                    doc = self._get_pdf_line(bom_id, product_id=product_variant_id, unfolded=True)
+                    doc = self._get_pdf_line(bom_id, product_id=product_variant_id, qty=float(data.get('quantity')), unfolded=True)
                 doc['report_type'] = 'pdf'
                 doc['report_structure'] = data and data.get('report_type') or 'all'
                 docs.append(doc)
@@ -28,7 +28,7 @@ class ReportBomStructure(models.AbstractModel):
                 if data and data.get('childs'):
                     doc = self._get_pdf_line(bom_id, qty=float(data.get('quantity')), child_bom_ids=json.loads(data.get('childs')))
                 else:
-                    doc = self._get_pdf_line(bom_id, unfolded=True)
+                    doc = self._get_pdf_line(bom_id, qty=float(data.get('quantity')), unfolded=True)
                 doc['report_type'] = 'pdf'
                 doc['report_structure'] = data and data.get('report_type') or 'all'
                 docs.append(doc)

--- a/addons/mrp/static/src/js/mrp_bom_report.js
+++ b/addons/mrp/static/src/js/mrp_bom_report.js
@@ -120,10 +120,11 @@ var MrpBomReport = stock_report_generic.extend({
             return $(el).data('id');
         });
         framework.blockUI();
-        var reportname = 'mrp.report_bom_structure?docids=' + this.given_context.active_id + '&report_type=' + this.given_context.report_type;
+        var reportname = 'mrp.report_bom_structure?docids=' + this.given_context.active_id +
+                        '&report_type=' + this.given_context.report_type +
+                        '&quantity=' + (this.given_context.searchQty || 1);
         if (! $(ev.currentTarget).hasClass('o_mrp_bom_print_unfolded')) {
-            reportname += '&quantity=' + (this.given_context.searchQty || 1) +
-                          '&childs=' + JSON.stringify(childBomIDs);
+            reportname += '&childs=' + JSON.stringify(childBomIDs);
         }
         if (this.given_context.searchVariant) {
             reportname += '&variant=' + this.given_context.searchVariant;


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This commit is related to issue: https://github.com/odoo/odoo/issues/27549

Current behavior before PR:
BOM structure and cost report only prints quantity 1 though we change quantity value

Desired behavior after PR is merged:
BOM structure and cost report will be printed with dynamic quantity



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
