### PR TITLE
[REF] purchase_stock: push the extra quantity

### DIFF
--- a/addons/purchase_mrp/models/mrp_production.py
+++ b/addons/purchase_mrp/models/mrp_production.py
@@ -12,14 +12,15 @@ class MrpProduction(models.Model):
         compute='_compute_purchase_order_count',
         groups='purchase.group_purchase_user')
 
-    @api.depends('procurement_group_id.stock_move_ids.created_purchase_line_id.order_id')
+    @api.depends('procurement_group_id.stock_move_ids.created_purchase_line_id.order_id', 'procurement_group_id.stock_move_ids.move_orig_ids.purchase_line_id.order_id')
     def _compute_purchase_order_count(self):
         for production in self:
-            production.purchase_order_count = len(production.procurement_group_id.stock_move_ids.created_purchase_line_id.order_id)
+            production.purchase_order_count = len(production.procurement_group_id.stock_move_ids.created_purchase_line_id.order_id |
+                                                  production.procurement_group_id.stock_move_ids.move_orig_ids.purchase_line_id.order_id)
 
     def action_view_purchase_orders(self):
         self.ensure_one()
-        purchase_order_ids = self.procurement_group_id.stock_move_ids.created_purchase_line_id.order_id.ids
+        purchase_order_ids = (self.procurement_group_id.stock_move_ids.created_purchase_line_id.order_id | self.procurement_group_id.stock_move_ids.move_orig_ids.purchase_line_id.order_id).ids
         action = {
             'res_model': 'purchase.order',
             'type': 'ir.actions.act_window',

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -93,6 +93,8 @@ class StockMove(models.Model):
     def _get_upstream_documents_and_responsibles(self, visited):
         if self.created_purchase_line_id and self.created_purchase_line_id.state not in ('done', 'cancel'):
             return [(self.created_purchase_line_id.order_id, self.created_purchase_line_id.order_id.user_id, visited)]
+        elif self.purchase_line_id and self.purchase_line_id.state not in ('done', 'cancel'):
+            return[(self.purchase_line_id.order_id, self.purchase_line_id.order_id.user_id, visited)]
         else:
             return super(StockMove, self)._get_upstream_documents_and_responsibles(visited)
 

--- a/addons/sale_purchase_stock/models/purchase_order.py
+++ b/addons/sale_purchase_stock/models/purchase_order.py
@@ -7,9 +7,9 @@ from odoo import api, models
 class PurchaseOrder(models.Model):
     _inherit = 'purchase.order'
 
-    @api.depends('order_line.move_dest_ids.group_id.sale_id')
+    @api.depends('order_line.move_dest_ids.group_id.sale_id', 'order_line.move_ids.move_dest_ids.group_id.sale_id')
     def _compute_sale_order_count(self):
         super(PurchaseOrder, self)._compute_sale_order_count()
 
     def _get_sale_orders(self):
-        return super(PurchaseOrder, self)._get_sale_orders() | self.order_line.move_dest_ids.group_id.sale_id
+        return super(PurchaseOrder, self)._get_sale_orders() | self.order_line.move_dest_ids.group_id.sale_id | self.order_line.move_ids.move_dest_ids.group_id.sale_id

--- a/addons/sale_purchase_stock/models/sale_order.py
+++ b/addons/sale_purchase_stock/models/sale_order.py
@@ -7,9 +7,9 @@ from odoo import api, models
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
-    @api.depends('procurement_group_id.stock_move_ids.created_purchase_line_id.order_id')
+    @api.depends('procurement_group_id.stock_move_ids.created_purchase_line_id.order_id', 'procurement_group_id.stock_move_ids.move_orig_ids.purchase_line_id.order_id')
     def _compute_purchase_order_count(self):
         super(SaleOrder, self)._compute_purchase_order_count()
 
     def _get_purchase_orders(self):
-        return super(SaleOrder, self)._get_purchase_orders() | self.procurement_group_id.stock_move_ids.created_purchase_line_id.order_id
+        return super(SaleOrder, self)._get_purchase_orders() | self.procurement_group_id.stock_move_ids.created_purchase_line_id.order_id | self.procurement_group_id.stock_move_ids.move_orig_ids.purchase_line_id.order_id

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -207,7 +207,8 @@ class StockRule(models.Model):
             'picking_type_id': self.picking_type_id.id,
             'propagate_cancel': self.propagate_cancel,
             'warehouse_id': self.warehouse_id.id,
-            'delay_alert': self.delay_alert
+            'delay_alert': self.delay_alert,
+            'procure_method': 'make_to_order',
         }
         return new_move_vals
 


### PR DESCRIPTION
With a product configured as buy on order and a warehouse configured as
receipt in two steps, if the user increases the quantity on a po line
generated by a sale order before confirming it, the system will send all
the quantity to input but only the ordered quantity to customer. The
issue is that the "extra quantity" will stay in input.

We fix this issue by creating a new move with the extra quantity to the
input location so that push rules will send the extra quantity to stock
while the ordered quantity will be sent to the customer.

We also take care of creating the new move with the same characteristics
as the existing one so that they are properly merged.

task-1981355
_EDIT: task-2178408_
