### PR TITLE
[IMP] mrp: improvements in Partial production with Quality Check

### DIFF
--- a/addons/mrp/models/mrp_abstract_workorder.py
+++ b/addons/mrp/models/mrp_abstract_workorder.py
@@ -53,7 +53,7 @@ class MrpAbstractWorkorder(models.AbstractModel):
         workorder line in order to match the new quantity to consume for each
         component and their reserved quantity.
         """
-        if self.qty_producing <= 0:
+        if self.qty_producing < 0:
             raise UserError(_('You have to produce at least one %s.') % self.product_uom_id.name)
         line_values = self._update_workorder_lines()
         for values in line_values['to_create']:

--- a/addons/mrp/wizard/change_production_qty.py
+++ b/addons/mrp/wizard/change_production_qty.py
@@ -91,15 +91,10 @@ class ChangeProductionQty(models.TransientModel):
                     wo.duration_expected = (operation.workcenter_id.time_start +
                                  operation.workcenter_id.time_stop +
                                  cycle_number * operation.time_cycle * 100.0 / operation.workcenter_id.time_efficiency)
-                quantity = wo.qty_production - wo.qty_produced
-                if production.product_id.tracking == 'serial':
-                    quantity = 1.0 if not float_is_zero(quantity, precision_digits=precision) else 0.0
-                else:
-                    quantity = quantity if (quantity > 0) else 0
-                if float_is_zero(quantity, precision_digits=precision):
+                wo._defaults_from_finished_workorder_line()
+                if float_is_zero(wo.qty_remaining, precision_digits=precision):
                     wo.finished_lot_id = False
                     wo._workorder_line_ids().unlink()
-                wo.qty_producing = quantity
                 if wo.qty_produced < wo.qty_production and wo.state == 'done':
                     wo.state = 'progress'
                 if wo.qty_produced == wo.qty_production and wo.state == 'progress':


### PR DESCRIPTION
In this commit -
If final product is not serial tracking, then system will suggest the units to produce in next WO according
to the previous one.
For example - If we have MO like, MO0001 (5 qty)-> WO01, WO02, WO03

Then in WO01, if only 2 qtys are produced then, in WO02, 2 qty will be sugested insteasd of 5.

Task-2088002

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
