### PR TITLE
[IMP] l10n_lu/l10n_cn*: improved translation

### DIFF
--- a/addons/l10n_ch/i18n_extra/it.po
+++ b/addons/l10n_ch/i18n_extra/it.po
@@ -985,7 +985,7 @@ msgstr ""
 #. module: l10n_ch
 #: model:account.tax.group,name:l10n_ch.tax_group_tva_0
 msgid "TVA 0%"
-msgstr ""
+msgstr "IVA 0%"
 
 #. module: l10n_ch
 #: model:account.tax.template,name:l10n_ch.vat_O_import
@@ -1000,7 +1000,7 @@ msgstr "IVA 0% Esclusa"
 #. module: l10n_ch
 #: model:account.tax.group,name:l10n_ch.tax_group_tva_25
 msgid "TVA 2.5%"
-msgstr ""
+msgstr "IVA 2.5%"
 
 #. module: l10n_ch
 #: model:account.tax.template,name:l10n_ch.vat_25_purchase_incl
@@ -1025,7 +1025,7 @@ msgstr "IVA 2.5% Investimenti e altri costi (TR)"
 #. module: l10n_ch
 #: model:account.tax.group,name:l10n_ch.tax_group_tva_37
 msgid "TVA 3.7%"
-msgstr ""
+msgstr "IVA 3.7%"
 
 #. module: l10n_ch
 #: model:account.tax.template,name:l10n_ch.vat_37_purchase_incl
@@ -1050,7 +1050,7 @@ msgstr ""
 #. module: l10n_ch
 #: model:account.tax.group,name:l10n_ch.tax_group_tva_77
 msgid "TVA 7.7%"
-msgstr ""
+msgstr "IVA 7.7%"
 
 #. module: l10n_ch
 #: model:account.tax.template,name:l10n_ch.vat_77_purchase_incl

--- a/addons/l10n_cn/i18n/en_US.po
+++ b/addons/l10n_cn/i18n/en_US.po
@@ -1,0 +1,192 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* l10n_cn
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-05-07 12:02+0000\n"
+"PO-Revision-Date: 2019-05-07 12:02+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_SH
+msgid "上海市"
+msgstr ""
+
+#. module: l10n_cn
+#: model:account.account.type,name:l10n_cn.user_type_all
+msgid "不显示在报表上"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_YN
+msgid "云南省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_NM
+msgid "内蒙古自治区"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_BJ
+msgid "北京市"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_TW
+msgid "台湾省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_JL
+msgid "吉林省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_SC
+msgid "四川省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_TJ
+msgid "天津市"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_NX
+msgid "宁夏回族自治区"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_AH
+msgid "安徽省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_SD
+msgid "山东省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_SX
+msgid "山西省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_GD
+msgid "广东省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_GX
+msgid "广西壮族自治区"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_XJ
+msgid "新疆维吾尔自治区"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_JS
+msgid "江苏省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_JX
+msgid "江西省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_HE
+msgid "河北省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_HA
+msgid "河南省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_ZJ
+msgid "浙江省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_HI
+msgid "海南省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_HB
+msgid "湖北省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_HN
+msgid "湖南省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_MO
+msgid "澳门特别行政区"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_GS
+msgid "甘肃省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_FJ
+msgid "福建省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_XZ
+msgid "西藏自治区"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_GZ
+msgid "贵州省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_LN
+msgid "辽宁省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_CQ
+msgid "重庆市"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_SN
+msgid "陕西省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_QH
+msgid "青海省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_HK
+msgid "香港特别行政区"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_HL
+msgid "黑龙江省"
+msgstr ""
+

--- a/addons/l10n_cn/i18n/l10n_cn.pot
+++ b/addons/l10n_cn/i18n/l10n_cn.pot
@@ -1,0 +1,212 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* l10n_cn
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-05-07 12:00+0000\n"
+"PO-Revision-Date: 2019-05-07 12:00+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_cn
+#: model:account.tax.group,name:l10n_cn.l10n_cn_tax_group_vat_11
+msgid "VAT 11%"
+msgstr ""
+
+#. module: l10n_cn
+#: model:account.tax.group,name:l10n_cn.l10n_cn_tax_group_vat_17
+msgid "VAT 17%"
+msgstr ""
+
+#. module: l10n_cn
+#: model:account.tax.group,name:l10n_cn.l10n_cn_tax_group_vat_3
+msgid "VAT 3%"
+msgstr ""
+
+#. module: l10n_cn
+#: model:account.tax.group,name:l10n_cn.l10n_cn_tax_group_vat_6
+msgid "VAT 6%"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_SH
+msgid "上海市"
+msgstr ""
+
+#. module: l10n_cn
+#: model:account.account.type,name:l10n_cn.user_type_all
+msgid "不显示在报表上"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_YN
+msgid "云南省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_NM
+msgid "内蒙古自治区"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_BJ
+msgid "北京市"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_TW
+msgid "台湾省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_JL
+msgid "吉林省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_SC
+msgid "四川省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_TJ
+msgid "天津市"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_NX
+msgid "宁夏回族自治区"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_AH
+msgid "安徽省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_SD
+msgid "山东省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_SX
+msgid "山西省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_GD
+msgid "广东省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_GX
+msgid "广西壮族自治区"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_XJ
+msgid "新疆维吾尔自治区"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_JS
+msgid "江苏省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_JX
+msgid "江西省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_HE
+msgid "河北省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_HA
+msgid "河南省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_ZJ
+msgid "浙江省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_HI
+msgid "海南省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_HB
+msgid "湖北省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_HN
+msgid "湖南省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_MO
+msgid "澳门特别行政区"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_GS
+msgid "甘肃省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_FJ
+msgid "福建省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_XZ
+msgid "西藏自治区"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_GZ
+msgid "贵州省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_LN
+msgid "辽宁省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_CQ
+msgid "重庆市"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_SN
+msgid "陕西省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_QH
+msgid "青海省"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_HK
+msgid "香港特别行政区"
+msgstr ""
+
+#. module: l10n_cn
+#: model:res.country.state,name:l10n_cn.state_HL
+msgid "黑龙江省"
+msgstr ""
+

--- a/addons/l10n_cn/i18n_extra/en_US.po
+++ b/addons/l10n_cn/i18n_extra/en_US.po
@@ -1,0 +1,37 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* l10n_cn
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-05-07 12:02+0000\n"
+"PO-Revision-Date: 2019-05-07 12:02+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_cn
+#: model:account.tax.group,name:l10n_cn.l10n_cn_tax_group_vat_11
+msgid "VAT 11%"
+msgstr ""
+
+#. module: l10n_cn
+#: model:account.tax.group,name:l10n_cn.l10n_cn_tax_group_vat_17
+msgid "VAT 17%"
+msgstr ""
+
+#. module: l10n_cn
+#: model:account.tax.group,name:l10n_cn.l10n_cn_tax_group_vat_3
+msgid "VAT 3%"
+msgstr ""
+
+#. module: l10n_cn
+#: model:account.tax.group,name:l10n_cn.l10n_cn_tax_group_vat_6
+msgid "VAT 6%"
+msgstr ""
+

--- a/addons/l10n_cn_small_business/i18n_extra/en_US.po
+++ b/addons/l10n_cn_small_business/i18n_extra/en_US.po
@@ -16,303 +16,250 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2711
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2711
 msgid "專項應付款"
 msgstr "Account payable special funds"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6401
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6401
 msgid "主營業務成本"
 msgstr "Main Business Cost"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6001
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6001
 msgid "主營業務收入"
 msgstr "Main Business Income"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1101
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1101
 msgid "交易性金融資産"
 msgstr "Transactional Financial Assets"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6901
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6901
 msgid "以前年度損益調整"
 msgstr "Prior year income adjustment"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6101
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6101
 msgid "公允價值變動損益"
 msgstr "Gains and Losses of fair value change"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6402
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6402
 msgid "其他業務成本"
 msgstr "Other Operating Costs"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6051
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6051
 msgid "其他業務收入"
 msgstr "Other Business Income"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2501
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2501
 msgid "其他應付款"
 msgstr "Other payable"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1221
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1221
 msgid "其他應收款"
 msgstr "Other Receivable"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_4003
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_4003
 msgid "其他綜合收益"
 msgstr "Other Comprehensive Income"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1012
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1012
 msgid "其他貨幣資金"
 msgstr "Other Monetary Funds"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_4104
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_4104
 msgid "利潤分配"
 msgstr "Profit distribution"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_5101
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_5101
 msgid "制造費用"
 msgstr "Manufacturing Expenses"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_5201
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_5201
 msgid "勞務成本"
 msgstr "Service Cost"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1403
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1403
 msgid "原材料"
 msgstr "Raw Material"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1406
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1406
 msgid "發出商品"
 msgstr "Goods shipped in transit"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1503
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1503
 msgid "可供出售金融資産"
 msgstr "Available for sale financial assets"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1407
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1407
 msgid "商品進銷差價"
 msgstr "Differences between purchasing and selling price"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1711
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1711
 msgid "商譽"
 msgstr "Goodwill"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1601
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1601
 msgid "固定資産"
 msgstr "Fixed assets"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1603
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1603
 msgid "固定資産减值準備"
 msgstr "Fixed assets depreciation reserves"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1606
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1606
 msgid "固定資産情况"
 msgstr "Liquidation of fixed assets"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1604
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1604
 msgid "在建工程"
 msgstr "Construction in progress"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1402
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1402
 msgid "在途物資"
 msgstr "Materials in transit"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1231
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1231
 msgid "壞賬準備"
 msgstr "Bad Debt Provisions"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_11
 #: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_11
 msgid "税收11％"
 msgstr "Tax 11%"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_11
 #: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_11
 msgid "税收11％ - 中国小企业会计科目表"
 msgstr "Tax 11%"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_11
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_11
 #: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_11
 #: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_included_11
 msgid "税收11％"
 msgstr "Tax 11%"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_11
 #: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_11
 msgid "税收11％ - 中国小企业会计科目表"
 msgstr "Tax 11%"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_11
 #: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_included_11
 msgid "税收11％（含） - 中国小企业会计科目表"
 msgstr "Tax 11% (Incl.)"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_17
 #: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_17
 msgid "税收17％"
 msgstr "Tax 17%"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_17
 #: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_17
 msgid "税收17％ - 中国小企业会计科目表"
 msgstr "Tax 17%"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_17
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_17
 #: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_17
 #: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_included_17
 msgid "税收17％"
 msgstr "Tax 17%"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_17
 #: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_17
 msgid "税收17％ - 中国小企业会计科目表"
 msgstr "Tax 17%"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_17
 #: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_included_17
 msgid "税收17％（含） - 中国小企业会计科目表"
 msgstr "Tax 17% (Incl.)"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_3
 #: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_3
 msgid "税收3％"
 msgstr "Tax 3%"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_3
 #: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_3
 msgid "税收3％ - 中国小企业会计科目表"
 msgstr "Tax 3%"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_3
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_3
 #: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_3
 #: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_included_3
 msgid "税收3％"
 msgstr "Tax 3%"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_3
 #: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_3
 msgid "税收3％ - 中国小企业会计科目表"
 msgstr "Tax 3%"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_3
 #: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_included_3
 msgid "税收3％（含） - 中国小企业会计科目表"
 msgstr "Tax 3% (Incl.)"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_6
 #: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_6
 msgid "税收6％"
 msgstr "Tax 6%"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_6
 #: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_6
 msgid "税收6％ - 中国小企业会计科目表"
 msgstr "Tax 6%"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_6
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_6
 #: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_6
 #: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_included_6
 msgid "税收6％"
 msgstr "Tax 6%"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_6
 #: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_6
 msgid "税收6％ - 中国小企业会计科目表"
 msgstr "Tax 6%"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_6
 #: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_included_6
 msgid "税收6％（含） - 中国小企业会计科目表"
 msgstr "Tax 6% (Incl.)"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1408
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1408
 msgid "委托加工物資"
 msgstr "Consigned processing materials"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1471
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1471
 msgid "存貨跌價準備"
 msgstr "Inventory falling price reserves"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_4001
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_4001
 msgid "實收資本"
 msgstr "Paid in capital"
@@ -323,277 +270,231 @@ msgid "小企业会计科目表（财会[2011]17号《小企业会计准则》�
 msgstr "Chinese CoA (for small companies)"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1605
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1605
 msgid "工程物資"
 msgstr "Engineering materials"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1405
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1405
 msgid "庫存商品"
 msgstr "Merchandise Inventory"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2221
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2221
 msgid "應交税費"
 msgstr "Tax payable"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2502
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2502
 msgid "應付債券"
 msgstr "Bonds Payable"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2231
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2231
 msgid "應付利息"
 msgstr "Interest payable"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2201
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2201
 msgid "應付票據"
 msgstr "Bills Payable"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2211
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2211
 msgid "應付職工薪酬"
 msgstr "Payroll payable"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2241
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2241
 msgid "應付股利"
 msgstr "Dividents payable"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1122
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1122
 msgid "應付賬款"
 msgstr "Accounts Receivable"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2202
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2202
 msgid "應付賬款"
 msgstr "Accounts Payable"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1132
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1132
 msgid "應收利息"
 msgstr "Interest Receivable"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1121
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1121
 msgid "應收票據"
 msgstr "Bills Receivable"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1131
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1131
 msgid "應收股利"
 msgstr "Divident Receivable"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6801
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6801
 msgid "所得税費用"
 msgstr "Income Tax Expense"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1521
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1521
 msgid "投資性房地産"
 msgstr "Investmental real estate"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6111
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6111
 msgid "投資收益"
 msgstr "Income from investment"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1501
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1501
 msgid "持有至到期投資"
 msgstr "Held to maturity Investment"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1502
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1502
 msgid "持有至到期投資减值準備"
 msgstr "Provision for impairment of investments held to maturity"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1701
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1701
 msgid "無形資産"
 msgstr "Intangible Assets"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1703
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1703
 msgid "無形資産减值準備"
 msgstr "Intangible Assets Depreciation Reserves"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_4103
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_4103
 msgid "本年利潤"
 msgstr "Profit for the year"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1404
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1404
 msgid "材料成本差异"
 msgstr "Material Cost Variance"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1401
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1401
 msgid "材料采購"
 msgstr "Material Purchasing"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_5001
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_5001
 msgid "生産成本"
 msgstr "Production Costs"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_4101
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_4101
 msgid "盈餘公積"
 msgstr "Surplus Reserve"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2001
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2001
 msgid "短期借款"
 msgstr "Short-term borrowing"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_5301
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_5301
 msgid "研發支出"
 msgstr "R & D expenditure"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6602
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6602
 msgid "管理費用"
 msgstr "Management Expenses"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1602
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1602
 msgid "累計折舊"
 msgstr "Accumulated depreciation"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1702
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1702
 msgid "累計攤銷"
 msgstr "Accumulated amortization"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6711
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6711
 msgid "營業外支出"
 msgstr "Non-operating expenses"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6301
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6301
 msgid "營業外收入"
 msgstr "Non-operating Income"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6403
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6403
 msgid "營業税及附加"
 msgstr "Operating Taxes and Surcharges"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6603
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6603
 msgid "財務費用"
 msgstr "Financial Expenses"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6701
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6701
 msgid "資産减值損失"
 msgstr "Assets impairment Loss"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_4002
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_4002
 msgid "資本公積金"
 msgstr "Capital Surplus"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2901
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2901
 msgid "遞延所得税負債"
 msgstr "Deferred Tax Liability"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6601
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6601
 msgid "銷售費用"
 msgstr "Selling Expenses"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2701
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2701
 msgid "長期應付款"
 msgstr "Long Term payables"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1531
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1531
 msgid "長期應收款"
 msgstr "Long-term receivables"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1801
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1801
 msgid "長期待攤銷費用"
 msgstr "Long-term amortized expenses"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1511
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1511
 msgid "長期股權投資"
 msgstr "Long-term equity investment"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1512
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1512
 msgid "長期股權投資减值準備"
 msgstr "Impairment provision for long-term equity investments"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1123
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1123
 msgid "預付賬款"
 msgstr "Advance Payment"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2203
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2203
 msgid "預收賬款"
 msgstr "Deposit Received"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2801
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2801
 msgid "預計負債"
 msgstr "Projected liabilities"

--- a/addons/l10n_cn_small_business/i18n_extra/l10n_cn_small_business.pot
+++ b/addons/l10n_cn_small_business/i18n_extra/l10n_cn_small_business.pot
@@ -16,303 +16,250 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2711
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2711
 msgid "專項應付款"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6401
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6401
 msgid "主營業務成本"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6001
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6001
 msgid "主營業務收入"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1101
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1101
 msgid "交易性金融資産"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6901
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6901
 msgid "以前年度損益調整"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6101
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6101
 msgid "公允價值變動損益"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6402
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6402
 msgid "其他業務成本"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6051
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6051
 msgid "其他業務收入"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2501
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2501
 msgid "其他應付款"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1221
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1221
 msgid "其他應收款"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_4003
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_4003
 msgid "其他綜合收益"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1012
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1012
 msgid "其他貨幣資金"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_4104
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_4104
 msgid "利潤分配"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_5101
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_5101
 msgid "制造費用"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_5201
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_5201
 msgid "勞務成本"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1403
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1403
 msgid "原材料"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1406
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1406
 msgid "發出商品"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1503
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1503
 msgid "可供出售金融資産"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1407
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1407
 msgid "商品進銷差價"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1711
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1711
 msgid "商譽"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1601
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1601
 msgid "固定資産"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1603
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1603
 msgid "固定資産减值準備"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1606
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1606
 msgid "固定資産情况"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1604
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1604
 msgid "在建工程"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1402
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1402
 msgid "在途物資"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1231
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1231
 msgid "壞賬準備"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_11
 #: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_11
 msgid "税收11％"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_11
 #: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_11
 msgid "税收11％ - 中国小企业会计科目表"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_11
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_11
 #: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_11
 #: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_included_11
 msgid "税收11％"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_11
 #: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_11
 msgid "税收11％ - 中国小企业会计科目表"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_11
 #: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_included_11
 msgid "税收11％（含） - 中国小企业会计科目表"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_17
 #: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_17
 msgid "税收17％"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_17
 #: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_17
 msgid "税收17％ - 中国小企业会计科目表"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_17
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_17
 #: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_17
 #: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_included_17
 msgid "税收17％"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_17
 #: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_17
 msgid "税收17％ - 中国小企业会计科目表"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_17
 #: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_included_17
 msgid "税收17％（含） - 中国小企业会计科目表"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_3
 #: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_3
 msgid "税收3％"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_3
 #: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_3
 msgid "税收3％ - 中国小企业会计科目表"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_3
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_3
 #: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_3
 #: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_included_3
 msgid "税收3％"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_3
 #: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_3
 msgid "税收3％ - 中国小企业会计科目表"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_3
 #: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_included_3
 msgid "税收3％（含） - 中国小企业会计科目表"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_6
 #: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_6
 msgid "税收6％"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_6
 #: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_6
 msgid "税收6％ - 中国小企业会计科目表"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_6
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_6
 #: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_6
 #: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_included_6
 msgid "税收6％"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_6
 #: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_6
 msgid "税收6％ - 中国小企业会计科目表"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_6
 #: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_included_6
 msgid "税收6％（含） - 中国小企业会计科目表"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1408
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1408
 msgid "委托加工物資"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1471
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1471
 msgid "存貨跌價準備"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_4001
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_4001
 msgid "實收資本"
 msgstr ""
@@ -323,277 +270,231 @@ msgid "小企业会计科目表（财会[2011]17号《小企业会计准则》�
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1605
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1605
 msgid "工程物資"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1405
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1405
 msgid "庫存商品"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2221
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2221
 msgid "應交税費"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2502
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2502
 msgid "應付債券"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2231
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2231
 msgid "應付利息"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2201
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2201
 msgid "應付票據"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2211
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2211
 msgid "應付職工薪酬"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2241
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2241
 msgid "應付股利"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1122
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1122
 msgid "應付賬款"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2202
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2202
 msgid "應付賬款"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1132
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1132
 msgid "應收利息"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1121
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1121
 msgid "應收票據"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1131
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1131
 msgid "應收股利"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6801
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6801
 msgid "所得税費用"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1521
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1521
 msgid "投資性房地産"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6111
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6111
 msgid "投資收益"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1501
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1501
 msgid "持有至到期投資"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1502
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1502
 msgid "持有至到期投資减值準備"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1701
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1701
 msgid "無形資産"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1703
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1703
 msgid "無形資産减值準備"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_4103
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_4103
 msgid "本年利潤"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1404
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1404
 msgid "材料成本差异"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1401
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1401
 msgid "材料采購"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_5001
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_5001
 msgid "生産成本"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_4101
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_4101
 msgid "盈餘公積"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2001
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2001
 msgid "短期借款"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_5301
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_5301
 msgid "研發支出"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6602
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6602
 msgid "管理費用"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1602
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1602
 msgid "累計折舊"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1702
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1702
 msgid "累計攤銷"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6711
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6711
 msgid "營業外支出"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6301
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6301
 msgid "營業外收入"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6403
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6403
 msgid "營業税及附加"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6603
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6603
 msgid "財務費用"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6701
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6701
 msgid "資産减值損失"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_4002
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_4002
 msgid "資本公積金"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2901
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2901
 msgid "遞延所得税負債"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_6601
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_6601
 msgid "銷售費用"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2701
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2701
 msgid "長期應付款"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1531
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1531
 msgid "長期應收款"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1801
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1801
 msgid "長期待攤銷費用"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1511
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1511
 msgid "長期股權投資"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1512
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1512
 msgid "長期股權投資减值準備"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_1123
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_1123
 msgid "預付賬款"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2203
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2203
 msgid "預收賬款"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.account,name:l10n_cn_small_business.1_l10n_cn_2801
 #: model:account.account.template,name:l10n_cn_small_business.l10n_cn_2801
 msgid "預計負債"
 msgstr ""

--- a/addons/l10n_cn_standard/i18n_extra/en_US.po
+++ b/addons/l10n_cn_standard/i18n_extra/en_US.po
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_4102
 #: model:account.account.template,name:l10n_cn_standard.account_4102
 msgid "一般风险准备"
 msgstr "一般风险准备"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2711
 #: model:account.account.template,name:l10n_cn_standard.account_2711
 msgid "专项应付款"
 msgstr "Account payable special funds"
@@ -33,1161 +31,965 @@ msgid "中国会计科目表 （财会[2006]3号《企业会计准则》"
 msgstr "Chinese CoA (standard)"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6401
 #: model:account.account.template,name:l10n_cn_standard.account_6401
 msgid "主营业务成本"
 msgstr "Main Business Cost"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6001
 #: model:account.account.template,name:l10n_cn_standard.account_6001
 msgid "主营业务收入"
 msgstr "Main Business Income"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1111
 #: model:account.account.template,name:l10n_cn_standard.account_1111
 msgid "买入返售金融资产"
 msgstr "买入返售金融资产"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2101
 #: model:account.account.template,name:l10n_cn_standard.account_2101
 msgid "交易性金融负债"
 msgstr "交易性金融负债"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1101
 #: model:account.account.template,name:l10n_cn_standard.account_1101
 msgid "交易性金融资产"
 msgstr "Transactional Financial Assets"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2314
 #: model:account.account.template,name:l10n_cn_standard.account_2314
 msgid "代理业务负债"
 msgstr "代理业务负债"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1321
 #: model:account.account.template,name:l10n_cn_standard.account_1321
 msgid "代理业务资产"
 msgstr "代理业务资产"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2311
 #: model:account.account.template,name:l10n_cn_standard.account_2311
 msgid "代理买卖证券款"
 msgstr "代理买卖证券款"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1311
 #: model:account.account.template,name:l10n_cn_standard.account_1311
 msgid "代理兑付证券"
 msgstr "代理兑付证券"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2313
 #: model:account.account.template,name:l10n_cn_standard.account_2313
 msgid "代理兑付证券款"
 msgstr "代理兑付证券款"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2312
 #: model:account.account.template,name:l10n_cn_standard.account_2312
 msgid "代理承销证券款"
 msgstr "代理承销证券款"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6901
 #: model:account.account.template,name:l10n_cn_standard.account_6901
 msgid "以前年度损益调整"
 msgstr "Prior year income adjustment"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6521
 #: model:account.account.template,name:l10n_cn_standard.account_6521
 msgid "保单红利支出"
 msgstr "保单红利支出"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2611
 #: model:account.account.template,name:l10n_cn_standard.account_2611
 msgid "保户储金"
 msgstr "保户储金"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6031
 #: model:account.account.template,name:l10n_cn_standard.account_6031
 msgid "保费收入"
 msgstr "保费收入"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2602
 #: model:account.account.template,name:l10n_cn_standard.account_2602
 msgid "保险责任准备金"
 msgstr "保险责任准备金"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6101
 #: model:account.account.template,name:l10n_cn_standard.account_6101
 msgid "公允价值变动损益"
 msgstr "Gains and Losses of fair value change"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1623
 #: model:account.account.template,name:l10n_cn_standard.account_1623
 msgid "公益性生物资产"
 msgstr "公益性生物资产"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6402
 #: model:account.account.template,name:l10n_cn_standard.account_6402
 msgid "其他业务成本"
 msgstr "Other Operating Costs"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6051
 #: model:account.account.template,name:l10n_cn_standard.account_6051
 msgid "其他业务收入"
 msgstr "Other Business Income"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2241
 #: model:account.account.template,name:l10n_cn_standard.account_2241
 msgid "其他应付款"
 msgstr "Other payable"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1221
 #: model:account.account.template,name:l10n_cn_standard.account_1221
 msgid "其他应收款"
 msgstr "Other Receivable"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1012
 #: model:account.account.template,name:l10n_cn_standard.account_1012
 msgid "其他货币资金"
 msgstr "Other Monetary Funds"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_1_4
 #: model:account.account.template,name:l10n_cn_standard.account_2221_1_4
 msgid "减免税款"
 msgstr "减免税款"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_1_8
 #: model:account.account.template,name:l10n_cn_standard.account_2221_1_8
 msgid "出口抵减内销产品应纳税额"
 msgstr "出口抵减内销产品应纳税额"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_1_6
 #: model:account.account.template,name:l10n_cn_standard.account_2221_1_6
 msgid "出口退税"
 msgstr "出口退税"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6542
 #: model:account.account.template,name:l10n_cn_standard.account_6542
 msgid "分保费用"
 msgstr "分保费用"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6541
 #: model:account.account.template,name:l10n_cn_standard.account_6541
 msgid "分出保费"
 msgstr "分出保费"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6411
 #: model:account.account.template,name:l10n_cn_standard.account_6411
 msgid "利息支出"
 msgstr "利息支出"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6011
 #: model:account.account.template,name:l10n_cn_standard.account_6011
 msgid "利息收入"
 msgstr "利息收入"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_4104
 #: model:account.account.template,name:l10n_cn_standard.account_4104
 msgid "利润分配"
 msgstr "Profit distribution"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_5101
 #: model:account.account.template,name:l10n_cn_standard.account_5101
 msgid "制造费用"
 msgstr "Manufacturing Expenses"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_5201
 #: model:account.account.template,name:l10n_cn_standard.account_5201
 msgid "劳务成本"
 msgstr "Service Cost"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6604
 #: model:account.account.template,name:l10n_cn_standard.account_6604
 msgid "勘探费用"
 msgstr "勘探费用"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2111
 #: model:account.account.template,name:l10n_cn_standard.account_2111
 msgid "卖出回购金融资产款"
 msgstr "卖出回购金融资产款"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1403
 #: model:account.account.template,name:l10n_cn_standard.account_1403
 msgid "原材料"
 msgstr "Raw Material"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1406
 #: model:account.account.template,name:l10n_cn_standard.account_1406
 msgid "发出商品"
 msgstr "Goods shipped in transit"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1503
 #: model:account.account.template,name:l10n_cn_standard.account_1503
 msgid "可供出售金融资产"
 msgstr "Available for sale financial assets"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2012
 #: model:account.account.template,name:l10n_cn_standard.account_2012
 msgid "同业存放"
 msgstr "同业存放"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2004
 #: model:account.account.template,name:l10n_cn_standard.account_2004
 msgid "向中央银行借款"
 msgstr "向中央银行借款"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2011
 #: model:account.account.template,name:l10n_cn_standard.account_2011
 msgid "吸收存款"
 msgstr "吸收存款"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1411
 #: model:account.account.template,name:l10n_cn_standard.account_1411
 msgid "周转材料"
 msgstr "周转材料"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1407
 #: model:account.account.template,name:l10n_cn_standard.account_1407
 msgid "商品进销差价"
 msgstr "Differences between purchasing and selling price"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1711
 #: model:account.account.template,name:l10n_cn_standard.account_1711
 msgid "商誉"
 msgstr "Goodwill"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1601
 #: model:account.account.template,name:l10n_cn_standard.account_1601
 msgid "固定资产"
 msgstr "Fixed assets"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1603
 #: model:account.account.template,name:l10n_cn_standard.account_1603
 msgid "固定资产减值准备"
 msgstr "Fixed assets depreciation reserves"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1606
 #: model:account.account.template,name:l10n_cn_standard.account_1606
 msgid "固定资产清理"
 msgstr "Liquidation of fixed assets"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1604
 #: model:account.account.template,name:l10n_cn_standard.account_1604
 msgid "在建工程"
 msgstr "Construction in progress"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1402
 #: model:account.account.template,name:l10n_cn_standard.account_1402
 msgid "在途物资"
 msgstr "Materials in transit"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1231
 #: model:account.account.template,name:l10n_cn_standard.account_1231
 msgid "坏账准备"
 msgstr "Bad Debt Provisions"
 
 #. module: l10n_cn_standard
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_11
 #: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_purchase_excluded_11
 msgid "税收11％"
 msgstr "Tax 11%"
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_11
 #: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_purchase_excluded_11
 msgid "税收11％ - 中国会计科目表-企业会计准则"
 msgstr "Tax 11%"
 
 #. module: l10n_cn_standard
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_11
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_included_11
 #: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_excluded_11
 #: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_included_11
 msgid "税收11％"
 msgstr "Tax 11%"
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_11
 #: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_excluded_11
 msgid "税收11％ - 中国会计科目表-企业会计准则"
 msgstr "Tax 11%"
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_included_11
 #: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_included_11
 msgid "税收11％（含） - 中国会计科目表-企业会计准则"
 msgstr "Tax 11% (Incl.)"
 
 #. module: l10n_cn_standard
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_17
 #: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_purchase_excluded_17
 msgid "税收17％"
 msgstr "Tax 17%"
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_17
 #: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_purchase_excluded_17
 msgid "税收17％ - 中国会计科目表-企业会计准则"
 msgstr "Tax 17%"
 
 #. module: l10n_cn_standard
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_17
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_included_17
 #: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_excluded_17
 #: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_included_17
 msgid "税收17％"
 msgstr "Tax 17%"
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_17
 #: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_excluded_17
 msgid "税收17％ - 中国会计科目表-企业会计准则"
 msgstr "Tax 17%"
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_included_17
 #: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_included_17
 msgid "税收17％（含） - 中国会计科目表-企业会计准则"
 msgstr "Tax 17% (Incl.)"
 
 #. module: l10n_cn_standard
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_3
 #: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_purchase_excluded_3
 msgid "税收3％"
 msgstr "Tax 3%"
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_3
 #: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_purchase_excluded_3
 msgid "税收3％ - 中国会计科目表-企业会计准则"
 msgstr "Tax 3%"
 
 #. module: l10n_cn_standard
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_small_3
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_included_3
 #: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_excluded_small_3
 #: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_included_3
 msgid "税收3％"
 msgstr "Tax 3%"
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_small_3
 #: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_excluded_small_3
 msgid "税收3％ - 中国会计科目表-企业会计准则"
 msgstr "Tax 3%"
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_included_3
 #: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_included_3
 msgid "税收3％（含） - 中国会计科目表-企业会计准则"
 msgstr "Tax 3% (Incl.)"
 
 #. module: l10n_cn_standard
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_6
 #: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_purchase_excluded_6
 msgid "税收6％"
 msgstr "Tax 6%"
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_6
 #: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_purchase_excluded_6
 msgid "税收6％ - 中国会计科目表-企业会计准则"
 msgstr "Tax 6%"
 
 #. module: l10n_cn_standard
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_6
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_included_6
 #: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_excluded_6
 #: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_included_6
 msgid "税收6％"
 msgstr "Tax 6%"
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_6
 #: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_excluded_6
 msgid "税收6％ - 中国会计科目表-企业会计准则"
 msgstr "Tax 6%"
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_included_6
 #: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_included_6
 msgid "税收6％（含） - 中国会计科目表-企业会计准则"
 msgstr "Tax 6% (Incl.)"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_3201
 #: model:account.account.template,name:l10n_cn_standard.account_3201
 msgid "套期工具"
 msgstr "套期工具"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1408
 #: model:account.account.template,name:l10n_cn_standard.account_1408
 msgid "委托加工物资"
 msgstr "Consigned processing materials"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2002
 #: model:account.account.template,name:l10n_cn_standard.account_2002
 msgid "存入保证金"
 msgstr "存入保证金"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1031
 #: model:account.account.template,name:l10n_cn_standard.account_1031
 msgid "存出保证金"
 msgstr "存出保证金"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1541
 #: model:account.account.template,name:l10n_cn_standard.account_1541
 msgid "存出资本保证金"
 msgstr "存出资本保证金"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1011
 #: model:account.account.template,name:l10n_cn_standard.account_1011
 msgid "存放同业"
 msgstr "存放同业"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1471
 #: model:account.account.template,name:l10n_cn_standard.account_1471
 msgid "存货跌价准备"
 msgstr "存货跌价准备"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_4001
 #: model:account.account.template,name:l10n_cn_standard.account_4001
 msgid "实收资本"
 msgstr "Paid in capital"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_5401
 #: model:account.account.template,name:l10n_cn_standard.account_5401
 msgid "工程施工"
 msgstr "工程施工"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1605
 #: model:account.account.template,name:l10n_cn_standard.account_1605
 msgid "工程物资"
 msgstr "Engineering materials"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_5402
 #: model:account.account.template,name:l10n_cn_standard.account_5402
 msgid "工程结算"
 msgstr "工程结算"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_1_2
 #: model:account.account.template,name:l10n_cn_standard.account_2221_1_2
 msgid "已交税金"
 msgstr "已交税金"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1405
 #: model:account.account.template,name:l10n_cn_standard.account_1405
 msgid "库存商品"
 msgstr "Merchandise Inventory"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_4201
 #: model:account.account.template,name:l10n_cn_standard.account_4201
 msgid "库存股"
 msgstr "库存股"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_11
 #: model:account.account.template,name:l10n_cn_standard.account_2221_11
 msgid "应交个人所得税"
 msgstr "应交个人所得税"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_9
 #: model:account.account.template,name:l10n_cn_standard.account_2221_9
 msgid "应交土地使用税"
 msgstr "应交土地使用税"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_6
 #: model:account.account.template,name:l10n_cn_standard.account_2221_6
 msgid "应交土地增值税"
 msgstr "应交土地增值税"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_7
 #: model:account.account.template,name:l10n_cn_standard.account_2221_7
 msgid "应交城市维护建设税"
 msgstr "应交城市维护建设税"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_8
 #: model:account.account.template,name:l10n_cn_standard.account_2221_8
 msgid "应交房产税"
 msgstr "应交房产税"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_5
 #: model:account.account.template,name:l10n_cn_standard.account_2221_5
 msgid "应交所得税"
 msgstr "应交所得税"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_3
 #: model:account.account.template,name:l10n_cn_standard.account_2221_3
 msgid "应交消费税"
 msgstr "应交消费税"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221
 #: model:account.account.template,name:l10n_cn_standard.account_2221
 msgid "应交税费"
 msgstr "Tax payable"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_2
 #: model:account.account.template,name:l10n_cn_standard.account_2221_2
 msgid "应交营业税"
 msgstr "应交营业税"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_4
 #: model:account.account.template,name:l10n_cn_standard.account_2221_4
 msgid "应交资源税"
 msgstr "应交资源税"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_10
 #: model:account.account.template,name:l10n_cn_standard.account_2221_10
 msgid "应交车船使用税"
 msgstr "应交车船使用税"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2251
 #: model:account.account.template,name:l10n_cn_standard.account_2251
 msgid "应付保单红利"
 msgstr "应付保单红利"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2502
 #: model:account.account.template,name:l10n_cn_standard.account_2502
 msgid "应付债券"
 msgstr "Bonds Payable"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2261
 #: model:account.account.template,name:l10n_cn_standard.account_2261
 msgid "应付分保账款"
 msgstr "应付分保账款"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2231
 #: model:account.account.template,name:l10n_cn_standard.account_2231
 msgid "应付利息"
 msgstr "Interest payable"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2201
 #: model:account.account.template,name:l10n_cn_standard.account_2201
 msgid "应付票据"
 msgstr "Bills Payable"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2211
 #: model:account.account.template,name:l10n_cn_standard.account_2211
 msgid "应付职工薪酬"
 msgstr "Payroll payable"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2232
 #: model:account.account.template,name:l10n_cn_standard.account_2232
 msgid "应付股利"
 msgstr "Dividents payable"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2202
 #: model:account.account.template,name:l10n_cn_standard.account_2202
 msgid "应付账款"
 msgstr "Accounts Payable"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1201
 #: model:account.account.template,name:l10n_cn_standard.account_1201
 msgid "应收代位追偿款"
 msgstr "应收代位追偿款"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1212
 #: model:account.account.template,name:l10n_cn_standard.account_1212
 msgid "应收分保合同准备金"
 msgstr "应收分保合同准备金"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1211
 #: model:account.account.template,name:l10n_cn_standard.account_1211
 msgid "应收分保账款"
 msgstr "应收分保账款"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1132
 #: model:account.account.template,name:l10n_cn_standard.account_1132
 msgid "应收利息"
 msgstr "Interest Receivable"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1121
 #: model:account.account.template,name:l10n_cn_standard.account_1121
 msgid "应收票据"
 msgstr "Bills Receivable"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1131
 #: model:account.account.template,name:l10n_cn_standard.account_1131
 msgid "应收股利"
 msgstr "Divident Receivable"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1122
 #: model:account.account.template,name:l10n_cn_standard.account_1122
 msgid "应收账款"
 msgstr "Accounts Receivable"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1901
 #: model:account.account.template,name:l10n_cn_standard.account_1901
 msgid "待处理财产损溢"
 msgstr "Disposal of property damage"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6801
 #: model:account.account.template,name:l10n_cn_standard.account_6801
 msgid "所得税费用"
 msgstr "Income Tax Expense"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6421
 #: model:account.account.template,name:l10n_cn_standard.account_6421
 msgid "手续费及佣金支出"
 msgstr "手续费及佣金支出"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6021
 #: model:account.account.template,name:l10n_cn_standard.account_6021
 msgid "手续费及佣金收入"
 msgstr "手续费及佣金收入"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1521
 #: model:account.account.template,name:l10n_cn_standard.account_1521
 msgid "投资性房地产"
 msgstr "Investmental real estate"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6111
 #: model:account.account.template,name:l10n_cn_standard.account_6111
 msgid "投资收益"
 msgstr "Income from investment"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1441
 #: model:account.account.template,name:l10n_cn_standard.account_1441
 msgid "抵债资产"
 msgstr "抵债资产"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2003
 #: model:account.account.template,name:l10n_cn_standard.account_2003
 msgid "拆入资金"
 msgstr "拆入资金"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1302
 #: model:account.account.template,name:l10n_cn_standard.account_1302
 msgid "拆出资金"
 msgstr "拆出资金"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1501
 #: model:account.account.template,name:l10n_cn_standard.account_1501
 msgid "持有至到期投资"
 msgstr "Held to maturity Investment"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1502
 #: model:account.account.template,name:l10n_cn_standard.account_1502
 msgid "持有至到期投资减值准备"
 msgstr "Provision for impairment of investments held to maturity"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1451
 #: model:account.account.template,name:l10n_cn_standard.account_1451
 msgid "损余物资"
 msgstr "损余物资"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6502
 #: model:account.account.template,name:l10n_cn_standard.account_6502
 msgid "提取保险责任准备金"
 msgstr "提取保险责任准备金"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6501
 #: model:account.account.template,name:l10n_cn_standard.account_6501
 msgid "提取未到期责任准备金"
 msgstr "提取未到期责任准备金"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6201
 #: model:account.account.template,name:l10n_cn_standard.account_6201
 msgid "摊回保险责任准备金"
 msgstr "摊回保险责任准备金"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6203
 #: model:account.account.template,name:l10n_cn_standard.account_6203
 msgid "摊回分保费用"
 msgstr "摊回分保费用"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6202
 #: model:account.account.template,name:l10n_cn_standard.account_6202
 msgid "摊回赔付支出"
 msgstr "摊回赔付支出"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1701
 #: model:account.account.template,name:l10n_cn_standard.account_1701
 msgid "无形资产"
 msgstr "Intangible Assets"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1703
 #: model:account.account.template,name:l10n_cn_standard.account_1703
 msgid "无形资产减值准备"
 msgstr "Intangible Assets Depreciation Reserves"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_1_10
 #: model:account.account.template,name:l10n_cn_standard.account_2221_1_10
 msgid "未交增值税"
 msgstr "未交增值税"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2601
 #: model:account.account.template,name:l10n_cn_standard.account_2601
 msgid "未到期责任准备金"
 msgstr "未到期责任准备金"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1532
 #: model:account.account.template,name:l10n_cn_standard.account_1532
 msgid "未实现融资收益"
 msgstr "未实现融资收益"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1611
 #: model:account.account.template,name:l10n_cn_standard.account_1611
 msgid "未担保余值"
 msgstr "未担保余值"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2702
 #: model:account.account.template,name:l10n_cn_standard.account_2702
 msgid "未确认融资费用"
 msgstr "未确认融资费用"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_4103
 #: model:account.account.template,name:l10n_cn_standard.account_4103
 msgid "本年利润"
 msgstr "Profit for the year"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_5403
 #: model:account.account.template,name:l10n_cn_standard.account_5403
 msgid "机械作业"
 msgstr "机械作业"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1404
 #: model:account.account.template,name:l10n_cn_standard.account_1404
 msgid "材料成本差异"
 msgstr "Material Cost Variance"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1401
 #: model:account.account.template,name:l10n_cn_standard.account_1401
 msgid "材料采购"
 msgstr "Material Purchasing"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6061
 #: model:account.account.template,name:l10n_cn_standard.account_6061
 msgid "汇兑损益"
 msgstr "汇兑损益"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1631
 #: model:account.account.template,name:l10n_cn_standard.account_1631
 msgid "油气资产"
 msgstr "油气资产"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1421
 #: model:account.account.template,name:l10n_cn_standard.account_1421
 msgid "消耗性生物资产"
 msgstr "消耗性生物资产"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_3001
 #: model:account.account.template,name:l10n_cn_standard.account_3001
 msgid "清算资金往来"
 msgstr "Clearing funds"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2621
 #: model:account.account.template,name:l10n_cn_standard.account_2621
 msgid "独立账户负债"
 msgstr "独立账户负债"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1821
 #: model:account.account.template,name:l10n_cn_standard.account_1821
 msgid "独立账户资产"
 msgstr "独立账户资产"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1621
 #: model:account.account.template,name:l10n_cn_standard.account_1621
 msgid "生产性生物资产"
 msgstr "生产性生物资产"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1622
 #: model:account.account.template,name:l10n_cn_standard.account_1622
 msgid "生产性生物资产累计折旧"
 msgstr "生产性生物资产累计折旧"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_5001
 #: model:account.account.template,name:l10n_cn_standard.account_5001
 msgid "生产成本"
 msgstr "Production Costs"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_4101
 #: model:account.account.template,name:l10n_cn_standard.account_4101
 msgid "盈余公积"
 msgstr "Surplus Reserve"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2001
 #: model:account.account.template,name:l10n_cn_standard.account_2001
 msgid "短期借款"
 msgstr "Short-term borrowing"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_5301
 #: model:account.account.template,name:l10n_cn_standard.account_5301
 msgid "研发支出"
 msgstr "R & D expenditure"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6041
 #: model:account.account.template,name:l10n_cn_standard.account_6041
 msgid "租赁收入"
 msgstr "租赁收入"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6602
 #: model:account.account.template,name:l10n_cn_standard.account_6602
 msgid "管理费用"
 msgstr "Management Expenses"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1602
 #: model:account.account.template,name:l10n_cn_standard.account_1602
 msgid "累计折旧"
 msgstr "Accumulated depreciation"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1632
 #: model:account.account.template,name:l10n_cn_standard.account_1632
 msgid "累计折耗"
 msgstr "累计折耗"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1702
 #: model:account.account.template,name:l10n_cn_standard.account_1702
 msgid "累计摊销"
 msgstr "Accumulated amortization"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1021
 #: model:account.account.template,name:l10n_cn_standard.account_1021
 msgid "结算备付金"
 msgstr "结算备付金"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6711
 #: model:account.account.template,name:l10n_cn_standard.account_6711
 msgid "营业外支出"
 msgstr "Non-operating expenses"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6301
 #: model:account.account.template,name:l10n_cn_standard.account_6301
 msgid "营业外收入"
 msgstr "Non-operating Income"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6403
 #: model:account.account.template,name:l10n_cn_standard.account_6403
 msgid "营业税金及附加"
 msgstr "Operating Taxes and Surcharges"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1461
 #: model:account.account.template,name:l10n_cn_standard.account_1461
 msgid "融资租赁资产"
 msgstr "融资租赁资产"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_3101
 #: model:account.account.template,name:l10n_cn_standard.account_3101
 msgid "衍生工具"
 msgstr "Currency Exchange"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_3202
 #: model:account.account.template,name:l10n_cn_standard.account_3202
 msgid "被套期项目"
 msgstr "被套期项目"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6603
 #: model:account.account.template,name:l10n_cn_standard.account_6603
 msgid "财务费用"
 msgstr "Financial Expenses"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_3002
 #: model:account.account.template,name:l10n_cn_standard.account_3002
 msgid "货币兑换"
 msgstr "货币兑换"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2021
 #: model:account.account.template,name:l10n_cn_standard.account_2021
 msgid "贴现负债"
 msgstr "贴现负债"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1301
 #: model:account.account.template,name:l10n_cn_standard.account_1301
 msgid "贴现资产"
 msgstr "贴现资产"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1431
 #: model:account.account.template,name:l10n_cn_standard.account_1431
 msgid "贵金属"
 msgstr "贵金属"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1303
 #: model:account.account.template,name:l10n_cn_standard.account_1303
 msgid "贷款"
 msgstr "贷款"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1304
 #: model:account.account.template,name:l10n_cn_standard.account_1304
 msgid "贷款损失准备"
 msgstr "贷款损失准备"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6701
 #: model:account.account.template,name:l10n_cn_standard.account_6701
 msgid "资产减值损失"
 msgstr "Assets impairment Loss"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_4002
 #: model:account.account.template,name:l10n_cn_standard.account_4002
 msgid "资本公积"
 msgstr "Capital Surplus"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6511
 #: model:account.account.template,name:l10n_cn_standard.account_6511
 msgid "赔付支出"
 msgstr "赔付支出"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_1_9
 #: model:account.account.template,name:l10n_cn_standard.account_2221_1_9
 msgid "转出多交增值税"
 msgstr "转出多交增值税"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_1_3
 #: model:account.account.template,name:l10n_cn_standard.account_2221_1_3
 msgid "转出未交增值税"
 msgstr "转出未交增值税"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1003
 #: model:account.account.template,name:l10n_cn_standard.account_1003
 msgid "转让帐户"
 msgstr "转让帐户"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_1_1
 #: model:account.account.template,name:l10n_cn_standard.account_2221_1_1
 msgid "进项税额"
 msgstr "进项税额"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_1_7
 #: model:account.account.template,name:l10n_cn_standard.account_2221_1_7
 msgid "进项税额转出"
 msgstr "进项税额转出"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6531
 #: model:account.account.template,name:l10n_cn_standard.account_6531
 msgid "退保金"
 msgstr "退保金"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2901
 #: model:account.account.template,name:l10n_cn_standard.account_2901
 msgid "递延所得税负债"
 msgstr "Deferred Tax Liability"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1811
 #: model:account.account.template,name:l10n_cn_standard.account_1811
 msgid "递延所得税资产"
 msgstr "Deffered tax assets"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2401
 #: model:account.account.template,name:l10n_cn_standard.account_2401
 msgid "递延收益"
 msgstr "递延收益"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6601
 #: model:account.account.template,name:l10n_cn_standard.account_6601
 msgid "销售费用"
 msgstr "Selling Expenses"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_1_5
 #: model:account.account.template,name:l10n_cn_standard.account_2221_1_5
 msgid "销项税额"
 msgstr "销项税额"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2501
 #: model:account.account.template,name:l10n_cn_standard.account_2501
 msgid "长期借款"
 msgstr "长期借款"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2701
 #: model:account.account.template,name:l10n_cn_standard.account_2701
 msgid "长期应付款"
 msgstr "Long Term payables"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1531
 #: model:account.account.template,name:l10n_cn_standard.account_1531
 msgid "长期应收款"
 msgstr "Long-term receivables"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1801
 #: model:account.account.template,name:l10n_cn_standard.account_1801
 msgid "长期待摊费用"
 msgstr "Long-term amortized expenses"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1511
 #: model:account.account.template,name:l10n_cn_standard.account_1511
 msgid "长期股权投资"
 msgstr "Long-term equity investment"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1512
 #: model:account.account.template,name:l10n_cn_standard.account_1512
 msgid "长期股权投资减值准备"
 msgstr "Impairment provision for long-term equity investments"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1123
 #: model:account.account.template,name:l10n_cn_standard.account_1123
 msgid "预付账款"
 msgstr "Advance Payment"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2203
 #: model:account.account.template,name:l10n_cn_standard.account_2203
 msgid "预收账款"
 msgstr "Deposit Received"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2801
 #: model:account.account.template,name:l10n_cn_standard.account_2801
 msgid "预计负债"
 msgstr "Projected liabilities"

--- a/addons/l10n_cn_standard/i18n_extra/l10n_cn_standard.pot
+++ b/addons/l10n_cn_standard/i18n_extra/l10n_cn_standard.pot
@@ -16,13 +16,11 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_4102
 #: model:account.account.template,name:l10n_cn_standard.account_4102
 msgid "一般风险准备"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2711
 #: model:account.account.template,name:l10n_cn_standard.account_2711
 msgid "专项应付款"
 msgstr ""
@@ -33,1161 +31,965 @@ msgid "中国会计科目表 （财会[2006]3号《企业会计准则》"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6401
 #: model:account.account.template,name:l10n_cn_standard.account_6401
 msgid "主营业务成本"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6001
 #: model:account.account.template,name:l10n_cn_standard.account_6001
 msgid "主营业务收入"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1111
 #: model:account.account.template,name:l10n_cn_standard.account_1111
 msgid "买入返售金融资产"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2101
 #: model:account.account.template,name:l10n_cn_standard.account_2101
 msgid "交易性金融负债"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1101
 #: model:account.account.template,name:l10n_cn_standard.account_1101
 msgid "交易性金融资产"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2314
 #: model:account.account.template,name:l10n_cn_standard.account_2314
 msgid "代理业务负债"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1321
 #: model:account.account.template,name:l10n_cn_standard.account_1321
 msgid "代理业务资产"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2311
 #: model:account.account.template,name:l10n_cn_standard.account_2311
 msgid "代理买卖证券款"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1311
 #: model:account.account.template,name:l10n_cn_standard.account_1311
 msgid "代理兑付证券"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2313
 #: model:account.account.template,name:l10n_cn_standard.account_2313
 msgid "代理兑付证券款"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2312
 #: model:account.account.template,name:l10n_cn_standard.account_2312
 msgid "代理承销证券款"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6901
 #: model:account.account.template,name:l10n_cn_standard.account_6901
 msgid "以前年度损益调整"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6521
 #: model:account.account.template,name:l10n_cn_standard.account_6521
 msgid "保单红利支出"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2611
 #: model:account.account.template,name:l10n_cn_standard.account_2611
 msgid "保户储金"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6031
 #: model:account.account.template,name:l10n_cn_standard.account_6031
 msgid "保费收入"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2602
 #: model:account.account.template,name:l10n_cn_standard.account_2602
 msgid "保险责任准备金"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6101
 #: model:account.account.template,name:l10n_cn_standard.account_6101
 msgid "公允价值变动损益"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1623
 #: model:account.account.template,name:l10n_cn_standard.account_1623
 msgid "公益性生物资产"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6402
 #: model:account.account.template,name:l10n_cn_standard.account_6402
 msgid "其他业务成本"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6051
 #: model:account.account.template,name:l10n_cn_standard.account_6051
 msgid "其他业务收入"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2241
 #: model:account.account.template,name:l10n_cn_standard.account_2241
 msgid "其他应付款"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1221
 #: model:account.account.template,name:l10n_cn_standard.account_1221
 msgid "其他应收款"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1012
 #: model:account.account.template,name:l10n_cn_standard.account_1012
 msgid "其他货币资金"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_1_4
 #: model:account.account.template,name:l10n_cn_standard.account_2221_1_4
 msgid "减免税款"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_1_8
 #: model:account.account.template,name:l10n_cn_standard.account_2221_1_8
 msgid "出口抵减内销产品应纳税额"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_1_6
 #: model:account.account.template,name:l10n_cn_standard.account_2221_1_6
 msgid "出口退税"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6542
 #: model:account.account.template,name:l10n_cn_standard.account_6542
 msgid "分保费用"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6541
 #: model:account.account.template,name:l10n_cn_standard.account_6541
 msgid "分出保费"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6411
 #: model:account.account.template,name:l10n_cn_standard.account_6411
 msgid "利息支出"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6011
 #: model:account.account.template,name:l10n_cn_standard.account_6011
 msgid "利息收入"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_4104
 #: model:account.account.template,name:l10n_cn_standard.account_4104
 msgid "利润分配"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_5101
 #: model:account.account.template,name:l10n_cn_standard.account_5101
 msgid "制造费用"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_5201
 #: model:account.account.template,name:l10n_cn_standard.account_5201
 msgid "劳务成本"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6604
 #: model:account.account.template,name:l10n_cn_standard.account_6604
 msgid "勘探费用"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2111
 #: model:account.account.template,name:l10n_cn_standard.account_2111
 msgid "卖出回购金融资产款"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1403
 #: model:account.account.template,name:l10n_cn_standard.account_1403
 msgid "原材料"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1406
 #: model:account.account.template,name:l10n_cn_standard.account_1406
 msgid "发出商品"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1503
 #: model:account.account.template,name:l10n_cn_standard.account_1503
 msgid "可供出售金融资产"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2012
 #: model:account.account.template,name:l10n_cn_standard.account_2012
 msgid "同业存放"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2004
 #: model:account.account.template,name:l10n_cn_standard.account_2004
 msgid "向中央银行借款"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2011
 #: model:account.account.template,name:l10n_cn_standard.account_2011
 msgid "吸收存款"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1411
 #: model:account.account.template,name:l10n_cn_standard.account_1411
 msgid "周转材料"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1407
 #: model:account.account.template,name:l10n_cn_standard.account_1407
 msgid "商品进销差价"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1711
 #: model:account.account.template,name:l10n_cn_standard.account_1711
 msgid "商誉"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1601
 #: model:account.account.template,name:l10n_cn_standard.account_1601
 msgid "固定资产"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1603
 #: model:account.account.template,name:l10n_cn_standard.account_1603
 msgid "固定资产减值准备"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1606
 #: model:account.account.template,name:l10n_cn_standard.account_1606
 msgid "固定资产清理"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1604
 #: model:account.account.template,name:l10n_cn_standard.account_1604
 msgid "在建工程"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1402
 #: model:account.account.template,name:l10n_cn_standard.account_1402
 msgid "在途物资"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1231
 #: model:account.account.template,name:l10n_cn_standard.account_1231
 msgid "坏账准备"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_11
 #: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_purchase_excluded_11
 msgid "税收11％"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_11
 #: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_purchase_excluded_11
 msgid "税收11％ - 中国会计科目表-企业会计准则"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_11
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_included_11
 #: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_excluded_11
 #: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_included_11
 msgid "税收11％"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_11
 #: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_excluded_11
 msgid "税收11％ - 中国会计科目表-企业会计准则"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_included_11
 #: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_included_11
 msgid "税收11％（含） - 中国会计科目表-企业会计准则"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_17
 #: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_purchase_excluded_17
 msgid "税收17％"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_17
 #: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_purchase_excluded_17
 msgid "税收17％ - 中国会计科目表-企业会计准则"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_17
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_included_17
 #: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_excluded_17
 #: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_included_17
 msgid "税收17％"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_17
 #: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_excluded_17
 msgid "税收17％ - 中国会计科目表-企业会计准则"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_included_17
 #: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_included_17
 msgid "税收17％（含） - 中国会计科目表-企业会计准则"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_3
 #: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_purchase_excluded_3
 msgid "税收3％"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_3
 #: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_purchase_excluded_3
 msgid "税收3％ - 中国会计科目表-企业会计准则"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_small_3
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_included_3
 #: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_excluded_small_3
 #: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_included_3
 msgid "税收3％"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_small_3
 #: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_excluded_small_3
 msgid "税收3％ - 中国会计科目表-企业会计准则"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_included_3
 #: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_included_3
 msgid "税收3％（含） - 中国会计科目表-企业会计准则"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_6
 #: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_purchase_excluded_6
 msgid "税收6％"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_6
 #: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_purchase_excluded_6
 msgid "税收6％ - 中国会计科目表-企业会计准则"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_6
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_included_6
 #: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_excluded_6
 #: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_included_6
 msgid "税收6％"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_6
 #: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_excluded_6
 msgid "税收6％ - 中国会计科目表-企业会计准则"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_included_6
 #: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_included_6
 msgid "税收6％（含） - 中国会计科目表-企业会计准则"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_3201
 #: model:account.account.template,name:l10n_cn_standard.account_3201
 msgid "套期工具"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1408
 #: model:account.account.template,name:l10n_cn_standard.account_1408
 msgid "委托加工物资"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2002
 #: model:account.account.template,name:l10n_cn_standard.account_2002
 msgid "存入保证金"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1031
 #: model:account.account.template,name:l10n_cn_standard.account_1031
 msgid "存出保证金"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1541
 #: model:account.account.template,name:l10n_cn_standard.account_1541
 msgid "存出资本保证金"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1011
 #: model:account.account.template,name:l10n_cn_standard.account_1011
 msgid "存放同业"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1471
 #: model:account.account.template,name:l10n_cn_standard.account_1471
 msgid "存货跌价准备"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_4001
 #: model:account.account.template,name:l10n_cn_standard.account_4001
 msgid "实收资本"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_5401
 #: model:account.account.template,name:l10n_cn_standard.account_5401
 msgid "工程施工"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1605
 #: model:account.account.template,name:l10n_cn_standard.account_1605
 msgid "工程物资"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_5402
 #: model:account.account.template,name:l10n_cn_standard.account_5402
 msgid "工程结算"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_1_2
 #: model:account.account.template,name:l10n_cn_standard.account_2221_1_2
 msgid "已交税金"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1405
 #: model:account.account.template,name:l10n_cn_standard.account_1405
 msgid "库存商品"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_4201
 #: model:account.account.template,name:l10n_cn_standard.account_4201
 msgid "库存股"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_11
 #: model:account.account.template,name:l10n_cn_standard.account_2221_11
 msgid "应交个人所得税"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_9
 #: model:account.account.template,name:l10n_cn_standard.account_2221_9
 msgid "应交土地使用税"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_6
 #: model:account.account.template,name:l10n_cn_standard.account_2221_6
 msgid "应交土地增值税"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_7
 #: model:account.account.template,name:l10n_cn_standard.account_2221_7
 msgid "应交城市维护建设税"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_8
 #: model:account.account.template,name:l10n_cn_standard.account_2221_8
 msgid "应交房产税"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_5
 #: model:account.account.template,name:l10n_cn_standard.account_2221_5
 msgid "应交所得税"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_3
 #: model:account.account.template,name:l10n_cn_standard.account_2221_3
 msgid "应交消费税"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221
 #: model:account.account.template,name:l10n_cn_standard.account_2221
 msgid "应交税费"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_2
 #: model:account.account.template,name:l10n_cn_standard.account_2221_2
 msgid "应交营业税"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_4
 #: model:account.account.template,name:l10n_cn_standard.account_2221_4
 msgid "应交资源税"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_10
 #: model:account.account.template,name:l10n_cn_standard.account_2221_10
 msgid "应交车船使用税"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2251
 #: model:account.account.template,name:l10n_cn_standard.account_2251
 msgid "应付保单红利"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2502
 #: model:account.account.template,name:l10n_cn_standard.account_2502
 msgid "应付债券"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2261
 #: model:account.account.template,name:l10n_cn_standard.account_2261
 msgid "应付分保账款"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2231
 #: model:account.account.template,name:l10n_cn_standard.account_2231
 msgid "应付利息"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2201
 #: model:account.account.template,name:l10n_cn_standard.account_2201
 msgid "应付票据"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2211
 #: model:account.account.template,name:l10n_cn_standard.account_2211
 msgid "应付职工薪酬"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2232
 #: model:account.account.template,name:l10n_cn_standard.account_2232
 msgid "应付股利"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2202
 #: model:account.account.template,name:l10n_cn_standard.account_2202
 msgid "应付账款"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1201
 #: model:account.account.template,name:l10n_cn_standard.account_1201
 msgid "应收代位追偿款"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1212
 #: model:account.account.template,name:l10n_cn_standard.account_1212
 msgid "应收分保合同准备金"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1211
 #: model:account.account.template,name:l10n_cn_standard.account_1211
 msgid "应收分保账款"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1132
 #: model:account.account.template,name:l10n_cn_standard.account_1132
 msgid "应收利息"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1121
 #: model:account.account.template,name:l10n_cn_standard.account_1121
 msgid "应收票据"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1131
 #: model:account.account.template,name:l10n_cn_standard.account_1131
 msgid "应收股利"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1122
 #: model:account.account.template,name:l10n_cn_standard.account_1122
 msgid "应收账款"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1901
 #: model:account.account.template,name:l10n_cn_standard.account_1901
 msgid "待处理财产损溢"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6801
 #: model:account.account.template,name:l10n_cn_standard.account_6801
 msgid "所得税费用"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6421
 #: model:account.account.template,name:l10n_cn_standard.account_6421
 msgid "手续费及佣金支出"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6021
 #: model:account.account.template,name:l10n_cn_standard.account_6021
 msgid "手续费及佣金收入"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1521
 #: model:account.account.template,name:l10n_cn_standard.account_1521
 msgid "投资性房地产"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6111
 #: model:account.account.template,name:l10n_cn_standard.account_6111
 msgid "投资收益"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1441
 #: model:account.account.template,name:l10n_cn_standard.account_1441
 msgid "抵债资产"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2003
 #: model:account.account.template,name:l10n_cn_standard.account_2003
 msgid "拆入资金"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1302
 #: model:account.account.template,name:l10n_cn_standard.account_1302
 msgid "拆出资金"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1501
 #: model:account.account.template,name:l10n_cn_standard.account_1501
 msgid "持有至到期投资"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1502
 #: model:account.account.template,name:l10n_cn_standard.account_1502
 msgid "持有至到期投资减值准备"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1451
 #: model:account.account.template,name:l10n_cn_standard.account_1451
 msgid "损余物资"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6502
 #: model:account.account.template,name:l10n_cn_standard.account_6502
 msgid "提取保险责任准备金"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6501
 #: model:account.account.template,name:l10n_cn_standard.account_6501
 msgid "提取未到期责任准备金"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6201
 #: model:account.account.template,name:l10n_cn_standard.account_6201
 msgid "摊回保险责任准备金"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6203
 #: model:account.account.template,name:l10n_cn_standard.account_6203
 msgid "摊回分保费用"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6202
 #: model:account.account.template,name:l10n_cn_standard.account_6202
 msgid "摊回赔付支出"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1701
 #: model:account.account.template,name:l10n_cn_standard.account_1701
 msgid "无形资产"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1703
 #: model:account.account.template,name:l10n_cn_standard.account_1703
 msgid "无形资产减值准备"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_1_10
 #: model:account.account.template,name:l10n_cn_standard.account_2221_1_10
 msgid "未交增值税"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2601
 #: model:account.account.template,name:l10n_cn_standard.account_2601
 msgid "未到期责任准备金"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1532
 #: model:account.account.template,name:l10n_cn_standard.account_1532
 msgid "未实现融资收益"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1611
 #: model:account.account.template,name:l10n_cn_standard.account_1611
 msgid "未担保余值"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2702
 #: model:account.account.template,name:l10n_cn_standard.account_2702
 msgid "未确认融资费用"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_4103
 #: model:account.account.template,name:l10n_cn_standard.account_4103
 msgid "本年利润"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_5403
 #: model:account.account.template,name:l10n_cn_standard.account_5403
 msgid "机械作业"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1404
 #: model:account.account.template,name:l10n_cn_standard.account_1404
 msgid "材料成本差异"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1401
 #: model:account.account.template,name:l10n_cn_standard.account_1401
 msgid "材料采购"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6061
 #: model:account.account.template,name:l10n_cn_standard.account_6061
 msgid "汇兑损益"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1631
 #: model:account.account.template,name:l10n_cn_standard.account_1631
 msgid "油气资产"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1421
 #: model:account.account.template,name:l10n_cn_standard.account_1421
 msgid "消耗性生物资产"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_3001
 #: model:account.account.template,name:l10n_cn_standard.account_3001
 msgid "清算资金往来"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2621
 #: model:account.account.template,name:l10n_cn_standard.account_2621
 msgid "独立账户负债"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1821
 #: model:account.account.template,name:l10n_cn_standard.account_1821
 msgid "独立账户资产"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1621
 #: model:account.account.template,name:l10n_cn_standard.account_1621
 msgid "生产性生物资产"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1622
 #: model:account.account.template,name:l10n_cn_standard.account_1622
 msgid "生产性生物资产累计折旧"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_5001
 #: model:account.account.template,name:l10n_cn_standard.account_5001
 msgid "生产成本"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_4101
 #: model:account.account.template,name:l10n_cn_standard.account_4101
 msgid "盈余公积"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2001
 #: model:account.account.template,name:l10n_cn_standard.account_2001
 msgid "短期借款"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_5301
 #: model:account.account.template,name:l10n_cn_standard.account_5301
 msgid "研发支出"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6041
 #: model:account.account.template,name:l10n_cn_standard.account_6041
 msgid "租赁收入"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6602
 #: model:account.account.template,name:l10n_cn_standard.account_6602
 msgid "管理费用"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1602
 #: model:account.account.template,name:l10n_cn_standard.account_1602
 msgid "累计折旧"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1632
 #: model:account.account.template,name:l10n_cn_standard.account_1632
 msgid "累计折耗"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1702
 #: model:account.account.template,name:l10n_cn_standard.account_1702
 msgid "累计摊销"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1021
 #: model:account.account.template,name:l10n_cn_standard.account_1021
 msgid "结算备付金"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6711
 #: model:account.account.template,name:l10n_cn_standard.account_6711
 msgid "营业外支出"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6301
 #: model:account.account.template,name:l10n_cn_standard.account_6301
 msgid "营业外收入"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6403
 #: model:account.account.template,name:l10n_cn_standard.account_6403
 msgid "营业税金及附加"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1461
 #: model:account.account.template,name:l10n_cn_standard.account_1461
 msgid "融资租赁资产"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_3101
 #: model:account.account.template,name:l10n_cn_standard.account_3101
 msgid "衍生工具"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_3202
 #: model:account.account.template,name:l10n_cn_standard.account_3202
 msgid "被套期项目"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6603
 #: model:account.account.template,name:l10n_cn_standard.account_6603
 msgid "财务费用"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_3002
 #: model:account.account.template,name:l10n_cn_standard.account_3002
 msgid "货币兑换"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2021
 #: model:account.account.template,name:l10n_cn_standard.account_2021
 msgid "贴现负债"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1301
 #: model:account.account.template,name:l10n_cn_standard.account_1301
 msgid "贴现资产"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1431
 #: model:account.account.template,name:l10n_cn_standard.account_1431
 msgid "贵金属"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1303
 #: model:account.account.template,name:l10n_cn_standard.account_1303
 msgid "贷款"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1304
 #: model:account.account.template,name:l10n_cn_standard.account_1304
 msgid "贷款损失准备"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6701
 #: model:account.account.template,name:l10n_cn_standard.account_6701
 msgid "资产减值损失"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_4002
 #: model:account.account.template,name:l10n_cn_standard.account_4002
 msgid "资本公积"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6511
 #: model:account.account.template,name:l10n_cn_standard.account_6511
 msgid "赔付支出"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_1_9
 #: model:account.account.template,name:l10n_cn_standard.account_2221_1_9
 msgid "转出多交增值税"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_1_3
 #: model:account.account.template,name:l10n_cn_standard.account_2221_1_3
 msgid "转出未交增值税"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1003
 #: model:account.account.template,name:l10n_cn_standard.account_1003
 msgid "转让帐户"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_1_1
 #: model:account.account.template,name:l10n_cn_standard.account_2221_1_1
 msgid "进项税额"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_1_7
 #: model:account.account.template,name:l10n_cn_standard.account_2221_1_7
 msgid "进项税额转出"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6531
 #: model:account.account.template,name:l10n_cn_standard.account_6531
 msgid "退保金"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2901
 #: model:account.account.template,name:l10n_cn_standard.account_2901
 msgid "递延所得税负债"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1811
 #: model:account.account.template,name:l10n_cn_standard.account_1811
 msgid "递延所得税资产"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2401
 #: model:account.account.template,name:l10n_cn_standard.account_2401
 msgid "递延收益"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_6601
 #: model:account.account.template,name:l10n_cn_standard.account_6601
 msgid "销售费用"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2221_1_5
 #: model:account.account.template,name:l10n_cn_standard.account_2221_1_5
 msgid "销项税额"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2501
 #: model:account.account.template,name:l10n_cn_standard.account_2501
 msgid "长期借款"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2701
 #: model:account.account.template,name:l10n_cn_standard.account_2701
 msgid "长期应付款"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1531
 #: model:account.account.template,name:l10n_cn_standard.account_1531
 msgid "长期应收款"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1801
 #: model:account.account.template,name:l10n_cn_standard.account_1801
 msgid "长期待摊费用"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1511
 #: model:account.account.template,name:l10n_cn_standard.account_1511
 msgid "长期股权投资"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1512
 #: model:account.account.template,name:l10n_cn_standard.account_1512
 msgid "长期股权投资减值准备"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_1123
 #: model:account.account.template,name:l10n_cn_standard.account_1123
 msgid "预付账款"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2203
 #: model:account.account.template,name:l10n_cn_standard.account_2203
 msgid "预收账款"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.account,name:l10n_cn_standard.1_account_2801
 #: model:account.account.template,name:l10n_cn_standard.account_2801
 msgid "预计负债"
 msgstr ""

--- a/addons/l10n_lu/i18n_extra/de.po
+++ b/addons/l10n_lu/i18n_extra/de.po
@@ -4968,6 +4968,51 @@ msgid "Surveys and research costs (not included in the production of goods and s
 msgstr "Gutachten und Forschungsarbeiten (nicht für Werklieferungen)"
 
 #. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_0
+msgid "TVA 0%"
+msgstr "MwSt 0%"
+
+#. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_10
+msgid "TVA 10%"
+msgstr "MwSt 10%"
+
+#. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_12
+msgid "TVA 12%"
+msgstr "MwSt 12%"
+
+#. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_14
+msgid "TVA 14%"
+msgstr "MwSt 14%"
+
+#. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_15
+msgid "TVA 15%"
+msgstr "MwSt 15%"
+
+#. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_17
+msgid "TVA 17%"
+msgstr "MwSt 17%"
+
+#. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_3
+msgid "TVA 3%"
+msgstr "MwSt 3%"
+
+#. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_6
+msgid "TVA 6%"
+msgstr "MwSt 6%"
+
+#. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_8
+msgid "TVA 8%"
+msgstr "MwSt 8%"
+
+#. module: l10n_lu
 #: model:account.account.template,name:l10n_lu.lu_2011_account_608211
 msgid "Tailoring"
 msgstr "Lohnverarbeitung"
@@ -5322,25 +5367,21 @@ msgid "on sales"
 msgstr "auf Verkäufe"
 
 #. module: l10n_lu
-#: model:account.fiscal.position,name:l10n_lu.1_account_fiscal_position_template_LU_EC
 #: model:account.fiscal.position.template,name:l10n_lu.account_fiscal_position_template_LU_EC
 msgid "Extra-Community Taxable Person"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.fiscal.position,name:l10n_lu.1_account_fiscal_position_template_LU_IC
 #: model:account.fiscal.position.template,name:l10n_lu.account_fiscal_position_template_LU_IC
 msgid "Intra-Community Taxable Person"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.fiscal.position,name:l10n_lu.1_account_fiscal_position_template_LU_LU
 #: model:account.fiscal.position.template,name:l10n_lu.account_fiscal_position_template_LU_LU
 msgid "Luxembourgish Taxable Person"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.fiscal.position,name:l10n_lu.1_account_fiscal_position_template_LU_NO
 #: model:account.fiscal.position.template,name:l10n_lu.account_fiscal_position_template_LU_NO
 msgid "Not liable to VAT"
 msgstr ""

--- a/addons/l10n_lu/i18n_extra/fr.po
+++ b/addons/l10n_lu/i18n_extra/fr.po
@@ -4970,6 +4970,51 @@ msgid "Surveys and research costs (not included in the production of goods and s
 msgstr "Etudes et recherches (non incorporées dans les produits)"
 
 #. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_0
+msgid "TVA 0%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_10
+msgid "TVA 10%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_12
+msgid "TVA 12%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_14
+msgid "TVA 14%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_15
+msgid "TVA 15%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_17
+msgid "TVA 17%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_3
+msgid "TVA 3%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_6
+msgid "TVA 6%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_8
+msgid "TVA 8%"
+msgstr ""
+
+#. module: l10n_lu
 #: model:account.account.template,name:l10n_lu.lu_2011_account_608211
 msgid "Tailoring"
 msgstr "Travail à façon"
@@ -5323,25 +5368,21 @@ msgid "on sales"
 msgstr "sur ventes"
 
 #. module: l10n_lu
-#: model:account.fiscal.position,name:l10n_lu.1_account_fiscal_position_template_LU_EC
 #: model:account.fiscal.position.template,name:l10n_lu.account_fiscal_position_template_LU_EC
 msgid "Extra-Community Taxable Person"
 msgstr "Asujetti Extracommunautaire"
 
 #. module: l10n_lu
-#: model:account.fiscal.position,name:l10n_lu.1_account_fiscal_position_template_LU_IC
 #: model:account.fiscal.position.template,name:l10n_lu.account_fiscal_position_template_LU_IC
 msgid "Intra-Community Taxable Person"
 msgstr "Asujetti Intracommunautaire"
 
 #. module: l10n_lu
-#: model:account.fiscal.position,name:l10n_lu.1_account_fiscal_position_template_LU_LU
 #: model:account.fiscal.position.template,name:l10n_lu.account_fiscal_position_template_LU_LU
 msgid "Luxembourgish Taxable Person"
 msgstr "Asujetti Luxembourgeois"
 
 #. module: l10n_lu
-#: model:account.fiscal.position,name:l10n_lu.1_account_fiscal_position_template_LU_NO
 #: model:account.fiscal.position.template,name:l10n_lu.account_fiscal_position_template_LU_NO
 msgid "Not liable to VAT"
 msgstr "Non-assujetti"

--- a/addons/l10n_lu/i18n_extra/l10n_lu_multilang.pot
+++ b/addons/l10n_lu/i18n_extra/l10n_lu_multilang.pot
@@ -4909,6 +4909,51 @@ msgid "Surveys and research costs (not included in the production of goods and s
 msgstr ""
 
 #. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_0
+msgid "TVA 0%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_10
+msgid "TVA 10%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_12
+msgid "TVA 12%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_14
+msgid "TVA 14%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_15
+msgid "TVA 15%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_17
+msgid "TVA 17%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_3
+msgid "TVA 3%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_6
+msgid "TVA 6%"
+msgstr ""
+
+#. module: l10n_lu
+#: model:account.tax.group,name:l10n_lu.tax_group_8
+msgid "TVA 8%"
+msgstr ""
+
+#. module: l10n_lu
 #: model:account.account.template,name:l10n_lu.lu_2011_account_608211
 msgid "Tailoring"
 msgstr ""
@@ -5260,25 +5305,21 @@ msgid "on sales"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.fiscal.position,name:l10n_lu.1_account_fiscal_position_template_LU_EC
 #: model:account.fiscal.position.template,name:l10n_lu.account_fiscal_position_template_LU_EC
 msgid "Extra-Community Taxable Person"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.fiscal.position,name:l10n_lu.1_account_fiscal_position_template_LU_IC
 #: model:account.fiscal.position.template,name:l10n_lu.account_fiscal_position_template_LU_IC
 msgid "Intra-Community Taxable Person"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.fiscal.position,name:l10n_lu.1_account_fiscal_position_template_LU_LU
 #: model:account.fiscal.position.template,name:l10n_lu.account_fiscal_position_template_LU_LU
 msgid "Luxembourgish Taxable Person"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.fiscal.position,name:l10n_lu.1_account_fiscal_position_template_LU_NO
 #: model:account.fiscal.position.template,name:l10n_lu.account_fiscal_position_template_LU_NO
 msgid "Not liable to VAT"
 msgstr ""


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Improved translations for module l10n_cn and l10n_lu
Task :- https://www.odoo.com/web#id=1922590&action=327&model=project.task&view_type=form&menu_id=4720
Pad:-https://pad.odoo.com/p/r.0e9d23f1ae22ff7f2dbe4faaf902c6cc

Desired behavior after PR is merged:  
Removed the translations for models
- account.account
- account.tax
- account.fiscal.position.tax
- account.fiscal.position.account
- account.fiscal.position
- account.reconcile.model

which were no longer required as these were already translated in its templates.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
