### PR TITLE
fullscreen form view should always be in edit mode

### DIFF
--- a/addons/web/static/src/js/chrome/action_manager_act_window.js
+++ b/addons/web/static/src/js/chrome/action_manager_act_window.js
@@ -420,6 +420,7 @@ ActionManager.include({
             hasSidebar: !popup && !inline,
             headless: (popup || inline) && form,
             mode: (popup || inline || action.target === 'fullscreen') && 'edit',
+            isFullscreen: action.target === 'fullscreen',
         });
     },
     /**

--- a/addons/web/static/src/js/views/form/form_controller.js
+++ b/addons/web/static/src/js/views/form/form_controller.js
@@ -38,16 +38,19 @@ var FormController = BasicController.extend({
         this.footerToButtons = params.footerToButtons;
         this.defaultButtons = params.defaultButtons;
         this.hasSidebar = params.hasSidebar;
+        this.isFullscreen = params.isFullscreen;
         this.toolbarActions = params.toolbarActions || {};
     },
     /**
      * Force mode back to readonly. Whenever we leave a form view, it is saved,
      * and should no longer be in edit mode.
+     * However, there is an exception, if action target is fullscreen then form view
+     * is opened in fullscreen mode, so in this case mode will be edit.
      *
      * @override
      */
     willRestore: function () {
-        this.mode = 'readonly';
+        this.mode = this.isFullscreen ? 'edit' : 'readonly';
     },
 
     //--------------------------------------------------------------------------

--- a/addons/web/static/src/js/views/form/form_view.js
+++ b/addons/web/static/src/js/views/form/form_view.js
@@ -37,6 +37,7 @@ var FormView = BasicView.extend({
         this.controllerParams.footerToButtons = params.footerToButtons;
         if ('action' in params && 'flags' in params.action) {
             this.controllerParams.footerToButtons = params.action.flags.footerToButtons;
+            this.controllerParams.isFullscreen = params.action.flags.isFullscreen;
         }
         var defaultButtons = 'default_buttons' in params ? params.default_buttons : true;
         this.controllerParams.defaultButtons = defaultButtons;

--- a/addons/web/static/tests/views/form_tests.js
+++ b/addons/web/static/tests/views/form_tests.js
@@ -6025,6 +6025,62 @@ QUnit.module('Views', {
         _t.database.multi_lang = multi_lang;
     });
 
+    QUnit.test('reverse breadcrumb sets form mode=edit if target is fullscreen', function (assert) {
+        assert.expect(6);
+
+        var archs = {
+            'partner,false,form': '<form string="Partners">' +
+                '<field name="foo"/>' +
+                '</form>',
+            'partner,false,search': '<search></search>',
+            'partner,false,list': '<tree>' +
+                '<field name="name"/>' +
+                '</tree>',
+        };
+
+        var actions = [{
+            id: 1,
+            name: 'Partner',
+            res_model: 'partner',
+            type: 'ir.actions.act_window',
+            views: [[false, 'form']],
+            target: 'fullscreen',
+            res_id: 1,
+        }, {
+            id: 2,
+            name: 'Partner2',
+            res_model: 'partner',
+            type: 'ir.actions.act_window',
+            views: [[false, 'list']],
+        }];
+
+        var actionManager = createActionManager({
+            actions: actions,
+            archs: archs,
+            data: this.data,
+            intercepts: {
+                toggle_fullscreen: function () {
+                    assert.step('toggle_fullscreen');
+                },
+            },
+        });
+        actionManager.doAction(1);
+        assert.containsOnce(actionManager, '.o_form_editable',
+            "form should be in edit mode");
+
+        actionManager.doAction(2);
+        $('.o_control_panel .breadcrumb a:first').click();
+        assert.containsOnce(actionManager, '.o_form_editable',
+            "form should be in edit mode on reverse breadcrumb");
+        assert.verifySteps([
+            'toggle_fullscreen',
+            'toggle_fullscreen',
+            'toggle_fullscreen',
+        ]);
+
+        actionManager.destroy();
+    });
+
     QUnit.test('buttons are disabled until status bar action is resolved', function (assert) {
         assert.expect(9);
 


### PR DESCRIPTION
Task:https://www.odoo.com/web#id=2146856&action=333&active_id=1251&model=project.task&view_type=form&menu_id=4720

Pad: https://pad.odoo.com/p/r.938a0bb2310a8f21fa9584a4bd15a9a3


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
