### PR TITLE
[FIX] mrp: structure report print all variant

### DIFF
--- a/addons/mrp/report/mrp_report_bom_structure.py
+++ b/addons/mrp/report/mrp_report_bom_structure.py
@@ -14,7 +14,7 @@ class ReportBomStructure(models.AbstractModel):
         docs = []
         for bom_id in docids:
             bom = self.env['mrp.bom'].browse(bom_id)
-            variant = data and data.get('variant')
+            variant = bom.product_id or (data and data.get('variant'))
             candidates = variant and self.env['product.product'].browse(variant) or bom.product_tmpl_id.product_variant_ids
             for product_variant_id in candidates:
                 if data and data.get('childs'):


### PR DESCRIPTION
Usecase:
- Create a Product with 2 variants
- Create 2 BoMs (one for each variant with product_id set on BoM)
- Go on a BoM and print the report.

A page is generated for each variant.

It happens because the system only filter if a specific variant
is given from the javascript. However in the case where the variant
is set on the BoM and not on the BoM's lines, the variant is not manage
by the js.

This commit first check if the BoM is specific to a variant and then
check if a variant is given from the js.

Close #34025

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
