### PR TITLE
[FIX] purchase: PO stat button in product views

### DIFF
--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -36,14 +36,14 @@
                 <field name="barcode" attrs="{'invisible': [('product_variant_count', '>', 1)]}"/>
             </field>
 
-            <div name="button_box" position="inside">
+            <xpath expr="//div[@name='button_box']" position="inside">
                 <button name="%(product.product_variant_action)d" type="action"
                     icon="fa-sitemap" class="oe_stat_button"
                     attrs="{'invisible': [('product_variant_count', '&lt;=', 1)]}"
                     groups="product.group_product_variant">
                     <field string="Variants" name="product_variant_count" widget="statinfo" />
                 </button>
-            </div>
+            </xpath>
 
             <xpath expr="//page[@name='general_information']" position="after">
                 <page name="variants" string="Variants" groups="product.group_product_variant">

--- a/addons/purchase/views/product_views.xml
+++ b/addons/purchase/views/product_views.xml
@@ -71,7 +71,7 @@
             <field name="inherit_id" ref="product.product_template_only_form_view"/>
             <field name="groups_id" eval="[(4, ref('purchase.group_purchase_user'))]"/>
             <field name="arch" type="xml">
-                <div name="button_box" position="inside">
+                <xpath expr="//div[@name='button_box']" position="inside">
                     <button class="oe_stat_button" name="action_view_po"
                         type="object" icon="fa-shopping-cart" attrs="{'invisible': [('purchase_ok', '=', False)]}" help="Purchased in the last 365 days">
                         <div class="o_field_widget o_stat_info">
@@ -82,7 +82,7 @@
                             <span class="o_stat_text">Purchased</span>
                         </div>
                     </button>
-                </div>
+                </xpath>
             </field>
         </record>
 
@@ -103,7 +103,7 @@
             <field name="inherit_id" ref="product.product_normal_form_view"/>
             <field name="groups_id" eval="[(4, ref('purchase.group_purchase_user'))]"/>
             <field name="arch" type="xml">
-                <div name="button_box" position="inside">
+                <xpath expr="//div[@name='button_box']" position="inside">
                     <button class="oe_stat_button" name="action_view_po"
                         type="object" icon="fa-shopping-cart" attrs="{'invisible': [('purchase_ok', '=', False)]}" help="Purchased in the last 365 days">
                         <div class="o_field_widget o_stat_info">
@@ -114,7 +114,7 @@
                             <span class="o_stat_text">Purchased</span>
                         </div>
                     </button>
-                </div>
+                </xpath>
             </field>
         </record>
 

--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -1027,7 +1027,7 @@
             <field name="inherit_id" ref="product.product_normal_form_view"/>
             <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
             <field name="arch" type="xml">
-                <div name="button_box" position="inside">
+                <xpath expr="//div[@name='button_box']" position="inside">
                     <button class="oe_stat_button" name="action_view_sales"
                         type="object" icon="fa-signal" groups="sales_team.group_sale_salesman" help="Sold in the last 365 days" attrs="{'invisible': [('sale_ok', '=', False)]}">
                         <div class="o_field_widget o_stat_info">
@@ -1038,7 +1038,7 @@
                             <span class="o_stat_text">Sold</span>
                         </div>
                     </button>
-                </div>
+                </xpath>
                 <group name="description" position="after">
                     <group string="Warning when Selling this Product" groups="sale.group_warning_sale">
                         <field name="sale_line_warn" nolabel="1"/>
@@ -1055,7 +1055,7 @@
             <field name="inherit_id" ref="product.product_template_only_form_view"/>
             <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
             <field name="arch" type="xml">
-                <div name="button_box" position="inside">
+                <xpath expr="//div[@name='button_box']" position="inside">
                     <button class="oe_stat_button" name="action_view_sales"
                         type="object" icon="fa-signal" groups="sales_team.group_sale_salesman" help="Sold in the last 365 days" attrs="{'invisible': [('sale_ok', '=', False)]}">
                         <div class="o_field_widget o_stat_info">
@@ -1066,14 +1066,14 @@
                             <span class="o_stat_text">Sold</span>
                         </div>
                     </button>
-                </div>
-                <group name="description" position="after">
+                </xpath>
+                <xpath expr="//group[@name='description']" position="after">
                     <group string="Warning when Selling this Product" groups="sale.group_warning_sale">
                         <field name="sale_line_warn" nolabel="1"/>
                         <field name="sale_line_warn_msg" colspan="3" nolabel="1"
                                 attrs="{'required':[('sale_line_warn','!=','no-message')],'readonly':[('sale_line_warn','=','no-message')], 'invisible':[('sale_line_warn','=','no-message')]}"/>
                     </group>
-                </group>
+                </xpath>
             </field>
         </record>
 

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -183,13 +183,13 @@
                             attrs="{'invisible': [('type', '!=', 'product')]}"/>
                     </header>
                 </sheet>
-                <div name="button_box" position="inside">
+                <xpath expr="//div[@name='button_box']" position="inside">
                     <button string="Putaway Rules" type="object"
                         name="action_view_related_putaway_rules"
                         class="oe_stat_button" icon="fa-random" groups="stock.group_stock_multi_locations"
                         attrs="{'invisible': [('type', '=', 'service')]}"
                         context="{'invisible_handle': True, 'single_product': True}"/>
-                </div>
+                </xpath>
             </field>
         </record>
 
@@ -211,7 +211,7 @@
                             groups="stock.group_stock_user"
                             attrs="{'invisible': [('type', '!=', 'product')]}"/>
                     </header>
-                    <div name="button_box" position="inside">
+                    <xpath expr="//div[@name='button_box']" position="inside">
                         <button class="oe_stat_button"
                                name="action_open_quants"
                                icon="fa-cubes"
@@ -279,7 +279,7 @@
                             class="oe_stat_button" icon="fa-random" groups="stock.group_stock_multi_locations"
                             attrs="{'invisible': [('type', '=', 'service')]}"
                             context="{'invisible_handle': True, 'single_product': True}"/>
-                    </div>
+                    </xpath>
                     <xpath expr="//field[@name='product_tmpl_id']" position="attributes">
                         <attribute name="context">{'quantity_available_locations_domain': ('internal',)}</attribute>
                     </xpath>
@@ -305,7 +305,7 @@
                             groups="stock.group_stock_user"
                             attrs="{'invisible': [('type', '!=', 'product')]}"/>
                     </header>
-                    <div name="button_box" position="inside">
+                    <xpath expr="//div[@name='button_box']" position="inside">
                         <button type="object"
                             name="action_open_quants"
                             attrs="{'invisible':[('type', '!=', 'product')]}"
@@ -377,7 +377,7 @@
                                 'invisible_handle': True,
                                 'single_product': product_variant_count == 1,
                             }"/>
-                    </div>
+                    </xpath>
 
                     <!-- change attrs of fields added in view_template_property_form
                     to restrict the display for templates -->

--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -98,9 +98,9 @@
             <xpath expr="//group[@name='description']" position="attributes">
                 <attribute name="invisible">0</attribute>
             </xpath>
-            <div name="button_box" position="inside">
+            <xpath expr="//div[@name='button_box']" position="inside">
                 <field name="is_published" widget="website_redirect_button" attrs="{'invisible': [('sale_ok','=',False)]}"/>
-            </div>
+            </xpath>
             <xpath expr="//page[@name='sales']" position="after">
                 <page name="shop" string="eCommerce" attrs="{'invisible': [('sale_ok','=',False)]}">
                     <group name="shop">

--- a/addons/website_sale_digital/views/website_sale_digital_view.xml
+++ b/addons/website_sale_digital/views/website_sale_digital_view.xml
@@ -5,11 +5,11 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_only_form_view" />
         <field name="arch" type="xml">
-            <div name="button_box" position="inside">
+            <xpath expr="//div[@name='button_box']" position="inside">
                 <button class="oe_stat_button" name="action_open_attachments" type="object" icon="fa-file-text-o">
                     <field string="Digital Files" name="attachment_count" widget="statinfo" />
                 </button>
-            </div>
+            </xpath>
         </field>
     </record>
 
@@ -18,11 +18,11 @@
         <field name="model">product.product</field>
         <field name="inherit_id" ref="product.product_normal_form_view"/>
         <field name="arch" type="xml">
-             <div name="button_box" position="inside">
+             <xpath expr="//div[@name='button_box']" position="inside">
                 <button class="oe_stat_button" name="action_open_attachments" type="object" icon="fa-file-text-o">
                     <field string="Digital Files" name="attachment_count" widget="statinfo" />
                 </button>
-            </div>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
The stat button for the action `action_view_po` was
improperly injected in the product template views, causing studio
to crash when editing the product template form view.

TaskID: 2052317
