### PR TITLE
[IMP] support Access-Control-Allow-Credentials

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -451,6 +451,7 @@ def route(route=None, **kw):
     :param methods: A sequence of http methods this route applies to. If not
                     specified, all methods are allowed.
     :param cors: The Access-Control-Allow-Origin cors directive value.
+    :param bool cors_credentials: The Access-Control-Allow-Credentials header.
     :param bool csrf: Whether CSRF protection should be enabled for the route.
 
                       Defaults to ``True``. See :ref:`CSRF Protection
@@ -1212,6 +1213,8 @@ class Response(werkzeug.wrappers.Response):
         # Support for Cross-Origin Resource Sharing
         if request.endpoint and 'cors' in request.endpoint.routing:
             self.headers.set('Access-Control-Allow-Origin', request.endpoint.routing['cors'])
+            if request.endpoint.routing.get('cors_credentials') == True:
+                self.headers.set('Access-Control-Allow-Credentials', 'true')
             methods = 'GET, POST'
             if request.endpoint.routing['type'] == 'json':
                 methods = 'POST'


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

Support for CORS was introduced in version 8.0 but there still lack support for
with Access-Control-Allow-Credentials header, which is required to access user
credentials.

### Current behavior before PR:

No way to set Access-Control-Allow-Credentials header through routing attribute.

### Desired behavior after PR is merged:

Introduce new attribute to set Access-Control-Allow-Credentials header.

### related specifications
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials
https://www.w3.org/TR/cors/#access-control-allow-credentials-response-header

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
