### PR TITLE
[FIX] web_editor: removed scroll for large links

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.ui.scss
+++ b/addons/web_editor/static/src/scss/web_editor.ui.scss
@@ -1626,6 +1626,9 @@ body .modal {
         }
         .o_link_dialog_preview {
             border-left: 1px solid gray('200');
+            #link-preview {
+                display: block;
+            }
         }
     }
     // Crop Dialog


### PR DESCRIPTION
Before this commit:
when opening link dialog in the website, there will be a vertical scroll bar for
a large type of links.

After this commit:
A scroll bar will be hidden for large links in link dialog

Task:
https://www.odoo.com/web#action=327&id=2073757&menu_id=4720&model=project.task&view_type=form

Pad:
https://pad.odoo.com/p/r.e299f8d666ba0dbe69016efa7589e27e

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
