### PR TITLE
[FIX] website: error on redirect old url

### DIFF
--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -123,6 +123,7 @@ class Page(models.Model):
         # Create redirect if needed
         if data['create_redirect']:
             self.env['website.rewrite'].create({
+                'name': data['name'],
                 'redirect_type': data['redirect_type'],
                 'url_from': original_url,
                 'url_to': url,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
when user ticks/sets to true redirect old url option in page properties
and tries to save, an error was generated saying mendatory field is not set.

Desired behavior after PR is merged:
 A mendatory field 'name' passed in method on save button
to avoid the issue




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
