### PR TITLE
account: dont put residual currency if it is the company currency

### DIFF
--- a/addons/account/models/account_invoice.py
+++ b/addons/account/models/account_invoice.py
@@ -915,10 +915,6 @@ class AccountInvoice(models.Model):
     def assign_outstanding_credit(self, credit_aml_id):
         self.ensure_one()
         credit_aml = self.env['account.move.line'].browse(credit_aml_id)
-        if not credit_aml.currency_id and self.currency_id != self.company_id.currency_id:
-            credit_aml.with_context(allow_amount_currency=True, check_move_validity=False).write({
-                'amount_currency': self.company_id.currency_id.with_context(date=credit_aml.date).compute(credit_aml.balance, self.currency_id),
-                'currency_id': self.currency_id.id})
         if credit_aml.payment_id:
             credit_aml.payment_id.write({'invoice_ids': [(4, self.id, None)]})
         return self.register_payment(credit_aml)


### PR DESCRIPTION
OPW 1925104
If a invoice is made in a foreign currency but is paid in the company currency, the amount_currency will be set on the account move line, messing with the reconciliation

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
