### PR TITLE
[IMP] base_vat: no reason it should depend on account

### DIFF
--- a/addons/base_vat/__manifest__.py
+++ b/addons/base_vat/__manifest__.py
@@ -34,7 +34,7 @@ Supported countries currently include EU countries, and a few non-EU countries
 such as Chile, Colombia, Mexico, Norway or Russia. For unsupported countries,
 only the country code will be validated.
     """,
-    'depends': ['account'],
+    'depends': ['base'],
     'data': [
         'views/res_company_views.xml',
         'views/res_partner_views.xml',


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

base_vat depends on account, but we would like to have l10n_xx_base modules extending this behaviour and those modules don't depend on account.  

Current behavior before PR:
depends on account
Desired behavior after PR is merged:
only depends on base



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
