### PR TITLE
Optional actions on CrashManager

### DIFF
--- a/addons/base_automation/data/base_automation_data.xml
+++ b/addons/base_automation/data/base_automation_data.xml
@@ -13,4 +13,39 @@
             <field name="active" eval="False" />
         </record>
     </data>
+    <data>
+        <record id="base_automation_failure_wizard_form" model="ir.ui.view">
+            <field name="name">Failed automated action</field>
+            <field name="model">base.automation.failure.wizard</field>
+            <field name="arch" type="xml">
+                <form>
+                    <div class="row container">
+                        <div class="col-12 text-center">
+                          <div class="card text-white bg-danger mb-3 w-75 ml64">
+                            <div class="card-header">
+                                    <span class="fa fa-2x fa-warning" t-translation="off">&amp;nbsp;</span>
+                                    <span class="text-white text-uppercase">Danger Zone</span>
+                            </div>
+                            <div class="card-body bg-transparent text-center">
+                              <p>Performing this action will enable you to continue your workflow
+                                  but any data created after this could potentially be corrupted,
+                                  as you are effectively disabling a customization that may set
+                                  important and/or required fields.</p>
+                              <p>Please confirm that you want to deactivate this automated action.</p>
+                            </div>
+                          </div>
+                        </div>
+                    </div>
+                    <footer>
+                        <button
+                            string="Yes, I understand the risks"
+                            type="object"
+                            name="deactivate"
+                            class="btn-secondary"/>
+                        <button special="cancel" string="Oops, no!" class="btn-primary"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+    </data>
 </odoo>

--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -26,6 +26,19 @@ DATE_RANGE_FUNCTION = {
 }
 
 
+class AutomationFailureWizard(models.TransientModel):
+    _name = 'base.automation.failure.wizard'
+    _description = 'Automated action failure wizard'
+
+    def deactivate(self):
+        failures = self.env['base.automation'].browse(self._context.get('failed_automation_ids'))
+        failures.write({'active': False})
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'reload',
+        }
+
+
 class BaseAutomation(models.Model):
     _name = 'base.automation'
     _description = 'Automated Action'
@@ -171,6 +184,32 @@ class BaseAutomation(models.Model):
         else:
             return records, None
 
+    @api.model
+    def _add_postmortem_action(self, e):
+        if self.user_has_groups('base.group_system'):
+            view1 = self.env.ref('base_automation.base_automation_failure_wizard_form')
+            view2 = self.env.ref('base_automation.view_base_automation_form')
+            e.actions = [{
+                'label': _('Disable action'),
+                'action': {
+                    'type': 'ir.actions.act_window',
+                    'res_model': 'base.automation.failure.wizard',
+                    'target': 'new',
+                    'views': [[view1.id, 'form']],
+                    },
+                'options': {'additional_context': {'failed_automation_ids': self.ids}},
+            }, {
+                'label': _('Go to action'),
+                'action': {
+                    'type': 'ir.actions.act_window',
+                    'res_model': 'base.automation',
+                    'res_id': self.id,
+                    'target': 'new',
+                    'views': [[view2.id, 'form']],
+                    },
+                'description': _("Go to the back-end view of the faulty action to fix it")
+            }]
+
     def _process(self, records, domain_post=None):
         """ Process action ``self`` on the ``records`` that have not been done yet. """
         # filter out the records on which self has already been done
@@ -204,7 +243,11 @@ class BaseAutomation(models.Model):
                         'active_id': record.id,
                         'domain_post': domain_post,
                     }
-                    self.action_server_id.with_context(**ctx).run()
+                    try:
+                        self.action_server_id.with_context(**ctx).run()
+                    except Exception as e:
+                        self._add_postmortem_action(e)
+                        raise e
 
     def _check_trigger_fields(self, record):
         """ Return whether any of the trigger fields has been modified on ``record``. """
@@ -329,7 +372,12 @@ class BaseAutomation(models.Model):
                 action_rule = self.env['base.automation'].browse(action_rule_id)
                 result = {}
                 server_action = action_rule.action_server_id.with_context(active_model=self._name, onchange_self=self)
-                res = server_action.run()
+                try:
+                    res = server_action.run()
+                except Exception as e:
+                    self._add_postmortem_action(e)
+                    raise e
+
                 if res:
                     if 'value' in res:
                         res['value'].pop('id', None)

--- a/addons/web/static/src/js/chrome/abstract_web_client.js
+++ b/addons/web/static/src/js/chrome/abstract_web_client.js
@@ -153,6 +153,9 @@ var AbstractWebClient = Widget.extend(ServiceProviderMixin, KeyboardNavigationMi
             }).then(function () {
                 // Listen to 'scroll' event and propagate it on main bus
                 self.action_manager.$el.on('scroll', core.bus.trigger.bind(core.bus, 'scroll'));
+                core.bus.on('do_action', self, function (action, options) {
+                    self.action_manager.do_action(action, options);
+                });
                 core.bus.trigger('web_client_ready');
                 odoo.isReady = true;
                 if (session.uid === 1) {

--- a/addons/web/static/src/js/core/dialog.js
+++ b/addons/web/static/src/js/core/dialog.js
@@ -84,6 +84,7 @@ var Dialog = Widget.extend({
             renderHeader: true,
             renderFooter: true,
             onForceClose: false,
+            description: '',
         });
 
         this.$content = options.$content;
@@ -99,6 +100,7 @@ var Dialog = Widget.extend({
         this.renderHeader = options.renderHeader;
         this.renderFooter = options.renderFooter;
         this.onForceClose = options.onForceClose;
+        this.description = options.description;
 
         core.bus.on('close_dialogs', this, this.destroy.bind(this));
     },
@@ -119,6 +121,7 @@ var Dialog = Widget.extend({
                 technical: self.technical,
                 renderHeader: self.renderHeader,
                 renderFooter: self.renderFooter,
+                description: self.description,
             }));
             switch (self.size) {
                 case 'extra-large':
@@ -191,7 +194,7 @@ var Dialog = Widget.extend({
 
         var self = this;
         this.appendTo($('<div/>')).then(function () {
-            self.$modal.find(".modal-body").replaceWith(self.$el);
+            self.$modal.find(".modal-body").first().replaceWith(self.$el);
             self.$modal.attr('open', true);
             self.$modal.removeAttr("aria-hidden");
             if (self.$parentNode) {

--- a/odoo/exceptions.py
+++ b/odoo/exceptions.py
@@ -28,6 +28,7 @@ class except_orm(Exception):
         self.name = name
         self.value = value
         self.args = (name, value)
+        self.actions = []
 
 
 class UserError(except_orm):

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -686,7 +686,8 @@ def serialize_exception(e):
         "debug": traceback.format_exc(),
         "message": ustr(e),
         "arguments": e.args,
-        "exception_type": "internal_error"
+        "exception_type": "internal_error",
+        "actions": getattr(e, 'actions', []),
     }
     if isinstance(e, odoo.exceptions.UserError):
         tmp["exception_type"] = "user_error"


### PR DESCRIPTION
This PR implements:

1) Actions to be executed in case of an Exception during a business flow (`except_orm`) in the form of buttons.

2) Two actions implemented in the case of an Automated Action that crashes:
        - Disable the action (archive)
        - Go to the form view of the action in edit mode (presumably to fix the action)

Crash during a business flow:
![crashmanager1](https://user-images.githubusercontent.com/4931545/70803354-23ca4a00-1db4-11ea-9c94-9a6913aa740d.png)

Opening the action form view in edit mode:
![crashmanager2](https://user-images.githubusercontent.com/4931545/70803384-38a6dd80-1db4-11ea-94df-984369e461bd.png)

Disabling the action itself:
![crashmanager3](https://user-images.githubusercontent.com/4931545/70803411-45c3cc80-1db4-11ea-92c9-afb9e3b9424d.png)

Supersedes (partially) https://github.com/odoo/odoo/pull/32876