### PR TITLE
[FIX] web: fix M2O widget with computed name at create

### DIFF
--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -1536,7 +1536,7 @@ var BasicModel = AbstractModel.extend({
         // but directly in the data (as the co-model isn't fixed)
         var coModel = field.type === 'reference' ? data.model : field.relation;
         var def;
-        if (rel_data.display_name === undefined) {
+        if (rel_data.display_name === undefined || rel_data.display_name === false) {
             // TODO: refactor this to use _fetchNameGet
             def = this._rpc({
                     model: coModel,


### PR DESCRIPTION
### Issue

Create a model where the name is computed **into the create method** if
not provided by the form.

When a many2one field for this model is placed into a form and you click
on the Create and Edit link into the selection list. once the new record
is saved, the many2one field stay empty and it's not possible to select
the new entry.

See example: https://github.com/jvm-odoo/odoo_bug_m2o_computed_name

### Cause

The display_name value is `false` when saving the record.

### Solution

When it's undefined, a name_get is triggered so I did the same for
the false value.

**OPW-2152343**

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
