### PR TITLE
[FIX] web: fix list view rendering in no leaf mode

### DIFF
--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -4165,6 +4165,7 @@ var BasicModel = AbstractModel.extend({
                 list.count = 0;
                 var defs = [];
                 var openGroupCount = 0;
+                var noLeaf = list.context && !!list.context.group_by_no_leaf;
 
                 _.each(groups, function (group) {
                     var aggregateValues = {};
@@ -4184,7 +4185,7 @@ var BasicModel = AbstractModel.extend({
                     }
                     var newGroup = self._makeDataPoint({
                         modelName: list.model,
-                        count: group[rawGroupBy + '_count'],
+                        count: noLeaf ? group['__count'] : group[rawGroupBy + '_count'],
                         domain: group.__domain,
                         context: list.context,
                         fields: list.fields,

--- a/addons/web/static/src/js/views/list/list_renderer.js
+++ b/addons/web/static/src/js/views/list/list_renderer.js
@@ -67,6 +67,7 @@ var ListRenderer = BasicRenderer.extend({
         this.pagers = []; // instantiated pagers (only for grouped lists)
         this.editable = params.editable;
         this.isGrouped = this.state.groupedBy.length > 0;
+        this.noLeaf = params.noLeaf;
     },
 
     //--------------------------------------------------------------------------
@@ -451,7 +452,7 @@ var ListRenderer = BasicRenderer.extend({
             .css('padding-left', (groupLevel * 20) + 'px')
             .css('padding-right', '5px')
             .addClass('fa');
-        if (group.count > 0) {
+        if (group.count > 0 && !(this.noLeaf && _.isEmpty(group.groupedBy))) {
             $arrow.toggleClass('fa-caret-right', !group.isOpen)
                 .toggleClass('fa-caret-down', group.isOpen);
         }
@@ -804,8 +805,9 @@ var ListRenderer = BasicRenderer.extend({
      * @param {MouseEvent} event
      */
     _onToggleGroup: function (event) {
+        var self = this;
         var group = $(event.currentTarget).data('group');
-        if (group.count) {
+        if (group.count && !(self.noLeaf && _.isEmpty(group.groupedBy))) {
             this.trigger_up('toggle_group', { group: group });
         }
     },

--- a/addons/web/static/src/js/views/list/list_view.js
+++ b/addons/web/static/src/js/views/list/list_view.js
@@ -51,6 +51,7 @@ var ListView = BasicView.extend({
                 'hasSelectors' in params ? params.hasSelectors : true;
         this.rendererParams.editable = params.readonly ? false : this.arch.attrs.editable;
         this.rendererParams.selectedRecords = selectedRecords;
+        this.rendererParams.noLeaf = !!this.loadParams.context.group_by_no_leaf;
 
         this.loadParams.limit = this.loadParams.limit || 80;
         this.loadParams.type = 'list';

--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -840,8 +840,8 @@ var MockServer = Class.extend({
 
             // compute count key to match dumb server logic...
             var countKey;
-            if (kwargs.lazy) {
-                countKey = groupBy[0].split(':')[0] + "_count";
+            if (kwargs.lazy && (groupBy.length >= 2 || !(kwargs.context || {}).group_by_no_leaf)) {
+                countKey = (groupBy.length >= 1 ? groupBy[0].split(':')[0] : "_") + "_count";
             } else {
                 countKey = "__count";
             }

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -2331,6 +2331,45 @@ QUnit.module('Views', {
         list.destroy();
     });
 
+    QUnit.test('grouped list with group_by_no_leaf in context', function (assert) {
+        assert.expect(6);
+
+        this.data.foo.records.push({id: 5, foo: "blip", int_field: -7, m2o: 1});
+        this.data.foo.records.push({id: 6, foo: "blip", int_field: 5, m2o: 2});
+
+        var list = createView({
+            View: ListView,
+            model: 'foo',
+            data: this.data,
+            arch: '<tree><field name="id"/><field name="int_field"/></tree>',
+            groupBy: ['m2o', 'foo'],
+            context: {'group_by_no_leaf': 1},
+        });
+
+        assert.strictEqual(list.$('tr.o_group_header').length, 2,
+            "should have 2 .o_group_header");
+        assert.strictEqual(list.$('th.o_group_name').length, 2,
+            "should have 2 .o_group_name");
+        assert.strictEqual(list.$('th.o_group_name > span.fa-caret-right').length, 2,
+            "should have caret on first level group");
+
+        // open the first group
+        list.$('.o_group_header:first').click();
+
+        var $openGroup = list.$('tbody:nth(1)');
+        assert.strictEqual($openGroup.find('tr').length, 3,
+            "should have 3 subgroups");
+        assert.strictEqual($openGroup.find('th.o_group_name > span.fa-caret-right').length, 0,
+            "should have no caret on last level group");
+
+        // try opening the first group on second (and last) level
+        $openGroup.find('.o_group_header:first').click();
+        assert.strictEqual(list.$('.o_data_row').length, 0,
+            "should have no data row displayed");
+
+        list.destroy();
+    });
+
     QUnit.test('edition: create new line, then discard', function (assert) {
         assert.expect(8);
 


### PR DESCRIPTION
When having an action context with {'group_by_no_leaf': 1} and
trying to group record in a list view, we expect a specific
rendering limited to only group headers.

- BasicModel: in no leaf mode,
   * fix group count, as ORM will set count in '__count' key
     insteaf of '{GROUBYFIELD}_count' key.

- ListRenderer: in no leaf mode,
    * remove group arrow
    * clicking on the group should not trigger group opening

OPW-1971475

Description of the issue/feature this PR addresses:

Re-add support for group_by_no_leaf: 1 mode on list view, which is:
- only group header (with aggregate)
- no possibility to open group (no arrow on group header, clic on group shoud not trigger "open")

Current behavior before PR:

Steps to reproduce:
- on runbot, install Indian Payroll ( l10n_in_hr_payroll)
- go to "Payroll / Reporting / Advice / Advices Analysis"

In v10, the list correctly render:

![screenshot-649](https://user-images.githubusercontent.com/2605529/56415760-f82baa00-628e-11e9-8c5b-281311076872.png)

In v12, nothing renders:
![screenshot-650](https://user-images.githubusercontent.com/2605529/56415775-04176c00-628f-11e9-8ca1-f5b753207e60.png)

Note: in you need to test on a model with more data, add "List" to "Sales Analysis" (menu: "Sales / Reporting / Sales Analysis):

Again in v10, rendering is Ok:

![screenshot-653](https://user-images.githubusercontent.com/2605529/56416100-28c01380-6290-11e9-94f2-48dd101da446.png)

Again in v12, nothing renders:
![screenshot-654](https://user-images.githubusercontent.com/2605529/56416136-3d041080-6290-11e9-9049-94023bf85043.png)



Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
