### PR TITLE
[FIX] mass mailing : mailing Bugfixes

### DIFF
--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -142,7 +142,7 @@
                             <div>
                                 <div class="row">
                                     <div class="col-xs-12 col-md-3" >
-                                        <field name="mailing_model_id" widget="selection" 
+                                        <field name="mailing_model_id" widget="selection" required="True"
                                             attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
                                     </div>
                                     <div attrs="{'invisible': [('mailing_model_name', '!=', 'mailing.list')]}" class="col-xs-12 col-md-9 pt-1">
@@ -158,12 +158,10 @@
 
                                 <field name="mailing_model_name" invisible="1"/>
                                 <field name="mailing_model_real" invisible="1"/>
-                                <field name="mailing_domain" widget="domain" options="{'model': 'mailing_model_real'}"
-                                    attrs="{
-                                        'invisible': [('mailing_model_name', '=', 'mailing.list')],
-                                        'readonly': [('state', 'in', ('sending', 'done'))]
-                                }">
-                                </field>                                
+                                <div attrs="{'invisible': [('mailing_model_name', '=', 'mailing.list')]}">
+                                    <field name="mailing_domain" widget="domain" options="{'model': 'mailing_model_real'}"
+                                    attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
+                                </div>
                             </div>
                         </group>
                         <notebook>
@@ -186,7 +184,6 @@
                                 <group>
                                     <group>
                                         <field name="user_id"/>
-                                        <field name="unique_ab_testing" groups="base.group_no_one" attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
                                         <field name="email_from" attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
                                         <label for="reply_to"/>
                                         <div name="reply_to_details">
@@ -215,7 +212,8 @@
                                         <field name="campaign_id"
                                             string="Mailing Campaign"
                                             groups="mass_mailing.group_mass_mailing_campaign"
-                                            attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
+                                            attrs="{'readonly': [('state', 'in', ('sending', 'done'))],
+                                                    'required': [('unique_ab_testing', '=', True)]}"/>
                                         <field name="source_id"
                                             string="Source"
                                             readonly="1"
@@ -227,6 +225,9 @@
                                              required="True"
                                              groups="base.group_no_one"
                                              attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
+                                        <field name="unique_ab_testing" 
+                                            groups="mass_mailing.group_mass_mailing_campaign"
+                                            attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
                                         <label for="contact_ab_pc" groups="mass_mailing.group_mass_mailing_campaign"/>
                                         <div groups="mass_mailing.group_mass_mailing_campaign">
                                             <field name="contact_ab_pc" 


### PR DESCRIPTION
- In the email/sms marketing form (edition), only on debug mode, we can
get a js traceback (bootstrap tooltip can't be show for a invisible
element, the domain field in this case) when we change
the recipient model from Mailing List ->
a other model -> Mailing List. We avoid the traceback by putting invisible
a parent div of the domain fields instead of the domain field itself.

-  In the email/sms marketing form (edition), we can create a
email/sms marketing without any recipient model which cause
a issue on the kanban view (blanck space). Also behind the scene the
mass mailing contact model is used. To clarify and fix the issue in
kanban view, the recipient model is now required in the form view.

- In the email/sms marketing form (debug mode only), we can create a
email/sms marketing with "allow A/B testing" checked without a
campaign marketing (not logical), which lead to a traceback when the
email are sent. To fix this issue, we move the "Allow A/B testing"
field in the group form called "marketing" and when it is
checked the marketing campaign marketing is mandatory.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
