### PR TITLE
[FIX] web: input field not updated after onchange

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -301,6 +301,7 @@ var InputField = DebouncedField.extend({
      * @param {OdooEvent} event 'field_changed' event
      */
     _onFieldChanged: function (event) {
+        this.isDirty = true;
         this.lastChangeEvent = event;
     },
     /**
@@ -311,7 +312,6 @@ var InputField = DebouncedField.extend({
      * @private
      */
     _onInput: function () {
-        this.isDirty = true;
         this._doDebouncedAction();
     },
     /**


### PR DESCRIPTION
Currently, when we write in an input field it sets the field as dirty whether
the input contains any value or not. and because of this issue occurs.
So, set the field as dirty only when there is an input value.

after applied this commit:
- For Ex: When creating an invoice line, before selecting a product write
something in the description field and then erase it. Then select a product. So,
it will display the field's value of the selected product.

task-1958793

Description of the issue/feature this PR addresses:
the description of the product is not updated with the selection of the product

Current behavior before PR:
the description of the product is not updated with the selection of the product

Desired behavior after PR is merged:
the description of the product is updated with the selection of the product

Issue: 
https://www.odoo.com/web#id=1958793&action=327&model=project.task&view_type=form&menu_id=4720

Pad:
https://pad.odoo.com/p/r.b9210ba509fbe32eaf681b7b0829b837

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
