### PR TITLE
[FIX] point_of_sale: duplicate default payment methods

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -558,7 +558,7 @@ class PosConfig(models.Model):
         if not companies:
             companies = self.env['res.company'].search([])
         for company in companies:
-            if company.chart_template_id:
+            if company.chart_template_id and not self.env['pos.payment.method'].search([('company_id', '=', company.id)], limit=1):
                 cash_journal = self.env['account.journal'].search([('company_id', '=', company.id), ('type', '=', 'cash')], limit=1)
                 pos_receivable_account = company.account_default_pos_receivable_account_id
                 payment_methods = self.env['pos.payment.method']


### PR DESCRIPTION
Calling odoo-bin -i <module> in database that already has the <module>
triggers the loading of data even if the xml data has noupdate="1". Because
of this, the `post_install_pos_localisation` is triggered creating duplicates
of the already existing payment methods. This commit fixes this behavior
by preventing the creation of pos.payment.method if they already exists.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
