### PR TITLE
[IMP] rating : review Access Controll List

### DIFF
--- a/addons/rating/models/mail_message.py
+++ b/addons/rating/models/mail_message.py
@@ -12,7 +12,7 @@ class MailMessage(models.Model):
 
     @api.depends('rating_ids', 'rating_ids.rating')
     def _compute_rating_value(self):
-        ratings = self.env['rating.rating'].search([('message_id', 'in', self.ids), ('consumed', '=', True)], order='create_date DESC')
+        ratings = self.env['rating.rating'].sudo().search([('message_id', 'in', self.ids), ('consumed', '=', True)], order='create_date DESC')
         mapping = dict((r.message_id.id, r.rating) for r in ratings)
         for message in self:
             message.rating_value = mapping.get(message.id, 0.0)

--- a/addons/rating/models/mail_thread.py
+++ b/addons/rating/models/mail_thread.py
@@ -13,7 +13,7 @@ class MailThread(models.AbstractModel):
         message = super(MailThread, self).message_post(**kwargs)
         if rating_value:
             ir_model = self.env['ir.model'].sudo().search([('model', '=', self._name)])
-            self.env['rating.rating'].create({
+            self.env['rating.rating'].sudo().create({
                 'rating': float(rating_value) if rating_value is not None else False,
                 'res_model_id': ir_model.id,
                 'res_id': self.id,

--- a/addons/rating/security/ir.model.access.csv
+++ b/addons/rating/security/ir.model.access.csv
@@ -1,4 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_rating_user,rating.rating.user,rating.model_rating_rating,base.group_user,1,1,1,0
-access_rating_public,rating.rating.public,rating.model_rating_rating,base.group_public,1,1,1,0
-access_rating_portal,rating.rating.portal,rating.model_rating_rating,base.group_portal,1,1,1,0
+access_rating_public,rating.rating.public,rating.model_rating_rating,base.group_public,0,0,0,0
+access_rating_portal,rating.rating.portal,rating.model_rating_rating,base.group_portal,0,0,0,0

--- a/addons/rating/tests/__init__.py
+++ b/addons/rating/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_security

--- a/addons/rating/tests/test_security.py
+++ b/addons/rating/tests/test_security.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.exceptions import AccessError
+from odoo.tests import tagged, common, new_test_user
+from odoo.tools import mute_logger
+
+from functools import partial
+
+rating_new_test_user = partial(new_test_user, context={'mail_create_nolog': True, 'mail_create_nosubscribe': True, 'mail_notrack': True, 'no_reset_password': True})
+
+
+@tagged('security')
+class TestAccessRating(common.SavepointCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestAccessRating, cls).setUpClass()
+
+        cls.user_manager_partner = rating_new_test_user(
+            cls.env, name='Jean Admin', login='user_mana', email='admin@example.com',
+            groups='base.group_partner_manager,base.group_system'
+        )
+
+        cls.user_emp = rating_new_test_user(
+            cls.env, name='Eglantine Employee', login='user_emp', email='employee@example.com',
+            groups='base.group_user'
+        )
+
+        cls.user_portal = rating_new_test_user(
+            cls.env, name='Patrick Portal', login='user_portal', email='portal@example.com',
+            groups='base.group_portal'
+        )
+
+        cls.user_public = rating_new_test_user(
+            cls.env, name='Pauline Public', login='user_public', email='public@example.com',
+            groups='base.group_public'
+        )
+
+        cls.partner_to_rate = cls.env['res.partner'].with_user(cls.user_manager_partner).create({
+            "name": "Partner to Rate :("
+        })
+
+
+    @mute_logger('odoo.models', 'odoo.addons.base.models.ir_rule')
+    def test_rating_access(self):
+        """
+        Test that only a employee (user group) can create and write rating object
+        """
+
+        # Public and portal user can't Access direclty to the ratings
+        with self.assertRaises(AccessError):
+            self.env['rating.rating'].with_user(self.user_portal).create({
+                'res_model_id': self.env['ir.model'].sudo().search([('model', '=', 'res.partner')], limit=1).id,
+                'res_model': 'res.partner',
+                'res_id': self.partner_to_rate.id,
+                'rating': 2
+            })
+        with self.assertRaises(AccessError):
+            self.env['rating.rating'].with_user(self.user_public).create({
+                'res_model_id': self.env['ir.model'].sudo().search([('model', '=', 'res.partner')], limit=1).id,
+                'res_model': 'res.partner',
+                'res_id': self.partner_to_rate.id,
+                'rating': 5
+            })
+
+        # No error with employee
+        ratting = self.env['rating.rating'].with_user(self.user_emp).create({ 
+            'res_model_id': self.env['ir.model'].sudo().search([('model', '=', 'res.partner')], limit=1).id,
+            'res_model': 'res.partner',
+            'res_id': self.partner_to_rate.id,
+            'rating': 5
+        })
+
+        with self.assertRaises(AccessError):
+            ratting.with_user(self.user_portal).write({
+                'feedback': 'You should not pass!'
+            })
+        with self.assertRaises(AccessError):
+            ratting.with_user(self.user_public).write({ 
+                'feedback': 'You should not pass!'
+            })

--- a/addons/website_livechat/controllers/main.py
+++ b/addons/website_livechat/controllers/main.py
@@ -24,7 +24,7 @@ class WebsiteLivechat(http.Controller):
             ('res_model', '=', 'mail.channel'), ('res_id', 'in', channel.sudo().channel_ids.ids),
             ('consumed', '=', True), ('rating', '>=', 1),
         ]
-        ratings = request.env['rating.rating'].search(domain, order='create_date desc', limit=100)
+        ratings = request.env['rating.rating'].sudo().search(domain, order='create_date desc', limit=100)
         repartition = channel.sudo().channel_ids.rating_get_grades(domain=domain)
 
         # compute percentage

--- a/addons/website_slides/controllers/mail.py
+++ b/addons/website_slides/controllers/mail.py
@@ -46,7 +46,7 @@ class SlidesMail(http.Controller):
         # update rating
         if post.get('rating_value'):
             domain = [('res_model', '=', res_model), ('res_id', '=', res_id), ('website_published', '=', True), ('message_id', '=', message.id)]
-            rating = request.env['rating.rating'].search(domain, order='write_date DESC', limit=1)
+            rating = request.env['rating.rating'].sudo().search(domain, order='write_date DESC', limit=1)
             rating.write({
                 'rating': float(post['rating_value'])
             })


### PR DESCRIPTION
Before, rating model was accessible (read, write, create) by everyone
without any restriction. We change the ACLs for rating
to be accessible only by employees and by all previous
functional flow of rating model (by adding sudo).

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
