### PR TITLE
some improvements in daterangepicker

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -666,10 +666,12 @@ var FieldDateRange = InputField.extend({
             endDate = this._formatValue(this.value);
         }
         this.dateRangePickerOptions.startDate = startDate || moment();
-        this.dateRangePickerOptions.endDate = endDate || (startDate && moment(startDate) || moment()).add(24, 'hour');
+        this.dateRangePickerOptions.endDate = endDate ||
+            (startDate && moment(startDate, this.isDateField ? time.getLangDateFormat() : time.getLangDatetimeFormat()) || moment()).add(24, 'hour');
 
         this.$el.daterangepicker(this.dateRangePickerOptions);
         this.$el.on('apply.daterangepicker', this._applyChanges.bind(this));
+        this.$el.on('cancel.daterangepicker', this._applyChanges.bind(this));
         this.$el.on('show.daterangepicker', this._applyChanges.bind(this));
         this.$el.on('clickDate.daterangepicker', this._applyChanges.bind(this));
         this.$el.on('timeChanged.daterangepicker', this._applyChanges.bind(this));

--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -619,7 +619,9 @@ var FieldDateRange = InputField.extend({
     _applyChanges: function (ev, picker) {
         var changes = {};
         var displayStartDate = field_utils.format[this.formatType](picker.startDate, {}, {timezone: false});
-        var displayEndDate = field_utils.format[this.formatType](picker.endDate, {}, {timezone: false});
+        if (picker.endDate !== null) {
+            var displayEndDate = field_utils.format[this.formatType](picker.endDate, {}, {timezone: false});
+        }
         var changedStartDate = picker.startDate;
         var changedEndDate = picker.endDate;
         if (this.isDateField) {
@@ -627,7 +629,9 @@ var FieldDateRange = InputField.extend({
             // time at 00:00:00. So, Odoo will consider it as UTC. To fix this added browser
             // timezone offset in dates to get a correct selected date.
             changedStartDate = picker.startDate.add(session.getTZOffset(picker.startDate), 'minutes');
-            changedEndDate = picker.endDate.startOf('day').add(session.getTZOffset(picker.endDate), 'minutes');
+            if (picker.endDate !== null) {
+                changedEndDate = picker.endDate.startOf('day').add(session.getTZOffset(picker.endDate), 'minutes');
+            }
         }
         if (this.relatedEndDate) {
             this.$el.val(displayStartDate);
@@ -662,10 +666,13 @@ var FieldDateRange = InputField.extend({
             endDate = this._formatValue(this.value);
         }
         this.dateRangePickerOptions.startDate = startDate || moment();
-        this.dateRangePickerOptions.endDate = endDate || moment();
+        this.dateRangePickerOptions.endDate = endDate || (startDate && moment(startDate) || moment()).add(24, 'hour');
 
         this.$el.daterangepicker(this.dateRangePickerOptions);
         this.$el.on('apply.daterangepicker', this._applyChanges.bind(this));
+        this.$el.on('show.daterangepicker', this._applyChanges.bind(this));
+        this.$el.on('clickDate.daterangepicker', this._applyChanges.bind(this));
+        this.$el.on('timeChanged.daterangepicker', this._applyChanges.bind(this));
         this.$el.off('keyup.daterangepicker');
         this.$pickerContainer = this.$el.data('daterangepicker').container;
 

--- a/addons/web/static/src/js/libs/daterangepicker.js
+++ b/addons/web/static/src/js/libs/daterangepicker.js
@@ -2,13 +2,21 @@ odoo.define('web.daterangepicker.extensions', function () {
 'use strict';
 
 /**
- * Don't allow user to select off days(Dates which are out of current calendar).
+ * Update date in input field when user change the date
  */
 var clickDateFunction = daterangepicker.prototype.clickDate;
 daterangepicker.prototype.clickDate = function (ev) {
-    if (!$(ev.target).hasClass('off')) {
-        clickDateFunction.apply(this, arguments);
-    }
+    clickDateFunction.apply(this, arguments);
+    this.element.trigger('clickDate.daterangepicker', this);
+};
+
+/**
+ * Update time in input field when user change the time
+ */
+var timeChangedFunction = daterangepicker.prototype.timeChanged;
+daterangepicker.prototype.timeChanged = function(ev) {
+    timeChangedFunction.apply(this, arguments);
+    this.element.trigger('timeChanged.daterangepicker', this);
 };
 
 });


### PR DESCRIPTION
- Clicking on the input field display the start and end date
- Changes in the date or time reflect in the input field
- Click on Apply or outside the box do the same thing

Task:https://www.odoo.com/web#id=2042617&action=333&active_id=1361&model=project.task&view_type=form&menu_id=4720

Pad: https://pad.odoo.com/p/r.1878019d0f0c1ff59c17fd52d0383e88


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr