### PR TITLE
[FIX] web: dashboard graphs proper float rounding

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -78,12 +78,13 @@ class account_journal(models.Model):
     # Below method is used to get data of bank and cash statemens
     def get_line_graph_datas(self):
         """Computes the data used to display the graph for bank and cash journals in the accounting dashboard"""
+        currency = self.currency_id or self.company_id.currency_id
 
         def build_graph_data(date, amount):
             #display date in locale format
             name = format_date(date, 'd LLLL Y', locale=locale)
             short_name = format_date(date, 'd MMM', locale=locale)
-            return {'x':short_name,'y': amount, 'name':name}
+            return {'x':short_name,'y': "%.2f" % amount, 'name':name}
 
         self.ensure_one()
         BankStatement = self.env['account.bank.statement']
@@ -117,7 +118,7 @@ class account_journal(models.Model):
             date = val['date']
             if date != today.strftime(DF):  # make sure the last point in the graph is today
                 data[:0] = [build_graph_data(date, amount)]
-            amount -= val['amount']
+            amount = currency.round(amount - val['amount'])
 
         # make sure the graph starts 1 month ago
         if date.strftime(DF) != last_month.strftime(DF):

--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -2889,6 +2889,22 @@ var JournalDashboardGraph = AbstractField.extend({
                     intersect: false,
                     position: 'nearest',
                     caretSize: 0,
+                    callbacks: {
+                        label: function(tooltipItem, data) {
+                            var label = data.datasets[tooltipItem.datasetIndex].label || '';
+
+                            if (label) {
+                                label += ': ';
+                            }
+                            if (!(tooltipItem.value === null || typeof tooltipItem.value === 'undefined')) {
+                                label += parseFloat(tooltipItem.value).toFixed(2);
+                            } else {
+                                label += isNaN(tooltipItem.yLabel) ? tooltipItem.yLabel : tooltipItem.yLabel.toFixed(2);
+                            }
+
+                            return label;
+                        }
+                    }
                 },
             },
         };
@@ -2925,6 +2941,22 @@ var JournalDashboardGraph = AbstractField.extend({
                     intersect: false,
                     position: 'nearest',
                     caretSize: 0,
+                    callbacks: {
+                        label: function(tooltipItem, data) {
+                            var label = data.datasets[tooltipItem.datasetIndex].label || '';
+
+                            if (label) {
+                                label += ': ';
+                            }
+                            if (!(tooltipItem.value === null || typeof tooltipItem.value === 'undefined')) {
+                                label += parseFloat(tooltipItem.value).toFixed(2);
+                            } else {
+                                label += isNaN(tooltipItem.yLabel) ? tooltipItem.yLabel : tooltipItem.yLabel.toFixed(2);
+                            }
+
+                            return label;
+                        }
+                    }
                 },
                 elements: {
                     line: {


### PR DESCRIPTION
Steps to reproduce:
- install accounting
- go to the accounting main view and hover some of the graphs

Previous behavior:
rounding was inconsistent and would lead to weird js floats
like 65.00000000000001

Current behavior:
floats are rounded to 2 digits after

opw-2172686