### PR TITLE
[FIX] stock: wrong location destination id at package level

### DIFF
--- a/addons/stock/models/stock_package_level.py
+++ b/addons/stock/models/stock_package_level.py
@@ -131,8 +131,7 @@ class StockPackageLevel(models.Model):
     def create(self, vals):
         result = super(StockPackageLevel, self).create(vals)
         if vals.get('location_dest_id'):
-            result.mapped('move_line_ids').write({'location_dest_id': vals['location_dest_id']})
-            result.mapped('move_ids').write({'location_dest_id': vals['location_dest_id']})
+            result.location_dest_id = result.location_dest_id.get_putaway_strategy(result.package_id.quant_ids.mapped('product_id')).id or result.location_dest_id.id
         if result.picking_id.state != 'draft' and result.location_id and result.location_dest_id and not result.move_ids and not result.move_line_ids:
             result._generate_moves()
         return result


### PR DESCRIPTION
With configuration -
1) Product Packagings  - True
2) Delivery Packages - True
3) Multi-Step Routes Warehouse - True
4) Storage Locations - True
5) Warehouse -> WH/Stock -> 2 step incoming
6) Location -> WH/Stock -> Put away rule for Shelf-1 (loc)

If a Receipt transfter is created with Packages and validated.
It will create a internal transfer with -
locations from Stock\Input -> Stock\Shelf-1

But when internal trasnfer is created manually, location dest id
will not changed from WH/STOCK -> STOCK/SHELF-1.

After this commit, PUT AWAY Strategy will be also work even if INT
is created manually.

Task-2148494
when this Receipt will be validated, it will create a Internal
Transfer Like -

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
