### PR TITLE
[FIX] mail: The method  returns None attrs from parent and cannot assign field_data['tracking'] to NoneType.

### DIFF
--- a/addons/mail/models/ir_model.py
+++ b/addons/mail/models/ir_model.py
@@ -111,6 +111,6 @@ class IrModelField(models.Model):
 
     def _instanciate_attrs(self, field_data):
         attrs = super(IrModelField, self)._instanciate_attrs(field_data)
-        if field_data.get('tracking'):
+        if attrs and field_data.get('tracking'):
             attrs['tracking'] = field_data['tracking']
         return attrs


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

As in,
https://github.com/odoo/saas-migration/blob/93c06f31486944d9a12438c6c912957ad81e6a37/migrations/mail/saas~12.2.1.0/pre-migrate.py#L6

The field of module mail has been renamed from track_visibility to tracking, for the same the code adaption was done in file,

https://github.com/odoo/odoo/blob/saas-12.3/addons/mail/models/ir_model.py#L114

Since the method _instanciate_attrs receives the attrs from parent and though the parent return None , it threw the Traceback for

Traceback (most recent call last):
File "/src/odoo/saas-12.3/odoo/service/server.py", line 1121, in preload_registries
registry = Registry.new(dbname, update_module=update_module)
File "/src/odoo/saas-12.3/odoo/modules/registry.py", line 86, in new
odoo.modules.load_modules(registry._db, force_demo, status, update_module)
File "/src/odoo/saas-12.3/odoo/modules/loading.py", line 417, in load_modules
force, status, report, loaded_modules, update_module, models_to_check)
File "/src/odoo/saas-12.3/odoo/modules/loading.py", line 313, in load_marked_modules
perform_checks=perform_checks, models_to_check=models_to_check
File "/src/odoo/saas-12.3/odoo/modules/loading.py", line 194, in load_module_graph
registry.setup_models(cr)
File "/src/odoo/saas-12.3/odoo/modules/registry.py", line 264, in setup_models
model._setup_base()
File "/src/odoo/saas-12.3/odoo/models.py", line 2596, in _setup_base
self.env['ir.model.fields']._add_manual_fields(self)
File "/src/odoo/saas-12.3/odoo/addons/base/models/ir_model.py", line 966, in _add_manual_fields
field = self._instanciate(field_data)
File "/src/odoo/saas-12.3/odoo/addons/base/models/ir_model.py", line 957, in _instanciate
attrs = self._instanciate_attrs(field_data)
File "/src/odoo/saas-12.3/addons/mail/models/ir_model.py", line 115, in _instanciate_attrs
attrs['tracking'] = field_data['tracking']
TypeError: 'NoneType' object does not support item assignment

Hence comparing both the files from v12.0 and saas-12.3 respectively,

12.0 : https://github.com/odoo/odoo/blob/12.0/addons/mail/models/ir_model.py#L96
saas-12.3 : https://github.com/odoo/odoo/blob/saas-12.3/addons/mail/models/ir_model.py#L114

Current behavior before PR:

If parent won't return attrs to the child method _instanciate_attrs in mail, still it will set the value of field tracking in attrs of tracking (attrs['tracking']) .

Desired behavior after PR is merged:

Scenario later this would be, if attrs would be return as None it wont set the value for field tracking in attrs of tracking (attrs['tracking']) .

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr