### PR TITLE
[FIX] web: Invalid date field raised traceback

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -507,6 +507,17 @@ var FieldDate = InputField.extend({
         );
     },
     /**
+     * In edit mode, FieldDate must be invalid when DateWidget datepicker is invalid.
+     *
+     * @override
+     */
+    isValid: function () {
+        return (
+            this._super.apply(this, arguments)
+            && (!this.datewidget || this.datewidget.isValid())
+        );
+    },
+    /**
      * In edit mode, instantiates a DateWidget datepicker and listen to changes.
      *
      * @override

--- a/addons/web/static/src/js/widgets/date_picker.js
+++ b/addons/web/static/src/js/widgets/date_picker.js
@@ -43,6 +43,7 @@ var DateWidget = Widget.extend({
                 clear: 'fa fa-delete',
                 close: 'fa fa-times'
             },
+            keepInvalid: true,
             calendarWeeks: true,
             buttons: {
                 showToday: false,

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -2667,8 +2667,8 @@ QUnit.module('basic_fields', {
         form.destroy();
     });
 
-    QUnit.test('date field should remove the date  if the date is not valid', function (assert) {
-        assert.expect(1);
+    QUnit.test('date field should keep the date  if the date is not valid', function (assert) {
+        assert.expect(3);
 
         var form = createView({
             View: FormView,
@@ -2682,7 +2682,13 @@ QUnit.module('basic_fields', {
         // set an invalid date
         var $input = form.$('.o_field_widget[name=date] input');
         $input.val('mmmh').trigger('change');
-        assert.strictEqual($input.text(), "", "The date field should be empty");
+        // save the change
+        form.$buttons.find('.o_form_button_save').click();
+        assert.strictEqual($input.val(), "mmmh", "The wrong value should be kept");
+        assert.ok(form.$('.o_form_view').hasClass('o_form_editable'),
+            "form view should still be editable");
+        assert.ok(form.$('.o_field_widget').hasClass('o_field_invalid'),
+            "image field should be displayed as invalid");
         form.destroy();
     });
 


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a SO, set a validity_date and save
- Edit the SO and set a wrong value to the validity_date

Bug:

An traceback coming from tempusdominus was raised (in function _setValue
when this._dates[index] was undefined)

To keep the same behavior as in 10.0, now a warning box just appears
when trying to save a wrong value and the field is in red.

opw:1974747