### PR TITLE
[IMP] web: add a new field ``html_popover``

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -3348,6 +3348,70 @@ var FieldColor = AbstractField.extend({
     },
 });
 
+
+/**
+ * HTML Popover
+ */
+var HtmlPopover = AbstractField.extend({
+    template: 'HtmlPopover',
+    supportedFieldTypes: ['html'],
+
+    events: _.extend({}, AbstractField.prototype.events, {
+        'click': '_onClick',
+    }),
+
+    init : function() {
+        var ret = this._super.apply(this, arguments);
+
+        this.title = this.nodeOptions && this.nodeOptions.title || '';
+        this.icon = this.nodeOptions && this.nodeOptions.icon || 'fa fa-info-circle';
+        this.trigger = this.nodeOptions && this.nodeOptions.trigger || 'focus';
+        this.placement = this.nodeOptions && this.nodeOptions.placement || 'bottom';
+
+        if (this.nodeOptions && this.nodeOptions.color_field) {
+            this.color = this.recordData[this.nodeOptions.color_field];
+        } else {
+            this.color = this.nodeOptions && this.nodeOptions.color || 'text-primary';
+        }
+
+        return ret;
+    },
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    /**
+    * @private
+    */
+    _onClick: function (event) {
+        event.stopPropagation();
+    },
+
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+    /**
+    * @override
+    * @private
+    */
+    _render: function () {
+        var ret = this._super.apply(this, arguments);
+        if (this.value) {
+            this.$el.find('a').popover({
+                html: true,
+                placement: this.placement,
+                trigger: this.trigger,
+                title: this.title,
+                content: this.value,
+            });
+        }
+        return ret;
+    },
+});
+
+
 return {
     TranslatableFieldMixin: TranslatableFieldMixin,
     DebouncedField: DebouncedField,
@@ -3393,6 +3457,7 @@ return {
     JournalDashboardGraph: JournalDashboardGraph,
     AceEditor: AceEditor,
     FieldColor: FieldColor,
+    HtmlPopover: HtmlPopover,
 };
 
 });

--- a/addons/web/static/src/js/fields/field_registry.js
+++ b/addons/web/static/src/js/fields/field_registry.js
@@ -61,7 +61,8 @@ registry
     .add('toggle_button', basic_fields.FieldToggleBoolean)
     .add('dashboard_graph', basic_fields.JournalDashboardGraph)
     .add('ace', basic_fields.AceEditor)
-    .add('color', basic_fields.FieldColor);
+    .add('color', basic_fields.FieldColor)
+    .add('html_popover', basic_fields.HtmlPopover);
 
 // Relational fields
 registry

--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -1563,6 +1563,15 @@
     </div>
 </t>
 
+<t t-name="HtmlPopover">
+    <div>
+        <a t-if="widget.value" t-att-class="widget.icon + ' ' + widget.color"
+            data-toggle="popover"
+            tabindex="0"
+            t-att-content="widget.value || ''"/>
+    </div>
+</t>
+
 <t t-name="SignButton">
     <button t-attf-class="btn o_sign_button #{widget.node.attrs.highlight?'btn-primary':'btn-secondary'}">
         <span class="o_sign_label"><t t-esc="widget.node.attrs.string"/></span>


### PR DESCRIPTION
Options
=======
This field supports some options
- icon: class used to display the icon (e.g.: "fa fa-exclamation")
- trigger: how the popover is triggered (click | hover | focus | ...)
- placement: where the popup is displayed (right | top | bottom | right)
- color_field: name of the field used to change the background color of the widget
- color: static color used to change the background color of the widget (used if ``color_field`` is not set)

Example
=======
```xml
<field name="html_field" widget="html_popover"/>
<field name="html_field" widget="html_popover" options="{'color_field': 'html_color_field', 'title': 'Super title', 'trigger: 'hover'}"/>
```

Task #2153126