### PR TITLE
[FIX] payment_stripe_sca: user-friendly error message on checkout

### DIFF
--- a/addons/payment_stripe_sca/models/payment.py
+++ b/addons/payment_stripe_sca/models/payment.py
@@ -54,6 +54,12 @@ class PaymentAcquirerStripeSCA(models.Model):
             resp.raise_for_status()
         except:
             _logger.error(resp.text)
+            try:
+                error = resp.json()
+            except ValueError:  # .json() raise ValueError if the response body does not contain valid json. So we fallback on original Exception
+                pass
+            else:
+                raise Exception(error.get('error', {}).get('message'))
             raise
         return resp.json()
 


### PR DESCRIPTION
Before this commit, when a 400 error was triggered
when trying to process the payment, there was
just a message with
`"400 Client Error: Bad Request for url: ..."`
showed. It didn't allow the customer to handle
the issue in any case.
![opw-2092926-2](https://user-images.githubusercontent.com/44965478/67662929-a31ad000-f964-11e9-9abd-cfa538ec19ee.png)

Now, the message is clearer for the customer.
As Stripe is giving the specific error, it is
showed to the customer. Letting him be able
to handle most of the cases.
![opw-2092926-1](https://user-images.githubusercontent.com/44965478/67662930-a31ad000-f964-11e9-9af3-8f9a6daf18b5.png)

OPW-2092926

Retarget 11.0 of https://github.com/odoo/odoo/pull/39413