### PR TITLE
[WIP] enable product_configurator for mobile

### DIFF
--- a/addons/event_sale/views/sale_order_views.xml
+++ b/addons/event_sale/views/sale_order_views.xml
@@ -5,7 +5,7 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='order_line']//form//field[@name='product_id']" position="after">
+            <xpath expr="//field[@name='order_line']//form//field[@name='product_template_id']" position="after">
                 <field
                     name="event_id"
                     domain="[
@@ -13,7 +13,9 @@
                         ('date_end','&gt;=',time.strftime('%Y-%m-%d 00:00:00')),
                         '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)
                     ]"
-                    attrs="{'invisible': [('event_ok', '=', False)], 'required': [('event_ok', '!=', False)]}"
+                    attrs="{
+                        'invisible': [('event_ok', '=', False)],
+                        'required': [('event_ok', '!=', False)]}"
                     options="{'no_open': True, 'no_create': True}"
                 />
                 <field

--- a/addons/product_matrix/static/src/js/section_and_note_widget.js
+++ b/addons/product_matrix/static/src/js/section_and_note_widget.js
@@ -57,6 +57,7 @@ SectionAndNoteFieldOne2Many.include({
         var productTemplateId = ev.data.product_template_id;
         var editedCellAttributes = ev.data.editedCellAttributes;
         if (!ev.data.edit) {
+            // VFE NOTE In mobile/responsive, the delete operation has no impact.
             // remove the line used to open the matrix
             this._setValue({operation: 'DELETE', ids: [dataPointId]});
         }

--- a/addons/purchase_product_matrix/static/src/js/product_matrix_configurator.js
+++ b/addons/purchase_product_matrix/static/src/js/product_matrix_configurator.js
@@ -153,6 +153,7 @@ var MatrixConfiguratorWidget = relationalFields.FieldMany2One.extend({
     },
 
     _openMatrix: function (productTemplateId, dataPointId, edit) {
+        var self = this;
         var attribs = edit ? this._getPTAVS() : [];
         this.trigger_up('open_matrix', {
             product_template_id: productTemplateId,
@@ -162,6 +163,9 @@ var MatrixConfiguratorWidget = relationalFields.FieldMany2One.extend({
             editedCellAttributes: attribs,
             // used to focus the cell representing the line on which the pencil was clicked.
         });
+        if (self.getParent().arch.tag === 'form') {
+            self.trigger_up('formClose', {res_model: 'purchase.order.line'});
+        }
     },
 
     /**

--- a/addons/sale/static/src/js/product_configurator_widget.js
+++ b/addons/sale/static/src/js/product_configurator_widget.js
@@ -120,11 +120,18 @@ var ProductConfiguratorWidget = relationalFields.FieldMany2One.extend({
         if (ev.data.changes && !ev.data.preventProductIdCheck && ev.data.changes.product_template_id) {
             self._onTemplateChange(ev.data.changes.product_template_id.id, ev.data.dataPointID);
         } else if (ev.data.changes && ev.data.changes.product_id) {
-            self._onProductChange(ev.data.changes.product_id.id, ev.data.dataPointID).then(function (wizardOpened) {
-                if (!wizardOpened) {
-                    self._onLineConfigured();
-                }
-            });
+            if (self.getParent().arch.tag === 'tree') {
+                self._onProductChange(ev.data.changes.product_id.id, ev.data.dataPointID).then(function (wizardOpened) {
+                    if (!wizardOpened) {
+                        self._onLineConfigured();
+                    }
+                });
+            } else { // mobile/responsive
+                // Apply options and leave form view if no further information is expected/required
+                // DO NOT open line configurators, their fields are expected to be
+                // editable on the form view.
+                self._onLineConfigured();
+            }
         }
     },
 

--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -350,6 +350,24 @@
                                                 force_save="1"
                                                 widget="many2one_barcode"
                                                />
+                                             <field name="product_template_id"
+                                               string="Product"
+                                               invisible="1"
+                                               attrs="{
+                                                   'readonly': [('product_updatable', '=', False)],
+                                                   'required': [('display_type', '=', False)],
+                                               }"
+                                               options="{'no_open': True}"
+                                               context="{
+                                                   'partner_id': parent.partner_id,
+                                                   'quantity': product_uom_qty,
+                                                   'pricelist': parent.pricelist_id,
+                                                   'uom':product_uom,
+                                                   'company_id': parent.company_id,
+                                                   'default_lst_price': price_unit,
+                                                   'default_description_sale': name
+                                               }"
+                                               widget="product_configurator"/>
                                             <field name="invoice_status" invisible="1"/>
                                             <field name="qty_to_invoice" invisible="1"/>
                                             <field name="qty_delivered_manual" invisible="1"/>
@@ -544,6 +562,7 @@
                                 <kanban class="o_kanban_mobile">
                                     <field name="name"/>
                                     <field name="product_id"/>
+                                    <field name="product_template_id"/>
                                     <field name="product_uom_qty"/>
                                     <field name="product_uom" groups="uom.group_uom"/>
                                     <field name="price_subtotal"/>

--- a/addons/sale_product_configurator/views/sale_views.xml
+++ b/addons/sale_product_configurator/views/sale_views.xml
@@ -37,6 +37,34 @@
             <xpath expr="//tree/field[@name='product_id']" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
+            <xpath expr="//form/group/group/field[@name='product_template_id']" position="attributes">
+                <attribute name="invisible">0</attribute>
+            </xpath>
+            <xpath expr="//form/group/group/field[@name='product_template_id']" position="after">
+                <field name="product_template_attribute_value_ids" invisible="1" />
+                <field name="product_custom_attribute_value_ids" invisible="1" >
+                    <tree>
+                        <field name="custom_product_template_attribute_value_id" />
+                        <field name="custom_value" />
+                    </tree>
+                </field>
+                <field name="product_no_variant_attribute_value_ids" invisible="1" />
+                <field name="is_configurable_product" invisible="1" />
+            </xpath>
+            <xpath expr="//form/group/group/field[@name='product_id']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="//kanban/field[@name='product_template_id']" position="after">
+                <field name="product_template_attribute_value_ids" invisible="1" />
+                <field name="product_custom_attribute_value_ids" invisible="1" >
+                    <tree>
+                        <field name="custom_product_template_attribute_value_id" />
+                        <field name="custom_value" />
+                    </tree>
+                </field>
+                <field name="product_no_variant_attribute_value_ids" invisible="1" />
+                <field name="is_configurable_product" invisible="1" />
+            </xpath>
         </field>
     </record>
 </odoo>

--- a/addons/sale_product_matrix/static/src/js/product_matrix_configurator.js
+++ b/addons/sale_product_matrix/static/src/js/product_matrix_configurator.js
@@ -27,6 +27,7 @@ ProductConfiguratorWidget.include({
     },
 
     _openGridConfigurator: function (productTemplateId, dataPointId, edit) {
+        var self = this;
         var attribs = edit ? this._getPTAVS() : [];
         this.trigger_up('open_matrix', {
             product_template_id: productTemplateId,
@@ -35,6 +36,9 @@ ProductConfiguratorWidget.include({
             edit: edit,
             editedCellAttributes: attribs,
         });
+        if (self.getParent().arch.tag === 'form') {
+            self.trigger_up('formClose', {res_model: 'sale.order.line'});
+        }
     },
 
     _onEditProductConfiguration: function () {

--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -1645,6 +1645,7 @@ var FieldOne2Many = FieldX2Many.extend({
             { additionalContext: params.context }
         ));
         this.trigger_up('open_one2many_record', _.extend(params, {
+            parent: this,
             domain: this.record.getDomain(this.recordParams),
             context: context,
             field: this.field,

--- a/addons/web/static/src/js/views/form/form_controller.js
+++ b/addons/web/static/src/js/views/form/form_controller.js
@@ -691,7 +691,7 @@ var FormController = BasicController.extend({
         // Sync with the mutex to wait for potential onchanges
         await this.model.mutex.getUnlockedDef();
 
-        new dialogs.FormViewDialog(this, {
+        new dialogs.FormViewDialog(data.parent || this, {
             context: data.context,
             domain: data.domain,
             fields_view: data.fields_view,

--- a/addons/web/static/src/js/views/view_dialogs.js
+++ b/addons/web/static/src/js/views/view_dialogs.js
@@ -59,6 +59,10 @@ var ViewDialog = Dialog.extend({
  * Create and edit dialog (displays a form view record and leave once saved)
  */
 var FormViewDialog = ViewDialog.extend({
+    custom_events: _.extend({}, Dialog.prototype.custom_events, {
+        saveAndClose: '_onSaveAndClose',
+        formClose: '_onFormClose',
+    }),
     /**
      * @param {Widget} parent
      * @param {Object} [options]
@@ -243,6 +247,35 @@ var FormViewDialog = ViewDialog.extend({
             },
         });
         return isFocusSet;
+    },
+
+    /**
+     * Closes the dialog without saving its content.
+     *
+     * @param {OdooEvent} [ev]
+     * @param {string} [ev.data.res_model] Restricted res_model for which
+     * the event applies.  Security check to ensure this event is targeted
+     * and cannot impact unexpected dialogs.
+     * @private
+     */
+    _onFormClose: function (ev) {
+        ev.stopPropagation();
+        if (this.res_model === ev.data.res_model) {
+            this.close();
+        }
+    },
+
+    /**
+     * Try to save and close the current dialog.
+     * Will raise an Error to the User if required fields aren't set.
+     *
+     * @param {OdooEvent} [ev]
+     * @private
+     */
+    _onSaveAndClose: function (ev) {
+        ev.stopPropagation();
+        var self = this;
+        this._save().then(self.close.bind(self));
     },
 
     /**


### PR DESCRIPTION
TOFIX : 

- [x] Make sale_product_configurator work in mobile :

- [ ] Bridge many2one_barcode and product configurators (sale_product_configurator, sale_product_matrix, purchase_product_matrix) to support product_product configuration based on barcodes even when the product_id field is invisible (and only the product_template_id is visible). 

Modules to check:
- [x] event_sale: less complex line configurator
- [x] sale_product_configurator: product configurator
- [x] sale_rental : date is taken from other lines by default --> It won't work in mobile IMO...
- [x] sale_product_matrix : so_line is removed on matrix opening, so will the widget be able to trigger its changes ?


### Current State:
Configurators work fine BUT:
When matrix/product_configurator is installed (`sale_product_configurator, sale_product_matrix, purchase_product_matrix`), the `product_id` field is invisible and only the `product_template_id` is shown.  Therefore, the many2one_barcode isn't rendered and doesn't work !


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
