### PR TITLE
[IMP] base_vat: and auto vat format for Chile and Colombian

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -212,26 +212,6 @@ class ResPartner(models.Model):
         checksum = extra + sum((8-i) * int(x) for i, x in enumerate(vat[:7]))
         return 'WABCDEFGHIJKLMNOPQRSTUV'[checksum % 23]
 
-    def check_vat_co(self, rut):
-        '''
-        Check Colombian RUT number.
-        Method copied from vatnumber 1.2 lib https://code.google.com/archive/p/vatnumber/
-        '''
-        if len(rut) != 10:
-            return False
-        try:
-            int(rut)
-        except ValueError:
-            return False
-        nums = [3, 7, 13, 17, 19, 23, 29, 37, 41, 43, 47, 53, 59, 67, 71]
-        sum = 0
-        for i in range(len(rut) - 2, -1, -1):
-            sum += int(rut[i]) * nums[len(rut) - 2 - i]
-        if sum % 11 > 1:
-            return int(rut[-1]) == 11 - (sum % 11)
-        else:
-            return int(rut[-1]) == sum % 11
-
     def check_vat_ie(self, vat):
         """ Temporary Ireland VAT validation to support the new format
         introduced in January 2013 in Ireland, until upstream is fixed.
@@ -494,6 +474,12 @@ class ResPartner(models.Model):
         if format_func:
             vat_number = format_func(vat_number)
         return vat_country.upper() + vat_number
+
+    def format_vat_cl(self, vat):
+        return stdnum.util.get_cc_module('cl','vat').format(vat)
+
+    def format_vat_co(self, vat):
+        return stdnum.util.get_cc_module('co','vat').format(vat)
 
     @api.model_create_multi
     def create(self, vals_list):


### PR DESCRIPTION
format vat using stdnum library as presented by the Government
remove custom vat check for Colombian(check_vat_co) because stdnum library have vat check for Colombian
another reason to remove is that custom vat have commented that this method is copied from outdated vatnumber library

task-2029742






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
