### PR TITLE
[FIX] product_pricelist: pricelist hidden rounding

### DIFF
--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -461,12 +461,13 @@ class PricelistItem(models.Model):
         else:
             self.name = _("All Products")
 
+        p = str(self.env['decimal.precision'].precision_get('Product Price'))
         if self.compute_price == 'fixed':
-            self.price = ("%s %s") % (self.fixed_price, self.pricelist_id.currency_id.name)
+            self.price = ("%."+p+"g %s") % (self.fixed_price, self.pricelist_id.currency_id.name)
         elif self.compute_price == 'percentage':
             self.price = _("%s %% discount") % (self.percent_price)
         else:
-            self.price = _("%s %% discount and %s surcharge") % (self.price_discount, self.price_surcharge)
+            self.price = _("%.2g %% discount and %s surcharge") % (self.price_discount, self.price_surcharge)
 
     @api.onchange('applied_on')
     def _onchange_applied_on(self):


### PR DESCRIPTION
OPW 1921804
In some cases, numbers displayed differ by a very small amount (10^-15) to what is inputted, even if the correct amount is stored in the database

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
