### PR TITLE
[FIX] mrp : chnage description of workorders actions when there is no…

### DIFF
--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -502,11 +502,9 @@
         <field name="context">{'search_default_ready': True, 'search_default_progress': True, 'search_default_pending': True}</field>
         <field name="help" type="html">
           <p class="o_view_nocontent_smiling_face">
-            Start a new work order
+            Plan a Manufacturing Order
           </p><p>
-            Work Orders are operations to be processed at a Work Center to realize a
-            Manufacturing Order. Work Orders are trigerred by Manufacturing Orders,
-            they are based on the Routing defined on these ones
+            Work orders correspond to the different operations, taking place at specific workcenters,which are performed to manufacture a product.Those can be defined in a routing that will be assigned to a bill of material.
             </p>
         </field>
     </record>


### PR DESCRIPTION
Before this commit when there is no work order the message having spelling mistake so change the whole string 

Description of the issue/feature this PR addresses:

Replace the description when there are no work orders to show:
Plan a Manufacturing Order
Work orders corresponds to the different operations, taking place at specific workcenters, which are performed to manufacture a product. Those can be defined in a routing which will be assigned to a bill of material.

Task ID : 2128553

Desired behavior after PR is merged: corrected the description




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
