### PR TITLE
[FIX] model: catch misuses of `user_has_groups`

### DIFF
--- a/addons/mrp/report/mrp_report_bom_structure.py
+++ b/addons/mrp/report/mrp_report_bom_structure.py
@@ -88,8 +88,8 @@ class ReportBomStructure(models.AbstractModel):
             'variants': bom_product_variants,
             'bom_uom_name': bom_uom_name,
             'bom_qty': bom_quantity,
-            'is_variant_applied': self.env.user.user_has_groups('product.group_product_variant') and len(bom_product_variants) > 1,
-            'is_uom_applied': self.env.user.user_has_groups('uom.group_uom')
+            'is_variant_applied': self.user_has_groups('product.group_product_variant') and len(bom_product_variants) > 1,
+            'is_uom_applied': self.user_has_groups('uom.group_uom')
         }
 
     def _get_bom(self, bom_id=False, product_id=False, line_qty=False, line_id=False, level=False):

--- a/addons/website/views/website_navbar_templates.xml
+++ b/addons/website/views/website_navbar_templates.xml
@@ -65,7 +65,7 @@
                 </ul>
 
                 <ul class="o_menu_systray d-none d-md-block" groups="website.group_website_publisher">
-                    <li t-if="'website_published' in main_object.fields_get()" t-attf-class="js_publish_management #{main_object.website_published and 'css_published' or 'css_unpublished'}" t-att-data-id="main_object.id" t-att-data-object="main_object._name" t-att-data-controller="publish_controller">
+                    <li t-if="'website_published' in main_object" t-attf-class="js_publish_management #{main_object.website_published and 'css_published' or 'css_unpublished'}" t-att-data-id="main_object.id" t-att-data-object="main_object._name" t-att-data-controller="publish_controller">
                         <label class="o_switch o_switch_danger js_publish_btn" for="id">
                             <input type="checkbox" t-att-checked="main_object.website_published" id="id"/>
                             <span/>
@@ -166,7 +166,7 @@
                     <li t-if="not translatable" id="edit-page-menu">
                         <a data-action="edit" href="#"><span class="fa fa-pencil"/>Edit</a>
                     </li>
-                    <li t-if="'website_published' in main_object.fields_get() and main_object._name != 'website.page'">
+                    <li t-if="'website_published' in main_object and main_object._name != 'website.page'">
                         <a role="button" class="btn btn-primary btn-sm dropdown-toggle css_edit_dynamic" data-toggle="dropdown">
                             <span class="sr-only">Toggle Dropdown</span>
                         </a>

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1197,6 +1197,13 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         from odoo.http import request
         user = self.env.user
 
+        if self._name == "res.users" and self:
+            raise ValueError(
+                "`user_has_groups` works on environment's user, not on %r. "
+                "Use `has_group()` method instead."
+                % (self,)
+            )
+
         has_groups = []
         not_has_groups = []
         for group_ext_id in groups.split(','):


### PR DESCRIPTION
As shown by 385342b575f6f8510cea6c90108be7b510fd1fa1 and 29052c5328756a0bdae443f7cec0a95c4413bd1f,
`user_has_groups` can be misused and lead to subtle bugs.