### PR TITLE
[FIX] stock: moves w/h package unlink management

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -654,7 +654,9 @@ class Picking(models.Model):
             picking.move_ids_without_package = move_ids_without_package.filtered(lambda ml: ml.scrapped == False)
 
     def _set_move_without_package(self):
-        self.move_lines |= self.move_ids_without_package
+        package_move_lines = self.move_lines.filtered(lambda m: m.package_level_id or (m.state in ('assigned', 'done') and all(ml.package_level_id for ml in m.move_line_ids)))
+        (self.move_lines - (self.move_ids_without_package | package_move_lines)).unlink()
+        self.move_lines = self.move_ids_without_package | package_move_lines
 
     def _check_move_lines_map_quant_package(self, package):
         """ This method checks that all product of the package (quant) are well present in the move_line_ids of the picking. """


### PR DESCRIPTION
Usecase to reproduce:
- Create a picking with 2 moves
- Confirm the picking
- Edit -> delete a move -> Save

-> The move unlinked is readded in the picking after the save.

It happens because the write receive the unlink for the
move_ids_without_package. It trigger the inverse function that will
do a |= on move_lines. However move_lines still contains the deleted
records which result as stock_move(1, 2) |= stock_move(1). So the
move is not removed from the real one2many move_lines and is not
unlink.

This commit modify the inverse field in order to save the change on
move_ids_without_package and ignore move with a package by automatically
keeping them in the move_lines.