### PR TITLE
[FIX] product: Fix kanban template layout

### DIFF
--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -78,7 +78,7 @@
                 <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                 <templates>
                     <t t-name="kanban-box">
-                        <div class="oe_kanban_global_click">
+                        <div class="oe_kanban_global_click o_kanban_record_has_image_fill">
                             <div class="o_kanban_image">
                                 <img t-att-src="kanban_image('product.template', 'image_128', record.id.raw_value)" alt="Product" class="o_image_64_contain"/>
                             </div>


### PR DESCRIPTION
The text is displayed below the product image instead of next to it.

See commit message for a beautiful ascii art


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
