### PR TITLE
FIX web_editor/assets.py: unmodifying theme customisations

### DIFF
--- a/addons/web_editor/models/assets.py
+++ b/addons/web_editor/models/assets.py
@@ -182,6 +182,8 @@ class Assets(models.AbstractModel):
             new_attach.update(self._save_asset_attachment_hook())
             self.env["ir.attachment"].create(new_attach)
 
+        attachment_view = self.env["ir.ui.view"].search([['name', '=', custom_url]])
+        if not attachment_view:
             # Create a view to extend the template which adds the original file
             # to link the new modified version instead
             file_type_info = {


### PR DESCRIPTION
This fix should solve the issue where website customisation from the user are ignored.

Before this commit:
When uninstalling then reinstall website, the view applying user web customisation is missing.
Therefore, the customisations asked by the user were ignored.

With this commit:
The view is automatically re-generated if missing


OPW-2187849
May also be a solution for OPW-2160501 and OPW-2169899
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
