### PR TITLE
[FIX] fields: do not always recompute fields

### DIFF
--- a/odoo/addons/test_new_api/models.py
+++ b/odoo/addons/test_new_api/models.py
@@ -778,12 +778,18 @@ class ModelChildM2o(models.Model):
     parent_id = fields.Many2one('test_new_api.model_parent_m2o', ondelete='cascade')
     size1 = fields.Integer(compute='_compute_sizes', store=True)
     size2 = fields.Integer(compute='_compute_sizes', store=True)
+    cost = fields.Integer(compute='_compute_cost', store=True, readonly=False)
 
     @api.depends('parent_id.name')
     def _compute_sizes(self):
         for record in self:
             record.size1 = len(self.parent_id.name)
             record.size2 = len(self.parent_id.name)
+
+    @api.depends('name')
+    def _compute_cost(self):
+        for record in self:
+            record.cost = len(record.name)
 
     def write(self, vals):
         res = super(ModelChildM2o, self).write(vals)
@@ -798,3 +804,9 @@ class ModelParentM2o(models.Model):
 
     name = fields.Char('Name')
     child_ids = fields.One2many('test_new_api.model_child_m2o', 'parent_id', string="Children")
+    cost = fields.Integer(compute='_compute_cost', store=True)
+
+    @api.depends('child_ids.cost')
+    def _compute_cost(self):
+        for record in self:
+            record.cost = sum(child.cost for child in record.child_ids)

--- a/odoo/addons/test_new_api/tests/test_onchange.py
+++ b/odoo/addons/test_new_api/tests/test_onchange.py
@@ -675,3 +675,31 @@ class TestComputeOnchange(common.TransactionCase):
         form.foo = "foo6"
         self.assertEqual(form.bar, "foo6")
         self.assertEqual(form.baz, "baz5")
+
+    def test_onchange_one2many(self):
+        record = self.env['test_new_api.model_parent_m2o'].create({
+            'name': 'Family',
+            'child_ids': [
+                (0, 0, {'name': 'W', 'cost': 10}),
+                (0, 0, {'name': 'X', 'cost': 10}),
+                (0, 0, {'name': 'Y'}),
+                (0, 0, {'name': 'Z'}),
+            ],
+        })
+        record.flush()
+        self.assertEqual(record.child_ids.mapped('name'), list('WXYZ'))
+        self.assertEqual(record.cost, 22)
+
+        # modifying a line should not recompute the cost on other lines
+        with common.Form(record) as form:
+            with form.child_ids.edit(1) as line:
+                line.name = 'XXX'
+            self.assertEqual(form.cost, 15)
+
+            with form.child_ids.edit(1) as line:
+                line.cost = 20
+            self.assertEqual(form.cost, 32)
+
+            with form.child_ids.edit(2) as line:
+                line.cost = 30
+            self.assertEqual(form.cost, 61)

--- a/odoo/addons/test_new_api/views.xml
+++ b/odoo/addons/test_new_api/views.xml
@@ -296,5 +296,28 @@
                 </form>
             </field>
         </record>
+
+        <!-- Multi form view -->
+        <record id="model_parent_form" model="ir.ui.view">
+            <field name="name">model parent form view</field>
+            <field name="model">test_new_api.model_parent_m2o</field>
+            <field name="arch" type="xml">
+                <form string="Model Parent">
+                    <sheet>
+                        <group>
+                            <field name="name"/>
+                            <field name="cost"/>
+                        </group>
+                        <label for="child_ids"/>
+                        <field name="child_ids">
+                            <tree string="Children" editable="bottom">
+                                <field name="name"/>
+                                <field name="cost"/>
+                            </tree>
+                        </field>
+                    </sheet>
+                </form>
+            </field>
+        </record>
     </data>
 </odoo>

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6017,7 +6017,7 @@ Record ids: %(records)s
         snapshot0 = Snapshot(record, nametree)
 
         # store changed values in cache, and update snapshot0
-        record._update_cache(changed_values, validate=False)
+        record._update_cache(changed_values, validate=True)
         for name in names:
             snapshot0.fetch(name)
 


### PR DESCRIPTION
Use case: a new record has no value for a computed stored field in
cache, and the field is not marked to compute.  We should retrieve the
field from the database (`record._origin`) instead of recomputing it.
Otherwise, onchange unexpectedly triggers recomputations of
compute-onchange fields on new records without data in cache.