### PR TITLE
[FIX] account: choose grid lines while creating new tax

### DIFF
--- a/addons/account/models/account.py
+++ b/addons/account/models/account.py
@@ -1071,16 +1071,18 @@ class AccountTax(models.Model):
         rslt = super(AccountTax, self).default_get(vals + ['company_id'])
 
         company_id = rslt.get('company_id')
+        company_rec = self.env['res.company'].browse(company_id)
+        country_id = company_rec.country_id if company_rec else self.env.company.country_id
         if 'refund_repartition_line_ids' in vals:
             rslt['refund_repartition_line_ids'] = [
-                (0, 0, { 'repartition_type': 'base', 'factor_percent': 100.0, 'tag_ids': [], 'company_id': company_id}),
-                (0, 0, { 'repartition_type': 'tax', 'factor_percent': 100.0, 'tag_ids': [], 'company_id': company_id}),
+                (0, 0, { 'repartition_type': 'base', 'factor_percent': 100.0, 'tag_ids': [], 'company_id': company_id, 'country_id': country_id.id}),
+                (0, 0, { 'repartition_type': 'tax', 'factor_percent': 100.0, 'tag_ids': [], 'company_id': company_id, 'country_id': country_id.id}),
             ]
 
         if 'invoice_repartition_line_ids' in vals:
             rslt['invoice_repartition_line_ids'] = [
-                (0, 0, { 'repartition_type': 'base', 'factor_percent': 100.0, 'tag_ids': [], 'company_id': company_id}),
-                (0, 0, { 'repartition_type': 'tax', 'factor_percent': 100.0, 'tag_ids': [], 'company_id': company_id}),
+                (0, 0, { 'repartition_type': 'base', 'factor_percent': 100.0, 'tag_ids': [], 'company_id': company_id, 'country_id': country_id.id}),
+                (0, 0, { 'repartition_type': 'tax', 'factor_percent': 100.0, 'tag_ids': [], 'company_id': company_id, 'country_id': country_id.id}),
             ]
 
         return rslt


### PR DESCRIPTION
user will now able to select Tax Grid
from repartition of invoices and repartition of credit notes,
while creating a new tax.

task - https://www.odoo.com/web?#id=2026349&action=327&model=project.task&view_type=form&menu_id=4720
pad - https://pad.odoo.com/p/r.57c0b6b04d2a5118489fe5019982e0a0

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
