### PR TITLE
[IMP] base: Add contact format field on res.country

### DIFF
--- a/odoo/addons/base/data/res_country_data.xml
+++ b/odoo/addons/base/data/res_country_data.xml
@@ -308,6 +308,7 @@
             <field name="code">ch</field>
             <field file="base/static/img/country_flags/ch.png" name="image" type="base64" />
             <field name="address_format" eval="'%(street)s\n%(street2)s\n%(zip)s %(city)s\n%(country_name)s'" />
+            <field name="contact_format" eval="'%s\n%s'" />
             <field name="currency_id" ref="CHF" />
             <field eval="41" name="phone_code" />
         </record>

--- a/odoo/addons/base/models/res_country.py
+++ b/odoo/addons/base/models/res_country.py
@@ -47,7 +47,7 @@ class Country(models.Model):
              "\n%(country_name)s: the name of the country"
              "\n%(country_code)s: the code of the country",
         default='%(street)s\n%(street2)s\n%(city)s %(state_code)s %(zip)s\n%(country_name)s')
-    contact_format = fields.Char(
+    contact_format = fields.Text(
         string="Contact layout",
         help="Display format to use for contact person belonging to this country.\n",
         default="%s, %s",

--- a/odoo/addons/base/models/res_country.py
+++ b/odoo/addons/base/models/res_country.py
@@ -47,6 +47,11 @@ class Country(models.Model):
              "\n%(country_name)s: the name of the country"
              "\n%(country_code)s: the code of the country",
         default='%(street)s\n%(street2)s\n%(city)s %(state_code)s %(zip)s\n%(country_name)s')
+    contact_format = fields.Char(
+        string="Contact layout",
+        help="Display format to use for contact person belonging to this country.\n",
+        default="%s, %s",
+    )
     address_view_id = fields.Many2one(
         comodel_name='ir.ui.view', string="Input View",
         domain=[('model', '=', 'res.partner'), ('type', '=', 'form')],

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -619,12 +619,12 @@ class Partner(models.Model):
         """ Utility method to allow name_get to be overrided without re-browse the partner """
         partner = self
         name = partner.name or ''
-
         if partner.company_name or partner.parent_id:
             if not name and partner.type in ['invoice', 'delivery', 'other']:
                 name = dict(self.fields_get(['type'])['type']['selection'])[partner.type]
             if not partner.is_company:
-                name = "%s, %s" % (partner.commercial_company_name or partner.sudo().parent_id.name, name)
+                contact_format = partner.country_id.contact_format or partner.sudo().parent_id.country_id.contact_format or "%s, %s"
+                name = contact_format % (partner.commercial_company_name or partner.sudo().parent_id.name, name)
         if self._context.get('show_address_only'):
             name = partner._display_address(without_company=True)
         if self._context.get('show_address'):

--- a/odoo/addons/base/views/res_country_views.xml
+++ b/odoo/addons/base/views/res_country_views.xml
@@ -40,6 +40,7 @@
                                 <field name="address_format" placeholder="Address format..."/>
                                 <div colspan="2" name="div_address_format" class="text-muted">Change the way addresses are displayed in reports</div>
                                 <field name="name_position"/>
+                                <field name="contact_format" />
                             </group>
                         </group>
                         <label for="state_ids"/>


### PR DESCRIPTION
In switzerland a contact person is always written on a new line.
Therefore we would like to be able to have the following display on the reports:
Company Name
Contact person
Street Nr
Zip City
COUNTRY

However, it is not possible to do a proper extension, as the format string is hardcoded in _get_name function.
With this new field on res.country, we're able to define a specific contact for each country that needs it.

Description of the issue/feature this PR addresses / What are the steps to reproduce your issue?:
1. Define a company with country Switzerland 
     (e.g. Camptocamp SA, 
             EPFL Innovation Park, PSE-A
             1015 Lausanne
             SWITZERLAND)
2. Define an invoice address for this company (e.g. Luc Maurer)
3. Create an invoice using invoice address created on point 2.
4. Print the invoice report

Current behavior before PR:
The address will be displayed on the report as follows:
Camptocamp SA, Luc Maurer
EPFL Innovation Park, PSE-A
1015 Lausanne
SWITZERLAND

Desired behavior after PR is merged:
In switzerland a contact person is always written on a new line. Therefore we would like to be able to have the following display:
Camptocamp SA
Luc Maurer
EPFL Innovation Park, PSE-A
1015 Lausanne
SWITZERLAND

However, it is not possible to do a proper extension, as the format string is hardcoded at https://github.com/odoo/odoo/blob/12.0/odoo/addons/base/models/res_partner.py#L688

Proposition:
Add a contact_format field on res.country to be able to define a specific contact format for each country that has its specifics.


Clone of #37479 
Odoo Ticket: 2077294
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
