### PR TITLE
[Master] improve mrp extendability

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -750,6 +750,12 @@ class MrpProduction(models.Model):
                 for ml in move_lines:
                     error_msg += ml.product_id.display_name + ' (' + ml.lot_produced_id.name +')\n'
                 raise UserError(error_msg)
+            
+    @api.multi
+    def action_start(self):
+        self.write({
+            'date_start': datetime.now()
+            })
 
     @api.multi
     def action_cancel(self):


### PR DESCRIPTION
When starting a work order, Odoo create a new timeline (a `mrp.workcenter.productivity` record) inside the method `button_start`. The value preparation for timeline is also put in the same method which causes problems for extensions.

This commit split the method into multiple dedicated methods so that others can modify/inject more data easily.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
