### PR TITLE
[fix] sales_team : type 'date' is not JSON serializable

### DIFF
--- a/addons/sales_team/models/crm_team.py
+++ b/addons/sales_team/models/crm_team.py
@@ -94,7 +94,7 @@ class CrmTeam(models.Model):
                 team.dashboard_graph_type = 'bar'
             else:
                 team.dashboard_graph_type = 'line'
-            team.dashboard_graph_data = json.dumps(team._get_graph())
+            team.dashboard_graph_data = json.dumps(team._get_graph(), default=str)
 
     def _compute_is_favorite(self):
         for team in self:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When customer open his sales team  at that time getting the error like 
    return json_encoder_default(self, o)
  File "/usr/lib/python3.6/json/encoder.py", line 180, in default
    o.__class__.__name__)
TypeError: Object of type 'date' is not JSON serializable

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
