### PR TITLE
[FIX] web: quick create in kanban view

### DIFF
--- a/addons/web/static/src/js/views/kanban/kanban_column.js
+++ b/addons/web/static/src/js/views/kanban/kanban_column.js
@@ -219,8 +219,11 @@ var KanbanColumn = Widget.extend({
      * Closes the quick create widget if it isn't dirty.
      */
     cancelQuickCreate: function () {
+        var self = this;
         if (this.quickCreateWidget) {
-            this.quickCreateWidget.cancel();
+            this.quickCreateWidget.cancel(true).then(function () {
+                self._cancelQuickCreate();
+            });
         }
     },
     /**

--- a/addons/web/static/src/js/views/kanban/kanban_record_quick_create.js
+++ b/addons/web/static/src/js/views/kanban/kanban_record_quick_create.js
@@ -115,10 +115,10 @@ var RecordQuickCreate = Widget.extend({
      * @private
      * @returns {Promise}
      */
-    cancel: function () {
+    cancel: function (doNotTriggerCancel) {
         var self = this;
         return this.controller.commitChanges().then(function () {
-            if (!self.controller.isDirty()) {
+            if (!self.controller.isDirty() && !doNotTriggerCancel) {
                 self._cancel();
             }
         });

--- a/addons/web/static/tests/views/kanban_tests.js
+++ b/addons/web/static/tests/views/kanban_tests.js
@@ -918,6 +918,42 @@ QUnit.module('Views', {
         kanban.destroy();
     });
 
+    QUnit.test('quick create record: cancel quick create by clicking on add button on second column', async function (assert) {
+        assert.expect(3);
+
+        // var nbRecords = 4;
+        var kanban = await createView({
+            View: KanbanView,
+            model: 'partner',
+            data: this.data,
+            arch: '<kanban on_create="quick_create">' +
+                        '<field name="bar"/>' +
+                        '<templates><t t-name="kanban-box">' +
+                        '<div><field name="foo"/></div>' +
+                    '</t></templates></kanban>',
+            groupBy: ['bar'],
+        });
+
+        // click to add an element and cancel the quick creation by clicking on second column add icon
+        await testUtils.dom.click(kanban.$('.o_kanban_header .o_kanban_quick_add i').first());
+
+        var $quickCreate = kanban.$('.o_kanban_group:first .o_kanban_quick_create');
+        assert.strictEqual($quickCreate.length, 1,
+            "should have a quick create element in first kanban group");
+
+        await testUtils.dom.click(kanban.$('.o_kanban_header .o_kanban_quick_add i').eq(1));
+
+        $quickCreate = kanban.$('.o_kanban_group:first .o_kanban_quick_create');
+        assert.strictEqual($quickCreate.length, 0,
+            "should not have a quick create element in first kanban group");
+
+        $quickCreate = kanban.$('.o_kanban_group:eq(1) .o_kanban_quick_create');
+        assert.strictEqual($quickCreate.length, 1,
+            "should have a quick create element in second kanban group");
+
+        kanban.destroy();
+    });
+
     QUnit.test('quick create record: validate with ENTER', async function (assert) {
         // in this test, we accurately mock the behavior of the webclient by specifying a
         // fieldDebounce > 0, meaning that the changes in an InputField aren't notified to the model


### PR DESCRIPTION
quick create in kanban view throws traceback when quick create is open
and click + icon to open quick create in second column

pad- https://pad.odoo.com/p/r.8c834b53265c8b32cfc319cee53455da
task- https://www.odoo.com/web#id=2042919&action=333&active_id=1691&model=project.task&view_type=form&menu_id=4720

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
