### PR TITLE
[FIX] stock_picking_batch: make it works with lot

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -73,7 +73,7 @@ class StockPickingBatch(models.Model):
                 picking_type = picking.picking_type_id
                 if (picking_type.use_create_lots or picking_type.use_existing_lots):
                     for ml in picking.move_line_ids:
-                        if ml.product_id.tracking != 'none':
+                        if ml.product_id.tracking != 'none' and not (ml.lot_id or ml.lot_name):
                             raise UserError(_('Some products require lots/serial numbers, so you need to specify those first!'))
                 # Check if we need to set some qty done.
                 picking_without_qty_done |= picking


### PR DESCRIPTION
Usecase to reproduce:
- Create 2 picking assigned with a product tracked by lot.
- Enough quantity in stock. Lots are correctly reserve. (no qty_done on
the stock.move.line)
- Create a batch with both pickings.
- Validate the batch picking.
-> User error asking to specify lot serial number however they are
already specified since they are reserve. It should rather return the
immediate transfer wizard.

It happens since the condition check if the product is tracked but do
not check if a lot is missing or not.