### PR TITLE
[IMP] hr_timesheet: add id on timesheets tab

### DIFF
--- a/addons/hr_timesheet/views/project_views.xml
+++ b/addons/hr_timesheet/views/project_views.xml
@@ -56,7 +56,7 @@
                 <xpath expr="//notebook/page[@name='description_page']" position="after">
                     <field name="analytic_account_active" invisible="1"/>
                     <field name="allow_timesheets" invisible="1"/>
-                    <page string="Timesheets" attrs="{'invisible': [('allow_timesheets', '=', False)]}">
+                    <page string="Timesheets" id="timesheets_tab" attrs="{'invisible': [('allow_timesheets', '=', False)]}">
                         <group>
                             <group>
                                 <field name="planned_hours" widget="float_time"/>

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -513,6 +513,7 @@ class Task(models.Model):
         string='Customer',
         default=lambda self: self._get_default_partner(),
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
+    partner_city = fields.Char(related='partner_id.city', readonly=False)
     manager_id = fields.Many2one('res.users', string='Project Manager', related='project_id.user_id', readonly=True, related_sudo=False)
     company_id = fields.Many2one('res.company', string='Company', required=True, default=_default_company_id)
     color = fields.Integer(string='Color Index')

--- a/addons/project/report/project_report_views.xml
+++ b/addons/project/report/project_report_views.xml
@@ -72,7 +72,7 @@
                     <group expand="1" string="Group By">
                         <filter string="Project" name="project" context="{'group_by': 'project_id'}"/>
                         <filter string="Assigned to" name="User" context="{'group_by': 'user_id'}"/>
-                        <filter string="Stage" name="Stage" context="{'group_by':' stage_id'}"/>
+                        <filter string="Stage" name="Stage" context="{'group_by': 'stage_id'}"/>
                         <filter string="Assignation Date" name="assignation_month" context="{'group_by': 'date_assign:month'}"/>
                         <filter string="Company" name="company" context="{'group_by': 'company_id'}" groups="base.group_multi_company"/>
                     </group>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -564,14 +564,15 @@
                             <div class="oe_kanban_content">
                                 <div class="o_kanban_record_top">
                                     <div class="o_kanban_record_headings">
-                                        <strong class="o_kanban_record_title"><field name="name"/></strong><br/>
-                                        <small class="o_kanban_record_subtitle text-muted">
-                                            <field name="project_id" invisible="context.get('default_project_id', False)"/>
-                                        </small>
-                                        <small class="o_kanban_record_subtitle text-muted">
-                                            <t t-if="record.partner_id.value"><span><field name="partner_id"/></span></t>
-                                            <t t-else="record.email_from.raw_value"><span><field name="email_from"/></span></t>
-                                        </small>
+                                        <strong class="o_kanban_record_title"><field name="name"/></strong>
+                                        <span  invisible="context.get('default_project_id', False) or context.get('fsm_mode', False)"><br/><field name="project_id"/></span>
+                                        <br />
+                                        <t t-if="record.partner_id.value">
+                                            <span>
+                                                <field name="partner_id"/><t t-if="record.partner_city.value"> • <field name="partner_city" /></t>
+                                            </span>
+                                        </t>
+                                        <t t-else="record.email_from.raw_value"><span><field name="email_from"/></span></t>
                                     </div>
                                     <div class="o_dropdown_kanban dropdown" t-if="!selection_mode" groups="base.group_user">
                                         <a role="button" class="dropdown-toggle o-no-caret btn" data-toggle="dropdown" data-display="static" href="#" aria-label="Dropdown menu" title="Dropdown menu">
@@ -588,7 +589,7 @@
                                     </div>
                                 </div>
                                 <div class="o_kanban_record_body">
-                                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" invisible="context.get('fsm_mode', False)"/>
                                     <div t-if="record.displayed_image_id.value">
                                         <field name="displayed_image_id" widget="attachment_image"/>
                                     </div>
@@ -607,10 +608,12 @@
                                         </b>
                                         <t t-if="record.date_deadline.raw_value and moment(record.date_deadline.raw_value.toISOString()).startOf('day') lt moment().startOf('day')" t-set="deadline_class">oe_kanban_text_red</t>
                                         <t t-elif="record.date_deadline.raw_value and moment(record.date_deadline.raw_value.toISOString()).startOf('day') lt moment().endOf('day')" t-set="deadline_class">text-warning font-weight-bold</t>
-                                        <span t-attf-class="#{deadline_class || ''}"><field name="date_deadline"/></span>
+                                        <t t-if="record.date_deadline.raw_value and moment(record.date_deadline.raw_value.toISOString()).startOf('day') lt moment().startOf('day')" t-set="date" t-value="moment(record.date_deadline.raw_value.toISOString()).format('h:mm A')" />
+                                        <t t-elif="record.date_deadline.raw_value and moment(record.date_deadline.raw_value.toISOString()).startOf('day') lt moment().endOf('day')" t-set="date" t-value="moment(record.date_deadline.raw_value.toISOString()).format('h:mm A')" />
+                                        <span name="date" t-attf-class="#{deadline_class || ''}"><t t-esc="date" /></span>
                                     </div>
                                     <div class="oe_kanban_bottom_right" t-if="!selection_mode">
-                                        <field name="kanban_state" widget="state_selection" groups="base.group_user"/>
+                                        <field name="kanban_state" widget="state_selection" groups="base.group_user" invisible="context.get('fsm_mode', False)"/>
                                         <img t-att-src="kanban_image('res.users', 'image_64', record.user_id.raw_value)" t-att-title="record.user_id.value" t-att-alt="record.user_id.value" width="24" height="24" class="oe_kanban_avatar"/>
                                     </div>
                                 </div>


### PR DESCRIPTION
Add an id on the timesheet tab on Task form view in order to refine
visibility behavior of this tab from another module (industry_fsm in
enterprise). We want to be able to hide this tab for FSM tasks.

Task-2052287

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
