### PR TITLE
[FIX] account: do not show name and date in reconciled lines tree view

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -11,6 +11,7 @@ from itertools import zip_longest
 from hashlib import sha256
 from json import dumps
 
+import ast
 import json
 import re
 
@@ -3967,9 +3968,12 @@ class AccountMoveLine(models.Model):
         return ids
 
     def open_reconcile_view(self):
-        [action] = self.env.ref('account.action_account_moves_all_a').read()
+        [action] = self.env.ref('account.action_account_moves_journal_misc').read()
         ids = self._reconciled_lines()
         action['domain'] = [('id', 'in', ids)]
+        action['context'] = ast.literal_eval(action['context'])
+        action['context']['search_default_misc_filter'] = 0
+        action['context']['search_default_posted'] = 0
         return action
 
     def action_accrual_entry(self):


### PR DESCRIPTION
As the view is grouped by default by journal entry, we do not want to
see the field `move_id` and `date` in the list view as it is redundant.
Moreover, the name_get was returning something weird to see because of
the format done with the `name_groupby` key.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
