### PR TITLE
[FIX] sale: better error handling while signing SO

### DIFF
--- a/addons/sale/i18n/sale.pot
+++ b/addons/sale/i18n/sale.pot
@@ -588,6 +588,12 @@ msgid "Analytic lines"
 msgstr ""
 
 #. module: sale
+#: code:addons/sale/controllers/portal.py:216
+#, python-format
+msgid "An error occurred, please contact the administrator."
+msgstr ""
+
+#. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.sale_onboarding_quotation_layout_form
 msgid "Apply"
 msgstr ""


### PR DESCRIPTION
Before this commit, when a customer clicked on "Accept & Sign"
button on a SO in the portal, if the SO confirmation failed,
nothing was raised to the customer. It was just spinning.
You had to open a JS console to see the actual traceback.

Now, an error is showed to the customer and the error is logged.

Steps to reproduce:
- Have a db with at least sale_management, stock, mrp
- Create a product with "Make To Order" but without any route or BOM
- Create a SO with the product, check "Online Signature", uncheck "Online Payment"
- Send the SO by email
- Try to confirm the SO, it should raise an error (just to have confirmation it fails)
- Preview the SO in incognito mode
- Try to sign it

See OPW-2149938