### PR TITLE
[FIX] point_of_sale: error when sending invoiced order

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -649,7 +649,6 @@ class PosOrder(models.Model):
                 'name': filename,
                 'type': 'binary',
                 'datas': base64.b64encode(report[0]),
-                'datas_fname': filename,
                 'store_fname': filename,
                 'res_model': 'account.move',
                 'res_id': order_ids[0],


### PR DESCRIPTION
When an order is tagged to be invoiced and sent via email, an error is
raised because of the datas_fname field which has been removed from the
ir.attachment model.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
