### PR TITLE
[IMP] account: add company_id on account.group

### DIFF
--- a/addons/account/models/account.py
+++ b/addons/account/models/account.py
@@ -538,6 +538,7 @@ class AccountGroup(models.Model):
     parent_path = fields.Char(index=True)
     name = fields.Char(required=True)
     code_prefix = fields.Char()
+    company_id = fields.Many2one('res.company', required=True, default=lambda self: self.env.company)
 
     def name_get(self):
         result = []

--- a/addons/account/security/account_security.xml
+++ b/addons/account/security/account_security.xml
@@ -124,6 +124,13 @@
         <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
     </record>
 
+    <record id="account_group_comp_rule" model="ir.rule">
+        <field name="name">Account Group multi-company</field>
+        <field name="model_id" ref="model_account_group"/>
+        <field name="global" eval="True"/>
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
+    </record>
+
     <record id="account_root_comp_rule" model="ir.rule">
         <field name="name">Account Root multi-company</field>
         <field name="model_id" ref="model_account_root"/>

--- a/addons/account/views/account_view.xml
+++ b/addons/account/views/account_view.xml
@@ -1876,6 +1876,7 @@ action = model.setting_init_bank_account_action()
                         <field name="name"/>
                         <field name="code_prefix"/>
                         <field name="parent_id"/>
+                        <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
                     </group>
                 </sheet>
                 </form>
@@ -1901,6 +1902,7 @@ action = model.setting_init_bank_account_action()
                 <tree string="Account Group">
                     <field name="code_prefix"/>
                     <field name="name"/>
+                    <field name="company_id" groups="base.group_multi_company"/>
                 </tree>
             </field>
         </record>


### PR DESCRIPTION
Task [2065440](https://www.odoo.com/web#id=2065440&action=333&active_id=967&model=project.task&view_type=form&menu_id=4720)
Even though this should have been done a long time ago, this was needed
so that we can active the hierarchy option if there are account groups
for the company.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
