### PR TITLE
[FIX] project: adding channels members to a private project

### DIFF
--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -51,7 +51,9 @@
         <field name="model_id" ref="model_project_project"/>
         <field name="domain_force">['|',
                                         ('privacy_visibility', '!=', 'followers'),
-                                        ('message_partner_ids', 'in', [user.partner_id.id])
+                                        '|',
+                                            ('message_partner_ids', 'in', [user.partner_id.id]),
+                                            ('message_channel_ids', 'in', user.partner_id.channel_ids.ids),
                                     ]</field>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
     </record>


### PR DESCRIPTION
Steps to reproduce:
- Create a channels C with user A linked to an employee E
- Create project P with privacy_visibility='followers' meaning only visible for employees that follow P
- Add the channel C as a follower of P
- Log as user A go to Project app

Bug:
The project P is not readable for A

opw:1958386
