### PR TITLE
[FIX] website: Background Color is kept after changing it from editor.

### DIFF
--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -24,6 +24,7 @@ class Page(models.Model):
     # Page options
     header_overlay = fields.Boolean()
     header_color = fields.Char()
+    header_inline_color = fields.Char()
     header_visible = fields.Boolean(default=True)
     footer_visible = fields.Boolean(default=True)
 

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -1654,6 +1654,10 @@ options.registry.TopMenuVisibility = VisibilityPageOptionUpdate.extend({
                 params: [{name: 'header_color', value: ''}],
                 onSuccess: () => resolve(),
             });
+            this.trigger_up('action_demand', {
+                actionName: 'toggle_page_option',
+                params: [{name: 'header_inline_color', value: ''}],
+            });
         });
     },
 
@@ -1688,12 +1692,17 @@ options.registry.topMenuColor = options.Class.extend({
     /**
      * @override
      */
-    selectStyle(previewMode, widgetValue, params) {
-        this._super(...arguments);
-        const className = widgetValue ? (params.colorPrefix + widgetValue) : '';
+    async selectStyle(previewMode, widgetValue, params) {
+        await this._super(...arguments);
+        const className = widgetValue && !ColorpickerWidget.isCSSColor(widgetValue) ? (params.colorPrefix + widgetValue) : '';
+        const inlineColor = ColorpickerWidget.isCSSColor(widgetValue) ? widgetValue : '';
         this.trigger_up('action_demand', {
             actionName: 'toggle_page_option',
             params: [{name: 'header_color', value: className}],
+        });
+        this.trigger_up('action_demand', {
+            actionName: 'toggle_page_option',
+            params: [{name: 'header_inline_color', value: inlineColor}],
         });
     },
 

--- a/addons/website/static/src/js/menu/content.js
+++ b/addons/website/static/src/js/menu/content.js
@@ -798,6 +798,9 @@ var ContentMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
             $('#wrapwrap > header').removeClass(this.value)
                                    .addClass(value);
         },
+        header_inline_color: function (value) {
+            $('#wrapwrap > header').css('background-color', value);
+        },
         header_visible: function (value) {
             $('#wrapwrap > header').toggleClass('d-none o_snippet_invisible', !value);
         },

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -518,7 +518,7 @@
             data-select-style="true"
             data-css-property="background-color"
             data-color-prefix="bg-"
-            data-excluded="theme, common, custom"/>
+            data-excluded="theme, common"/>
     </div>
 
     <div data-selector="#wrapwrap > footer"

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -179,7 +179,7 @@
     <!-- Page options -->
     <xpath expr="//div[@id='wrapwrap']" position="before">
         <t groups="website.group_website_publisher">
-            <t t-foreach="['header_overlay', 'header_color', 'header_visible', 'footer_visible']" t-as="optionName">
+            <t t-foreach="['header_overlay', 'header_color', 'header_inline_color', 'header_visible', 'footer_visible']" t-as="optionName">
                 <input t-if="optionName in main_object" type="hidden" class="o_page_option_data" t-att-name="optionName" t-att-value="main_object[optionName]"/>
             </t>
         </t>
@@ -189,6 +189,7 @@
     </xpath>
     <xpath expr="//header" position="attributes">
         <attribute name="t-attf-class" add="#{main_object.header_color if 'header_color' in main_object else ''}" separator=" "/>
+        <attribute name="t-attf-style" add="background-color: #{main_object.header_inline_color if 'header_inline_color' in main_object and main_object.header_inline_color else ''}" separator=" "/>
     </xpath>
     <xpath expr="//header" position="attributes">
         <attribute name="t-attf-class" add="#{'d-none o_snippet_invisible' if 'header_visible' in main_object and not main_object.header_visible else ''}" separator=" "/>


### PR DESCRIPTION
Previously when we try to apply custom color on the transparent header, then it shows changes on the fly but it was disappearing after a click on the Save button.

In this commit, we have fixed the above issue and introduced new field 'header_inline_color' for CSS colors. we are now able to save a selected custom color as the background color of the transparent header.

task- 2151408