### PR TITLE
[IMP] survey : save questions on time limit reached

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -307,6 +307,11 @@ class Survey(http.Controller):
             }
         survey_sudo, answer_sudo = access_data['survey_sudo'], access_data['answer_sudo']
 
+        if answer_sudo.state == 'done':
+            return {
+                'error': "survey_done",
+            }
+
         questions, page_or_question_id = survey_sudo._get_survey_questions(answer=answer_sudo,
                                                                            page_id=post.get('page_id'),
                                                                            question_id=post.get('question_id'))

--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -315,28 +315,32 @@ class Survey(http.Controller):
             # prevent cheating with users creating multiple 'user_input' before their last attempt
             return {}
 
-        if not answer_sudo.is_time_limit_reached:
-            # Prepare answers and comment by question
-            prepared_questions = {}
-            for question in questions:
-                answer_full = post.get(str(question.id))
-                answer_without_comment, comment = self._extract_comment_from_answers(question, answer_full)
-                prepared_questions[question.id] = {'answer': answer_without_comment, 'comment': comment}
+        # Prepare answers and comment by question
+        prepared_questions = {}
+        for question in questions:
+            answer_full = post.get(str(question.id))
+            answer_without_comment, comment = self._extract_comment_from_answers(question, answer_full)
+            prepared_questions[question.id] = {'answer': answer_without_comment, 'comment': comment}
 
-            # Questions Validation
-            errors = {}
-            for question in questions:
-                answer = prepared_questions[question.id]['answer']
-                comment = prepared_questions[question.id]['comment']
-                errors.update(question.validate_question(answer, comment))
-            if errors:
+        # If time limit reached, no validation, submit directly what can be saved,
+        # to be able to compute score on not finished survey
+        # Questions Validation
+        errors = {}
+        for question in questions:
+            answer = prepared_questions[question.id]['answer']
+            comment = prepared_questions[question.id]['comment']
+            errors.update(question.validate_question(answer, comment))
+        if errors:
+            if answer_sudo.is_time_limit_reached:
+                questions = questions.filtered(lambda q: q.id not in errors.keys())
+            else:
                 return {'error': 'validation', 'fields': errors}
 
-            # Submitting questions
-            for question in questions:
-                answer = prepared_questions[question.id]['answer']
-                comment = prepared_questions[question.id]['comment']
-                answer_sudo.save_lines(question, answer, comment)
+        # Submitting questions
+        for question in questions:
+            answer = prepared_questions[question.id]['answer']
+            comment = prepared_questions[question.id]['comment']
+            answer_sudo.save_lines(question, answer, comment)
 
         if answer_sudo.is_time_limit_reached or survey_sudo.questions_layout == 'one_page':
             answer_sudo._mark_done()

--- a/addons/survey/models/survey_user.py
+++ b/addons/survey/models/survey_user.py
@@ -186,7 +186,7 @@ class SurveyUserInput(models.Model):
     # CREATE / UPDATE LINES FROM SURVEY FRONTEND INPUT
     # ------------------------------------------------------------
 
-    def save_lines(self, question, answer, comment=None):
+    def save_lines(self, question, answer, comment=None, skip=False):
         """ Save answers to questions, depending on question type
 
             If an answer already exists for question and user_input_id, it will be


### PR DESCRIPTION
Purpose
=======

If the timer goes to 00:00, the form is automatically submitted but the answers
are not saved. The form should be submited, validation should be skipped to
avoid showing validation errors on the form, and save answers.
If the answer is not in the correct format : skip the question
If the answer is required but there is no answer : skip the question

This way, we can still compute score.

Specifications
==============

This commit makes the validation running only if the timer is not over.
If time limit is reached, no validation, submit directly what can be saved,
to be able to compute score on not finished survey.

Task ID: 2093033