### PR TITLE
FIX purchase_requisition: company attribute missing from env

### DIFF
--- a/addons/purchase_requisition/models/purchase_requisition.py
+++ b/addons/purchase_requisition/models/purchase_requisition.py
@@ -86,9 +86,9 @@ class PurchaseRequisition(models.Model):
     @api.onchange('vendor_id')
     def _onchange_vendor(self):
         if not self.vendor_id:
-            self.currency_id = self.env.user.company_id.currency_id.id
+            self.currency_id = self.env.user._get_company().currency_id.id
         else:
-            self.currency_id = self.vendor_id.property_purchase_currency_id.id or self.env.user.company_id.currency_id.id
+            self.currency_id = self.vendor_id.property_purchase_currency_id.id or self.env.user._get_company().currency_id.id
 
         requisitions = self.env['purchase.requisition'].search([
             ('vendor_id', '=', self.vendor_id.id),


### PR DESCRIPTION
Before this commit:
A traceback was thrown when we try to create a new purchase agreement from the request for quotation view.

With this commit:
The company of the user is took therefore no error trigger.

OPW - 2190392
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
