### PR TITLE
[IMP] utm, *: Improve campaign kanban design

### DIFF
--- a/addons/crm/views/utm_campaign_views.xml
+++ b/addons/crm/views/utm_campaign_views.xml
@@ -8,13 +8,13 @@
             <xpath expr="//div[@id='utm_statistics']" position="inside">
                 <field name="crm_lead_activated" invisible="1"/>
                 <div class="px-2 text-center" groups="sales_team.group_sale_salesman"
-                    attrs="{'invisible': [('crm_lead_activated', '=', False)]}">
-                    <small>Leads:</small>
+                    attrs="{'invisible': [('crm_lead_activated', '=', False)]}" title="Leads">
+                    <i class="fa fa-star"></i>
                     <small class="font-weight-bold"><field name="lead_count"/></small>
                 </div>
                 <div class="px-2 text-center" groups="sales_team.group_sale_salesman"
-                    attrs="{'invisible': [('crm_lead_activated', '=', True)]}">
-                    <small>Opportunities:</small>
+                    attrs="{'invisible': [('crm_lead_activated', '=', True)]}" title="Opportunities">
+                    <i class="fa fa-star"></i>
                     <small class="font-weight-bold"><field name="opportunity_count"/></small>
                 </div>
             </xpath>

--- a/addons/link_tracker/views/utm_campaign_views.xml
+++ b/addons/link_tracker/views/utm_campaign_views.xml
@@ -23,8 +23,8 @@
                 <field name="click_count"/>
             </xpath>
             <xpath expr="//div[@id='utm_statistics']" position="inside">
-                <div class="px-2 text-center">
-                    <small>Clicks:</small>
+                <div class="px-2 text-center" title="Clicks">
+                    <i class="fa fa-mouse-pointer"></i>
                     <small class="font-weight-bold" t-esc="record.click_count.raw_value" />
                 </div>
             </xpath>

--- a/addons/sale/views/utm_campaign_views.xml
+++ b/addons/sale/views/utm_campaign_views.xml
@@ -6,14 +6,14 @@
     <field name="inherit_id" ref="utm.utm_campaign_view_kanban"/>
     <field name="arch" type="xml">
         <xpath expr="//div[@id='utm_statistics']" position="inside">
-            <div class="px-2 text-center">
-                <small>Quotations:</small>
+            <div class="px-2 text-center" title="Quotations">
+                <i class="fa fa-usd"></i>
                 <small class="font-weight-bold">
                     <field name="quotation_count"/>
                 </small>
             </div>
-            <div class="px-2 text-center">
-                <small>Revenues:</small>
+            <div class="px-2 text-center" title="Revenues">
+                <i class="fa fa-money"></i>
                 <small class="font-weight-bold">
                     <field name="invoiced_amount" widget="monetary" options="{'currency_field': 'currency_id'}"/>
                 </small>

--- a/addons/utm/views/utm_campaign_views.xml
+++ b/addons/utm/views/utm_campaign_views.xml
@@ -90,11 +90,10 @@
                                 <div class="o_kanban_record_body px-2">
                                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                                 </div>
-                                <div id="utm_statistics" class="d-flex bg-100 px-3 py-1 border-bottom border-top justify-content-between"/>
-                                <div class="d-flex flex-grow-0 flex-column align-items-end px-3 py-2">
+                                <div id="utm_statistics" class="d-flex mt-4 px-3 py-1 border-bottom border-top justify-content-between align-items-center">
                                     <img t-att-src="kanban_image('res.users', 'image_128', record.user_id.raw_value)"
                                         t-att-data-member_id="record.user_id.raw_value"
-                                        t-att-alt="record.user_id.raw_value" width="32" height="32" class="oe_kanban_avatar"/>
+                                        t-att-alt="record.user_id.raw_value" width="32" height="32" class="oe_kanban_avatar order-5"/>
                                 </div>
                             </div>
                             <div class="oe_clear"></div>


### PR DESCRIPTION
Instead of having a grey area for the statistics in the middle of
the kanban card, statistics will be placed alonside the user image
at the bottom of the card.

TaskID: 2077579
PR: #XXXXXX

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
