### PR TITLE
[FIX] product: vendor price list recorded with wrong UoM

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -720,7 +720,6 @@ class SupplierInfo(models.Model):
         'Sequence', default=1, help="Assigns the priority to the list of product vendor.")
     product_uom = fields.Many2one(
         'uom.uom', 'Unit of Measure',
-        related='product_tmpl_id.uom_po_id',
         help="This comes from the product form.")
     min_qty = fields.Float(
         'Quantity', default=0.0, required=True,
@@ -754,3 +753,10 @@ class SupplierInfo(models.Model):
             'label': _('Import Template for Vendor Pricelists'),
             'template': '/product/static/xls/product_supplierinfo.xls'
         }]
+
+    @api.model_create_single
+    def create(self, vals):
+        if 'product_uom' not in vals:
+            vals['product_uom'] = self.env['product.template'].browse(vals['product_tmpl_id']).uom_po_id.id
+
+        return super().create(vals)


### PR DESCRIPTION
-Define "g" as the default UoM for a product.
-Make a purchase order with that product and select the "kg" UoM in the order
line.
-Check the Purchase tab of the product.

Before this commit:

the UoM of the price created is the default UoM for the product, "g".

After this commit:

the price is created with the UoM setted in the purchase order, "kg".

OPW: 2076722

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
