### PR TITLE
[FIX] hr: move print_employee_badge to the hr module

### DIFF
--- a/addons/hr/__manifest__.py
+++ b/addons/hr/__manifest__.py
@@ -31,6 +31,7 @@
         'views/res_config_settings_views.xml',
         'views/mail_channel_views.xml',
         'data/hr_data.xml',
+        'report/hr_employee_badge.xml'
     ],
     'demo': [
         'data/hr_demo.xml'

--- a/addons/hr/report/hr_employee_badge.xml
+++ b/addons/hr/report/hr_employee_badge.xml
@@ -5,8 +5,8 @@
         string="Print Badge"
         model="hr.employee"
         report_type="qweb-pdf"
-        name="hr_attendance.print_employee_badge"
-        file="hr_attendance.print_employee_badge"
+        name="hr.print_employee_badge"
+        file="hr.print_employee_badge"
         print_report_name="'Print Badge - %s' % (object.name).replace('/', '')"
     />
 

--- a/addons/hr_attendance/__manifest__.py
+++ b/addons/hr_attendance/__manifest__.py
@@ -22,7 +22,6 @@ actions(Check in/Check out) performed by them.
         'security/ir.model.access.csv',
         'views/web_asset_backend_template.xml',
         'views/hr_attendance_view.xml',
-        'report/hr_employee_badge.xml',
         'views/hr_department_view.xml',
         'views/hr_employee_view.xml',
         'views/res_config_settings_views.xml',


### PR DESCRIPTION
Since employee pin and barcode were moved to the hr module, so should the possibility to print employee badges.

Current behavior before PR: Attendance module needed to print the employee badges.

Desired behavior after PR is merged: Employee badges can be printed with only the hr module installed.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
