### PR TITLE
[FIX] web: avoid 'future warning' in non-UTC timezones

### DIFF
--- a/addons/web/static/src/js/widgets/date_picker.js
+++ b/addons/web/static/src/js/widgets/date_picker.js
@@ -200,7 +200,7 @@ var DateWidget = Widget.extend({
             this.$warning.attr('title', title);
             this.$input.after(this.$warning);
         }
-        if (currentDate && currentDate.isAfter(moment())) {
+        if (currentDate && (currentDate.dayOfYear() > moment().dayOfYear())) {
             this.$warning.show();
         } else {
             this.$warning.hide();


### PR DESCRIPTION
Steps to reproduce:
- Create an invoice in a timezone in which the day is
different from UTC's day (e.g. 2AM in Australia/Adelaide)
- Set the Invoice Date to Adelaide's same day
- We get a warning that the date is in the future

In the backend everything is stored in UTC.
However to get the date in the correct day, moment.js is used to get it in
the user's locale.

We are interested in the dates, not datetimes,
so the comparisons should be made up to days; however we have
currentDate.isAfter(moment(), 'day') === true
whereas
currentDate.dayOfYear() > moment().dayOfYear() === false;
in fact currentDate.dayOfYear() === moment().dayOfYear()

opw 2093186

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
