### PR TITLE
[FIX] website_slides: resolved traceback when open or save quiz

### DIFF
--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -277,7 +277,7 @@ class Slide(models.Model):
             result[cid].update(cdata)
 
         for record in self:
-            record.update(result[record.id])
+            record.update(result[record.id if type(record.id) == int else record.id.origin])
 
     def _compute_slides_statistics_type(self, read_group_res):
         """ Compute statistics based on all existing slide types """


### PR DESCRIPTION
Before this commit:
when trying to save a quiz, it gives a traceback

After this commit:
create a course or save a quiz will work as expected

Task:
https://www.odoo.com/web?debug=assets#id=2068739&action=327&model=project.task&view_type=form&menu_id=4720

Pad:
https://pad.odoo.com/p/r.5fcab3710b288d772d70c4011355a112

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
