### PR TITLE
[FIX] crm: delete cascade on required M2O to ir.model.field

### DIFF
--- a/addons/crm/models/crm_lead_scoring_frequency.py
+++ b/addons/crm/models/crm_lead_scoring_frequency.py
@@ -18,4 +18,4 @@ class FrequencyField(models.Model):
     _description = 'Fields that can be used for predictive lead scoring computation'
 
     name = fields.Char(related="field_id.field_description")
-    field_id = fields.Many2one('ir.model.fields', domain=[('model_id.model', '=', 'crm.lead')], required=True)
+    field_id = fields.Many2one('ir.model.fields', domain=[('model_id.model', '=', 'crm.lead')], required=True, ondelete="cascade")


### PR DESCRIPTION
When removing a field, ondelete=setnull violate the required constraint. 
Deleting a custom field on crm.lead should be possible, even if a lead 
scoring was using it.
