### PR TITLE
[FIX] sms - mass_mailing : small view fixes

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -103,6 +103,7 @@ class MassMailing(models.Model):
         help="Use a specific mail server in priority. Otherwise Odoo relies on the first outgoing mail server available (based on their sequencing) as it does for normal mails.")
     contact_list_ids = fields.Many2many('mailing.list', 'mail_mass_mailing_list_rel',
         string='Mailing Lists')
+    contact_list_count = fields.Integer('# Contact List', compute='_compute_contact_list_count')
     contact_ab_pc = fields.Integer(string='A/B Testing percentage',
         help='Percentage of the contacts that will be mailed. Recipients will be taken randomly.', default=100)
     unique_ab_testing = fields.Boolean(string='Allow A/B Testing', default=False,
@@ -127,6 +128,10 @@ class MassMailing(models.Model):
     replied_ratio = fields.Integer(compute="_compute_statistics", string='Replied Ratio')
     bounced_ratio = fields.Integer(compute="_compute_statistics", string='Bounced Ratio')
     next_departure = fields.Datetime(compute="_compute_next_departure", string='Scheduled date')
+
+    def _compute_contact_list_count(self):
+        for mass_mailing in self:
+            mass_mailing.contact_list_count = len(mass_mailing.contact_list_ids)
 
     def _compute_total(self):
         for mass_mailing in self:
@@ -209,14 +214,12 @@ class MassMailing(models.Model):
                 if self.mailing_model_name == 'mailing.list':
                     if self.contact_list_ids:
                         mailing_domain = [('list_ids', 'in', self.contact_list_ids.ids)]
-                    else:
-                        mailing_domain = [(0, '=', 1)]
-                elif self.mailing_model_name == 'res.partner':
+                elif self.mailing_model_name == 'res.partner' and 'customer_rank' in self.env['res.partner']._fields:
                     mailing_domain = [('customer_rank', '>', 0)]
                 elif 'opt_out' in self.env[self.mailing_model_name]._fields and not self.mailing_domain:
                     mailing_domain = [('opt_out', '=', False)]
         else:
-            mailing_domain = [(0, '=', 1)]
+            mailing_domain = []
         self.mailing_domain = repr(mailing_domain)
 
     @api.onchange('mailing_type')

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -260,6 +260,8 @@
                     <field name='failed'/>
                     <field name='total'/>
                     <field name='mailing_model_id'/>
+                    <field name='mailing_model_name'/>
+                    <field name='contact_list_count'/>
                     <field name='sent_date'/>
                     <field name='active'/>
                     <templates>
@@ -331,8 +333,9 @@
                                     <img t-att-src="kanban_image('res.users', 'image_64', record.user_id.raw_value)" t-att-title="record.user_id.value" t-att-alt="record.user_id.value" width="24" height="24" class="oe_kanban_avatar float-right"/>
                                 </div>
                                 <div name="div_total_model" class="oe_clear text-muted" style="display: inline;">
-                                    <field name='total'/>
-                                    <field name='mailing_model_id'/>
+                                    <field name='total' attrs="{'invisible':  [('mailing_model_name', '==', 'mailing.list')]}"/>
+                                    <field name='contact_list_count' attrs="{'invisible':  [('mailing_model_name', '!=', 'mailing.list')]}"/>
+                                    <field name='mailing_model_id'/><span attrs="{'invisible':  [('mailing_model_name', '!=', 'mailing.list')]}"> Contact</span>
                                 </div>
                             </div>
                         </t>

--- a/addons/mass_mailing_sms/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_mailing_views.xml
@@ -31,7 +31,7 @@
             <!-- Headers / Warnings -->
             <xpath expr="//header" position="after">
                 <field name="sms_has_insufficient_credit" invisible="1"/>
-                <div class="alert alert-warning text-center" attrs="{'invisible': [('sms_has_insufficient_credit', '=', False)]}" role="alert">
+                <div class="alert alert-warning text-center" attrs="{'invisible': ['|',('sms_has_insufficient_credit', '=', False), ('mailing_type', '!=', 'sms')]}" role="alert">
                     <button class="btn-link py-0"
                             name="action_buy_sms_credits"
                             type="object">
@@ -145,7 +145,7 @@
                 <attribute name="attrs">{'invisible': [('mailing_type', '!=', 'mail')]}</attribute>
             </xpath>
             <xpath expr="//div[@name='div_total_model']" position="after">
-                <div class="alert alert-warning" role="alert" attrs="{'invisible': ['&amp;',('sms_has_insufficient_credit', '=', False), ('mailing_type', '!=', 'mail')]}">
+                <div class="alert alert-warning" role="alert" attrs="{'invisible': ['|',('sms_has_insufficient_credit', '=', False), ('mailing_type', '!=', 'sms')]}">
                     <a name="action_buy_sms_credits" type="object">Insufficient credits</a>
                 </div>
             </xpath>

--- a/addons/mass_mailing_sms/wizard/mailing_sms_test_views.xml
+++ b/addons/mass_mailing_sms/wizard/mailing_sms_test_views.xml
@@ -10,7 +10,6 @@
                 </p>
                 <group>
                     <field name="numbers" placeholder="+32 495 85 85 77, +33 545 55 55 55"/>
-                    <field name="sanitized_numbers" invisible="1"/>
                     <field name="mailing_id" invisible="1"/>
                 </group>
                 <footer>


### PR DESCRIPTION
- sms composer view : the count of all record doesn't match
the reality in a multi-company environment.
The search_count was done is sudo, then records of other
company was taken in account in the count. Fix by
explicitly call sudo(False) before the search.

- sms composer, mass composition : blocking message when
validate the composer sms with records which doesn't have
phone number. Instead, to be more user-friendly
we doesn't block the user, and sms will fail in any case.

- mass mailing, kanban view of mail marketing :
A warning ribbon ("insufficient credit") appeared on the
kanban item of mass mailing, but the message was
for sms marketing views only. Change the attributes
to be invisible for mail marketing.

- On the form of mass mailing :
Weird default domain filter ([0 = 1]) was display instead of a
empty domain filter.

TASK_ID : 2073016

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
