### PR TITLE
[FIX] account: fpos country without multicompany

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -96,7 +96,7 @@ class AccountFiscalPosition(models.Model):
         if not country_id:
             return False
         base_domain = [('auto_apply', '=', True), ('vat_required', '=', vat_required)]
-        if self.env.context.get('force_company'):
+        if self.env.context.get('force_company') and self.env.user.has_group('base.group_multi_company'):
             base_domain.append(('company_id', '=', self.env.context.get('force_company')))
         null_state_dom = state_domain = [('state_ids', '=', False)]
         null_zip_dom = zip_domain = [('zip_from', '=', 0), ('zip_to', '=', 0)]

--- a/addons/account/tests/test_fiscal_position.py
+++ b/addons/account/tests/test_fiscal_position.py
@@ -125,3 +125,20 @@ class TestFiscalPosition(common.TransactionCase):
         # Dedicated position has max precedence
         george.property_account_position_id = self.be_nat
         assert_fp(george, self.be_nat, "Forced position has max precedence")
+
+    def test_20_country_multicompany_on_off(self):
+        user = self.env.user
+        company = user.company_id
+        partner = self.ben
+
+        self.assertFalse(self.be_nat.company_id)
+        self.assertFalse(user.has_group('base.group_multi_company'))
+        fpos = self.fp.with_context(force_company=company.id).get_fiscal_position(partner_id=partner.id)
+        self.assertEquals(self.be_nat.id, fpos)
+
+        user.write({
+            'groups_id': [(4, self.env.ref('base.group_multi_company').id, False)]
+        })
+        self.assertTrue(user.has_group('base.group_multi_company'))
+        fpos = self.fp.with_context(force_company=company.id).get_fiscal_position(partner_id=partner.id)
+        self.assertFalse(fpos)


### PR DESCRIPTION
Have a fiscal position that should apply when a partner belongs to a particular country
Do not activate the multicompany
call the get_fpos function, in a context where force company is present and set
(It happens all the time, for example when creating purchase order through reordering rules)

Before this commit, the fiscal position was not found. This was because force_company
added a strict company domain on the search for fiscal position
This is irrelevant nay wrong when not in multicompany, since fiscal position
are created with company=False by default

After this commit, the fiscal position is found according to the country of the partner

OPW 2059491

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
