### PR TITLE
[FIX] web: Date widget displays datetime field

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -404,6 +404,14 @@ var FieldDate = InputField.extend({
         this._super.apply(this, arguments);
         // use the session timezone when formatting dates
         this.formatOptions.timezone = true;
+
+        if (this.formatType === 'date' && this.field.type === 'datetime') {
+            // displaying a datetime with a Date widget
+            // We receive UTC
+            // We display the date as seen from UTC
+            // We send just a date to the server (which will translate it to midnight UTC)
+            this.formatOptions.timezone = false;
+        }
         this.datepickerOptions = _.defaults(
             this.nodeOptions.datepicker || {},
             {defaultDate: this.value}


### PR DESCRIPTION
Be in a timezone West from UTC
Make a datetime field display with the Date field widget

Before this commit, the timezone switch was not handled correctly.
Namely, when changing the date and then blur the input, the date changed to
the day before the one choosen.
This was because, when changing the date, the widget sets it to midnight UTC
which, makes the day before in the user timezone

After this commit, this is handled correctly.
- Reading UTC from the server makes the displayed date correct from UTC perspective
- Both in edit mode and read mode of the field
- Sending a write will send the correct date to the server
which will get translated to date + midnight by the server

OPW 1950830

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
