### PR TITLE
[FIX] web: display datetime as date

### DIFF
--- a/addons/web/static/src/js/fields/abstract_field.js
+++ b/addons/web/static/src/js/fields/abstract_field.js
@@ -168,6 +168,8 @@ var AbstractField = Widget.extend({
         this.formatType = this.attrs.widget in field_utils.format ?
                             this.attrs.widget :
                             this.field.type;
+        // Same as formatType; but for parse method
+        this.parseType = this.formatType;
         // formatOptions (resp. parseOptions) is a dict of options passed to
         // calls to the format (resp. parse) function.
         this.formatOptions = {};
@@ -336,7 +338,7 @@ var AbstractField = Widget.extend({
      * @returns {any}
      */
     _parseValue: function (value) {
-        return field_utils.parse[this.formatType](value, this.field, this.parseOptions);
+        return field_utils.parse[this.parseType](value, this.field, this.parseOptions);
     },
     /**
      * main rendering function.  Override this if your widget has the same render

--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -408,9 +408,10 @@ var FieldDate = InputField.extend({
 
         // displaying a datetime with a Date widget
         this._datetimeAsDate = this.formatType === 'date' && this.field.type === 'datetime';
+        this.managesDateTime = this.formatType === 'datetime' || this._datetimeAsDate;
 
          // displaying a datetime with a Date widget
-        if (this._datetimeAsDate) {
+        if (this.managesDateTime) {
             // With a datetime field we know that:
             // 1. We receive UTC value from the server: this.formatOptions.timezone = true
             // 2. We display a date to the user: this.formatType = 'date'
@@ -468,7 +469,7 @@ var FieldDate = InputField.extend({
      */
     _getValue: function () {
         var value = this.datewidget.getValue();
-        if (this._datetimeAsDate) {
+        if (this.managesDateTime) {
             value = this._offsetValueByTz('to_utc', value);
         }
         return value;
@@ -481,11 +482,11 @@ var FieldDate = InputField.extend({
      */
     _isSameValue: function (value) {
         var resolution = 'day'
+        if (this.managesDateTime) {
+            resolution = undefined;
+        }
         if (value === false) {
             return this.value === false;
-        }
-        if (this._datetimeAsDate) {
-            resolution = undefined;
         }
         return value.isSame(this.value, resolution);
     },
@@ -496,7 +497,7 @@ var FieldDate = InputField.extend({
      */
     _makeDatePicker: function () {
         var datePickerWidget = datepicker.DateWidget;
-        if (this._datetimeAsDate) {
+        if (this.managesDateTime) {
             datePickerWidget = datepicker.DateTimeWidget;
         }
         return new datePickerWidget(this, this.datepickerOptions);
@@ -510,7 +511,7 @@ var FieldDate = InputField.extend({
      */
     _renderEdit: function () {
         var value = this.value;
-        if (this._datetimeAsDate) {
+        if (this.managesDateTime) {
             value = this._offsetValueByTz('from_utc', value);
         }
         this.datewidget.setValue(value);
@@ -538,60 +539,6 @@ var FieldDate = InputField.extend({
 
 var FieldDateTime = FieldDate.extend({
     supportedFieldTypes: ['datetime'],
-
-    /**
-     * @override
-     */
-    init: function () {
-        this._super.apply(this, arguments);
-        if (this.value) {
-            var displayedValue = this._offsetValueByTz('from_utc', this.value)
-            this.datepickerOptions.defaultDate = displayedValue;
-        }
-    },
-    //--------------------------------------------------------------------------
-    // Private
-    //--------------------------------------------------------------------------
-
-    /**
-     * return the datepicker value
-     *
-     * @private
-     */
-    _getValue: function () {
-        var value = this.datewidget.getValue();
-        return this._offsetValueByTz('to_utc', value)
-    },
-    /**
-     * @override
-     * @private
-     */
-    _isSameValue: function (value) {
-        if (value === false) {
-            return this.value === false;
-        }
-        return value.isSame(this.value);
-    },
-    /**
-     * Instantiates a new DateTimeWidget datepicker rather than DateWidget.
-     *
-     * @override
-     * @private
-     */
-    _makeDatePicker: function () {
-        return new datepicker.DateTimeWidget(this, this.datepickerOptions);
-    },
-    /**
-     * Set the datepicker to the right value rather than the default one.
-     *
-     * @override
-     * @private
-     */
-    _renderEdit: function () {
-        var value = this._offsetValueByTz('from_utc', this.value)
-        this.datewidget.setValue(value);
-        this.$input = this.datewidget.$input;
-    },
 });
 
 var FieldMonetary = InputField.extend({

--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -408,9 +408,9 @@ var FieldDate = InputField.extend({
 
         // displaying a datetime with a Date widget
         this._datetimeAsDate = this.formatType === 'date' && this.field.type === 'datetime';
-        this.managesDateTime = this.formatType === 'datetime' || this._datetimeAsDate;
 
-         // displaying a datetime with a Date widget
+        // The widget manages a datetime
+        this.managesDateTime = this.formatType === 'datetime' || this._datetimeAsDate;
         if (this.managesDateTime) {
             // With a datetime field we know that:
             // 1. We receive UTC value from the server: this.formatOptions.timezone = true
@@ -481,7 +481,7 @@ var FieldDate = InputField.extend({
      * @returns {boolean}
      */
     _isSameValue: function (value) {
-        var resolution = 'day'
+        var resolution = 'day';
         if (this.managesDateTime) {
             resolution = undefined;
         }

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -2028,6 +2028,58 @@ QUnit.module('basic_fields', {
 
     QUnit.module('FieldDate');
 
+    QUnit.test('change datetime field handled by date widget with timezone', function (assert) {
+        assert.expect(9);
+
+         this.data.partner.records[0].datetime = '2019-03-25 01:00:00';
+
+         var form = createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch:'<form string="Partners"><field name="datetime" widget="date"/></form>',
+            translateParameters: {  // Avoid issues due to localization formats
+                date_format: '%m/%d/%Y',
+                time_format: '%H:%M:%S',
+            },
+            res_id: 1,
+            session: {
+                getTZOffset: function () {
+                    return -180;
+                },
+            },
+            mockRPC: function (route, args) {
+                assert.step(args.method);
+                if (args.method === 'write') {
+                    assert.deepEqual(args.args[1], {datetime: '2017-02-09 02:00:00'},
+                        'The right UTC value should have been sent to the server');
+                }
+                return this._super.apply(this, arguments);
+            },
+        });
+
+         assert.strictEqual(form.$('.o_field_date').text(), '03/24/2019',
+            'Read mode: The display of the date should be in user TZ');
+
+         form.$buttons.find('.o_form_button_edit').click();
+
+         assert.strictEqual(form.$('.o_datepicker_input').val(), '03/24/2019 22:00:00',
+            'Edit mode: The display of the date should be in user TZ datetime format');
+
+         form.$('input[name="datetime"]').val('02/08/2017 23:00:00').trigger('input').trigger('change');
+        assert.strictEqual(form.$('.o_datepicker_input').val(), '02/08/2017 23:00:00',
+            'Edit mode: The display of the new date should be in user TZ datetime format');
+
+         form.$buttons.find('.o_form_button_save').click();
+
+         assert.strictEqual(form.$('.o_field_date').text(), '02/08/2017',
+            'Read mode: The display of the new date should be in user TZ');
+
+         assert.verifySteps(['read', 'write', 'read']);
+
+         form.destroy();
+    });
+
     QUnit.test('date field is empty if no date is set', function (assert) {
         assert.expect(2);
 

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -2285,8 +2285,8 @@ QUnit.module('basic_fields', {
         form.destroy();
     });
 
-    QUnit.test('do not trigger a field_changed for datetime field with date widget', function (assert) {
-        assert.expect(3);
+    QUnit.test('do trigger a field_changed for datetime field with date widget', function (assert) {
+        assert.expect(6);
 
         var form = createView({
             View: FormView,
@@ -2303,17 +2303,21 @@ QUnit.module('basic_fields', {
             },
             mockRPC: function (route, args) {
                 assert.step(args.method);
+                if (args.method === 'write') {
+                    assert.deepEqual(args.args[1], {datetime: '2017-02-08 00:00:00'},
+                        'We should send full datetime UTC value');
+                }
                 return this._super.apply(this, arguments);
             },
         });
 
-        assert.strictEqual(form.$('.o_datepicker_input').val(), '02/08/2017',
+        assert.strictEqual(form.$('.o_datepicker_input').val(), '02/08/2017 10:00:00',
             'the date should be correct');
 
         form.$('input[name="datetime"]').val('02/08/2017').trigger('input').trigger('change');
         form.$buttons.find('.o_form_button_save').click();
 
-        assert.verifySteps(['read']); // should not have save as nothing changed
+        assert.verifySteps(['read', 'write', 'read']);
 
         form.destroy();
     });


### PR DESCRIPTION
WIP AND POC !
- display datetime picker when a datetime is displayed with the date widget
- display the actual datetime in edit mode
- display only date in readonly mode
- convert to/from utc when sending/receiving from server


Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
