### PR TITLE
[FIX] pos_restaurant: restrict floor editing to managers

### DIFF
--- a/addons/pos_restaurant/static/src/xml/floors.xml
+++ b/addons/pos_restaurant/static/src/xml/floors.xml
@@ -107,7 +107,7 @@
                         This floor has no tables yet, use the <i class="fa fa-plus" role="img" aria-label="Add button" title="Add button"></i> button in the editing toolbar to create new tables.
                     </div>
                     <div class='tables'></div>
-                    <span t-if="widget.pos.user.role == 'manager'" class='edit-button editing'><i class='fa fa-pencil' role="img" aria-label="Edit" title="Edit"></i></span>
+                    <span t-if="widget.pos.get('cashier').role == 'manager' || widget.pos.get_cashier.role == 'manager'" class='edit-button editing'><i class='fa fa-pencil' role="img" aria-label="Edit" title="Edit"></i></span>
                     <div class='edit-bar oe_hidden'>
                         <span class='edit-button new-table'>
                             <i class='fa fa-plus' role="img" aria-label="Add" title="Add"></i>


### PR DESCRIPTION
Before this commit the manager rights where not checked the right
way for editing floors in the pos-frontend. Due to this normal employees
where seen as administrators if the session was started by an
manager.

After this fix the rights are checked on the currently logged in
cashier/waiter. If this person has no manager rights he/she
cannot edit the floors.

to fix this the manager rights are checked on the cashier field instead
of the user field.