### PR TITLE
[FIX] website_slides: improve z-index of fullscreen slide

### DIFF
--- a/addons/website_slides/static/src/scss/slides_slide_fullscreen.scss
+++ b/addons/website_slides/static/src/scss/slides_slide_fullscreen.scss
@@ -1,7 +1,7 @@
 
 .o_wslides_fs_main {
     @include o-position-absolute(0,0,0,0);
-    z-index: $zindex-dropdown - 1;
+    z-index: $zindex-dropdown;
     background-image: linear-gradient(120deg, $o-wslides-color-dark2, $o-wslides-color-dark3);
 
     .o_wslides_slide_fs_header {
@@ -113,5 +113,11 @@
         &.completed-disabled{
             pointer-events: none;
         }
+    }
+}
+
+.modal-open {
+    > .modal-backdrop {
+        z-index: $zindex-dropdown - 1;
     }
 }


### PR DESCRIPTION
Before, Once quiz is completed in website slide fullscreen view, A pop-up
is displayed, that makes a black overlay on full-screen, so that we can not
click anywhere on the screen.

Now, updating z-index value fix the issue and make screen clickable.

Task: 2044221
