### PR TITLE
[FIX] web: Date widget displays datetime field

### DIFF
--- a/addons/web/static/src/js/fields/abstract_field.js
+++ b/addons/web/static/src/js/fields/abstract_field.js
@@ -158,7 +158,7 @@ var AbstractField = Widget.extend({
         // used to avoid setting the value twice in a row with the exact value.
         this.lastSetValue = undefined;
 
-        // formatType is used to determine which format (and parse) functions
+        // formatType is used to determine which format functions
         // to call to format the field's value to insert into the DOM (typically
         // put into a span or an input), and to parse the value from the input
         // to send it to the server. These functions are chosen according to
@@ -168,6 +168,8 @@ var AbstractField = Widget.extend({
         this.formatType = this.attrs.widget in field_utils.format ?
                             this.attrs.widget :
                             this.field.type;
+        // Same as formatType; but for parse method
+        this.parseType = this.formatType;
         // formatOptions (resp. parseOptions) is a dict of options passed to
         // calls to the format (resp. parse) function.
         this.formatOptions = {};
@@ -336,7 +338,7 @@ var AbstractField = Widget.extend({
      * @returns {any}
      */
     _parseValue: function (value) {
-        return field_utils.parse[this.formatType](value, this.field, this.parseOptions);
+        return field_utils.parse[this.parseType](value, this.field, this.parseOptions);
     },
     /**
      * main rendering function.  Override this if your widget has the same render

--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -404,9 +404,26 @@ var FieldDate = InputField.extend({
         this._super.apply(this, arguments);
         // use the session timezone when formatting dates
         this.formatOptions.timezone = true;
+        var datePickerDefaultValue = this.value;
+
+        // displaying a datetime with a Date widget
+        if (this.formatType === 'date' && this.field.type === 'datetime') {
+            // With a datetime field we know that:
+            // 1. We receive UTC value from the server: this.formatOptions.timezone = true
+            // 2. We display a date to the user: this.formatType = 'date'
+            // 3. The date that is displayed is expressed according to the user's timezone
+            datePickerDefaultValue = datePickerDefaultValue && datePickerDefaultValue
+                .clone()
+                .add(session.getTZOffset(datePickerDefaultValue), 'minutes');
+            // 4. We send full datetime value to the server
+            this.parseType = 'datetime';
+            // 5. We send UTC value to the server
+            this.parseOptions.timezone = true;
+        };
+
         this.datepickerOptions = _.defaults(
             this.nodeOptions.datepicker || {},
-            {defaultDate: this.value}
+            {defaultDate: datePickerDefaultValue}
         );
     },
     /**


### PR DESCRIPTION
Be in a timezone West from UTC
Make a datetime field display with the Date field widget

Before this commit, the timezone switch was not handled correctly.
Namely, when changing the date and then blur the input, the date changed to
the day before the one choosen.
This was because, when changing the date, the widget sets it to midnight UTC
which, makes the day before in the user timezone

After this commit, this is handled correctly.
- Reading UTC from the server makes the displayed date correct in TZ
- Both in edit mode and read mode of the field
- Sending a write will send the correct datetime UTC to the server

OPW 1950830

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
