### PR TITLE
[FIX] base: only migrate modules with a non-null latest_version

### DIFF
--- a/odoo/modules/migration.py
+++ b/odoo/modules/migration.py
@@ -157,7 +157,13 @@ class MigrationManager(object):
             lst.sort()
             return lst
 
-        installed_version = getattr(pkg, 'load_version', pkg.installed_version) or ''
+        installed_version = getattr(pkg, 'load_version', pkg.installed_version)
+
+        if installed_version is None:
+            raise ValueError(
+                "Module %s cannot be migrated because it has no latest_version defined" % pkg.name
+            )
+
         parsed_installed_version = parse_version(installed_version)
         current_version = parse_version(convert_version(pkg.data['version']))
 


### PR DESCRIPTION
For whatever reason, some modules may have a `latest_version` set to
`NULL`, this means that during a module update the module will also be
migrated which is not intended.

This happens because any installed module with a lower version number
than the version number of the module in disk is considered as 'to
migrate' and None being lower than any version number, means that any
module with `latest_version` set to `NULL` will always be migrated.

An unintended migration might leave a database in an unstable state and
potentially corrupt data.

To avoid this, we raise an error during migration if the installed
version of the module is `NULL`, this will stop the migration of the
module and undo the module update until manual intervention.

Apparently this sometimes happens in the SaaS.
Supersedes #36547