### PR TITLE
[FIX] im_livechat: chat widget doesn't work

### DIFF
--- a/addons/im_livechat/static/src/js/ajax_external.js
+++ b/addons/im_livechat/static/src/js/ajax_external.js
@@ -1,0 +1,14 @@
+odoo.define('web.ajax_external', function (require) {
+"use strict";
+
+var ajax = require('web.ajax');
+
+/**
+  * This file should be used in the context of an external widget loading (e.g: live chat in a non-Odoo website)
+  * It overrides the 'loadJS' method that is supposed to load additional scripts, based on a relative URL (e.g: '/web/webclient/locale/en_US')
+  * As we're not in an Odoo website context, the calls will not work, and we avoid a 404 request.
+  */
+ajax.loadJS = function (url) {
+    console.warn('Tried to load the following script on an external website: ' + url);
+};
+});

--- a/addons/im_livechat/views/im_livechat_channel_templates.xml
+++ b/addons/im_livechat/views/im_livechat_channel_templates.xml
@@ -134,6 +134,7 @@
             <script type="text/javascript" src="/web/static/src/js/core/collections.js"/>
             <script type="text/javascript" src="/web/static/src/js/core/translation.js"></script>
             <script type="text/javascript" src="/web/static/src/js/core/ajax.js"></script>
+            <script type="text/javascript" src="/im_livechat/static/src/js/ajax_external.js"></script>
             <script type="text/javascript" src="/web/static/src/js/core/time.js"></script>
             <script type="text/javascript" src="/web/static/src/js/core/mixins.js"></script>
             <script type="text/javascript" src="/web/static/src/js/core/service_mixins.js"></script>
@@ -155,6 +156,7 @@
             <script type="text/javascript" src="/web/static/src/js/public/public_widget.js"/>
             <script type="text/javascript" src="/web/static/src/js/services/ajax_service.js"></script>
             <script type="text/javascript" src="/web/static/src/js/services/local_storage_service.js"></script>
+            <script type="text/javascript" src="/web/static/src/js/public/lazyloader.js"/>
             <!-- Bus, Mail, Livechat -->
                 <!-- thread windows -->
                 <script type="text/javascript" src="/mail/static/src/js/thread_windows/abstract_thread_window.js"></script>


### PR DESCRIPTION
Bug
===
- A dependecie is missing "lazyloader.js"
- The file "public_root.js" try to load "/web/webclient/locale/en_US" but this file might not exist on the website which is using the widget

Fix
===
- Add the missing dependecie
- Catch the error is we cannot load the file "/web/webclient/locale/en_US"

Task #2081146