### PR TITLE
[FIX] l10n_ar: fix errors on installation (move_id/company_partner)

### DIFF
--- a/addons/l10n_ar/demo/account_customer_refund_demo.xml
+++ b/addons/l10n_ar/demo/account_customer_refund_demo.xml
@@ -5,11 +5,7 @@
     <record id="demo_refund_invoice_3" model="account.move.reversal">
         <field name="reason">Mercadería defectuosa</field>
         <field name="refund_method">refund</field>
-        <field name="move_id" ref="demo_invoice_3"/>
     </record>
-
-        <function model="account.move.reversal" name="_onchange_move_id"
-           eval="[ref('demo_refund_invoice_3')]" context="{'active_ids': [ref('demo_invoice_3')], 'active_model': 'account.move'}"/>
 
         <function model="account.move.reversal" name="reverse_moves"
            eval="[ref('demo_refund_invoice_3')]" context="{'active_ids': [ref('demo_invoice_3')], 'active_model': 'account.move'}"/>
@@ -18,11 +14,7 @@
     <record id="demo_refund_invoice_4" model="account.move.reversal">
         <field name="reason">Venta cancelada</field>
         <field name="refund_method">cancel</field>
-        <field name="move_id" ref="demo_invoice_4"/>
     </record>
-
-        <function model="account.move.reversal" name="_onchange_move_id"
-           eval="[ref('demo_refund_invoice_4')]" context="{'active_ids': [ref('demo_invoice_4')], 'active_model': 'account.move'}"/>
 
         <function model="account.move.reversal" name="reverse_moves"
            eval="[ref('demo_refund_invoice_4')]" context="{'active_ids': [ref('demo_invoice_4')], 'active_model': 'account.move'}"/>
@@ -31,11 +23,7 @@
     <record id="demo_refund_invoice_16" model="account.move.reversal">
         <field name="reason">Venta cancelada</field>
         <field name="refund_method">cancel</field>
-        <field name="move_id" ref="demo_invoice_16"/>
     </record>
-
-        <function model="account.move.reversal" name="_onchange_move_id"
-           eval="[ref('demo_refund_invoice_16')]" context="{'active_ids': [ref('demo_invoice_16')], 'active_model': 'account.move'}"/>
 
         <function model="account.move.reversal" name="reverse_moves"
            eval="[ref('demo_refund_invoice_16')]" context="{'active_ids': [ref('demo_invoice_16')], 'active_model': 'account.move'}"/>

--- a/addons/l10n_ar/demo/account_supplier_refund_demo.xml
+++ b/addons/l10n_ar/demo/account_supplier_refund_demo.xml
@@ -6,11 +6,7 @@
         <field name="reason">Mercadería defectuosa</field>
         <field name="refund_method">refund</field>
         <field name="l10n_latam_document_number">0001-01234567</field>
-        <field name="move_id" ref="demo_sup_invoice_3"/>
     </record>
-
-        <function model="account.move.reversal" name="_onchange_move_id"
-           eval="[ref('demo_sup_refund_invoice_3')]" context="{'active_ids': [ref('demo_sup_invoice_3')], 'active_model': 'account.move'}"/>
 
         <function model="account.move.reversal" name="reverse_moves"
            eval="[ref('demo_sup_refund_invoice_3')]" context="{'active_ids': [ref('demo_sup_invoice_3')], 'active_model': 'account.move'}"/>
@@ -20,11 +16,7 @@
         <field name="reason">Venta cancelada</field>
         <field name="l10n_latam_document_number">0001-01234566</field>
         <field name="refund_method">cancel</field>
-        <field name="move_id" ref="demo_sup_invoice_4"/>
     </record>
-
-        <function model="account.move.reversal" name="_onchange_move_id"
-           eval="[ref('demo_sup_refund_invoice_4')]" context="{'active_ids': [ref('demo_sup_invoice_4')], 'active_model': 'account.move'}"/>
 
         <function model="account.move.reversal" name="reverse_moves"
            eval="[ref('demo_sup_refund_invoice_4')]" context="{'active_ids': [ref('demo_sup_invoice_4')], 'active_model': 'account.move'}"/>

--- a/addons/l10n_ar/views/account_journal_view.xml
+++ b/addons/l10n_ar/views/account_journal_view.xml
@@ -29,6 +29,7 @@
                 <field name="l10n_ar_afip_pos_number" attrs="{'invisible':['|', '|', ('l10n_latam_country_code', '!=', 'AR'), ('l10n_latam_use_documents', '=', False), ('type', '!=', 'sale')], 'required':[('l10n_latam_country_code', '=', 'AR'), ('l10n_latam_use_documents', '=', True), ('type', '=', 'sale')]}"/>
                 <field name="l10n_ar_afip_pos_partner_id" attrs="{'invisible':['|', '|', ('l10n_latam_country_code', '!=', 'AR'), ('l10n_latam_use_documents', '=', False), ('type', '!=', 'sale')], 'required':[('l10n_latam_country_code', '=', 'AR'), ('l10n_latam_use_documents', '=', True), ('type', '=', 'sale')]}"/>
                 <field name="l10n_ar_share_sequences" attrs="{'invisible':[('l10n_ar_afip_pos_system', '!=', 'II_IM')]}"/>
+                <field name="company_partner" invisible="1"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
move_id is simply removed from the account.move.reversal wizard, so no
need to set it anymore in the demo data

Also the domain of the 'afip pos' partner on the journal has a company_partner
that was not in the view, so we added it.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
