### PR TITLE
[FIX] stock, delivery: Quantity done not set properly

### DIFF
--- a/addons/delivery/wizard/choose_delivery_package.py
+++ b/addons/delivery/wizard/choose_delivery_package.py
@@ -43,10 +43,7 @@ class ChooseDeliveryPackage(models.TransientModel):
             return {'warning': warning_mess}
 
     def put_in_pack(self):
-        move_line_ids = self.picking_id.move_line_ids.filtered(lambda ml:
-            float_compare(ml.qty_done, 0.0, precision_rounding=ml.product_uom_id.rounding) > 0
-            and not ml.result_package_id
-        )
+        move_line_ids = self.picking_id._get_move_lines_to_package()
         delivery_package = self.picking_id._put_in_pack(move_line_ids)
         # write shipping weight and product_packaging on 'stock_quant_package' if needed
         if self.delivery_packaging_id:


### PR DESCRIPTION
When there is no quantity done set before calling `put_in_pack`,
those quantities were automatically updated before raising the wizards.
This was problematic because changes on the quantities done were made
even if the wizards are discarded.

TaskID: BugsLogistics
