### PR TITLE
[FIX] crm: Impossible to change sales channel

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -865,7 +865,8 @@ class Lead(models.Model):
             if team_id:
                 value['team_id'] = team_id
             if user_ids:
-                value['user_id'] = user_ids[index]
+                if lead.user_id.id != user_ids[index]:
+                    value['user_id'] = user_ids[index]
                 # Cycle through user_ids
                 index = (index + 1) % len(user_ids)
             if value:


### PR DESCRIPTION
Let's consider two sales channels SC1 and SC2
Let's consider a user U member of SC1

Steps to reproduce the bug:

- Create a lead with U as salesperson and SC1 as sales channel
- Click on "Convert to opportunity"
- Change the sales channel to SC2 and Conversion Action = Convert to opportunity
- Click on "Apply"

Bug:

The sales channel of the opportunity is SC1 instead of SC2.

opw:1914453
