### PR TITLE
Fix base amount for global_rounding on invoice tax

### DIFF
--- a/addons/account/models/account.py
+++ b/addons/account/models/account.py
@@ -775,14 +775,17 @@ class AccountTax(models.Model):
             round_tax = bool(self.env.context['round'])
             round_total = bool(self.env.context['round'])
 
-        if not round_tax:
-            prec += 5
-
         base_values = self.env.context.get('base_values')
         if not base_values:
             total_excluded = total_included = base = round(price_unit * quantity, prec)
         else:
             total_excluded, total_included, base = base_values
+
+        # Additional precision must be done only on tax computation
+        # Base amount must be set to currency precision in order to have
+        # a sum of tax lines base amount equals to invoice untaxed_amount.
+        if not round_tax:
+            prec += 5
 
         # Sorting key is mandatory in this case. When no key is provided, sorted() will perform a
         # search. However, the search method is overridden in account.tax in order to add a domain


### PR DESCRIPTION
This can replace https://github.com/odoo/odoo/commit/b131658966a3

Not rounding base with currency precision at this point seems to be an error.

IMO, taxes should be computed after rounding base amount not before.

Rounded base amount should be the real value of what you invoice.


cc @rafaelbn
