### PR TITLE
[FIX] web: close dropdown when clicking outside of the search input

### DIFF
--- a/addons/web/static/src/js/views/control_panel/search/search_bar.js
+++ b/addons/web/static/src/js/views/control_panel/search/search_bar.js
@@ -2,6 +2,7 @@ odoo.define('web.SearchBar', function (require) {
 "use strict";
 
 var AutoComplete = require('web.AutoComplete');
+const core = require('web.core');
 var searchBarAutocompleteRegistry = require('web.search_bar_autocomplete_sources_registry');
 var SearchFacet = require('web.SearchFacet');
 var Widget = require('web.Widget');
@@ -42,6 +43,10 @@ var SearchBar = Widget.extend({
     start: function () {
         this.$input = this.$('input');
         var self = this;
+
+        // close dropdown when user click outside the search view
+        core.bus.on('click', this, this._onWindowClicked.bind(this));
+
         var defs = [this._super.apply(this, arguments)];
         _.each(this.facets, function (facet) {
             defs.push(self._renderFacet(facet));
@@ -251,6 +256,15 @@ var SearchBar = Widget.extend({
                     this.trigger_up('reload');
                 }
                 break;
+        }
+    },
+    /**
+     * When a click happens outside the search view, we want to close the dropdown
+     */
+    _onWindowClicked(ev) {
+        if (this.autoComplete && !$(ev.target).closest('.o_searchview_input_container').length) {
+            this.autoComplete.close();
+            this.$input.val('');
         }
     },
 });

--- a/addons/web/static/tests/views/search_view_tests.js
+++ b/addons/web/static/tests/views/search_view_tests.js
@@ -1657,6 +1657,43 @@ QUnit.module('Search View', {
         actionManager.destroy();
     });
 
+    QUnit.test('clicking outside the search view should closed the seach autocomplete dropdown', async function (assert) {
+        assert.expect(3);
+
+        const actionManager = await createActionManager({
+            actions: this.actions,
+            archs: this.archs,
+            data: this.data,
+        });
+
+        await actionManager.doAction(10);
+        await testUtils.nextTick();
+
+        // press key 'a' to open search autocomplete
+        actionManager.$('.o_searchview_input').val('a');
+        actionManager.$('.o_searchview_input').trigger($.Event('keypress', { which: 65, keyCode: 65 }));
+        await testUtils.nextTick();
+        assert.containsOnce(actionManager, '.o_searchview_autocomplete',
+            'autocomplete dropdown should be visible');
+        // click on the body should close autocomplete dropdown
+        await testUtils.dom.click($('body'));
+        assert.containsNone($('.o_searchview_autocomplete'),
+            'clicking on outside the search view should close the dropdown');
+
+        // press key 'b' to open search autocomplete
+        actionManager.$('.o_searchview_input').val('b');
+        actionManager.$('.o_searchview_input').trigger($.Event('keypress', { which: 65, keyCode: 65 }));
+        await testUtils.nextTick();
+        actionManager.$('.o_searchview_input').trigger($.Event('keydown', { which: $.ui.keyCode.DOWN, keyCode: $.ui.keyCode.DOWN }));
+        await testUtils.nextTick();
+        // click on search autocomplete dropdown element should not close dropdown
+        await testUtils.dom.triggerMouseEvent(actionManager.$('.o_searchview_input_container a.o-expand'), "mousedown");
+        assert.containsOnce(actionManager, '.o_searchview_autocomplete',
+            'autocomplete dropdown should be visible on expanding searchview');
+
+        actionManager.destroy();
+    });
+
     QUnit.module('TimeRangeMenu');
 
     QUnit.test('time range menu stays hidden', async function (assert) {


### PR DESCRIPTION
task : https://www.odoo.com/web#id=2082491&action=327&model=project.task&view_type=form&menu_id=4720

pad : https://pad.odoo.com/p/r.1d8e343dc2bc89d51b15fafdfaae03b2

before this commit,
 The search view autocomplete dropdown does not close
 when clicking outside of the search bar

after this commit,
 The dropdown will be closed when clicking outside of the input container
 or autocomplete dropdown of the search view

task - 2082491

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
