### PR TITLE
Saas 12.5 elearning creation certif frontend fle

### DIFF
--- a/addons/website_profile/views/website_profile.xml
+++ b/addons/website_profile/views/website_profile.xml
@@ -368,8 +368,10 @@
                         <div class="card">
                             <div class="card-body p-2 pr-3">
                                 <div class="media align-items-center">
-                                  <img height="38" t-att-src="website.image_url(badge.badge_id, 'image_64')" class="mr-0"/>
-                                  <div class="media-body col-md-10 p-0">
+                                <img t-if="not badge.badge_id.image_1920 and badge.badge_id.level" t-attf-src="/website_profile/static/src/img/badge_#{badge.badge_id.level}.svg"
+                                    class="my-1" style="height:2.5em" t-att-alt="badge.badge_id.name"/>
+                                <img t-else="" height="38" t-att-src="website.image_url(badge.badge_id, 'image_64')" class="mr-0"/>
+                                <div class="media-body col-md-10 p-l1">
                                     <h6 class="my-0 text-truncate" t-field="badge.badge_id.name"/>
                                   </div>
                                 </div>

--- a/addons/website_sale_slides/models/slide_channel.py
+++ b/addons/website_sale_slides/models/slide_channel.py
@@ -9,9 +9,10 @@ class Channel(models.Model):
 
     enroll = fields.Selection(selection_add=[('payment', 'On payment')])
     product_id = fields.Many2one('product.product', 'Product', index=True)
-    product_sale_revenues = fields.Float(
+    product_sale_revenues = fields.Monetary(
         string='Total revenues', compute='_compute_product_sale_revenues',
         groups="sales_team.group_sale_salesman")
+    currency_id = fields.Many2one(related='product_id.currency_id')
 
     _sql_constraints = [
         ('product_id_check', "CHECK( enroll!='payment' OR product_id IS NOT NULL )", "Product is required for on payment channels.")

--- a/addons/website_sale_slides/views/slide_channel_views.xml
+++ b/addons/website_sale_slides/views/slide_channel_views.xml
@@ -33,7 +33,8 @@
             <xpath expr="//div[@name='info_total_time']" position="after">
                 <div class="d-flex" attrs="{'invisible': [('enroll', '!=', 'payment')]}">
                     <span class="mr-auto"><label for="product_sale_revenues" class="mb0">Sales</label></span>
-                    <field name="product_sale_revenues"/>
+                    <field name="product_sale_revenues" widget="monetary" options="{'currency_field': 'currency_id'}"/>
+                    <field name="currency_id" attrs="{'invisible': True}"/>
                 </div>
             </xpath>
             <xpath expr="//a[@name='action_channel_invite']" position="attributes">

--- a/addons/website_slides/data/mail_data.xml
+++ b/addons/website_slides/data/mail_data.xml
@@ -11,11 +11,13 @@
                         Hello<br/><br/>
                         There is something new in the course <strong>${object.channel_id.name}</strong> you are following:<br/><br/>
                         <center><strong>${object.name}</strong></center>
+                        % if object.image_1024
                         <div style="margin: 16px 8px 16px 8px; text-align: center;">
                             <a href="${object.website_url}">
                                 <img alt="${object.name}" src="${ctx['base_url']}/web/image/slide.slide/${object.id}/image_1024" style="height:auto; width:150px; margin: 16px;"/>
                             </a>
                         </div>
+                        % endif
                         <div style="margin: 16px 8px 16px 8px; text-align: center;">
                             <a href="${object.website_url}"
                                 style="background-color: #875a7b; padding: 8px 16px 8px 16px; text-decoration: none; color: #fff; border-radius: 5px;">View content</a>

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -106,7 +106,7 @@ class Channel(models.Model):
         ('latest', 'Latest Published'),
         ('most_voted', 'Most Voted'),
         ('most_viewed', 'Most Viewed')],
-        string="Featuring Policy", default='latest', required=True)
+        string="Featured Content", default='latest', required=True)
     access_token = fields.Char("Security Token", copy=False, default=_default_access_token)
     nbr_presentation = fields.Integer('Presentations', compute='_compute_slides_statistics', store=True)
     nbr_document = fields.Integer('Documents', compute='_compute_slides_statistics', store=True)
@@ -130,11 +130,11 @@ class Channel(models.Model):
         help="Email template to send slide publication through email",
         default=lambda self: self.env['ir.model.data'].xmlid_to_res_id('website_slides.slide_template_published'))
     share_template_id = fields.Many2one(
-        'mail.template', string='Shared Template',
+        'mail.template', string='Share Template',
         help="Email template used when sharing a slide",
         default=lambda self: self.env['ir.model.data'].xmlid_to_res_id('website_slides.slide_template_shared'))
     enroll = fields.Selection([
-        ('public', 'Public'), ('invite', 'Invite')],
+        ('public', 'Public'), ('invite', 'On Invitation')],
         default='public', string='Enroll Policy', required=True,
         help='Condition to enroll: everyone, on invite, on payment (sale bridge).')
     enroll_msg = fields.Html(
@@ -142,7 +142,7 @@ class Channel(models.Model):
         default=False, translate=tools.html_translate, sanitize_attributes=False)
     enroll_group_ids = fields.Many2many('res.groups', string='Auto Enroll Groups', help="Members of those groups are automatically added as members of the channel.")
     visibility = fields.Selection([
-        ('public', 'Public'), ('members', 'Members')],
+        ('public', 'Public'), ('members', 'Members Only')],
         default='public', string='Visibility', required=True,
         help='Applied directly as ACLs. Allow to hide channels and their content for non members.')
     partner_ids = fields.Many2many(
@@ -154,7 +154,7 @@ class Channel(models.Model):
     channel_partner_ids = fields.One2many('slide.channel.partner', 'channel_id', string='Members Information', groups='website.group_website_publisher', depends=['partner_ids'])
     upload_group_ids = fields.Many2many(
         'res.groups', 'rel_upload_groups', 'channel_id', 'group_id', string='Upload Groups',
-        help="Who can publish: responsible, members of upload_group_ids if defined or website publisher group members.")
+        help="Group of users allowed to publish contents on a documentation course.")
     # not stored access fields, depending on each user
     completed = fields.Boolean('Done', compute='_compute_user_statistics', compute_sudo=False)
     completion = fields.Integer('Completion', compute='_compute_user_statistics', compute_sudo=False)
@@ -375,6 +375,11 @@ class Channel(models.Model):
     # Business / Actions
     # ---------------------------------------------------------
 
+    def action_redirect_to_contents(self):
+        action = self.env.ref('website_slides.slide_slide_action').read()[0]
+        action['domain'] = [('channel_id', 'in', self.ids), ('is_category', '=', False)]
+        return action
+
     def action_redirect_to_members(self, state=None):
         action = self.env.ref('website_slides.slide_channel_partner_action').read()[0]
         action['domain'] = [('channel_id', 'in', self.ids)]
@@ -489,7 +494,7 @@ class Channel(models.Model):
     def action_view_slides(self):
         action = self.env.ref('website_slides.slide_slide_action').read()[0]
         action['context'] = {'default_channel_id': self.id}
-        action['domain'] = [('channel_id', "=", self.id)]
+        action['domain'] = [('channel_id', "=", self.id), ('is_category', '=', False)]
         return action
 
     def action_view_ratings(self):
@@ -519,16 +524,7 @@ class Channel(models.Model):
         all_slides = self.env['slide.slide'].sudo().search(base_domain, order=order)
         category_data = []
 
-        # First add uncategorized slides
-        uncategorized_slides = all_slides.filtered(lambda slide: not slide.category_id)
-        if uncategorized_slides or force_void:
-            category_data.append({
-                'category': False, 'id': False,
-                'name': _('Uncategorized'), 'slug_name': _('Uncategorized'),
-                'total_slides': len(uncategorized_slides),
-                'slides': uncategorized_slides[(offset or 0):(offset + limit or len(uncategorized_slides))],
-            })
-        # Then all categories by natural order
+        # First add all categories by natural order
         for category in all_categories:
             category_slides = all_slides.filtered(lambda slide: slide.category_id == category)
             if not category_slides and not force_void:
@@ -538,6 +534,15 @@ class Channel(models.Model):
                 'name': category.name, 'slug_name': slug(category),
                 'total_slides': len(category_slides),
                 'slides': category_slides[(offset or 0):(limit + offset or len(category_slides))],
+            })
+        # Then add uncategorized slides
+        uncategorized_slides = all_slides.filtered(lambda slide: not slide.category_id)
+        if uncategorized_slides or force_void:
+            category_data.append({
+                'category': False, 'id': False,
+                'name': _('Uncategorized'), 'slug_name': _('Uncategorized'),
+                'total_slides': len(uncategorized_slides),
+                'slides': uncategorized_slides[(offset or 0):(offset + limit or len(uncategorized_slides))],
             })
         return category_data
 

--- a/addons/website_slides/models/slide_question.py
+++ b/addons/website_slides/models/slide_question.py
@@ -11,7 +11,7 @@ class SlideQuestion(models.Model):
     _description = "Slide Quiz Question"
 
     sequence = fields.Integer("Sequence", default=10)
-    question = fields.Char("Question Name", required=True, translate=True)
+    question = fields.Char("Question Name", translate=True, required=True)
     slide_id = fields.Many2one('slide.slide', string="Slide", required=True)
     answer_ids = fields.One2many('slide.answer', 'question_id', string="Answer")
     # statistics
@@ -39,7 +39,7 @@ class SlideQuestion(models.Model):
     def _check_at_least_2_answers(self):
         for question in self:
             if len(question.answer_ids) < 2:
-                raise ValidationError(_("A question must at least have two possible answers"))
+                raise ValidationError(_('The question "%s" has no valid answer, please set one') % question.question)
 
     @api.depends('slide_id')
     def _compute_statistics(self):
@@ -66,5 +66,5 @@ class SlideAnswer(models.Model):
     _order = 'question_id, id'
 
     question_id = fields.Many2one('slide.question', string="Question", required=True)
-    text_value = fields.Char("Answer", required=True, translate=True)
+    text_value = fields.Char("Answer", translate=True, required=True)
     is_correct = fields.Boolean("Is correct answer")

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -59,7 +59,7 @@ class SlideLink(models.Model):
 
     slide_id = fields.Many2one('slide.slide', required=True, ondelete='cascade')
     name = fields.Char('Title', required=True)
-    link = fields.Char('External Link', required=True)
+    link = fields.Char('Link', required=True)
 
 
 class EmbeddedSlide(models.Model):
@@ -123,8 +123,8 @@ class Slide(models.Model):
     description = fields.Text('Description', translate=True)
     channel_id = fields.Many2one('slide.channel', string="Channel", required=True)
     tag_ids = fields.Many2many('slide.tag', 'rel_slide_tag', 'slide_id', 'tag_id', string='Tags')
-    is_preview = fields.Boolean('Is Preview', default=False, help="The course is accessible by anyone : the users don't need to join the channel to access the content of the course.")
-    completion_time = fields.Float('Completion Time', digits=(10, 4), help="The estimated completion time for this slide")
+    is_preview = fields.Boolean('Allow Preview', default=False, help="The course is accessible by anyone : the users don't need to join the channel to access the content of the course.")
+    completion_time = fields.Float('Duration', digits=(10, 4), help="The estimated completion time for this slide")
     # Categories
     is_category = fields.Boolean('Is a category', default=False)
     category_id = fields.Many2one('slide.slide', string="Category", compute="_compute_category_id", store=True)
@@ -138,6 +138,7 @@ class Slide(models.Model):
         help="Subscriber information for the current logged in user")
     # Quiz related fields
     question_ids = fields.One2many("slide.question", "slide_id", string="Questions")
+    questions_count = fields.Integer(string="Numbers of Questions", compute='_compute_questions_count')
     quiz_first_attempt_reward = fields.Integer("First attempt reward", default=10)
     quiz_second_attempt_reward = fields.Integer("Second attempt reward", default=7)
     quiz_third_attempt_reward = fields.Integer("Third attempt reward", default=5,)
@@ -161,7 +162,7 @@ class Slide(models.Model):
     html_content = fields.Html("HTML Content", help="Custom HTML content for slides of type 'Web Page'.", translate=True)
     # website
     website_id = fields.Many2one(related='channel_id.website_id', readonly=True)
-    date_published = fields.Datetime('Publish Date')
+    date_published = fields.Datetime('Publish Date', readonly=True, tracking=True)
     likes = fields.Integer('Likes', compute='_compute_user_info', store=True, compute_sudo=False)
     dislikes = fields.Integer('Dislikes', compute='_compute_user_info', store=True, compute_sudo=False)
     user_vote = fields.Integer('User vote', compute='_compute_user_info', compute_sudo=False)
@@ -211,6 +212,11 @@ class Slide(models.Model):
                     current_category = slide
                 elif slide.category_id != current_category:
                     slide.category_id = current_category.id
+
+    @api.depends('question_ids')
+    def _compute_questions_count(self):
+        for slide in self:
+            slide.questions_count = len(slide.question_ids)
 
     @api.depends('website_message_ids.res_id', 'website_message_ids.model', 'website_message_ids.message_type')
     def _compute_comments_count(self):
@@ -391,7 +397,7 @@ class Slide(models.Model):
 
         slide = super(Slide, self).create(values)
 
-        if slide.is_published:
+        if slide.is_published and not slide.is_category:
             slide._post_publication()
         return slide
 

--- a/addons/website_slides/static/src/js/slides_course_slides_list.js
+++ b/addons/website_slides/static/src/js/slides_course_slides_list.js
@@ -64,7 +64,12 @@ publicWidget.registry.websiteSlidesCourseSlidesList = publicWidget.Widget.extend
 
     _getSlides: function (){
         var categories = [];
-        this.$('.o_wslides_js_list_item').each(function (){
+        // first get all slides that have no category
+        this.$('.o_wslides_slide_list_no_category .o_wslides_js_list_item').each(function () {
+            categories.push(parseInt($(this).data('slideId')));
+        });
+        // then get the remaining
+        this.$('.o_wslides_slide_list_category, .o_wslides_slide_list_category .o_wslides_js_list_item').each(function () {
             categories.push(parseInt($(this).data('slideId')));
         });
         return categories;

--- a/addons/website_slides/static/src/js/slides_upload.js
+++ b/addons/website_slides/static/src/js/slides_upload.js
@@ -351,6 +351,15 @@ var SlideUploadDialog = Dialog.extend({
         };
     },
     /**
+     * Show the preview/right column and resize the modal
+     * @private
+     */
+    _showPreviewColumn: function() {
+        this.$('#slide_js_upload_left_column').removeClass('col').addClass('col-md-6');
+        this.$('#slide_js_upload_preview_column').removeClass('d-none');
+        this.$modal.find('.modal-dialog').addClass('modal-lg');
+    },
+    /**
      * @private
      */
     // TODO: Remove this part, as now SVG support in image resize tools is included
@@ -389,6 +398,8 @@ var SlideUploadDialog = Dialog.extend({
         } else {
             this.set_title(_t("Upload a document"));
         }
+
+        this.$modal.find('.modal-dialog').removeClass('modal-lg');
     },
     _onChangeCanSubmitForm: function (ev) {
         if (this.get('can_submit_form')) {
@@ -426,6 +437,7 @@ var SlideUploadDialog = Dialog.extend({
             }
             buffer = buffer.split(',')[1];
             self.file.data = buffer;
+            self._showPreviewColumn();
         });
 
         if (file.type === 'application/pdf') {
@@ -478,6 +490,7 @@ var SlideUploadDialog = Dialog.extend({
                                 self.set('can_submit_form', true);
                             }
                             loaded = true;
+                            self._showPreviewColumn();
                         });
                     });
                 });
@@ -510,6 +523,7 @@ var SlideUploadDialog = Dialog.extend({
                 self._formSetFieldValue('description', data.description);
 
                 self.isValidUrl = true;
+                self._showPreviewColumn();
             }
         });
     },

--- a/addons/website_slides/static/src/scss/backend.scss
+++ b/addons/website_slides/static/src/scss/backend.scss
@@ -1,6 +1,12 @@
+// category
 table.o_section_list_view tr.o_data_row.o_is_section {
     font-weight: bold;
     background-color: #DDD;
     border-top: 1px solid #BBB;
     border-bottom: 1px solid #BBB;
+}
+
+// question and answers modal
+div.o_question_form_answers[name="answer_ids"] th[data-name="is_correct"] {
+    width: 25% !important;
 }

--- a/addons/website_slides/static/src/scss/rating_rating_views.scss
+++ b/addons/website_slides/static/src/scss/rating_rating_views.scss
@@ -7,5 +7,9 @@ $o-kanban-large-record-width: 350px;
 
     .o_slide_rating_kanban_left {
     	min-width: 80px;
+
+    	.o_slide_rating_value {
+    	    font-size: 4rem;
+    	}
     }
 }

--- a/addons/website_slides/static/src/scss/slides_slide_fullscreen.scss
+++ b/addons/website_slides/static/src/scss/slides_slide_fullscreen.scss
@@ -35,6 +35,7 @@
     .o_wslides_fs_sidebar {
         background-image: linear-gradient(160deg, $o-wslides-color-dark1, $o-wslides-color-dark2);
         position: relative;
+        z-index: $zindex-fixed;
 
         .o_wslides_fs_sidebar_content {
             min-width: $o-wslides-fs-side-width;

--- a/addons/website_slides/static/src/xml/website_slides_channel.xml
+++ b/addons/website_slides/static/src/xml/website_slides_channel.xml
@@ -6,47 +6,37 @@
         <div>
             <form action="/slides/channel/add" method="POST" id="slide_channel_add_form">
                 <input type="hidden" name="csrf_token" t-att-value="csrf_token"/>
-                <div class="form-group row">
-                    <label for="title" class="col-sm-3 col-form-label">Title</label>
-                    <div class="col-sm-9">
-                        <input type="text" class="form-control" name="name" id="title" placeholder="Course Title" required="1"/>
-                        <p id="title-required" class="text-danger mt-1 mb-0 d-none">Please fill in this field</p>
-                    </div>
+                <div class="form-group">
+                    <label for="title" class="col-form-label">Title</label>
+                    <input type="text" class="form-control" name="name" id="title" placeholder="Course Title" required="1"/>
+                    <p id="title-required" class="text-danger mt-1 mb-0 d-none">Please fill in this field</p>
                 </div>
-                <div class="form-group row">
-                    <label for="tag_ids" class="col-sm-3 col-form-label">Tags</label>
-                    <div class="col-sm-9">
-                        <input type="text" class="form-control" name="tag_ids" id="tag_ids" placeholder="Tags"/>
-                    </div>
+                <div class="form-group">
+                    <label for="tag_ids" class="col-form-label">Tags</label>
+                    <input type="text" class="form-control" name="tag_ids" id="tag_ids" placeholder="Tags"/>
                 </div>
                 <fieldset class="form-group">
-                    <div class="row">
-                        <label for="channel_type" class="col-sm-3">Type</label>
-                        <div class="col-sm-9">
-                            <div class="form-check">
-                              <input class="form-check-input" type="radio" name="channel_type" id="channel_type1" value="training" checked="checked"/>
-                              <span class="form-check-label" for="channel_type1">
-                                    Training (with progress)
-                              </span>
-                            </div>
-                            <div class="form-check">
-                              <input class="form-check-input" type="radio" name="channel_type" id="channel_type2" value="documentation"/>
-                              <span class="form-check-label" for="channel_type2">
-                                    Documentation
-                              </span>
-                            </div>
-                        </div>
+                    <label for="channel_type">Type</label>
+                    <div class="form-check">
+                      <input class="form-check-input" type="radio" name="channel_type" id="channel_type1" value="training" checked="checked"/>
+                      <span class="form-check-label" for="channel_type1">
+                            Training (with progress)
+                      </span>
+                    </div>
+                    <div class="form-check">
+                      <input class="form-check-input" type="radio" name="channel_type" id="channel_type2" value="documentation"/>
+                      <span class="form-check-label" for="channel_type2">
+                            Documentation
+                      </span>
                     </div>
                 </fieldset>
-                <div class="form-group row">
-                    <label for="title" class="col-sm-3">Description</label>
-                    <div class="col-sm-9">
-                        <textarea name="description" id="description" style="height:8em" class="form-control" placeholder="Write here a short description of your first course"/>
-                    </div>
+                <div class="form-group">
+                    <label for="title">Description</label>
+                    <textarea name="description" id="description" style="height:8em" class="form-control" placeholder="Write here a short description of your first course"/>
                 </div>
-                <div class="form-group row">
-                    <label id="communication-label" class="col-sm-3">Review</label>
-                    <div class="col-sm-9 o_wslide_channel_communication_type">
+                <div class="form-group">
+                    <label id="communication-label">Review</label>
+                    <div class="o_wslide_channel_communication_type">
                         <div class="form-check">
                             <input class="form-check-input" type="checkbox" id="allow_comment" name="allow_comment"/>
                             <span class="form-check-label" for="allow_comment">Allow review on Course</span>

--- a/addons/website_slides/static/src/xml/website_slides_upload.xml
+++ b/addons/website_slides/static/src/xml/website_slides_upload.xml
@@ -73,7 +73,7 @@
         <div class="form-group">
             <label for="duration" class="col-form-label">Duration</label>
             <div class="input-group">
-                <input type="number" id="duration" name="duration" placeholder="Estimated slide completion time" class="form-control"/>
+                <input type="number" id="duration" min="0" name="duration" placeholder="Estimated slide completion time" class="form-control"/>
                     <div class="input-group-prepend">
                     <span class="input-group-text">Minutes</span>
                 </div>

--- a/addons/website_slides/static/src/xml/website_slides_upload.xml
+++ b/addons/website_slides/static/src/xml/website_slides_upload.xml
@@ -58,28 +58,25 @@
         Slide Type common form part template
     -->
     <t t-name="website.slide.upload.modal.common">
-        <div class="form-group row">
-            <label for="name" class="col-form-label col-md-3">Title</label>
-            <div class="col-md-9">
-                <input id="name" name="name" placeholder="Title" class="form-control" required="required"/>
-            </div>
+        <div class="form-group">
+            <label for="name" class="col-form-label">Title</label>
+            <input id="name" name="name" placeholder="Title" class="form-control" required="required"/>
         </div>
-        <div t-if="!widget.defaultCategoryID" class="form-group row">
-            <label for="category_id" class="col-form-label col-md-3">Category</label>
-            <div class="controls col-md-9">
-                <input class="form-control" id="category_id"/>
-            </div>
+        <div t-if="!widget.defaultCategoryID" class="form-group">
+            <label for="category_id" class="col-form-label">Category</label>
+            <input class="form-control" id="category_id"/>
         </div>
-        <div class="form-group row">
-            <label for="tag_ids" class="col-form-label col-md-3">Tags</label>
-            <div class="controls col-md-9">
-                <input id="tag_ids" name="tag_ids" type="hidden"/>
-            </div>
+        <div class="form-group">
+            <label for="tag_ids" class="col-form-label">Tags</label>
+            <input id="tag_ids" name="tag_ids" type="hidden"/>
         </div>
-        <div class="form-group row">
-            <label for="duration" class="col-form-label col-md-3">Completion Time (minutes)</label>
-            <div class="col-md-9">
+        <div class="form-group">
+            <label for="duration" class="col-form-label">Duration</label>
+            <div class="input-group">
                 <input type="number" id="duration" name="duration" placeholder="Estimated slide completion time" class="form-control"/>
+                    <div class="input-group-prepend">
+                    <span class="input-group-text">Minutes</span>
+                </div>
             </div>
         </div>
     </t>
@@ -90,27 +87,23 @@
     <t t-name="website.slide.upload.modal.presentation">
         <div>
             <form class="clearfix">
-                <div class="form-group row">
-                    <div class="col-md-4">
+                <div class="row">
+                    <div id="slide_js_upload_left_column" class="col">
+                        <div class="form-group">
+                            <label for="upload" class="col-form-label">Choose a PDF or an Image</label>
+                            <input id="upload" name="file" class="form-control" accept="image/*,application/pdf" type="file" required="required"/>
+                        </div>
+                        <canvas id="data_canvas" class="d-none"></canvas>
+                        <t t-call="website.slide.upload.modal.common"/>
+                    </div>
+                    <div id="slide_js_upload_preview_column" class="col-md-6 d-none">
                         <div class="img-thumbnail">
                             <div class="o_slide_preview">
                                 <img src="/website_slides/static/src/img/document.png" id="slide-image" title="Content Preview" alt="Content Preview" class="img-fluid"/>
                             </div>
                         </div>
                     </div>
-                    <div class="col-md-8">
-                        <ul class="list-group">
-                            <li class="list-group-item">
-                                <h5 class="list-group-item-heading">
-                                    <label for="upload" class="col-form-label">PDF or Image File</label>
-                                </h5>
-                                <input id="upload" name="file" class="form-control" accept="image/*,application/pdf" type="file" required="required"/>
-                            </li>
-                        </ul>
-                    </div>
                 </div>
-                <canvas id="data_canvas" class="d-none"></canvas>
-                <t t-call="website.slide.upload.modal.common"/>
             </form>
         </div>
     </t>
@@ -118,27 +111,23 @@
     <t t-name="website.slide.upload.modal.webpage">
         <div>
             <form class="clearfix">
-                <t t-call="website.slide.upload.modal.common"/>
-                <div class="form-group row">
-                    <div class="col-md-4">
+                <div class="row">
+                    <div id="slide_js_upload_left_column" class="col">
+                        <div class="form-group">
+                            <label for="upload" class="col-form-label">Choose a Cover Image</label>
+                            <input id="upload" name="file" class="form-control" accept="image/*" type="file" required="required"/>
+                        </div>
+                        <canvas id="data_canvas" class="d-none"></canvas>
+                        <t t-call="website.slide.upload.modal.common"/>
+                    </div>
+                    <div id="slide_js_upload_preview_column" class="col-md-6 d-none">
                         <div class="img-thumbnail">
                             <div class="o_slide_preview">
                                 <img src="/website_slides/static/src/img/document.png" id="slide-image" title="Content Preview" alt="Content Preview" class="img-fluid"/>
                             </div>
                         </div>
                     </div>
-                    <div class="col-md-8">
-                        <ul class="list-group">
-                            <li class="list-group-item">
-                                <h5 class="list-group-item-heading">
-                                    <label for="upload" class="col-form-label">Cover Image File</label>
-                                </h5>
-                                <input id="upload" name="file" class="form-control" accept="image/*" type="file" required="required" data-prevent-onchange="1"/>
-                            </li>
-                        </ul>
-                    </div>
                 </div>
-                <canvas id="data_canvas" class="d-none"></canvas>
             </form>
         </div>
     </t>
@@ -146,27 +135,23 @@
     <t t-name="website.slide.upload.modal.video">
         <div>
             <form class="clearfix">
-                <div class="form-group row">
-                    <div class="col-md-4">
+                <div class="row">
+                    <div id="slide_js_upload_left_column" class="col">
+                        <div class="form-group">
+                            <label for="url" class="col-form-label">Youtube Link</label>
+                            <input id="url" name="url" class="form-control" placeholder="Youtube Video URL" required="required"/>
+                        </div>
+                        <canvas id="data_canvas" class="d-none"></canvas>
+                        <t t-call="website.slide.upload.modal.common"/>
+                    </div>
+                    <div id="slide_js_upload_preview_column" class="col-md-6 d-none">
                         <div class="img-thumbnail">
                             <div class="o_slide_preview">
                                 <img src="/website_slides/static/src/img/document.png" id="slide-image" title="Content Preview" alt="Content Preview" class="img-fluid"/>
                             </div>
                         </div>
                     </div>
-                    <div class="col-md-8">
-                        <ul class="list-group">
-                            <li class="list-group-item">
-                                <h5 class="list-group-item-heading">
-                                    <label for="url" class="col-form-label">Youtube Link</label>
-                                </h5>
-                                <input id="url" name="url" class="form-control" placeholder="Youtube Video URL" required="required"/>
-                            </li>
-                        </ul>
-                    </div>
                 </div>
-                <canvas id="data_canvas" class="d-none"></canvas>
-                <t t-call="website.slide.upload.modal.common"/>
             </form>
         </div>
     </t>

--- a/addons/website_slides/views/assets.xml
+++ b/addons/website_slides/views/assets.xml
@@ -5,7 +5,7 @@
             <xpath expr="." position="inside">
                 <link rel="stylesheet" type="text/scss" href="/website_slides/static/src/scss/rating_rating_views.scss"/>
                 <link rel="stylesheet" type="text/scss" href="/website_slides/static/src/scss/slide_channel_views.scss"/>
-                <link rel="stylesheet" type="text/scss" href="/website_slides/static/src/scss/category_backend.scss" t-ignore="true"/>
+                <link rel="stylesheet" type="text/scss" href="/website_slides/static/src/scss/backend.scss" t-ignore="true"/>
                 <script type="text/javascript" src="/website_slides/static/src/js/slide_category_one2many.js"/>
                 <script type="text/javascript" src="/website_slides/static/src/js/rating_field_backend.js"/>
             </xpath>

--- a/addons/website_slides/views/rating_rating_views.xml
+++ b/addons/website_slides/views/rating_rating_views.xml
@@ -18,14 +18,15 @@
                         <t t-set="empty_star" t-value="5 - (val_integer + Math.ceil(val_decimal))"/>
                         <div class="oe_kanban_card oe_kanban_global_click">
                             <div class="d-flex flex-row">
-                                <div class="o_slide_rating_kanban_left">
+                                <div class="o_slide_rating_kanban_left mr-3">
+                                    <h1 class="o_slide_rating_value text-center text-primary" t-esc="val_stars"/>
                                     <t t-foreach="_.range(0, val_integer)" t-as="num">
-                                        <i class="fa fa-star" role="img" aria-label="One star" title="One star"></i>
+                                        <i class="fa fa-star" role="img"></i>
                                     </t>
                                     <t t-if="val_decimal">
-                                        <i class="fa fa-star-half-o" role="img" aria-label="Half a star" title="Half a star"></i>
+                                        <i class="fa fa-star-half-o" role="img"></i>
                                     </t>
-                                    <t t-foreach="_.range(0, empty_star)" t-as="num" role="img" t-attf-aria-label="#{empty_star} on 5" t-attf-title="#{empty_star} on 5">
+                                    <t t-foreach="_.range(0, empty_star)" t-as="num" role="img">
                                         <i class="fa fa-star text-black-25"></i>
                                     </t>
                                 </div>
@@ -36,14 +37,14 @@
                                         </div>
                                     </div>
                                     <div class="o_kanban_card_content mt0 d-flex flex-column">
-                                        <span>for
+                                        <span>
+                                            <i class="fa fa-folder mr-2"></i>
                                             <a type="object" name="action_open_rated_object" t-att-title="record.res_name.raw_value">
                                                 <field name="res_name" />
                                             </a>
                                         </span>
-                                        <span><i class="fa fa-clock-o mr-2"/>on <field name="create_date" /></span>
+                                        <span><i class="fa fa-clock-o mr-2"/> <field name="create_date" /></span>
                                         <div class="d-flex mt-2">
-                                            <i t-if="record.feedback.raw_value" class="fa fa-comment mr-2" t-att-title="record.feedback.raw_value"  t-att-aria-label="record.feedback.raw_value" role="img"/>
                                             <span t-esc="record.feedback.raw_value"/>
                                         </div>
                                     </div>
@@ -74,19 +75,32 @@
     </record>
 
     <record id="rating_rating_view_graph_slide_channel" model="ir.ui.view">
-       <field name="name">rating.rating.graph</field>
-       <field name="model">rating.rating</field>
-       <field name="priority">20</field>
-       <field name="arch" type="xml">
-            <graph string="Rating Average" type="bar" stacked="False">
+        <field name="name">rating.rating.graph</field>
+        <field name="model">rating.rating</field>
+        <field name="priority">20</field>
+        <field name="arch" type="xml">
+            <graph string="Rating Average" type="bar">
                 <field name="res_name" type="row"/>
-                <field name="rating" type="col"/>
+                <field name="rating" type="measure"/>
             </graph>
         </field>
     </record>
 
+    <record id="rating_rating_view_pivot_slide_channel" model="ir.ui.view">
+        <field name="name">rating.rating.pivot</field>
+        <field name="model">rating.rating</field>
+        <field name="priority">20</field>
+        <field name="arch" type="xml">
+            <pivot>
+                <field name="res_name" type="row"/>
+                <field name="rating_text" type="col"/>
+                <field name="rating" type="measure"/>
+            </pivot>
+        </field>
+    </record>
+
     <record id="rating_rating_action_slide_channel" model="ir.actions.act_window">
-        <field name="name">Courses Rating</field>
+        <field name="name">Rating</field>
         <field name="res_model">rating.rating</field>
         <field name="view_mode">kanban,tree,graph,pivot,form</field>
         <field name="domain">[('consumed', '=', True), ('res_model', '=', 'slide.channel')]</field>
@@ -101,13 +115,15 @@
     </record>
 
     <record id="rating_rating_action_slide_channel_report" model="ir.actions.act_window">
-        <field name="name">Courses Rating</field>
+        <field name="name">Rating</field>
         <field name="res_model">rating.rating</field>
-        <field name="view_mode">graph,tree</field>
         <field name="domain">[('consumed', '=', True), ('res_model', '=', 'slide.channel')]</field>
         <field name="context">{}</field>
         <field name="search_view_id" ref="rating_rating_view_search_slide_channel"/>
-        <field name="view_id" ref="rating_rating_view_graph_slide_channel"/>
+        <field name="view_ids" eval="[(5,0,0),
+                                      (0,0,{'view_mode':'graph', 'view_id': ref('rating_rating_view_graph_slide_channel')}),
+                                      (0,0,{'view_mode':'pivot', 'view_id': ref('rating_rating_view_pivot_slide_channel')}),
+                                      (0,0,{'view_mode':'tree'})]"/>
         <field name="help" type="html">
             <p class="o_view_nocontent_empty_folder">
                 There is no rating for these courses at the moment

--- a/addons/website_slides/views/slide_channel_views.xml
+++ b/addons/website_slides/views/slide_channel_views.xml
@@ -12,6 +12,17 @@
                     </header>
                     <sheet>
                         <div class="oe_button_box" name="button_box">
+                            <button name="action_redirect_to_contents"
+                                type="object"
+                                icon="fa-files-o"
+                                class="oe_stat_button"
+                                groups="website.group_website_publisher">
+                                <div class="o_field_widget o_stat_info">
+                                    <span class="o_stat_value"><field name="total_slides" nolabel="1"/></span>
+                                    <span name="stat_label" class="o_stat_text">Contents</span>
+                                </div>
+                            </button>
+
                             <button name="action_redirect_to_done_members"
                                 type="object"
                                 icon="fa-trophy"
@@ -45,12 +56,11 @@
                             <label for="name" class="oe_edit_only" string="Course Title"/>
                             <h1><field name="name" default_focus="1" placeholder="Course Title"/></h1>
                         </div>
-                        <group>
-                            <group>
-                                <field name="active" invisible="1"/>
-                                <field name="tag_ids" widget="many2many_tags" placeholder="Tags"/>
-                            </group>
-                        </group>
+                        <div>
+                            <field name="active" invisible="1"/>
+                            <label for="tag_ids"/>
+                            <field name="tag_ids" widget="many2many_tags" placeholder="Tags"/>
+                        </div>
                         <notebook colspan="4">
                             <page name="content" string="Content">
                                 <field name="slide_ids" colspan="4" nolabel="1" widget="slide_category_one2many" context="{'default_channel_id': active_id}">
@@ -81,15 +91,15 @@
                                     </group>
                                     <group name="access_rights" string="Access Rights">
                                         <field name="enroll" widget="radio" options="{'horizontal': true}"/>
-                                        <field name="upload_group_ids" string="New Content" widget="many2many_tags"/>
+                                        <field name="upload_group_ids" widget="many2many_tags" groups="base.group_no_one"/>
                                         <field name="enroll_group_ids" widget="many2many_tags" groups="base.group_no_one"/>
                                     </group>
                                 </group>
                                 <group>
                                     <group name="communication" string="Communication">
                                         <field string="Allow Rating" name="allow_comment"/>
-                                        <field name="publish_template_id" domain="[('model','=','slide.slide')]"/>
-                                        <field name="share_template_id" domain="[('model','=','slide.slide')]"/>
+                                        <field name="publish_template_id" domain="[('model','=','slide.slide')]" groups="base.group_no_one"/>
+                                        <field name="share_template_id" domain="[('model','=','slide.slide')]" groups="base.group_no_one"/>
                                     </group>
                                     <group name="display" string="Display">
                                         <field name="visibility" widget="radio"/>
@@ -119,8 +129,6 @@
                                         <field name="nbr_infographic"/>
                                         <field name="nbr_quiz" string="Quizzes"/>
                                         <field name="nbr_webpage"/>
-                                        <separator/>
-                                        <field name="total_slides"/>
                                     </group>
                                     <group name="view_stats">
                                         <field name="total_views" string="Visits"/>
@@ -241,23 +249,21 @@
                                     </div>
                                 </div>
                                 <div class="container o_kanban_card_content mt0">
-                                    <div class="row">
+                                    <div class="row mb16">
                                         <div class="col-6 o_kanban_primary_left">
                                             <button class="btn btn-primary" name="open_website_url" type="object">View course</button>
                                         </div>
                                         <div class="col-6 o_kanban_primary_right">
                                             <div class="d-flex">
-                                                <span class="mr-auto"><label for="rating_avg" class="mb0">Rating</label></span>
-                                                <a name="action_view_ratings" type="object">
-                                                    <field name="rating_count"/><span class="ml-2">reviews</span> (<field name="rating_avg_stars"/>/5)
-                                                </a>
+                                                <a name="action_view_ratings" type="object" class="mr-auto"><field name="rating_count"/> reviews</a>
+                                                <span><field name="rating_avg_stars"/> / 5</span>
                                             </div>
                                             <div class="d-flex">
                                                 <span class="mr-auto"><label for="total_views" class="mb0">Views</label></span>
                                                 <field name="total_views"/>
                                             </div>
                                             <div class="d-flex" name="info_total_time">
-                                                <span class="mr-auto"><label for="total_time" class="mb0">Completion Time</label></span>
+                                                <span class="mr-auto"><label for="total_time" class="mb0">Duration</label></span>
                                                 <field name="total_time" widget="float_time"/>
                                             </div>
                                         </div>

--- a/addons/website_slides/views/slide_question_views.xml
+++ b/addons/website_slides/views/slide_question_views.xml
@@ -12,7 +12,7 @@
                     <h1>
                         <field name="question" default_focus="1" placeholder="Name"/>
                     </h1>
-                    <field name="answer_ids">
+                    <field name="answer_ids" class="o_question_form_answers">
                         <tree editable="bottom" create="true" delete="true">
                             <field name="text_value"/>
                             <field name="is_correct"/>

--- a/addons/website_slides/views/slide_slide_views.xml
+++ b/addons/website_slides/views/slide_slide_views.xml
@@ -50,10 +50,10 @@
                         />
                         <div class="oe_title">
                             <div>
-                                <label for="name" string="Name"/>
+                                <label for="name" string="Content Title"/>
                             </div>
                             <h1>
-                                <field name="name" default_focus="1" placeholder="Title"/>
+                                <field name="name" default_focus="1" placeholder="e.g. How to grow your business with Odoo?"/>
                                 <field name="is_category" invisible="1"/>
                             </h1>
                             <field name="tag_ids" attrs="{'invisible': [('is_category', '=', True)]}" widget="many2many_tags" placeholder="Tags..."/>
@@ -63,6 +63,7 @@
                                 <group>
                                     <group name="lesson_details">
                                         <field name="active" invisible="1"/>
+                                        <field name="channel_id"/>
                                         <field name="slide_type"/>
                                         <field name="url" attrs="{
                                             'required': [('slide_type', 'in', ('video'))],
@@ -74,28 +75,26 @@
                                     </group>
                                     <group name="related_details">
                                         <field name="user_id"/>
-                                        <field name="channel_id"/>
                                         <field name="website_id" groups="website.group_multi_website"/>
-                                        <field name="website_url"/>
                                         <field name="is_preview"/>
-                                        <label for="completion_time" string="Completion Time"/>
+                                        <label for="completion_time"/>
                                         <div>
                                             <field name="completion_time" widget="float_time" class="oe_inline"/>
                                             <span> hours</span>
                                         </div>
-                                        <field name="date_published" string="Published Date"/>
+                                        <field name="date_published" string="Published Date" attrs="{'invisible': [('date_published', '=', False)]}" groups="base.group_no_one"/>
                                     </group>
                                 </group>
                             </page>
                             <page name="description" string="Description">
-                                <field name="description"/>
+                                <field name="description" placeholder="e.g. In this video, we'll give you the keys on how Odoo can help you to grow your business. At the end, we'll propose you a quiz to test your knowledge."/>
                             </page>
                             <page string="External Links" name="external_links" >
                                 <group>
                                     <field name="link_ids" widget="one2many" nolabel="1">
                                         <tree editable="top">
                                             <field name="name"/>
-                                            <field name="link" widget="url"/>
+                                            <field name="link" widget="url" placeholder="e.g. https://www.odoo.com"/>
                                         </tree>
                                     </field>
                                 </group>
@@ -149,10 +148,11 @@
             <field name="name">slide.slide.view.kanban</field>
             <field name="model">slide.slide</field>
             <field name="arch" type="xml">
-                <kanban edit="false">
+                <kanban edit="false" class="o_slide_channel_kanban">
                     <field name="id"/>
                     <field name="channel_id"/>
                     <field name="slide_type"/>
+                    <field name="user_id"/>
                     <templates>
                         <t t-name="kanban-box">
                             <div class="oe_kanban_global_click o_kanban_record_has_image_fill">
@@ -171,21 +171,23 @@
                                 </div>
                                 <div class="oe_kanban_details d-flex flex-column">
                                     <strong class="o_kanban_record_title oe_partner_heading"><field name="display_name"/></strong>
+                                    <div class="text-mutex"><field name="channel_id"/></div>
                                     <div class="o_kanban_tags_section">
                                         <span class="oe_kanban_list_many2many">
                                             <field name="tag_ids" widget="many2many_tags"/>
                                         </span>
                                     </div>
-                                    <span class="text-primary"><field name="channel_id"/></span>
-                                    <span class="text-primary"><field name="user_id"/></span>
-                                    <div class=" mt-auto d-flex justify-content-between">
-                                        <span class="badge badge-pill">
+                                    <div class="o_kanban_record_bottom d-flex justify-content-between">
+                                        <span>
                                             <i class="fa fa-clock-o mr-2" aria-label="Duration" role="img" title="Duration"/><field name="completion_time" widget="float_time"/>
                                         </span>
-                                        <span class="badge badge-pill">
+                                        <span>
+                                            <i class="fa fa-question mr-2" aria-label="Number of Questions" role="img" title="Number of Questions"/><field name="questions_count"/>
+                                        </span>
+                                        <span>
                                             <i class="fa fa-eye mr-2" aria-label="Views" role="img" title="Views"/><field name="total_views"/>
                                         </span>
-                                        <span class="badge badge-pill">
+                                        <span>
                                             <t t-if="record.slide_type.raw_value == 'infographic'">
                                                 <i class="fa fa-file-image-o mr-2" aria-label="Infographic" role="img" title="Infographic"/>
                                             </t>
@@ -201,6 +203,7 @@
                                             <t t-else=""><i class="fa fa-file-pdf-o mr-2" aria-label="Document" role="img" title="Document"/></t>
                                             <field name="slide_type"/>
                                         </span>
+                                        <img t-att-src="kanban_image('res.users', 'image_64', record.user_id.raw_value)" t-att-title="record.user_id.value" t-att-alt="record.user_id.value" width="24" height="24" class="oe_kanban_avatar"/>
                                     </div>
                                 </div>
                             </div>
@@ -215,7 +218,7 @@
             <field name="model">slide.slide</field>
             <field name="arch" type="xml">
                 <tree string="Contents">
-                    <field name="name"/>
+                    <field name="name" widget="section_and_note_text"/>
                     <field name="website_id" groups="website.group_multi_website"/>
                     <field name="active" invisible="1"/>
                     <field name="slide_type"/>
@@ -265,6 +268,7 @@
             <field name="res_model">slide.slide</field>
             <field name="view_mode">kanban,tree,form</field>
             <field name="context"></field>
+            <field name="domain">[('is_category', '=', False)]</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     Add a new lesson

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -237,6 +237,37 @@
                 </t>
             </div>
         </div>
+
+        <div class="modal fade" id="slideChannelShareModal" tabindex="-1" role="dialog" aria-labelledby="slideChannelShareModalLabel" aria-hidden="true">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="slideChannelShareModalLabel">
+                            Share
+                        </h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span>&amp;times;</span>
+                        </button>
+                    </div>
+                    <div class="modal-body">
+                        <h5>Share on Social Networks</h5>
+                        <t t-call="website_slides.slides_share">
+                            <t t-set="record" t-value="channel"/>
+                        </t>
+                        <h5 class="mt16">Share Link</h5>
+                        <div class="input-group">
+                            <input type="text" class="form-control o_wslides_js_share_link" readonly="readonly" onclick="this.select();"
+                                t-att-value="channel.website_url"/>
+                            <div class="input-group-append">
+                                <button class="btn btn-sm btn-primary o_clipboard_button" >
+                                    <span class="fa fa-clipboard"> Copy Text</span>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
     </t>
 </template>
 
@@ -299,47 +330,6 @@
                     data-toggle="modal" data-target="#slideChannelShareModal">
                     <i class="fa fa-share-square fa-fw"/> Share
                 </button>
-                <div class="modal fade" id="slideChannelShareModal" tabindex="-1" role="dialog" aria-labelledby="slideChannelShareModalLabel" aria-hidden="true">
-                    <div class="modal-dialog" role="document">
-                        <div class="modal-content">
-                            <div class="modal-header">
-                                <h5 class="modal-title" id="slideChannelShareModalLabel">
-                                    Share
-                                </h5>
-                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                                    <span>&amp;times;</span>
-                                </button>
-                            </div>
-                            <div class="modal-body">
-                                <h5>Share on Social Networks</h5>
-                                <t t-call="website_slides.slides_share">
-                                    <t t-set="record" t-value="channel"/>
-                                </t>
-                                <h5 class="mt16">Share Link</h5>
-                                <div class="input-group">
-                                    <input type="text" class="form-control o_wslides_js_share_link" readonly="readonly" onclick="this.select();"
-                                        t-att-value="channel.website_url"/>
-                                    <div class="input-group-append">
-                                        <button class="btn btn-sm btn-primary o_clipboard_button" >
-                                            <span class="fa fa-clipboard"> Copy Text</span>
-                                        </button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <div t-if="channel.can_upload" class="justify-content-center mt-1">
-                <a role="button" class="btn btn-link btn-block o_wslides_js_slide_upload" title="Upload Presentation"
-                    aria-label="Upload Presentation" href="#"
-                    t-att-data-modules-to-install="modules_to_install"
-                    t-att-data-channel-id="channel.id"
-                    t-att-data-can-upload="channel.can_upload"
-                    t-att-data-can-publish="channel.can_publish">
-                    <i class="fa fa-cloud-upload fa-fw"/> Upload
-                </a>
             </div>
         </div>
     </div>
@@ -353,7 +343,7 @@
             <t t-foreach="category_data" t-as="category">
                 <t t-set="category_id" t-value="category['id'] if category['id'] else None"/>
 
-                <li t-if="category['total_slides'] or channel.can_publish" t-att-class="'o_wslides_slide_list_category o_wslides_js_list_item mb-2' if category_id else 'mb-3'" t-att-data-slide-id="category_id" t-att-data-category-id="category_id">
+                <li t-if="category['total_slides'] or channel.can_publish" t-att-class="'o_wslides_slide_list_category o_wslides_js_list_item mb-2' if category_id else 'o_wslides_slide_list_no_category mt-4'" t-att-data-slide-id="category_id" t-att-data-category-id="category_id">
                     <div t-att-data-category-id="category_id"
                          t-att-class="'o_wslides_slide_list_category_header position-relative d-flex justify-content-between align-items-center %s' % ('o_wslides_js_category bg-white shadow-sm border-bottom-0' if category_id and channel.can_upload  else 'border-0 py-1')">
                         <div t-att-class="'d-flex align-items-center pl-3 %s' % ('o_wslides_slides_list_drag' if channel.can_publish else '')">
@@ -399,10 +389,10 @@
                 t-att-data-modules-to-install="modules_to_install"
                 t-att-data-channel-id="channel.id"
                 t-att-data-can-upload="channel.can_upload"
-                t-att-data-can-publish="channel.can_publish"><i class="fa fa-plus mr-1 align-middle"/><span>Add Content</span></a>
+                t-att-data-can-publish="channel.can_publish"><i class="fa fa-plus mr-1"/><span>Add Content</span></a>
             <a class="o_wslides_js_slide_section_add border btn btn-light bg-white" t-attf-channel_id="#{channel.id}"
                 href="#" role="button"
-                groups="website.group_website_publisher"><i class="fa fa-folder-o mr-1 align-middle"/><span>Add Section</span></a>
+                groups="website.group_website_publisher"><i class="fa fa-folder-o mr-1"/><span>Add Section</span></a>
         </div>
     </div>
     <div t-field="channel.description_html"/>
@@ -416,12 +406,14 @@
         <t t-call="website_slides.slide_icon">
             <t t-set="icon_class" t-value="'py-2 mx-2'"/>
         </t>
-        <a t-if="slide.is_preview or channel.is_member or channel.can_publish" class="o_wslides_js_slides_list_slide_link mr-auto" t-attf-href="/slides/slide/#{slug(slide)}">
-            <span t-field="slide.name"/>
-        </a>
-        <span t-else="" class="mr-auto">
-            <span t-esc="slide.name"/>
-        </span>
+        <div class="text-truncate mr-auto">
+            <a t-if="slide.is_preview or channel.is_member or channel.can_publish" class="o_wslides_js_slides_list_slide_link" t-attf-href="/slides/slide/#{slug(slide)}">
+                <span t-field="slide.name"/>
+            </a>
+            <span t-else="">
+                <span t-esc="slide.name"/>
+            </span>
+        </div>
 
         <div class="d-flex flex-wrap">
             <span t-if="slide.question_ids" t-att-class="'badge font-weight-bold px-2 py-1 m-1 %s' % ('badge-success' if channel_progress[slide.id].get('completed') else 'badge-warning')">
@@ -435,14 +427,13 @@
             <span t-elif="slide.is_preview and not channel.is_member" class="badge badge-success font-weight-normal px-2 py-1 m-1">Free preview</span>
         </div>
 
-        <div t-if="channel.is_member or channel.can_publish" class="pt-2 pb-2 border-left ml-2 mr-2 pl-2 d-flex align-items-center o_wslides_slides_list_slide_controls">
+        <div t-if="channel.is_member or channel.can_publish" class="pt-2 pb-2 border-left ml-2 mr-2 pl-2 d-flex flex-row align-items-center o_wslides_slides_list_slide_controls">
             <t t-if="channel.is_member">
                 <i t-if="not channel_progress[slide.id].get('completed')" class="check-done fa fa-circle-o text-500 px-2"></i>
                 <i t-else="" class="check-done text-success fa fa-check-circle px-2"></i>
             </t>
-            <span t-if="channel.can_publish" class="d-none d-md-inline-block">
-                <a t-if="slide.slide_type == 'webpage'" class="px-2 o_text_link text-primary" target="_blank" t-attf-href="/slides/slide/#{slug(slide)}?enable_editor=1"><span class="fa fa-pencil"/></a>
-                <a t-else="" class="px-2 o_text_link text-primary" target="_blank" t-attf-href="/web#id=#{slide.id}&amp;action=#{slide_action}&amp;model=slide.slide&amp;view_type=form"><span class="fa fa-pencil"/></a>
+            <span t-if="channel.can_publish" class="d-none d-md-flex">
+                <a class="px-2 o_text_link text-primary" t-attf-href="/slides/slide/#{slug(slide)}?enable_editor=1"><span class="fa fa-pencil"/></a>
                 <a href="#" t-att-data-slide-id="slide.id" class="o_text_link text-danger px-2 o_wslides_js_slide_archive"><span class="fa fa-trash"/></a>
             </span>
         </div>

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -11,10 +11,10 @@
                     <a href="/profile/users" class="btn btn-primary btn-lg">Go meet them</a>
                 </div>
                 <div class="col-12 col-md-5" t-if="top3_users">
-                    <div class="ml-4">
+                    <div class="ml-4 ml-md-2 mt-3">
                         <t t-foreach="top3_users" t-as="user">
                             <img class="rounded-circle img-fluid shadow ml-n4"
-                                style="border: 6px solid white"
+                                style="border: 6px solid white; max-width: 40%"
                                 t-attf-src="/web/image/res.users/#{user['id']}/image_128"/>
                         </t>
                     </div>

--- a/addons/website_slides_survey/__manifest__.py
+++ b/addons/website_slides_survey/__manifest__.py
@@ -23,6 +23,8 @@
         'views/website_profile.xml',
         'data/mail_template_data.xml',
         'data/gamification_data.xml',
+        'security/ir.model.access.csv',
+        'security/website_slides_survey_security.xml',
     ],
     'demo': [
         'data/survey_demo.xml',

--- a/addons/website_slides_survey/controllers/main.py
+++ b/addons/website_slides_survey/controllers/main.py
@@ -8,6 +8,8 @@ from odoo.http import request
 class WebsiteSlidesSurvey(http.Controller):
     @http.route(['/slides_survey/certification/search_read'], type='json', auth='user', methods=['POST'], website=True)
     def slides_certification_search_read(self, fields):
+        can_create = request.env['survey.survey'].check_access_rights('create', raise_exception=False)
         return {
             'read_results': request.env['survey.survey'].search_read([('certificate', '=', True)], fields),
+            'can_create': can_create,
         }

--- a/addons/website_slides_survey/security/website_slides_survey_security.xml
+++ b/addons/website_slides_survey/security/website_slides_survey_security.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="0">
+        <record id="rule_survey_website_publisher" model="ir.rule">
+            <field name="name">Survey: website group: access read</field>
+            <field name="model_id" ref="model_survey_survey"/>
+            <field name="groups" eval="[(4, ref('website.group_website_publisher'))]"/>
+            <field name="domain_force">[('certificate', '=', True)]</field>
+            <field name="perm_unlink" eval="0"/>
+            <field name="perm_write" eval="0"/>
+            <field name="perm_read" eval="1"/>
+            <field name="perm_create" eval="0"/>
+        </record>
+    </data>
+</odoo>

--- a/addons/website_slides_survey/static/src/js/slides_upload.js
+++ b/addons/website_slides_survey/static/src/js/slides_upload.js
@@ -38,7 +38,7 @@ SlidesUpload.SlideUploadDialog.include({
                 return self._rpc({
                     route: '/slides_survey/certification/search_read',
                     params: {
-                        fields: ['title'],
+                        fields: ['title','certification_badge_id'],
                     }
                 });
             }, 'title')
@@ -67,7 +67,6 @@ SlidesUpload.SlideUploadDialog.include({
                 $select2Container.addClass('is-valid');
             }
         }
-
         return result;
     },
     /**
@@ -80,13 +79,17 @@ SlidesUpload.SlideUploadDialog.include({
         var result = this._super.apply(this, arguments);
 
         var certificateValue = this.$('#certification_id').select2('data');
-        if (certificateValue) {
-            result['survey_id'] =  certificateValue.id;
+        if (certificateValue && certificateValue.create) {
+            result['survey_id'] =  [0, {'title': certificateValue.text}];
+        } else if (certificateValue) {
+            result['survey_id'] =  [certificateValue.id];
+        }
+        if (this.$('#certification_give_badge').is(':checked')) {
+            result['badge_id'] = [$("#certification_badge_id_readonly").val()]
         }
         return result;
     }
 });
-
 SlidesUpload.websiteSlidesUpload.include({
     xmlDependencies: (SlidesUpload.websiteSlidesUpload.prototype.xmlDependencies || []).concat(
         ["/website_slides_survey/static/src/xml/website_slide_upload.xml"]

--- a/addons/website_slides_survey/static/src/xml/website_slide_upload.xml
+++ b/addons/website_slides_survey/static/src/xml/website_slide_upload.xml
@@ -3,33 +3,36 @@
     <t t-name="website.slide.upload.modal.certification">
         <div>
             <form class="clearfix">
-                <div class="form-group row">
-                    <label for="certification_id" class="col-form-label col-md-3">Certification</label>
-                    <div class="controls col-md-9">
-                        <input class="form-control" id="certification_id" required="required"/>
-                    </div>
+                <div id="warning-no-certif" class="o_hidden" style="color: red;text-align: right;">
+                    There is no certification available, please contact your administrator.
                 </div>
-                <t t-call="website.slide.upload.modal.common"/>
-                <div class="form-group row">
-                    <div class="col-md-4">
+                <div class="row">
+                    <div id="slide_js_upload_left_column" class="col">
+                        <div class="form-group">
+                            <label for="certification_id" class="col-form-label col-md-3">Certification</label>
+                            <input class="form-control" id="certification_id" required="required"/>
+                        </div>
+                        <div class="form-group">
+                            <label for="upload" class="col-form-label">Choose an Image</label>
+                            <input id="upload" name="file" class="form-control" accept="image/*" type="file" required="required"/>
+                        </div>
+                        <t t-call="website.slide.upload.modal.common"/>
+                        <div class="form-group">
+                            <label for="certification_give_badge" class="col-form-labe">Give badge</label>
+                            <input id="certification_give_badge" class="align-middle ml-3" name="certification_give_badge" type="checkbox" checked="checked"/>
+                            <input id="certification_badge_id_readonly" class="d-none" name="certification_badge_id_readonly" readonly="True"/>
+                        </div>
+                        <canvas id="data_canvas" class="d-none"></canvas>
+                    </div>
+ 
+                    <div id="slide_js_upload_preview_column" class="col-md-6 d-none">
                         <div class="img-thumbnail">
                             <div class="o_slide_preview">
                                 <img src="/website_slides/static/src/img/document.png" id="slide-image" title="Content Preview" alt="Content Preview" class="img-fluid"/>
                             </div>
                         </div>
-                    </div>
-                    <div class="col-md-8">
-                        <ul class="list-group">
-                            <li class="list-group-item">
-                                <h5 class="list-group-item-heading">
-                                    <label for="upload" class="col-form-label">Cover Image File</label>
-                                </h5>
-                                <input id="upload" name="file" class="form-control" accept="image/*" type="file" required="required" data-prevent-onchange="1"/>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-                <canvas id="data_canvas" class="d-none"></canvas>
+                    </div>        
+                </div>  
             </form>
         </div>
     </t>


### PR DESCRIPTION
[IMP] eLearning: allow creation of certification on frontend

Before, you had to create a certification in the backend before adding it
to a course. Now, when you create a new certification, you can choose an
existing one or create a new one. If you create a new one, you are redirected
on the backend to complete the survey after the creation of the slide.
A member of website_publisher without right on survey can now add a certification
only if there was already one available. If there is no certification, a simple message
is displayed to the use. It is also possible to add a badge to a certification in the frontend
if there is already a badge for the certification, this badge is used,
otherwise a badge with the name/image of the certification is created.

task-id:1981399



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
