### PR TITLE
[FIX] mrp_bom_cost: compute from BoM w/h quantity

### DIFF
--- a/addons/mrp_bom_cost/models/product.py
+++ b/addons/mrp_bom_cost/models/product.py
@@ -50,6 +50,8 @@ class ProductProduct(models.Model):
 
     def _compute_bom_price(self, bom, boms_to_recompute=False):
         self.ensure_one()
+        if not bom.product_qty:
+            return self.standard_price
         if not boms_to_recompute:
             boms_to_recompute = []
         total = 0


### PR DESCRIPTION
Usecase to reproduce:
- Create a BoM for a product with 0 quantity for final product
- Compute price from BoM
Traceback no division by zero.

It happens because _bom_find could returns BoM without quantity.
And it will return the total price of the BoM divied by its quantity
in order to have the price/unit.

It's not possible to directly add the domain product_qty > 0 in
_bom_find since it could introduce unexpected side effect. It's also
not possible to process the returns since it's limit=1.

Fixes #29552
