### PR TITLE
[FIX] account: Better user error message on invoice misconfiguration

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -10852,6 +10852,14 @@ msgid ""
 msgstr ""
 
 #. module: account
+#: code:addons/account/models/account_payment.py:375
+#, python-format
+msgid ""
+"There is no Receivable or Payable Account defined in the invoice lines.\n"
+"Please check that you are using the correct accounts and their configuration."
+msgstr ""
+
+#. module: account
 #: code:addons/account/models/account_payment.py:0
 #, python-format
 msgid ""

--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -366,9 +366,13 @@ class account_payment(models.Model):
     def _compute_destination_account_id(self):
         for payment in self:
             if payment.invoice_ids:
-                payment.destination_account_id = payment.invoice_ids[0].mapped(
+                destination_account_id = payment.invoice_ids[0].mapped(
                     'line_ids.account_id').filtered(
-                        lambda account: account.user_type_id.type in ('receivable', 'payable'))[0]
+                        lambda account: account.user_type_id.type in ('receivable', 'payable'))
+                if destination_account_id:
+                    payment.destination_account_id = destination_account_id[0]
+                else:
+                    raise UserError(_('There is no Receivable or Payable Account defined in the invoice lines.\nPlease check that you are using the correct accounts and their configuration.'))
             elif payment.payment_type == 'transfer':
                 if not payment.company_id.transfer_account_id.id:
                     raise UserError(_('There is no Transfer Account defined in the accounting settings. Please define one to be able to confirm this transfer.'))


### PR DESCRIPTION
Before this commit, a traceback was shown when there were no payable or receivable account defined on the account move lines of an invoice.
This commit adds a user friendly error message.

OPW-2152270