### PR TITLE
[FIX] hr_holidays: Impossible to allocate future leave type

### DIFF
--- a/addons/hr_holidays/i18n/hr_holidays.pot
+++ b/addons/hr_holidays/i18n/hr_holidays.pot
@@ -2465,6 +2465,12 @@ msgstr ""
 #. module: hr_holidays
 #: code:addons/hr_holidays/models/hr_leave_allocation.py:326
 #, python-format
+msgid "You can allocate %s only before %s"
+msgstr ""
+
+#. module: hr_holidays
+#: code:addons/hr_holidays/models/hr_leave_allocation.py:0
+#, python-format
 msgid "You can allocate %s only between %s and %s"
 msgstr ""
 

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -342,14 +342,12 @@ class HolidaysAllocation(models.Model):
     @api.constrains('holiday_status_id')
     def _check_leave_type_validity(self):
         for allocation in self:
-            if allocation.holiday_status_id.validity_start and allocation.holiday_status_id.validity_stop:
-                vstart = allocation.holiday_status_id.validity_start
+            if allocation.holiday_status_id.validity_stop:
                 vstop = allocation.holiday_status_id.validity_stop
                 today = fields.Date.today()
 
-                if vstart > today or vstop < today:
-                    raise UserError(_('You can allocate %s only between %s and %s') % (allocation.holiday_status_id.display_name,
-                                                                                  allocation.holiday_status_id.validity_start, allocation.holiday_status_id.validity_stop))
+                if vstop < today:
+                    raise ValidationError(_('You can allocate %s only before %s') % (allocation.holiday_status_id.display_name, allocation.holiday_status_id.validity_stop))
 
     @api.model
     def create(self, values):


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider Today = 21/11/2019 and Employee E
- Create a new hr.leave.type LT and set a validity from 01/01/2020 to 31/12/2020
- Set mode = Free Allocation Request and Validation = No Validation
- Try to create leave allocations for LT

Bug:

It was impossible to create a leave allocation for LT because Today < 01/01/2020
So it was impossible to allocate future leave.
We had to wait the 01/01/2020 to make the allocation of LT leaves

opw:2126300