### PR TITLE
[FIX] registry: avoid re-signaling invalidated cache

### DIFF
--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -66,9 +66,9 @@ class Http(models.AbstractModel):
         return super(Http, cls).routing_map(key=key)
 
     @classmethod
-    def clear_caches(cls):
+    def clear_caches(cls, signal=True):
         super(Http, cls)._clear_routing_map()
-        return super(Http, cls).clear_caches()
+        return super(Http, cls).clear_caches(signal)
 
     @classmethod
     def _slug_matching(cls, adapter, endpoint, **kw):

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1763,13 +1763,13 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         return defaults
 
     @classmethod
-    def clear_caches(cls):
+    def clear_caches(cls, signal=True):
         """ Clear the caches
 
         This clears the caches associated to methods decorated with
         ``tools.ormcache`` or ``tools.ormcache_multi``.
         """
-        cls.pool._clear_cache()
+        cls.pool._clear_cache(signal)
 
     @api.model
     def _read_group_expand_full(self, groups, domain, order):

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -394,17 +394,18 @@ class Registry(Mapping):
         # this lazy_property is automatically reset by lazy_property.reset_all()
         return LRU(8192)
 
-    def _clear_cache(self):
+    def _clear_cache(self, signal=True):
         """ Clear the cache and mark it as invalidated. """
         self.cache.clear()
-        self.cache_invalidated = True
+        if signal:
+            self.cache_invalidated = True
 
-    def clear_caches(self):
+    def clear_caches(self, signal=True):
         """ Clear the caches associated to methods decorated with
         ``tools.ormcache`` or ``tools.ormcache_multi`` for all the models.
         """
         for model in self.models.values():
-            model.clear_caches()
+            model.clear_caches(signal)
 
     def is_an_ordinary_table(self, model):
         """ Return whether the given model has an ordinary table. """
@@ -469,8 +470,7 @@ class Registry(Mapping):
             # Check if the model caches must be invalidated.
             elif self.cache_sequence != c:
                 _logger.info("Invalidating all model caches after database signaling.")
-                self.clear_caches()
-                self.cache_invalidated = False
+                self.clear_caches(invalidate=False)
             self.registry_sequence = r
             self.cache_sequence = c
 


### PR DESCRIPTION
More extensible/modular fix for https://github.com/odoo/odoo/pull/40983

In a multithreaded environment, when the cache is being cleared through
a call to `registry.clear_caches`, it's possible any number of other
threads signal the database that the cache has been invalidated.

A scenario where this can cause issues:

1) There are 2 threads busy threating a request each, [A] & [B].
2) The database has it's ´base_cache_signaling´ sequence increased.
3) [A] calls `registry.check_signaling`, sees the cache should be
   invalidated and calls `registry.clear_caches`, setting
   `registry.cache_invalidated` to True for each model it clears the
   cache for.
4) [B] finished serving its request, calls `check_signaling`, sees
   `registry.clear_caches` is True and signals the database by
   increasing the `base_cache_signaling` sequence.

Should 2 or more multi-threaded servers run in parallel on the same
database (both handling many concurrent requests), it's possible this
triggers alternatively on each server and loops indefinitely.

To fix this problem, we avoid setting `registry.cache_invalidated` to
True when clearing the cache.

It's interesting to note that the cache invalidation is not thread-safe,
and can lead to inconsistent cache states during its invalidation &
clearing. Fixing this fully requires a bigger design change that may come
in the future, but most likely not as a fix in a stable version.