### PR TITLE
[FIX] website: the rte tour was undeterministic

### DIFF
--- a/addons/website/static/src/js/tours/rte.js
+++ b/addons/website/static/src/js/tours/rte.js
@@ -64,6 +64,7 @@ tour.register('rte_translator', {
 }, {
     content : "click language dropdown",
     trigger : '.js_language_selector .dropdown-toggle',
+    extra_trigger: 'body:not(.o_wait_reload):not(:has(.note-editor)) a[data-action="edit"]',
 }, {
     content: "click on french version",
     trigger: '.js_language_selector a[data-lang="fr_BE"]',
@@ -110,6 +111,7 @@ tour.register('rte_translator', {
 }, {
     content: "check: content is translated",
     trigger: '#wrap p font:first:contains(translated french text)',
+    extra_trigger: 'body:not(.o_wait_reload):not(:has(.note-editor)) a[data-action="edit_master"]',
     run: function () {}, // it's a check
 }, {
     content: "check: content with special char is translated",
@@ -156,7 +158,7 @@ tour.register('rte_translator', {
     }, {
     content : "click language dropdown",
     trigger : '.js_language_selector .dropdown-toggle',
-
+    extra_trigger: 'body:not(.o_wait_reload):not(:has(.note-editor)) a[data-action="edit"]',
 }, {
     content: "return in french",
     trigger: 'html[lang="en-US"] .js_language_selector a[data-lang="fr_BE"]',


### PR DESCRIPTION
Backport of 9424ed30b25a7ab1bfdb70514cb8c7cd745993e4.

The tour try to click on the language dropdown before the reloading of the
page if the server is slow.
To fix it, we avoid the reloading by the rte, and trigger the reload
in '_reload' method of editor menu who add the class 'o_wait_reload'.
We add a selector and trigger in the test to avoid undeterministic error.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
