### PR TITLE
[FIX] l10n_*: no spaces in xml_ids checks #38139

### DIFF
--- a/addons/l10n_do/data/account_tax_report_data.xml
+++ b/addons/l10n_do/data/account_tax_report_data.xml
@@ -59,7 +59,7 @@
         <field name="country_id" ref="base.do"/>
     </record>
 
-    <record id="account_financial_report_line_02_01_do account_tax_report_total_itbs" model="account.tax.report.line">
+    <record id="account_tax_report_total_itbs" model="account.tax.report.line">
         <field name="name">III.10 TOTAL ITBIS COBRADO (Sumar casillas 8+9)</field>
         <field name="sequence" eval="1"/>
         <field name="parent_id" ref="account_tax_report_3_liquidacion"/>
@@ -71,14 +71,14 @@
         <field name="tag_name">III.8</field>
         <field name="code">DOTAX020101</field>
         <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="account_financial_report_line_02_01_do account_tax_report_total_itbs"/>
+        <field name="parent_id" ref="account_tax_report_total_itbs"/>
         <field name="country_id" ref="base.do"/>
     </record>
 
     <record id="account_tax_report_tbs_11_casilla" model="account.tax.report.line">
         <field name="name">III.9 TBIS COBRADO (11% de la casilla 7)</field>
         <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="account_financial_report_line_02_01_do account_tax_report_total_itbs"/>
+        <field name="parent_id" ref="account_tax_report_total_itbs"/>
         <field name="country_id" ref="base.do"/>
     </record>
 

--- a/addons/l10n_it/data/account_tax_template.xml
+++ b/addons/l10n_it/data/account_tax_template.xml
@@ -1073,7 +1073,7 @@
         ]"/>
     </record>
 
-    <record id="22v INC" model="account.tax.template">
+    <record id="22v_INC" model="account.tax.template">
         <field name="description">22v INC</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 22% (debito) INC</field>
@@ -1107,7 +1107,7 @@
         ]"/>
     </record>
 
-    <record id="21v INC" model="account.tax.template">
+    <record id="21v_INC" model="account.tax.template">
         <field name="description">21v INC</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 21% (debito) INC</field>
@@ -1141,7 +1141,7 @@
         ]"/>
     </record>
 
-    <record id="20v INC" model="account.tax.template">
+    <record id="20v_INC" model="account.tax.template">
         <field name="description">20v INC</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 20% (debito) INC</field>
@@ -1175,7 +1175,7 @@
         ]"/>
     </record>
 
-    <record id="10v INC" model="account.tax.template">
+    <record id="10v_INC" model="account.tax.template">
         <field name="description">10v INC</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 10% (debito) INC</field>
@@ -1209,7 +1209,7 @@
         ]"/>
     </record>
 
-    <record id="12v INC" model="account.tax.template">
+    <record id="12v_INC" model="account.tax.template">
         <field name="description">12v INC</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva 12% (debito) INC</field>
@@ -1243,7 +1243,7 @@
         ]"/>
     </record>
 
-    <record id="2v INC" model="account.tax.template">
+    <record id="2v_INC" model="account.tax.template">
         <field name="description">2v INC</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva 2% (debito) INC</field>
@@ -1277,7 +1277,7 @@
         ]"/>
     </record>
 
-    <record id="4v INC" model="account.tax.template">
+    <record id="4v_INC" model="account.tax.template">
         <field name="description">4v INC</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva 4% (debito) INC</field>
@@ -1311,7 +1311,7 @@
         ]"/>
     </record>
 
-    <record id="00v INC" model="account.tax.template">
+    <record id="00v_INC" model="account.tax.template">
         <field name="description">00v INC</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Fuori Campo IVA (debito) INC</field>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
fix no spaces in xml ids
Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
