### PR TITLE
[IMP] account: unable to create customer payment

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -211,13 +211,6 @@ class account_payment(models.Model):
                 self.partner_bank_account_id = False
         return {'domain': {'partner_bank_account_id': [('partner_id', 'in', [self.partner_id.id, self.partner_id.commercial_partner_id.id])]}}
 
-    @api.onchange('partner_type')
-    def _onchange_partner_type(self):
-        self.ensure_one()
-        # Set partner_id domain
-        if self.partner_type:
-            return {'domain': {'partner_id': [(self.partner_type, '=', True)]}}
-
     @api.onchange('payment_type')
     def _onchange_payment_type(self):
         if not self.invoice_ids and not self.partner_type:


### PR DESCRIPTION
Before this task,
We were not able to create customer payment.

Reason:
The 'customer' and 'supplier' fields were removed as shown
in following commit:
https://github.com/odoo-dev/odoo/commit/3e97cff7797c4f7e695d20def6b920561b6a6525

task-https://www.odoo.com/web#id=2055695&action=327&model=project.task&view_type=form&menu_id=4720
pad- https://pad.odoo.com/p/r.797ee616bb87ff85884b23ba520c2ca3