### PR TITLE
[IMP] website_slides: Improve empty course onboarding

### DIFF
--- a/addons/website_slides/static/src/js/slides_upload.js
+++ b/addons/website_slides/static/src/js/slides_upload.js
@@ -182,6 +182,7 @@ var SlideUploadDialog = Dialog.extend({
     _getModalButtons: function () {
         var btnList = [];
         var state = this.get('state');
+        console.log(this);
         if (state === '_select') {
             btnList.push({text: _t("Cancel"), classes: 'o_w_slide_cancel', close: true});
         } else if (state === '_import') {

--- a/addons/website_slides/static/src/scss/website_slides.scss
+++ b/addons/website_slides/static/src/scss/website_slides.scss
@@ -143,6 +143,21 @@ $o-wslides-fs-side-width: 300px;
     }
 }
 
+.o_wslides_empty_course_content {
+    background-color:  rgba(0,0,0,.02);
+
+    .o_wslides_empty_list_icon {
+        width: 100%;
+        div {
+            background-color: #dcdcdc;
+            border-radius: 10px;
+            height: 30px;
+            margin-bottom: 20px;
+            width: 50%;
+        }
+    }
+}
+
 @mixin o-wslides-tabs($tab-active-color: $o-wslides-color-bg) {
     margin-top: ($o-wslides-tabs-height * -1) + 0.05rem;
     border-bottom: 0;

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -109,7 +109,7 @@
     </t>
     <t t-set="body_classname" t-value="'o_wslides_body'"/>
     <t t-call="website.layout">
-        <div id="wrap" t-attf-class="wrap mt-0">
+        <div id="wrap" t-attf-class="wrap mt-0 mb256">
             <div t-attf-class="o_wslides_course_header o_wslides_gradient position-relative text-white pb-md-0 pt-2 pt-md-5 #{'pb-3' if channel.channel_type == 'training' else 'o_wslides_course_doc_header pb-5'}">
                 <t t-call="website_slides.course_nav"/>
 
@@ -171,15 +171,15 @@
                         <div class="col-12 col-md-8 col-lg-9">
                             <ul class="nav nav-tabs o_wslides_nav_tabs flex-nowrap" role="tablist" id="profile_extra_info_tablist">
                                 <li class="nav-item o_wslides_course_header_nav_home_training">
-                                    <a t-att-class="'nav-link %s' % ('active' if active_tab == 'home' else '')" 
-                                        id="home-tab" data-toggle="pill" href="#home" role="tab" aria-controls="home" 
+                                    <a t-att-class="'nav-link %s' % ('active' if active_tab == 'home' else '')"
+                                        id="home-tab" data-toggle="pill" href="#home" role="tab" aria-controls="home"
                                         t-att-aria-selected="'true' if active_tab == 'home' else 'false'">
                                         <i class="fa fa-home"/> Course
                                     </a>
                                 </li>
                                 <li t-if="channel.allow_comment" class="nav-item">
-                                    <a t-att-class="'nav-link %s' % ('active' if active_tab == 'review' else '')" 
-                                        id="review-tab" data-toggle="pill" href="#review" role="tab" aria-controls="review" 
+                                    <a t-att-class="'nav-link %s' % ('active' if active_tab == 'review' else '')"
+                                        id="review-tab" data-toggle="pill" href="#review" role="tab" aria-controls="review"
                                         t-att-aria-selected="'true' if active_tab == 'review' else 'false'">
                                         Review
                                     </a>
@@ -188,7 +188,8 @@
 
                             <div class="tab-content py-4 o_wslides_tabs_content mb-4" id="courseMainTabContent">
                                 <div t-att-class="'tab-pane fade %s' % ('show active' if active_tab == 'home' else '')" id="home" role="tabpanel" aria-labelledby="home-tab">
-                                    <t t-if="channel.channel_type == 'training'" t-call="website_slides.course_slides_list"/>
+                                    <t t-if="channel.channel_type == 'training' and len(channel.slide_ids) > 0" t-call="website_slides.course_slides_list"/>
+                                    <t t-else="channel.channel_type == 'training'" t-call="website_slides.empty_course_controls"/>
                                 </div>
                                 <div t-if="channel.allow_comment" t-att-class="'tab-pane fade %s' % ('show active' if active_tab == 'review' else '')" id="review" role="tabpanel" aria-labelledby="review-tab">
                                     <t t-call="portal.message_thread">
@@ -343,6 +344,29 @@
                     <i class="fa fa-share-square fa-fw"/> Share
                 </button>
             </div>
+        </div>
+    </div>
+</template>
+
+<template id="empty_course_controls" name="No content controls">
+    <div class="o_wslides_empty_course_content d-flex flex-column align-items-center justify-content-around border rounded pb64 pt64 my-4">
+        <div class="o_wslides_empty_list_icon d-flex flex-column justify-content-center align-items-center mb64">
+            <div/><div/><div/><div/>
+        </div>
+        <div t-if="channel.can_upload" class="d-flex align-items-center justify-content-center btn-group w-100">
+            <a class="o_wslides_js_slide_upload border btn btn-light bg-white d-block py-3 mx-3"
+                role="button"
+                aria-label="Upload Presentation"
+                href="#"
+                t-att-data-open-modal="enable_slide_upload"
+                t-att-data-modules-to-install="modules_to_install"
+                t-att-data-channel-id="channel.id"
+                t-att-data-can-upload="channel.can_upload"
+                t-att-data-can-publish="channel.can_publish"><i class="fa fa-plus mr-2"/><span>Add Content</span></a>
+            <a class="o_wslides_js_slide_section_add border btn btn-light bg-white d-block py-3 mx-3"
+                t-attf-channel_id="#{channel.id}"
+                href="#" role="button"
+                groups="website.group_website_publisher"><i class="fa fa-folder-o mr-2"/><span>Add Section</span></a>
         </div>
     </div>
 </template>


### PR DESCRIPTION
Before this commit, the course homepage was pretty barren when there
wasn't any content in the course. In fact, it was just the exact same design
but with no list displayed.

This commit changes that by adding a dedicated template in case of no content.
This template adds a placeholder for the list with the buttons necesary to
add sections or content.

TaskID: 2088209
PR: #XXXXXX

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
