### PR TITLE
[IMP] l10n_ca/l10n_ch: improved translations

### DIFF
--- a/addons/l10n_ca/i18n_extra/fr_CA.po
+++ b/addons/l10n_ca/i18n_extra/fr_CA.po
@@ -153,6 +153,21 @@ msgid "GST + QST for sales"
 msgstr "TPS + TVQ sur les ventes"
 
 #. module: l10n_ca
+#: model:account.tax.group,name:l10n_ca.tax_group_gst_5
+msgid "GST 5%"
+msgstr "TPS 5%"
+
+#. module: l10n_ca
+#: model:account.tax.group,name:l10n_ca.tax_group_gst_7
+msgid "GST 7%"
+msgstr "TPS 7%"
+
+#. module: l10n_ca
+#: model:account.tax.group,name:l10n_ca.tax_group_gst_8
+msgid "GST 8%"
+msgstr "TPS 8%"
+
+#. module: l10n_ca
 #: model:account.tax.template,name:l10n_ca.gst_purc_en
 msgid "GST for purchases - 5%"
 msgstr "TPS sur les achats - 5%"
@@ -226,6 +241,21 @@ msgstr "Régime de pension collective à payer - Contribution des employés"
 #: model:account.account.template,name:l10n_ca.chart218502_en
 msgid "Group Pension Plan to pay - Employer Contribution"
 msgstr "Régime de pension collective à payer - Contribution de l'employeur"
+
+#. module: l10n_ca
+#: model:account.tax.group,name:l10n_ca.tax_group_hst_13
+msgid "HST 13%"
+msgstr "TVH 13%"
+
+#. module: l10n_ca
+#: model:account.tax.group,name:l10n_ca.tax_group_hst_14
+msgid "HST 14%"
+msgstr "TVH 14%"
+
+#. module: l10n_ca
+#: model:account.tax.group,name:l10n_ca.tax_group_hst_15
+msgid "HST 15%"
+msgstr "TVH 15%"
 
 #. module: l10n_ca
 #: model:account.tax.template,name:l10n_ca.hst13_purc_en
@@ -398,6 +428,16 @@ msgid "Ontario (ON)"
 msgstr "Ontario (ON)"
 
 #. module: l10n_ca
+#: model:account.tax.group,name:l10n_ca.tax_group_pst_5
+msgid "PST 5%"
+msgstr "TVP 5%"
+
+#. module: l10n_ca
+#: model:account.tax.group,name:l10n_ca.tax_group_pst_8
+msgid "PST 8%"
+msgstr "TVP 8%"
+
+#. module: l10n_ca
 #: model:account.tax.template,name:l10n_ca.pst_sk_purc_en
 msgid "PST for purchases - 5% (SK)"
 msgstr "TVP sur les achats - 5% (SK)"
@@ -493,6 +533,11 @@ msgid "Purchases in non-harmonized provinces"
 msgstr "Achats dans des provinces non-harmonisées"
 
 #. module: l10n_ca
+#: model:account.tax.group,name:l10n_ca.tax_group_qst_9975
+msgid "QST 9.975%"
+msgstr "TVQ 9.975%"
+
+#. module: l10n_ca
 #: model:account.tax.template,name:l10n_ca.qst_purc_en
 msgid "QST for purchases - 9.975%"
 msgstr "TVQ sur les achats - 9,975%"
@@ -552,6 +597,11 @@ msgstr "Stock disponible"
 #: model:account.account.template,name:l10n_ca.chart2171_en
 msgid "Stock Received But Not Billed"
 msgstr "Marchandises reçues non-facturées"
+
+#. module: l10n_ca
+#: model:account.tax.group,name:l10n_ca.tax_group_fix
+msgid "Taxes"
+msgstr "Taxes"
 
 #. module: l10n_ca
 #: model:account.account.template,name:l10n_ca.chart113_en

--- a/addons/l10n_ca/i18n_extra/l10n_ca.pot
+++ b/addons/l10n_ca/i18n_extra/l10n_ca.pot
@@ -152,6 +152,21 @@ msgid "GST + QST for sales"
 msgstr ""
 
 #. module: l10n_ca
+#: model:account.tax.group,name:l10n_ca.tax_group_gst_5
+msgid "GST 5%"
+msgstr ""
+
+#. module: l10n_ca
+#: model:account.tax.group,name:l10n_ca.tax_group_gst_7
+msgid "GST 7%"
+msgstr ""
+
+#. module: l10n_ca
+#: model:account.tax.group,name:l10n_ca.tax_group_gst_8
+msgid "GST 8%"
+msgstr ""
+
+#. module: l10n_ca
 #: model:account.tax.template,name:l10n_ca.gst_purc_en
 msgid "GST for purchases - 5%"
 msgstr ""
@@ -224,6 +239,21 @@ msgstr ""
 #. module: l10n_ca
 #: model:account.account.template,name:l10n_ca.chart218502_en
 msgid "Group Pension Plan to pay - Employer Contribution"
+msgstr ""
+
+#. module: l10n_ca
+#: model:account.tax.group,name:l10n_ca.tax_group_hst_13
+msgid "HST 13%"
+msgstr ""
+
+#. module: l10n_ca
+#: model:account.tax.group,name:l10n_ca.tax_group_hst_14
+msgid "HST 14%"
+msgstr ""
+
+#. module: l10n_ca
+#: model:account.tax.group,name:l10n_ca.tax_group_hst_15
+msgid "HST 15%"
 msgstr ""
 
 #. module: l10n_ca
@@ -397,6 +427,16 @@ msgid "Ontario (ON)"
 msgstr ""
 
 #. module: l10n_ca
+#: model:account.tax.group,name:l10n_ca.tax_group_pst_5
+msgid "PST 5%"
+msgstr ""
+
+#. module: l10n_ca
+#: model:account.tax.group,name:l10n_ca.tax_group_pst_8
+msgid "PST 8%"
+msgstr ""
+
+#. module: l10n_ca
 #: model:account.tax.template,name:l10n_ca.pst_sk_purc_en
 msgid "PST for purchases - 5% (SK)"
 msgstr ""
@@ -492,6 +532,11 @@ msgid "Purchases in non-harmonized provinces"
 msgstr ""
 
 #. module: l10n_ca
+#: model:account.tax.group,name:l10n_ca.tax_group_qst_9975
+msgid "QST 9.975%"
+msgstr ""
+
+#. module: l10n_ca
 #: model:account.tax.template,name:l10n_ca.qst_purc_en
 msgid "QST for purchases - 9.975%"
 msgstr ""
@@ -550,6 +595,11 @@ msgstr ""
 #. module: l10n_ca
 #: model:account.account.template,name:l10n_ca.chart2171_en
 msgid "Stock Received But Not Billed"
+msgstr ""
+
+#. module: l10n_ca
+#: model:account.tax.group,name:l10n_ca.tax_group_fix
+msgid "Taxes"
 msgstr ""
 
 #. module: l10n_ca

--- a/addons/l10n_ch/data/l10n_ch_chart_data.xml
+++ b/addons/l10n_ch/data/l10n_ch_chart_data.xml
@@ -5,7 +5,7 @@
     <data noupdate="1">
          <!-- Account Tags -->
 
-        <record id="transfer_account_id" model="account.account.template">
+        <record id="ch_transfer_account_id" model="account.account.template">
             <field name="code">1090</field>
             <field name="name">Transferts internes</field>
             <field name="user_type_id" ref="account.data_account_type_current_assets"/>
@@ -17,10 +17,10 @@
             <field name="bank_account_code_prefix">102</field>
             <field name="cash_account_code_prefix">100</field>
             <field name="currency_id" ref="base.CHF"/>
-            <field name="transfer_account_id" ref="transfer_account_id"/>
+            <field name="transfer_account_id" ref="ch_transfer_account_id"/>
             <field name="spoken_languages" eval="'it_IT;de_DE;de_CH'"/>
         </record>
-        <record id="transfer_account_id" model="account.account.template">
+        <record id="ch_transfer_account_id" model="account.account.template">
             <field name="chart_template_id" ref="l10nch_chart_template"/>
         </record>
         <!-- Accounts Templates -->

--- a/addons/l10n_ch/i18n_extra/de.po
+++ b/addons/l10n_ch/i18n_extra/de.po
@@ -17,13 +17,11 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_O_exclude
 #: model:account.tax.template,description:l10n_ch.vat_O_exclude
 msgid "0% excl."
 msgstr "0% Exkl."
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_O_import
 #: model:account.tax.template,description:l10n_ch.vat_O_import
 msgid "0% import."
 msgstr "0% Import."
@@ -34,115 +32,96 @@ msgid "100% dédouanement TVA"
 msgstr "100% Verzollung MwSt."
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_100_import
 #: model:account.tax.template,description:l10n_ch.vat_100_import
 msgid "100% imp."
 msgstr "100% Imp."
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_25
 #: model:account.tax.template,description:l10n_ch.vat_25
 msgid "2.5%"
 msgstr "2.5%"
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_25_incl
 #: model:account.tax.template,description:l10n_ch.vat_25_incl
 msgid "2.5% Incl."
 msgstr "2.5% Inkl."
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_25_purchase
 #: model:account.tax.template,description:l10n_ch.vat_25_purchase
 msgid "2.5% achat"
 msgstr "2.5% Einkauf"
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_25_purchase_incl
 #: model:account.tax.template,description:l10n_ch.vat_25_purchase_incl
 msgid "2.5% achat Incl."
 msgstr "2.5% Einkauf Inkl."
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_25_invest
 #: model:account.tax.template,description:l10n_ch.vat_25_invest
 msgid "2.5% invest."
 msgstr "2.5% Invest."
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_25_invest_incl
 #: model:account.tax.template,description:l10n_ch.vat_25_invest_incl
 msgid "2.5% invest. Incl."
 msgstr "2.5% Invest. Inkl."
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_38
 #: model:account.tax.template,description:l10n_ch.vat_38
 msgid "3.8%"
 msgstr "3.8%"
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_38_incl
 #: model:account.tax.template,description:l10n_ch.vat_38_incl
 msgid "3.8% Incl."
 msgstr "3.8% Inkl."
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_38_purchase
 #: model:account.tax.template,description:l10n_ch.vat_38_purchase
 msgid "3.8% achat"
 msgstr "3.8% Einkauf"
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_38_purchase_incl
 #: model:account.tax.template,description:l10n_ch.vat_38_purchase_incl
 msgid "3.8% achat Incl."
 msgstr "3.8% Einkauf Inkl."
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_38_invest
 #: model:account.tax.template,description:l10n_ch.vat_38_invest
 msgid "3.8% invest"
 msgstr "3.8% Invest."
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_38_invest_incl
 #: model:account.tax.template,description:l10n_ch.vat_38_invest_incl
 msgid "3.8% invest Incl."
 msgstr "3.8% Invest. Inkl."
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_80
 #: model:account.tax.template,description:l10n_ch.vat_80
 msgid "8.0%"
 msgstr "8.0%"
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_80_incl
 #: model:account.tax.template,description:l10n_ch.vat_80_incl
 msgid "8.0% Incl."
 msgstr "8.0% Inkl."
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_80_purchase
 #: model:account.tax.template,description:l10n_ch.vat_80_purchase
 msgid "8.0% achat"
 msgstr "8.0% Einkauf"
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_80_purchase_incl
 #: model:account.tax.template,description:l10n_ch.vat_80_purchase_incl
 msgid "8.0% achat Incl."
 msgstr "8.0% Einkauf Inkl."
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_80_invest
 #: model:account.tax.template,description:l10n_ch.vat_80_invest
 msgid "8.0% invest."
 msgstr "8.0% Invest."
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_80_invest_incl
 #: model:account.tax.template,description:l10n_ch.vat_80_invest_incl
 msgid "8.0% invest. Incl."
 msgstr "8.0% Invest. Inkl."
@@ -1145,6 +1124,11 @@ msgid "Switzerland VAT Form: grid 420"
 msgstr ""
 
 #. module: l10n_ch
+#: model:account.tax.group,name:l10n_ch.tax_group_tva_0
+msgid "TVA 0%"
+msgstr "MwSt. 0%"
+
+#. module: l10n_ch
 #: model:account.tax.template,name:l10n_ch.vat_O_import
 msgid "TVA 0% Importations de biens et services"
 msgstr "MwSt. 0% auf Importe von Gütern und Dienstleistungen"
@@ -1153,6 +1137,11 @@ msgstr "MwSt. 0% auf Importe von Gütern und Dienstleistungen"
 #: model:account.tax.template,name:l10n_ch.vat_O_exclude
 msgid "TVA 0% exclue"
 msgstr "MwSt. 0% ausgeschlossen"
+
+#. module: l10n_ch
+#: model:account.tax.group,name:l10n_ch.tax_group_tva_25
+msgid "TVA 2.5%"
+msgstr "MwSt. 2.5%"
 
 #. module: l10n_ch
 #: model:account.tax.template,name:l10n_ch.vat_25_purchase_incl
@@ -1175,6 +1164,16 @@ msgid "TVA 2.5% sur invest. et autres ch. (TR)"
 msgstr "MwSt. 2,5% auf Invest. und sonst. Aufw. (USt)"
 
 #. module: l10n_ch
+#: model:account.tax.group,name:l10n_ch.tax_group_tva_37
+msgid "TVA 3.7%"
+msgstr "MwSt. 3.7%"
+
+#. module: l10n_ch
+#: model:account.tax.group,name:l10n_ch.tax_group_tva_38
+msgid "TVA 3.8%"
+msgstr "MwSt. 3.8%"
+
+#. module: l10n_ch
 #: model:account.tax.template,name:l10n_ch.vat_38_purchase_incl
 msgid "TVA 3.8% sur achat B&S (Incl. TS)"
 msgstr "MwSt. 3,8% auf Einkäufe B&S (inkl. LSt)"
@@ -1193,6 +1192,16 @@ msgstr "MwSt. 3,8% auf Invest. und sonst. Aufw. (inkl. LSt)"
 #: model:account.tax.template,name:l10n_ch.vat_38_invest
 msgid "TVA 3.8% sur invest. et autres ch. (TS)"
 msgstr "MwSt. 3,8% auf Invest. und sonst. Aufw. (LSt)"
+
+#. module: l10n_ch
+#: model:account.tax.group,name:l10n_ch.tax_group_tva_77
+msgid "TVA 7.7%"
+msgstr "MwSt. 7.7%"
+
+#. module: l10n_ch
+#: model:account.tax.group,name:l10n_ch.tax_group_tva_8
+msgid "TVA 8%"
+msgstr "MwSt. 8%"
 
 #. module: l10n_ch
 #: model:account.tax.template,name:l10n_ch.vat_80_purchase_incl

--- a/addons/l10n_ch/i18n_extra/de.po
+++ b/addons/l10n_ch/i18n_extra/de.po
@@ -1306,7 +1306,7 @@ msgid "Titres à long terme"
 msgstr "Wertschriften"
 
 #. module: l10n_ch
-#: model:account.account.template,name:l10n_ch.transfer_account_id
+#: model:account.account.template,name:l10n_ch.ch_transfer_account_id
 msgid "Transferts internes"
 msgstr "Interne Verrechnungen"
 

--- a/addons/l10n_ch/i18n_extra/it.po
+++ b/addons/l10n_ch/i18n_extra/it.po
@@ -17,201 +17,167 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_O_exclude
 #: model:account.tax.template,description:l10n_ch.vat_O_exclude
 msgid "0% excl."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_O_import
 #: model:account.tax.template,description:l10n_ch.vat_O_import
 msgid "0% import."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_100_import
 #: model:account.tax.template,name:l10n_ch.vat_100_import
 msgid "100% dédouanement TVA"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_100_import
 #: model:account.tax.template,description:l10n_ch.vat_100_import
 msgid "100% imp."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_25
 #: model:account.tax.template,description:l10n_ch.vat_25
 msgid "2.5%"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_25_incl
 #: model:account.tax.template,description:l10n_ch.vat_25_incl
 msgid "2.5% Incl."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_25_purchase
 #: model:account.tax.template,description:l10n_ch.vat_25_purchase
 msgid "2.5% achat"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_25_purchase_incl
 #: model:account.tax.template,description:l10n_ch.vat_25_purchase_incl
 msgid "2.5% achat Incl."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_25_invest
 #: model:account.tax.template,description:l10n_ch.vat_25_invest
 msgid "2.5% invest."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_25_invest_incl
 #: model:account.tax.template,description:l10n_ch.vat_25_invest_incl
 msgid "2.5% invest. Incl."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_38
 #: model:account.tax.template,description:l10n_ch.vat_38
 msgid "3.8%"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_38_incl
 #: model:account.tax.template,description:l10n_ch.vat_38_incl
 msgid "3.8% Incl."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_38_purchase
 #: model:account.tax.template,description:l10n_ch.vat_38_purchase
 msgid "3.8% achat"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_38_purchase_incl
 #: model:account.tax.template,description:l10n_ch.vat_38_purchase_incl
 msgid "3.8% achat Incl."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_38_invest
 #: model:account.tax.template,description:l10n_ch.vat_38_invest
 msgid "3.8% invest"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_38_invest_incl
 #: model:account.tax.template,description:l10n_ch.vat_38_invest_incl
 msgid "3.8% invest Incl."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_80
 #: model:account.tax.template,description:l10n_ch.vat_80
 msgid "8.0%"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_80_incl
 #: model:account.tax.template,description:l10n_ch.vat_80_incl
 msgid "8.0% Incl."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_80_purchase
 #: model:account.tax.template,description:l10n_ch.vat_80_purchase
 msgid "8.0% achat"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_80_purchase_incl
 #: model:account.tax.template,description:l10n_ch.vat_80_purchase_incl
 msgid "8.0% achat Incl."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_80_invest
 #: model:account.tax.template,description:l10n_ch.vat_80_invest
 msgid "8.0% invest."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_80_invest_incl
 #: model:account.tax.template,description:l10n_ch.vat_80_invest_incl
 msgid "8.0% invest. Incl."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4200
 #: model:account.account.template,name:l10n_ch.ch_coa_4200
 msgid "Achats de marchandises destinées à la revente"
 msgstr "Costi delle merci di rivendita"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2030
 #: model:account.account.template,name:l10n_ch.ch_coa_2030
 msgid "Acomptes de clients"
 msgstr "Acconti ricevuti"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1208
 #: model:account.account.template,name:l10n_ch.ch_coa_1208
 msgid "Acomptes sur les marchandises commerciales"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1218
 #: model:account.account.template,name:l10n_ch.ch_coa_1218
 msgid "Acomptes sur matières premières"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1149
 #: model:account.account.template,name:l10n_ch.ch_coa_1149
 msgid "Ajustement de la valeur des avances et des prêts"
 msgstr "Rettifica valore anticipi e prestiti"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1199
 #: model:account.account.template,name:l10n_ch.ch_coa_1199
 msgid "Ajustement de la valeur des créances à court terme"
 msgstr "Rettifica valore crediti diversi a breve termine"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1449
 #: model:account.account.template,name:l10n_ch.ch_coa_1449
 msgid "Ajustement de la valeur des créances à long terme"
 msgstr "Rettifica valore crediti a lungo termine"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1779
 #: model:account.account.template,name:l10n_ch.ch_coa_1779
 msgid "Ajustement de la valeur des goodwill"
 msgstr "Rettifica valore goodwill"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1489
 #: model:account.account.template,name:l10n_ch.ch_coa_1489
 msgid "Ajustement de la valeur des participations"
 msgstr "Rettifica valore partecipazioni"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1069
-#: model:account.account,name:l10n_ch.1_ch_coa_1409
 #: model:account.account.template,name:l10n_ch.ch_coa_1069
 #: model:account.account.template,name:l10n_ch.ch_coa_1409
 msgid "Ajustement de la valeur des titres"
 msgstr "Rettifica valore titoli"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6800
 #: model:account.account.template,name:l10n_ch.ch_coa_6800
 msgid ""
 "Amortissements et ajustements de valeur des postes sur immobilisations "
@@ -219,127 +185,106 @@ msgid ""
 msgstr "Ammortamenti e rettifiche di valore dell’attivo fisso"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1519
 #: model:account.account.template,name:l10n_ch.ch_coa_1519
 msgid "Amortissements sur le mobilier et les installations"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1599
 #: model:account.account.template,name:l10n_ch.ch_coa_1599
 msgid "Amortissements sur les autres immobilisations corporelles meubles"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1709
 #: model:account.account.template,name:l10n_ch.ch_coa_1709
 msgid "Amortissements sur les brevets, know-how, licences, droits, dév."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1609
 #: model:account.account.template,name:l10n_ch.ch_coa_1609
 msgid "Amortissements sur les immeubles d’exploitation"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1559
 #: model:account.account.template,name:l10n_ch.ch_coa_1559
 msgid "Amortissements sur les installations de stockage"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1529
 #: model:account.account.template,name:l10n_ch.ch_coa_1529
 msgid "Amortissements sur les machines de bureau, inf. et syst. comm."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1509
 #: model:account.account.template,name:l10n_ch.ch_coa_1509
 msgid "Amortissements sur les machines et appareils"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1549
 #: model:account.account.template,name:l10n_ch.ch_coa_1549
 msgid "Amortissements sur les outillages et appareils"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1539
 #: model:account.account.template,name:l10n_ch.ch_coa_1539
 msgid "Amortissements sur les véhicules"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1579
 #: model:account.account.template,name:l10n_ch.ch_coa_1579
 msgid "Amortissements sur les équipements et installations"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2270
 #: model:account.account.template,name:l10n_ch.ch_coa_2270
 msgid "Assurances sociales et institutions de prévoyance"
 msgstr "Assicurazioni sociali e istituti di previdenza"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6300
 #: model:account.account.template,name:l10n_ch.ch_coa_6300
 msgid "Assurances-choses, droits, taxes, autorisations"
 msgstr "Assicurazioni cose, contributi, tasse e autorizzazioni"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_5800
 #: model:account.account.template,name:l10n_ch.ch_coa_5800
 msgid "Autres charges du personnel"
 msgstr "Altri costi del personale"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6700
 #: model:account.account.template,name:l10n_ch.ch_coa_6700
 msgid "Autres charges d‘exploitation"
 msgstr "Altri costi d’esercizio"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1190
 #: model:account.account.template,name:l10n_ch.ch_coa_1190
 msgid "Autres créances à court terme"
 msgstr "Altri crediti a breve termine"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2210
 #: model:account.account.template,name:l10n_ch.ch_coa_2210
 msgid "Autres dettes à court terme"
 msgstr "Altri debiti a breve termine"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2140
 #: model:account.account.template,name:l10n_ch.ch_coa_2140
 msgid "Autres dettes à court terme rémunérées"
 msgstr "Altri debiti onerosi"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2500
 #: model:account.account.template,name:l10n_ch.ch_coa_2500
 msgid "Autres dettes à long terme"
 msgstr "Altri debiti a lungo termine"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1590
 #: model:account.account.template,name:l10n_ch.ch_coa_1590
 msgid "Autres immobilisations corporelles meubles"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3600
 #: model:account.account.template,name:l10n_ch.ch_coa_3600
 msgid "Autres ventes et prestations de services"
 msgstr "Altri ricavi e prestazioni di servizi"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1140
 #: model:account.account.template,name:l10n_ch.ch_coa_1140
 msgid "Avances et prêts"
 msgstr "Anticipi e prestiti"
@@ -376,19 +321,16 @@ msgid ""
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1700
 #: model:account.account.template,name:l10n_ch.ch_coa_1700
 msgid "Brevets, know-how, licences, droits, développement"
 msgstr "Patenti, know-how, licenze, diritti e sviluppo"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2979
 #: model:account.account.template,name:l10n_ch.ch_coa_2979
 msgid "Bénéfice / perte de l’exercice"
 msgstr "Utile/perdita annuale"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2970
 #: model:account.account.template,name:l10n_ch.ch_coa_2970
 msgid "Bénéfice / perte reporté"
 msgstr "Utile / perdita riportata"
@@ -399,7 +341,6 @@ msgid "CHF ISR reference"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1850
 #: model:account.account.template,name:l10n_ch.ch_coa_1850
 msgid ""
 "Capital actions, capital social, droits de participations ou capital de "
@@ -409,7 +350,6 @@ msgstr ""
 "della fondazione non versati"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2800
 #: model:account.account.template,name:l10n_ch.ch_coa_2800
 msgid "Capital-actions, capital social, capital de fondation"
 msgstr ""
@@ -417,109 +357,91 @@ msgstr ""
 "della fondazione"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4521
 #: model:account.account.template,name:l10n_ch.ch_coa_4521
 msgid "Charbon, briquettes, bois"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_7010
 #: model:account.account.template,name:l10n_ch.ch_coa_7010
 msgid "Charges accessoires"
 msgstr "Costi attività accessoria"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6000
 #: model:account.account.template,name:l10n_ch.ch_coa_6000
 msgid "Charges de locaux"
 msgstr "Costi dei locali"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4000
 #: model:account.account.template,name:l10n_ch.ch_coa_4000
 msgid "Charges de matériel de l‘atelier"
 msgstr "Costi materiale per la fabbricazione"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_5900
 #: model:account.account.template,name:l10n_ch.ch_coa_5900
 msgid "Charges de personnels temporaires"
 msgstr "Prestazioni di terz"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6200
 #: model:account.account.template,name:l10n_ch.ch_coa_6200
 msgid "Charges de véhicules et de transport"
 msgstr "Costi auto e di trasporto"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_7510
 #: model:account.account.template,name:l10n_ch.ch_coa_7510
 msgid "Charges des immeubles d‘exploitation"
 msgstr "Costi immobili aziendali"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6500
 #: model:account.account.template,name:l10n_ch.ch_coa_6500
 msgid "Charges d‘administration"
 msgstr "Costi amministrativi"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6400
 #: model:account.account.template,name:l10n_ch.ch_coa_6400
 msgid "Charges d’énergie et évacuation des déchets"
 msgstr "Costi energia e smaltimento"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6570
 #: model:account.account.template,name:l10n_ch.ch_coa_6570
 msgid "Charges et leasing d’informatique"
 msgstr "Costi informatici incluso leasing"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_8500
 #: model:account.account.template,name:l10n_ch.ch_coa_8500
 msgid "Charges extraordinaires, exceptionnelles ou hors période"
 msgstr "Costi straordinari, unici o relativi ad altri periodi contabili"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6900
 #: model:account.account.template,name:l10n_ch.ch_coa_6900
 msgid "Charges financières"
 msgstr "Costi finanziari"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_8000
 #: model:account.account.template,name:l10n_ch.ch_coa_8000
 msgid "Charges hors exploitation"
 msgstr "Costi estranei"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1300
 #: model:account.account.template,name:l10n_ch.ch_coa_1300
 msgid "Charges payées d‘avance"
 msgstr "Costi anticipati"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_5700
 #: model:account.account.template,name:l10n_ch.ch_coa_5700
 msgid "Charges sociales"
 msgstr "Oneri sociali"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2300
 #: model:account.account.template,name:l10n_ch.ch_coa_2300
 msgid "Charges à payer"
 msgstr "Costi da pagare"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3803
 #: model:account.account.template,name:l10n_ch.ch_coa_3803
 msgid "Commissions de tiers"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4903
 #: model:account.account.template,name:l10n_ch.ch_coa_4903
 msgid "Commissions obtenues sur achats"
 msgstr ""
@@ -530,61 +452,51 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1099
 #: model:account.account.template,name:l10n_ch.ch_coa_1099
 msgid "Compte d'attente autre"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1091
 #: model:account.account.template,name:l10n_ch.ch_coa_1091
 msgid "Compte d'attente pour salaires"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3710
 #: model:account.account.template,name:l10n_ch.ch_coa_3710
 msgid "Consommations propres"
 msgstr "Consumo proprio"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1269
 #: model:account.account.template,name:l10n_ch.ch_coa_1269
 msgid "Correction de la valeur de stocks de produits finis"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1279
 #: model:account.account.template,name:l10n_ch.ch_coa_1279
 msgid "Corrections de la valeur des stock produits semi-ouvrés"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1209
 #: model:account.account.template,name:l10n_ch.ch_coa_1209
 msgid "Corrections de la valeur des stocks de marchandises"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1289
 #: model:account.account.template,name:l10n_ch.ch_coa_1289
 msgid "Corrections de la valeur des travaux en cours"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1219
 #: model:account.account.template,name:l10n_ch.ch_coa_1219
 msgid "Corrections de la valeur sur matières premières"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1180
 #: model:account.account.template,name:l10n_ch.ch_coa_1180
 msgid "Créances envers les assurances sociales et institutions de prévoyance"
 msgstr "Crediti da assicurazioni sociali e istituti di previdenza"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2000
 #: model:account.account.template,name:l10n_ch.ch_coa_2000
 msgid "Créanciers"
 msgstr "Debiti per forniture e prestazioni (creditori)"
@@ -595,65 +507,53 @@ msgid "Currency"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2100
-#: model:account.account,name:l10n_ch.1_ch_coa_2400
 #: model:account.account.template,name:l10n_ch.ch_coa_2100
 #: model:account.account.template,name:l10n_ch.ch_coa_2400
 msgid "Dettes bancaires"
 msgstr "Banca passiva"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2160
 #: model:account.account.template,name:l10n_ch.ch_coa_2160
 msgid "Dettes envers l'actionnaire"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3806
-#: model:account.account,name:l10n_ch.1_ch_coa_4906
 #: model:account.account.template,name:l10n_ch.ch_coa_3806
 #: model:account.account.template,name:l10n_ch.ch_coa_4906
 msgid "Différences de change"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2261
 #: model:account.account.template,name:l10n_ch.ch_coa_2261
 msgid "Dividendes"
 msgstr "Dividendi"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4071
 #: model:account.account.template,name:l10n_ch.ch_coa_4071
 msgid "Droits de douanes à l'importation"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1109
 #: model:account.account.template,name:l10n_ch.ch_coa_1109
 msgid "Ducroire"
 msgstr "Delcredere"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1100
 #: model:account.account.template,name:l10n_ch.ch_coa_1100
 msgid "Débiteurs"
 msgstr "Crediti da forniture e prestazioni (debitori)"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2201
 #: model:account.account.template,name:l10n_ch.ch_coa_2201
 msgid "Décompte TVA"
 msgstr "IVA, rendiconto"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4009
 #: model:account.account.template,name:l10n_ch.ch_coa_4009
 msgid "Déductions obtenues sur achats"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3009
 #: model:account.account.template,name:l10n_ch.ch_coa_3009
 msgid "Déductions sur ventes"
 msgstr "Diminuzione di ricavi"
@@ -664,13 +564,11 @@ msgid "EUR ISR reference"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4540
 #: model:account.account.template,name:l10n_ch.ch_coa_4540
 msgid "Eau"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4500
 #: model:account.account.template,name:l10n_ch.ch_coa_4500
 msgid "Electricité"
 msgstr ""
@@ -686,91 +584,74 @@ msgid "Email composition wizard"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2450
 #: model:account.account.template,name:l10n_ch.ch_coa_2450
 msgid "Emprunts"
 msgstr "Prestiti"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2430
 #: model:account.account.template,name:l10n_ch.ch_coa_2430
 msgid "Emprunts obligataires"
 msgstr "Prestiti obbligazionari"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2120
-#: model:account.account,name:l10n_ch.1_ch_coa_2420
 #: model:account.account.template,name:l10n_ch.ch_coa_2120
 #: model:account.account.template,name:l10n_ch.ch_coa_2420
 msgid "Engagements de financement par leasing"
 msgstr "Impegni leasing finanziari"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6100
 #: model:account.account.template,name:l10n_ch.ch_coa_6100
 msgid ""
 "Entretien, réparations et remplacement des inst. servant à l’exploitation"
 msgstr "Manutenzioni, riparazioni e sostituzione immobilizzazioni mobiliari"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1570
 #: model:account.account.template,name:l10n_ch.ch_coa_1570
 msgid "Equipements et Installations"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3800
-#: model:account.account,name:l10n_ch.1_ch_coa_4900
 #: model:account.account.template,name:l10n_ch.ch_coa_3800
 #: model:account.account.template,name:l10n_ch.ch_coa_4900
 msgid "Escomptes"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4530
 #: model:account.account.template,name:l10n_ch.ch_coa_4530
 msgid "Essence"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3804
 #: model:account.account.template,name:l10n_ch.ch_coa_3804
 msgid "Frais d'encaissement"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3807
 #: model:account.account.template,name:l10n_ch.ch_coa_3807
 msgid "Frais d'expédition"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4072
 #: model:account.account.template,name:l10n_ch.ch_coa_4072
 msgid "Frais de transport à l'achat"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4070
 #: model:account.account.template,name:l10n_ch.ch_coa_4070
 msgid "Frêts à l'achat"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4510
 #: model:account.account.template,name:l10n_ch.ch_coa_4510
 msgid "Gaz"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1770
 #: model:account.account.template,name:l10n_ch.ch_coa_1770
 msgid "Goodwill"
 msgstr "Goodwill"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1441
-#: model:account.account,name:l10n_ch.1_ch_coa_2451
 #: model:account.account.template,name:l10n_ch.ch_coa_1441
 #: model:account.account.template,name:l10n_ch.ch_coa_2451
 msgid "Hypothèques"
@@ -805,59 +686,48 @@ msgid "ISR sent"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1600
 #: model:account.account.template,name:l10n_ch.ch_coa_1600
 msgid "Immeubles d’exploitation"
 msgstr "Immobili aziendali"
 
 #. module: l10n_ch
-#: model:account.fiscal.position,name:l10n_ch.1_fiscal_position_template_import
 #: model:account.fiscal.position.template,name:l10n_ch.fiscal_position_template_import
 msgid "Import/Export"
 msgstr "Import/Export"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1176
 #: model:account.account.template,name:l10n_ch.ch_coa_1176
 msgid "Impôt anticipé"
 msgstr "Imposta preventiva"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2206
 #: model:account.account.template,name:l10n_ch.ch_coa_2206
 msgid "Impôt anticipé dû"
 msgstr "Imposta preventiva"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1171
 #: model:account.account.template,name:l10n_ch.ch_coa_1171
 msgid "Impôt préalable: TVA s/investissements et autres charges d’exploitation"
 msgstr "IVA, imposta precedente su investimenti e altri costi d’esercizio"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1170
 #: model:account.account.template,name:l10n_ch.ch_coa_1170
 msgid "Impôt préalable: TVA s/matériel, marchandises, prestations et énergie"
 msgstr "IVA, Imposta precedente su materiale, merce, servizi e energia"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1189
-#: model:account.account,name:l10n_ch.1_ch_coa_2279
 #: model:account.account.template,name:l10n_ch.ch_coa_1189
 #: model:account.account.template,name:l10n_ch.ch_coa_2279
 msgid "Impôt à la source"
 msgstr "Imposte alla fonte"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2208
-#: model:account.account,name:l10n_ch.1_ch_coa_8900
 #: model:account.account.template,name:l10n_ch.ch_coa_2208
 #: model:account.account.template,name:l10n_ch.ch_coa_8900
 msgid "Impôts directs"
 msgstr "Imposte dirette"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1550
 #: model:account.account.template,name:l10n_ch.ch_coa_1550
 msgid "Installations de stockage"
 msgstr ""
@@ -908,67 +778,56 @@ msgid "L10N Ch Postal"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6260
 #: model:account.account.template,name:l10n_ch.ch_coa_6260
 msgid "Leasing et location de véhicules"
 msgstr "Leasing e noleggio auto"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6105
 #: model:account.account.template,name:l10n_ch.ch_coa_6105
 msgid "Leasing immobilisations corporelles meubles"
 msgstr "Costi leasing immobilizzazioni mobiliari"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1520
 #: model:account.account.template,name:l10n_ch.ch_coa_1520
 msgid "Machines de bureau, informatique, systèmes de communication"
 msgstr "Macchine ufficio, informatica e tecnologia della comunicazione"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1500
 #: model:account.account.template,name:l10n_ch.ch_coa_1500
 msgid "Machines et appareils"
 msgstr "Macchine e attrezzature"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1200
 #: model:account.account.template,name:l10n_ch.ch_coa_1200
 msgid "Marchandises commerciales"
 msgstr "Merce di rivendita"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1250
 #: model:account.account.template,name:l10n_ch.ch_coa_1250
 msgid "Marchandises en consignation"
 msgstr "Merce in consegna"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1220
 #: model:account.account.template,name:l10n_ch.ch_coa_1220
 msgid "Matières auxiliaires"
 msgstr "Materia ausiliaria"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1230
 #: model:account.account.template,name:l10n_ch.ch_coa_1230
 msgid "Matières consommables"
 msgstr "Materiale di consumo"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1210
 #: model:account.account.template,name:l10n_ch.ch_coa_1210
 msgid "Matières premières"
 msgstr "Materia prima"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4520
 #: model:account.account.template,name:l10n_ch.ch_coa_4520
 msgid "Mazout"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1510
 #: model:account.account.template,name:l10n_ch.ch_coa_1510
 msgid "Mobilier et installations"
 msgstr "Mobilio e installazioni"
@@ -979,25 +838,21 @@ msgid "Optical reading line, as it will be printed on ISR"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1540
 #: model:account.account.template,name:l10n_ch.ch_coa_1540
 msgid "Outillages et appareils"
 msgstr "Utensili e apparecchiature"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1480
 #: model:account.account.template,name:l10n_ch.ch_coa_1480
 msgid "Participations"
 msgstr "Partecipazioni"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4086
 #: model:account.account.template,name:l10n_ch.ch_coa_4086
 msgid "Pertes de matières"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3805
 #: model:account.account.template,name:l10n_ch.ch_coa_3805
 msgid "Pertes sur créances clients, variation ducroire"
 msgstr ""
@@ -1015,13 +870,11 @@ msgid ""
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4400
 #: model:account.account.template,name:l10n_ch.ch_coa_4400
 msgid "Prestations / travaux de tiers"
 msgstr "Lavori di terzi / prestazioni di subappaltanti"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3700
 #: model:account.account.template,name:l10n_ch.ch_coa_3700
 msgid "Prestations propres"
 msgstr "Lavori interni"
@@ -1051,49 +904,41 @@ msgid ""
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_7000
 #: model:account.account.template,name:l10n_ch.ch_coa_7000
 msgid "Produits accessoires"
 msgstr "Ricavi attività accessoria"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_7500
 #: model:account.account.template,name:l10n_ch.ch_coa_7500
 msgid "Produits des immeubles d‘exploitation"
 msgstr "Ricavi immobili aziendali"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2301
 #: model:account.account.template,name:l10n_ch.ch_coa_2301
 msgid "Produits encaissés d’avance"
 msgstr "Ricavi incassati dell’anno seguente"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_8510
 #: model:account.account.template,name:l10n_ch.ch_coa_8510
 msgid "Produits extraordinaires, exceptionnels ou hors période"
 msgstr "Ricavi straordinari, unici o relativi ad altri periodi contabili"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6950
 #: model:account.account.template,name:l10n_ch.ch_coa_6950
 msgid "Produits financiers"
 msgstr "Ricavi finanziari"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_8100
 #: model:account.account.template,name:l10n_ch.ch_coa_8100
 msgid "Produits hors exploitation"
 msgstr "Ricavi estranei"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1301
 #: model:account.account.template,name:l10n_ch.ch_coa_1301
 msgid "Produits à recevoir"
 msgstr "Ricavi da incassare"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2980
 #: model:account.account.template,name:l10n_ch.ch_coa_2980
 msgid ""
 "Propres actions, parts sociales, droits de participations (poste négatif)"
@@ -1101,87 +946,72 @@ msgstr ""
 "Azioni proprie, parti sociali, diritti di partecipazione (posta negativa)"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2600
 #: model:account.account.template,name:l10n_ch.ch_coa_2600
 msgid "Provisions"
 msgstr "Accantonamenti"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2330
 #: model:account.account.template,name:l10n_ch.ch_coa_2330
 msgid "Provisions à court terme"
 msgstr "Accantonamenti a breve termine"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1440
 #: model:account.account.template,name:l10n_ch.ch_coa_1440
 msgid "Prêts"
 msgstr "Prestiti"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6600
 #: model:account.account.template,name:l10n_ch.ch_coa_6600
 msgid "Publicité"
 msgstr "Costi pubblicitari"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3801
 #: model:account.account.template,name:l10n_ch.ch_coa_3801
 msgid "Rabais et réduction de prix"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4901
 #: model:account.account.template,name:l10n_ch.ch_coa_4901
 msgid "Rabais et réductions de prix"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3802
-#: model:account.account,name:l10n_ch.1_ch_coa_4092
 #: model:account.account.template,name:l10n_ch.ch_coa_3802
 #: model:account.account.template,name:l10n_ch.ch_coa_4092
 msgid "Ristournes"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2940
 #: model:account.account.template,name:l10n_ch.ch_coa_2940
 msgid "Réserves d‘évaluation"
 msgstr "Riserve da rivalutazioni"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2960
 #: model:account.account.template,name:l10n_ch.ch_coa_2960
 msgid "Réserves libres"
 msgstr "Riserve facoltative da utili"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2950
 #: model:account.account.template,name:l10n_ch.ch_coa_2950
 msgid "Réserves légales issues du bénéfice"
 msgstr "Riserva legale da utili"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2900
 #: model:account.account.template,name:l10n_ch.ch_coa_2900
 msgid "Réserves légales issues du capital"
 msgstr "Riserva legale da capitale"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_5000
 #: model:account.account.template,name:l10n_ch.ch_coa_5000
 msgid "Salaires"
 msgstr "Salari"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1260
 #: model:account.account.template,name:l10n_ch.ch_coa_1260
 msgid "Stocks de produits finis"
 msgstr "Prodotti finiti"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1270
 #: model:account.account.template,name:l10n_ch.ch_coa_1270
 msgid "Stocks de produits semi-ouvrés"
 msgstr ""
@@ -1297,133 +1127,141 @@ msgid "Switzerland VAT Form: grid 420"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_O_import
+#: model:account.tax.group,name:l10n_ch.tax_group_tva_0
+msgid "TVA 0%"
+msgstr "IVA 0%"
+
+#. module: l10n_ch
 #: model:account.tax.template,name:l10n_ch.vat_O_import
 msgid "TVA 0% Importations de biens et services"
 msgstr "IVA 0% Importazioni di bene e servizi"
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_O_exclude
 #: model:account.tax.template,name:l10n_ch.vat_O_exclude
 msgid "TVA 0% exclue"
 msgstr "IVA 0% Esclusa"
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_25_purchase_incl
+#: model:account.tax.group,name:l10n_ch.tax_group_tva_25
+msgid "TVA 2.5%"
+msgstr "IVA 2.5%"
+
+#. module: l10n_ch
 #: model:account.tax.template,name:l10n_ch.vat_25_purchase_incl
 msgid "TVA 2.5% sur achat B&S (Incl. TR)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_25_purchase
 #: model:account.tax.template,name:l10n_ch.vat_25_purchase
 msgid "TVA 2.5% sur achat B&S (TR)"
 msgstr "TVA 2.5% sur achat B&S (TR)"
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_25_invest_incl
 #: model:account.tax.template,name:l10n_ch.vat_25_invest_incl
 msgid "TVA 2.5% sur invest. et autres ch. (Incl. TR)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_25_invest
 #: model:account.tax.template,name:l10n_ch.vat_25_invest
 msgid "TVA 2.5% sur invest. et autres ch. (TR)"
 msgstr "IVA 2.5% Investimenti e altri costi (TR)"
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_38_purchase_incl
+#: model:account.tax.group,name:l10n_ch.tax_group_tva_37
+msgid "TVA 3.7%"
+msgstr "IVA 3.7%"
+
+#. module: l10n_ch
+#: model:account.tax.group,name:l10n_ch.tax_group_tva_38
+msgid "TVA 3.8%"
+msgstr "IVA 3.8%"
+
+#. module: l10n_ch
 #: model:account.tax.template,name:l10n_ch.vat_38_purchase_incl
 msgid "TVA 3.8% sur achat B&S (Incl. TS)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_38_purchase
 #: model:account.tax.template,name:l10n_ch.vat_38_purchase
 msgid "TVA 3.8% sur achat B&S (TS)"
 msgstr "TVA 3.8% sur achat B&S (TS)"
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_38_invest_incl
 #: model:account.tax.template,name:l10n_ch.vat_38_invest_incl
 msgid "TVA 3.8% sur invest. et autres ch. (Incl. TS)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_38_invest
 #: model:account.tax.template,name:l10n_ch.vat_38_invest
 msgid "TVA 3.8% sur invest. et autres ch. (TS)"
 msgstr "IVA 3.8% Investimenti e altri costi (TS)"
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_80_purchase_incl
+#: model:account.tax.group,name:l10n_ch.tax_group_tva_77
+msgid "TVA 7.7%"
+msgstr "IVA 7.7%"
+
+#. module: l10n_ch
+#: model:account.tax.group,name:l10n_ch.tax_group_tva_8
+msgid "TVA 8%"
+msgstr "IVA 8%"
+
+#. module: l10n_ch
 #: model:account.tax.template,name:l10n_ch.vat_80_purchase_incl
 msgid "TVA 8.0% sur achat B&S (Incl. TN)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_80_purchase
 #: model:account.tax.template,name:l10n_ch.vat_80_purchase
 msgid "TVA 8.0% sur achat B&S (TN)"
 msgstr "TVA 8.0% sur achat B&S (TN)"
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_80_invest_incl
 #: model:account.tax.template,name:l10n_ch.vat_80_invest_incl
 msgid "TVA 8.0% sur invest. et autres ch. (Incl. TN)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_80_invest
 #: model:account.tax.template,name:l10n_ch.vat_80_invest
 msgid "TVA 8.0% sur invest. et autres ch. (TN)"
 msgstr "IVA 8.0%  Investimenti e altri costi (TN)"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2200
 #: model:account.account.template,name:l10n_ch.ch_coa_2200
 msgid "TVA due"
 msgstr "IVA dovuta"
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_XO
 #: model:account.tax.template,name:l10n_ch.vat_XO
 msgid "TVA due a 0% (Exportations)"
 msgstr "IVA Vendite 0% (Export)"
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_25
 #: model:account.tax.template,name:l10n_ch.vat_25
 msgid "TVA due a 2.5% (TR)"
 msgstr "IVA Vendite al 2.5% (TR)"
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_38
 #: model:account.tax.template,name:l10n_ch.vat_38
 msgid "TVA due a 3.8% (TS)"
 msgstr "IVA Vendite al 3.8% (TS)"
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_80
 #: model:account.tax.template,name:l10n_ch.vat_80
 msgid "TVA due a 8.0% (TN)"
 msgstr "IVA Vendite al 8.0% (TN)"
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_25_incl
 #: model:account.tax.template,name:l10n_ch.vat_25_incl
 msgid "TVA due à 2.5% (Incl. TR)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_38_incl
 #: model:account.tax.template,name:l10n_ch.vat_38_incl
 msgid "TVA due à 3.8% (Incl. TS)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_80_incl
 #: model:account.tax.template,name:l10n_ch.vat_80_incl
 msgid "TVA due à 8.0% (Incl. TN)"
 msgstr ""
@@ -1461,113 +1299,93 @@ msgid "The reference number associated with this invoice"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1060
 #: model:account.account.template,name:l10n_ch.ch_coa_1060
 msgid "Titres"
 msgstr "Titoli"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1400
 #: model:account.account.template,name:l10n_ch.ch_coa_1400
 msgid "Titres à long terme"
 msgstr "Titoli"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_transfer_account_id
 #: model:account.account.template,name:l10n_ch.transfer_account_id
 msgid "Transferts internes"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1280
 #: model:account.account.template,name:l10n_ch.ch_coa_1280
 msgid "Travaux en cours"
 msgstr "Prodotti in corso di fabbricazione"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3940
 #: model:account.account.template,name:l10n_ch.ch_coa_3940
 msgid "Variation de la valeur des prestations non facturées"
 msgstr "Variazione prestazioni di servizi non fatturate"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1287
 #: model:account.account.template,name:l10n_ch.ch_coa_1287
 msgid "Variation de la valeur des travaux en cours"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1277
 #: model:account.account.template,name:l10n_ch.ch_coa_1277
 msgid "Variation de stock produits semi-ouvrés"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1267
 #: model:account.account.template,name:l10n_ch.ch_coa_1267
 msgid "Variation de stocks de produits finis"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1207
-#: model:account.account,name:l10n_ch.1_ch_coa_4800
 #: model:account.account.template,name:l10n_ch.ch_coa_1207
 #: model:account.account.template,name:l10n_ch.ch_coa_4800
 msgid "Variation des stocks de marchandises"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4801
 #: model:account.account.template,name:l10n_ch.ch_coa_4801
 msgid "Variation des stocks de matières premières"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3901
 #: model:account.account.template,name:l10n_ch.ch_coa_3901
 msgid "Variation des stocks de produits finis"
 msgstr "Variazione delle scorte di prodotti finiti"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3900
 #: model:account.account.template,name:l10n_ch.ch_coa_3900
 msgid "Variation des stocks de produits semi-finis"
 msgstr "Variazione delle scorte di prodotti in corso di fabbricazione"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1217
 #: model:account.account.template,name:l10n_ch.ch_coa_1217
 msgid "Variation des stocks des matières premières"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4008
-#: model:account.account,name:l10n_ch.1_ch_coa_4080
 #: model:account.account.template,name:l10n_ch.ch_coa_4008
 #: model:account.account.template,name:l10n_ch.ch_coa_4080
 msgid "Variations de stocks"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3200
 #: model:account.account.template,name:l10n_ch.ch_coa_3200
 msgid "Ventes de marchandises"
 msgstr "Ricavi merci di rivendita"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3400
 #: model:account.account.template,name:l10n_ch.ch_coa_3400
 msgid "Ventes de prestations"
 msgstr "Ricavi prestazioni di servizi"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3000
 #: model:account.account.template,name:l10n_ch.ch_coa_3000
 msgid "Ventes de produits fabriqués"
 msgstr "Ricavi prodotti fabbricati"
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1530
 #: model:account.account.template,name:l10n_ch.ch_coa_1530
 msgid "Véhicules"
 msgstr "Veicoli"

--- a/addons/l10n_ch/i18n_extra/it.po
+++ b/addons/l10n_ch/i18n_extra/it.po
@@ -1309,7 +1309,7 @@ msgid "Titres à long terme"
 msgstr "Titoli"
 
 #. module: l10n_ch
-#: model:account.account.template,name:l10n_ch.transfer_account_id
+#: model:account.account.template,name:l10n_ch.ch_transfer_account_id
 msgid "Transferts internes"
 msgstr ""
 

--- a/addons/l10n_ch/i18n_extra/l10n_ch.pot
+++ b/addons/l10n_ch/i18n_extra/l10n_ch.pot
@@ -16,327 +16,272 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_O_exclude
 #: model:account.tax.template,description:l10n_ch.vat_O_exclude
 msgid "0% excl."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_O_import
 #: model:account.tax.template,description:l10n_ch.vat_O_import
 msgid "0% import."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_100_import
 #: model:account.tax.template,name:l10n_ch.vat_100_import
 msgid "100% dédouanement TVA"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_100_import
 #: model:account.tax.template,description:l10n_ch.vat_100_import
 msgid "100% imp."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_25
 #: model:account.tax.template,description:l10n_ch.vat_25
 msgid "2.5%"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_25_incl
 #: model:account.tax.template,description:l10n_ch.vat_25_incl
 msgid "2.5% Incl."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_25_purchase
 #: model:account.tax.template,description:l10n_ch.vat_25_purchase
 msgid "2.5% achat"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_25_purchase_incl
 #: model:account.tax.template,description:l10n_ch.vat_25_purchase_incl
 msgid "2.5% achat Incl."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_25_invest
 #: model:account.tax.template,description:l10n_ch.vat_25_invest
 msgid "2.5% invest."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_25_invest_incl
 #: model:account.tax.template,description:l10n_ch.vat_25_invest_incl
 msgid "2.5% invest. Incl."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_38
 #: model:account.tax.template,description:l10n_ch.vat_38
 msgid "3.8%"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_38_incl
 #: model:account.tax.template,description:l10n_ch.vat_38_incl
 msgid "3.8% Incl."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_38_purchase
 #: model:account.tax.template,description:l10n_ch.vat_38_purchase
 msgid "3.8% achat"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_38_purchase_incl
 #: model:account.tax.template,description:l10n_ch.vat_38_purchase_incl
 msgid "3.8% achat Incl."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_38_invest
 #: model:account.tax.template,description:l10n_ch.vat_38_invest
 msgid "3.8% invest"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_38_invest_incl
 #: model:account.tax.template,description:l10n_ch.vat_38_invest_incl
 msgid "3.8% invest Incl."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_80
 #: model:account.tax.template,description:l10n_ch.vat_80
 msgid "8.0%"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_80_incl
 #: model:account.tax.template,description:l10n_ch.vat_80_incl
 msgid "8.0% Incl."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_80_purchase
 #: model:account.tax.template,description:l10n_ch.vat_80_purchase
 msgid "8.0% achat"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_80_purchase_incl
 #: model:account.tax.template,description:l10n_ch.vat_80_purchase_incl
 msgid "8.0% achat Incl."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_80_invest
 #: model:account.tax.template,description:l10n_ch.vat_80_invest
 msgid "8.0% invest."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,description:l10n_ch.1_vat_80_invest_incl
 #: model:account.tax.template,description:l10n_ch.vat_80_invest_incl
 msgid "8.0% invest. Incl."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4200
 #: model:account.account.template,name:l10n_ch.ch_coa_4200
 msgid "Achats de marchandises destinées à la revente"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2030
 #: model:account.account.template,name:l10n_ch.ch_coa_2030
 msgid "Acomptes de clients"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1208
 #: model:account.account.template,name:l10n_ch.ch_coa_1208
 msgid "Acomptes sur les marchandises commerciales"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1218
 #: model:account.account.template,name:l10n_ch.ch_coa_1218
 msgid "Acomptes sur matières premières"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1149
 #: model:account.account.template,name:l10n_ch.ch_coa_1149
 msgid "Ajustement de la valeur des avances et des prêts"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1199
 #: model:account.account.template,name:l10n_ch.ch_coa_1199
 msgid "Ajustement de la valeur des créances à court terme"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1449
 #: model:account.account.template,name:l10n_ch.ch_coa_1449
 msgid "Ajustement de la valeur des créances à long terme"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1779
 #: model:account.account.template,name:l10n_ch.ch_coa_1779
 msgid "Ajustement de la valeur des goodwill"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1489
 #: model:account.account.template,name:l10n_ch.ch_coa_1489
 msgid "Ajustement de la valeur des participations"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1069
-#: model:account.account,name:l10n_ch.1_ch_coa_1409
 #: model:account.account.template,name:l10n_ch.ch_coa_1069
 #: model:account.account.template,name:l10n_ch.ch_coa_1409
 msgid "Ajustement de la valeur des titres"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6800
 #: model:account.account.template,name:l10n_ch.ch_coa_6800
 msgid "Amortissements et ajustements de valeur des postes sur immobilisations corporelles"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1519
 #: model:account.account.template,name:l10n_ch.ch_coa_1519
 msgid "Amortissements sur le mobilier et les installations"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1599
 #: model:account.account.template,name:l10n_ch.ch_coa_1599
 msgid "Amortissements sur les autres immobilisations corporelles meubles"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1709
 #: model:account.account.template,name:l10n_ch.ch_coa_1709
 msgid "Amortissements sur les brevets, know-how, licences, droits, dév."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1609
 #: model:account.account.template,name:l10n_ch.ch_coa_1609
 msgid "Amortissements sur les immeubles d’exploitation"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1559
 #: model:account.account.template,name:l10n_ch.ch_coa_1559
 msgid "Amortissements sur les installations de stockage"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1529
 #: model:account.account.template,name:l10n_ch.ch_coa_1529
 msgid "Amortissements sur les machines de bureau, inf. et syst. comm."
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1509
 #: model:account.account.template,name:l10n_ch.ch_coa_1509
 msgid "Amortissements sur les machines et appareils"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1549
 #: model:account.account.template,name:l10n_ch.ch_coa_1549
 msgid "Amortissements sur les outillages et appareils"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1539
 #: model:account.account.template,name:l10n_ch.ch_coa_1539
 msgid "Amortissements sur les véhicules"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1579
 #: model:account.account.template,name:l10n_ch.ch_coa_1579
 msgid "Amortissements sur les équipements et installations"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2270
 #: model:account.account.template,name:l10n_ch.ch_coa_2270
 msgid "Assurances sociales et institutions de prévoyance"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6300
 #: model:account.account.template,name:l10n_ch.ch_coa_6300
 msgid "Assurances-choses, droits, taxes, autorisations"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_5800
 #: model:account.account.template,name:l10n_ch.ch_coa_5800
 msgid "Autres charges du personnel"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6700
 #: model:account.account.template,name:l10n_ch.ch_coa_6700
 msgid "Autres charges d‘exploitation"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1190
 #: model:account.account.template,name:l10n_ch.ch_coa_1190
 msgid "Autres créances à court terme"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2210
 #: model:account.account.template,name:l10n_ch.ch_coa_2210
 msgid "Autres dettes à court terme"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2140
 #: model:account.account.template,name:l10n_ch.ch_coa_2140
 msgid "Autres dettes à court terme rémunérées"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2500
 #: model:account.account.template,name:l10n_ch.ch_coa_2500
 msgid "Autres dettes à long terme"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1590
 #: model:account.account.template,name:l10n_ch.ch_coa_1590
 msgid "Autres immobilisations corporelles meubles"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3600
 #: model:account.account.template,name:l10n_ch.ch_coa_3600
 msgid "Autres ventes et prestations de services"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1140
 #: model:account.account.template,name:l10n_ch.ch_coa_1140
 msgid "Avances et prêts"
 msgstr ""
@@ -368,19 +313,16 @@ msgid "Boolean value. True iff all the data required to generate the ISR are pre
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1700
 #: model:account.account.template,name:l10n_ch.ch_coa_1700
 msgid "Brevets, know-how, licences, droits, développement"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2979
 #: model:account.account.template,name:l10n_ch.ch_coa_2979
 msgid "Bénéfice / perte de l’exercice"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2970
 #: model:account.account.template,name:l10n_ch.ch_coa_2970
 msgid "Bénéfice / perte reporté"
 msgstr ""
@@ -391,121 +333,101 @@ msgid "CHF ISR reference"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1850
 #: model:account.account.template,name:l10n_ch.ch_coa_1850
 msgid "Capital actions, capital social, droits de participations ou capital de fondation non versés"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2800
 #: model:account.account.template,name:l10n_ch.ch_coa_2800
 msgid "Capital-actions, capital social, capital de fondation"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4521
 #: model:account.account.template,name:l10n_ch.ch_coa_4521
 msgid "Charbon, briquettes, bois"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_7010
 #: model:account.account.template,name:l10n_ch.ch_coa_7010
 msgid "Charges accessoires"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6000
 #: model:account.account.template,name:l10n_ch.ch_coa_6000
 msgid "Charges de locaux"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4000
 #: model:account.account.template,name:l10n_ch.ch_coa_4000
 msgid "Charges de matériel de l‘atelier"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_5900
 #: model:account.account.template,name:l10n_ch.ch_coa_5900
 msgid "Charges de personnels temporaires"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6200
 #: model:account.account.template,name:l10n_ch.ch_coa_6200
 msgid "Charges de véhicules et de transport"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_7510
 #: model:account.account.template,name:l10n_ch.ch_coa_7510
 msgid "Charges des immeubles d‘exploitation"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6500
 #: model:account.account.template,name:l10n_ch.ch_coa_6500
 msgid "Charges d‘administration"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6400
 #: model:account.account.template,name:l10n_ch.ch_coa_6400
 msgid "Charges d’énergie et évacuation des déchets"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6570
 #: model:account.account.template,name:l10n_ch.ch_coa_6570
 msgid "Charges et leasing d’informatique"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_8500
 #: model:account.account.template,name:l10n_ch.ch_coa_8500
 msgid "Charges extraordinaires, exceptionnelles ou hors période"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6900
 #: model:account.account.template,name:l10n_ch.ch_coa_6900
 msgid "Charges financières"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_8000
 #: model:account.account.template,name:l10n_ch.ch_coa_8000
 msgid "Charges hors exploitation"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1300
 #: model:account.account.template,name:l10n_ch.ch_coa_1300
 msgid "Charges payées d‘avance"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_5700
 #: model:account.account.template,name:l10n_ch.ch_coa_5700
 msgid "Charges sociales"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2300
 #: model:account.account.template,name:l10n_ch.ch_coa_2300
 msgid "Charges à payer"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3803
 #: model:account.account.template,name:l10n_ch.ch_coa_3803
 msgid "Commissions de tiers"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4903
 #: model:account.account.template,name:l10n_ch.ch_coa_4903
 msgid "Commissions obtenues sur achats"
 msgstr ""
@@ -516,61 +438,51 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1099
 #: model:account.account.template,name:l10n_ch.ch_coa_1099
 msgid "Compte d'attente autre"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1091
 #: model:account.account.template,name:l10n_ch.ch_coa_1091
 msgid "Compte d'attente pour salaires"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3710
 #: model:account.account.template,name:l10n_ch.ch_coa_3710
 msgid "Consommations propres"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1269
 #: model:account.account.template,name:l10n_ch.ch_coa_1269
 msgid "Correction de la valeur de stocks de produits finis"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1279
 #: model:account.account.template,name:l10n_ch.ch_coa_1279
 msgid "Corrections de la valeur des stock produits semi-ouvrés"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1209
 #: model:account.account.template,name:l10n_ch.ch_coa_1209
 msgid "Corrections de la valeur des stocks de marchandises"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1289
 #: model:account.account.template,name:l10n_ch.ch_coa_1289
 msgid "Corrections de la valeur des travaux en cours"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1219
 #: model:account.account.template,name:l10n_ch.ch_coa_1219
 msgid "Corrections de la valeur sur matières premières"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1180
 #: model:account.account.template,name:l10n_ch.ch_coa_1180
 msgid "Créances envers les assurances sociales et institutions de prévoyance"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2000
 #: model:account.account.template,name:l10n_ch.ch_coa_2000
 msgid "Créanciers"
 msgstr ""
@@ -581,65 +493,53 @@ msgid "Currency"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2100
-#: model:account.account,name:l10n_ch.1_ch_coa_2400
 #: model:account.account.template,name:l10n_ch.ch_coa_2100
 #: model:account.account.template,name:l10n_ch.ch_coa_2400
 msgid "Dettes bancaires"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2160
 #: model:account.account.template,name:l10n_ch.ch_coa_2160
 msgid "Dettes envers l'actionnaire"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3806
-#: model:account.account,name:l10n_ch.1_ch_coa_4906
 #: model:account.account.template,name:l10n_ch.ch_coa_3806
 #: model:account.account.template,name:l10n_ch.ch_coa_4906
 msgid "Différences de change"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2261
 #: model:account.account.template,name:l10n_ch.ch_coa_2261
 msgid "Dividendes"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4071
 #: model:account.account.template,name:l10n_ch.ch_coa_4071
 msgid "Droits de douanes à l'importation"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1109
 #: model:account.account.template,name:l10n_ch.ch_coa_1109
 msgid "Ducroire"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1100
 #: model:account.account.template,name:l10n_ch.ch_coa_1100
 msgid "Débiteurs"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2201
 #: model:account.account.template,name:l10n_ch.ch_coa_2201
 msgid "Décompte TVA"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4009
 #: model:account.account.template,name:l10n_ch.ch_coa_4009
 msgid "Déductions obtenues sur achats"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3009
 #: model:account.account.template,name:l10n_ch.ch_coa_3009
 msgid "Déductions sur ventes"
 msgstr ""
@@ -650,13 +550,11 @@ msgid "EUR ISR reference"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4540
 #: model:account.account.template,name:l10n_ch.ch_coa_4540
 msgid "Eau"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4500
 #: model:account.account.template,name:l10n_ch.ch_coa_4500
 msgid "Electricité"
 msgstr ""
@@ -672,90 +570,73 @@ msgid "Email composition wizard"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2450
 #: model:account.account.template,name:l10n_ch.ch_coa_2450
 msgid "Emprunts"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2430
 #: model:account.account.template,name:l10n_ch.ch_coa_2430
 msgid "Emprunts obligataires"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2120
-#: model:account.account,name:l10n_ch.1_ch_coa_2420
 #: model:account.account.template,name:l10n_ch.ch_coa_2120
 #: model:account.account.template,name:l10n_ch.ch_coa_2420
 msgid "Engagements de financement par leasing"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6100
 #: model:account.account.template,name:l10n_ch.ch_coa_6100
 msgid "Entretien, réparations et remplacement des inst. servant à l’exploitation"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1570
 #: model:account.account.template,name:l10n_ch.ch_coa_1570
 msgid "Equipements et Installations"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3800
-#: model:account.account,name:l10n_ch.1_ch_coa_4900
 #: model:account.account.template,name:l10n_ch.ch_coa_3800
 #: model:account.account.template,name:l10n_ch.ch_coa_4900
 msgid "Escomptes"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4530
 #: model:account.account.template,name:l10n_ch.ch_coa_4530
 msgid "Essence"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3804
 #: model:account.account.template,name:l10n_ch.ch_coa_3804
 msgid "Frais d'encaissement"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3807
 #: model:account.account.template,name:l10n_ch.ch_coa_3807
 msgid "Frais d'expédition"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4072
 #: model:account.account.template,name:l10n_ch.ch_coa_4072
 msgid "Frais de transport à l'achat"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4070
 #: model:account.account.template,name:l10n_ch.ch_coa_4070
 msgid "Frêts à l'achat"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4510
 #: model:account.account.template,name:l10n_ch.ch_coa_4510
 msgid "Gaz"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1770
 #: model:account.account.template,name:l10n_ch.ch_coa_1770
 msgid "Goodwill"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1441
-#: model:account.account,name:l10n_ch.1_ch_coa_2451
 #: model:account.account.template,name:l10n_ch.ch_coa_1441
 #: model:account.account.template,name:l10n_ch.ch_coa_2451
 msgid "Hypothèques"
@@ -788,59 +669,48 @@ msgid "ISR sent"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1600
 #: model:account.account.template,name:l10n_ch.ch_coa_1600
 msgid "Immeubles d’exploitation"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.fiscal.position,name:l10n_ch.1_fiscal_position_template_import
 #: model:account.fiscal.position.template,name:l10n_ch.fiscal_position_template_import
 msgid "Import/Export"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1176
 #: model:account.account.template,name:l10n_ch.ch_coa_1176
 msgid "Impôt anticipé"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2206
 #: model:account.account.template,name:l10n_ch.ch_coa_2206
 msgid "Impôt anticipé dû"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1171
 #: model:account.account.template,name:l10n_ch.ch_coa_1171
 msgid "Impôt préalable: TVA s/investissements et autres charges d’exploitation"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1170
 #: model:account.account.template,name:l10n_ch.ch_coa_1170
 msgid "Impôt préalable: TVA s/matériel, marchandises, prestations et énergie"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1189
-#: model:account.account,name:l10n_ch.1_ch_coa_2279
 #: model:account.account.template,name:l10n_ch.ch_coa_1189
 #: model:account.account.template,name:l10n_ch.ch_coa_2279
 msgid "Impôt à la source"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2208
-#: model:account.account,name:l10n_ch.1_ch_coa_8900
 #: model:account.account.template,name:l10n_ch.ch_coa_2208
 #: model:account.account.template,name:l10n_ch.ch_coa_8900
 msgid "Impôts directs"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1550
 #: model:account.account.template,name:l10n_ch.ch_coa_1550
 msgid "Installations de stockage"
 msgstr ""
@@ -891,67 +761,56 @@ msgid "L10N Ch Postal"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6260
 #: model:account.account.template,name:l10n_ch.ch_coa_6260
 msgid "Leasing et location de véhicules"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6105
 #: model:account.account.template,name:l10n_ch.ch_coa_6105
 msgid "Leasing immobilisations corporelles meubles"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1520
 #: model:account.account.template,name:l10n_ch.ch_coa_1520
 msgid "Machines de bureau, informatique, systèmes de communication"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1500
 #: model:account.account.template,name:l10n_ch.ch_coa_1500
 msgid "Machines et appareils"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1200
 #: model:account.account.template,name:l10n_ch.ch_coa_1200
 msgid "Marchandises commerciales"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1250
 #: model:account.account.template,name:l10n_ch.ch_coa_1250
 msgid "Marchandises en consignation"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1220
 #: model:account.account.template,name:l10n_ch.ch_coa_1220
 msgid "Matières auxiliaires"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1230
 #: model:account.account.template,name:l10n_ch.ch_coa_1230
 msgid "Matières consommables"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1210
 #: model:account.account.template,name:l10n_ch.ch_coa_1210
 msgid "Matières premières"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4520
 #: model:account.account.template,name:l10n_ch.ch_coa_4520
 msgid "Mazout"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1510
 #: model:account.account.template,name:l10n_ch.ch_coa_1510
 msgid "Mobilier et installations"
 msgstr ""
@@ -962,25 +821,21 @@ msgid "Optical reading line, as it will be printed on ISR"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1540
 #: model:account.account.template,name:l10n_ch.ch_coa_1540
 msgid "Outillages et appareils"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1480
 #: model:account.account.template,name:l10n_ch.ch_coa_1480
 msgid "Participations"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4086
 #: model:account.account.template,name:l10n_ch.ch_coa_4086
 msgid "Pertes de matières"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3805
 #: model:account.account.template,name:l10n_ch.ch_coa_3805
 msgid "Pertes sur créances clients, variation ducroire"
 msgstr ""
@@ -996,13 +851,11 @@ msgid "Postal reference of the bank, formated with '-' and without the padding z
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4400
 #: model:account.account.template,name:l10n_ch.ch_coa_4400
 msgid "Prestations / travaux de tiers"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3700
 #: model:account.account.template,name:l10n_ch.ch_coa_3700
 msgid "Prestations propres"
 msgstr ""
@@ -1029,135 +882,112 @@ msgid "Print the coordinates of your bank under the 'Payment for' title of the I
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_7000
 #: model:account.account.template,name:l10n_ch.ch_coa_7000
 msgid "Produits accessoires"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_7500
 #: model:account.account.template,name:l10n_ch.ch_coa_7500
 msgid "Produits des immeubles d‘exploitation"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2301
 #: model:account.account.template,name:l10n_ch.ch_coa_2301
 msgid "Produits encaissés d’avance"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_8510
 #: model:account.account.template,name:l10n_ch.ch_coa_8510
 msgid "Produits extraordinaires, exceptionnels ou hors période"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6950
 #: model:account.account.template,name:l10n_ch.ch_coa_6950
 msgid "Produits financiers"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_8100
 #: model:account.account.template,name:l10n_ch.ch_coa_8100
 msgid "Produits hors exploitation"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1301
 #: model:account.account.template,name:l10n_ch.ch_coa_1301
 msgid "Produits à recevoir"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2980
 #: model:account.account.template,name:l10n_ch.ch_coa_2980
 msgid "Propres actions, parts sociales, droits de participations (poste négatif)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2600
 #: model:account.account.template,name:l10n_ch.ch_coa_2600
 msgid "Provisions"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2330
 #: model:account.account.template,name:l10n_ch.ch_coa_2330
 msgid "Provisions à court terme"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1440
 #: model:account.account.template,name:l10n_ch.ch_coa_1440
 msgid "Prêts"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_6600
 #: model:account.account.template,name:l10n_ch.ch_coa_6600
 msgid "Publicité"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3801
 #: model:account.account.template,name:l10n_ch.ch_coa_3801
 msgid "Rabais et réduction de prix"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4901
 #: model:account.account.template,name:l10n_ch.ch_coa_4901
 msgid "Rabais et réductions de prix"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3802
-#: model:account.account,name:l10n_ch.1_ch_coa_4092
 #: model:account.account.template,name:l10n_ch.ch_coa_3802
 #: model:account.account.template,name:l10n_ch.ch_coa_4092
 msgid "Ristournes"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2940
 #: model:account.account.template,name:l10n_ch.ch_coa_2940
 msgid "Réserves d‘évaluation"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2960
 #: model:account.account.template,name:l10n_ch.ch_coa_2960
 msgid "Réserves libres"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2950
 #: model:account.account.template,name:l10n_ch.ch_coa_2950
 msgid "Réserves légales issues du bénéfice"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2900
 #: model:account.account.template,name:l10n_ch.ch_coa_2900
 msgid "Réserves légales issues du capital"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_5000
 #: model:account.account.template,name:l10n_ch.ch_coa_5000
 msgid "Salaires"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1260
 #: model:account.account.template,name:l10n_ch.ch_coa_1260
 msgid "Stocks de produits finis"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1270
 #: model:account.account.template,name:l10n_ch.ch_coa_1270
 msgid "Stocks de produits semi-ouvrés"
 msgstr ""
@@ -1273,133 +1103,141 @@ msgid "Switzerland VAT Form: grid 420"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_O_import
+#: model:account.tax.group,name:l10n_ch.tax_group_tva_0
+msgid "TVA 0%"
+msgstr ""
+
+#. module: l10n_ch
 #: model:account.tax.template,name:l10n_ch.vat_O_import
 msgid "TVA 0% Importations de biens et services"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_O_exclude
 #: model:account.tax.template,name:l10n_ch.vat_O_exclude
 msgid "TVA 0% exclue"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_25_purchase_incl
+#: model:account.tax.group,name:l10n_ch.tax_group_tva_25
+msgid "TVA 2.5%"
+msgstr ""
+
+#. module: l10n_ch
 #: model:account.tax.template,name:l10n_ch.vat_25_purchase_incl
 msgid "TVA 2.5% sur achat B&S (Incl. TR)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_25_purchase
 #: model:account.tax.template,name:l10n_ch.vat_25_purchase
 msgid "TVA 2.5% sur achat B&S (TR)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_25_invest_incl
 #: model:account.tax.template,name:l10n_ch.vat_25_invest_incl
 msgid "TVA 2.5% sur invest. et autres ch. (Incl. TR)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_25_invest
 #: model:account.tax.template,name:l10n_ch.vat_25_invest
 msgid "TVA 2.5% sur invest. et autres ch. (TR)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_38_purchase_incl
+#: model:account.tax.group,name:l10n_ch.tax_group_tva_37
+msgid "TVA 3.7%"
+msgstr ""
+
+#. module: l10n_ch
+#: model:account.tax.group,name:l10n_ch.tax_group_tva_38
+msgid "TVA 3.8%"
+msgstr ""
+
+#. module: l10n_ch
 #: model:account.tax.template,name:l10n_ch.vat_38_purchase_incl
 msgid "TVA 3.8% sur achat B&S (Incl. TS)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_38_purchase
 #: model:account.tax.template,name:l10n_ch.vat_38_purchase
 msgid "TVA 3.8% sur achat B&S (TS)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_38_invest_incl
 #: model:account.tax.template,name:l10n_ch.vat_38_invest_incl
 msgid "TVA 3.8% sur invest. et autres ch. (Incl. TS)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_38_invest
 #: model:account.tax.template,name:l10n_ch.vat_38_invest
 msgid "TVA 3.8% sur invest. et autres ch. (TS)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_80_purchase_incl
+#: model:account.tax.group,name:l10n_ch.tax_group_tva_77
+msgid "TVA 7.7%"
+msgstr ""
+
+#. module: l10n_ch
+#: model:account.tax.group,name:l10n_ch.tax_group_tva_8
+msgid "TVA 8%"
+msgstr ""
+
+#. module: l10n_ch
 #: model:account.tax.template,name:l10n_ch.vat_80_purchase_incl
 msgid "TVA 8.0% sur achat B&S (Incl. TN)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_80_purchase
 #: model:account.tax.template,name:l10n_ch.vat_80_purchase
 msgid "TVA 8.0% sur achat B&S (TN)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_80_invest_incl
 #: model:account.tax.template,name:l10n_ch.vat_80_invest_incl
 msgid "TVA 8.0% sur invest. et autres ch. (Incl. TN)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_80_invest
 #: model:account.tax.template,name:l10n_ch.vat_80_invest
 msgid "TVA 8.0% sur invest. et autres ch. (TN)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_2200
 #: model:account.account.template,name:l10n_ch.ch_coa_2200
 msgid "TVA due"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_XO
 #: model:account.tax.template,name:l10n_ch.vat_XO
 msgid "TVA due a 0% (Exportations)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_25
 #: model:account.tax.template,name:l10n_ch.vat_25
 msgid "TVA due a 2.5% (TR)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_38
 #: model:account.tax.template,name:l10n_ch.vat_38
 msgid "TVA due a 3.8% (TS)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_80
 #: model:account.tax.template,name:l10n_ch.vat_80
 msgid "TVA due a 8.0% (TN)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_25_incl
 #: model:account.tax.template,name:l10n_ch.vat_25_incl
 msgid "TVA due à 2.5% (Incl. TR)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_38_incl
 #: model:account.tax.template,name:l10n_ch.vat_38_incl
 msgid "TVA due à 3.8% (Incl. TS)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax,name:l10n_ch.1_vat_80_incl
 #: model:account.tax.template,name:l10n_ch.vat_80_incl
 msgid "TVA due à 8.0% (Incl. TN)"
 msgstr ""
@@ -1435,113 +1273,93 @@ msgid "The reference number associated with this invoice"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1060
 #: model:account.account.template,name:l10n_ch.ch_coa_1060
 msgid "Titres"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1400
 #: model:account.account.template,name:l10n_ch.ch_coa_1400
 msgid "Titres à long terme"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_transfer_account_id
 #: model:account.account.template,name:l10n_ch.transfer_account_id
 msgid "Transferts internes"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1280
 #: model:account.account.template,name:l10n_ch.ch_coa_1280
 msgid "Travaux en cours"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3940
 #: model:account.account.template,name:l10n_ch.ch_coa_3940
 msgid "Variation de la valeur des prestations non facturées"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1287
 #: model:account.account.template,name:l10n_ch.ch_coa_1287
 msgid "Variation de la valeur des travaux en cours"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1277
 #: model:account.account.template,name:l10n_ch.ch_coa_1277
 msgid "Variation de stock produits semi-ouvrés"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1267
 #: model:account.account.template,name:l10n_ch.ch_coa_1267
 msgid "Variation de stocks de produits finis"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1207
-#: model:account.account,name:l10n_ch.1_ch_coa_4800
 #: model:account.account.template,name:l10n_ch.ch_coa_1207
 #: model:account.account.template,name:l10n_ch.ch_coa_4800
 msgid "Variation des stocks de marchandises"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4801
 #: model:account.account.template,name:l10n_ch.ch_coa_4801
 msgid "Variation des stocks de matières premières"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3901
 #: model:account.account.template,name:l10n_ch.ch_coa_3901
 msgid "Variation des stocks de produits finis"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3900
 #: model:account.account.template,name:l10n_ch.ch_coa_3900
 msgid "Variation des stocks de produits semi-finis"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1217
 #: model:account.account.template,name:l10n_ch.ch_coa_1217
 msgid "Variation des stocks des matières premières"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_4008
-#: model:account.account,name:l10n_ch.1_ch_coa_4080
 #: model:account.account.template,name:l10n_ch.ch_coa_4008
 #: model:account.account.template,name:l10n_ch.ch_coa_4080
 msgid "Variations de stocks"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3200
 #: model:account.account.template,name:l10n_ch.ch_coa_3200
 msgid "Ventes de marchandises"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3400
 #: model:account.account.template,name:l10n_ch.ch_coa_3400
 msgid "Ventes de prestations"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_3000
 #: model:account.account.template,name:l10n_ch.ch_coa_3000
 msgid "Ventes de produits fabriqués"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account,name:l10n_ch.1_ch_coa_1530
 #: model:account.account.template,name:l10n_ch.ch_coa_1530
 msgid "Véhicules"
 msgstr ""

--- a/addons/l10n_ch/i18n_extra/l10n_ch.pot
+++ b/addons/l10n_ch/i18n_extra/l10n_ch.pot
@@ -1283,7 +1283,7 @@ msgid "Titres à long terme"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.account.template,name:l10n_ch.transfer_account_id
+#: model:account.account.template,name:l10n_ch.ch_transfer_account_id
 msgid "Transferts internes"
 msgstr ""
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Improved translations
Task:- https://www.odoo.com/web#id=1922590&action=327&model=project.task&view_type=form&menu_id=4720
Pad:-https://pad.odoo.com/p/r.0e9d23f1ae22ff7f2dbe4faaf902c6cc

Desired behavior after PR is merged:  
Removed the translations for models
- account.account
- account.tax
- account.fiscal.position.tax
- account.fiscal.position.account
- account.fiscal.position
- account.reconcile.model

which were no longer required as these were already translated in its templates.






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr