### PR TITLE
[FIX] eLearning, forum : tab visibility

### DIFF
--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -170,13 +170,19 @@
                         <!-- Training Content -->
                         <div class="col-12 col-md-8 col-lg-9">
                             <ul class="nav nav-tabs o_wslides_nav_tabs flex-nowrap" role="tablist" id="profile_extra_info_tablist">
-                                <li class="nav-item o_wslides_course_header_nav_home">
-                                    <a t-att-class="'nav-link %s' % ('active' if active_tab == 'home' else '')" id="home-tab" data-toggle="pill" href="#home" role="tab" aria-controls="home" t-att-aria-selected="'true' if active_tab == 'home' else 'false'">
+                                <li class="nav-item o_wslides_course_header_nav_home_training">
+                                    <a t-att-class="'nav-link %s' % ('active' if active_tab == 'home' else '')" 
+                                        id="home-tab" data-toggle="pill" href="#home" role="tab" aria-controls="home" 
+                                        t-att-aria-selected="'true' if active_tab == 'home' else 'false'">
                                         <i class="fa fa-home"/> Course
                                     </a>
                                 </li>
                                 <li t-if="channel.allow_comment" class="nav-item">
-                                    <a t-att-class="'nav-link %s' % ('active' if active_tab == 'review' else '')" id="review-tab" data-toggle="pill" href="#review" role="tab" aria-controls="review" t-att-aria-selected="'true' if active_tab == 'review' else 'false'">Review</a>
+                                    <a t-att-class="'nav-link %s' % ('active' if active_tab == 'review' else '')" 
+                                        id="review-tab" data-toggle="pill" href="#review" role="tab" aria-controls="review" 
+                                        t-att-aria-selected="'true' if active_tab == 'review' else 'false'">
+                                        Review
+                                    </a>
                                 </li>
                             </ul>
 
@@ -204,13 +210,20 @@
                         <div class="row">
                             <div class="col-12 col-md-8 offset-md-4 col-lg-9 offset-lg-3">
                                 <ul class="nav nav-tabs o_wslides_nav_tabs o_wslides_doc_nav_tabs flex-nowrap" role="tablist" id="profile_extra_info_tablist">
-                                    <li class="nav-item o_wslides_course_header_nav_home">
-                                        <a class="nav-link active" id="home-tab" data-toggle="pill" href="#home" role="tab" aria-controls="home" aria-selected="true">
-                                            <i class="fa fa-home"/> Course
+                                    <li class="nav-item o_wslides_course_header_nav_home_documentation">
+                                        <a t-att-class="'nav-link %s' % ('active' if active_tab == 'home' else '')"
+                                            id="home-tab" data-toggle="pill" href="#home" role="tab" aria-controls="home"
+                                            t-att-aria-selected="'true' if active_tab == 'home' else 'false'">
+                                            <i class="fa fa-home"/>
+                                            Course
                                         </a>
                                     </li>
-                                    <li class="nav-item">
-                                        <a class="nav-link" id="review-tab" data-toggle="pill" href="#review" role="tab" aria-controls="review" aria-selected="false">Review</a>
+                                    <li t-if="channel.allow_comment" class="nav-item">
+                                        <a t-att-class="'nav-link %s' % ('active' if active_tab == 'review' else '')"
+                                            id="review-tab" data-toggle="pill" href="#review" role="tab" aria-controls="review"
+                                            t-att-aria-selected="'true' if active_tab == 'review' else 'false'">
+                                            Review
+                                        </a>
                                     </li>
                                 </ul>
                             </div>
@@ -218,10 +231,10 @@
                     </div>
 
                     <div class="tab-content pb-5" id="courseMainTabContent">
-                        <div class="tab-pane fade show active" id="home" role="tabpanel" aria-labelledby="home-tab">
+                        <div t-att-class="'tab-pane fade %s' % ('show active' if active_tab == 'home' else '')" id="home" role="tabpanel" aria-labelledby="home-tab">
                             <t t-if="channel.channel_type == 'documentation'" t-call="website_slides.course_slides_cards"/>
                         </div>
-                        <div class="tab-pane fade" id="review" role="tabpanel" aria-labelledby="review-tab">
+                        <div t-if="channel.allow_comment" t-att-class="'tab-pane fade %s' % ('show active' if active_tab == 'review' else '')" id="review" role="tabpanel" aria-labelledby="review-tab">
                             <div class="container pt-4">
                                 <t t-call="portal.message_thread">
                                     <t t-set="object" t-value="channel"/>

--- a/addons/website_slides_forum/views/website_slides_forum_templates.xml
+++ b/addons/website_slides_forum/views/website_slides_forum_templates.xml
@@ -14,7 +14,7 @@
                             <li class="nav-item">
                                 <a t-att-href="'/forum/%s' % (slug(forum))" t-att-class="'nav-link active o_wprofile_navlink'" style="border-left: 0px">Forum</a>
                             </li>
-                            <li class="nav-item">
+                            <li t-if="forum.slide_channel_id.allow_comment" class="nav-item">
                                 <a t-att-href="'/slides/%s?active_tab=review' % (slug(forum.slide_channel_id))"
                                     t-att-class="'nav-link o_wprofile_navlink'" style="border-left: 0px">Review</a>
                             </li>

--- a/addons/website_slides_forum/views/website_slides_templates.xml
+++ b/addons/website_slides_forum/views/website_slides_templates.xml
@@ -1,8 +1,15 @@
 <?xml version="1.0" ?>
 <odoo><data>
     <template id='course_main' inherit_id="website_slides.course_main">
-        <!-- Channel main template: add link to forum -->
-        <xpath expr="//li[hasclass('o_wslides_course_header_nav_home')]" position="after">
+        <!-- Channel (training) main template: add link to forum -->
+        <xpath expr="//li[hasclass('o_wslides_course_header_nav_home_training')]" position="after">
+            <li class="nav-item" t-if="channel.forum_id">
+            <a t-att-href="'/forum/%s' % (slug(channel.forum_id))"
+                t-att-class="'nav-link'" target="new">Forum</a>
+            </li>
+        </xpath>
+        <!-- Channel (documentation) main template: add link to forum -->
+        <xpath expr="//li[hasclass('o_wslides_course_header_nav_home_documentation')]" position="after">
             <li class="nav-item" t-if="channel.forum_id">
                 <a t-att-href="'/forum/%s' % (slug(channel.forum_id))"
                     t-att-class="'nav-link'" target="new">Forum</a>


### PR DESCRIPTION

From Website (Frontend) / From the Courses / From a course (with settings course : Course type = "Documentation" & Forum mentioned):
--> The tab for the forum isn't there

From Website (Frontend) / From the Courses / From a course (with settings course : Course type = "Documentation" &  "Allow rating on Course" disabled):
--> The tab for the review is always there

From Website (Frontend) / From the Forum / From a course (with settings course : Course type = "Documentation" & "Allow rating on Course" activivated):
--> Click the tab for the review, the returned view is the course tab and not the review tab

From Website (Frontend) / From the Forum  / From a course (with settings course : "Allow rating on Course" disabled):
--> The tab for the review is always there

TASK-ID:  2074030
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
