### PR TITLE
[FIX] base_address_extended: None values in compute should be False v…

### DIFF
--- a/addons/base_address_extended/models/base_address_extended.py
+++ b/addons/base_address_extended/models/base_address_extended.py
@@ -128,7 +128,7 @@ class Partner(models.Model):
         for partner in self:
             if not partner.street:
                 for field in street_fields:
-                    partner[field] = None
+                    partner[field] = False
                 continue
 
             street_format = (partner.country_id.street_format or
@@ -139,7 +139,7 @@ class Partner(models.Model):
             for k, v in vals.items():
                 partner[k] = v
             for k in set(street_fields) - set(vals):
-                partner[k] = None
+                partner[k] = False
 
     def write(self, vals):
         res = super(Partner, self).write(vals)


### PR DESCRIPTION
…alues to be in the cache

Description of the issue/feature this PR addresses:

Current behavior before PR:
Creating a new company on a fully installed runbot, gives errors that the streets are not correctly calculated

Desired behavior after PR is merged:
No problems with it



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
