### PR TITLE
[IMP] product : add new field for chart of account when customer credit note generate.

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -119,8 +119,10 @@ class AccountChartTemplate(models.Model):
     property_account_payable_id = fields.Many2one('account.account.template', string='Payable Account', oldname="property_account_payable")
     property_account_expense_categ_id = fields.Many2one('account.account.template', string='Category of Expense Account', oldname="property_account_expense_categ")
     property_account_income_categ_id = fields.Many2one('account.account.template', string='Category of Income Account', oldname="property_account_income_categ")
+    property_account_income_refund_categ_id = fields.Many2one('account.account.template', string='Category of Income Refund Account')
     property_account_expense_id = fields.Many2one('account.account.template', string='Expense Account on Product Template', oldname="property_account_expense")
     property_account_income_id = fields.Many2one('account.account.template', string='Income Account on Product Template', oldname="property_account_income")
+    property_account_income_refund_id = fields.Many2one('account.account.template', string='Income Refund Account on Product Template')
     property_stock_account_input_categ_id = fields.Many2one('account.account.template', string="Input Account for Stock Valuation", oldname="property_stock_account_input_categ")
     property_stock_account_output_categ_id = fields.Many2one('account.account.template', string="Output Account for Stock Valuation", oldname="property_stock_account_output_categ")
     property_stock_valuation_account_id = fields.Many2one('account.account.template', string="Account Template for Stock Valuation")
@@ -458,12 +460,22 @@ class AccountChartTemplate(models.Model):
             ('property_account_payable_id', 'res.partner', 'account.account'),
             ('property_account_expense_categ_id', 'product.category', 'account.account'),
             ('property_account_income_categ_id', 'product.category', 'account.account'),
+            ('property_account_income_refund_categ_id', 'product.category', 'account.account'),
             ('property_account_expense_id', 'product.template', 'account.account'),
             ('property_account_income_id', 'product.template', 'account.account'),
+            ('property_account_income_refund_id', 'product.template', 'account.account'),
         ]
         for record in todo_list:
             account = getattr(self, record[0])
             value = account and 'account.account,' + str(acc_template_ref[account.id]) or False
+            # If a CoA is not defining `property_account_income_refund_categ_id` and/or `property_account_income_refund_id`,
+            # it should be set with the value of `property_account_income_categ_id` and/or `property_account_income_id` respectively
+            if record[0] == 'property_account_income_refund_categ_id' and not value:
+                account = getattr(self, 'property_account_income_categ_id')
+                value = account and 'account.account,' + str(acc_template_ref[account.id]) or False
+            elif record[0] == 'property_account_income_refund_id' and not value:
+                account = getattr(self, 'property_account_income_id')
+                value = account and 'account.account,' + str(acc_template_ref[account.id]) or False
             if value:
                 field = self.env['ir.model.fields'].search([('name', '=', record[0]), ('model', '=', record[1]), ('relation', '=', record[2])], limit=1)
                 vals = {

--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -10,11 +10,15 @@ class ProductCategory(models.Model):
     property_account_income_categ_id = fields.Many2one('account.account', company_dependent=True,
         string="Income Account", oldname="property_account_income_categ",
         domain=[('deprecated', '=', False)],
-        help="This account will be used when validating a customer invoice.")
+        help="This account will be used by default on customer \n invoices if no income account is set on the product.")
     property_account_expense_categ_id = fields.Many2one('account.account', company_dependent=True,
         string="Expense Account", oldname="property_account_expense_categ",
         domain=[('deprecated', '=', False)],
         help="The expense is accounted for when a vendor bill is validated, except in anglo-saxon accounting with perpetual inventory valuation in which case the expense (Cost of Goods Sold account) is recognized at the customer invoice validation.")
+    property_account_income_refund_categ_id = fields.Many2one('account.account', company_dependent=True,
+        string="Income Refund Account",
+        domain=[('deprecated', '=', False)],
+        help="This account will be used by default on customer credit notes if no income refund account is set on the product")
 
 #----------------------------------------------------------
 # Products
@@ -29,16 +33,21 @@ class ProductTemplate(models.Model):
     property_account_income_id = fields.Many2one('account.account', company_dependent=True,
         string="Income Account", oldname="property_account_income",
         domain=[('deprecated', '=', False)],
-        help="Keep this field empty to use the default value from the product category.")
+        help="This account will by default on customer invoices.")
     property_account_expense_id = fields.Many2one('account.account', company_dependent=True,
         string="Expense Account", oldname="property_account_expense",
         domain=[('deprecated', '=', False)],
         help="Keep this field empty to use the default value from the product category. If anglo-saxon accounting with automated valuation method is configured, the expense account on the product category will be used.")
+    property_account_income_refund_id = fields.Many2one('account.account', company_dependent=True,
+        string="Income Refund Account",
+        domain=[('deprecated', '=', False)],
+        help="This account will be used by default on customer credit notes")
 
     @api.multi
     def _get_product_accounts(self):
         return {
             'income': self.property_account_income_id or self.categ_id.property_account_income_categ_id,
+            'income_refund': self.property_account_income_refund_id or self.categ_id.property_account_income_refund_categ_id,
             'expense': self.property_account_expense_id or self.categ_id.property_account_expense_categ_id
         }
 

--- a/addons/account/views/product_view.xml
+++ b/addons/account/views/product_view.xml
@@ -17,6 +17,9 @@
                                 <field name="property_account_income_id"
                                     domain="[('internal_type','=','other'),('deprecated','=',False)]"
                                     groups="account.group_account_user"/>
+                                <field name="property_account_income_refund_id"
+                                    domain="[('internal_type','=','other'),('deprecated','=',False)]"
+                                    groups="account.group_account_user"/>
                             </group>
                             <group string="Payables" name="payables">
                                 <field name="property_account_expense_id"
@@ -45,6 +48,7 @@
                     <group name="account_property" >
                         <group string="Account Properties" groups="account.group_account_user">
                             <field name="property_account_income_categ_id" domain="[('internal_type','=','other'),('deprecated', '=', False)]"/>
+                            <field name="property_account_income_refund_categ_id" domain="[('internal_type','=','other'),('deprecated', '=', False)]"/>
                             <field name="property_account_expense_categ_id" domain="[('internal_type','=','other'),('deprecated', '=', False)]"/>
                         </group>
                     </group>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: 
if set then customer credit note entry generate this chart of account(income refund)
otherwise income account use.

Task: https://www.odoo.com/web?#id=46627&view_type=form&model=project.task&action=327&menu_id=4720
Pad: https://pad.odoo.com/p/r.6b565f03a9a95d8f606fcd4dc43a6aba

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
