### PR TITLE
[FIX] sale: Do not check hardcoded group

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -6,7 +6,7 @@ from functools import partial
 from itertools import groupby
 
 from odoo import api, fields, models, SUPERUSER_ID, _
-from odoo.exceptions import UserError, ValidationError
+from odoo.exceptions import UserError, ValidationError, AccessError
 from odoo.tools.misc import formatLang
 from odoo.osv import expression
 from odoo.tools import float_is_zero, float_compare
@@ -554,8 +554,11 @@ class SaleOrder(models.Model):
         :param final: if True, refunds will be generated if necessary
         :returns: list of created invoices
         """
-        if not self.env.user.has_group('sales_team.group_sale_salesman'):
-            return []
+        try:
+            self.check_access_rights("write")
+            self.check_access_rule('write')
+        except AccessError:
+            return self.env['account.move']
 
         precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
 


### PR DESCRIPTION
In case you are running _create_invoice with sudo
you have access to sale order modification
but you are not in the right group

Check that you have access to modify the sale order
that will generat the invoice instead

return an empty record set otherwise since the method
is supposed to return a record set of account.move

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
