### PR TITLE
[FIX]pos_restaurant: double printing not allowed.

### DIFF
--- a/addons/pos_restaurant/models/pos_order.py
+++ b/addons/pos_restaurant/models/pos_order.py
@@ -18,6 +18,7 @@ class PosOrder(models.Model):
 
     table_id = fields.Many2one('restaurant.table', string='Table', help='The table where this order was served')
     customer_count = fields.Integer(string='Guests', help='The amount of customers that have been served by this order.')
+    multiprint_resume = fields.Char()
 
     def _get_pack_lot_lines(self, order_lines):
         """Add pack_lot_lines to the order_lines.
@@ -131,6 +132,7 @@ class PosOrder(models.Model):
                     'create_uid',
                     'create_date',
                     'customer_count',
+                    'multiprint_resume',
                     'fiscal_position_id',
                     'table_id',
                     'to_invoice',
@@ -171,4 +173,5 @@ class PosOrder(models.Model):
         order_fields = super(PosOrder, self)._order_fields(ui_order)
         order_fields['table_id'] = ui_order.get('table_id', False)
         order_fields['customer_count'] = ui_order.get('customer_count', 0)
+        order_fields['multiprint_resume'] = ui_order.get('multiprint_resume')
         return order_fields

--- a/addons/pos_restaurant/static/src/js/multiprint.js
+++ b/addons/pos_restaurant/static/src/js/multiprint.js
@@ -190,16 +190,16 @@ models.Order = models.Order.extend({
         this.trigger('change',this);
     },
     computeChanges: function(categories){
-        var current_res = this.build_line_resume();
-        var old_res     = this.saved_resume || {};
+        var curr_list   = Object.values(this.build_line_resume());
+        var old_list    = this.saved_resume? Object.values(this.saved_resume): [];
         var json        = this.export_as_JSON();
         var add = [];
         var rem = [];
         var line_hash;
 
-        for ( line_hash in current_res) {
-            var curr = current_res[line_hash];
-            var old  = old_res[line_hash];
+        for (var id in curr_list) {
+            var curr = curr_list[id];
+            var old = old_list.find(function(line) {return curr.product_id === line.product_id});
 
             if (typeof old === 'undefined') {
                 add.push({
@@ -228,9 +228,10 @@ models.Order = models.Order.extend({
             }
         }
 
-        for (line_hash in old_res) {
-            if (typeof current_res[line_hash] === 'undefined') {
-                var old = old_res[line_hash];
+        for (id in old_list) {
+            var old = old_list[id];
+            var curr = curr_list.find(function(line) {return old.product_id === line.product_id});
+            if (typeof curr === 'undefined' && old.qty != 0) {
                 rem.push({
                     'id':       old.product_id,
                     'name':     this.pos.db.get_product_by_id(old.product_id).display_name,
@@ -315,12 +316,12 @@ models.Order = models.Order.extend({
     },
     export_as_JSON: function(){
         var json = _super_order.export_as_JSON.apply(this,arguments);
-        json.multiprint_resume = this.saved_resume;
+        json.multiprint_resume = JSON.stringify(this.saved_resume);
         return json;
     },
     init_from_JSON: function(json){
         _super_order.init_from_JSON.apply(this,arguments);
-        this.saved_resume = json.multiprint_resume;
+        this.saved_resume = JSON.parse(json.multiprint_resume);
     },
 });
 


### PR DESCRIPTION
Before this, when we printed a ticket for the kitchen, if we went back to the table management and go back to the order, we could re print the same product.
Now, we can only reprint the order if there is something different.

Task-id: 2123029
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
