### PR TITLE
[IMP] project_timesheet_holidays: prevent modifying leave timesheets

### DIFF
--- a/addons/project_timesheet_holidays/models/account_analytic.py
+++ b/addons/project_timesheet_holidays/models/account_analytic.py
@@ -10,7 +10,25 @@ class AccountAnalyticLine(models.Model):
 
     holiday_id = fields.Many2one("hr.leave", string='Leave Request')
 
+    @api.model
+    def _get_leave_timesheet_protected_fields(self):
+        return [
+            'name',
+            'project_id',
+            'task_id',
+            'account_id',
+            'unit_amount',
+            'user_id',
+            'date',
+            'employee_id',
+        ]
+
+    def write(self, values):
+        if self.filtered('holiday_id') and any(f in values for f in self._get_leave_timesheet_protected_fields()):
+            raise UserError(_('You cannot modify timesheet lines attached to a leave.'))
+        return super(AccountAnalyticLine, self).write(values)
+
     def unlink(self):
-        if any(line.holiday_id for line in self):
-            raise UserError(_('You cannot delete timesheet lines attached to a leaves. Please cancel the leaves instead.'))
+        if self.filtered('holiday_id'):
+            raise UserError(_('You cannot delete timesheet lines attached to a leave. Please cancel the leave instead.'))
         return super(AccountAnalyticLine, self).unlink()


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
#30850

Current behavior before PR:
 * Can modify timesheet lines on approved leaves

Desired behavior after PR is merged:
 * Can not modify timesheet lines on approved leaves



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
