### PR TITLE
[IMP] account: reconciliation improve filter on date

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import time
+from datetime import datetime
 from collections import OrderedDict
 from odoo import api, fields, models, _
 from odoo.osv import expression
@@ -724,11 +725,18 @@ class AccountMoveLine(models.Model):
                 return unsigned_domain
 
             return expression.OR([unsigned_domain, build_for_amount(-amount)])
+            
+        date = str
+        try:
+            format = self.env['res.lang']._lang_get(self.env.user.lang).date_format
+            date = fields.Date.to_string(datetime.strptime(str, format).date())
+        except ValueError:
+            pass
 
         str_domain = [
             '|', ('move_id.name', 'ilike', str),
             '|', ('move_id.ref', 'ilike', str),
-            '|', ('date_maturity', 'like', str),
+            '|', ('date_maturity', 'like', date),
             '&', ('name', '!=', '/'), ('name', 'ilike', str)
         ]
         if str[0] in ['-', '+']:


### PR DESCRIPTION
Filter is now independant of the server format. It can be written in DMY or YMD, and with - or / as separator

#28156
OPW 1903580

Description of the issue/feature this PR addresses:

Current behavior before PR:
I try to use the instance format date to search and does not work.
Only work when typing date in format YYYY-MM-DD when the regional configuration is MM/DD/YYYY

Desired behavior after PR is merged:
Should be great to be able to search in the same format date MM/DD/YYYY as it is configured in the instance: this is a more logical conclusion for the not technical users.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
