### PR TITLE
[ADD] l10n_il: display Original or Copy on the pdf

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2353,6 +2353,19 @@ class AccountMove(models.Model):
         action['res_id'] = self.copy().id
         return action
 
+    def is_original_pdf(self):
+        """
+        Is it the first printed pdf version of this invoice ?
+
+        :return: True if original pdf doesn't exist yet, false otherwise
+        :rtype: bool
+        """
+        make_pdf_action = self.env['ir.actions.report'].search(
+            [('model', '=', 'account.move'), ('report_name', '=', 'account.report_invoice'),
+             ('report_type', '=', 'qweb-pdf')])
+        original_name = safe_eval(make_pdf_action.attachment, ctx={'object': self})
+        return not any(self.env['ir.attachment'].search([('res_id', '=', self.id), ('name', '=', original_name)]))
+
 
 class AccountMoveLine(models.Model):
     _name = "account.move.line"

--- a/addons/l10n_il/__manifest__.py
+++ b/addons/l10n_il/__manifest__.py
@@ -22,5 +22,6 @@ This module consists:
         'data/account_tax_template_data.xml',
         'data/account_chart_template_post_data.xml',
         'data/account_chart_template_configure_data.xml',
+        'views/report_invoice.xml'
     ],
 }

--- a/addons/l10n_il/views/report_invoice.xml
+++ b/addons/l10n_il/views/report_invoice.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="l10n_il_report_invoice_document_inherit" inherit_id="account.report_invoice_document">
+        <xpath expr="//h2" position="after">
+            <div t-if="o.is_original_pdf() and o.state == 'posted'">Original</div>
+            <div t-else="o.state == 'posted'">Copy</div>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Pt. 2 of this task

Current behavior before PR:
PDF doesn't state if it's the an original or a copy beneath the title.

Desired behavior after PR is merged:
PDF states if it's the an original or a copy beneath the title.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr