### PR TITLE
[FIX] website_blog: prevent 403 and 404 error when loading images

### DIFF
--- a/addons/website_blog/static/src/js/s_latest_posts_frontend.js
+++ b/addons/website_blog/static/src/js/s_latest_posts_frontend.js
@@ -112,7 +112,7 @@ sAnimation.registry.js_get_posts = sAnimation.Class.extend({
             $progress.appendTo($loadingContainer);
             $post.appendTo(self.$target);
 
-            var m = $thumb.css('background-image').match(/url\(["']?(.+)["']?\)/);
+            var m = $thumb.css('background-image').match(/url\(["|']+(.+)['|"]+\)/);
             var bg = m ? m[1] : 'none';
             var loaded = false;
 


### PR DESCRIPTION
When you add the snippet "Latest Posts - Big Images" or "Latest Posts -
List", a 404 error appears in the console when displaying images.

This is due to the regular expression that kept the last quotation mark
of the image url (translated by a %22 at the end of the url)

osw 2061596

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
