### PR TITLE
[FIX] base: correct caching and query for ir_defaults

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -503,8 +503,6 @@ class Users(models.Model):
                 # if partner is global we keep it that way
                 if user.partner_id.company_id and user.partner_id.company_id.id != values['company_id']:
                     user.partner_id.write({'company_id': user.company_id.id})
-            # clear default ir values when company changes
-            self.env['ir.default'].clear_caches()
 
         if 'company_id' in values or 'company_ids' in values:
             # Reset lazy properties `company` & `companies` on all envs


### PR DESCRIPTION
The ir.default model was not adapted to multi-company changes and still
used the 'company_id' field of the user, which does not accurately
reflect the current environment anymore.

This commit fixes this behaviour by using the company from the env
instead of the user one in the query plus adding a cache key for the
environment's company - and thus removing a cache invalidation that
is no longer necessary (since the cache key is now correctly used).