### PR TITLE
[FIX] base: add more information if wrong related field

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -524,7 +524,11 @@ class Field(MetaField('DummyField', (object,), {})):
         # determine the chain of fields, and make sure they are all set up
         model_name = self.model_name
         for name in self.related.split('.'):
-            field = model.pool[model_name]._fields[name]
+            field = model.pool[model_name]._fields.get(name)
+            if field is None:
+                raise KeyError(
+                    f"Field {name} referenced in related field definition {self} does not exist."
+                )
             if not field._setup_done:
                 field.setup(model.env[model_name])
             model_name = field.comodel_name


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
During a migration process if a field have change/removed, during the installation there is a KeyError on related field.

Before :
`KeyError: "purchase_line_id"`

After
`KeyError: "Wrong related field, 'stock.move.purchase_order_id', relation : 'purchase_line_id.order_id', wrong field : 'purchase_line_id'"`

@odony @nim-odoo

cc @sla-subteno-it 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
