### PR TITLE
[IMP] stock: Immediate transfer & put in pack

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -171,7 +171,7 @@ class StockMoveLine(models.Model):
             # associated done move.
             if 'picking_id' in vals and not vals.get('move_id'):
                 picking = self.env['stock.picking'].browse(vals['picking_id'])
-                if picking.state == 'done':
+                if picking.state == 'done' or (picking.immediate_transfer and picking.state == 'draft' and self.env.user.has_group('stock.group_tracking_lot')):
                     product = self.env['product.product'].browse(vals['product_id'])
                     new_move = self.env['stock.move'].create({
                         'name': _('New Move:') + product.display_name,
@@ -180,7 +180,7 @@ class StockMoveLine(models.Model):
                         'product_uom': vals['product_uom_id'],
                         'location_id': 'location_id' in vals and vals['location_id'] or picking.location_id.id,
                         'location_dest_id': 'location_dest_id' in vals and vals['location_dest_id'] or picking.location_dest_id.id,
-                        'state': 'done',
+                        'state': picking.state,
                         'additional': True,
                         'picking_id': picking.id,
                     })


### PR DESCRIPTION
PURPOSE

Allow the 'PUT IN PACK' button in case they did not have a stock move.

SPECIFICATIONS

When creating an immediate transfer for an operation type which
has "show detailed" selected, you directly have to enter an SML.
When doing so, the transfer remains in a draft state, cannot be
confirmed, so the 'PUT IN PACK' button doesn't appear. The Button 
does not appear in draft state because they restricted by the condition 
of the state. 

To do that, we change the state of picking 'draft' to 'ready' if picking
doesn't have a stock move so the 'PUT IN PACK' button appears.

LINKS

PR #44565
Task 2184131


Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
