### PR TITLE
[FIX] product,stock: display volume/weight

### DIFF
--- a/addons/delivery/views/product_template_view.xml
+++ b/addons/delivery/views/product_template_view.xml
@@ -12,4 +12,15 @@
     </field>
 </record>
 
+<record model="ir.ui.view" id="product_variant_easy_edit_view_hs_code">
+    <field name="name">product.product.view.form.easy.hs_code</field>
+    <field name="model">product.product</field>
+    <field name="inherit_id" ref="product.product_variant_easy_edit_view"/>
+    <field name="arch" type="xml">
+        <xpath expr="//group[@name='weight']" position="inside">
+            <field name="hs_code"/>
+        </xpath>
+    </field>
+</record>
+
 </odoo>

--- a/addons/mrp/views/product_views.xml
+++ b/addons/mrp/views/product_views.xml
@@ -62,6 +62,7 @@
             <field name="name">Product Variants</field>
             <field name="res_model">product.product</field>
             <field name="view_type">form</field>
+            <field name="context">{'display_product_variant_view': True}</field>
             <field name="search_view_id" ref="mrp_product_product_search_view"/>
             <field name="view_mode">kanban,tree,form</field>
         </record>

--- a/addons/point_of_sale/views/product_view.xml
+++ b/addons/point_of_sale/views/product_view.xml
@@ -25,7 +25,11 @@
         <field name="res_model">product.product</field>
         <field name="view_type">form</field>
         <field name="view_mode">kanban,tree,form,activity</field>
-        <field name="context" eval="{'search_default_filter_to_availabe_pos': 1, 'default_available_in_pos': True}"/>
+        <field name="context">{
+            'default_available_in_pos': True,
+            'display_product_variant_view': True,
+            'search_default_filter_to_availabe_pos': 1,
+        }</field>
         <field name="domain" eval="[]"/>
         <field name="search_view_id" eval="False"/> <!-- Force empty -->
         <field name="view_id" ref="product.product_product_tree_view"/>

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -156,6 +156,7 @@ class ProductTemplate(models.Model):
         inverse='_set_default_code', store=True)
 
     item_ids = fields.One2many('product.pricelist.item', 'product_tmpl_id', 'Pricelist Items')
+    show_logistic_parameters = fields.Boolean(compute='_compute_show_logistic_parameters')
 
     @api.depends('product_variant_ids')
     def _compute_product_variant_id(self):
@@ -171,6 +172,14 @@ class ProductTemplate(models.Model):
     def _compute_cost_currency_id(self):
         for template in self:
             template.cost_currency_id = self.env.user.company_id.currency_id.id
+
+    def _compute_show_logistic_parameters(self):
+        display_product_variant_view = self.env.context.get('display_product_variant_view')
+        for template in self:
+            if display_product_variant_view or template.product_variant_count == 1:
+                template.show_logistic_parameters = True
+            else:
+                template.show_logistic_parameters = False
 
     @api.multi
     def _compute_template_price(self):

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -150,14 +150,15 @@
                         </page>
                         <page string="Inventory" name="inventory" groups="product.group_stock_packaging" attrs="{'invisible':[('type', '=', 'service')]}">
                             <group name="inventory">
+                                <field name="show_logistic_parameters" invisible="1"/>
                                 <group name="group_lots_and_weight" string="Logistics" attrs="{'invisible': [('type', 'not in', ['product', 'consu'])]}">
-                                    <label for="weight" attrs="{'invisible':[('product_variant_count', '>', 1)]}"/>
-                                    <div class="o_row" name="weight" attrs="{'invisible':[('product_variant_count', '>', 1)]}">
+                                    <label for="weight" attrs="{'invisible':[('show_logistic_parameters', '=', False)]}"/>
+                                    <div class="o_row" name="weight" attrs="{'invisible':[('show_logistic_parameters', '=', False)]}">
                                         <field name="weight"/>
                                         <span><field name="weight_uom_name"/></span>
                                     </div>
-                                    <label for="volume" attrs="{'invisible':[('product_variant_count', '>', 1)]}"/>
-                                    <div class="o_row" name="volume" attrs="{'invisible':[('product_variant_count', '>', 1)]}">
+                                    <label for="volume" attrs="{'invisible':[('show_logistic_parameters', '=', False)]}"/>
+                                    <div class="o_row" name="volume" attrs="{'invisible':[('show_logistic_parameters', '=', False)]}">
                                         <field name="volume" string="Volume"/>
                                         <span><field name="volume_uom_name"/></span>
                                     </div>
@@ -253,6 +254,7 @@
             <field name="view_type">form</field>
             <field name="search_view_id" ref="product_search_form_view"/>
             <field name="view_id" eval="False"/> <!-- Force empty -->
+            <field name="context">{'display_product_variant_view': True}</field>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">
                 Create a new product variant
@@ -465,7 +467,10 @@
             <field name="res_model">product.product</field>
             <field name="view_mode">kanban,tree,form,activity</field>
             <field name="view_type">form</field>
-            <field name="context">{"search_default_filter_to_sell":1}</field>
+            <field name="context">{
+                'display_product_variant_view': True,
+                'search_default_filter_to_sell': 1,
+            }</field>
             <field name="view_id" ref="product_product_tree_view"/>
             <field name="search_view_id" ref="product_search_form_view"/>
             <field name="help" type="html">

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -81,7 +81,10 @@
             <field name="view_mode">tree,kanban,form,activity</field>
             <field name="view_type">form</field>
             <field name="search_view_id" ref="product.product_search_form_view"/>
-            <field name="context">{"search_default_filter_to_purchase": 1}</field>
+            <field name="context">{
+                'display_product_variant_view': True,
+                'search_default_filter_to_purchase': 1,
+            }</field>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">
                 Create a new product variant

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -406,6 +406,7 @@
         <field name="res_model">product.product</field>
         <field name="view_mode">tree,form,kanban</field>
         <field name="view_type">form</field>
+        <field name="context">{'display_product_variant_view': True}</field>
         <field name="search_view_id" ref="stock_product_search_form_view"/>
     </record>
 


### PR DESCRIPTION
Before this commit, on product variant form view, the fields `volume` and `weight` were hidden when the product template of the variant has multiple variants.