### PR TITLE
[POC] framework: allow restarting a migration

### DIFF
--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -427,6 +427,7 @@ def load_modules(db, force_demo=False, status=None, update_module=False):
         migrations = odoo.modules.migration.MigrationManager(cr, graph)
         for package in graph:
             migrations.migrate_module(package, 'end')
+        migrations._clean_migration_history()
 
         # STEP 4: Finish and cleanup installations
         if processed_modules:


### PR DESCRIPTION
The point of this commit is to add the possibility to restart a
migration where it stopped in its previous attempt. This should be
used for debugging purposes more than for production migrations -
as stated in the docstring, if an explicit commit happen in the upgrade
scripts, this will most likely *not* work.

Since this is a stable release, this feature had to be introduced
without breaking anything; hence the weird usage of the ir_logging table
as temporary storage. Ideally we should do something smarter in master.

This plugs into the loading of modules to:
- add the 3 stages of module migration in a temporary place, marking
them as not yet done - this is done every time the migration manager
is init'd with a new graph
- mark as step as processed for a certain module once it's done
- check if a step was already done and skip it if that's the case
- delete the complete migration history once all modules have been
loaded and end scripts applied successfully

Some notes:
- the cursor is explicitely committed after each module load; which
means that in all normal cases, you should be able to restart an upgrade
right after the post step of a module - and all modules coming after
that should still be unprocessed from a migration PoV
This also means that once the post scripts for a module have been
processed, the module is marked as updated (w. regards to the
`latest_version` field) in database - even though its end script have
*not* been processed.
Therefore, when checking whether end scripts have been applied, we
cannot trust the value on the package and instead have to check the
presence of end scripts for that module in the temporary ir_loggin
entries.
- ideally, an explicit commit should be added in loading.py right after
the end scripts are processed and the temporary table is cleaned to
ensure a correct state; I dared not do that in a stable release


Test cases where it should not crash/change existing behaviours:
- [ ] init db
- [ ] upgrading modules in same version
- [ ] uninstalling modules
- [ ] installing modules
- [ ] adding new modules in stable version (e.g. fix module)

Test cases where it should allow restarting an upgrade:
- [ ] upgrading modules after manifest version bump (but not server bump)
- [ ] upgrading modules with server bump

Open q&a:
- allow an autocommit mode where each migration script if committed in db, allowing the restart at the exact file you crash last time? pbly overkill
