### PR TITLE
[FIX] payment_authorize: payment button not loading on s2s

### DIFF
--- a/addons/payment_authorize/static/src/js/payment_form.js
+++ b/addons/payment_authorize/static/src/js/payment_form.js
@@ -96,6 +96,7 @@ PaymentForm.include({
         }
         ajax.loadJS(AcceptJs).then(function () {
             self.$button.trigger('click');
+            self.enableButton(button);
         });
     },
     /**


### PR DESCRIPTION
Steps to reproduce:
- install sales and authorize.net payment acquirer
- setup your authorize.net account and activate the payment acquirer
- go to invoicing > configuration > payments acquirers > authorize.net
- click edit > configuration > payment flow > check "payment on odoo"
- go to sales > configuration > settings > check online payments
- go to sales > quotations > create a new quotation and send it
- click customer preview > click pay now > select authorize.net
- click pay > wait for the popup to be loaded then close it

Previous behavior:
the payment button is set to its loading state and never resets

Current behavior:
given that we know when s2s is used, we can afford to not set
the button to its loading state (since it will be covered by the
iframe)

opw-2167792