### PR TITLE
[FIX] l10n_ch: ISR report margins

### DIFF
--- a/addons/l10n_ch/models/res_company.py
+++ b/addons/l10n_ch/models/res_company.py
@@ -11,6 +11,8 @@ class Company(models.Model):
     l10n_ch_isr_print_bank_location = fields.Boolean(string='Print bank location', default=False, help='Boolean option field indicating whether or not the alternate layout (the one printing bank name and address) must be used when generating an ISR.')
     l10n_ch_isr_scan_line_left = fields.Float(string='Scan line horizontal offset (mm)', compute='_compute_l10n_ch_isr', inverse='_set_l10n_ch_isr')
     l10n_ch_isr_scan_line_top = fields.Float(string='Scan line vertical offset (mm)', compute='_compute_l10n_ch_isr', inverse='_set_l10n_ch_isr')
+    l10n_ch_isr_margin_left = fields.Float(string='Horizontal margin (mm)', compute='_compute_l10n_ch_isr', inverse='_set_l10n_ch_isr')
+    l10n_ch_isr_margin_top = fields.Float(string='Vertical margin (mm)', compute='_compute_l10n_ch_isr', inverse='_set_l10n_ch_isr')
 
     def _compute_l10n_ch_isr(self):
         get_param = self.env['ir.config_parameter'].sudo().get_param
@@ -19,6 +21,8 @@ class Company(models.Model):
             company.l10n_ch_isr_preprinted_bank = bool(get_param('l10n_ch.isr_preprinted_bank', default=False))
             company.l10n_ch_isr_scan_line_top = float(get_param('l10n_ch.isr_scan_line_top', default=0))
             company.l10n_ch_isr_scan_line_left = float(get_param('l10n_ch.isr_scan_line_left', default=0))
+            company.l10n_ch_isr_margin_top = float(get_param('l10n_ch.isr_margin_top', default=7))
+            company.l10n_ch_isr_margin_left = float(get_param('l10n_ch.isr_margin_left', default=7))
 
     def _set_l10n_ch_isr(self):
         set_param = self.env['ir.config_parameter'].sudo().set_param
@@ -27,3 +31,5 @@ class Company(models.Model):
             set_param("l10n_ch.isr_preprinted_bank", company.l10n_ch_isr_preprinted_bank)
             set_param("l10n_ch.isr_scan_line_top", company.l10n_ch_isr_scan_line_top)
             set_param("l10n_ch.isr_scan_line_left", company.l10n_ch_isr_scan_line_left)
+            set_param("l10n_ch.isr_margin_top", company.l10n_ch_isr_margin_top)
+            set_param("l10n_ch.isr_margin_left", company.l10n_ch_isr_margin_left)

--- a/addons/l10n_ch/models/res_config_settings.py
+++ b/addons/l10n_ch/models/res_config_settings.py
@@ -18,4 +18,8 @@ class ResConfigSettings(models.TransientModel):
         related="company_id.l10n_ch_isr_scan_line_left", readonly=False)
     l10n_ch_isr_scan_line_top = fields.Float(string='Vertical offset',
         related="company_id.l10n_ch_isr_scan_line_top", readonly=False)
+    l10n_ch_isr_margin_left = fields.Float(string='Horizontal margin',
+        related="company_id.l10n_ch_isr_margin_left", readonly=False)
+    l10n_ch_isr_margin_top = fields.Float(string='Vertical margin',
+        related="company_id.l10n_ch_isr_margin_top", readonly=False)
     l10n_ch_print_qrcode = fields.Boolean("Print Swiss QR Code", config_parameter='l10n_ch.print_qrcode')

--- a/addons/l10n_ch/report/isr_report.xml
+++ b/addons/l10n_ch/report/isr_report.xml
@@ -38,16 +38,13 @@
         </template>
 
         <template id="l10n_ch_isr_report_template">
-            <t t-call="web.external_layout">
+            <t t-call="l10n_ch.external_layout_l10n_ch_isr">
                 <t t-set="split_total_amount" t-value="invoice.split_total_amount()"/>
                 <t t-set="print_bank" t-value="invoice.company_id.l10n_ch_isr_print_bank_location"/>
 
-                <!-- add class to body tag -->
-                <script>document.body.className += " l10n_ch_isr";</script>
-
                 <!-- since the body content take the whole page we need a way to add margin
                      back on content outside the ISR so it does not overlap with the header -->
-                <div id="content_outside_isr">
+                <div id="content_outside_isr" t-attf-style="padding-left: {{ invoice.company_id.l10n_ch_isr_margin_left }}mm;">
                     <h1>ISR for invoice <t t-esc="invoice.name"/></h1>
                 </div>
 
@@ -60,7 +57,7 @@
                         <!--If we use the alternate ISR layout, displaying name
                         and location of the bank.-->
                         <t t-if="print_bank">
-                            <div id="voucher-for-bank">
+                            <div id="voucher-for-bank" t-attf-style="left: {{ invoice.company_id.l10n_ch_isr_margin_left }}mm;">
                                 <p t-if="not invoice.company_id.l10n_ch_isr_preprinted_bank">
                                     <t t-esc="invoice.invoice_partner_bank_id.bank_id.name"/><br />
                                     <t t-esc="invoice.invoice_partner_bank_id.bank_id.zip"/>
@@ -69,7 +66,7 @@
                             </div>
                             <!--Zugunsten von/En faveur de/A favore di-->
                         </t>
-                        <div id="voucher-for-contact">
+                        <div id="voucher-for-contact" t-attf-style="left: {{ invoice.company_id.l10n_ch_isr_margin_left }}mm;">
                             <p id="voucher-for_name" t-field="invoice.company_id.display_name"/>
                             <p id="voucher-for_address1" t-field="invoice.company_id.street"/>
                             <p id="voucher-for_address2" t-field="invoice.company_id.street2"/>
@@ -87,7 +84,7 @@
                         <p id="voucher-amount_units" t-esc="split_total_amount[0]"/>
                         <p id="voucher-amount_cents" t-esc="split_total_amount[1]"/>
 
-                        <div id="voucher-by">
+                        <div id="voucher-by" t-attf-style="left: {{ invoice.company_id.l10n_ch_isr_margin_left }}mm;">
                             <!--Einbezahlt von/Versé par/Versato da-->
                             <p id="voucher-by_reference_number" t-field="invoice.l10n_ch_isr_number"/>
                             <address id="voucher-by_customer_address" t-field="invoice.partner_id" t-options='{"widget": "contact", "fields": ["address","name"], "no_marker": True}' />
@@ -149,6 +146,52 @@
                     </div>
                 </div>
             </t>
+        </template>
+
+        <template id="external_layout_l10n_ch_isr">
+            <t t-if="not o" t-set="o" t-value="doc"/>
+
+            <t t-if="not company">
+                <!-- Multicompany -->
+                <t t-if="company_id">
+                    <t t-set="company" t-value="company_id"/>
+                </t>
+                <t t-elif="o and 'company_id' in o">
+                    <t t-set="company" t-value="o.company_id.sudo()"/>
+                </t>
+                <t t-else="else">
+                    <t t-set="company" t-value="res_company"/>
+                </t>
+            </t>
+
+            <t t-esc="company.update_scss()"/>
+
+            <div class="header" t-attf-style="padding-top: {{ invoice.company_id.l10n_ch_isr_margin_top }}mm; padding-left: {{ invoice.company_id.l10n_ch_isr_margin_left }}mm;">
+                <div class="row">
+                    <div class="col-3 mb4">
+                        <img t-if="company.logo" t-att-src="image_data_uri(company.logo)" style="max-height: 45px;" alt="Logo"/>
+                    </div>
+                    <div class="col-9 text-right" style="margin-top:22px;" t-field="company.report_header" name="moto"/>
+                </div>
+                <div t-if="company.logo or company.report_header" class="row zero_min_height">
+                    <div class="col-12">
+                        <div style="border-bottom: 1px solid black;"/>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-6" name="company_address">
+                        <div t-field="company.partner_id"
+                            t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'
+                        />
+                    </div>
+                </div>
+            </div>
+
+            <div class="article o_report_layout_standard l10n_ch_isr"  t-att-data-oe-model="o and o._name" t-att-data-oe-id="o and o.id" t-att-data-oe-lang="o and o.env.context.get('lang')">
+                <t t-call="web.address_layout"/>
+                <t t-raw="0"/>
+            </div>
+
         </template>
 
         <template id="l10n_ch.isr_report_main">

--- a/addons/l10n_ch/static/src/scss/report_isr.scss
+++ b/addons/l10n_ch/static/src/scss/report_isr.scss
@@ -28,7 +28,7 @@
     /* content outside isr needs margins to not overlap header */
     #content_outside_isr {
         padding: 15px;
-        padding-top: 150px;
+        padding-top: 250px;
     }
 
     /* ISR is intended for pre-printed paper, we don't want stylistic background */

--- a/addons/l10n_ch/views/res_config_settings_views.xml
+++ b/addons/l10n_ch/views/res_config_settings_views.xml
@@ -57,6 +57,25 @@
                             </div>
                         </div>
                     </div>
+                    <div class="col-12 col-lg-6 o_setting_box" id="l10n_ch-isr_print_scanline_offset">
+                        <div class="o_setting_left_pane"/>
+                        <div class="o_setting_right_pane">
+                            <span class="o_form_label">ISR margin</span>
+                            <div class="text-muted">
+                                Margin to print the report in mm
+                            </div>
+                            <div class="content-group">
+                                <div class="row mt16">
+                                    <label for="l10n_ch_isr_margin_top" class="col-lg-4 o_light_label"/>
+                                    <field name="l10n_ch_isr_margin_top"/>
+                                </div>
+                                <div class="row">
+                                    <label for="l10n_ch_isr_margin_left" class="col-lg-4 o_light_label"/>
+                                    <field name="l10n_ch_isr_margin_left"/>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
OPW 2151580
Some printers have trouble printing reports with very low margins. There
is no real way to be independant from the printer, so we are adding a
template that allows to adapt manually the margins in GUI.
The css has also been adapted so that the margins are wider by default.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
