### PR TITLE
[PATCH] account, purchase: Duplicating vendor bills linked to a PO

### DIFF
--- a/addons/account/models/account_invoice.py
+++ b/addons/account/models/account_invoice.py
@@ -244,7 +244,7 @@ class AccountInvoice(models.Model):
 
     origin = fields.Char(string='Source Document',
         help="Reference of the document that produced this invoice.",
-        readonly=True, states={'draft': [('readonly', False)]})
+        readonly=True, states={'draft': [('readonly', False)]}, copy=False)
     type = fields.Selection([
             ('out_invoice','Customer Invoice'),
             ('in_invoice','Vendor Bill'),

--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -268,6 +268,6 @@ class AccountInvoiceLine(models.Model):
     """ Override AccountInvoice_line to add the link to the purchase order line it is related to"""
     _inherit = 'account.invoice.line'
 
-    purchase_line_id = fields.Many2one('purchase.order.line', 'Purchase Order Line', ondelete='set null', index=True, readonly=True)
+    purchase_line_id = fields.Many2one('purchase.order.line', 'Purchase Order Line', ondelete='set null', index=True, readonly=True, copy=False)
     purchase_id = fields.Many2one('purchase.order', related='purchase_line_id.order_id', string='Purchase Order', store=False, readonly=True, related_sudo=False,
-        help='Associated Purchase Order. Filled in automatically when a PO is chosen on the vendor bill.')
+        help='Associated Purchase Order. Filled in automatically when a PO is chosen on the vendor bill.', copy=False)


### PR DESCRIPTION
When duplicating a vendor bill VB1 linked to a PO, it also linked the
duplicated vendor bill VB2 with the PO of VB1 which affected the
billed quantity on the PO.

As it changes the actual behavior, this patch cannot be merged in 11.0

opw:2028624