### PR TITLE
[FIX] web_tour: fixed drag and drop issue in tour

### DIFF
--- a/addons/web_tour/static/src/js/tip.js
+++ b/addons/web_tour/static/src/js/tip.js
@@ -305,6 +305,8 @@ Tip.getConsumeEventType = function ($element) {
         return !type || !!type.match(/^(email|number|password|search|tel|text|url)$/);
     })) {
         return "input";
+    } else if ($element.is('div') && $element.hasClass('ui-draggable ui-draggable-handle')) {
+        return "drag";
     }
     return "click";
 };


### PR DESCRIPTION
Currently, when running tour manually at the step of drag and drop, a tip is not
moving ahead it is showing bubble on the drag element even after drag and drop.

After this commit:
After drag and drop, the bubble will be move on to the next element.

Task: 
https://www.odoo.com/web#action=327&id=2071632&menu_id=4720&model=project.task&view_type=form

Pad:
https://pad.odoo.com/p/r.b2e8c40d2d539d0262d076876ad10eb5

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
