### PR TITLE
[FIX] website_mail: Portal messages hidden after website install

### DIFF
--- a/addons/website_mail/__init__.py
+++ b/addons/website_mail/__init__.py
@@ -3,3 +3,10 @@
 
 from . import controllers
 from . import models
+
+from odoo import api, SUPERUSER_ID
+
+
+def post_init_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env['mail.message'].search([('model', '=', 'sale.order')]).write({'website_published': True})

--- a/addons/website_mail/__manifest__.py
+++ b/addons/website_mail/__manifest__.py
@@ -21,4 +21,5 @@ It is responsible of comments moderation for published documents (forum, slides,
     ],
     'installable': True,
     'auto_install': True,
+    'post_init_hook': 'post_init_hook',
 }


### PR DESCRIPTION
Steps to reproduce the bug:
- Start on a base runbot
- Install sale_management
- Add a message on the chatter of a sales order
- View the same order from the portal as public user with access token
- The chatter messages are visible
- Now install website
- Refresh the page with the order as public user

Bug:

- The messages became invisible

opw:2043131