### PR TITLE
[IMP] orm: fields x2m are not sortable

### DIFF
--- a/odoo/addons/test_new_api/tests/test_schema.py
+++ b/odoo/addons/test_new_api/tests/test_schema.py
@@ -51,6 +51,12 @@ class TestReflection(common.TransactionCase):
                     else:
                         self.assertEqual(selection, [])
 
+                field_description = field.get_description(self.env)
+                if field.type in ('many2many', 'one2many'):
+                    self.assertFalse(field_description['sortable'])
+                elif field.store and field.column_type:
+                    self.assertTrue(field_description['sortable'])
+
 
 class TestSchema(common.TransactionCase):
 

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -715,7 +715,7 @@ class Field(MetaField('DummyField', (object,), {})):
 
     @property
     def _description_sortable(self):
-        return self.store or (self.inherited and self.related_field._description_sortable)
+        return (self.column_type and self.store) or (self.inherited and self.related_field._description_sortable)
 
     def _description_string(self, env):
         if self.string and env.lang:


### PR DESCRIPTION
Before this commit, x2m fields were described as 'sortable'
This was odd since:
- When actually sorting on one of those fields through the webclient
the sorting was gibbrish
- Even the orm silently warned in the log that
the field was not a sql column and therefore was not sortable

After this commit, only a field which is column (and a few other conditions)
can be sorted

Task 1863492

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
