### PR TITLE
[FIX] project: Missing date format in deadline date

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -544,7 +544,7 @@ class Task(models.Model):
 
     @api.depends('date_deadline')
     def _compute_date_deadline_formatted(self):
-        date_format = self.env['res.lang']._lang_get(self.env.user.lang).date_format
+        date_format = self.env['res.lang']._lang_get(self.env.user.lang).date_format or '%Y-%m-%d'
         for task in self:
             task.date_deadline_formatted = task.date_deadline.strftime(date_format) if task.date_deadline else None
 


### PR DESCRIPTION
If user's lang is not set, there is a TypeError when formatting
the deadline date of a task in the kanban view.

Description of the issue/feature this PR addresses:

Current behavior before PR:
opw-2146479

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
