### PR TITLE
Master unece jco

### DIFF
--- a/addons/account/models/account.py
+++ b/addons/account/models/account.py
@@ -923,6 +923,9 @@ class AccountTax(models.Model):
         domain=[('deprecated', '=', False)],
         string='Base Tax Received Account',
         help='Account that will be set on lines created in cash basis journal entry and used to keep track of the tax base amount.')
+    unece_type_code = fields.Char('UNECE type code')
+    unece_categ_code = fields.Char('UNECE categ code')
+    unece_due_date_code = fields.Char('UNECE due date code')
 
     _sql_constraints = [
         ('name_company_uniq', 'unique(name, company_id, type_tax_use)', 'Tax names must be unique !'),

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -832,6 +832,9 @@ class AccountTaxTemplate(models.Model):
         domain=[('deprecated', '=', False)],
         string='Base Tax Received Account',
         help='Account that will be set on lines created in cash basis journal entry and used to keep track of the tax base amount.')
+    unece_type_code = fields.Char('UNECE type code')
+    unece_categ_code = fields.Char('UNECE categ code')
+    unece_due_date_code = fields.Char('UNECE due date code')
 
     _sql_constraints = [
         ('name_company_uniq', 'unique(name, type_tax_use, chart_template_id)', 'Tax names must be unique !'),

--- a/addons/uom/data/uom_data.xml
+++ b/addons/uom/data/uom_data.xml
@@ -32,35 +32,41 @@
             <field name="name">Unit(s)</field>
             <field name="factor" eval="1.0"/>
             <field name="rounding" eval="0.001"/>
+            <field name="unece_code">C62</field>
         </record>
-       <record id="product_uom_dozen" model="uom.uom">
+        <record id="product_uom_dozen" model="uom.uom">
             <field name="category_id" ref="uom.product_uom_categ_unit"/>
             <field name="name">Dozen(s)</field>
             <field name="factor_inv" eval="12"/>
             <field name="uom_type">bigger</field>
+            <field name="unece_code">DPC</field>
         </record>
         <record id="product_uom_kgm" model="uom.uom">
             <field name="category_id" ref="product_uom_categ_kgm"/>
             <field name="name">kg</field>
             <field name="factor" eval="1"/>
             <field name="rounding" eval="0.001"/>
+            <field name="unece_code">KGM</field>
         </record>
         <record id="product_uom_gram" model="uom.uom">
             <field name="category_id" ref="product_uom_categ_kgm"/>
             <field name="name">g</field>
             <field name="factor" eval="1000"/>
             <field name="uom_type">smaller</field>
+            <field name="unece_code">GRM</field>
         </record>
         <record id="product_uom_day" model="uom.uom">
             <field name="name">Day(s)</field>
             <field eval="uom_categ_wtime" name="category_id"/>
             <field name="factor" eval="1.0"/>
+            <field name="unece_code">DAY</field>
         </record>
         <record id="product_uom_hour" model="uom.uom">
             <field name="name">Hour(s)</field>
             <field eval="uom_categ_wtime" name="category_id"/>
             <field name="factor" eval="8.0"/>
             <field name="uom_type">smaller</field>
+            <field name="unece_code">HUR</field>
         </record>
         <record id="product_uom_ton" model="uom.uom">
             <field name="category_id" ref="product_uom_categ_kgm"/>
@@ -69,28 +75,33 @@
             <field name="name">t</field>
             <field name="factor_inv" eval="1000"/>
             <field name="uom_type">bigger</field>
+            <field name="unece_code">TNE</field>
         </record>
         <record id="product_uom_meter" model="uom.uom">
             <field name="category_id" ref="uom_categ_length"/>
             <field name="name">m</field>
             <field name="factor" eval="1.0"/>
+            <field name="unece_code">MTR</field>
         </record>
         <record id="product_uom_km" model="uom.uom">
             <field name="category_id" ref="uom_categ_length"/>
             <field name="name">km</field>
             <field name="factor_inv" eval="1000"/>
             <field name="uom_type">bigger</field>
+            <field name="unece_code">KTM</field>
         </record>
         <record id="product_uom_cm" model="uom.uom">
             <field name="category_id" ref="uom_categ_length"/>
             <field name="name">cm</field>
             <field name="factor" eval="100"/>
             <field name="uom_type">smaller</field>
+            <field name="unece_code">CMT</field>
         </record>
         <record id="product_uom_litre" model="uom.uom">
             <field name="name">Liter(s)</field>
             <field name="category_id" ref="product_uom_categ_vol"/>
             <field name="factor">1.0</field>
+            <field name="unece_code">LTR</field>
         </record>
 
         <!--Americanization of units of measure-->
@@ -99,48 +110,56 @@
             <field name="category_id" ref="product_uom_categ_kgm"/>
             <field name="factor">2.20462</field>
             <field name="uom_type">smaller</field>
+            <field name="unece_code">LBR</field>
         </record>
         <record id="product_uom_oz" model="uom.uom">
             <field name="name">oz(s)</field>
             <field name="category_id" ref="product_uom_categ_kgm"/>
             <field name="factor">35.274</field>
             <field name="uom_type">smaller</field>
+            <field name="unece_code">ONZ</field>
         </record>
         <record id="product_uom_inch" model="uom.uom">
             <field name="name">inch(es)</field>
             <field name="category_id" ref="uom_categ_length"/>
             <field name="factor">39.3701</field>
             <field name="uom_type">smaller</field>
+            <field name="unece_code">INH</field>
         </record>
         <record id="product_uom_foot" model="uom.uom">
             <field name="name">foot(ft)</field>
             <field name="category_id" ref="uom_categ_length"/>
             <field name="factor">3.28084</field>
             <field name="uom_type">smaller</field>
+            <field name="unece_code">FOT</field>
         </record>
         <record id="product_uom_mile" model="uom.uom">
             <field name="name">mile(s)</field>
             <field name="category_id" ref="uom_categ_length"/>
             <field name="factor_inv" eval="1609.34"/>
             <field name="uom_type">bigger</field>
+            <field name="unece_code">SMI</field>
         </record>
         <record id="product_uom_floz" model="uom.uom">
             <field name="name">fl oz</field>
             <field name="category_id" ref="product_uom_categ_vol"/>
             <field name="factor">33.814</field>
             <field name="uom_type">smaller</field>
+            <field name="unece_code">OZA</field>
         </record>
         <record id="product_uom_qt" model="uom.uom">
             <field name="name">qt</field>
             <field name="category_id" ref="product_uom_categ_vol"/>
             <field name="factor">1.05669</field>
             <field name="uom_type">smaller</field>
+            <field name="unece_code">QT</field>
         </record>
         <record id="product_uom_gal" model="uom.uom">
             <field name="name">gal(s)</field>
             <field name="category_id" ref="product_uom_categ_vol"/>
             <field name="factor_inv" eval="3.78541"/>
             <field name="uom_type">bigger</field>
+            <field name="unece_code">GLL</field>
         </record>
     </data>
 </odoo>

--- a/addons/uom/models/uom_uom.py
+++ b/addons/uom/models/uom_uom.py
@@ -56,6 +56,7 @@ class UoM(models.Model):
         ('smaller', 'Smaller than the reference Unit of Measure')], 'Type',
         default='reference', required=1)
     measure_type = fields.Selection(string="Type of measurement category", related='category_id.measure_type', store=True, readonly=True)
+    unece_code = fields.Char('UNECE code', help="This is an international code to ease the interchange of documents e.g. for electronic invoicing.  ")
 
     _sql_constraints = [
         ('factor_gt_zero', 'CHECK (factor!=0)', 'The conversion ratio for a unit of measure cannot be 0!'),

--- a/addons/uom/views/uom_uom_views.xml
+++ b/addons/uom/views/uom_uom_views.xml
@@ -37,6 +37,7 @@
                              <p attrs="{'invisible':[('uom_type','!=','bigger')]}" class="oe_grey" colspan="2">
                                  e.g: 1 * (this unit) = ratio * (reference unit)
                              </p>
+                             <field name="unece_code" groups="base.group_no_one"/>
                          </group>
                          <group name="active_rounding">
                              <field name="active"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Provide UoMs and taxes with UNECE codes such that when we exchange e.g. invoices we have immediately the right UoM or the right tax.  

See discussion https://github.com/odoo/odoo/pull/24303#issuecomment-470076741

This PR should not be merged (for the moment), but is to discuss the general model. 

Current behavior before PR is merged:
Taxes and UoMs are matched by chance on import of an electronic invoice

Desired behavior after PR is merged:
Taxes and UoMs are matched



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
