### PR TITLE
[FIX] stock: recompute move state

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -222,6 +222,7 @@ class StockMoveLine(models.Model):
         if 'product_id' in vals and any(vals.get('state', ml.state) != 'draft' and vals['product_id'] != ml.product_id.id for ml in self):
             raise UserError(_("Changing the product is only allowed in 'Draft' state."))
 
+        moves_to_recompute_state = self.env['stock.move']
         Quant = self.env['stock.quant']
         precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
         # We forbid to change the reserved quantity in the interace, but it is needed in the
@@ -280,6 +281,7 @@ class StockMoveLine(models.Model):
                                 pass
                     if new_product_qty != ml.product_qty:
                         new_product_uom_qty = ml.product_id.uom_id._compute_quantity(new_product_qty, ml.product_uom_id, rounding_method='HALF-UP')
+                        moves_to_recompute_state |= ml.move_id
                         ml.with_context(bypass_reservation_update=True).product_uom_qty = new_product_uom_qty
 
         # When editing a done move line, the reserved availability of a potential chained move is impacted. Take care of running again `_action_assign` on the concerned moves.
@@ -344,6 +346,10 @@ class StockMoveLine(models.Model):
                 move.product_uom_qty = move.quantity_done
         next_moves._do_unreserve()
         next_moves._action_assign()
+
+        if moves_to_recompute_state:
+            moves_to_recompute_state._recompute_state()
+
         return res
 
     def unlink(self):

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -2276,12 +2276,14 @@ class StockMove(TransactionCase):
         move1._action_confirm()
         move1._action_assign()
 
+        self.assertEqual(move1.move_line_ids.state, 'assigned')
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product1, shelf1_location), 0.0)
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product1, shelf2_location), 0.0)
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product1, self.stock_location), 0.0)
 
         move1.move_line_ids.location_id = shelf2_location.id
 
+        self.assertEqual(move1.move_line_ids.state, 'confirmed')
         self.assertEqual(move1.reserved_availability, 0.0)
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product1, self.stock_location), 1.0)
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product1, shelf1_location), 1.0)


### PR DESCRIPTION
Before this commit, a move can be 'assigned' even if it has no reserved quantity.

How to reproduce:
* For a tracked product, add some quantities for a LN/SN. Create an another LN/SN with no quantity;
* Create a delivery for this product;
* Confirm it and check availability;
* On the move line, change the SN/LN for the one without quantity.
    --> The move has no reserved quantity but is still marked as `assigned`.

This issue was due to two facts:
1. The move method `_recompute_state` wasn't called in this case.
2. The move method `_compute_reserved_availability` didn't work well because it's based on the move line `product_qty` field who is also computed, and at the time it gets it, the `read_group` didn't have access to the updated value of `product_qty` (that's why we call `recompute` in move line to force it).

task-2171546