### PR TITLE
[IMP] sms : add SMS icon on fields for contact

### DIFF
--- a/addons/sms/static/src/js/fields_phone_widget.js
+++ b/addons/sms/static/src/js/fields_phone_widget.js
@@ -63,7 +63,7 @@ Phone.include({
             });
             $composerButton.prepend($('<i>', {class: 'fa fa-mobile'}));
             $composerButton.on('click', this._onClickSMS.bind(this));
-            this.$el = $('<div/>').append(this.$el).append($composerButton);
+            this.$el.html($('<div/>').append(this.$el.clone()).append($composerButton));
         }
 
         return def;

--- a/addons/sms/views/res_partner_views.xml
+++ b/addons/sms/views/res_partner_views.xml
@@ -23,6 +23,18 @@
                     <field name="mobile" widget="phone" options="{'enable_sms': True}"/>
                 </div>
             </xpath>
+            <xpath expr="//field[@name='child_ids']/form//field[@name='mobile']"  position="attributes">
+                <attribute name="options">{'enable_sms': True}</attribute>
+            </xpath>
+            <xpath expr="//field[@name='child_ids']/form//field[@name='phone']"  position="attributes">
+                <attribute name="options">{'enable_sms': True}</attribute>
+            </xpath>
+            <xpath expr="//field[@name='child_ids']/kanban/templates//field[@name='mobile']" position="attributes">
+                <attribute name="options">{'enable_sms': True}</attribute>
+            </xpath>
+            <xpath expr="//field[@name='child_ids']/kanban/templates//field[@name='phone']" position="attributes">
+                <attribute name="options">{'enable_sms': True}</attribute>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
Purpose
=======
In the partner form, in the page "Contacts and Addresses",
Add next to the phone and mobile fields
the sms option to send directly message from
the kanban view and also from the small form when we click on
a card.

Bug
===
In ``fields_phone_widget.js`` we need to
- use ``this.$e.html`` instead of ``this.$e = ``
- clone ``this.$e`` (to avoid recursion error)

Task #2086735

Co-authored-by: ryv-odoo <ryv@odoo.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
