### PR TITLE
[FIX] mail: mail header names escape

### DIFF
--- a/odoo/addons/base/tests/test_mail.py
+++ b/odoo/addons/base/tests/test_mail.py
@@ -346,7 +346,7 @@ class TestEmailTools(BaseCase):
         We check that in both cases, decoding is idempotent,
         and we get back get the right name/address couples
         """
-        froms = [
+        headers = [
             "From: pen pen <pen@odoodoo.com>",
             "From: pen, pen <pen@odoodoo.com>",
             "From: =?UTF-8?B?8J+QpyBwZW4gcGVuIPCfkKc=?= <pen@odoodoo.com>",  # basic unicode
@@ -354,17 +354,25 @@ class TestEmailTools(BaseCase):
             "From: =?UTF-8?B?8J+QpyIsIGxlbg==?= <pen@odoodoo.com >",  # with double quote
             "From: =?UTF-8?B?8J+QpycsIGxlbg==?= <pen@odoodoo.com >",  # with single quote
             "From: =?UTF-8?B?8J+Qp1wnLCBsZVxu?= <pen@odoodoo.com >",  # with backslash
+            # composite ones:
+            "To: min@oobo.com, max@oobo.com",
+            "To: min@oobo.com, Mitchell Admin <admin@oobo.com>",
+            "Cc: min@oobo.com, =?UTF-8?B?8J+QpyBwZW4gcGVuIPCfkKc=?= <pen@oobo.com>",
+            "Cc: <min@oobo.com>, =?UTF-8?B?8J+QpyBwZW4gcGVuIPCfkKc=?= <pen@oobo.com>",
+            "Cc: =?UTF-8?B?8J+QpyBwZW4gcGVuIPCfkKc=?= <pen@oobo.com>, <min@oobo.com>, "
+                "=?UTF-8?B?8J+Qp1wnLCBsZVxu?= <pen@odoodoo.com >",
         ]
-        for header_from in froms:
-            decoded_from = decode_smtp_header(header_from, escape_names=True)
+        for header in headers:
+            decoded_from = decode_smtp_header(header, escape_names=True)
             addresses_from = email.utils.getaddresses([decoded_from])
             re_encoded = ir_mail_server.encode_rfc2822_address_header(decoded_from)
             redecoded_from = decode_smtp_header(re_encoded, escape_names=True)
             addresses_from_redecoded = email.utils.getaddresses([redecoded_from])
 
             self.assertEqual(len(addresses_from), len(addresses_from_redecoded))
-            self.assertEqual(addresses_from[0][1], addresses_from_redecoded[0][1])
-            self.assertEqual(addresses_from[0][0], addresses_from_redecoded[0][0])
+            for i in range(len(addresses_from)):
+                self.assertEqual(addresses_from[i][1], addresses_from_redecoded[i][1])
+                self.assertEqual(addresses_from[i][0], addresses_from_redecoded[i][0])
 
 
 class EmailConfigCase(SavepointCase):

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -543,9 +543,14 @@ def decode_smtp_header(smtp_header, escape_names=False):
         if not escape_names:
             return sep.join([ustr(x[0], x[1]) for x in text])
         else:
-            # getaddresses is "-aware, but we need quote to take care of pesky \ and "
-            f = lambda s: '"' + quote(s) + '"' if any(ss in s for ss in [',', '"', '\\']) else s
-            return sep.join([ustr(f(ustr(x[0])), x[1]) for x in text])
+            quote_name = lambda n: '"' + quote(n) + '"' if any(ss in n for ss in [',', '"', '\\']) else n
+            decode = lambda encoded: ''.join([ustr(*n) for n in decode_header(encoded)])
+            squash = lambda name, address: name + ' <' + address + '>' if name else address
+            encoded_address_pairs = ", ".join(
+                squash(quote_name(decode(name)), decode(address))
+                for name, address in getaddresses([smtp_header])
+            )
+            return encoded_address_pairs
     return u''
 
 # was mail_thread.decode_header()


### PR DESCRIPTION
Fine-tuning of commit 55754c6af174dfe9cc8a1a1d1cf968aa305b6b3b

By https://tools.ietf.org/html/rfc2822#section-3.4,
we have that the address headers are of the form
$address(, $address)* with address = $addr-spec | name <$addr-spec>
where name can be quoted and/or encoded if needed,
depending on the presence of special characters (", ") or unicode ones.
If it's not necessary, no encoding is performed, everything is ASCII.

So the task is to segment the header, decode the encoded parts, then
write it as a decoded string that can be segmented back to get the
(name?, address) couples.
Decode header returns a list of couples (dstr, encoding) for each dstr
encoded differently in the header.
It does not segment the tokens semantically.
If we have =?UTF-8?B?8J+QpyBwZW4gcGVuIPCfkKc=?= <pen@oobo.com>, then
we have two dstr, one for the name and one for the address.
If we have "a1@a.com, a2@a.com" there is only one dstr, which is already
ASCII.

In the first case we should look to see if the name needs to be quoted
because we decode the header, so we need to make sure it can be
segmented after our operation.
In the second case we decode nothing, so there is nothing to do;
it's the responsibility of the mail sender to make sure that it can
be segmented.

What happens if we quote such a string it that "a1@a.com, a2@a.com"
becomes a name, instead of a couple of addresses.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
