### PR TITLE
show percentage symbol outside the input in percentage widget

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -1325,8 +1325,41 @@ var FieldFloatToggle = AbstractField.extend({
 });
 
 var FieldPercentage = FieldFloat.extend({
+    className: 'o_field_float_percentage o_field_number',
     description: _lt("Percentage"),
-    formatType:'percentage',
+    formatType: 'percentage',
+
+    init() {
+        this._super.apply(this, arguments);
+
+        if (this.mode === 'edit') {
+            this.tagName = 'div';
+            this.className += ' o_input';
+
+            // do not display percentage symbol in edit as it is explicitly added after input
+            this.formatOptions.noSymbol = true;
+        }
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * For percentage widget, the input is inside a div, alongside a span
+     * containing the percentage(%) symbol.
+     *
+     * @override
+     * @private
+     */
+    _renderEdit() {
+        this.$el.empty();
+        // Prepare and add the input
+        const def = this._prepareInput(this.$input).appendTo(this.$el);
+        const $percentageSymbol = $('<span>', { text: '%' });
+        this.$el.append($percentageSymbol);
+        return def;
+    },
 });
 
 var FieldText = InputField.extend(TranslatableFieldMixin, {

--- a/addons/web/static/src/js/fields/field_utils.js
+++ b/addons/web/static/src/js/fields/field_utils.js
@@ -374,7 +374,11 @@ function formatPercentage(value, field, options) {
     if (options.humanReadable && options.humanReadable(value * 100)) {
         return result + "%";
     }
-    return (parseFloat(result) + "%").replace('.', _t.database.parameters.decimal_point);
+    const formattedValue = String((parseFloat(result))).replace('.', _t.database.parameters.decimal_point);
+    if (options.noSymbol) {
+        return formattedValue;
+    }
+    return formattedValue + "%";
 }
 /**
  * Returns a string representing the value of the selection.

--- a/addons/web/static/src/scss/fields.scss
+++ b/addons/web/static/src/scss/fields.scss
@@ -38,7 +38,7 @@
     }
 
     // Flex fields (inline)
-    &.o_field_many2one, &.o_field_radio, &.o_field_many2manytags, &.o_field_percent_pie, &.o_field_monetary, &.o_field_binary_file {
+    &.o_field_many2one, &.o_field_radio, &.o_field_many2manytags, &.o_field_percent_pie, &.o_field_monetary, &.o_field_binary_file, &.o_field_float_percentage {
         display: inline-flex;
         > span, > button {
             flex: 0 0 auto;
@@ -72,7 +72,7 @@
     }
 
     // Monetary
-    &.o_field_monetary {
+    &.o_field_monetary, &.o_field_float_percentage {
         &.o_input {
             align-items: baseline;
 

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -903,6 +903,42 @@ QUnit.module('basic_fields', {
         form.destroy();
     });
 
+    QUnit.module('Percentage');
+
+    QUnit.test('percentage widget in form view', async function (assert) {
+        assert.expect(5);
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: `<form string="Partners">
+                <group>
+                <field name="qux" widget="percentage"/>
+                </group>
+                </form>`,
+            res_id: 1,
+        });
+
+        assert.strictEqual(form.$('.o_field_widget').first().text(), '44.4%',
+            'The value should be displayed properly.');
+
+        await testUtils.form.clickEdit(form);
+        assert.strictEqual(form.$('.o_field_widget[name=qux] input').val(), '44.4',
+            'The input should be rendered without the percentage symbol.');
+        assert.strictEqual(form.$('.o_field_widget[name=qux] input').parent().children().last().text(), '%',
+            'The input should be followed by a span containing the percentage symbol.');
+
+        await testUtils.fields.editInput(form.$('.o_field_float_percentage input'), '0.24');
+        assert.strictEqual(form.$('.o_field_widget[name=qux] input').val(), '0.24',
+            'The value should not be formated yet.');
+
+        await testUtils.form.clickSave(form);
+        assert.strictEqual(form.$('.o_field_widget').first().text(), '24%',
+            'The new value should be formatted properly.');
+
+        form.destroy();
+    });
 
     QUnit.module('FieldEmail');
 

--- a/addons/web/static/tests/fields/field_utils_tests.js
+++ b/addons/web/static/tests/fields/field_utils_tests.js
@@ -135,7 +135,7 @@ QUnit.test('format binary', function (assert) {
 });
 
 QUnit.test('format percentage', function (assert) {
-    assert.expect(11);
+    assert.expect(12);
 
     var originalParameters = _.clone(core._t.database.parameters);
 
@@ -161,6 +161,7 @@ QUnit.test('format percentage', function (assert) {
     });
     assert.strictEqual(fieldUtils.format.percentage(0.125), '12,5%');
     assert.strictEqual(fieldUtils.format.percentage(0.666666), '66,67%');
+    assert.strictEqual(fieldUtils.format.percentage(0.5, null, { noSymbol: true }), '50');
 
     core._t.database.parameters = originalParameters;
 });


### PR DESCRIPTION
Task:https://www.odoo.com/web#id=2065078&action=333&active_id=1251&model=project.task&view_type=form&menu_id=4720

Pad: https://pad.odoo.com/p/r.b977cf30780545734e4a2ab4d1186e4d


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
