### PR TITLE
[FIX] base : avoid crash when visitor lang is not installed on system when rendering template

### DIFF
--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -135,8 +135,8 @@ class FieldConverter(models.AbstractModel):
 
         :returns: Model[res.lang]
         """
-        lang_code = self._context.get('lang') or 'en_US'
-        return self.env['res.lang']._lang_get(lang_code)
+        lang_code = self._context.get('lang')
+        return self.env['res.lang']._lang_get(lang_code) or self.env['res.lang'].search([('code', '=', 'en_US')])
 
 
 class IntegerConverter(models.AbstractModel):


### PR DESCRIPTION
If the visitor has a lang that is not installed on the system,
get_lang method returns False. The qweb template translator crashes because
he cannot access lang.code as lang is None.

Task ID: 2076656