### PR TITLE
[IMP] website, *: allow signup/in page customization

### DIFF
--- a/addons/auth_signup/views/auth_signup_login_templates.xml
+++ b/addons/auth_signup/views/auth_signup_login_templates.xml
@@ -38,6 +38,7 @@
 
         <template id="auth_signup.signup" name="Sign up login">
             <t t-call="web.login_layout">
+                <div class="oe_structure"/>
                 <form class="oe_signup_form" role="form" method="post" t-if="not message">
                   <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
 
@@ -56,11 +57,13 @@
                         <div class="o_login_auth"/>
                     </div>
                 </form>
+                <div class="oe_structure"/>
             </t>
         </template>
 
         <template id="auth_signup.reset_password" name="Reset password">
             <t t-call="web.login_layout">
+                <div class="oe_structure"/>
                 <div t-if="message">
                     <p class="alert alert-success" t-if="message" role="status">
                         <t t-esc="message"/>
@@ -98,9 +101,8 @@
                         </div>
                         <div class="o_login_auth"/>
                     </div>
-
                 </form>
-
+                <div class="oe_structure"/>
             </t>
         </template>
 </odoo>

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -549,6 +549,7 @@
 
     <template id="web.login" name="Login">
         <t t-call="web.login_layout">
+            <div class="oe_structure"/>
             <form class="oe_login_form" role="form" t-attf-action="/web/login" method="post" onsubmit="this.action = this.action + location.hash">
                 <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
 
@@ -589,6 +590,7 @@
 
                 <input type="hidden" name="redirect" t-att-value="redirect"/>
             </form>
+            <div class="oe_structure"/>
         </t>
     </template>
 

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -698,6 +698,41 @@
     </t>
 </template>
 
+<template id="website.signup" inherit_id="auth_signup.signup" name="Website signup" customize_show="False">
+    <xpath expr="//form" position="replace">
+        <div class="container">
+            <div class="row align-items-center">
+                <div class="col-lg-7">
+                    <div class="oe_structure">
+                        <section class="s_banner parallax s_parallax_is_fixed pt96 pb96 s_parallax_no_overflow_hidden" data-scroll-background-ratio="1" data-name="Banner" style="background-image: none;">
+                        <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_banner_default_image'); background-position: 50% 0;"></span>
+                        <div class="container">
+                            <div class="row s_nb_column_fixed">
+                            <div class="col-lg-7 bg-white jumbotron rounded pt32 pb32" data-name="Box">
+                                <div class="row">
+                                <div class="col-lg-12 s_title s_col_no_bgcolor" data-name="Title">
+                                    <h1 class="s_title_thin">
+                                        <font style="font-size: 62px;"><b>Sign Up.</b> Easily.</font>
+                                    </h1>
+                                </div>
+                                <div class="col-lg-12 pt8 pb32 s_col_no_bgcolor" data-name="Text">
+                                    <p class="lead">Create an account to stay up to date.<br/>Get the full experience now !</p>
+                                </div>
+                                </div>
+                            </div>
+                            </div>
+                        </div>
+                        </section>
+                    </div>
+                </div>
+                <div class="col-lg">
+                    <t>$0</t>
+                </div>
+            </div>
+        </div>
+    </xpath>
+</template>
+
 <template id="qweb_500" inherit_id="http_routing.500">
     <!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
     <!-- This template should not use any variable except those provided by website.ir_http._handle_exception  -->


### PR DESCRIPTION
* = auth_signup, web

It is now possible to drop snippets in the /web/signup, /web/login
and /web/reset_password pages.
The signup page now has a customize show option that adds a snippet drop
zone on the left of the form. This zone is prefilled with a banner.

task-2118648

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
