### PR TITLE
[IMP] mail: add author field on mail template

### DIFF
--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -47,7 +47,7 @@ class TestImLivechatMessage(TransactionCase):
             'attachment_ids': [],
             'author': {
                 'id': self.users[1].partner_id.id,
-                'name': "test1",
+                'name': self.users[1].partner_id.name,
             },
             'body': message.body,
             'date': message.date,
@@ -72,6 +72,10 @@ class TestImLivechatMessage(TransactionCase):
             'recipients': [],
             'record_name': "test1 Ernest Employee",
             'res_id': channel_livechat_1.id,
+            'sender': {
+                'id': self.users[0].partner_id.id,
+                'name': self.users[0].partner_id.name,
+            },
             'sms_ids': [],
             'starred_partner_ids': [],
             'subject': False,

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2761,7 +2761,7 @@ class MailThread(models.AbstractModel):
 
         author_id = msg_vals.get('author_id') or message.author_id.id
         for pid, pdata in res.items():
-            if pid and pid == author_id and not self.env.context.get('mail_notify_author'):  # do not notify the author of its own messages
+            if pid and pid in [author_id, self.env.user.partner_id.id] and not self.env.context.get('mail_notify_author'):  # do not notify the author of its own messages
                 continue
             if pdata['active'] is False:
                 continue

--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -72,6 +72,10 @@
                                             <t t-esc="messageView.message.author.nameOrDisplayName"/>
                                         </t>
                                     </strong>
+                                    <span t-if="messageView.message.sender and messageView.message.sender !== messageView.message.author"
+                                        class="me-1 small fw-light">
+                                        impersonated by <t t-esc="messageView.message.sender.nameOrDisplayName"/>
+                                    </span>
                                 </t>
                                 <t t-elif="messageView.message.guestAuthor">
                                     <strong class="o_Message_authorName me-2 text-truncate text-muted">

--- a/addons/mail/static/src/models/message.js
+++ b/addons/mail/static/src/models/message.js
@@ -24,6 +24,9 @@ registerModel({
             if ('author' in data) {
                 data2.author = data.author;
             }
+            if ('sender' in data) {
+                data2.sender = data.sender;
+            }
             if ('body' in data) {
                 data2.body = data.body;
             }
@@ -285,6 +288,10 @@ registerModel({
         attachments: many('Attachment', {
             inverse: 'messages',
         }),
+        /**
+         * This value describes the author of the message. It's not necessarily the sender of
+         * the message but the individual used to be impersonated by the sender.
+         */
         author: one('Partner'),
         avatarUrl: attr({
             compute() {
@@ -714,6 +721,12 @@ registerModel({
             },
         }),
         recipients: many('Partner'),
+        /**
+         * The sender is the one that wrote and send the message. By default, the sender
+         * and the author are the same. They can be different when an author is specified
+         * manually on a template.
+         */
+         sender: one('Partner'),
         shortTime: attr({
             compute() {
                 if (!this.momentDate) {

--- a/addons/mail/static/src/models/partner.js
+++ b/addons/mail/static/src/models/partner.js
@@ -333,6 +333,7 @@ registerModel({
             },
         }),
         is_public: attr(),
+        messagesAsSender: one('Message'),
         model: attr({
             default: 'res.partner',
         }),

--- a/addons/mail/views/mail_template_views.xml
+++ b/addons/mail/views/mail_template_views.xml
@@ -60,6 +60,8 @@
                             </page>
                             <page string="Email Configuration" name="email_configuration">
                                 <group>
+                                    <field name="author"
+                                            placeholder="Author user's id, override the author"/>
                                     <field name="email_from"
                                             placeholder="Override author's email"/>
                                     <field name="use_default_to"/>
@@ -115,6 +117,7 @@
                     <field name="model_id" groups="base.group_no_one"/>
                     <field name="description"/>
                     <field name="subject" optional="hidden"/>
+                    <field name="author" optional="hidden"/>
                     <field name="email_from" optional="hidden"/>
                     <field name="email_to" optional="hidden"/>
                     <field name="partner_to" optional="hidden"/>

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -413,6 +413,8 @@ class MailComposer(models.TransientModel):
                 # rendered values using template
                 email_dict = rendered_values[res_id]
                 mail_values['partner_ids'] += email_dict.pop('partner_ids', [])
+                if email_dict.get('author'):
+                    mail_values['author_id'] = int(email_dict.pop('author'))
                 mail_values.update(email_dict)
                 if not self.reply_to_force_new:
                     mail_values.pop('reply_to')
@@ -568,7 +570,7 @@ class MailComposer(models.TransientModel):
             values = self.generate_email_for_composer(
                 template_id, [res_id],
                 ['subject', 'body_html',
-                 'email_from',
+                 'author', 'email_from',
                  'email_cc', 'email_to', 'partner_to', 'reply_to',
                  'attachment_ids', 'mail_server_id'
                 ]
@@ -588,6 +590,7 @@ class MailComposer(models.TransientModel):
                 attachment_ids.append(Attachment.create(data_attach).id)
             if values.get('attachment_ids', []) or attachment_ids:
                 values['attachment_ids'] = [Command.set(values.get('attachment_ids', []) + attachment_ids)]
+            values['author_id'] = int(values.pop('author')) if values.get('author') else self.env.user.partner_id.id
         else:
             default_values = self.with_context(
                 default_composition_mode=composition_mode,
@@ -664,7 +667,7 @@ class MailComposer(models.TransientModel):
         if self.template_id:
             template_values = self.generate_email_for_composer(
                 self.template_id.id, res_ids,
-                ['email_to', 'partner_to', 'email_cc', 'attachment_ids', 'mail_server_id'])
+                ['email_to', 'partner_to', 'email_cc', 'attachment_ids', 'mail_server_id', 'author', 'email_from'])
         else:
             template_values = {}
 
@@ -674,6 +677,7 @@ class MailComposer(models.TransientModel):
                 results[res_id].pop('partner_ids', None)
                 results[res_id].pop('email_to', None)
                 results[res_id].pop('email_cc', None)
+                results[res_id].pop('email_from', None)
                 # remove attachments from template values as they should not be rendered
                 template_values[res_id].pop('attachment_ids', None)
             else:

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -22,6 +22,7 @@
                         <field name="res_id" invisible="1"/>
                         <field name="subtype_id" invisible="1"/>
                         <!-- visible wizard -->
+                        <field name="author_id" attrs="{'invisible':[('composition_mode', '!=', 'mass_mail')]}"/>
                         <field name="email_from"
                             attrs="{'invisible':[('composition_mode', '!=', 'mass_mail')]}"/>
                         <label for="partner_ids" string="Recipients" attrs="{'invisible': ['|', ('is_log', '=', True), ('composition_mode', '!=', 'comment')]}"/>

--- a/addons/test_event_full/tests/test_performance.py
+++ b/addons/test_event_full/tests/test_performance.py
@@ -234,7 +234,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=684):  # tef 639 / com 681
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=685):  # tef 639 / com 681
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = [
                 dict(reg_data,
@@ -280,7 +280,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         form like) """
         event = self.env['event.event'].browse(self.test_event.ids)
 
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=698):  # tef 652 - com 694
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=699):  # tef 652 - com 694
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = [
                 dict(reg_data,
@@ -358,7 +358,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         event = self.env['event.event'].browse(self.test_event.ids)
 
         # partner-based customer
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=129):  # tef 122 / com 127
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=130):  # tef 122 / com 127
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = {
                 'event_id': event.id,
@@ -388,7 +388,7 @@ class TestRegistrationPerformance(EventPerformanceCase):
         event = self.env['event.event'].browse(self.test_event.ids)
 
         # website customer data
-        with freeze_time(self.reference_now), self.assertQueryCount(event_user=135):  # tef 126 / com 130
+        with freeze_time(self.reference_now), self.assertQueryCount(event_user=136):  # tef 126 / com 130
             self.env.cr._now = self.reference_now  # force create_date to check schedulers
             registration_values = dict(
                 self.website_customer_data[0],

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -387,7 +387,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 composer_form.attachment_ids.add(attachment)
             composer = composer_form.save()
 
-        with self.assertQueryCount(__system__=39, employee=47):  # tm+com 38/46
+        with self.assertQueryCount(__system__=40, employee=48):  # tm+com 38/46
             composer._action_send_mail()
 
         # notifications
@@ -508,7 +508,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             )
             composer = composer_form.save()
 
-        with self.assertQueryCount(__system__=35, employee=41):
+        with self.assertQueryCount(__system__=36, employee=42):
             composer._action_send_mail()
 
         # notifications
@@ -538,7 +538,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             )
             composer = composer_form.save()
 
-        with self.assertQueryCount(__system__=47, employee=64):
+        with self.assertQueryCount(__system__=48, employee=65):
             composer._action_send_mail()
 
         # notifications
@@ -568,7 +568,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_assignation_inbox(self):
         record = self.env['mail.test.track'].create({'name': 'Test'})
-        with self.assertQueryCount(__system__=19, employee=21):
+        with self.assertQueryCount(__system__=20, employee=22):
             record.write({
                 'user_id': self.user_test.id,
             })
@@ -654,7 +654,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_message_post_one_inbox_notification(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(__system__=14, employee=18):
+        with self.assertQueryCount(__system__=15, employee=19):
             record.message_post(
                 body='<p>Test Post Performances with an inbox ping</p>',
                 partner_ids=self.user_test.partner_id.ids,
@@ -1175,7 +1175,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
             ]
         }])
 
-        with self.assertQueryCount(employee=6):
+        with self.assertQueryCount(employee=8):
             res = messages.message_format()
             self.assertEqual(len(res), 2)
             for message in res:
@@ -1184,7 +1184,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         self.env.flush_all()
         self.env.invalidate_all()
 
-        with self.assertQueryCount(employee=19):
+        with self.assertQueryCount(employee=21):
             res = messages.message_format()
             self.assertEqual(len(res), 2)
             for message in res:
@@ -1205,14 +1205,14 @@ class TestMailComplexPerformance(BaseMailPerformance):
             'res_id': record.id
         } for record in records])
 
-        with self.assertQueryCount(employee=5):
+        with self.assertQueryCount(employee=6):
             res = messages.message_format()
             self.assertEqual(len(res), 6)
 
         self.env.flush_all()
         self.env.invalidate_all()
 
-        with self.assertQueryCount(employee=14):
+        with self.assertQueryCount(employee=16):
             res = messages.message_format()
             self.assertEqual(len(res), 6)
 
@@ -1288,7 +1288,7 @@ class TestMailHeavyPerformancePost(BaseMailPerformance):
         ]
         attachments = self.env['ir.attachment'].with_user(self.env.user).create(self.test_attachments_vals)
         enable_logging = self.cr._enable_logging() if self.warm else nullcontext()
-        with self.assertQueryCount(employee=49), enable_logging:
+        with self.assertQueryCount(employee=50), enable_logging:
             record_container.with_context({}).message_post(
                 body='<p>Test body <img src="cid:cid1"> <img src="cid:cid2"></p>',
                 subject='Test Subject',

--- a/addons/test_mail_full/tests/test_rating.py
+++ b/addons/test_mail_full/tests/test_rating.py
@@ -147,13 +147,13 @@ class TestRatingPerformance(TestRatingCommon):
             } for idx in range(RECORD_COUNT)])
             self.flush_tracking()
 
-        with self.assertQueryCount(employee=2004):  # tmf 2004
+        with self.assertQueryCount(employee=2104):  # tmf 2104
             for record in record_ratings:
                 access_token = record._rating_get_access_token()
                 record.rating_apply(1, token=access_token)
             self.flush_tracking()
 
-        with self.assertQueryCount(employee=2003):  # tmf 2003
+        with self.assertQueryCount(employee=2103):  # tmf 2103
             for record in record_ratings:
                 access_token = record._rating_get_access_token()
                 record.rating_apply(5, token=access_token)


### PR DESCRIPTION
# Purpose

When you configure a mail template, the format to specify an email_from is complex. We introduce an author field to simplify the template configuration.

# Specifications

When an author is specify and an email_from not, the email from is set to the email_formatted linked to the author in order to simplify the configuration of a template. In place of writting :
`{{object.user_id.email_formatted |safe}}`, the user has the possibility to write `{{object.user_id.id}}`, which is easier to use.

task-2091859