### PR TITLE
[FIX] mrp: WO processed when not available

### DIFF
--- a/addons/mrp/i18n/mrp.pot
+++ b/addons/mrp/i18n/mrp.pot
@@ -4163,6 +4163,12 @@ msgid "You need to define at least one productivity loss in the category 'Perfor
 msgstr ""
 
 #. module: mrp
+#: code:addons/mrp/models/mrp_workorder.py:458
+#, python-format
+msgid "You need to process the workorder order %s - %s before processing this one."
+msgstr ""
+
+#. module: mrp
 #: code:addons/mrp/models/mrp_workorder.py:418
 #, python-format
 msgid "You need to define at least one productivity loss in the category 'Productivity'. Create one from the Manufacturing app, menu: Configuration / Productivity Losses."

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -453,6 +453,9 @@ class MrpWorkorder(models.Model):
                 'date_start': datetime.now(),
                 'user_id': self.env.user.id
             })
+        previous_wo = self.search([('next_work_order_id', '=', self.id), ('operation_id.batch', '=', 'no'), ('state', 'in', ('draft', 'ready', 'pending'))])
+        if previous_wo:
+            raise UserError(_("You need to process the workorder order %s - %s before processing this one.") % (previous_wo.production_id.name, previous_wo.name))
         return self.write({'state': 'progress',
                     'date_start': datetime.now(),
         })


### PR DESCRIPTION
Steps to reproduce:p
- Create three products: P1(with route = manufacture), P2 and P3
- Create a BOM for P1 with two companents P2 and P3
- Create a work center WC with two oprations Op1 and Op2
- Set Op1 with batch = 'no' meaning that Op2 cannot be processed
if Op1 is not finished
- Set the routing of the BOM to WC
- Create a MO for the BOM and click on Plan
- Click on Operations > Work Orders and remove "In Progress or Ready" filter
- Click on MO - Op2

Bug:

It was possible to process MO - Op2 even if MO - Op1 was not processed.

Now it's not possible to process MO - Op2 if the previous WO in batch = 'no' are not processed
and a UserError is raised.

opw:1971767
