### PR TITLE
[IMP] graph: add cumulative data in line chart

### DIFF
--- a/addons/web/static/src/js/views/graph/graph_controller.js
+++ b/addons/web/static/src/js/views/graph/graph_controller.js
@@ -145,6 +145,15 @@ var GraphController = AbstractController.extend(GroupByMenuMixin,{
     /**
      * @private
      *
+     * @param {boolean} accumulated
+     */
+    _toggleAccumulationMode: function (accumulated) {
+        this.update({accumulated: accumulated});
+        this._updateButtons();
+    },
+    /**
+     * @private
+     *
      * @param {boolean} stacked
      */
     _toggleStackMode: function (stacked) {
@@ -178,6 +187,11 @@ var GraphController = AbstractController.extend(GroupByMenuMixin,{
             .data('stacked', state.stacked)
             .toggleClass('active', state.stacked)
             .toggleClass('o_hidden', state.mode !== 'bar');
+        this.$buttons
+            .find('.o_graph_button[data-mode="accumulation"]')
+            .data('accumulated', state.accumulated)
+            .toggleClass('active', state.accumulated)
+            .toggleClass('o_hidden', state.mode !== 'line');
         _.each(this.$measureList.find('.dropdown-item'), function (item) {
             var $item = $(item);
             $item.toggleClass('selected', $item.data('field') === state.measure);
@@ -202,6 +216,8 @@ var GraphController = AbstractController.extend(GroupByMenuMixin,{
                 this._setMode($target.data('mode'));
             } else if ($target.data('mode') === 'stack') {
                 this._toggleStackMode(!$target.data('stacked'));
+            } else if ($target.data('mode') === 'accumulation') {
+                this._toggleAccumulationMode(!$target.data('accumulated'));
             }
         } else if ($target.parents('.o_graph_measures_list').length) {
             ev.preventDefault();

--- a/addons/web/static/src/js/views/graph/graph_model.js
+++ b/addons/web/static/src/js/views/graph/graph_model.js
@@ -53,6 +53,7 @@ return AbstractModel.extend({
      * @param {string[]} params.groupBys a list of valid field names
      * @param {string[]} params.groupedBy a list of valid field names
      * @param {boolean} params.stacked
+     * @param {boolean} params.accumulated
      * @param {string[]} params.timeRange
      * @param {string} params.comparisonField
      * @param {string} params.comparisonTimeRangeDescription
@@ -81,6 +82,7 @@ return AbstractModel.extend({
             mode: params.context.graph_mode || params.mode,
             origins: [],
             stacked: params.stacked,
+            accumulated: params.accumulated,
             timeRange: params.timeRange,
             timeRangeDescription: params.timeRangeDescription,
         };
@@ -141,6 +143,10 @@ return AbstractModel.extend({
         }
         if ('stacked' in params) {
             this.chart.stacked = params.stacked;
+            return Promise.resolve();
+        }
+        if ('accumulated' in params) {
+            this.chart.accumulated = params.accumulated;
             return Promise.resolve();
         }
         return this._loadGraph(this._getDomains());

--- a/addons/web/static/src/js/views/graph/graph_renderer.js
+++ b/addons/web/static/src/js/views/graph/graph_renderer.js
@@ -831,6 +831,15 @@ return AbstractRenderer.extend({
             }
             dataset.pointBackgroundColor = dataset.borderColor;
             dataset.pointBorderColor = 'rgba(0,0,0,0.2)';
+
+            if (self.state.accumulated) {
+                var accumulator = 0;
+                dataset.data = dataset.data.map(function (value) {
+                    var result = value + accumulator;
+                    accumulator += value;
+                    return result;
+                });
+            }
         });
         if (data.datasets.length === 1) {
             const dataset = data.datasets[0];

--- a/addons/web/static/src/js/views/graph/graph_view.js
+++ b/addons/web/static/src/js/views/graph/graph_view.js
@@ -86,6 +86,7 @@ var GraphView = AbstractView.extend({
         this.loadParams.fields = this.fields;
         this.loadParams.comparisonDomain = params.comparisonDomain;
         this.loadParams.stacked = this.arch.attrs.stacked !== "False";
+        this.loadParams.accumulated = this.arch.attrs.accumulated && this.arch.attrs.accumulated !== "False" || false;
     },
 });
 

--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -431,6 +431,7 @@
     </div>
     <div class="btn-group" role="toolbar" aria-label="Change graph">
         <button class="btn btn-secondary fa fa-database o_graph_button" title="Stacked" aria-label="Stacked" data-mode="stack"/>
+        <button class="btn btn-secondary fa fa-line-chart o_graph_button" title="Accumulated" aria-label="Accumulated" data-mode="accumulation"/>
     </div>
 </t>
 

--- a/odoo/addons/base/rng/graph_view.rng
+++ b/odoo/addons/base/rng/graph_view.rng
@@ -21,6 +21,7 @@
             </rng:optional>
             <rng:optional><rng:attribute name="js_class"/></rng:optional>
             <rng:optional><rng:attribute name="stacked"/></rng:optional>
+            <rng:optional><rng:attribute name="accumulated"/></rng:optional>
             <rng:optional><rng:attribute name="orientation"/></rng:optional>
             <rng:optional><rng:attribute name="interval"/></rng:optional>
             <rng:zeroOrMore>


### PR DESCRIPTION
This commit adds cumulative data line in graph view.

The cumulative data could be interesting in some applications like sales
which would allow to show accumulation of benefits over time.

Task: 2146487
