### PR TITLE
[FIX] l10n_vn: anglo-saxon accounting set default as true

### DIFF
--- a/addons/l10n_vn/data/l10n_vn_chart_data.xml
+++ b/addons/l10n_vn/data/l10n_vn_chart_data.xml
@@ -11,6 +11,7 @@
         <field name="bank_account_code_prefix">112</field>
         <field name="cash_account_code_prefix">111</field>
         <field name="transfer_account_code_prefix">113</field>
+        <field name="use_anglo_saxon" eval="True"/>
     </record>
 </data>
 </odoo>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
task- 2124104

Current behavior before PR:
anglo-section accounting is false default for Vietnam.

Desired behavior after PR is merged:
anglo-section accounting by default true.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
