### PR TITLE
[FIX] account: Link between analytic line and move line

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1255,6 +1255,8 @@ class AccountMoveLine(models.Model):
             #hackish workaround to write the amount_currency when assigning a payment to an invoice through the 'add' button
             #this is needed to compute the correct amount_residual_currency and potentially create an exchange difference entry
             self._update_check()
+        if ('analytic_account_id' in vals):
+            self.mapped('analytic_line_ids').write({'account_id': vals['analytic_account_id']})
         #when we set the expected payment date, log a note on the invoice_id related (if any)
         if vals.get('expected_pay_date') and self.invoice_id:
             str_expected_pay_date = vals['expected_pay_date']


### PR DESCRIPTION
Steps to reproduce the bug:

- Create an analytic account AA
- Create a journal entry with a debit(L1) and a credit(L2)
- Set an analytic account on L1
- Validate the journal entry and an account analytic line AAL has been created
- Go on the journal item  L1 by the menu Journal Items
- Remove the analytic account of L1

Bug:

The account analytic of AAL was still AA

opw:2158057