### PR TITLE
[FIX] test_main_flows: correct tour

### DIFF
--- a/odoo/addons/test_main_flows/static/src/js/tour.js
+++ b/odoo/addons/test_main_flows/static/src/js/tour.js
@@ -548,6 +548,7 @@ tour.register('main_flow_tour', {
     position: 'bottom',
 }, {
     trigger: '.o_data_row:has(.o_data_cell:contains("the_flow.product")):first',
+    extra_trigger: 'body:not(:has(> .o_loading:visible))',
     content: _t('Select the generated manufacturing order'),
     position: 'bottom',
 }, {


### PR DESCRIPTION
At some point, the tour opens "Manufacturing" app and goes to the
"Manufacturing Orders" menu. However, in community version, it happen to
be the first menu available, meaning it action is already loaded.
Clicking on the menu simply reload the current action.
There is a race condition between the tree view reload on the next tour
step that open one order.

By waiting all rpc are terminated (done via watching for the "loading"
tag to disappear), we ensure the opening of the form view actually
happen.
