### PR TITLE
[FIX] translate: fix re for model_terms xmlid support hyphen(-)

### DIFF
--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -542,7 +542,7 @@ class PoFileReader:
             translation = entry.msgstr
             found_code_occurrence = False
             for occurrence, line_number in entry.occurrences:
-                match = re.match(r'(model|model_terms):([\w.]+),([\w]+):(\w+)\.(\w+)', occurrence)
+                match = re.match(r'(model|model_terms):([\w.]+),([\w]+):(\w+)\.([\w+\-]+)', occurrence)
                 if match:
                     type, model_name, field_name, module, xmlid = match.groups()
                     yield {


### PR DESCRIPTION
===================
before this commit
===================

Translation broken when xml id have hyphen(-)
because of the regular expression is trim the xmlid after hyphen(-)

=================
After this commit
=================

Translation also work when xml id have hyphen(-)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
