### PR TITLE
[FIX] web: giving rebirth to auto_search action parameter

### DIFF
--- a/addons/web/static/src/js/views/abstract_view.js
+++ b/addons/web/static/src/js/views/abstract_view.js
@@ -99,6 +99,7 @@ var AbstractView = Class.extend({
             res_id: params.currentId,
             res_ids: params.ids,
             orderedBy: params.context ? params.context.orderedBy : [],
+            flags: params.action && params.action.flags || {},
         };
         if (params.modelName) {
             this.loadParams.modelName = params.modelName;

--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -691,7 +691,7 @@ var BasicModel = AbstractModel.extend({
             return this._makeDefaultRecord(params.modelName, params);
         }
         var dataPoint = this._makeDataPoint(params);
-        return this._load(dataPoint).then(function () {
+        return this._load(dataPoint, {flags: params.flags}).then(function () {
             return dataPoint.id;
         });
     },
@@ -3241,8 +3241,13 @@ var BasicModel = AbstractModel.extend({
      * @returns {Deferred}
      */
     _load: function (dataPoint, options) {
-        if (options && options.onlyGroups &&
-          !(dataPoint.type === 'list' && dataPoint.groupedBy.length)) {
+        if (
+                (
+                    options && options.onlyGroups &&
+                    !(dataPoint.type === 'list' && dataPoint.groupedBy.length)
+                ) ||
+                options && options.flags && options.flags.auto_search === false
+            ) {
             return $.when(dataPoint);
         }
 


### PR DESCRIPTION
In v10.0 and probably downward, ir.actions had a boolean auto_search
which was used to allow the spontaneaous loading of records at the time
of loading the view, or not.

It is still the case in v11.0, but the webClient lost its
hability to handle it.
The feature disappeared in v11.0 because of the new views and murdered
in v11.3 (probably) because of the refactoring of action_manager

This commit proposes to make it work again.
Obviously, some more work in v11.3 onward is necessary, as well as testing!

OPW 1918828
related #29615

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
