### PR TITLE
[FIX] Base: Don't crash on manual_field issue

### DIFF
--- a/odoo/addons/base/ir/ir_model.py
+++ b/odoo/addons/base/ir/ir_model.py
@@ -12,7 +12,7 @@ from odoo.modules.registry import Registry
 from odoo.osv import expression
 from odoo.tools import pycompat
 from odoo.tools.safe_eval import safe_eval
-from openerp.modules.module import get_modules
+from odoo.modules.module import get_modules
 
 _logger = logging.getLogger(__name__)
 
@@ -923,7 +923,7 @@ class IrModelFields(models.Model):
                         """
                         SELECT d.module
                         FROM ir_model m
-                        JOIN ir_model_data d ON d.res_id = m.id AND d.model = 'ir.model'
+                        LEFT JOIN ir_model_data d ON d.res_id = m.id AND d.model = 'ir.model'
                         WHERE m.model = %s
                         """,
                         [field_data["relation"]],

--- a/odoo/addons/base/ir/ir_model.py
+++ b/odoo/addons/base/ir/ir_model.py
@@ -911,12 +911,9 @@ class IrModelFields(models.Model):
     def _add_manual_fields(self, model):
         """ Add extra fields on model. """
         fields_data = self._get_manual_field_data(model._name)
+        modules_in_addon_path = get_modules()
         for name, field_data in fields_data.items():
             if name not in model._fields and field_data['state'] == 'manual':
-                modules_in_addon_path = get_modules()
-                custom_modules = [r['name'] for r in self.env['ir.module.module'].search_read([
-                ('name', 'not in', modules_in_addon_path + ['studio_customization'])
-                ], ['name'])]
                 try:
                     field = self._instanciate(field_data)
                     if field:
@@ -933,7 +930,7 @@ class IrModelFields(models.Model):
                     )
                     modules = [e["module"] for e in self.env.cr.dictfetchall()]
                     modules_not_in_addons_path = [
-                        module for module in modules if module in custom_modules
+                        module for module in modules if module not in modules_in_addon_path
                     ]
                     if len(modules_not_in_addons_path):
                         if len(modules_not_in_addons_path)==1:

--- a/odoo/addons/base/ir/ir_model.py
+++ b/odoo/addons/base/ir/ir_model.py
@@ -917,6 +917,7 @@ class IrModelFields(models.Model):
                     if field:
                         model._add_field(name, field)
                 except:
+                    type(self)._bad_fields[name] = name
                     _logger.warning("Manual field '{}' : loading skipped".format(
                         field_data['name']))
 

--- a/odoo/addons/base/ir/ir_model.py
+++ b/odoo/addons/base/ir/ir_model.py
@@ -919,30 +919,8 @@ class IrModelFields(models.Model):
                     if field:
                         model._add_field(name, field)
                 except:
-                    self.env.cr.execute(
-                        """
-                        SELECT d.module
-                        FROM ir_model m
-                        LEFT JOIN ir_model_data d ON d.res_id = m.id AND d.model = 'ir.model'
-                        WHERE m.model = %s
-                        """,
-                        [field_data["relation"]],
-                    )
-                    modules = [e["module"] for e in self.env.cr.dictfetchall()]
-                    modules_not_in_addons_path = [
-                        module for module in modules if module not in modules_in_addon_path
-                    ]
-                    if len(modules_not_in_addons_path):
-                        if len(modules_not_in_addons_path)==1:
-                            _logger.warning("Field {} not loaded:"
-                            " module '{}' is not found in the addons-path".format(
-                                field_data['name'], modules_not_in_addons_path[0]))
-                        else:
-                            _logger.warning("Field {} not loaded:"
-                            " some of the module(s) '({})' are not found in the addons-path".format(
-                                field_data['name'], modules_not_in_addons_path))
-                    else:
-                        raise
+                    _logger.warning("Manual field '{}' : loading skipped".format(
+                        field_data['name']))
 
 class IrModelConstraint(models.Model):
     """

--- a/odoo/addons/base/ir/ir_model.py
+++ b/odoo/addons/base/ir/ir_model.py
@@ -932,7 +932,9 @@ class IrModelFields(models.Model):
                         [field_data["relation"]],
                     )
                     modules = [e["module"] for e in self.env.cr.dictfetchall()]
-                    modules_not_in_addons_path = list(filter(lambda module: modules not in custom_modules, modules))
+                    modules_not_in_addons_path = [
+                        module for module in modules if module in custom_modules
+                    ]
                     if len(modules_not_in_addons_path):
                         if len(modules_not_in_addons_path)==1:
                             _logger.warning("Field {} not loaded:"

--- a/odoo/addons/base/ir/ir_model.py
+++ b/odoo/addons/base/ir/ir_model.py
@@ -12,7 +12,6 @@ from odoo.modules.registry import Registry
 from odoo.osv import expression
 from odoo.tools import pycompat
 from odoo.tools.safe_eval import safe_eval
-from odoo.modules.module import get_modules
 
 _logger = logging.getLogger(__name__)
 
@@ -911,7 +910,6 @@ class IrModelFields(models.Model):
     def _add_manual_fields(self, model):
         """ Add extra fields on model. """
         fields_data = self._get_manual_field_data(model._name)
-        modules_in_addon_path = get_modules()
         for name, field_data in fields_data.items():
             if name not in model._fields and field_data['state'] == 'manual':
                 try:

--- a/odoo/addons/base/ir/ir_model.py
+++ b/odoo/addons/base/ir/ir_model.py
@@ -916,8 +916,8 @@ class IrModelFields(models.Model):
                     field = self._instanciate(field_data)
                     if field:
                         model._add_field(name, field)
-                except:
-                    type(self)._bad_fields[name] = name
+                except Exception:
+                    type(self)._bad_fields.add(name)
                     _logger.warning("Manual field '{}' : loading skipped".format(
                         field_data['name']))
 

--- a/odoo/addons/base/ir/ir_ui_view.py
+++ b/odoo/addons/base/ir/ir_ui_view.py
@@ -1065,7 +1065,10 @@ actual arch.
             if field in fields:
                 fields[field].update(fields_def[field])
             else:
-                message = _("Field `%(field_name)s` does not exist") % dict(field_name=field)
+                if field in Model._bad_fields:
+                    message = _("Field `%(field_name)s` is badly defined") % dict(field_name=field)
+                else:
+                    message = _("Field `%(field_name)s` does not exist") % dict(field_name=field)
                 self.raise_view_error(message, view_id)
 
         missing = [item for item in attrs_fields if item[0] not in fields]

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2357,7 +2357,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         cls = type(self)
         if cls._setup_done:
             return
-        cls._bad_fields = dict()
+        cls._bad_fields = set()
         # 1. determine the proper fields of the model: the fields defined on the
         # class and magic fields, not the inherited or custom ones
         cls0 = cls.pool.model_cache.get(cls._model_cache_key)
@@ -2446,7 +2446,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
 
         for name in bad_fields:
             if self.pool.loaded:
-                cls._bad_fields[name] = cls._fields[name]
+                cls._bad_fields.add(cls._fields[name])
             del cls._fields[name]
             delattr(cls, name)
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2357,7 +2357,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         cls = type(self)
         if cls._setup_done:
             return
-
+        cls._bad_fields = dict()
         # 1. determine the proper fields of the model: the fields defined on the
         # class and magic fields, not the inherited or custom ones
         cls0 = cls.pool.model_cache.get(cls._model_cache_key)
@@ -2388,7 +2388,6 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
             for name in cls._fields:
                 delattr(cls, name)
             cls._fields = OrderedDict()
-            cls._bad_fields = dict()
             for name, field in sorted(getmembers(cls, Field.__instancecheck__), key=lambda f: f[1]._sequence):
                 # do not retrieve magic, custom and inherited fields
                 if not any(field.args.get(k) for k in ('automatic', 'manual', 'inherited')):

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2445,9 +2445,8 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                     continue
                 raise
 
-        pool_loaded = self.pool.loaded
         for name in bad_fields:
-            if pool_loaded:
+            if self.pool.loaded:
                 cls._bad_fields[name] = cls._fields[name]
             del cls._fields[name]
             delattr(cls, name)

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2388,6 +2388,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
             for name in cls._fields:
                 delattr(cls, name)
             cls._fields = OrderedDict()
+            cls._bad_fields = dict()
             for name, field in sorted(getmembers(cls, Field.__instancecheck__), key=lambda f: f[1]._sequence):
                 # do not retrieve magic, custom and inherited fields
                 if not any(field.args.get(k) for k in ('automatic', 'manual', 'inherited')):
@@ -2431,35 +2432,11 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
 
         # set up fields
         bad_fields = []
-        modules_in_addon_path = odoo.modules.module.get_modules()
         for name, field in cls._fields.items():
             try:
                 field.setup_full(self)
             except Exception:
-                self.env.cr.execute(
-                        """
-                        SELECT d.module
-                        FROM ir_model_fields f
-                        LEFT JOIN ir_model_data d ON d.res_id=f.id AND d.model='ir.model.fields'
-                        WHERE f.name = %s AND f.model = %s
-                        """,
-                        (name, cls.__name__,)
-                    )
-                modules = [e["module"] for e in self.env.cr.dictfetchall()]
-                modules_not_in_addons_path = [
-                        module for module in modules if module not in modules_in_addon_path
-                    ]
-                if len(modules_not_in_addons_path):
-                    if len(modules_not_in_addons_path)==1:
-                        _logger.warning("Field {} not loaded:"
-                        " module '{}' is not found in the addons-path".format(
-                            name, modules_not_in_addons_path[0]))
-                    else:
-                        _logger.warning("Field {} not loaded:"
-                        " some of the module(s) '({})' are not found in the addons-path".format(
-                            name, modules_not_in_addons_path))
-                    continue
-                elif not self.pool.loaded and field.base_field.manual:
+                if field.base_field.manual:
                     # Something goes wrong when setup a manual field.
                     # This can happen with related fields using another manual many2one field
                     # that hasn't been loaded because the comodel does not exist yet.
@@ -2468,7 +2445,10 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                     continue
                 raise
 
+        pool_loaded = self.pool.loaded
         for name in bad_fields:
+            if pool_loaded:
+                cls._bad_fields[name] = cls._fields[name]
             del cls._fields[name]
             delattr(cls, name)
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When loading a module, don't crash if a manual field references another model not in the addons path

Current behavior before PR:
When loading a module, odoo crash if a manual field is loaded and references another module not in the addons path

Desired behavior after PR is merged:
When loading a module, odoo just skip the field 



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
