### PR TITLE
[FIX] point_of_sale: empty serial popup

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1564,6 +1564,10 @@ exports.Packlotline = Backbone.Model.extend({
     },
 
     remove: function(){
+        // prevent removing all serials/lots, instead replace the last one with an empty one
+        if (this.collection.length === 1) {
+            this.add();
+        }
         this.collection.remove(this);
     }
 });
@@ -1590,7 +1594,8 @@ var PacklotlineCollection = Backbone.Collection.extend({
 
     set_quantity_by_lot: function() {
         var valid_lots = this.get_valid_lots();
-        this.order_line.set_quantity(valid_lots.length);
+        // Set orderline quantity to number of serialnumbers, if no serialnumbers exist, set the quantity to 1
+        this.order_line.set_quantity(valid_lots.length >= 1 ? valid_lots.length : 1);
     }
 });
 


### PR DESCRIPTION
* open serial or lot popup in PoS session
* remove all lines

Current behaviour:
    * there will be no posibility to fill out a serial or lot number
    anymore
    * In case of serial number, the orderline amount will be set to 0

Behaviour after fix:
    * The last remaining line will be cleared from content but still visible
    * In case of serial number, the orderline amount will be 1, except
    if explicitly set to 0 by the user