### PR TITLE
[IMP] (hr_)fleet : modify car info accessibility

### DIFF
--- a/addons/fleet/data/fleet_demo.xml
+++ b/addons/fleet/data/fleet_demo.xml
@@ -45,11 +45,6 @@
           <field name="category">service</field>
       </record>
 
-      <record id="type_service_service_7" model="fleet.service.type">
-          <field name="name">Summer tires</field>
-          <field name="category">service</field>
-      </record>
-
       <record id="type_service_service_8" model="fleet.service.type">
           <field name="name">Repair and maintenance</field>
           <field name="category">service</field>

--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -314,6 +314,7 @@ class FleetVehicle(models.Model):
             'context': {'default_driver_id': self.driver_id.id, 'default_vehicle_id': self.id}
         }
 
+
 class FleetVehicleOdometer(models.Model):
     _name = 'fleet.vehicle.odometer'
     _description = 'Odometer log for a vehicle'
@@ -324,7 +325,7 @@ class FleetVehicleOdometer(models.Model):
     value = fields.Float('Odometer Value', group_operator="max")
     vehicle_id = fields.Many2one('fleet.vehicle', 'Vehicle', required=True)
     unit = fields.Selection(related='vehicle_id.odometer_unit', string="Unit", readonly=True)
-    driver_id = fields.Many2one(related="vehicle_id.driver_id", string="Driver", readonly=False)
+    driver_id = fields.Many2one('res.partner', "Driver", compute='_compute_driver_id', store=True)
 
     @api.depends('vehicle_id', 'date')
     def _compute_vehicle_log_name(self):
@@ -340,6 +341,11 @@ class FleetVehicleOdometer(models.Model):
     def _onchange_vehicle(self):
         if self.vehicle_id:
             self.unit = self.vehicle_id.odometer_unit
+
+    @api.depends('vehicle_id')
+    def _compute_driver_id(self):
+        for rec in self:
+            rec.driver_id = rec.vehicle_id.driver_id
 
 
 class FleetVehicleState(models.Model):

--- a/addons/fleet/security/fleet_security.xml
+++ b/addons/fleet/security/fleet_security.xml
@@ -28,7 +28,7 @@
             <field name="perm_write" eval="False"/>
             <field name="perm_create" eval="False"/>
             <field name="perm_unlink" eval="False"/>
-            <field name="domain_force">[('cost_id.vehicle_id.driver_id','=',user.partner_id.id)]</field>
+            <field name="domain_force">[('vehicle_id.driver_id','=',user.partner_id.id)]</field>
         </record>
         <record id="fleet_rule_service_visibility_user" model="ir.rule">
             <field name="name">User can only see his/her vehicle's services</field>
@@ -38,7 +38,7 @@
             <field name="perm_write" eval="False"/>
             <field name="perm_create" eval="False"/>
             <field name="perm_unlink" eval="False"/>
-            <field name="domain_force">[('cost_id.vehicle_id.driver_id','=',user.partner_id.id)]</field>
+            <field name="domain_force">[('vehicle_id.driver_id','=',user.partner_id.id)]</field>
         </record>
         <record id="fleet_rule_odometer_visibility_user" model="ir.rule">
             <field name="name">User can only see his/her vehicle's odometer</field>

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -15,7 +15,8 @@
                         <button name="open_assignation_logs"
                             type="object"
                             class="oe_stat_button"
-                            icon="fa-history">
+                            icon="fa-history"
+                            groups="fleet.fleet_group_user">
                             <field name="history_count" widget="statinfo" string="Drivers History"/>
                         </button>
                         <button name="return_action_to_open"
@@ -23,7 +24,8 @@
                             class="oe_stat_button"
                             icon="fa-book"
                             context="{'xml_id':'fleet_vehicle_log_contract_action'}"
-                            help="show the contract for this vehicle">
+                            help="show the contract for this vehicle"
+                            groups="fleet.fleet_group_user">
                             <field name="contract_count" widget="statinfo" string="Contracts"/>
                         </button>
                         <button name="return_action_to_open"
@@ -61,8 +63,8 @@
                         <group string="Driver">
                             <field name="active" invisible="1"/>
                             <field name="driver_id" domain="['|', ('company_id', '=', False ), ('company_id', '=', company_id)]"/>
-                            <label for="future_driver_id"/>
-                            <div class="o_row">
+                            <label for="future_driver_id" groups="fleet.fleet_group_manager"/>
+                            <div class="o_row" groups="fleet.fleet_group_manager">
                                 <field name="future_driver_id"/>
                                 <button string="Apply Change"
                                     class="btn btn-primary"
@@ -71,20 +73,20 @@
                                     attrs="{'invisible': [('future_driver_id', '=', False)]}"/>
                             </div>
                             <field name="plan_to_change_car" groups="fleet.fleet_group_manager"/>
-                            <field name="next_assignation_date"/>
-                            <field name="location"/>
+                            <field name="next_assignation_date" groups="fleet.fleet_group_manager"/>
+                            <field name="location" groups="fleet.fleet_group_manager"/>
                         </group>
                         <group string="Vehicle">
-                            <label for="odometer"/>
-                            <div class="o_row">
+                            <label for="odometer" groups="fleet.fleet_group_manager"/>
+                            <div class="o_row" groups="fleet.fleet_group_manager">
                                 <field name="odometer"/>
                                 <field name="odometer_unit"/>
                             </div>
                             <field name="acquisition_date"/>
                             <field name="vin_sn"/>
-                            <field name="car_value" widget="monetary"/>
-                            <field name="net_car_value" widget="monetary"/>
-                            <field name="residual_value" widget="monetary"/>
+                            <field name="car_value" widget="monetary" groups="fleet.fleet_group_manager"/>
+                            <field name="net_car_value" widget="monetary" groups="fleet.fleet_group_manager"/>
+                            <field name="residual_value" widget="monetary" groups="fleet.fleet_group_manager"/>
                             <field name="company_id" groups="base.group_multi_company"/>
                         </group>
                         <group string="Contract" name="contract">
@@ -233,7 +235,7 @@
                                     </li>
                                 </ul>
                             </div>
-                            <div class="o_kanban_button" t-if="!selection_mode">
+                            <div class="o_kanban_button" t-if="!selection_mode" groups="fleet.fleet_group_user">
                                 <a t-if="record.contract_count.raw_value>0" data-type="object"
                                    data-name="return_action_to_open" href="#" class="oe_kanban_action oe_kanban_action_a"
                                    data-context='{"xml_id":"fleet_vehicle_log_contract_action"}'>
@@ -247,7 +249,7 @@
                                     </span>
                                 </a>
                             </div>
-                            <div class="o_kanban_inline_block" t-if="!selection_mode">
+                            <div class="o_kanban_inline_block" t-if="!selection_mode" groups="fleet.fleet_group_user">
                                 <field name="activity_ids" widget="kanban_activity"/>
                             </div>
                         </div>

--- a/addons/hr_fleet/__manifest__.py
+++ b/addons/hr_fleet/__manifest__.py
@@ -8,6 +8,8 @@
     'description': "",
     'depends': ['hr', 'fleet'],
     'data': [
+        'security/security.xml',
+        'security/ir.model.access.csv',
         'views/employee_views.xml',
         'views/fleet_vehicle_views.xml',
         'wizard/hr_departure_wizard_views.xml'

--- a/addons/hr_fleet/models/employee.py
+++ b/addons/hr_fleet/models/employee.py
@@ -24,6 +24,18 @@ class Employee(models.Model):
             "name": "History Employee Cars",
         }
 
+    def action_open_current_employee_car(self):
+        self.ensure_one()
+        context = dict(self._context)
+        context['search_default_driver_id'] = self.env.user.partner_id.id
+        return {
+            "type": "ir.actions.act_window",
+            "res_model": "fleet.vehicle",
+            "views": [[False, "kanban"], [False, "form"], [False, "tree"]],
+            "context": dict(context, create=False),
+            "name": "Current Car"
+        }
+
     def _compute_employee_cars_count(self):
         driver_ids = (self.mapped('user_id.partner_id') | self.sudo().mapped('address_home_id')).ids
         fleet_data = self.env['fleet.vehicle.assignation.log'].read_group(

--- a/addons/hr_fleet/models/res_users.py
+++ b/addons/hr_fleet/models/res_users.py
@@ -24,3 +24,6 @@ class User(models.Model):
 
     def action_open_employee_cars(self):
         return self.employee_id.action_open_employee_cars()
+
+    def action_open_current_employee_car(self):
+        return self.employee_id.action_open_current_employee_car()

--- a/addons/hr_fleet/security/ir.model.access.csv
+++ b/addons/hr_fleet/security/ir.model.access.csv
@@ -1,0 +1,9 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_fleet_vehicle_user_readonly,access.fleet.vehicle.user.readonly,fleet.model_fleet_vehicle,base.group_user,1,0,0,0
+access_fleet_vehicle_tag_user_readonly,access.fleet.vehicle.tag.user.readonly,fleet.model_fleet_vehicle_tag,base.group_user,1,0,0,0
+access_fleet_vehicle_state_user_readonly,access.fleet.vehicle.state.user.Readonly,fleet.model_fleet_vehicle_state,base.group_user,1,0,0,0
+access_fleet_vehicle_odometer_user_readonly,access.fleet.vehicle.odometer.user.readonly,fleet.model_fleet_vehicle_odometer,base.group_user,1,0,0,0
+access_fleet_vehicle_log_contract_user_readonly,access.fleet.vehicle.log.contract.user.readonly,fleet.model_fleet_vehicle_log_contract,base.group_user,1,0,0,0
+access_fleet_service_type_user_readonly,access.fleet.service.type.user.readonly,fleet.model_fleet_service_type,base.group_user,1,0,0,0
+access_fleet_vehicle_log_services_user_readonly,access.fleet.vehicle.log.services.user.readonly,fleet.model_fleet_vehicle_log_services,base.group_user,1,0,0,0
+access_fleet_vehicle_assignation_log_user_readonly,access.fleet.vehicle.assignation.log.user.readonly,fleet.model_fleet_vehicle_assignation_log,base.group_user,1,0,0,0

--- a/addons/hr_fleet/security/security.xml
+++ b/addons/hr_fleet/security/security.xml
@@ -1,0 +1,30 @@
+<odoo>
+    <data noupdate="0">
+        <record id="fleet_vehicle_user_readonly" model="ir.rule">
+            <field name="name">fleet.vehicle : user readonly rule</field>
+            <field name="model_id" ref="fleet.model_fleet_vehicle"/>
+            <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+            <field name="domain_force">[
+                ('driver_id', '=', user.partner_id.id)
+            ]</field>
+        </record>
+
+        <record id="fleet_vehicle_odometer_user_readonly" model="ir.rule">
+            <field name="name">fleet.vehicle.odometer : user readonly rule</field>
+            <field name="model_id" ref="fleet.model_fleet_vehicle_odometer"/>
+            <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+            <field name="domain_force">[
+                ('driver_id', '=', user.partner_id.id)
+            ]</field>
+        </record>
+
+        <record id="fleet_vehicle_log_services_user_readonly" model="ir.rule">
+            <field name="name">fleet.vehicle.log.services : user readonly rule</field>
+            <field name="model_id" ref="fleet.model_fleet_vehicle_log_services"/>
+            <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+            <field name="domain_force">[
+                ('purchaser_id', '=', user.partner_id.id)
+            ]</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/hr_fleet/views/employee_views.xml
+++ b/addons/hr_fleet/views/employee_views.xml
@@ -9,13 +9,13 @@
                 <button name="action_get_claim_report" string="Claim Car Report"
                 class="btn btn-secondary"
                 type="object" groups="fleet.fleet_group_manager"
-                attrs="{'invisible': [('employee_cars_count','=', 0)]}"
+                attrs="{'invisible': [('employee_cars_count', '=', 0)]}"
                 confirm="This report will contain only PDF files. If you want all documents, please go on vehicle page. Do you want to proceed?"/>
             </xpath>
             <div name="button_box" position="inside">
                 <button name="action_open_employee_cars" type="object"
                         class="oe_stat_button" icon="fa-car" groups="fleet.fleet_group_manager"
-                        attrs="{'invisible': [('employee_cars_count','=', 0)]}">
+                        attrs="{'invisible': [('employee_cars_count', '=', 0)]}">
                     <field name="employee_cars_count" widget="statinfo" />
                 </button>
             </div>
@@ -36,14 +36,19 @@
                 <button name="action_get_claim_report" string="Claim Car Report"
                 class="btn btn-primary"
                 type="object" groups="fleet.fleet_group_manager"
-                attrs="{'invisible': [('employee_cars_count','=', 0)]}"
+                attrs="{'invisible': [('employee_cars_count', '=', 0)]}"
                 confirm="This report will contain only PDF files. If you want all documents, please go on vehicle page. Do you want to proceed?"/>
             </xpath>
             <xpath expr="//div[@name='button_box']" position="inside">
-                <button name="action_open_employee_cars" type="object"
-                        class="oe_stat_button" icon="fa-car" groups="fleet.fleet_group_manager"
-                        attrs="{'invisible': [('employee_cars_count','=', 0)]}">
-                    <field name="employee_cars_count" widget="statinfo" />
+                <button name="action_open_current_employee_car"
+                    type="object"
+                    class="o_stat_button"
+                    icon="fa-car"
+                    attrs="{'invisible': [('employee_cars_count', '=',  0)]}">
+                    <div class="o_stat_info">
+                        <field name="employee_cars_count" invisible="1"/>
+                        Current Car
+                    </div>
                 </button>
             </xpath>
         </field>

--- a/addons/hr_maintenance/models/res_users.py
+++ b/addons/hr_maintenance/models/res_users.py
@@ -5,7 +5,7 @@ class Users(models.Model):
     _inherit = 'res.users'
 
     equipment_ids = fields.One2many('maintenance.equipment', 'owner_user_id', string="Managed Equipments")
-    equipment_count = fields.Integer(related='employee_id.equipment_count', string="Assigned Equipments")
+    equipment_count = fields.Integer(related='employee_id.equipment_count', string="Equipments")
 
     def __init__(self, pool, cr):
         """ Override of __init__ to add access rights.


### PR DESCRIPTION
[IMP] (hr_)fleet : modify car info accessibility
-----------------------------------------------------------

- The stat button "Car" (now "Current car") from "My Profile" now opens the current car instead of the whole history. This stat button is available even for people who usually do not have any access to Fleet.
- Several modifications in the fleet_vehicle form view. Accessibility to particular fields has been refined. Now some fields are only available to the fleet administrator ("fleet_group_manager").
- Remove duplicate in demo data ("Summer tires").
- On fleet.vehicle.odometer and fleet.vehicle.log.services, respectively 'driver_id' and 'purchaser_id' are no longer related. Now, they keep the correct person that was the driver of the corresponding car at the record creation.
- FIX: cost_id was still used in security rules whereas this field apparently no longer exists.
- Some python linting.

[IMP] hr_maintenance : modify equipment_count string
-------------------------------------------------------------------------
Modify displayed string for equipment_count for res_users in hr_maintenance.

TASK#2032894
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
