### PR TITLE
[IMP] website_sale: enhance categories filtering

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_filter.js
+++ b/addons/website_sale/static/tests/tours/website_sale_filter.js
@@ -1,0 +1,106 @@
+odoo.define('website_sale.tour_filter', function (require) {
+    'use strict';
+
+    var tour = require("web_tour.tour");
+
+    tour.register('website_sale_category_filter', {
+        test: true,
+        url: '/shop',
+    }, [
+    {
+        content: "Open Customize menu",
+        trigger: '#customize-menu > a:contains("Customize")',
+    }, {
+        content: "Enable Categories",
+        trigger: 'a.dropdown-item label:contains("eCommerce Categories")',
+    }, { // No Filter: All categories
+        trigger: 'a:contains("(7)"):parent:contains("category_1")',
+        run: function () {},
+    }, {
+        trigger: 'a:contains("(2)"):parent:contains("category_1_1")',
+        run: function () {},
+    }, {
+        trigger: 'a:contains("(1)"):parent:contains("category_1_1_1")',
+        run: function () {},
+    }, {
+        trigger: 'a:contains("(2)"):parent:contains("category_1_2")',
+        run: function () {},
+    }, {
+        trigger: 'a:contains("(1)"):parent:contains("category_1_2_1")',
+        run: function () {},
+    }, {
+        trigger: 'a:contains("(2)"):parent:contains("category_2")',
+        run: function () {},
+    }, {
+        trigger: 'a:contains("(1)"):parent:contains("category_2_2")',
+        run: function () {},
+    }, {
+        trigger: 'a:contains("(1)"):parent:contains("category_3")',
+        run: function () {},
+    }, {
+        trigger: 'a:contains("(1)"):parent:contains("category_3_1")',
+        run: function () {},
+    }, {
+        trigger: 'a:contains("(1)"):parent:contains("category_4")',
+        run: function () {},
+    }, { // Products in multiple child categories
+        trigger: 'body',
+        run: function () {
+            window.location.href = window.location.origin + '/shop?search=product_d';
+        },
+    }, {
+        trigger: 'a:contains("(2)"):parent:contains("category_1")',
+        run: function () {},
+    }, {
+        trigger: 'a:contains("(2)"):parent:contains("category_1_1")',
+        run: function () {},
+    }, {
+        trigger: 'a:contains("(1)"):parent:contains("category_1_1_1")',
+        run: function () {},
+    }, {
+        trigger: 'a:contains("(1)"):parent:contains("category_2")',
+        run: function () {},
+    }, {
+        trigger: 'a:contains("(1)"):parent:contains("category_2_2")',
+        run: function () {},
+    }, {
+        trigger: 'a:contains("(1)"):parent:contains("category_3")',
+        run: function () {},
+    }, {
+        trigger: 'a:contains("(1)"):parent:contains("category_3_1")',
+        run: function () {},
+    }, { // Products in multiple main categories
+        trigger: 'body',
+        run: function () {
+            window.location.href = window.location.origin + '/shop?search=product_c';
+        },
+    }, {
+        trigger: 'a:contains("(1)"):parent:contains("category_1")',
+        run: function () {},
+    }, {
+        trigger: 'a:contains("(1)"):parent:contains("category_2")',
+        run: function () {},
+    }, { // Products in one child category
+        trigger: 'body',
+        run: function () {
+            window.location.href = window.location.origin + '/shop?search=product_f';
+        },
+    }, {
+        trigger: 'a:contains("(1)"):parent:contains("category_1")',
+        run: function () {},
+    }, {
+        trigger: 'a:contains("(1)"):parent:contains("category_1_2")',
+        run: function () {},
+    }, {
+        trigger: 'a:contains("(1)"):parent:contains("category_1_2_1")',
+        run: function () {},
+    }, { // Products in one main category
+        trigger: 'body',
+        run: function () {
+            window.location.href = window.location.origin + '/shop?search=product_h';
+        },
+    }, {
+        trigger: 'a:contains("(1)"):parent:contains("category_4")',
+        run: function () {},
+    }]);
+});

--- a/addons/website_sale/tests/__init__.py
+++ b/addons/website_sale/tests/__init__.py
@@ -11,3 +11,4 @@ from . import test_website_sale_product_attribute_value_config
 from . import test_website_sale_image
 from . import test_website_sequence
 from . import test_website_sale_visitor
+from . import test_website_sale_filter

--- a/addons/website_sale/tests/test_website_sale_filter.py
+++ b/addons/website_sale/tests/test_website_sale_filter.py
@@ -1,0 +1,56 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import odoo
+
+from odoo.tests.common import HttpCase, TransactionCase
+from odoo.addons.website_sale.controllers.main import WebsiteSale
+from odoo.addons.website.tools import MockRequest
+from odoo.osv import expression
+
+
+class TestUi(HttpCase, TransactionCase):
+
+    def setUp(self):
+        super(TestUi, self).setUp()
+
+        self.website = self.env['website'].browse(1)
+        self.WebsiteSaleController = WebsiteSale()
+
+        Category = self.env['product.public.category']
+        Product = self.env['product.template']
+
+        Category.search([]).unlink()  # remove demo data to ease testing
+
+        category_1 = Category.create({'name': "category_1"})
+        category_1_1 = Category.create({'name': "category_1_1", 'parent_id': category_1.id})
+        category_1_1_1 = Category.create({'name': "category_1_1_1", 'parent_id': category_1_1.id})
+        category_1_2 = Category.create({'name': "category_1_2", 'parent_id': category_1.id})
+        category_1_2_1 = Category.create({'name': "category_1_2_1", 'parent_id': category_1_2.id})
+
+        category_2 = Category.create({'name': "category_2"})
+        Category.create({'name': "category_2_1", 'parent_id': category_2.id})  # unused child category
+        category_2_2 = Category.create({'name': "category_2_2", 'parent_id': category_2.id})  # unused child category
+
+        category_3 = Category.create({'name': "category_3"})  # category without product
+        category_3_1 = Category.create({'name': "category_3_1", 'parent_id': category_3.id})  # Only the sub_category has product
+
+        category_4 = Category.create({'name': "category_4"})  # category without child
+
+        Category.create({'name': "category_5"})  # unused main category
+
+        Product.create({'name': "product_a", 'website_published': True, 'public_categ_ids': category_1})
+        Product.create({'name': "product_b", 'website_published': True, 'public_categ_ids': category_1})
+        Product.create({'name': "product_c_1", 'website_published': True, 'public_categ_ids': category_1})
+        Product.create({'name': "product_d_1", 'website_published': True, 'public_categ_ids': category_1_1})
+        Product.create({'name': "product_d_2", 'website_published': True, 'public_categ_ids': category_1_1_1})
+        Product.create({'name': "product_e", 'website_published': True, 'public_categ_ids': category_1_2})
+        Product.create({'name': "product_f", 'website_published': True, 'public_categ_ids': category_1_2_1})
+
+        Product.create({'name': "product_c_2", 'website_published': True, 'public_categ_ids': category_2})
+        Product.create({'name': "product_d_3", 'website_published': True, 'public_categ_ids': category_2_2})
+
+        Product.create({'name': "product_d_4", 'website_published': True, 'public_categ_ids': category_3_1})
+
+        Product.create({'name': "product_h", 'website_published': True, 'public_categ_ids': category_4})
+
+    def test_01_category_filtering(self):
+        self.start_tour("/shop", 'website_sale_category_filter', login='admin')

--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -131,7 +131,7 @@
                             <field name="name"/>
                             <field name="parent_id"/>
                             <field name="website_id" options="{'no_create': True}" groups="website.group_multi_website"/>
-                            <field name="sequence"/>
+                            <field name="sequence" groups="base.group_no_one"/>
                         </group>
                     </div>
                 </sheet>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -60,6 +60,7 @@
         <xpath expr="." position="inside">
             <script type="text/javascript" src="/website_sale/static/tests/tours/website_sale_buy.js"></script>
             <script type="text/javascript" src="/website_sale/static/tests/tours/website_sale_complete_flow.js"></script>
+            <script type="text/javascript" src="/website_sale/static/tests/tours/website_sale_filter.js"></script>
             <script type="text/javascript" src="/website_sale/static/tests/tours/website_sale_shop_cart_recovery.js"></script>
             <script type="text/javascript" src="/website_sale/static/tests/tours/website_sale_shop_mail.js"></script>
             <script type="text/javascript" src="/website_sale/static/tests/tours/website_sale_shop_customize.js"></script>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -326,12 +326,12 @@
         <li class="nav-item">
             <a t-att-href="keep('/shop/category/' + slug(c), category=0)" t-attf-class="nav-link #{'active' if c.id == category.id else ''}">
                 <span t-field="c.name"/>
+                <t t-if="show_product_count" t-esc="'(%d)' % all_categs_with_count[c.id]"/>
             </a>
-            <ul t-if="c.child_id" class="nav nav-pills flex-column nav-hierarchy">
-                <t t-foreach="c.child_id" t-as="c">
-                    <t t-if="not search or c.id in search_categories_ids">
-                        <t t-call="website_sale.categories_recursive" />
-                    </t>
+            <t t-set="children" t-value="c.child_id.filtered(lambda c: c.id in all_categs_with_count)"/>
+            <ul t-if="children" class="nav nav-pills flex-column nav-hierarchy">
+                <t t-foreach="children" t-as="c">
+                    <t t-call="website_sale.categories_recursive" />
                 </t>
             </ul>
         </li>
@@ -351,7 +351,8 @@
                     <li class="nav-item">
                         <a t-att-href="keep('/shop', category=0)" t-attf-class="nav-link #{'' if category else 'active'} o_not_editable">All Products</a>
                     </li>
-                    <t t-foreach="categories" t-as="c">
+                    <t t-set="show_product_count" t-value="False"/>
+                    <t t-foreach="main_categs" t-as="c">
                         <t t-call="website_sale.categories_recursive" />
                     </t>
                 </ul>
@@ -361,11 +362,14 @@
 
     <template id="option_collapse_categories_recursive" name="Collapse Category Recursive">
         <li class="nav-item">
-            <t t-set="children" t-value="not search and c.child_id or c.child_id.filtered(lambda c: c.id in search_categories_ids)"/>
+            <t t-set="children" t-value="c.child_id.filtered(lambda c: c.id in all_categs_with_count)"/>
             <i t-if="children" t-attf-class="text-primary fa #{'fa-chevron-down' if c.id in category.parents_and_self.ids else 'fa-chevron-right'}"
                t-attf-title="#{'Unfold' if c.id in category.parents_and_self.ids else 'Fold'}"
                t-attf-aria-label="#{'Unfold' if c.id in category.parents_and_self.ids else 'Fold'}" role="img"/>
-            <a t-att-href="keep('/shop/category/' + slug(c), category=0)" t-attf-class="nav-link #{'active' if c.id == category.id else ''}" t-field="c.name"></a>
+            <a t-att-href="keep('/shop/category/' + slug(c), category=0)" t-attf-class="nav-link #{'active' if c.id == category.id else ''}">
+                <span t-field="c.name"/>
+                <t t-if="show_product_count" t-esc="'(%d)' % all_categs_with_count[c.id]"/>
+            </a>
             <ul t-if="children" class="nav nav-pills flex-column nav-hierarchy" t-att-style="'display:block;' if c.id in category.parents_and_self.ids else 'display:none;'">
                 <t t-foreach="children" t-as="c">
                     <t t-call="website_sale.option_collapse_categories_recursive"/>
@@ -380,6 +384,12 @@
         </xpath>
         <xpath expr="//t[@t-call='website_sale.categories_recursive']" position="attributes">
             <attribute name="t-call">website_sale.option_collapse_categories_recursive</attribute>
+        </xpath>
+    </template>
+
+    <template id="option_count_products_categories" name="Product Count" inherit_id="website_sale.products_categories" active="True" customize_show="True">
+        <xpath expr="//t[@t-set='show_product_count']" position="attributes">
+            <attribute name="t-value">True</attribute>
         </xpath>
     </template>
 


### PR DESCRIPTION
Previously all the categories where visible even if there was no product
inside. now we only display categories with products inside.

We now take the search and filters into account to display only
categories with products inside.

It is now possible to add the number of products in the category next to
it, it is an option in the customize.

E-Commerce categories sequence in the form view only appear in debug now

task-2002125

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
