### PR TITLE
[FIX] base: issue in label for field with group

### DIFF
--- a/addons/web/static/src/js/views/form/form_renderer.js
+++ b/addons/web/static/src/js/views/form/form_renderer.js
@@ -802,7 +802,7 @@ var FormRenderer = BasicRenderer.extend({
         var fieldName = node.tag === 'label' ? node.attrs.for : node.attrs.name;
         if ('string' in node.attrs) { // allow empty string
             text = node.attrs.string;
-        } else if (fieldName) {
+        } else if (fieldName && this.state.fields[fieldName]) {
             text = this.state.fields[fieldName].string;
         } else  {
             return this._renderGenericTag(node);

--- a/addons/web/static/tests/views/form_tests.js
+++ b/addons/web/static/tests/views/form_tests.js
@@ -882,6 +882,27 @@ QUnit.module('Views', {
         form.destroy();
     });
 
+    QUnit.test('label should rendered even if field is not in the state', async function (assert) {
+        assert.expect(1);
+
+        var form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch:'<form string="Partners">' +
+                    '<sheet>' +
+                        '<group>' +
+                            '<label for="test"/>' +
+                        '</group>' +
+                    '</sheet>' +
+                '</form>',
+            res_id: 2,
+        });
+
+        assert.containsOnce(form, '.o_td_label', "label should be available in form");
+        form.destroy();
+    });
+
     QUnit.test('readonly attrs on fields are re-evaluated on field change', async function (assert) {
         assert.expect(4);
 


### PR DESCRIPTION
purpose of this commit is, don't allow the label to parse in arch if it's
field's group is not satisfied with the current user

before this commit:
get traceback when we use any field (which has a group) in a label because of
the group of the user is not satisfied with it

after this commit:
parse label in the arch only when a user has a particular group of the label
field

Issue: 
https://www.odoo.com/web#id=2025825&action=327&model=project.task&view_type=form&menu_id=4720

Pad:
https://pad.odoo.com/p/r.3cfd0c5a28d57431580fad0a2c7cf05b

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
