### PR TITLE
[FIX] website: the rte tour was undeterministic

### DIFF
--- a/addons/website/static/src/js/editor/editor_menu.js
+++ b/addons/website/static/src/js/editor/editor_menu.js
@@ -112,7 +112,7 @@ var EditorMenu = Widget.extend({
     save: function (reload) {
         var self = this;
         this.trigger_up('edition_will_stopped');
-        return this.wysiwyg.save(false).then(function (result) {
+        return this.wysiwyg.save().then(function (result) {
             var $wrapwrap = $('#wrapwrap');
             self.editable($wrapwrap).removeClass('o_editable');
             if (result.isDirty && reload !== false) {

--- a/addons/website/static/src/js/editor/editor_menu.js
+++ b/addons/website/static/src/js/editor/editor_menu.js
@@ -112,7 +112,7 @@ var EditorMenu = Widget.extend({
     save: function (reload) {
         var self = this;
         this.trigger_up('edition_will_stopped');
-        return this.wysiwyg.save().then(function (result) {
+        return this.wysiwyg.save(false).then(function (result) {
             var $wrapwrap = $('#wrapwrap');
             self.editable($wrapwrap).removeClass('o_editable');
             if (result.isDirty && reload !== false) {

--- a/addons/website/static/src/js/tours/rte.js
+++ b/addons/website/static/src/js/tours/rte.js
@@ -70,7 +70,7 @@ tour.register('rte_translator', {
 }, {
     content : "click language dropdown",
     trigger : '.js_language_selector .dropdown-toggle',
-    extra_trigger: 'body:not(.o_wait_reload):not(:has(.note-editor))',
+    extra_trigger: 'body:not(.o_wait_reload):not(:has(.note-editor)) a[data-action="edit"]',
 }, {
     content: "click on french version",
     trigger: '.js_language_selector a[data-lang="fr_BE"]',
@@ -91,6 +91,7 @@ tour.register('rte_translator', {
         action_helper.text('translated french text');
         Wysiwyg.setRange(this.$anchor.contents()[0], 22);
         this.$anchor.trigger($.Event( "keyup", {key: '_', keyCode: 95}));
+        this.$anchor.trigger('input');
     },
 }, {
     content: "translate text with special char",
@@ -100,6 +101,7 @@ tour.register('rte_translator', {
         this.$anchor.prepend('&lt;{translated}&gt;');
         Wysiwyg.setRange(this.$anchor.contents()[0], 0);
         this.$anchor.trigger($.Event( "keyup", {key: '_', keyCode: 95}));
+        this.$anchor.trigger('input');
     },
 }, {
     content: "click on input",
@@ -120,6 +122,7 @@ tour.register('rte_translator', {
 }, {
     content: "check: content is translated",
     trigger: '#wrap p font:first:contains(translated french text)',
+    extra_trigger: 'body:not(.o_wait_reload):not(:has(.note-editor)) a[data-action="edit_master"]',
     run: function () {}, // it's a check
 }, {
     content: "check: content with special char is translated",
@@ -168,7 +171,7 @@ tour.register('rte_translator', {
     }, {
     content : "click language dropdown",
     trigger : '.js_language_selector .dropdown-toggle',
-    extra_trigger: '#wrap p u',
+    extra_trigger: 'body:not(.o_wait_reload):not(:has(.note-editor)) a[data-action="edit"]',
 }, {
     content: "return in french",
     trigger : 'html[lang="en-US"] .js_language_selector .js_change_lang[data-lang="fr_BE"]',


### PR DESCRIPTION
Backport of 9424ed30b25a7ab1bfdb70514cb8c7cd745993e4.

The tour try to click on the language dropdown before the reloading of the
page if the server is slow.
To fix it, we avoid the reloading by the rte, and trigger the reload
in '_reload' method of editor menu who add the class 'o_wait_reload'.
We add a selector and trigger in the test to avoid undeterministic error.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
