### PR TITLE
[FIX] hr_holidays: Impossible to allocate future leaves

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -135,8 +135,10 @@ class HolidaysType(models.Model):
                 holiday_type.valid = True
 
     def _search_valid(self, operator, value):
-        dt = self._context.get('default_date_from') or fields.Date.context_today(self)
+        dt = self._context.get('default_date_from', False)
 
+        if not dt:
+            return []
         signs = ['>=', '<='] if operator == '=' else ['<=', '>=']
 
         return ['|', ('validity_stop', operator, False), '&',


### PR DESCRIPTION
Steps to reproduce the bug:
- Let's consider Today = 31/10/2019
- Create a new hr.leave.type LT and set a validity from 01/01/2020 to 31/12/2020
- Set mode = Free Allocation Request and Validation = No Validation
- Try to create leave allocations for LT

Bug:

It was impossible to create a leave allocation for LT because Today < 01/01/2020
So it was impossible to allocate future leave.
We had to wait the 01/01/2020 to make the allocation of LT leaves

So now, when no default_date_from is in the context, no domain is applied

opw:2092830