### PR TITLE
[FIX] sale:allow payment and automatic invoice with public user

### DIFF
--- a/addons/sale/models/payment.py
+++ b/addons/sale/models/payment.py
@@ -133,7 +133,7 @@ class PaymentTransaction(models.Model):
                                'force_company': trans.acquirer_id.company_id.id}
                 trans = trans.with_context(**ctx_company)
                 trans.sale_order_ids._force_lines_to_invoice_policy_order()
-                invoices = trans.sale_order_ids._create_invoices()
+                invoices = trans.sale_order_ids.sudo()._create_invoices()
                 trans.invoice_ids = [(6, 0, invoices.ids)]
 
     @api.model

--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -553,7 +553,7 @@ class SaleOrder(models.Model):
         :param final: if True, refunds will be generated if necessary
         :returns: list of created invoices
         """
-        if not self.env.user.has_group('sales_team.group_sale_salesman'):
+        if not self.env.is_superuser() and not self.user_has_groups('sales_team.group_sale_salesman'):
             return []
 
         precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')


### PR DESCRIPTION
Since commit https://github.com/odoo/odoo/commit/3abe78087a0426ad2783942baa01e1d5fbdff2d9#diff-39d0613187d36f16c541734e80925e9d we are restricting the access to invoices
creation in sale module, but this makes impossible to complete a payment with automatic invoicing activated
with public user.

Description of the issue/feature this PR addresses:
opw-2185680

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
