### PR TITLE
[IMP]: Check Quantity of stock moves while validate the MO

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1000,7 +1000,7 @@ class StockMove(models.Model):
             if move.move_orig_ids:
                 move_waiting |= move
             else:
-                if move.procure_method == 'make_to_order':
+                if move.procure_method == 'make_to_order' and move.product_uom_qty > 0:
                     move_create_proc |= move
                 else:
                     move_to_confirm |= move

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1181,6 +1181,8 @@ class StockMove(models.Model):
             else:
                 if not move.move_orig_ids:
                     if move.procure_method == 'make_to_order':
+                        if move.product_uom_qty == 0:
+                            assigned_moves |= move
                         continue
                     # If we don't need any quantity, consider the move assigned.
                     need = missing_reserved_quantity


### PR DESCRIPTION
Description of the issue/feature this PR addresses:  action_confirm of MO shouldn't validate the SM at zero

Task ID: 2159374

Current behavior before PR: 

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
