### PR TITLE
POC add property list view to property fields

### DIFF
--- a/addons/web/static/src/js/fields/abstract_field.js
+++ b/addons/web/static/src/js/fields/abstract_field.js
@@ -30,6 +30,7 @@ odoo.define('web.AbstractField', function (require) {
  * @module web.AbstractField
  */
 
+var config = require('web.config');
 var field_utils = require('web.field_utils');
 var Widget = require('web.Widget');
 
@@ -42,13 +43,12 @@ var PropertyFieldMixin = {
      * @private
      * @returns {jQuery}
      */
-    _renderPropertyButton: function () {
-        if (this.field.company_dependent === true) {
+    _renderPropertyButton() {
+        if (config.isDebug() && this.field.company_dependent === true && this.$el && !this.$('.o_field_property').length) {
             return $('<button>', {
-                    type: 'button',
-                    'class': 'o_field_property fa fa-th-list btn btn-link',
-                })
-                .on('click', this._propertyButtonClick.bind(this));
+                type: 'button',
+                class: 'o_field_property fa fa-th-list btn btn-link',
+            }).on('click', this._propertyButtonClick.bind(this));
         }
         return $();
     },
@@ -58,11 +58,11 @@ var PropertyFieldMixin = {
     //--------------------------------------------------------------------------
 
     /**
-     * open the translation view for the current field
+     * open the property view for the current field
      *
      * @private
      */
-    _propertyButtonClick: function () {
+    _propertyButtonClick() {
         this.trigger_up('open_property', {fieldName: this.name, id: this.dataPointID});
     },
 };

--- a/addons/web/static/src/js/views/basic/basic_controller.js
+++ b/addons/web/static/src/js/views/basic/basic_controller.js
@@ -562,7 +562,7 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
     _onDeletedRecords: function (ids) {
         this.update({});
     },
-    _onOpenProperty: function (ev) {
+    _onOpenProperty(ev) {
         ev.stopPropagation();
         var self = this;
         var record = this.model.get(ev.data.id, {raw: true});
@@ -570,7 +570,7 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
             route: '/web/dataset/call_button',
             params: {
                 model: 'ir.property',
-                method: 'get_values_action',
+                method: 'action_view_property',
                 args: [record.model, record.res_id, ev.data.fieldName],
                 kwargs: {context: record.getContext()},
             }

--- a/addons/web/static/src/js/views/basic/basic_controller.js
+++ b/addons/web/static/src/js/views/basic/basic_controller.js
@@ -19,6 +19,7 @@ var _t = core._t;
 var BasicController = AbstractController.extend(FieldManagerMixin, {
     custom_events: _.extend({}, AbstractController.prototype.custom_events, FieldManagerMixin.custom_events, {
         discard_changes: '_onDiscardChanges',
+        open_property: '_onOpenProperty',
         reload: '_onReload',
         resequence_records: '_onResequenceRecords',
         set_dirty: '_onSetDirty',
@@ -560,6 +561,22 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
      */
     _onDeletedRecords: function (ids) {
         this.update({});
+    },
+    _onOpenProperty: function (ev) {
+        ev.stopPropagation();
+        var self = this;
+        var record = this.model.get(ev.data.id, {raw: true});
+        this._rpc({
+            route: '/web/dataset/call_button',
+            params: {
+                model: 'ir.property',
+                method: 'get_values_action',
+                args: [record.model, record.res_id, ev.data.fieldName],
+                kwargs: {context: record.getContext()},
+            }
+        }).then(function (result) {
+            self.do_action(result);
+        });
     },
     /**
      * Saves the record whose ID is given, if necessary. Automatically leaves

--- a/addons/web/static/src/scss/fields.scss
+++ b/addons/web/static/src/scss/fields.scss
@@ -65,6 +65,20 @@
         }
     }
 
+    // Many2one property field
+    &.o_field_many2one_property {
+        .o_input_dropdown {
+            width: 93%;
+        }
+        &.o_with_button .o_field_property {
+            padding-left: 2px !important;
+            border: none;
+            &:hover {
+                background-color: transparent;
+            }
+        }
+    }
+
     // Text
     &.o_field_text, &.oe_form_field_text .oe_form_text_content {
         width: 100%;

--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -731,7 +731,7 @@
         <a t-if="!widget.noOpen" t-att-tabindex="widget.attrs.tabindex" class="o_form_uri" href="#"/>
         <span t-if="widget.noOpen"/>
     </t>
-    <div t-if="widget.mode === 'edit'" class="o_field_widget o_field_many2one" aria-atomic="true">
+    <div t-if="widget.mode === 'edit'" t-attf-class="o_field_widget o_field_many2one {{widget.field.company_dependent ? 'o_field_many2one_property' : ''}}" aria-atomic="true">
         <div class="o_input_dropdown">
             <input type="text" class="o_input"
                 t-att-barcode_events="widget.nodeOptions.barcode_events"

--- a/odoo/addons/base/models/ir_property.py
+++ b/odoo/addons/base/models/ir_property.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import json
+from lxml import etree
+
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.tools import ormcache
@@ -244,6 +247,43 @@ class Property(models.Model):
             return None
         company_id = self.env.company.id
         return [('fields_id', '=', res[0]), ('company_id', 'in', [company_id, False])]
+
+    @api.model
+    def get_values_action(self, model, res_id, field):
+        action = self.env.ref('base.ir_property_form').read()[0]
+        action['domain'] = [
+            ('name', '=', field),
+            ('res_id', '=', '%s,%s' % (model, res_id)),
+        ]
+        field_name = ''
+
+        # This gives at most one record per company
+        types = set(self.search(action['domain']).mapped('type'))
+        if len(types) == 1:
+            if types & {'integer', 'boolean'}:
+                field_name = 'value_integer'
+            elif types & {'float'}:
+                field_name = 'value_float'
+            elif types & {'char', 'text', 'selection'}:
+                field_name = 'value_text'
+            elif types & {'many2one'}:
+                field_name = 'value_reference'
+            elif types & {'binary'}:
+                field_name = 'value_binary'
+
+        if field_name:
+            action['context'] = json.dumps(dict(json.loads(action.get('context', '{}')), field_name=field_name))
+        return action
+
+    @api.model
+    def fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
+        res = super().fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
+        if view_type == 'tree' and self._context.get('field_name'):
+            doc = etree.XML(res['arch'])
+            element = etree.Element('field', {'name': self._context.get('field_name')})
+            doc.xpath("//field[@name='type']")[0].addnext(element)
+            res['arch'] = etree.tostring(doc, encoding='unicode')
+        return res
 
     @api.model
     def get_multi(self, name, model, ids):

--- a/odoo/addons/base/views/ir_property_views.xml
+++ b/odoo/addons/base/views/ir_property_views.xml
@@ -52,6 +52,12 @@
                     <field name="fields_id"/>
                     <field name="res_id"/>
                     <field name="type"/>
+                    <field name="value_integer" string="Value" invisible="not context.get('value_integer')"/>
+                    <field name="value_float" string="Value" invisible="not context.get('value_float')"/>
+                    <field name="value_datetime" string="Value" invisible="not context.get('value_datetime')"/>
+                    <field name="value_text" string="Value" invisible="not context.get('value_text')"/>
+                    <field name="value_reference" string="Value" invisible="not context.get('value_reference')"/>
+                    <field name="value_binary" string="Value" invisible="not context.get('value_binary')"/>
                 </tree>
             </field>
         </record>


### PR DESCRIPTION
In order to ease the debugging of ir.property fields, we should be able to easily see the values of those fields for each company.
This is done by adding a small button next to the field that leads to a tree view which will display the values for each company

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
