### PR TITLE
[IMP] l10n_nl: zip before city for Dutch people

### DIFF
--- a/addons/l10n_nl/__manifest__.py
+++ b/addons/l10n_nl/__manifest__.py
@@ -27,6 +27,7 @@
         'data/account_fiscal_position_account_template.xml',
         'data/account_chart_template_data.xml',
         'data/menuitem.xml',
+        'views/partner_address_view.xml',
     ],
     'demo': [],
     'auto_install': False,

--- a/addons/l10n_nl/views/partner_address_view.xml
+++ b/addons/l10n_nl/views/partner_address_view.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="view_res_partner_dutch" model="ir.ui.view">
+        <field name="name">res.partner.form.address.nl</field>
+        <field name="model">res.partner</field>
+        <field name="priority" eval="900"/>
+        <field name="arch" type="xml">
+            <form>
+                <div class="o_address_format">
+                    <field name="parent_id" invisible="1"/>
+                    <field name="type" invisible="1"/>
+                    <div attrs="{'invisible': ['|', ('parent_id', '=', False), ('type', '!=', 'contact')]}" class="oe_edit_only"><b>Company Address:</b></div>
+                    <div>
+                        <field name="street" class="oe_read_only"/>
+                    </div>
+                    <field name="street_name" placeholder="Street Name..." attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}" class="oe_edit_only"/>
+                    <div class="oe_edit_only o_row">
+                        <label for="street_number"/>
+                        <span> </span>
+                        <field name="street_number" attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}"/>
+                        <label for="street_number2"/>
+                        <field name="street_number2" attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}"/>
+                    </div>
+                    <field name="street2" invisible="1"/>
+                    <field name="zip" placeholder="ZIP" class="o_address_zip"
+                           attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}"/>&amp;nbsp;
+                    <field name="city" placeholder="City" class="o_address_city"
+                           attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}"/>
+                    <field name="state_id" class="o_address_state" placeholder="State" options='{"no_open": True}'
+                           attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}"/>
+                    <field name="country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'
+                           attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}"/>
+                </div>
+            </form>
+        </field>
+    </record>
+    <record id="base.nl" model="res.country">
+        <field name="address_view_id" ref="view_res_partner_dutch"/>
+    </record>
+</odoo>


### PR DESCRIPTION
The regular partner address format confuses Dutch
people as they are used to putting the zip code
before the city.

By using the address_view_id on the country, you will
see the zip code before the city in companies that are
located in the Netherlands.  Closes #27614

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
