### PR TITLE
[IMP] stock: hidden quants from product views

### DIFF
--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -279,7 +279,7 @@
                             context="{'invisible_handle': True, 'single_product': True}"/>
                     </div>
                     <xpath expr="//field[@name='product_tmpl_id']" position="attributes">
-                        <attribute name="context">{'quantity_available_locations_domain': ('internal',)}</attribute>
+                        <attribute name="context">{'quantity_available_locations_domain': ('internal', 'transit')}</attribute>
                     </xpath>
                 </data>
             </field>
@@ -394,7 +394,7 @@
         <field name="res_model">product.template</field>
         <field name="view_mode">kanban,tree,form</field>
         <field name="search_view_id" ref="product_template_search_form_view_stock"/>
-        <field name="context">{"search_default_consumable": 1, 'default_type': 'product', 'quantity_available_locations_domain': ('internal',)}</field>
+        <field name="context">{"search_default_consumable": 1, 'default_type': 'product', 'quantity_available_locations_domain': ('internal', 'transit')}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Create a new product
@@ -407,7 +407,7 @@
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">product.product</field>
         <field name="view_mode">tree,form,kanban</field>
-        <field name="context">{'quantity_available_locations_domain': ('internal',)}</field>
+        <field name="context">{'quantity_available_locations_domain': ('internal', 'transit')}</field>
         <field name="search_view_id" ref="stock_product_search_form_view"/>
     </record>
 


### PR DESCRIPTION
When coming from a product view, any quant from a transit location
was hidden because of the domain generation. This commit simply allows
those transit locations in the domain when specified.

TaskID: BugsLogistics