### PR TITLE
[fix] point_of_sale: Layout session many orders

### DIFF
--- a/addons/point_of_sale/static/src/js/chrome.js
+++ b/addons/point_of_sale/static/src/js/chrome.js
@@ -92,6 +92,10 @@ var UsernameWidget = PosBaseWidget.extend({
     get_name: function(){
         var user = this.pos.get_cashier();
         if(user){
+            $('div.oe_status:not(.js_synch)').css({
+                "min-width": user.name.length*10,
+                "text-align": "center",
+            });
             return user.name;
         }else{
             return "";


### PR DESCRIPTION
Before, when there were a lot of orders, the cashier name would be split over multiple lines.
Now the div containing the name is always big enough to be displayed in one line.

solves #37993 
