### PR TITLE
[FIX] account: avoid checking cash basis to generate full reconcile objects on non-receivable and non-payable accounts

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -849,7 +849,11 @@ class AccountMoveLine(models.Model):
         digits_rounding_precision = amls[0].company_id.currency_id.rounding
         if (
                 (
-                    not cash_basis_partial or (cash_basis_partial and all([p >= 1.0 for p in amls._get_matched_percentage().values()]))
+                    amls[0].account_id.internal_type not in ('receivable', 'payable') # We don't want to consider cash basis when reconciling something else (e.g. reconcilable tax account)
+                    or
+                    (   not cash_basis_partial
+                        or (cash_basis_partial and all([p >= 1.0 for p in amls._get_matched_percentage().values()]))
+                    )
                 ) and
                 (
                     currency and float_is_zero(total_amount_currency, precision_rounding=currency.rounding) or
@@ -1344,6 +1348,7 @@ class AccountMoveLine(models.Model):
                                 else:
                                     all_same_currency = False
                                     break
+
                 if not all_same_currency:
                     #we cannot rely on amount_currency fields as it is not present on all partial reconciliation
                     matched_percentage_per_move[line.move_id.id] = line.move_id.matched_percentage


### PR DESCRIPTION
Doing this made no sense. For example, when using reconcilable tax accounts and cash basis taxes, a full reconciliation was required on receivable/payable account (hence, a cash basis move with matched percentage = 1) in order to have a full reconcile on the tax account. This was obviously wrong, as those two concepts are independent.
