### PR TITLE
[FIX] sale: crash when SO confirmation date field is not set

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -231,7 +231,7 @@ class SaleOrder(models.Model):
         """
         for order in self:
             dates_list = []
-            confirm_date = fields.Datetime.from_string(order.confirmation_date if order.state in ['sale', 'done'] else fields.Datetime.now())
+            confirm_date = order.confirmation_date or fields.Datetime.now() if order.state in ['sale', 'done'] else fields.Datetime.now()
             for line in order.order_line.filtered(lambda x: x.state != 'cancel' and not x._is_delivery()):
                 dt = confirm_date + timedelta(days=line.customer_lead or 0.0)
                 dates_list.append(dt)


### PR DESCRIPTION
- When computing the field `expected_date` on sale orders the
  computed method crashes if the field `confirmation_date` is not set.

  This is because we try to do an addition between a `NoneType` and
  a `datetime.timedelta`.
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
