### PR TITLE
[WIP][FIX] tools, mail: store the email 'from' with quotes if it contains a comma

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1533,10 +1533,10 @@ class MailThread(models.AbstractModel):
             msg_dict['subject'] = tools.decode_smtp_header(message.get('Subject'))
 
         # Envelope fields not stored in mail.message but made available for message_new()
-        msg_dict['from'] = tools.decode_smtp_header(message.get('from'))
+        msg_dict['from'] = tools.decode_smtp_header_from(message.get('from'))
         msg_dict['to'] = tools.decode_smtp_header(message.get('to'))
         msg_dict['cc'] = tools.decode_smtp_header(message.get('cc'))
-        msg_dict['email_from'] = tools.decode_smtp_header(message.get('from'))
+        msg_dict['email_from'] = tools.decode_smtp_header_from(message.get('from'))
         partner_ids = self._message_find_partners(message, ['To', 'Cc'])
         msg_dict['partner_ids'] = [(4, partner_id) for partner_id in partner_ids]
 


### PR DESCRIPTION
Solves the issue described in https://github.com/odoo/odoo/issues/23502#issuecomment-486804676.
Gist reproduced here:
    - Quotation sent to customer
    - Answer by the customer with having this kind of email_from
    César Somesurname, SomeAdditionalString <cesar@somedomain.com>
    - It is parsed correctly and added to the thread
    - As soon it is tried to send this message to the other followers it will fail

The commit itself is commented to describe the issue and how to solve it.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
