### PR TITLE
[FIX] base: fix snailmail traceback when sending by post

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -398,7 +398,7 @@ class IrAttachment(models.Model):
         ids = super(IrAttachment, self)._search(args, offset=offset, limit=limit, order=order,
                                                 count=False, access_rights_uid=access_rights_uid)
 
-        if self.env.user._is_system():
+        if self.env.user._is_admin():
             # rules do not apply for the superuser
             return len(ids) if count else ids
 


### PR DESCRIPTION
- When we are sending by post using snailmail it throws traceback because at
that time snailmail try to create document and it access the company's partner
image  using logo_web field. In company logo_web is compute store field depends
on partner_id and partner_id.image which access company's partner
image and it doesn't have value because  at the time of initialising the
database due to super user access right issue. So followed by the default flow
in db logo_web will store null value.

- So when database is initialise super user doesn't have group called
base.group_system due to sequence issue between user and security group creation.

- When we try to access company's partner image it fetch data from ir.attachment
that read binary field using super user without having base.group_system group
due to that sequence issue between user and security group creation return
Null result. Because of this reference commit condition

(Ref: https://github.com/odoo/odoo/commit/62c9dedafda0cbdc618641eaa80c49535ab0b5f6#diff-65be9bcf9d09c93a04039c00e1861b9fR401)
This commit fix that issue

task-1984609
pad link- https://pad.odoo.com/p/r.afaed9c12d5172fea30cd2987c20ad70
