### PR TITLE
[IMP] website_slides : Add remove button to attendee tree view

### DIFF
--- a/addons/website_slides/views/res_partner_views.xml
+++ b/addons/website_slides/views/res_partner_views.xml
@@ -28,9 +28,4 @@
         </field>
     </record>
 
-    <record id="res_partner_action_slide_channel" model="ir.actions.act_window">
-        <field name="name">Attendees</field>
-        <field name="res_model">res.partner</field>
-        <field name="view_mode">kanban,tree,form</field>
-    </record>
 </data></odoo>

--- a/addons/website_slides/views/slide_channel_partner_views.xml
+++ b/addons/website_slides/views/slide_channel_partner_views.xml
@@ -29,8 +29,16 @@
                     <field name="partner_id" string="Contact"/>
                     <field name="partner_email"/>
                     <field name="channel_id" string="Channel" invisible="context.get('default_channel_id',False)" />
+                    <button name="unlink" class="text-danger" string="Remove" 
+                            icon="fa-times-circle" type="object"/>
                 </tree>
             </field>
+        </record>
+
+        <record id="slide_channel_partner_action" model="ir.actions.act_window">
+            <field name="name">Attendees</field>
+            <field name="res_model">slide.channel.partner</field>
+            <field name="view_mode">tree,form</field>
         </record>
     </data>
 </odoo>


### PR DESCRIPTION
In order to easily remove a attendee from a channel,
we add a button in the attendee tree view accessible from a channel.
Remove a slide_channel_partner, remove also
related slide_slide_partner.

TASK-ID : 2045620

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
