### PR TITLE
[POC] website_sale: avoid payment flow interruption issues

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -28,6 +28,7 @@ class SaleOrder(models.Model):
     cart_recovery_email_sent = fields.Boolean('Cart recovery email already sent')
     website_id = fields.Many2one('website', string='Website', readonly=True,
                                  help='Website through which this order was placed.')
+    original_cart_id = fields.Many2one('sale.order', string='Original Cart', help='This cart is a copy of the following cart created during the payment process.')
 
     @api.depends('order_line')
     def _compute_website_order_line(self):

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -353,7 +353,12 @@ class Website(models.Model):
 
         return sale_order
 
-    def sale_reset(self):
+    def sale_reset(self, force_unlink_id=False):
+        # if order was a 'safe payment' copy, delete the original to avoid sending
+        # a cart recovery email, etc.
+        order_id = request.session.get('sale_order_id')
+        if order_id and order_id == force_unlink_id:
+            request.env['sale.order'].sudo().browse(order_id).unlink()
         request.session.update({
             'sale_order_id': False,
             'website_sale_current_pl': False,


### PR DESCRIPTION
Some payment flows allow way to much stuff to happen to the cart
during the payment process.

For example, imagine a customer that pays using Paypal. Upon clicking
the 'Pay now' button, they get redirected to paypal.com where the
payment flow then goes on without our knowledge. Some customers (and
particularly nefarious ones) might try to modify their cart while they
are filling in the payment details, hoping that the extra value added
to the cart will be validated along with the rest even though the paid
amount no longer matches the total of the SO.

This is not a huge problem in and of itself, as the cart will not be
confirmed in such a case (indeed, the amount of the tx is checked upon
payment feedback). However, this is still annoying for the maintainer of
the database, since the payment/cart combination now has to be handled
manually (e.g. refund the payment entirely or contact the customer to
check the initial content of the cart and validate it with the correct
content).

In this commit, we introduce a mechanism to avoid this issue by
duplicating the cart when the payment flow starts. This way, the
duplicated cart is unavailable for the customer to modify and if the
payment goes through, we can be assured that the card has not been
modified in the mean time. The original cart gets deleted upon payment
(to avoid 'recovery email' for abandoned carts, since it was not
actually abandoned).

Note that for payments done using a token, there's no need for this
cart bait-and-switch since the payment is done in a single request - it
is not really possible (or at least very impractical) for a customer to
modify their cart during this process.

TO CHECK WITH WEBSITE TEAM:
- using sale_order_id get param in validation routes is unsightly
- polluting the session again
- session pollution logic should perhaps be factorized (used 2 times)
à-la payment portal controller
- m2o mechanism for original cart is a bit dumb maybe? + another
relational field again...

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
