### PR TITLE
[FIX] web: fallback orderedBy from datapoint

### DIFF
--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -4030,7 +4030,8 @@ var BasicModel = AbstractModel.extend({
 
         if (options.context !== undefined) {
             element.context = options.context;
-            element.orderedBy =  options.context.orderedBy || element.orderedBy;
+            element.orderedBy =
+                options.context.orderedBy && options.context.orderedBy.length ? options.context.orderedBy : element.orderedBy;
         }
         if (options.domain !== undefined) {
             element.domain = options.domain;

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -346,7 +346,7 @@ QUnit.module('Views', {
     });
 
     QUnit.test('Loading a filter with a sort attribute', function (assert) {
-        assert.expect(2);
+        assert.expect(3);
 
         this.data.foo.fields.foo.sortable = true;
         this.data.foo.fields.date.sortable = true;
@@ -377,6 +377,9 @@ QUnit.module('Views', {
                     } else if (searchReads === 1) {
                         assert.strictEqual(args.sort, 'date DESC, foo ASC',
                             'The sort attribute of the filter should be used by the next search_read');
+                    } else if (searchReads === 2) {
+                        assert.strictEqual(args.sort, 'date DESC, foo ASC',
+                            'The sort attribute on the element should be used by the next search_read');
                     }
                     searchReads += 1;
                 }
@@ -396,6 +399,13 @@ QUnit.module('Views', {
                     }]
                 }
             });
+
+        // Simulates going back to the list with breadcrumbs
+        list.update({
+            context: {
+                orderedBy: []
+            }
+        });
 
         list.destroy()
     });


### PR DESCRIPTION
Have a list/kanban with a default_order on the view
Have a default filter that applies

Click on a element of the list
Go back to the list with the breadcrumbs

Before this commit, the default_order was not applied
This is because the wrong check was made to determine the orderedBy of the model

After this commit, the previous order that has been set on the model is kept
when reloading the model

OPW 1922576

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
