### PR TITLE
[IMP] Master clean/add sms phone widget

### DIFF
--- a/addons/sms/__manifest__.py
+++ b/addons/sms/__manifest__.py
@@ -33,6 +33,7 @@ The service is provided by the In App Purchase Odoo platform.
     ],
     'qweb': [
         'static/src/xml/thread.xml',
+        'static/src/xml/fields_phone_widget.xml',
     ],
     'installable': True,
     'auto_install': True,

--- a/addons/sms/static/src/js/fields_phone_widget.js
+++ b/addons/sms/static/src/js/fields_phone_widget.js
@@ -4,7 +4,7 @@ odoo.define('sms.fields', function (require) {
 var basic_fields = require('web.basic_fields');
 var core = require('web.core');
 var session = require('web.session');
-
+var QWeb = core.qweb;
 var _t = core._t;
 
 /**
@@ -13,6 +13,9 @@ var _t = core._t;
 
 var Phone = basic_fields.FieldPhone;
 Phone.include({
+    events: _.extend({}, Phone.prototype.events, {
+        'click .o_field_phone_sms': '_onClickSMS'
+    }),
     //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------
@@ -53,20 +56,11 @@ Phone.include({
      * @private
      */
     _renderReadonly: function () {
-        var def = this._super.apply(this, arguments);
         if (this.nodeOptions.enable_sms) {
-            var $composerButton = $('<a>', {
-                title: _t('Send SMS Text Message'),
-                href: '',
-                class: 'ml-3 d-inline-flex align-items-center o_field_phone_sms',
-                html: $('<small>', {class: 'font-weight-bold ml-1', html: 'SMS'}),
-            });
-            $composerButton.prepend($('<i>', {class: 'fa fa-mobile'}));
-            $composerButton.on('click', this._onClickSMS.bind(this));
-            this.$el = $('<div/>').append(this.$el).append($composerButton);
+            this.$el.html(QWeb.render('field_phone_widget_readonly', {'widget': this}));
+        } else {
+            this._super.apply(this, arguments);
         }
-
-        return def;
     },
 });
 

--- a/addons/sms/static/src/js/fields_phone_widget.js
+++ b/addons/sms/static/src/js/fields_phone_widget.js
@@ -27,6 +27,7 @@ Phone.include({
      */
     _onClickSMS: function (ev) {
         ev.preventDefault();
+        ev.stopPropagation();
 
         var context = session.user_context;
         context = _.extend({}, context, {
@@ -56,10 +57,9 @@ Phone.include({
      * @private
      */
     _renderReadonly: function () {
+        this._super.apply(this, arguments);
         if (this.nodeOptions.enable_sms) {
             this.$el.html(QWeb.render('field_phone_widget_readonly', {'widget': this}));
-        } else {
-            this._super.apply(this, arguments);
         }
     },
 });

--- a/addons/sms/static/src/xml/fields_phone_widget.xml
+++ b/addons/sms/static/src/xml/fields_phone_widget.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="field_phone_widget_readonly">
+        <a t-attf-href="tel:{{widget.value || ''}}" t-esc="widget.value" class="o_field_phone o_field_widget o_form_uri"/>
+        <button t-if="widget.nodeOptions.enable_sms" title="Send SMS Text Message" class="ml-2 p-0 btn btn-link align-items-center o_field_phone_sms">
+            <i class="fa fa-mobile"/>
+            <small class="font-weight-bold ml-1">SMS</small>
+        </button>
+    </t>
+</templates>

--- a/addons/sms/views/res_partner_views.xml
+++ b/addons/sms/views/res_partner_views.xml
@@ -23,6 +23,18 @@
                     <field name="mobile" widget="phone" options="{'enable_sms': True}"/>
                 </div>
             </xpath>
+            <xpath expr="//field[@name='child_ids']/form//field[@name='mobile']"  position="attributes">
+                <attribute name="options">{'enable_sms': True}</attribute>
+            </xpath>
+            <xpath expr="//field[@name='child_ids']/form//field[@name='phone']"  position="attributes">
+                <attribute name="options">{'enable_sms': True}</attribute>
+            </xpath>
+            <xpath expr="//field[@name='child_ids']/kanban/templates//field[@name='mobile']" position="attributes">
+                <attribute name="options">{'enable_sms': True}</attribute>
+            </xpath>
+            <xpath expr="//field[@name='child_ids']/kanban/templates//field[@name='phone']" position="attributes">
+                <attribute name="options">{'enable_sms': True}</attribute>
+            </xpath>
         </field>
     </record>
 

--- a/addons/web/static/tests/fields/basic_fields_mobile_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_mobile_tests.js
@@ -73,7 +73,7 @@ QUnit.module('basic_fields', {
         var $phoneLink = form.$('a.o_form_uri.o_field_widget');
         assert.strictEqual($phoneLink.length, 1,
             "should have a anchor with correct classes");
-        assert.strictEqual($phoneLink.text(), 'yop',
+        assert.strictEqual($phoneLink.text().trim(), 'yop',
             "value should be displayed properly");
         assert.hasAttrValue($phoneLink, 'href', 'tel:yop',
             "should have proper tel prefix");
@@ -91,7 +91,7 @@ QUnit.module('basic_fields', {
         // save
         await testUtils.form.clickSave(form);
         $phoneLink = form.$('a.o_form_uri.o_field_widget');
-        assert.strictEqual($phoneLink.text(), 'new',
+        assert.strictEqual($phoneLink.text().trim(), 'new',
             "new value should be displayed properly");
         assert.hasAttrValue($phoneLink, 'href', 'tel:new',
             "should still have proper tel prefix");
@@ -111,7 +111,7 @@ QUnit.module('basic_fields', {
 
         assert.containsN(list, '.o_data_row', 3,
             "should have 3 record");
-        assert.strictEqual(list.$('tbody td:not(.o_list_record_selector)').first().text(), 'yop',
+        assert.strictEqual(list.$('tbody td:not(.o_list_record_selector)').first().text().trim(), 'yop',
             "value should be displayed properly");
 
         var $phoneLink = list.$('a.o_form_uri.o_field_widget');
@@ -132,7 +132,7 @@ QUnit.module('basic_fields', {
         await testUtils.dom.click(list.$buttons.find('.o_list_button_save'));
         $cell = list.$('tbody td:not(.o_list_record_selector)').first();
         assert.doesNotHaveClass($cell.parent(), 'o_selected_row', 'should not be in edit mode anymore');
-        assert.strictEqual(list.$('tbody td:not(.o_list_record_selector)').first().text(), 'new',
+        assert.strictEqual(list.$('tbody td:not(.o_list_record_selector)').first().text().trim(), 'new',
             "value should be properly updated");
         $phoneLink = list.$('a.o_form_uri.o_field_widget');
         assert.strictEqual($phoneLink.length, 3,
@@ -168,7 +168,7 @@ QUnit.module('basic_fields', {
 
         // save
         await testUtils.form.clickSave(form);
-        assert.strictEqual(form.$('.o_field_widget').text(), val,
+        assert.strictEqual(form.$('.o_field_widget').text().trim(), val,
             "value should have been correctly escaped");
 
         form.destroy();

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -4815,14 +4815,14 @@ QUnit.module('basic_fields', {
         var $phone = form.$('a.o_field_widget.o_form_uri');
         assert.strictEqual($phone.length, 1,
             "should have rendered the phone number as a link with correct classes");
-        assert.strictEqual($phone.text(), 'yop',
+        assert.strictEqual($phone.text().trim(), 'yop',
             "value should be displayed properly");
 
         // switch to edit mode and check the result
         await testUtils.form.clickEdit(form);
         assert.containsOnce(form, 'input[type="text"].o_field_widget',
             "should have an input for the phone field");
-        assert.strictEqual(form.$('input[type="text"].o_field_widget').val(), 'yop',
+        assert.strictEqual(form.$('input[type="text"].o_field_widget').val().trim(), 'yop',
             "input should contain field value in edit mode");
 
         // change value in edit mode
@@ -4830,7 +4830,7 @@ QUnit.module('basic_fields', {
 
         // save
         await testUtils.form.clickSave(form);
-        assert.strictEqual(form.$('a.o_field_widget.o_form_uri').text(), 'new',
+        assert.strictEqual(form.$('a.o_field_widget.o_form_uri').text().trim(), 'new',
             "new value should be displayed properly");
 
         form.destroy();
@@ -4852,7 +4852,7 @@ QUnit.module('basic_fields', {
         });
 
         assert.containsN(list, 'tbody td:not(.o_list_record_selector)', 5);
-        assert.strictEqual(list.$('tbody td:not(.o_list_record_selector)').first().text(), 'yop',
+        assert.strictEqual(list.$('tbody td:not(.o_list_record_selector)').first().text().trim(), 'yop',
             "value should be displayed properly");
 
         assert.containsN(list, 'a.o_field_widget.o_form_uri', 5,
@@ -4870,7 +4870,7 @@ QUnit.module('basic_fields', {
         await testUtils.dom.click(list.$buttons.find('.o_list_button_save'));
         $cell = list.$('tbody td:not(.o_list_record_selector)').first();
         assert.doesNotHaveClass($cell.parent(), 'o_selected_row', 'should not be in edit mode anymore');
-        assert.strictEqual(list.$('tbody td:not(.o_list_record_selector)').first().text(), 'new',
+        assert.strictEqual(list.$('tbody td:not(.o_list_record_selector)').first().text().trim(), 'new',
             "value should be properly updated");
         assert.containsN(list, 'a.o_field_widget.o_form_uri', 5,
             "should still have links with correct classes");


### PR DESCRIPTION
[REF] sms: clean phone widget

The sms extention for the phone widget wasn't
compliant with JS template and needed a refactor.

[IMP] sms: add SMS icon on fields for contact

In the partner form, in the page "Contacts and Addresses",
Add next to the phone and mobile fields
the sms option to send directly message from
the kanban view and also from the small form when we click on
a card.

task-2086735