### PR TITLE
[IMP] sale_stock: split the widget "qty_at_date_widget"

### DIFF
--- a/addons/sale_stock/static/src/xml/qty_at_date.xml
+++ b/addons/sale_stock/static/src/xml/qty_at_date.xml
@@ -1,15 +1,4 @@
 <templates>
-    <div t-name="sale_stock.qtyAtDate">
-        <div t-att-class="!widget.data.display_qty_widget ? 'd-none' : ''">
-            <t t-if="widget.data.virtual_available_at_date &lt; widget.data.qty_to_deliver and !widget.data.is_mto">
-                <a tabindex="0" class="fa fa-info-circle text-danger"/>
-            </t>
-            <t t-else="">
-                <a tabindex="0" class="fa fa-info-circle text-primary"/>
-            </t>
-        </div>
-    </div>
-
     <div t-name="sale_stock.QtyDetailPopOver">
         <table>
             <tbody>
@@ -17,12 +6,12 @@
                     <tr>
                         <td><strong>Forecasted Stock</strong><br /><small>On <span t-esc="data.delivery_date"/></small></td>
                         <td><t t-esc='data.virtual_available_at_date'/>
-                        <t t-esc='data.product_uom.data.display_name'/></td>
+                        <t t-if="data.product_uom" t-esc='data.product_uom.data.display_name'/></td>
                     </tr>
                     <tr>
                         <td><strong>Available</strong><br /><small>All planned operations included</small></td>
                         <td><t t-esc='data.free_qty_today'/>
-                        <t t-esc='data.product_uom.data.display_name'/></td>
+                        <t t-if="data.product_uom" t-esc='data.product_uom.data.display_name'/></td>
                     </tr>
                 </t>
                 <t t-else="">

--- a/addons/sale_stock/views/sale_order_views.xml
+++ b/addons/sale_stock/views/sale_order_views.xml
@@ -92,7 +92,8 @@
                     <field name="qty_to_deliver" invisible="1"/>
                     <field name="is_mto" invisible="1"/>
                     <field name="display_qty_widget" invisible="1"/>
-                    <widget name="qty_at_date_widget" width="0.1"/>
+                    <widget name="qty_at_date_widget" width="0.2" hide_field="scheduled_date"
+                        template="sale_stock.QtyDetailPopOver" title="Availability" placement="left" trigger="focus"/>
                 </xpath>
             </field>
         </record>

--- a/addons/stock/__manifest__.py
+++ b/addons/stock/__manifest__.py
@@ -79,6 +79,7 @@
     'qweb': [
         'static/src/xml/inventory_report.xml',
         'static/src/xml/inventory_lines.xml',
+        'static/src/xml/widget_popover.xml',
         'static/src/xml/stock_traceability_report_backend.xml',
     ],
     'installable': True,

--- a/addons/stock/static/src/js/widget_popover_abstract.js
+++ b/addons/stock/static/src/js/widget_popover_abstract.js
@@ -1,0 +1,96 @@
+odoo.define('stock.PopoverAbstract', function (require) {
+"use strict";
+
+var core = require('web.core');
+var QWeb = core.qweb;
+var Widget = require('web.Widget');
+var widget_registry = require('web.widget_registry');
+var _t = core._t;
+
+var PopoverAbstract = Widget.extend({
+    template: 'stock.popoverTemplate',
+
+    icon: 'fa fa-info-circle',
+    title: '',
+    trigger: 'focus',
+    placement: 'left',
+    color: 'text-primary',
+    popoverTemplate: '',
+    hide: false,
+
+    events: _.extend({}, Widget.prototype.events, {
+        'click .o_html_popover_icon': '_onClickButton',
+    }),
+
+    /**
+     * @override
+     * @param {Widget|null} parent
+     * @param {Object} params
+     */
+    init: function (parent, params) {
+        this.data = params.data;
+        this._willRender();
+        this.viewType = params.viewType;
+        this._super(parent);
+    },
+
+    start: function () {
+        var self = this;
+        return this._super.apply(this, arguments).then(function () {
+            self._setPopOver();
+        });
+    },
+
+    updateState: function (state) {
+        this.$el.find('a').popover('dispose');
+        var candidate = state.data[this.getParent().currentRow];
+        if (candidate) {
+            this.data = candidate.data;
+            this._willRender();
+            this.renderElement();
+            this._setPopOver();
+        }
+    },
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+    /**
+     * Set a bootstrap popover on the current QtyAtDate widget that display available
+     * quantity.
+     */
+    _setPopOver: function () {
+        if (!this.popoverTemplate) {
+            return;
+        }
+        this.$popover = $(QWeb.render(this.popoverTemplate, {data: this.data}));
+        this.$el.find('a').popover({
+            content: this.$popover,
+            html: true,
+            placement: this.placement,
+            title: this.title,
+            trigger: this.trigger,
+            delay: {'show': 0, 'hide': 100 },
+        });
+    },
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+    _onClickButton: function () {
+        // We add the property special click on the widget link.
+        // This hack allows us to trigger the popover (see _setPopOver) without
+        // triggering the _onRowClicked that opens the order line form view.
+        this.$el.find('.o_html_popover_icon').prop('special_click', true);
+    },
+
+    /**
+     * Call before rendering the icon.
+     * Can be used to calculate variable before rendering.
+     */
+    _willRender: function () {
+        // can be inherited
+    },
+});
+
+return PopoverAbstract;
+});

--- a/addons/stock/static/src/xml/widget_popover.xml
+++ b/addons/stock/static/src/xml/widget_popover.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates id="template" xml:space="preserve">
+    <div t-name="stock.popoverTemplate">
+        <div t-att-class="widget.hide ? 'd-none' : ''">
+            <a tabindex="0" t-att-class="widget.icon + ' o_html_popover_icon ' + widget.color"/>
+        </div>
+    </div>
+</templates>

--- a/addons/stock/views/stock_template.xml
+++ b/addons/stock/views/stock_template.xml
@@ -12,6 +12,7 @@
             <script type="text/javascript" src="/stock/static/src/js/stock_traceability_report_backend.js"></script>
             <script type="text/javascript" src="/stock/static/src/js/stock_traceability_report_widgets.js"></script>
             <script type="text/javascript" src="/stock/static/src/js/stock_location_hierarchy.js"></script>
+            <script type="text/javascript" src="/stock/static/src/js/widget_popover_abstract.js"></script>
             <link rel="stylesheet" type="text/scss" href="/stock/static/src/scss/stock_traceability_report.scss"/>
             <link rel="stylesheet" type="text/scss" href="/stock/static/src/scss/stock_location_hierarchy.scss"/>
         </xpath>


### PR DESCRIPTION
Purpose
=======
Use an abstract class for the popover widget, so we can create later others similar widgets.

How
===
The child widget inherit from "PopoverAbstract", and can add some attributes
- icon: icon displayed in the button
- title: title of the popover
- trigger: how the popover is triggered
- color: class used as color for the button
- popoverTemplate: name of the template used for the popover content
- hide: if true, the button is invisible
- placement: where the popover will spawn

Trick
=====
The method ``_willRender`` is call before rendering the widget.
If you want to implement some logic behind the color, icon, etc...
It's the method you search.
e.g.: In ``qty_at_date_widget``, the color depends on the ``virtual_available_at_date``.

We cannot do that in the ``init`` method, because in the ``one2many`` widget, the widget
is created, and then we can change the record...

Task #2153126
