### PR TITLE
[FIX] calendar : fix all day event switch side effect

### DIFF
--- a/addons/calendar/models/calendar.py
+++ b/addons/calendar/models/calendar.py
@@ -964,7 +964,9 @@ class Meeting(models.Model):
         if self.start_datetime:
             start = self.start_datetime
             self.start = self.start_datetime
-            self.stop = start + timedelta(hours=self.duration) - timedelta(seconds=1)
+            # check if this is a fake allday event : not allday but duration is multiple of 24h and start at midnight.
+            is_allday_event = self.duration % 24 == 0 and self.start_datetime.time() == datetime.time(0, 0)
+            self.stop = start + timedelta(hours=self.duration) - timedelta(seconds=1 if is_allday_event else 0)
 
     @api.onchange('start_date')
     def _onchange_start_date(self):


### PR DESCRIPTION
Related to issue : https://github.com/odoo/odoo/issues/37158

Since ec801b5, switching from all day event to not all day event
removes 1 second to duration to avoid pass to the next day.

But this was done for all type of event, allday and not all day event.

This commit applies the fix only if the duration is a multiple of 24h
and if the start time is at midnight, because this is the only case
where we want to stay on the same day when swithing the allday event flag.

Task ID: 2090172