### PR TITLE
[IMP] purchase_stock: picking return - perf

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -33,8 +33,7 @@ class PurchaseOrder(models.Model):
     group_id = fields.Many2one('procurement.group', string="Procurement Group", copy=False)
     is_shipped = fields.Boolean(compute="_compute_is_shipped")
 
-    @api.depends('order_line.move_ids.returned_move_ids',
-                 'order_line.move_ids.state',
+    @api.depends('order_line.move_ids.state',
                  'order_line.move_ids.picking_id')
     def _compute_picking(self):
         for order in self:
@@ -42,8 +41,7 @@ class PurchaseOrder(models.Model):
             for line in order.order_line:
                 # We keep a limited scope on purpose. Ideally, we should also use move_orig_ids and
                 # do some recursive search, but that could be prohibitive if not done correctly.
-                moves = line.move_ids | line.move_ids.mapped('returned_move_ids')
-                pickings |= moves.mapped('picking_id')
+                pickings |= line.move_ids.mapped('picking_id')
             order.picking_ids = pickings
             order.picking_count = len(pickings)
 

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -130,7 +130,7 @@ class StockMove(models.Model):
     inventory_id = fields.Many2one('stock.inventory', 'Inventory')
     move_line_ids = fields.One2many('stock.move.line', 'move_id')
     move_line_nosuggest_ids = fields.One2many('stock.move.line', 'move_id', domain=[('product_qty', '=', 0.0)])
-    origin_returned_move_id = fields.Many2one('stock.move', 'Origin return move', copy=False, help='Move that created the return move')
+    origin_returned_move_id = fields.Many2one('stock.move', 'Origin return move', copy=False, help='Move that created the return move', index=True)
     returned_move_ids = fields.One2many('stock.move', 'origin_returned_move_id', 'All returned moves', help='Optional: all returned moves created from this move')
     reserved_availability = fields.Float(
         'Quantity Reserved', compute='_compute_reserved_availability',


### PR DESCRIPTION
Before this commit:
When doing a return on a picking with multiple hundreds of products,
the return processing would timeout.

The main slowness culprit was
`line.move_ids.mapped('returned_move_ids')`
which was going through multiple one2many relations and prefetching a
lot of useless data.

Empirical testing shows the execution time of _compute_picking being decreased by a factor
of 30x on very large datasets.

opw-2161341