### PR TITLE
[REF] utm,link_tracker: Remove utm_* creations from default_get

### DIFF
--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -111,6 +111,12 @@ class LinkTracker(models.Model):
             tracker.favicon = icon_base64
 
     @api.model
+    def default_get(self, fields):
+        utm_fields = [fname for url_param, fname, cookie_name in self.env['utm.mixin'].tracking_fields()]
+        utm_force_default_ctx = dict((fname, self._context.get('default_%s' % fname)) for fname in utm_fields)
+        return super(LinkTracker, self.with_context(**utm_force_default_ctx)).default_get(fields)
+
+    @api.model
     def create(self, vals):
         create_vals = vals.copy()
 


### PR DESCRIPTION
This commit removes the creation of utm_source, utm_medium and utm_campaign
from the default_get in utm.mixin

After this commit the creation of those fields will be handled in the create
method.

TaskID : 2028310
PR:#34436


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
