### PR TITLE
[FIX] stock: serial number error shows product and serial

### DIFF
--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -517,7 +517,8 @@ msgstr ""
 #. module: stock
 #: code:addons/stock/models/stock_quant.py:80
 #, python-format
-msgid "A serial number should only be linked to a single product."
+msgid "A serial number should only be linked to a single product.\n"
+"Product: %s - Serial: %s"
 msgstr ""
 
 #. module: stock

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -77,7 +77,9 @@ class StockQuant(models.Model):
     def check_quantity(self):
         for quant in self:
             if float_compare(quant.quantity, 1, precision_rounding=quant.product_uom_id.rounding) > 0 and quant.lot_id and quant.product_id.tracking == 'serial':
-                raise ValidationError(_('A serial number should only be linked to a single product.'))
+                _logger.error(('A serial number should only be linked to a single product. Quant_id: %s - Product_id: %s - Lot_id: %s' % (quant.id, quant.product_id.id, quant.lot_id.id)))
+                raise ValidationError(_('A serial number should only be linked to a single product.\n'
+                                        'Product: %s - Serial: %s' % (quant.product_id.name, quant.lot_id.name)))
 
     @api.constrains('location_id')
     def check_location_id(self):

--- a/addons/stock/tests/test_inventory.py
+++ b/addons/stock/tests/test_inventory.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
+from odoo.tools import mute_logger
 
 
 class TestInventory(TransactionCase):
@@ -80,7 +81,7 @@ class TestInventory(TransactionCase):
         self.assertEqual(lot1.product_qty, 1.0)
 
     def test_inventory_3(self):
-        """ Check that it's not posisble to have multiple products with a serial number through an
+        """ Check that it's not possible to have multiple products with a serial number through an
         inventory adjustment
         """
         inventory = self.env['stock.inventory'].create({
@@ -102,7 +103,7 @@ class TestInventory(TransactionCase):
         inventory.line_ids.prod_lot_id = lot1
         inventory.line_ids.product_qty = 2
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ValidationError), mute_logger('odoo.addons.stock.models.stock_quant'):
             inventory.action_done()
 
     def test_inventory_4(self):


### PR DESCRIPTION
Before this commit, when a `ValidationError` occurred in
`check_quantity` on a stock_quant, the message was generic
and not giving precise information.

Now, the product name and serial number is showed to
the customer while the quant_id, the product_id and the
lot_id is logged for faster debugging.