### PR TITLE
[IMP] account: always create a jounral when adding a bank manualy

### DIFF
--- a/addons/account/models/account.py
+++ b/addons/account/models/account.py
@@ -1090,7 +1090,7 @@ class AccountJournal(models.Model):
         visible on dashboard if no bank statement source has been defined yet
         """
         # We simply call the setup bar function.
-        return self.env['res.company'].setting_init_bank_account_action()
+        return self.env['res.company'].with_context(journal_id=self.id).setting_init_bank_account_action()
 
     def create_invoice_from_attachment(self, attachment_ids=[]):
         ''' Create the invoices from files.

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -270,6 +270,7 @@ class ResCompany(models.Model):
                 'target': 'new',
                 'view_mode': 'form',
                 'views': [[view_id, 'form']],
+                'context': self.env.context,
         }
 
     @api.model

--- a/addons/account/wizard/setup_wizards.py
+++ b/addons/account/wizard/setup_wizards.py
@@ -4,7 +4,7 @@
 from datetime import date
 
 from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
+from odoo.exceptions import ValidationError, UserError
 
 
 class FinancialYearOpeningWizard(models.TransientModel):
@@ -66,13 +66,26 @@ class SetupBarBankConfigWizard(models.TransientModel):
     _description = 'Bank setup manual config'
 
     res_partner_bank_id = fields.Many2one(comodel_name='res.partner.bank', ondelete='cascade', required=True)
-    new_journal_name = fields.Char(default=lambda self: self.linked_journal_id.name, inverse='set_linked_journal_id', required=True, help='Will be used to name the Journal related to this bank account')
-    linked_journal_id = fields.Many2one(string="Journal", comodel_name='account.journal', inverse='set_linked_journal_id', compute="_compute_linked_journal_id")
-    new_journal_code = fields.Char(string="Code", required=True, default=lambda self: self._onchange_new_journal_code())
-    num_journals_without_account = fields.Integer(default=lambda self: self._number_unlinked_journal())
+    new_journal_name = fields.Char(required=True, help='Will be used to name the Journal related to this bank account')
+    new_journal_code = fields.Char(string="Code", required=True, default=lambda self: self.env['account.journal'].get_next_bank_cash_default_code('bank', self.env.company.id))
+    journal_id = fields.Many2one('account.journal')
     # field computing the type of the res.patrner.bank. It's behaves the same as a related res_part_bank_id.acc_type
     # except we want to display  this information while the record isn't yet saved.
     related_acc_type = fields.Selection(string="Account Type", selection=lambda x: x.env['res.partner.bank'].get_supported_account_types(), compute='_compute_related_acc_type')
+
+    @api.model
+    def default_get(self, fields_list):
+        values = super(SetupBarBankConfigWizard, self).default_get(fields_list)
+        if self.env.context.get('journal_id'):
+            journal = self.env['account.journal'].browse(self.env.context['journal_id'])
+            if journal.type != 'bank':
+                raise UserError(_('The configuration of a bank account needs to be done on a bank journal.'))
+            if journal.bank_account_id or journal.bank_statements_source != 'undefined':
+                raise UserError(_('This journal seems to already be configured'))
+            values['journal_id'] = journal.id
+            values['new_journal_name'] = journal.name
+            values['new_journal_code'] = journal.code
+        return values
 
     @api.depends('acc_number')
     def _compute_related_acc_type(self):
@@ -81,14 +94,6 @@ class SetupBarBankConfigWizard(models.TransientModel):
 
     def _number_unlinked_journal(self):
         return self.env['account.journal'].search([('type', '=', 'bank'), ('bank_account_id', '=', False)], count=True)
-
-    @api.onchange('linked_journal_id')
-    def _onchange_new_journal_code(self):
-        for record in self:
-            if not record.linked_journal_id:
-                record.new_journal_code = self.env['account.journal'].get_next_bank_cash_default_code('bank', self.env.company.id)
-            else:
-                record.new_journal_code = self.linked_journal_id.code
 
     @api.model
     def create(self, vals):
@@ -99,42 +104,21 @@ class SetupBarBankConfigWizard(models.TransientModel):
         vals['partner_id'] = self.env.company.partner_id.id
         return super(SetupBarBankConfigWizard, self).create(vals)
 
-    @api.onchange('linked_journal_id')
-    def _onchange_new_journal_related_data(self):
-        for record in self:
-            if record.linked_journal_id:
-                record.new_journal_name = record.linked_journal_id.name
-
-    @api.depends('journal_id')  # Despite its name, journal_id is actually a One2many field
-    def _compute_linked_journal_id(self):
-        for record in self:
-            record.linked_journal_id = record.journal_id and record.journal_id[0] or record.default_linked_journal_id()
-
-    def default_linked_journal_id(self):
-        default = self.env['account.journal'].search([('type', '=', 'bank'), ('bank_account_id', '=', False)], limit=1)
-        return default and default[0].id
-
-    def set_linked_journal_id(self):
-        """ Called when saving the wizard.
-        """
-        for record in self:
-            selected_journal = record.linked_journal_id
-            if record.num_journals_without_account == 0:
-                company = self.env.company
-                selected_journal = self.env['account.journal'].create({
-                    'name': record.new_journal_name,
-                    'code': record.new_journal_code,
-                    'type': 'bank',
-                    'company_id': company.id,
-                    'bank_account_id': record.res_partner_bank_id.id,
-                })
-            else:
-                selected_journal.bank_account_id = record.res_partner_bank_id.id
-                selected_journal.name = record.new_journal_name
-                selected_journal.code = record.new_journal_code
-
     def validate(self):
         """ Called by the validation button of this wizard. Serves as an
         extension hook in account_bank_statement_import.
         """
-        self.linked_journal_id.mark_bank_setup_as_done_action()
+        if not self.journal_id:
+            self.journal_id = self.env['account.journal'].create({
+                'name': self.new_journal_name,
+                'code': self.new_journal_code,
+                'type': 'bank',
+                'company_id': self.env.company.id,
+                'bank_account_id': self.res_partner_bank_id.id,
+            })
+        else:
+            self.journal_id.name = self.new_journal_name
+            self.journal_id.code = self.new_journal_code
+            self.journal_id.bank_account_id = self.res_partner_bank_id
+        self.journal_id.mark_bank_setup_as_done_action()
+        return self.journal_id

--- a/addons/account/wizard/setup_wizards_view.xml
+++ b/addons/account/wizard/setup_wizards_view.xml
@@ -35,9 +35,6 @@
             <field name="model">account.setup.bank.manual.config</field>
             <field name="arch" type="xml">
                 <form>
-                    <field name="num_journals_without_account" invisible="1"/>
-                    <field name="journal_id" invisible="1"/>
-                    <field name="linked_journal_id" invisible="1"/>
                     <sheet>
                         <div class="oe_title">
                             <h1><field name="new_journal_name" placeholder="e.g Checking account" class="oe_inline"/></h1>
@@ -51,14 +48,6 @@
                             <group>
                                 <field name="related_acc_type" attrs="{'invisible': [('acc_number','=',False)]}"/>
                             </group>
-                        </group>
-                        <group attrs="{'invisible': [('num_journals_without_account', '&lt;', 2)]}">
-                           <group>
-                            <field name="linked_journal_id" attrs="{'required': [('num_journals_without_account','!=',0)]}" domain="[('type','=','bank'), ('bank_account_id', '=', False)]"/>
-                          </group>
-                          <group>
-                               <span class="text-muted">Only journals not yet linked to a bank account are proposed</span>
-                           </group>
                         </group>
                     </sheet>
                     <footer>

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -702,6 +702,12 @@ tour.register('main_flow_tour', {
     position: "right",
     run: "text 867656544",
 }, {
+    edition: "enterprise",
+    trigger: ".o_field_widget[name=new_journal_name]",
+    content: _t("Enter a journal name"),
+    position: "right",
+    run: "text AwesomeBank",
+}, {
     trigger: ".modal-footer .btn-primary",
     content: _t('Save'),
     position: 'bottom',


### PR DESCRIPTION
Before we tried to be smart about the selection of the bank journal. But
selecting only the jounrals with a bank number on it is not right
because you can have a synchronisation without having a bank number and
we don't want to alter journals in this case.
There is also the question of
> Do we need to alter journals with entries on it?

We simply always create a new journal to solve this except when we click
on 'Configure' on a journal from the dashboard.

We still have the bank journal created by the installation of the CoA,
this will be dealt with in a later version to ensure flows are not
perturbed.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
