### PR TITLE
[FIX] account: Cancelled invoices show up on reconciliation

### DIFF
--- a/addons/account/models/reconciliation_widget.py
+++ b/addons/account/models/reconciliation_widget.py
@@ -519,6 +519,7 @@ class AccountReconciliation(models.AbstractModel):
             ])
         # filter on account.move.line having the same company as the statement line
         domain = expression.AND([domain, [('company_id', '=', st_line.company_id.id)]])
+        domain = expression.AND([domain, [('move_id.state', 'not in', ['draft', 'cancel'])]])
 
         if st_line.company_id.account_bank_reconciliation_start:
             domain = expression.AND([domain, [('date', '>=', st_line.company_id.account_bank_reconciliation_start)]])


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider customer P
- Create two customer invoices C1 and C2 for P
- Cancel C1
- Go to bank reconciliation
- Create a statement with a line for P
- Click on 'Reconcile'

Bug:

C1 was suggested to be reconciled

opw:2120756