### PR TITLE
[FIX] pos_fr_cert: Allow to use splitbill with pos french certification

### DIFF
--- a/addons/l10n_fr_pos_cert/static/src/js/pos.js
+++ b/addons/l10n_fr_pos_cert/static/src/js/pos.js
@@ -60,7 +60,7 @@ models.Orderline = models.Orderline.extend({
     set_quantity: function (quantity, keep_price) {
         var current_quantity = this.get_quantity();
         var new_quantity = parseFloat(quantity) || 0;
-        if (this.pos.is_french_country() && (new_quantity === 0 || new_quantity < current_quantity)) {
+        if (this.pos.is_french_country() && keep_price && (new_quantity === 0 || new_quantity < current_quantity)) {
             var quantity_to_decrease = current_quantity - new_quantity;
             this.pos.gui.show_popup("number", {
                 'title': _t("Decrease the quantity by"),

--- a/addons/pos_l10n_fr_split_bill/__manifest__.py
+++ b/addons/pos_l10n_fr_split_bill/__manifest__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'French Pos certification bill splitting',
+    'version': '1.0',
+    'category': 'Sales/Point Of Sale',
+    'summary': 'Restaurant bill splitting extension for the French Point of Sale ',
+    'description': """
+ """,
+    'depends': ['pos_restaurant', 'l10n_fr_pos_cert'],
+    'data': [
+        'views/pos_assets.xml',
+    ],
+    'installable': True,
+    'auto_install': True,
+}

--- a/addons/pos_l10n_fr_split_bill/static/src/js/splitbill.js
+++ b/addons/pos_l10n_fr_split_bill/static/src/js/splitbill.js
@@ -1,0 +1,150 @@
+odoo.define('pos_l10n_fr_split_bill.splitbill', function (require) {
+"use strict";
+
+    var models = require('point_of_sale.models');
+    var screens = require('point_of_sale.screens');
+    var core = require('web.core');
+    var utils = require('web.utils');
+    var SplitbillScreenWidget = require('pos_restaurant.splitbill').SplitbillScreenWidget;
+
+    var _t = core._t;
+    var round_di = utils.round_decimals;
+    var QWeb = core.qweb;
+
+    SplitbillScreenWidget.include({
+        set_line_on_order: function(neworder, split, line) {
+            if( split.quantity && this.pos.is_french_country()){
+                if ( !split.line ){
+                    split.line = line.clone();
+                    neworder.add_orderline(split.line);
+                }
+
+                if(!this.pos.is_french_country())
+                    split.line.set_quantity(split.quantity, 'do not recompute unit price');
+                else
+                    split.line.set_quantity(split.quantity);
+
+            }else if( split.line && this.pos.is_french_country()) {
+                neworder.remove_orderline(split.line);
+                split.line = null;
+            } else {
+                this._super(neworder, split, line);
+            }
+        },
+
+        set_quantity_on_order: function(splitlines, order) {
+            if(this.pos.is_french_country()) {
+                for(var id in splitlines){
+                    var split = splitlines[id];
+                    var line  = order.get_orderline(parseInt(id));
+
+                    if(!this.pos.is_french_country()) {
+                        line.set_quantity(line.get_quantity() - split.quantity);
+                        if(Math.abs(line.get_quantity()) < 0.00001){
+                            order.remove_orderline(line);
+                        }
+                    } else {
+                        var decrease_line = line.clone();
+                        decrease_line.order = order;
+                        decrease_line.set_quantity(-split.quantity);
+                        order.add_orderline(decrease_line);
+                    }
+                    delete splitlines[id];
+                }
+            } else {
+                 this._super(splitlines, order);
+            }
+        },
+
+        check_full_pay_order:function(order, splitlines) {
+            // Because of the lines added with negative quantity when we remove product,
+            // we have to check if the sum of the negative and positive lines are equals to the split.
+            if(this.pos.is_french_country()) {
+                var full = true;
+                order.get_orderlines().forEach(function(orderLine) {
+                    var split = splitlines[orderLine.id];
+                    if(orderLine.get_quantity() > 0) {
+                        if(!split) {
+                            full = false
+                        } else {
+                            if(split.quantity >= 0) {
+                                var qty = 0;
+                                var total_quantity = 0;
+                                var lines = order.get_orderlines();
+                                for(var i = 0; i < lines.length; i++){
+                                    if(lines[i].get_product().id === orderLine.get_product().id) {
+                                        total_quantity += lines[i].get_quantity();
+                                        qty += (splitlines[lines[i].id]? splitlines[lines[i].id].quantity : 0)
+                                    }
+                                }
+
+                                if(qty !== total_quantity)
+                                    full = false;
+                            }
+                        }
+                    }
+                });
+                return full;
+            } else {
+                this._super(order, splitlines);
+            }
+        },
+
+        lineselect: function($el,order,neworder,splitlines,line_id){
+            var split = splitlines[line_id] || {'quantity': 0, line: null};
+            var line  = order.get_orderline(line_id);
+
+            if(this.pos.is_french_country())
+                this.split_quantity(split, line, order, splitlines);
+            else
+                this.split_quantity(split, line);
+
+            this.set_line_on_order(neworder, split, line);
+
+            splitlines[line_id] = split;
+            $el.replaceWith($(QWeb.render('SplitOrderline',{
+                widget: this,
+                line: line,
+                selected: split.quantity !== 0,
+                quantity: split.quantity,
+                id: line_id,
+            })));
+            this.$('.order-info .subtotal').text(this.format_currency(neworder.get_subtotal()));
+        },
+
+        split_quantity: function(split, line, order, splitlines) {
+            if(this.pos.is_french_country()) {
+                var total_quantity = 0;
+                var splitted = 0;
+
+                order.get_orderlines().forEach(function(orderLine) {
+                    if(orderLine.get_product().id === line.product.id){
+                        total_quantity += orderLine.get_quantity();
+                        splitted += splitlines[orderLine.id]? splitlines[orderLine.id].quantity: 0;
+                    }
+                });
+
+                if(line.get_quantity() > 0) {
+                    if( !line.get_unit().is_pos_groupable ){
+                        if( split.quantity !== total_quantity){
+                            split.quantity = total_quantity;
+                        }else{
+                            split.quantity = 0;
+                        }
+                    }else{
+                        if( splitted < total_quantity && split.quantity < line.get_quantity()){
+                            split.quantity += line.get_unit().is_pos_groupable ? 1 : line.get_unit().rounding;
+                            if(splitted > total_quantity){
+                                split.quantity = line.get_quantity();
+                            }
+                        }else{
+                            split.quantity = 0;
+                        }
+                    }
+                }
+            } else {
+                this._super(split, line);
+            }
+        },
+    });
+});

--- a/addons/pos_l10n_fr_split_bill/views/pos_assets.xml
+++ b/addons/pos_l10n_fr_split_bill/views/pos_assets.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+     <template id="assets" inherit_id="point_of_sale.assets">
+        <xpath expr="." position="inside">
+            <script type="text/javascript" src="/pos_l10n_fr_split_bill/static/src/js/splitbill.js"></script>
+        </xpath>
+    </template>
+</odoo>

--- a/addons/pos_restaurant/static/src/js/splitbill.js
+++ b/addons/pos_restaurant/static/src/js/splitbill.js
@@ -40,10 +40,7 @@ var SplitbillScreenWidget = screens.ScreenWidget.extend({
         });
     },
 
-    lineselect: function($el,order,neworder,splitlines,line_id){
-        var split = splitlines[line_id] || {'quantity': 0, line: null};
-        var line  = order.get_orderline(line_id);
-        
+    split_quantity: function(split, line) {
         if( !line.get_unit().is_pos_groupable ){
             if( split.quantity !== line.get_quantity()){
                 split.quantity = line.get_quantity();
@@ -60,7 +57,9 @@ var SplitbillScreenWidget = screens.ScreenWidget.extend({
                 split.quantity = 0;
             }
         }
+    },
 
+    set_line_on_order: function(neworder, split, line) {
         if( split.quantity ){
             if ( !split.line ){
                 split.line = line.clone();
@@ -71,7 +70,16 @@ var SplitbillScreenWidget = screens.ScreenWidget.extend({
             neworder.remove_orderline(split.line);
             split.line = null;
         }
- 
+    },
+
+    lineselect: function($el,order,neworder,splitlines,line_id){
+        var split = splitlines[line_id] || {'quantity': 0, line: null};
+        var line  = order.get_orderline(line_id);
+
+        this.split_quantity(split, line);
+
+        this.set_line_on_order(neworder, split, line);
+
         splitlines[line_id] = split;
         $el.replaceWith($(QWeb.render('SplitOrderline',{
             widget: this,
@@ -83,60 +91,62 @@ var SplitbillScreenWidget = screens.ScreenWidget.extend({
         this.$('.order-info .subtotal').text(this.format_currency(neworder.get_subtotal()));
     },
 
-    pay: function(order,neworder,splitlines){
-        var orderlines = order.get_orderlines();
-        var empty = true;
-        var full  = true;
-
-        for(var i = 0; i < orderlines.length; i++){
-            var id = orderlines[i].id;
-            var split = splitlines[id];
-            if(!split){
-                full = false;
-            }else{
-                if(split.quantity){
-                    empty = false;
-                    if(split.quantity !== orderlines[i].get_quantity()){
+    check_full_pay_order:function (order, splitlines) {
+        var full = true
+        order.get_orderlines().forEach(function(orderLine) {
+            var split = splitlines[orderLine.id];
+            if(!split) {
+                full = false
+            } else {
+                if(split.quantity) {
+                    if(split.quantity !== orderLine.get_quantity())
                         full = false;
-                    }
                 }
             }
+        });
+        return full;
+    },
+
+    set_quantity_on_order: function(splitlines, order) {
+        for(var id in splitlines){
+            var split = splitlines[id];
+            var line  = order.get_orderline(parseInt(id));
+            line.set_quantity(line.get_quantity() - split.quantity, 'do not recompute unit price');
+            if(Math.abs(line.get_quantity()) < 0.00001){
+                order.remove_orderline(line);
+            }
+            delete splitlines[id];
         }
-        
-        if(empty){
+    },
+
+    pay: function(order,neworder,splitlines){
+        if(Object.keys(splitlines).length === 0)    // Splitlines is empty
             return;
-        }
 
         delete neworder.temporary;
 
-        if(full){
+        if(this.check_full_pay_order(order, splitlines)){
             this.gui.show_screen('payment');
         }else{
-            for(var id in splitlines){
-                var split = splitlines[id];
-                var line  = order.get_orderline(parseInt(id));
-                line.set_quantity(line.get_quantity() - split.quantity, 'do not recompute unit price');
-                if(Math.abs(line.get_quantity()) < 0.00001){
-                    order.remove_orderline(line);
-                }
-                delete splitlines[id];
-            }
+            this.set_quantity_on_order(splitlines, order);
+
             neworder.set_screen_data('screen','payment');
 
             // for the kitchen printer we assume that everything
-            // has already been sent to the kitchen before splitting 
-            // the bill. So we save all changes both for the old 
-            // order and for the new one. This is not entirely correct 
-            // but avoids flooding the kitchen with unnecessary orders. 
+            // has already been sent to the kitchen before splitting
+            // the bill. So we save all changes both for the old
+            // order and for the new one. This is not entirely correct
+            // but avoids flooding the kitchen with unnecessary orders.
             // Not sure what to do in this case.
 
-            if ( neworder.saveChanges ) { 
+            if ( neworder.saveChanges ) {
                 order.saveChanges();
                 neworder.saveChanges();
             }
 
             neworder.set_customer_count(1);
             order.set_customer_count(order.get_customer_count() - 1);
+            order.set_screen_data('screen','products');
 
             this.pos.get('orders').add(neworder);
             this.pos.set('selectedOrder',neworder);
@@ -169,9 +179,9 @@ var SplitbillScreenWidget = screens.ScreenWidget.extend({
 });
 
 gui.define_screen({
-    'name': 'splitbill', 
+    'name': 'splitbill',
     'widget': SplitbillScreenWidget,
-    'condition': function(){ 
+    'condition': function(){
         return this.pos.config.iface_splitbill;
     },
 });
@@ -199,4 +209,3 @@ return {
 }
 
 });
-


### PR DESCRIPTION
When using the french pos certification in a restaurant, we cannot decrease the quantity without making new order line with negative quantity. Because of that, when we split the bill, we have to take care of those lines with negative quantity.
Now when we split lines, the quantity is decreased in the main order with an order line with a negative quantity.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
