### PR TITLE
[IMP] web: read_group is faster for grouping and counting

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -131,7 +131,10 @@ class Base(models.AbstractModel):
             'quarter': 'QQQ yyyy',
             'year': 'yyyy'}
 
-        records_values = self.search_read(domain or [], [progress_bar['field'], group_by])
+        if self._fields[group_by].store and self._fields[progress_bar['field']].store:
+            records_values = self.read_group(domain or [], [progress_bar['field'], group_by], [progress_bar['field'], group_by], lazy=False)
+        else:
+            records_values = self.search_read(domain or [], [progress_bar['field'], group_by])
 
         data = {}
         field_type = self._fields[group_by].type
@@ -162,7 +165,7 @@ class Base(models.AbstractModel):
                     if group_by_value in selection_labels else False
 
             if type(group_by_value) == tuple:
-                group_by_value = group_by_value[1] # FIXME should use technical value (0)
+                group_by_value = str(group_by_value[1]) # FIXME should use technical value (0)
 
             if group_by_value not in data:
                 data[group_by_value] = {}
@@ -171,7 +174,7 @@ class Base(models.AbstractModel):
 
             field_value = record_values[progress_bar['field']]
             if field_value in data[group_by_value]:
-                data[group_by_value][field_value] += 1
+                data[group_by_value][field_value] += record_values.get("__count", 1)
 
         return data
 


### PR DESCRIPTION
When read_progress_bar is called on models with plenty of records, it's 
faster to retrieve only the needed info, instead of reading thousands of 
records to count them.

This requires the 2 fields to be stored. When one of the fields is not, fallback on the slower actual working.