### PR TITLE
[FIX] pos_sale: only show pos info to pos users

### DIFF
--- a/addons/pos_sale/views/sales_team_views.xml
+++ b/addons/pos_sale/views/sales_team_views.xml
@@ -34,6 +34,7 @@
     <record id="crm_team_salesteams_view_kanban_inherit_pos_sale" model="ir.ui.view"> 
         <field name="name">crm.team.kanban</field>
         <field name="model">crm.team</field>
+        <field name="groups_id" eval="[(4, ref('point_of_sale.group_pos_user'))]"/>
         <field name="inherit_id" ref="sales_team.crm_team_salesteams_view_kanban"/>
         <field name="arch" type="xml">
         <data>


### PR DESCRIPTION
When loading Team pipelines kanban view, only
show point of sale information to users who
have the right to see them, aka members of at
least pos users group.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
