### PR TITLE
[FIX] pos_hr: remove redundant close button

### DIFF
--- a/addons/pos_hr/static/src/css/pos.css
+++ b/addons/pos_hr/static/src/css/pos.css
@@ -1,3 +1,5 @@
+/*  ********* Login Screen ********* */
+
 .pos .login-overlay{
     position: fixed;
     left: 0;
@@ -36,22 +38,17 @@
     font-family: 'Lato';
 }
 .pos .login-title{
-    height: 40%;
+    height: 55%;
     vertical-align: middle;
     line-height: 5;
     font-size: larger;
 }
 .pos .login-body{
-    height:37%;
+    height:33%;
 }
-
-.pos .login-footer{
-    height:18%;
-}
-
 .pos .login-element{
     float: left;
-    width: 40%;
+    width: 45%;
     height: 60%;
 }
 .pos .login-barcode-img{

--- a/addons/pos_hr/static/src/js/screens.js
+++ b/addons/pos_hr/static/src/js/screens.js
@@ -73,11 +73,6 @@ var LoginScreenWidget = ScreenWidget.extend({
                 self.unlock_screen();
             });
         });
-
-        this.$('.close-session').click(function() {
-            self.gui.close();
-        });
-
         this._super();
     },
 

--- a/addons/pos_hr/static/src/xml/pos.xml
+++ b/addons/pos_hr/static/src/xml/pos.xml
@@ -14,11 +14,6 @@
                         <button class="login-button select-employee">Select Cashier</button>
                     </span>
                 </div>
-                 <div class="login-footer">
-                     <small>
-                         <button class="login-button close-session">Close session</button>
-                     </small>
-                 </div>
             </div>
         </div>
     </t>


### PR DESCRIPTION
Because of a bug the close-button for the point of sale session was not
visible anymore in the top-right button. Instead of fixing the problem a
close button was previously added to the lock-screen, making the
lockscreen useless.
This commit fixes the initial situation where the lock-screen can only
be left by logging in and the close button is visible in the top-right
of the session for the session manager.

Revert "[IMP] point_of_sale: Navigation as employee from frontend to backend."

This reverts commit 987951a8d44276d768566752fdf4be2a55dd25f2.