### PR TITLE
[FIX] account: Wrong unit price with included tax and fiscal position

### DIFF
--- a/addons/account/models/account_invoice.py
+++ b/addons/account/models/account_invoice.py
@@ -1830,7 +1830,6 @@ class AccountInvoiceLine(models.Model):
             account = self.get_invoice_line_account(type, product, fpos, company)
             if account:
                 self.account_id = account.id
-            self._set_taxes()
 
             product_name = self_lang._get_invoice_line_name_from_product()
             if product_name != None:
@@ -1840,6 +1839,7 @@ class AccountInvoiceLine(models.Model):
                 self.uom_id = product.uom_id.id
             domain['uom_id'] = [('category_id', '=', product.uom_id.category_id.id)]
 
+            self._set_taxes()
             if company and currency:
 
                 if self.uom_id and self.uom_id.id != product.uom_id.id:


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a sale included tax T1 of 10% and a sale excluded tax T2 of 0%
- Let's consider a product P with T1 and a sale price of 110€
- Let's consider a fiscal position FP that mappes T1 to T2
- Let's consider a customer C with FP as fiscal position
- Create a customer invoice for C
- Add P on the first line and T1 is replaced by T2

Bug:

The unit price of P was still 110€ instead of 100€ because the included tax was not removed from the base
price of P.

opw:2150564