### PR TITLE
[FIX] l10n_in :  Fix repartition line

### DIFF
--- a/addons/l10n_in/data/account_tax_template_data.xml
+++ b/addons/l10n_in/data/account_tax_template_data.xml
@@ -506,7 +506,7 @@ if tax > result:result=tax</field>
                 'factor_percent': 50,
                 'repartition_type': 'tax',
                 'account_id': ref('p10052'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst')],
+                'minus_report_line_ids': [ref('tax_report_line_cgst')],
             }),
         ]"/>
     </record>
@@ -554,7 +554,7 @@ if tax > result:result=tax</field>
                 'factor_percent': 50,
                 'repartition_type': 'tax',
                 'account_id': ref('p10052'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst')],
+                'minus_report_line_ids': [ref('tax_report_line_cgst')],
             }),
         ]"/>
     </record>
@@ -602,7 +602,7 @@ if tax > result:result=tax</field>
                 'factor_percent': 50,
                 'repartition_type': 'tax',
                 'account_id': ref('p10052'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst')],
+                'minus_report_line_ids': [ref('tax_report_line_cgst')],
             }),
         ]"/>
     </record>
@@ -650,7 +650,7 @@ if tax > result:result=tax</field>
                 'factor_percent': 50,
                 'repartition_type': 'tax',
                 'account_id': ref('p10052'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst')],
+                'minus_report_line_ids': [ref('tax_report_line_cgst')],
             }),
         ]"/>
     </record>
@@ -698,7 +698,7 @@ if tax > result:result=tax</field>
                 'factor_percent': 50,
                 'repartition_type': 'tax',
                 'account_id': ref('p10052'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst')],
+                'minus_report_line_ids': [ref('tax_report_line_cgst')],
             }),
         ]"/>
     </record>
@@ -747,7 +747,7 @@ if tax > result:result=tax</field>
                 'factor_percent': 50,
                 'repartition_type': 'tax',
                 'account_id': ref('p10052'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst')],
+                'minus_report_line_ids': [ref('tax_report_line_cgst')],
             }),
         ]"/>
     </record>
@@ -974,7 +974,7 @@ if tax > result:result=tax</field>
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('p10053'),
-                'plus_report_line_ids': [ref('tax_report_line_igst')],
+                'minus_report_line_ids': [ref('tax_report_line_igst')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -987,7 +987,7 @@ if tax > result:result=tax</field>
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('p11234'),
-                'minus_report_line_ids': [ref('tax_report_line_igst')],
+                'plus_report_line_ids': [ref('tax_report_line_igst')],
             }),
         ]"/>
     </record>
@@ -1010,7 +1010,7 @@ if tax > result:result=tax</field>
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('p10053'),
-                'plus_report_line_ids': [ref('tax_report_line_igst')],
+                'minus_report_line_ids': [ref('tax_report_line_igst')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -1023,7 +1023,7 @@ if tax > result:result=tax</field>
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('p11234'),
-                'minus_report_line_ids': [ref('tax_report_line_igst')],
+                'plus_report_line_ids': [ref('tax_report_line_igst')],
             }),
         ]"/>
     </record>
@@ -1046,7 +1046,7 @@ if tax > result:result=tax</field>
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('p10053'),
-                'plus_report_line_ids': [ref('tax_report_line_igst')],
+                'minus_report_line_ids': [ref('tax_report_line_igst')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -1059,7 +1059,7 @@ if tax > result:result=tax</field>
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('p11234'),
-                'minus_report_line_ids': [ref('tax_report_line_igst')],
+                'plus_report_line_ids': [ref('tax_report_line_igst')],
             }),
         ]"/>
     </record>
@@ -1082,7 +1082,7 @@ if tax > result:result=tax</field>
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('p10053'),
-                'plus_report_line_ids': [ref('tax_report_line_igst')],
+                'minus_report_line_ids': [ref('tax_report_line_igst')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -1095,7 +1095,7 @@ if tax > result:result=tax</field>
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('p11234'),
-                'minus_report_line_ids': [ref('tax_report_line_igst')],
+                'plus_report_line_ids': [ref('tax_report_line_igst')],
             }),
         ]"/>
     </record>
@@ -1118,7 +1118,7 @@ if tax > result:result=tax</field>
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('p10053'),
-                'plus_report_line_ids': [ref('tax_report_line_igst')],
+                'minus_report_line_ids': [ref('tax_report_line_igst')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -1131,7 +1131,7 @@ if tax > result:result=tax</field>
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('p11234'),
-                'minus_report_line_ids': [ref('tax_report_line_igst')],
+                'plus_report_line_ids': [ref('tax_report_line_igst')],
             }),
         ]"/>
     </record>
@@ -1154,7 +1154,7 @@ if tax > result:result=tax</field>
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('p10053'),
-                'plus_report_line_ids': [ref('tax_report_line_igst')],
+                'minus_report_line_ids': [ref('tax_report_line_igst')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -1167,7 +1167,7 @@ if tax > result:result=tax</field>
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('p11234'),
-                'minus_report_line_ids': [ref('tax_report_line_igst')],
+                'plus_report_line_ids': [ref('tax_report_line_igst')],
             }),
         ]"/>
     </record>
@@ -1191,13 +1191,13 @@ if tax > result:result=tax</field>
                 'factor_percent': 50,
                 'repartition_type': 'tax',
                 'account_id': ref('p10051'),
-                'plus_report_line_ids': [ref('tax_report_line_sgst')],
+                'minus_report_line_ids': [ref('tax_report_line_sgst')],
             }),
             (0,0, {
                 'factor_percent': 50,
                 'repartition_type': 'tax',
                 'account_id': ref('p10052'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst')],
+                'minus_report_line_ids': [ref('tax_report_line_cgst')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -1209,7 +1209,7 @@ if tax > result:result=tax</field>
                 'factor_percent': 50,
                 'repartition_type': 'tax',
                 'account_id': ref('p11232'),
-                'minus_report_line_ids': [ref('tax_report_line_sgst')],
+                'plus_report_line_ids': [ref('tax_report_line_sgst')],
             }),
             (0,0, {
                 'factor_percent': 50,
@@ -1238,13 +1238,13 @@ if tax > result:result=tax</field>
                 'factor_percent': 50,
                 'repartition_type': 'tax',
                 'account_id': ref('p10051'),
-                'plus_report_line_ids': [ref('tax_report_line_sgst')],
+                'minus_report_line_ids': [ref('tax_report_line_sgst')],
             }),
             (0,0, {
                 'factor_percent': 50,
                 'repartition_type': 'tax',
                 'account_id': ref('p10052'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst')],
+                'minus_report_line_ids': [ref('tax_report_line_cgst')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -1257,7 +1257,7 @@ if tax > result:result=tax</field>
                 'factor_percent': 50,
                 'repartition_type': 'tax',
                 'account_id': ref('p11232'),
-                'minus_report_line_ids': [ref('tax_report_line_sgst')],
+                'plus_report_line_ids': [ref('tax_report_line_sgst')],
             }),
             (0,0, {
                 'factor_percent': 50,
@@ -1286,13 +1286,13 @@ if tax > result:result=tax</field>
                 'factor_percent': 50,
                 'repartition_type': 'tax',
                 'account_id': ref('p10051'),
-                'plus_report_line_ids': [ref('tax_report_line_sgst')],
+                'minus_report_line_ids': [ref('tax_report_line_sgst')],
             }),
             (0,0, {
                 'factor_percent': 50,
                 'repartition_type': 'tax',
                 'account_id': ref('p10052'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst')],
+                'minus_report_line_ids': [ref('tax_report_line_cgst')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -1305,7 +1305,7 @@ if tax > result:result=tax</field>
                 'factor_percent': 50,
                 'repartition_type': 'tax',
                 'account_id': ref('p11232'),
-                'minus_report_line_ids': [ref('tax_report_line_sgst')],
+                'plus_report_line_ids': [ref('tax_report_line_sgst')],
             }),
             (0,0, {
                 'factor_percent': 50,
@@ -1334,13 +1334,13 @@ if tax > result:result=tax</field>
                 'factor_percent': 50,
                 'repartition_type': 'tax',
                 'account_id': ref('p10051'),
-                'plus_report_line_ids': [ref('tax_report_line_sgst')],
+                'minus_report_line_ids': [ref('tax_report_line_sgst')],
             }),
             (0,0, {
                 'factor_percent': 50,
                 'repartition_type': 'tax',
                 'account_id': ref('p10052'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst')],
+                'minus_report_line_ids': [ref('tax_report_line_cgst')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -1353,7 +1353,7 @@ if tax > result:result=tax</field>
                 'factor_percent': 50,
                 'repartition_type': 'tax',
                 'account_id': ref('p11232'),
-                'minus_report_line_ids': [ref('tax_report_line_sgst')],
+                'plus_report_line_ids': [ref('tax_report_line_sgst')],
             }),
             (0,0, {
                 'factor_percent': 50,
@@ -1382,13 +1382,13 @@ if tax > result:result=tax</field>
                 'factor_percent': 50,
                 'repartition_type': 'tax',
                 'account_id': ref('p10051'),
-                'plus_report_line_ids': [ref('tax_report_line_sgst')],
+                'minus_report_line_ids': [ref('tax_report_line_sgst')],
             }),
             (0,0, {
                 'factor_percent': 50,
                 'repartition_type': 'tax',
                 'account_id': ref('p10052'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst')],
+                'minus_report_line_ids': [ref('tax_report_line_cgst')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -1401,7 +1401,7 @@ if tax > result:result=tax</field>
                 'factor_percent': 50,
                 'repartition_type': 'tax',
                 'account_id': ref('p11232'),
-                'minus_report_line_ids': [ref('tax_report_line_sgst')],
+                'plus_report_line_ids': [ref('tax_report_line_sgst')],
             }),
             (0,0, {
                 'factor_percent': 50,
@@ -1431,13 +1431,13 @@ if tax > result:result=tax</field>
                 'factor_percent': 50,
                 'repartition_type': 'tax',
                 'account_id': ref('p10051'),
-                'plus_report_line_ids': [ref('tax_report_line_sgst')],
+                'minus_report_line_ids': [ref('tax_report_line_sgst')],
             }),
             (0,0, {
                 'factor_percent': 50,
                 'repartition_type': 'tax',
                 'account_id': ref('p10052'),
-                'plus_report_line_ids': [ref('tax_report_line_cgst')],
+                'minus_report_line_ids': [ref('tax_report_line_cgst')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -1450,7 +1450,7 @@ if tax > result:result=tax</field>
                 'factor_percent': 50,
                 'repartition_type': 'tax',
                 'account_id': ref('p11232'),
-                'minus_report_line_ids': [ref('tax_report_line_sgst')],
+                'plus_report_line_ids': [ref('tax_report_line_sgst')],
             }),
             (0,0, {
                 'factor_percent': 50,


### PR DESCRIPTION
tax report line is impacted positively by both invoice and refund it's wrong.
so change report line,  + for invoices and - for refunds

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
