### PR TITLE
[FIX] base: translation update on manifest changes

### DIFF
--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -727,6 +727,8 @@ class Module(models.Model):
                 mod = self.create(dict(name=mod_name, state=state, **values))
                 res[1] += 1
 
+            if updated_values.keys() & {'shortdesc', 'description', 'summary'}:
+                mod._update_translations()
             mod._update_dependencies(terp.get('depends', []))
             mod._update_exclusions(terp.get('excludes', []))
             mod._update_category(terp.get('category', 'Uncategorized'))


### PR DESCRIPTION
Steps to reproduce:
- install a new languague (french for example)
- change current user's language to french
- create a new module with the scaffolding tool using the command
./odoo-bin scaffold new_app addons
- change the name of the module in the manifest
- re-run the server and activate debug mode
- go to apps > "update the apps list"

Previous behavior:
there is a translation created with the original name of the module
this is not updated when the app is updated

Current behavior:
translations are updated if manifest-related fields have been updated

opw-2093016