### PR TITLE
[FIX] web: fix BasicModel not sending REMOVE_ALL for one2many

### DIFF
--- a/addons/web/static/tests/fields/relational_fields_tests.js
+++ b/addons/web/static/tests/fields/relational_fields_tests.js
@@ -6235,8 +6235,8 @@ QUnit.module('relational_fields', {
             mockRPC: function (method, args) {
                 if (args.method === 'write') {
                     assert.deepEqual(args.args[1].p, [
-                        [0, args.args[1].p[0][1], {display_name: 'z'}],
-                        [2, 2, false],
+                        [5, false, false],
+                        [0, args.args[1].p[1][1], {display_name: 'z'}],
                     ], "correct commands should be sent");
                 }
                 return this._super.apply(this, arguments);


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- Duplicate tax lines appearing on invoices

Quick summary:
- onchange() is sending [(5, 0), (0, 0, {...}), (0, 0, {...})] # ok
- web BasicModel is issues (for write/create) [(0, 0, {...}), (0, 0, {...}), (2, old_id1), (2, old_id2)] # not ok

Current behavior before PR:

Tested on runbot (odoo 11.0 & 12.0):
- Take a draft invoice, ensure there is 1 line with a tax.
- [TAB1] Open the invoice in form view
- [TAB2] Open the same invoice in form view
- [TAB1] Edit an invoice line, change the quantity (onchange() is call and update the tax lines) (Note: Do not save it now)
- [TAB2] Do the same operation, edit  and change quantity on an invoice line
- [TAB1] Save
- [TAB2] Save
- *We now have duplicate taxes lines on the invoices*

Desired behavior after PR is merged:

- Multiple users editing the same invoice should not create duplicate tax lines (last save should win)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
