### PR TITLE
[IMP] ir_actions_report: modifiy wkhtmltopdf footer generation

### DIFF
--- a/odoo/addons/base/__manifest__.py
+++ b/odoo/addons/base/__manifest__.py
@@ -58,6 +58,7 @@ The kernel of Odoo, needed for all installation.
         'wizard/base_update_translations_views.xml',
         'wizard/base_partner_merge_views.xml',
         'data/ir_actions_data.xml',
+        'data/ir_actions_report_data.xml',
         'data/ir_demo_failure_data.xml',
         'views/res_company_views.xml',
         'views/res_lang_views.xml',

--- a/odoo/addons/base/data/ir_actions_report_data.xml
+++ b/odoo/addons/base/data/ir_actions_report_data.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data>
+        <!-- Report dynamic footer -->
+        <record id="report_dynamic_footer" model="ir.config_parameter">
+            <field name="key">report.dynamic.footer</field>
+            <field name="value">True</field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Before this commit:
The footer of a report is generated through html and javascript script.
This can cause issue if the report is several page long as it will open all html pages at once.
It will then cause crashes such as "Buffer Overflow" or "Pipe Error"

After this commit:
We use native wkhtmltopdf keyword to generate the footer



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
