### PR TITLE
[FIX] point_of_sale: duplicate orders

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -422,8 +422,9 @@ class PosOrder(models.Model):
         for order in orders:
             existing_order = False
             if 'server_id' in order['data']:
-                existing_order = self.env['pos.order'].search([('id', '=', order['data']['server_id'])], limit=1)
-            order_ids.append(self._process_order(order, draft, existing_order))
+                existing_order = self.env['pos.order'].search(['|', ('id', '=', order['data']['server_id']), ('pos_reference', '=', order['data']['name'])], limit=1)
+            if (existing_order and existing_order.state == 'draft') or not existing_order:
+                order_ids.append(self._process_order(order, draft, existing_order))
 
         return self.env['pos.order'].search_read(domain = [('id', 'in', order_ids)], fields = ['id', 'pos_reference'])
 


### PR DESCRIPTION
When you create a pos order, it is possible that the request timeout or
the client loose the connection with the server, that will lead to not
have the server_id of the order sent to the server. So when the client
will try to synchronize the order again, it'll not send the server_id to
the server, and the server will create a new order which is a duplicate
of the one created when the client lost the connection.

To avoid this duplication, we are using the pos_reference to find if
there is an existing order like in 12.0 to avoid duplication.

TASK-ID: 2127656

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
