### PR TITLE
[FIX] delivery: apply margin on invoice at delivery

### DIFF
--- a/addons/delivery/models/stock_picking.py
+++ b/addons/delivery/models/stock_picking.py
@@ -182,7 +182,8 @@ class StockPicking(models.Model):
         self.ensure_one()
         sale_order = self.sale_id
         if sale_order.invoice_shipping_on_delivery:
-            sale_order._create_delivery_line(self.carrier_id, self.carrier_price)
+            carrier_price = self.carrier_price * (1.0 + (float(self.carrier_id.margin) / 100.0))
+            sale_order._create_delivery_line(self.carrier_id, carrier_price)
 
     @api.multi
     def open_website_url(self):


### PR DESCRIPTION
- Enable option 'Invoice Shipping on Delivery' on sale order.
- Add a margin on delivery carrier.

Validate the delivery. The sale order line created from the carrier
not contains the margin.