### PR TITLE
[IMP] website_slides_survey: allow certification creation form the frontend

### DIFF
--- a/addons/website_profile/views/website_profile.xml
+++ b/addons/website_profile/views/website_profile.xml
@@ -365,10 +365,12 @@
                         <div class="card">
                             <div class="card-body p-2 pr-3">
                                 <div class="media align-items-center">
-                                  <img width="38" height="38" t-att-src="website.image_url(badge.badge_id, 'image_128')" class="o_object_fit_cover mr-0"/>
-                                  <div class="media-body col-md-10 p-0">
-                                    <h6 class="my-0 text-truncate" t-field="badge.badge_id.name"/>
-                                  </div>
+                                    <img t-if="not badge.badge_id.image_1920 and badge.badge_id.level" width="38" height="38" t-attf-src="/website_profile/static/src/img/badge_#{badge.badge_id.level}.svg"
+                                        class="my-1" t-att-alt="badge.badge_id.name"/>
+                                    <img t-else="" width="38" height="38" t-att-src="website.image_url(badge.badge_id, 'image_128')" class="o_object_fit_cover mr-0"/>
+                                    <div class="media-body col-md-10 p-0">
+                                        <h6 class="my-0 pl-1 text-truncate" t-field="badge.badge_id.name"/>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/addons/website_slides/static/src/js/slides_upload.js
+++ b/addons/website_slides/static/src/js/slides_upload.js
@@ -145,7 +145,7 @@ var SlideUploadDialog = Dialog.extend({
 
         if (this.file.type === 'application/pdf') {
             _.extend(values, {
-                'image': canvas.toDataURL().split(',')[1],
+                'image_1920': canvas.toDataURL().split(',')[1],
                 'slide_type': canvas.height > canvas.width ? 'document' : 'presentation',
                 'mime_type': this.file.type,
                 'datas': this.file.data
@@ -153,7 +153,7 @@ var SlideUploadDialog = Dialog.extend({
         } else if (values['slide_type'] === 'webpage') {
             _.extend(values, {
                 'mime_type': 'text/html',
-                'image': this.file.type === 'image/svg+xml' ? this._svgToPng() : this.file.data,
+                'image_1920': this.file.type === 'image/svg+xml' ? this._svgToPng() : this.file.data,
             });
         } else if (/^image\/.*/.test(this.file.type)) {
             if (values['slide_type'] === 'presentation') {
@@ -164,7 +164,7 @@ var SlideUploadDialog = Dialog.extend({
                 });
             } else {
                 _.extend(values, {
-                    'image': this.file.type === 'image/svg+xml' ? this._svgToPng() : this.file.data,
+                    'image_1920': this.file.type === 'image/svg+xml' ? this._svgToPng() : this.file.data,
                 });
             }
         }

--- a/addons/website_slides/static/src/xml/website_slides_upload.xml
+++ b/addons/website_slides/static/src/xml/website_slides_upload.xml
@@ -73,7 +73,7 @@
         <div class="form-group">
             <label for="duration" class="col-form-label">Duration</label>
             <div class="input-group">
-                <input type="number" id="duration" name="duration" placeholder="Estimated slide completion time" class="form-control"/>
+                <input type="number" id="duration" min="0" name="duration" placeholder="Estimated slide completion time" class="form-control"/>
                     <div class="input-group-prepend">
                     <span class="input-group-text">Minutes</span>
                 </div>
@@ -91,7 +91,7 @@
                     <div id="o_wslides_js_slide_upload_left_column" class="col">
                         <div class="form-group">
                             <label for="upload" class="col-form-label">Choose a PDF or an Image</label>
-                            <input id="upload" name="file" class="form-control" accept="image/*,application/pdf" type="file" required="required"/>
+                            <input class="form-control o_wslides_js_slide_upload_input" name="file" accept="image/*,application/pdf" type="file" required="required"/>
                         </div>
                         <canvas id="data_canvas" class="d-none"></canvas>
                         <t t-call="website.slide.upload.modal.common"/>
@@ -115,7 +115,7 @@
                     <div id="o_wslides_js_slide_upload_left_column" class="col">
                         <div class="form-group">
                             <label for="upload" class="col-form-label">Choose a Cover Image</label>
-                            <input id="upload" name="file" class="form-control" accept="image/*" type="file" required="required"/>
+                            <input class="form-control o_wslides_js_slide_upload_input" name="file" accept="image/*" type="file" required="required"/>
                         </div>
                         <canvas id="data_canvas" class="d-none"></canvas>
                         <t t-call="website.slide.upload.modal.common"/>
@@ -139,7 +139,7 @@
                     <div id="o_wslides_js_slide_upload_left_column" class="col">
                         <div class="form-group">
                             <label for="url" class="col-form-label">Youtube Link</label>
-                            <input id="url" name="url" class="form-control" placeholder="Youtube Video URL" required="required"/>
+                            <input name="url" class="form-control o_wslides_js_slide_url" placeholder="Youtube Video URL" required="required"/>
                         </div>
                         <canvas id="data_canvas" class="d-none"></canvas>
                         <t t-call="website.slide.upload.modal.common"/>
@@ -192,7 +192,7 @@
                                             <h5 class="list-group-item-heading">
                                                 <label for="upload" class="col-form-label">Image File</label>
                                             </h5>
-                                            <input id="upload" name="file" class="form-control" accept="image/*,application/pdf" type="file"/>
+                                            <input class="form-control o_wslides_js_slide_upload_input" name="file" accept="image/*,application/pdf" type="file"/>
                                         </li>
                                     </ul>
                                 </div>

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -385,6 +385,7 @@
             </t>
         </ul>
         <div t-if="channel.can_upload" class="o_wslides_content_actions btn-group">
+            <div class="o_certification_upload_toast"/>
             <a  class="o_wslides_js_slide_upload mr-1 border btn btn-light bg-white"
                 role="button"
                 aria-label="Upload Presentation"

--- a/addons/website_slides_survey/__manifest__.py
+++ b/addons/website_slides_survey/__manifest__.py
@@ -24,6 +24,8 @@
         'views/website_profile.xml',
         'data/mail_template_data.xml',
         'data/gamification_data.xml',
+        'security/ir.model.access.csv',
+        'security/website_slides_survey_security.xml',
     ],
     'demo': [
         'data/survey_demo.xml',

--- a/addons/website_slides_survey/controllers/main.py
+++ b/addons/website_slides_survey/controllers/main.py
@@ -6,8 +6,10 @@ from odoo.http import request
 
 
 class WebsiteSlidesSurvey(http.Controller):
-    @http.route(['/slides_survey/certification/search_read'], type='json', auth='user', methods=['POST'], website=True)
-    def slides_certification_search_read(self, fields):
+    @http.route(['/slides_survey/certification/fetch_certification_info'], type='json', auth='user', methods=['POST'], website=True)
+    def slides_fetch_certification_info(self, fields):
+        can_create = request.env['survey.survey'].check_access_rights('create', raise_exception=False)
         return {
-            'read_results': request.env['survey.survey'].search_read([('certification', '=', True)], fields),
+            'read_results': request.env['survey.survey'].search_read([('certificate', '=', True)], fields),
+            'can_create': can_create,
         }

--- a/addons/website_slides_survey/security/website_slides_survey_security.xml
+++ b/addons/website_slides_survey/security/website_slides_survey_security.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="0">
+        <record id="rule_survey_website_publisher" model="ir.rule">
+            <field name="name">Survey: website group: access read</field>
+            <field name="model_id" ref="model_survey_survey"/>
+            <field name="groups" eval="[(4, ref('website.group_website_publisher'))]"/>
+            <field name="domain_force">[('certificate', '=', True)]</field>
+            <field name="perm_unlink" eval="0"/>
+            <field name="perm_write" eval="0"/>
+            <field name="perm_read" eval="1"/>
+            <field name="perm_create" eval="0"/>
+        </record>
+    </data>
+</odoo>

--- a/addons/website_slides_survey/static/src/js/slides_certification_upload_toast.js
+++ b/addons/website_slides_survey/static/src/js/slides_certification_upload_toast.js
@@ -1,0 +1,34 @@
+odoo.define('website_slides.certification_upload_toast', function (require) {
+'use strict';
+
+var publicWidget = require('web.public.widget');
+
+var sessionStorage = window.sessionStorage;
+var core = require('web.core');
+var _t = core._t;
+
+
+publicWidget.registry.CertificationUploadToast = publicWidget.Widget.extend({
+    selector: '.o_certification_upload_toast',
+    
+    /**
+     * @private
+     */
+    start: function () {
+        var self = this;
+        this._super.apply(this, arguments).then(function () {
+            var url = sessionStorage.getItem("certification_toast");
+            if (url) {
+                var message = _.str.sprintf(_t('Follow this link to add questions to your certification. <a href="%s">Edit certification</a>'), url);
+                self.displayNotification({
+                    type: 'info',
+                    title: _t('Certification created'),
+                    message: message,
+                    sticky: false
+            });
+            sessionStorage.removeItem("certification_toast");
+        }
+        });
+    },
+});
+});

--- a/addons/website_slides_survey/static/src/js/slides_upload.js
+++ b/addons/website_slides_survey/static/src/js/slides_upload.js
@@ -3,12 +3,19 @@ odoo.define('website_slides_survey.upload_modal', function (require) {
 
 var core = require('web.core');
 var _t = core._t;
-var SlidesUpload = require('website_slides.upload_modal');
 
+var SlidesUpload = require('website_slides.upload_modal');
 /**
  * Management of the new 'certification' slide_type
  */
 SlidesUpload.SlideUploadDialog.include({
+    events: _.extend({}, SlidesUpload.SlideUploadDialog.prototype.events || {}, {
+        'change .o_wslides_js_slide_certification_id': '_populateWithCertificationName'
+    }),
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
     /**
      * Overridden to add the "certification" slide type
      *
@@ -31,12 +38,11 @@ SlidesUpload.SlideUploadDialog.include({
      */
     _bindSelect2Dropdown: function () {
         this._super.apply(this, arguments);
-
         var self = this;
         this.$('#certification_id').select2(this._select2Wrapper(_t('Certification'), false,
             function () {
                 return self._rpc({
-                    route: '/slides_survey/certification/search_read',
+                    route: '/slides_survey/certification/fetch_certification_info',
                     params: {
                         fields: ['title'],
                     }
@@ -56,7 +62,7 @@ SlidesUpload.SlideUploadDialog.include({
         var result = this._super.apply(this, arguments);
 
         var $certificationInput = this.$('#certification_id');
-        if ($certificationInput.length !== 0){
+        if ($certificationInput.length !== 0) {
             var $select2Container = $certificationInput
                 .closest('.form-group')
                 .find('.select2-container');
@@ -67,7 +73,6 @@ SlidesUpload.SlideUploadDialog.include({
                 $select2Container.addClass('is-valid');
             }
         }
-
         return result;
     },
     /**
@@ -76,17 +81,29 @@ SlidesUpload.SlideUploadDialog.include({
      * @override
      * @private
      */
-    _getSelect2DropdownValues: function (){
+    _getSelect2DropdownValues: function () {
         var result = this._super.apply(this, arguments);
 
         var certificateValue = this.$('#certification_id').select2('data');
-        if (certificateValue) {
-            result['survey_id'] =  certificateValue.id;
+        var survey = {};
+        if (certificateValue && certificateValue.create) {
+            survey.id = false;
+            survey.title = certificateValue.text;
+        } else if (certificateValue) {
+            survey.id = certificateValue.id;
         }
+        result['survey'] = survey;
         return result;
-    }
+    },
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+    _populateWithCertificationName: function (ev) {
+        if (ev.added) {
+            this.$("#name").val(ev.added.text);
+        }
+    },
 });
-
 SlidesUpload.websiteSlidesUpload.include({
     xmlDependencies: (SlidesUpload.websiteSlidesUpload.prototype.xmlDependencies || []).concat(
         ["/website_slides_survey/static/src/xml/website_slide_upload.xml"]

--- a/addons/website_slides_survey/static/src/scss/website_slides_survey.scss
+++ b/addons/website_slides_survey/static/src/scss/website_slides_survey.scss
@@ -6,6 +6,33 @@ $o_wss_color_2 : #485761;
 .o_wss_certification_icon {
     @include size(1.4em, auto);
 }
+.img-hover{
+    .o_wss_icon_controls {
+        @include o-position-absolute(0, 0);
+        width: 100%;
+        color: white;
+        left: 15px;
+        width: calc(100% - 30px);
+        background-color: $o-enterprise-primary-color;
+        opacity: 0;
+        transition: opacity ease 400ms;
+
+        > button.fa {
+            border: none;
+            background-color: transparent;
+        }
+        > .fa {
+            margin-top: 5px;
+            margin-bottom: 5px;
+            margin-right: 5px;
+            cursor: pointer;
+        }
+    }
+    
+    &:hover .o_wss_icon_controls {
+        opacity: 0.8;
+    }
+}
 
 // Course page
 // **************************************************

--- a/addons/website_slides_survey/static/src/xml/website_slide_upload.xml
+++ b/addons/website_slides_survey/static/src/xml/website_slide_upload.xml
@@ -3,33 +3,28 @@
     <t t-name="website.slide.upload.modal.certification">
         <div>
             <form class="clearfix">
-                <div class="form-group row">
-                    <label for="certification_id" class="col-form-label col-md-3">Certification</label>
-                    <div class="controls col-md-9">
-                        <input class="form-control" id="certification_id" required="required"/>
+                <div class="row">
+                    <div class="col" id="o_wslides_js_slide_upload_left_column">
+                        <div class="form-group">
+                            <label for="certification_id" class="col-form-label col-md-3">Certification</label>
+                            <input id="certification_id" class="form-control o_wslides_js_slide_certification_id" required="required"/>
+                        </div>
+                        <div class="form-group">
+                            <label for="upload" class="col-form-label">Choose an Image</label>
+                            <input class="form-control o_wslides_js_slide_upload_input" data-prevent-onchange='true' name="file" accept="image/*" type="file" required="required"/>
+                        </div>
+                        <t t-call="website.slide.upload.modal.common"/>
+                        <canvas id="data_canvas" class="d-none"></canvas>
                     </div>
-                </div>
-                <t t-call="website.slide.upload.modal.common"/>
-                <div class="form-group row">
-                    <div class="col-md-4">
+ 
+                    <div id="o_wslides_js_slide_upload_preview_column" class="col-md-6 d-none">
                         <div class="img-thumbnail">
                             <div class="o_slide_preview">
                                 <img src="/website_slides/static/src/img/document.png" id="slide-image" title="Content Preview" alt="Content Preview" class="img-fluid"/>
                             </div>
                         </div>
-                    </div>
-                    <div class="col-md-8">
-                        <ul class="list-group">
-                            <li class="list-group-item">
-                                <h5 class="list-group-item-heading">
-                                    <label for="upload" class="col-form-label">Cover Image File</label>
-                                </h5>
-                                <input id="upload" name="file" class="form-control" accept="image/*" type="file" required="required" data-prevent-onchange="1"/>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-                <canvas id="data_canvas" class="d-none"></canvas>
+                    </div>        
+                </div>  
             </form>
         </div>
     </t>

--- a/addons/website_slides_survey/views/assets.xml
+++ b/addons/website_slides_survey/views/assets.xml
@@ -8,6 +8,7 @@
             <xpath expr="//script[last()]" position="after">
                 <script type="text/javascript" src="/website_slides_survey/static/src/js/slides_upload.js"/>
                 <script type="text/javascript" src="/website_slides_survey/static/src/js/slides_course_fullscreen_player.js"/>
+                <script type="text/javascript" src="/website_slides_survey/static/src/js/slides_certification_upload_toast.js"/>
             </xpath>
         </template>
     </data>


### PR DESCRIPTION
Before, you had to create a certification in the backend before adding it
to a course. Now, when you create a new certification, you can choose an
existing one or create a new one. If you create a new one, you are redirected
on the backend to complete the survey after the creation of the slide.
A member of website_publisher without right on survey can now add a certification
only if there was already one available. If there is no certification, a simple message
is displayed to the user. It is now possible to add/create a badge to a certification in the frontend




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
