### PR TITLE
[FIX] base: prevent `installed` modules with no `latest_version` number

### DIFF
--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -300,6 +300,7 @@ class Module(models.Model):
 
     _sql_constraints = [
         ('name_uniq', 'UNIQUE (name)', 'The name of the module must be unique!'),
+        ('version_mandatory_if_module_is_installed', "CHECK ((NOT state = 'installed') OR (latest_version IS NOT NULL))", "Installed modules must have an Installed Version number."),
     ]
 
     @api.multi


### PR DESCRIPTION
This commit is the first step towards finding some uninstallation
issues that cause modules to be registered as `installed` but with no
`latest_version` anymore.
Due to the current implementation of the Odoo framework, a module with
lower (or no) version number is considered as `to be migrated`. This
may lead to registry crashes and is currently worked around by putting
back version number in SQL.

We hope that this commit will raise a traceback at the exact place
where the version number gets wrongly removed.