### PR TITLE
[fix] sales_team : type 'date' is not JSON serializable

### DIFF
--- a/addons/sales_team/models/crm_team.py
+++ b/addons/sales_team/models/crm_team.py
@@ -261,7 +261,7 @@ class CrmTeam(models.Model):
 
         else:
             for data_item in graph_data:
-                values.append({x_field: data_item.get('x_value'), y_field: data_item.get('y_value')})
+                values.append({x_field: format_date(data_item.get('x_value'), locale=locale), y_field: data_item.get('y_value')})
 
         [graph_title, graph_key] = self._graph_title_and_key()
         color = '#875A7B' if '+e' in version else '#7c7bad'


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
I have tested this issue on runbot
If the sales team configure with  Content = Sales, Scale = Last Month and Group by = null and 
try to open the sales team at that time getting the error like
return json_encoder_default(self, o)
File "/usr/lib/python3.6/json/encoder.py", line 180, in default
o.class.name)
TypeError: Object of type 'date' is not JSON serializable

For more refer see the attached video 
[https://drive.google.com/file/d/1Yq_eIx94SDW1wuxhPGQek6UEEZ_afD9K/view](url)
Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
