### PR TITLE
[FIX] account, purchase, sale, stock: make message field invisible when no-message selected

### DIFF
--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -139,7 +139,7 @@
                         <separator string="Warning on the Invoice" colspan="4"/>
                         <field name="invoice_warn" nolabel="1" />
                         <field name="invoice_warn_msg" colspan="3" nolabel="1"
-                                attrs="{'required':[('invoice_warn','!=','no-message')],'readonly':[('invoice_warn','=','no-message')]}"/>
+                                attrs="{'required':[('invoice_warn','!=','no-message')],'invisible':[('invoice_warn','=','no-message')]}"/>
                     </group>
                 </page>
             </field>

--- a/addons/purchase/views/res_partner_views.xml
+++ b/addons/purchase/views/res_partner_views.xml
@@ -84,7 +84,7 @@
                         <separator string="Warning on the Purchase Order" colspan="4"/>
                         <field name="purchase_warn" nolabel="1" />
                         <field name="purchase_warn_msg" colspan="3" nolabel="1" 
-                                attrs="{'required':[('purchase_warn','!=','no-message')],'readonly':[('purchase_warn','=','no-message')]}"/>
+                                attrs="{'required':[('purchase_warn','!=','no-message')],'invisible':[('purchase_warn','=','no-message')]}"/>
                     </group>
                 </page>
             </field>

--- a/addons/sale/views/res_partner_views.xml
+++ b/addons/sale/views/res_partner_views.xml
@@ -52,7 +52,7 @@
                         <separator string="Warning on the Sales Order" colspan="4" />
                             <field name="sale_warn" nolabel="1" />
                             <field name="sale_warn_msg" colspan="3" nolabel="1" 
-                                    attrs="{'required':[('sale_warn','!=','no-message')],'readonly':[('sale_warn','=','no-message')]}"/>
+                                    attrs="{'required':[('sale_warn','!=','no-message')],'invisible':[('sale_warn','=','no-message')]}"/>
                     </group>
                 </page>
             </field>

--- a/addons/stock/views/res_partner_views.xml
+++ b/addons/stock/views/res_partner_views.xml
@@ -31,7 +31,7 @@
                     <separator string="Warning on the Picking" colspan="4"/>
                     <field name="picking_warn" nolabel="1" />
                     <field name="picking_warn_msg" colspan="3" nolabel="1" 
-                            attrs="{'required':[('picking_warn','!=','no-message')],'readonly':[('picking_warn','=','no-message')]}"/>
+                            attrs="{'required':[('picking_warn','!=','no-message')],'invisible':[('picking_warn','=','no-message')]}"/>
                 </group>
             </page>
         </field>


### PR DESCRIPTION
-Go in Contacts, tab "Internal notes" and click Edit.
-Select "Blocking Message" for "Warning on the Sales Order", write a message
and save.
-Edit again, and select "No Message" instead of "Blocking Message", then save.

Before this commit:

The message won't appear when creating a sales order, but it's still showing
in the "Internal Notes" tab. It's impossible to clear it.

After this commit:

The  message field is no longer visible when "No Message" selected.

Same principle for "Warning on the Picking", "Warning on the Invoice",
and "Warning on the Purchase Order".

Couldn't just use the "onchange" to clear the field because when selecting
"no-message", the message field would become readonly and readonly fields
are not sent when saving the record. As a consequence the message was never
overwritten using this technique.

OPW: 2069977

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
