### PR TITLE
[REM] base: conditional ir defaults

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -110,7 +110,7 @@ class AccountMove(models.Model):
             ('out_receipt', 'Sales Receipt'),
             ('in_receipt', 'Purchase Receipt'),
         ], string='Type', required=True, store=True, index=True, readonly=True, tracking=True,
-        default="entry", change_default=True)
+        default="entry")
     type_name = fields.Char('Type Name', compute='_compute_type_name')
     to_check = fields.Boolean(string='To Check', default=False,
         help='If this checkbox is ticked, it means that the user was not sure of all the related informations at the time of the creation of the move and that the move needs to be checked again.')
@@ -119,7 +119,7 @@ class AccountMove(models.Model):
         domain="[('company_id', '=', company_id)]",
         default=_get_default_journal)
     company_id = fields.Many2one(string='Company', store=True, readonly=True,
-        related='journal_id.company_id', change_default=True)
+        related='journal_id.company_id')
     company_currency_id = fields.Many2one(string='Company Currency', readonly=True,
         related='journal_id.company_id.currency_id')
     currency_id = fields.Many2one('res.currency', store=True, readonly=True, tracking=True, required=True,
@@ -131,7 +131,7 @@ class AccountMove(models.Model):
     partner_id = fields.Many2one('res.partner', readonly=True, tracking=True,
         states={'draft': [('readonly', False)]},
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]",
-        string='Partner', change_default=True)
+        string='Partner')
     commercial_partner_id = fields.Many2one('res.partner', string='Commercial Entity', store=True, readonly=True,
         compute='_compute_commercial_partner_id')
 

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -129,7 +129,7 @@ class Lead(models.Model):
     # Fields for address, due to separation from crm and res.partner
     street = fields.Char('Street')
     street2 = fields.Char('Street2')
-    zip = fields.Char('Zip', change_default=True)
+    zip = fields.Char('Zip')
     city = fields.Char('City')
     state_id = fields.Many2one("res.country.state", string='State', domain="[('country_id', '=?', country_id)]")
     country_id = fields.Many2one('res.country', string='Country')

--- a/addons/event/models/event.py
+++ b/addons/event/models/event.py
@@ -105,7 +105,7 @@ class EventEvent(models.Model):
         tracking=True,
         readonly=False, states={'done': [('readonly', True)]})
     company_id = fields.Many2one(
-        'res.company', string='Company', change_default=True,
+        'res.company', string='Company',
         default=lambda self: self.env.company,
         required=False, readonly=False, states={'done': [('readonly', True)]})
     organizer_id = fields.Many2one(

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -218,7 +218,7 @@ class PosOrder(models.Model):
     company_id = fields.Many2one('res.company', string='Company', required=True, readonly=True)
     pricelist_id = fields.Many2one('product.pricelist', string='Pricelist', required=True, states={
                                    'draft': [('readonly', False)]}, readonly=True)
-    partner_id = fields.Many2one('res.partner', string='Customer', change_default=True, index=True, states={'draft': [('readonly', False)], 'paid': [('readonly', False)]})
+    partner_id = fields.Many2one('res.partner', string='Customer', index=True, states={'draft': [('readonly', False)], 'paid': [('readonly', False)]})
     sequence_number = fields.Integer(string='Sequence Number', help='A session-unique sequence number for the order', default=1)
 
     session_id = fields.Many2one(
@@ -586,7 +586,7 @@ class PosOrderLine(models.Model):
     company_id = fields.Many2one('res.company', string='Company', related="order_id.company_id", store=True)
     name = fields.Char(string='Line No', required=True, copy=False)
     notice = fields.Char(string='Discount Notice')
-    product_id = fields.Many2one('product.product', string='Product', domain=[('sale_ok', '=', True)], required=True, change_default=True)
+    product_id = fields.Many2one('product.product', string='Product', domain=[('sale_ok', '=', True)], required=True)
     price_unit = fields.Float(string='Unit Price', digits=0)
     qty = fields.Float('Quantity', digits='Product Unit of Measure', default=1)
     price_subtotal = fields.Float(string='Subtotal w/o Tax', digits=0,

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -63,7 +63,7 @@ class ProductTemplate(models.Model):
     rental = fields.Boolean('Can be Rent')
     categ_id = fields.Many2one(
         'product.category', 'Product Category',
-        change_default=True, default=_get_default_category_id, group_expand='_read_group_categ_id',
+        default=_get_default_category_id, group_expand='_read_group_categ_id',
         required=True, help="Select category for the current product")
 
     currency_id = fields.Many2one(

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -489,7 +489,7 @@ class Task(models.Model):
         readonly=True)
     project_id = fields.Many2one('project.project', string='Project',
         compute='_compute_project_id', store=True, readonly=False,
-        index=True, tracking=True, check_company=True, change_default=True)
+        index=True, tracking=True, check_company=True)
     planned_hours = fields.Float("Planned Hours", help='It is the time planned to achieve the task. If this document has sub-tasks, it means the time needed to achieve this tasks and its childs.',tracking=True)
     subtask_planned_hours = fields.Float("Subtasks", compute='_compute_subtask_planned_hours', help="Computed using sum of hours planned of all subtasks created from main task. Usually these hours are less or equal to the Planned Hours (of main task).")
     user_id = fields.Many2one('res.users',

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -71,7 +71,7 @@ class PurchaseOrder(models.Model):
     date_order = fields.Datetime('Order Date', required=True, states=READONLY_STATES, index=True, copy=False, default=fields.Datetime.now,\
         help="Depicts the date where the Quotation should be validated and converted into a purchase order.")
     date_approve = fields.Datetime('Confirmation Date', readonly=1, index=True, copy=False)
-    partner_id = fields.Many2one('res.partner', string='Vendor', required=True, states=READONLY_STATES, change_default=True, tracking=True, domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]", help="You can find a vendor by its Name, TIN, Email or Internal Reference.")
+    partner_id = fields.Many2one('res.partner', string='Vendor', required=True, states=READONLY_STATES, tracking=True, domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]", help="You can find a vendor by its Name, TIN, Email or Internal Reference.")
     dest_address_id = fields.Many2one('res.partner', domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]", string='Drop Ship Address', states=READONLY_STATES,
         help="Put an address if you want to deliver directly from the vendor to the customer. "
              "Otherwise, keep empty to deliver to your own company.")
@@ -441,7 +441,7 @@ class PurchaseOrderLine(models.Model):
     taxes_id = fields.Many2many('account.tax', string='Taxes', domain=['|', ('active', '=', False), ('active', '=', True)])
     product_uom = fields.Many2one('uom.uom', string='Unit of Measure', domain="[('category_id', '=', product_uom_category_id)]")
     product_uom_category_id = fields.Many2one(related='product_id.uom_id.category_id')
-    product_id = fields.Many2one('product.product', string='Product', domain=[('purchase_ok', '=', True)], change_default=True)
+    product_id = fields.Many2one('product.product', string='Product', domain=[('purchase_ok', '=', True)])
     product_type = fields.Selection(related='product_id.type', readonly=True)
     price_unit = fields.Float(string='Unit Price', required=True, digits='Product Price')
 

--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -147,7 +147,7 @@ class SaleOrder(models.Model):
     partner_id = fields.Many2one(
         'res.partner', string='Customer', readonly=True,
         states={'draft': [('readonly', False)], 'sent': [('readonly', False)]},
-        required=True, change_default=True, index=True, tracking=1,
+        required=True, index=True, tracking=1,
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]",)
     partner_invoice_id = fields.Many2one(
         'res.partner', string='Invoice Address',
@@ -202,7 +202,7 @@ class SaleOrder(models.Model):
     company_id = fields.Many2one('res.company', 'Company', required=True, index=True, default=lambda self: self.env.company)
     team_id = fields.Many2one(
         'crm.team', 'Sales Team',
-        change_default=True, default=_get_default_team, check_company=True,  # Unrequired company
+        default=_get_default_team, check_company=True,  # Unrequired company
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
 
     signature = fields.Image('Signature', help='Signature received through the portal.', copy=False, attachment=True, max_width=1024, max_height=1024)
@@ -1196,7 +1196,7 @@ class SaleOrderLine(models.Model):
 
     product_id = fields.Many2one(
         'product.product', string='Product', domain="[('sale_ok', '=', True), '|', ('company_id', '=', False), ('company_id', '=', company_id)]",
-        change_default=True, ondelete='restrict', check_company=True)  # Unrequired company
+        ondelete='restrict', check_company=True)  # Unrequired company
     product_template_id = fields.Many2one(
         'product.template', string='Product Template',
         related="product_id.product_tmpl_id", domain=[('sale_ok', '=', True)])

--- a/addons/web/static/src/js/tools/debug_manager_backend.js
+++ b/addons/web/static/src/js/tools/debug_manager_backend.js
@@ -335,24 +335,6 @@ DebugManager.include({
             .sortBy(function (field) { return field.string; })
             .value();
 
-        var conditions = _.chain(fieldNamesInView)
-            .filter(function (fieldName) {
-                var fieldInfo = fields[fieldName];
-                return fieldInfo.change_default;
-            })
-            .map(function (fieldName) {
-                var fieldInfo = fields[fieldName];
-                var valueDisplayed = display(fieldInfo, fieldsValues[fieldName]);
-                var value = valueDisplayed[0];
-                var displayed = valueDisplayed[1];
-                return {
-                    name: fieldName,
-                    string: fieldInfo.string,
-                    value: value,
-                    displayed: displayed,
-                };
-            })
-            .value();
         var d = new Dialog(this, {
             title: _t("Set Default"),
             buttons: [
@@ -365,7 +347,6 @@ DebugManager.include({
                         return;
                     }
                     var selfUser = d.$el.find('#formview_default_self').is(':checked');
-                    var condition = d.$el.find('#formview_default_conditions').val();
                     var value = _.find(self.fields, function (field) {
                         return field.name === fieldToSet;
                     }).value;
@@ -378,7 +359,6 @@ DebugManager.include({
                             value,
                             selfUser,
                             true,
-                            condition || false,
                         ],
                     }).then(function () { d.close(); });
                 }}
@@ -386,7 +366,6 @@ DebugManager.include({
         });
         d.args = {
             fields: this.fields,
-            conditions: conditions,
         };
         d.template = 'FormView.set_default';
         d.open();

--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -51,10 +51,6 @@
             <span class="oe_tooltip_technical_title">Modifiers:</span>
             <t t-esc="JSON.stringify(widget.attrs.modifiers)"/>
         </li>
-        <li t-if="widget.field and widget.field.change_default" data-item="change_default">
-            <span class="oe_tooltip_technical_title">Change default:</span>
-            Yes
-        </li>
         <li t-if="widget.attrs.on_change" data-item="on_change">
             <span class="oe_tooltip_technical_title">On change:</span>
             <t t-esc="widget.attrs.on_change"/>
@@ -385,23 +381,6 @@
                     <option t-foreach="args.fields" t-as="field"
                             t-att-value="field.name">
                         <t t-esc="field.string"/> = <t t-esc="field.displayed"/>
-                    </option>
-                </select>
-            </td>
-        </tr>
-        <tr t-if="args.conditions.length">
-            <td>
-                <label for="formview_default_conditions"
-                       class="oe_label oe_align_right">
-                    Condition:
-                </label>
-            </td>
-            <td>
-                <select id="formview_default_conditions" class="o_input">
-                    <option value=""/>
-                    <option t-foreach="args.conditions" t-as="cond"
-                            t-att-value="cond.name + '=' + cond.value">
-                        <t t-esc="cond.string"/>=<t t-esc="cond.displayed"/>
                     </option>
                 </select>
             </td>

--- a/addons/web/static/tests/tools/debug_manager_tests.js
+++ b/addons/web/static/tests/tools/debug_manager_tests.js
@@ -130,7 +130,7 @@ QUnit.module('DebugManager', {}, function () {
             data: data,
             mockRPC: function (route, args) {
                 if (route == "/web/dataset/call_kw/ir.default/set") {
-                    assert.deepEqual(args.args, ["partner", "foo", "yop", true, true, false],
+                    assert.deepEqual(args.args, ["partner", "foo", "yop", true, true],
                         'Model, field, value and booleans for current user/company should have been passed');
                     return Promise.resolve();
                 }

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -585,7 +585,7 @@ class IrServerObjectLines(models.Model):
         ('value', 'Value'),
         ('reference', 'Reference'),
         ('equation', 'Python expression')
-    ], 'Evaluation Type', default='value', required=True, change_default=True)
+    ], 'Evaluation Type', default='value', required=True)
     resource_ref = fields.Reference(
         string='Record', selection='_selection_target_model',
         compute='_compute_resource_ref', inverse='_set_resource_ref')

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -301,10 +301,10 @@ class IrAttachment(models.Model):
     res_field = fields.Char('Resource Field', readonly=True)
     res_id = fields.Many2oneReference('Resource ID', model_field='res_model',
                                       readonly=True, help="The record id this is attached to.")
-    company_id = fields.Many2one('res.company', string='Company', change_default=True,
+    company_id = fields.Many2one('res.company', string='Company',
                                  default=lambda self: self.env.company)
     type = fields.Selection([('url', 'URL'), ('binary', 'File')],
-                            string='Type', required=True, default='binary', change_default=True,
+                            string='Type', required=True, default='binary',
                             help="You can either upload a file from your computer or copy/paste an internet link to your file.")
     url = fields.Char('Url', index=True, size=1024)
     public = fields.Boolean('Is public document')
@@ -519,7 +519,7 @@ class IrAttachment(models.Model):
             if 'datas' in values:
                 values.update(self._get_datas_related_values(values.pop('datas'), values['mimetype']))
             # 'check()' only uses res_model and res_id from values, and make an exists.
-            # We can group the values by model, res_id to make only one query when 
+            # We can group the values by model, res_id to make only one query when
             # creating multiple attachments on a single record.
             record_tuple = (values.get('res_model'), values.get('res_id'))
             record_tuple_set.add(record_tuple)

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -180,7 +180,7 @@ class Partner(models.Model):
         help="Invoice & Delivery addresses are used in sales orders. Private addresses are only visible by authorized users.")
     street = fields.Char()
     street2 = fields.Char()
-    zip = fields.Char(change_default=True)
+    zip = fields.Char()
     city = fields.Char()
     state_id = fields.Many2one("res.country.state", string='State', ondelete='restrict', domain="[('country_id', '=?', country_id)]")
     country_id = fields.Many2one('res.country', string='Country', ondelete='restrict')
@@ -701,7 +701,7 @@ class Partner(models.Model):
         self.flush()
         if args is None:
             args = []
-        order_by_rank = self.env.context.get('res_partner_search_mode') 
+        order_by_rank = self.env.context.get('res_partner_search_mode')
         if (name or order_by_rank) and operator in ('=', 'ilike', '=ilike', 'like', '=like'):
             self.check_access_rights('read')
             where_query = self._where_calc(args)

--- a/odoo/addons/base/tests/test_ir_default.py
+++ b/odoo/addons/base/tests/test_ir_default.py
@@ -58,29 +58,6 @@ class TestIrDefault(TransactionCase):
         default3 = IrDefault3.env['res.partner'].default_get(['ref']).get('ref')
         self.assertEqual(default3, 'GLOBAL', "Wrong default value.")
 
-    def test_conditions(self):
-        """ check user-defined defaults with condition """
-        IrDefault = self.env['ir.default']
-
-        # default without condition
-        IrDefault.search([('field_id.model', '=', 'res.partner')]).unlink()
-        IrDefault.set('res.partner', 'ref', 'X')
-        self.assertEqual(IrDefault.get_model_defaults('res.partner'),
-                         {'ref': 'X'})
-        self.assertEqual(IrDefault.get_model_defaults('res.partner', condition='name=Agrolait'),
-                         {})
-
-        # default with a condition
-        IrDefault.search([('field_id.model', '=', 'res.partner.title')]).unlink()
-        IrDefault.set('res.partner.title', 'shortcut', 'X')
-        IrDefault.set('res.partner.title', 'shortcut', 'Mr', condition='name=Mister')
-        self.assertEqual(IrDefault.get_model_defaults('res.partner.title'),
-                         {'shortcut': 'X'})
-        self.assertEqual(IrDefault.get_model_defaults('res.partner.title', condition='name=Miss'),
-                         {})
-        self.assertEqual(IrDefault.get_model_defaults('res.partner.title', condition='name=Mister'),
-                         {'shortcut': 'Mr'})
-
     def test_invalid(self):
         """ check error cases with 'ir.default' """
         IrDefault = self.env['ir.default']

--- a/odoo/addons/base/views/ir_default_views.xml
+++ b/odoo/addons/base/views/ir_default_views.xml
@@ -45,7 +45,7 @@
                 <field name="company_id" groups="base.group_multi_company"/>
                 <group expand="0" string="Group By">
                     <filter string="User" name="groupby_user" domain="[]" context="{'group_by':'user_id'}"/>
-                    <filter string="Company" name="groupby_company" domain="[]" context="{'group_by':'company_id'}"/>
+                    <filter string="Company" name="groupby_company" domain="[]" context="{'group_by':'company_id'}" groups="base.group_multi_company"/>
                 </group>
             </search>
         </field>

--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -341,7 +341,7 @@ class Foo(models.Model):
     _description = 'Test New API Foo'
 
     name = fields.Char()
-    value1 = fields.Integer(change_default=True)
+    value1 = fields.Integer()
     value2 = fields.Integer()
 
 

--- a/odoo/addons/test_new_api/tests/test_onchange.py
+++ b/odoo/addons/test_new_api/tests/test_onchange.py
@@ -359,28 +359,6 @@ class TestOnChange(SavepointCaseWithUserDemo):
             [(5,)] + [(4, user.id) for user in discussion.participants + demo],
         )
 
-    def test_onchange_default(self):
-        """ test the effect of a conditional user-default on a field """
-        Foo = self.env['test_new_api.foo']
-        field_onchange = Foo._onchange_spec()
-        self.assertTrue(Foo._fields['value1'].change_default)
-        self.assertEqual(field_onchange.get('value1'), '1')
-
-        # create a user-defined default based on 'value1'
-        self.env['ir.default'].set('test_new_api.foo', 'value2', 666, condition='value1=42')
-
-        # setting 'value1' to 42 should trigger the change of 'value2'
-        self.env.cache.invalidate()
-        values = {'name': 'X', 'value1': 42, 'value2': False}
-        result = Foo.onchange(values, 'value1', field_onchange)
-        self.assertEqual(result['value'], {'value2': 666})
-
-        # setting 'value1' to 24 should not trigger the change of 'value2'
-        self.env.cache.invalidate()
-        values = {'name': 'X', 'value1': 24, 'value2': False}
-        result = Foo.onchange(values, 'value1', field_onchange)
-        self.assertEqual(result['value'], {})
-
     def test_onchange_one2many_value(self):
         """ test the value of the one2many field inside the onchange """
         discussion = self.env.ref('test_new_api.discussion_0')

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -37,7 +37,7 @@ DATETIME_LENGTH = len(datetime.now().strftime(DATETIME_FORMAT))
 EMPTY_DICT = frozendict()
 
 RENAMED_ATTRS = [('select', 'index'), ('digits_compute', 'digits')]
-DEPRECATED_ATTRS = [("oldname", "use an upgrade script instead.")]
+DEPRECATED_ATTRS = [("oldname", "use an upgrade script instead."), ("change_default", "use onchanges or computed fields instead.")]
 
 IR_MODELS = (
     'ir.model', 'ir.model.data', 'ir.model.fields', 'ir.model.fields.selection',
@@ -244,7 +244,6 @@ class Field(MetaField('DummyField', (object,), {})):
         'required': False,              # whether the field is required
         'states': None,                 # set readonly and required depending on state
         'groups': None,                 # csv list of group xml ids
-        'change_default': False,        # whether the field may trigger a "user-onchange"
         'deprecated': None,             # whether the field is deprecated
 
         'related_field': None,          # corresponding related field
@@ -712,7 +711,6 @@ class Field(MetaField('DummyField', (object,), {})):
     _description_required = property(attrgetter('required'))
     _description_states = property(attrgetter('states'))
     _description_groups = property(attrgetter('groups'))
-    _description_change_default = property(attrgetter('change_default'))
     _description_deprecated = property(attrgetter('deprecated'))
     _description_group_operator = property(attrgetter('group_operator'))
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -676,17 +676,6 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                     _logger.warning("@onchange%r parameters must be field names", func._onchange)
                 methods[name].append(func)
 
-        # add onchange methods to implement "change_default" on fields
-        def onchange_default(field, self):
-            value = field.convert_to_write(self[field.name], self)
-            condition = "%s=%s" % (field.name, value)
-            defaults = self.env['ir.default'].get_model_defaults(self._name, condition)
-            self.update(defaults)
-
-        for name, field in cls._fields.items():
-            if field.change_default:
-                methods[name].append(functools.partial(onchange_default, field))
-
         # optimization: memoize result on cls, it will not be recomputed
         cls._onchange_methods = methods
         return methods
@@ -1894,7 +1883,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
     def _read_group_prepare(self, orderby, aggregated_fields, annotated_groupbys, query):
         """
         Prepares the GROUP BY and ORDER BY terms for the read_group method. Adds the missing JOIN clause
-        to the query if order should be computed against m2o field. 
+        to the query if order should be computed against m2o field.
         :param orderby: the orderby definition in the form "%(field)s %(order)s"
         :param aggregated_fields: list of aggregated fields in the query
         :param annotated_groupbys: list of dictionaries returned by _read_group_process_groupby
@@ -1991,9 +1980,9 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         return {
             'field': split[0],
             'groupby': gb,
-            'type': field_type, 
+            'type': field_type,
             'display_format': display_formats[gb_function or 'month'] if temporal else None,
-            'interval': time_intervals[gb_function or 'month'] if temporal else None,                
+            'interval': time_intervals[gb_function or 'month'] if temporal else None,
             'tz_convert': tz_convert,
             'qualified_field': qualified_field,
         }
@@ -2018,8 +2007,8 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
     @api.model
     def _read_group_format_result(self, data, annotated_groupbys, groupby, domain):
         """
-            Helper method to format the data contained in the dictionary data by 
-            adding the domain corresponding to its values, the groupbys in the 
+            Helper method to format the data contained in the dictionary data by
+            adding the domain corresponding to its values, the groupbys in the
             context and by properly formatting the date/datetime values.
 
         :param data: a single group
@@ -2096,10 +2085,10 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                 The possible aggregation functions are the ones provided by PostgreSQL
                 (https://www.postgresql.org/docs/current/static/functions-aggregate.html)
                 and 'count_distinct', with the expected meaning.
-        :param list groupby: list of groupby descriptions by which the records will be grouped.  
+        :param list groupby: list of groupby descriptions by which the records will be grouped.
                 A groupby description is either a field (then it will be grouped by that field)
                 or a string 'field:groupby_function'.  Right now, the only functions supported
-                are 'day', 'week', 'month', 'quarter' or 'year', and they only make sense for 
+                are 'day', 'week', 'month', 'quarter' or 'year', and they only make sense for
                 date/datetime fields.
         :param int offset: optional number of records to skip
         :param int limit: optional max number of records to return
@@ -2107,7 +2096,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                              overriding the natural sort ordering of the
                              groups, see also :py:meth:`~osv.osv.osv.search`
                              (supported only for many2one fields currently)
-        :param bool lazy: if true, the results are only grouped by the first groupby and the 
+        :param bool lazy: if true, the results are only grouped by the first groupby and the
                 remaining groupbys are put in the __context key.  If false, all the groupbys are
                 done in one call.
         :return: list of dictionaries(one dictionary for each record) containing:
@@ -2264,7 +2253,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
             # Right now, read_group only fill results in lazy mode (by default).
             # If you need to have the empty groups in 'eager' mode, then the
             # method _read_group_fill_results need to be completely reimplemented
-            # in a sane way 
+            # in a sane way
             result = self._read_group_fill_results(
                 domain, groupby_fields[0], groupby[len(annotated_groupbys):],
                 aggregated_fields, count_field, result, read_group_order=order,


### PR DESCRIPTION
Remove conditional ir defaults (old onchange functionality, shouldn't be used and supported anymore) (they needed fields with attribute `change_default=True` to be available, which isn't used much as functionality is unclear and not or not enough documented).

TODO: show condition field in views of 11-12-13 ?

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
