### PR TITLE
[IMP] utm: merge utm.campaign wizard

### DIFF
--- a/addons/link_tracker/tests/__init__.py
+++ b/addons/link_tracker/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import models
-from . import wizard
+from . import test_merge_utm_campaign
+

--- a/addons/link_tracker/tests/test_merge_utm_campaign.py
+++ b/addons/link_tracker/tests/test_merge_utm_campaign.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import SavepointCase
+
+
+class TestMergeUtmCampaign(SavepointCase):
+    def setUp(self):
+        super(TestMergeUtmCampaign, self).setUp()
+        self.utm_source = self.env['utm.source'].create({
+            'name': 'utm source'
+        })
+        self.utm_medium = self.env['utm.medium'].create({
+            'name': 'utm medium'
+        })
+        self.utm_campaign_1 = self.env['utm.campaign'].create({
+            'name': 'utm campaign 1'
+        })
+        self.utm_campaign_2 = self.env['utm.campaign'].create({
+            'name': 'utm campaign 2'
+        })
+        self.utm_campaign_3 = self.env['utm.campaign'].create({
+            'name': 'utm campaign 3'
+        })
+        self.link_tracker_1 = self.env['link.tracker'].create({
+            'url': 'www.dodd.com',
+            'campaign_id': self.utm_campaign_1.id,
+            'medium_id': self.utm_medium.id,
+            'source_id': self.utm_source.id
+        })
+        self.link_tracker_2 = self.env['link.tracker'].create({
+            'url': 'www.dodd.com',
+            'campaign_id': self.utm_campaign_2.id,
+            'medium_id': self.utm_medium.id,
+            'source_id': self.utm_source.id
+        })
+        self.link_tracker_3 = self.env['link.tracker'].create({
+            'url': 'www.odoo.com',
+            'campaign_id': self.utm_campaign_3.id,
+            'medium_id': self.utm_medium.id,
+            'source_id': self.utm_source.id
+        })
+        self.link_tracker_click_1 = self.env['link.tracker.click'].create({
+            'link_id': self.link_tracker_1.id
+        })
+        self.link_tracker_click_2 = self.env['link.tracker.click'].create({
+            'link_id': self.link_tracker_2.id
+        })
+        self.link_tracker_click_3 = self.env['link.tracker.click'].create({
+            'link_id': self.link_tracker_3.id
+        })
+
+    def test_merge_unique(self):
+        """ Merge 2 campaigns and check that everything is correctly cleaned up.
+        Link trackers should be cleaned in this case since they're not unique
+        anymore (see 'link_tracker.py'#_clean_duplicates) """
+        link_codes_1 = self.link_tracker_1.link_code_ids
+        link_clicks_1 = self.link_tracker_1.link_click_ids
+        link_codes_2 = self.link_tracker_2.link_code_ids
+        link_clicks_2 = self.link_tracker_2.link_click_ids
+        total_click_count = self.link_tracker_1.campaign_id.click_count + self.link_tracker_2.campaign_id.click_count
+
+        (self.utm_campaign_1 + self.utm_campaign_2)._merge_utm_campaigns(self.utm_campaign_1)
+
+        link_tracker = self.env['link.tracker'].search([('campaign_id', '=', self.utm_campaign_1.id)])
+        link_tracker_empty = self.env['link.tracker'].search([('campaign_id', '=', self.utm_campaign_2.id)])
+
+        self.assertFalse(self.utm_campaign_2.active,
+            "After merging utm.campaigns, unneeded campaigns should be archived. ")
+        self.assertEqual(self.utm_campaign_2.reference_utm_campaign_id, self.utm_campaign_1,
+            "After merging utm.campaigns, deactivated utm.campaign should refer to the merged campaign. ")
+        self.assertEqual(len(link_tracker.ids), 1,
+            "After merging utm.campaigns, duplicate link.trackers should be unlinked.")
+        self.assertEqual(len(link_tracker_empty.ids), 0,
+            "After merging utm.campaigns, no link.tracker link to deactivated utm.campaign.")
+        self.assertFalse(self.link_tracker_2 in self.env['link.tracker'].search([]),
+            "After merging utm.campaigns, duplicate link.trackers should be unlinked.")
+        self.assertEqual(link_tracker.link_code_ids, link_codes_1 + link_codes_2,
+            "After merging utm.campaigns, link.tracker.code of duplicate link.tracker should be redirected to the remaining one.")
+        self.assertEqual(link_tracker.link_click_ids, link_clicks_1 + link_clicks_2,
+            "After merging utm.campaigns, link.tracker.click of duplicate link.tracker should be redirected to the remaining one.")
+        self.assertEqual(self.link_tracker_1.campaign_id.click_count, total_click_count,
+            "After merging utm.campaigns, click count should be the sum of all merged campaigns.")
+
+    def test_merge_nonunique(self):
+        """ Merge 2 campaigns and check that everything unrelated remains
+        unchanged. Nothing but the campaign_id should be changed since the
+        unique constraint can still be met.
+        (see 'link_tracker.py'#_clean_duplicates) """
+        link_codes_3 = self.link_tracker_3.link_code_ids
+        link_clicks_3 = self.link_tracker_3.link_click_ids
+
+        (self.utm_campaign_1 + self.utm_campaign_3)._merge_utm_campaigns(self.utm_campaign_1)
+
+        link_trackers = self.env['link.tracker'].search([('campaign_id', '=', self.utm_campaign_1.id)])
+
+        self.assertEqual(self.link_tracker_1 + self.link_tracker_3, link_trackers,
+            "After merging utm.campaigns, link_trackers should be redirected to the merged campaign.")
+        self.assertEqual(self.link_tracker_3.link_code_ids, link_codes_3,
+            "After merging utm.campaigns, link.tracker.code remains unchanged.")
+        self.assertEqual(self.link_tracker_3.link_click_ids, link_clicks_3,
+            "After merging utm.campaigns, link.tracker.click remains unchanged.")

--- a/addons/utm/__manifest__.py
+++ b/addons/utm/__manifest__.py
@@ -14,6 +14,7 @@ Enable management of UTM trackers: campaign, medium, source.
         'views/assets.xml',
         'views/utm_campaign_views.xml',
         'views/utm_views.xml',
+        'wizard/utm_campaign_merge_views.xml',
         'security/ir.model.access.csv',
     ],
     'demo': [

--- a/addons/utm/models/utm.py
+++ b/addons/utm/models/utm.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, api, SUPERUSER_ID
+from odoo import fields, models, api, SUPERUSER_ID, _
+from odoo.exceptions import UserError
 
 
 class UtmMedium(models.Model):
@@ -34,6 +35,17 @@ class UtmCampaign(models.Model):
     is_website = fields.Boolean(default=False, help="Allows us to filter relevant Campaign")
     color = fields.Integer(string='Color Index')
 
+    active = fields.Boolean(default=True)
+    reference_utm_campaign_id = fields.Many2one('utm.campaign', string="Merged Into Campaign", readonly=True,
+        help="If this campaign was merged into another, we keep a reference to the merged campaign to be able to \
+              transfer any new statistics.")
+
+    def name_get(self):
+        if self.env.context.get('show_id', False):
+            return [(utm.id, "[%s] %s" % (utm.id, utm.name)) for utm in self]
+        else:
+            return super(UtmCampaign, self).name_get()
+
     @api.model
     def _group_expand_stage_ids(self, stages, domain, order):
         """ Read group customization in order to display all the stages in the
@@ -42,6 +54,63 @@ class UtmCampaign(models.Model):
         stage_ids = stages._search([], order=order, access_rights_uid=SUPERUSER_ID)
         return stages.browse(stage_ids)
 
+    def _merge_utm_campaigns(self, campaign_to_keep):
+        """Merge two or more campaigns. Archive all campaigns except
+        campaign_to_keep, and set a reference to campaign_to_keep for all
+        archived campaigns to lead statistics to the right campaign."""
+        if len(self) <= 1:
+            raise UserError(_('Please select more than one campaign from the list.'))
+        if not all(campaign.active for campaign in self):
+            raise UserError(_('Only active campaigns can be merged.'))
+        if not campaign_to_keep or campaign_to_keep not in self:
+            raise UserError(_('Kept campaign should be one of the merged campaigns.'))
+
+        merge_values = {
+            'is_website': any(campaign.is_website for campaign in self),
+            'tag_ids': self.mapped('tag_ids')
+        }
+        campaign_to_keep.update(merge_values)
+
+        deactivated_campaigns = self - campaign_to_keep
+        deactivated_campaigns.write({'active': False, 'reference_utm_campaign_id': campaign_to_keep.id})
+        self.search([('reference_utm_campaign_id', 'in', deactivated_campaigns.ids)]).write({
+            'reference_utm_campaign_id': campaign_to_keep.id
+        })
+
+        self._clean_merged_campaigns_references(campaign_to_keep)
+
+    def _clean_merged_campaigns_references(self, merged_campaign):
+        """After a campaign merge, other modules with m2o linked to deactivated
+        campaign should be redirect to the merged one. Search all fields that is
+        m2o and linked to utm.campaign and not related field. Also ignore
+        fields belong to AbstractModel and models we intentionally ignored."""
+        fields_to_check = self.env['ir.model.fields'].search([
+            ('ttype', '=', 'many2one'),
+            ('relation', '=', 'utm.campaign'),
+            ('related', '=', False)])
+        for field in fields_to_check:
+            if not field.model_id.transient:
+                model = self.env[field.model]
+                if model._auto and model._name not in self._get_ignored_merge_models():
+                    self._clean_merged_campaigns_reference(model._name, field.name, merged_campaign)
+
+    def _clean_merged_campaigns_reference(self, model_name, field_name, merged_campaign):
+        """Given a model_name and field_name of its m2o field link to
+        utm.campaign, change all records link to archived campaigns to the one
+        we keep."""
+        model = self.env[model_name]
+        records_to_redirect = model.sudo().search([(field_name, 'in', (self - merged_campaign).ids)])
+        if records_to_redirect:
+            records_to_redirect.sudo().write({field_name: merged_campaign.id})
+
+    def _get_ignored_merge_models(self):
+        """After a campaign merge, other models with m2o linked to deactivated
+        campaign should be redirect to the merge one, this is done
+        automatically. If manual redirection is unneeded, override the method
+        and append the module name to the list."""
+        return [self._name]
+
+
 class UtmSource(models.Model):
     _name = 'utm.source'
     _description = 'UTM Source'
@@ -49,7 +118,6 @@ class UtmSource(models.Model):
     name = fields.Char(string='Source Name', required=True, translate=True)
 
 class UtmStage(models.Model):
-
     """Stage for utm campaigns. """
     _name = 'utm.stage'
     _description = 'Campaign Stage'

--- a/addons/utm/wizard/__init__.py
+++ b/addons/utm/wizard/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import models
-from . import wizard
+from . import utm_campaign_merge

--- a/addons/utm/wizard/utm_campaign_merge.py
+++ b/addons/utm/wizard/utm_campaign_merge.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class MergeUtmCampaign(models.TransientModel):
+    _name = 'utm.campaign.merge'
+    _description = 'Merge UTM Campaigns'
+
+    @api.model
+    def default_get(self, fields):
+        """Use active_ids from the context to fetch the UTM campaign to merge."""
+        record_ids = self._context.get('active_ids')
+        result = super(MergeUtmCampaign, self).default_get(fields)
+        result['campaign_ids'] = record_ids
+        result['campaign_id'] = record_ids[0]
+        return result
+
+    campaign_id = fields.Many2one('utm.campaign', string='Campaign to Keep', required=True)
+    campaign_ids = fields.Many2many('utm.campaign', string='Campaigns')
+
+    def action_merge(self):
+        self.ensure_one()
+        self.campaign_ids._merge_utm_campaigns(self.campaign_id)
+
+        action = self.env.ref('utm.utm_campaign_action').read()[0]
+        action.update({
+            'views': [[False, 'form']],
+            'res_id': self.campaign_id.id,
+            'view_mode': 'form'
+        })
+        return action

--- a/addons/utm/wizard/utm_campaign_merge_views.xml
+++ b/addons/utm/wizard/utm_campaign_merge_views.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Merge UTM Campaigns  -->
+    <record id="utm_campaign_merge_view_form" model="ir.ui.view">
+        <field name="name">utm.campaign.merge.view.form</field>
+        <field name="model">utm.campaign.merge</field>
+        <field name="arch" type="xml">
+            <form string="Merge UTM Campaign">
+                <sheet>
+                    <group name="campaign_to_keep" col="1">
+                        <p class="oe_grey">
+                            Selected campaigns will be merged together.
+                            All documents and statistics linked to one of these
+                            campaigns will be redirected to the destination campaigns.
+                            You can remove campaigns from this list to avoid merging them.
+                        </p>
+                        <group col="2">
+                            <field name="campaign_id" string="Destination Campaign" domain="[('id', 'in', campaign_ids)]" context="{'show_id': 1}" options="{'no_create': True}"/>
+                        </group>
+                    </group>
+                    <group name="merged_campaigns" string="Merged Campaigns">
+                        <field name="campaign_ids" nolabel="1">
+                            <tree>
+                                <field name="id"/>
+                                <field name="name"/>
+                                <field name="user_id"/>
+                                <field name="stage_id"/>
+                                <field name="tag_ids" widget="many2many_tags"/>
+                            </tree>
+                        </field>
+                    </group>
+                </sheet>
+                <footer>
+                    <button name="action_merge" type="object" string="Merge" class="btn-primary"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <act_window
+        id="action_merge_utm_campaign"
+        name="Merge"
+        res_model="utm.campaign.merge"
+        binding_model="utm.campaign"
+        binding_views="list"
+        view_mode="form"
+        target="new"/>
+</odoo>


### PR DESCRIPTION
PURPOSE

When a company uses utm and martketing features intensively, campaigns
may quickly become a mess.

This commit is about creating a wizard to merge campaigns while keeping
statistics updated.

SPECIFICATIONS

In the tree view of utm.campaign, we now have a merge wizard that can
merge two or more campaigns. In the wizard form, a campaign can be chose
to keep as the final one, campaign infomation will be automatically
filled in to keep the same as the chosen one. The tag_ids will be the
union of all merged campaigns. Users can change If they want.

Merged campaigns except the kept one will be archived. To insure we don't
lose statistics when customers use the old campaigns. We set a reference
in all archived campaigns points to the kept campaigs. In utm.mixin, we
check if a incoming campaign is active, and use its reference if not.

After the merge, all models(not transient and _auto) with m2o (not related)
links to archived campaigns will be automatically redirected to the kept
one. Munual redirection can also be done by override methods when special
actions are needed.

In link.tracker, it requires unique (url, campaign_id, medium_id,
source_id). It's possible to create duplicates after merge campaigns, so
this model is ignored in automatical redirection. A manual redirection
is done with a cleaning process of possible duplicates. Link.tracker.click
and link.tracker.code are also redirect to correct link.trakcer after the
cleaning.

LINKS

PR #42087
Task 2146925