### PR TITLE
[IMP] calendar: show more meeting details

### DIFF
--- a/addons/calendar/views/calendar_templates.xml
+++ b/addons/calendar/views/calendar_templates.xml
@@ -42,6 +42,8 @@
                             <span class="float-right badge badge-info">
                                 <t t-if="attendee.state == 'accepted'">Yes I'm going.</t>
                                 <t t-if="attendee.state == 'declined'">No I'm not going.</t>
+                                <t t-if="attendee.state == 'tentative'">Tentative</t>
+                                <t t-if="attendee.state == 'needsAction'">No feedback yet</t>
                             </span>
                         </div>
 
@@ -68,6 +70,10 @@
                                             </li>
                                         </ul>
                                     </td>
+                                </tr>
+                                <tr>
+                                    <th>Description</th>
+                                    <td><t t-esc="event.description or '-'"/></td>
                                 </tr>
                             </table>
                         </div>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Before this commit there is no label shown at the top of the invite if the user hasn't done anything with the invite or if he chose 'tentative'. Now it always shows the informative label. This commit also adds the description of a meeting subject as it can be interesting and important in many cases.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
