### PR TITLE
[FIX] pos_hr: restaurant floors with employees

### DIFF
--- a/addons/pos_hr/static/src/js/screens.js
+++ b/addons/pos_hr/static/src/js/screens.js
@@ -78,7 +78,7 @@ var LoginScreenWidget = ScreenWidget.extend({
     },
 
     unlock_screen: function() {
-        var screen = (this.gui.pos.get_order() ? this.gui.pos.get_order().get_screen_data('previous-screen') : this.gui.default_screen) || this.gui.default_screen;
+        var screen = (this.gui.pos.get_order() ? this.gui.pos.get_order().get_screen_data('previous-screen') : this.gui.startup_screen) || this.gui.startup_screen;
         this.gui.show_screen(screen);
     }
 });


### PR DESCRIPTION
* Make a pos_config with 'login with employees' and floor management
enabled
* Open a new session and login with an employee

before this fix:
* Floor screen is not shown
* Orders cannot be created because no table
is selected.

after this fix:
* Floor screen is shown after login
* Orders can be created after selecting a table

The bug was caused by the selection of default_screen instead of
startup_screen after logging in with pos_hr installed.
