### PR TITLE
[FIX] point_of_sale: negative amount paid with payment terminal

### DIFF
--- a/addons/point_of_sale/static/src/js/screens.js
+++ b/addons/point_of_sale/static/src/js/screens.js
@@ -2098,7 +2098,7 @@ var PaymentScreenWidget = ScreenWidget.extend({
             this.reset_input();
 
             this.payment_interface = payment_method.payment_terminal;
-            if (this.payment_interface) {
+            if (this.payment_interface && order.selected_paymentline.amount > 0) {
                 order.selected_paymentline.set_payment_status('pending');
             }
 


### PR DESCRIPTION
It was described in this commit 5b769650d6416be123e972aa8f4b2b2c25ce438f
the purpose of allowing negative payment line - in summary, it is for
returns.

This behavior works well with normal payment methods except with
terminal payment methods. Before this commit, when adyen (or other
terminal payment method) is selected for negative due, a payment line is
registered for adyen but amount_return field is not calculated correctly
because the payment line is not `done`. And this resulted to the
creation of new payment for the order when it reaches the backend.

This commit implements the consistency of registering negative payments
among payment methods -- negative payments are registered regardless of
payment method.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
