### PR TITLE
[FIX] account_asset: Execute 'Generate asset entries' cron every week

### DIFF
--- a/addons/account_asset/data/account_asset_data.xml
+++ b/addons/account_asset/data/account_asset_data.xml
@@ -6,7 +6,7 @@
         <field name="state">code</field>
         <field name="code">model._cron_generate_entries()</field>
         <field name="interval_number">1</field>
-        <field name="interval_type">months</field>
+        <field name="interval_type">weeks</field>
         <field name="numbercall">-1</field>
         <field name="doall" eval="False"/>
     </record>


### PR DESCRIPTION
By default, the cron 'Generate asset entries' was executed once a month.
If there were many entries to process, it would just time out, then the same
issue would occur the month after.
We execute it every week instead.

opw 2118306
opw 2158655

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
