### PR TITLE
[MERGE] event: allow to send mail on stage change and improve its usability

### DIFF
--- a/addons/event/__manifest__.py
+++ b/addons/event/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'Events Organization',
-    'version': '1.3',
+    'version': '1.4',
     'website': 'https://www.odoo.com/page/events',
     'category': 'Marketing/Events',
     'summary': 'Trainings, Conferences, Meetings, Exhibitions, Registrations',

--- a/addons/event/__manifest__.py
+++ b/addons/event/__manifest__.py
@@ -43,4 +43,7 @@ Key Features
     ],
     'installable': True,
     'auto_install': False,
+    'qweb': [
+        'static/src/xml/field_icon_selection.xml',
+    ],
 }

--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -487,6 +487,7 @@ class EventEvent(models.Model):
         vals.update(self._sync_required_computed(vals))
 
         res = super(EventEvent, self).create(vals)
+        res._trigger_stage_based_events()
         if res.organizer_id:
             res.message_subscribe([res.organizer_id.id])
         res.flush()
@@ -496,6 +497,8 @@ class EventEvent(models.Model):
         res = super(EventEvent, self).write(vals)
         if vals.get('organizer_id'):
             self.message_subscribe([vals['organizer_id']])
+        if 'stage_id' in vals:
+            self._trigger_stage_based_events()
         return res
 
     @api.returns('self', lambda value: value.id)
@@ -566,3 +569,14 @@ class EventEvent(models.Model):
         ])
         if ended_events:
             ended_events.action_set_done()
+
+    def _trigger_stage_based_events(self):
+        """Trigger the event mail which are based on the stage change."""
+        for event in self:
+            event_mail_ids = event.event_mail_ids.filtered(
+                lambda event_mail:
+                event_mail.interval_type == 'stage_update'
+                and not event_mail.trigger_stage_date
+                and event_mail.trigger_stage_id.id == event.stage_id.id)
+            if event_mail_ids:
+                event_mail_ids.trigger_stage_date = fields.Datetime.now()

--- a/addons/event/static/src/js/field_icon_selection.js
+++ b/addons/event/static/src/js/field_icon_selection.js
@@ -1,0 +1,29 @@
+odoo.define('event.field_icon_selection', function (require) {
+"use strict";
+
+var core = require('web.core');
+var registry = require('web.field_registry');
+var AbstractField = require('web.AbstractField');
+var QWeb = core.qweb;
+
+var IconSelection = AbstractField.extend({
+    supportedFieldTypes: ['char', 'text', 'selection'],
+
+    /**
+    * @override
+    * @private
+    */
+    _render: function () {
+        this._super.apply(this, arguments);
+        this.icon = this.nodeOptions[this.value];
+        this.title = this.value.charAt(0).toUpperCase() + this.value.slice(1);
+        this.$el.html(QWeb.render('event.IconSelection', {'widget': this}));
+    },
+
+});
+
+registry.add('icon_selection', IconSelection);
+
+return IconSelection;
+
+});

--- a/addons/event/static/src/xml/field_icon_selection.xml
+++ b/addons/event/static/src/xml/field_icon_selection.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates xml:space="preserve">
+    <t t-name="event.IconSelection">
+        <i t-attt-class="fa #{widget.icon}" t-att-title="widget.title"/>
+    </t>
+</templates>

--- a/addons/event/tests/test_event_mail_schedule.py
+++ b/addons/event/tests/test_event_mail_schedule.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import datetime
 from dateutil.relativedelta import relativedelta
 
 from odoo import fields
@@ -9,62 +10,63 @@ from odoo.tools import mute_logger
 
 
 class TestMailSchedule(TestEventCommon):
-
-    @mute_logger('odoo.addons.base.models.ir_model', 'odoo.models')
-    def test_event_mail_schedule(self):
-        """ Test mail scheduling for events """
-        now = fields.Datetime.now()
-        event_date_begin = now + relativedelta(days=1)
-        event_date_end = now + relativedelta(days=3)
-
-        test_event = self.env['event.event'].with_user(self.user_eventmanager).create({
+    @classmethod
+    def setUpClass(cls):
+        super(TestMailSchedule, cls).setUpClass()
+        cls.now = fields.Datetime.now()
+        cls.event_date_begin = cls.now + relativedelta(days=1)
+        cls.event_date_end = cls.now + relativedelta(days=3)
+        cls.test_event = cls.env['event.event'].with_user(cls.user_eventmanager).create({
             'name': 'TestEventMail',
             'auto_confirm': True,
-            'date_begin': event_date_begin,
-            'date_end': event_date_end,
+            'date_begin': cls.event_date_begin,
+            'date_end': cls.event_date_end,
             'event_mail_ids': [
                 (0, 0, {  # right at subscription
                     'interval_unit': 'now',
                     'interval_type': 'after_sub',
-                    'template_id': self.env['ir.model.data'].xmlid_to_res_id('event.event_subscription')}),
+                    'template_id': cls.env['ir.model.data'].xmlid_to_res_id('event.event_subscription')}),
                 (0, 0, {  # 1 days before event
                     'interval_nbr': 1,
                     'interval_unit': 'days',
                     'interval_type': 'before_event',
-                    'template_id': self.env['ir.model.data'].xmlid_to_res_id('event.event_reminder')}),
+                    'template_id': cls.env['ir.model.data'].xmlid_to_res_id('event.event_reminder')}),
             ]
         })
 
+    @mute_logger('odoo.addons.base.models.ir_model', 'odoo.models')
+    def test_event_mail_schedule(self):
+        """ Test mail scheduling for events """
         # create some registrations
         self.env['event.registration'].with_user(self.user_eventuser).create({
-            'event_id': test_event.id,
+            'event_id': self.test_event.id,
             'name': 'Reg0',
             'email': 'reg0@example.com',
         })
         self.env['event.registration'].with_user(self.user_eventuser).create({
-            'event_id': test_event.id,
+            'event_id': self.test_event.id,
             'name': 'Reg1',
             'email': 'reg1@example.com',
         })
 
         # check subscription scheduler
-        schedulers = self.env['event.mail'].search([('event_id', '=', test_event.id), ('interval_type', '=', 'after_sub')])
+        schedulers = self.env['event.mail'].search([('event_id', '=', self.test_event.id), ('interval_type', '=', 'after_sub')])
         self.assertEqual(len(schedulers), 1, 'event: wrong scheduler creation')
-        self.assertEqual(schedulers[0].scheduled_date, test_event.create_date, 'event: incorrect scheduled date for checking controller')
+        self.assertEqual(schedulers[0].scheduled_date, self.test_event.create_date, 'event: incorrect scheduled date for checking controller')
 
         # verify that subscription scheduler was auto-executed after each registration
         self.assertEqual(len(schedulers[0].mail_registration_ids), 2, 'event: incorrect number of mail scheduled date')
 
-        mails = self.env['mail.mail'].sudo().search([('subject', 'ilike', 'registration'), ('date', '>=', now)], order='date DESC', limit=3)
+        mails = self.env['mail.mail'].sudo().search([('subject', 'ilike', 'registration'), ('date', '>=', self.now)], order='date DESC', limit=3)
         self.assertEqual(len(mails), 2, 'event: wrong number of registration mail sent')
 
         for registration in schedulers[0].mail_registration_ids:
             self.assertTrue(registration.mail_sent, 'event: wrongly confirmed mailing on registration')
 
         # check before event scheduler
-        schedulers = self.env['event.mail'].search([('event_id', '=', test_event.id), ('interval_type', '=', 'before_event')])
+        schedulers = self.env['event.mail'].search([('event_id', '=', self.test_event.id), ('interval_type', '=', 'before_event')])
         self.assertEqual(len(schedulers), 1, 'event: wrong scheduler creation')
-        self.assertEqual(schedulers[0].scheduled_date, event_date_begin + relativedelta(days=-1), 'event: incorrect scheduled date')
+        self.assertEqual(schedulers[0].scheduled_date, self.event_date_begin + relativedelta(days=-1), 'event: incorrect scheduled date')
 
         # execute event reminder scheduler explicitly
         schedulers[0].execute()
@@ -72,5 +74,31 @@ class TestMailSchedule(TestEventCommon):
         self.assertTrue(schedulers[0].mail_sent, 'event: reminder scheduler should have sent an email')
         self.assertTrue(schedulers[0].done, 'event: reminder scheduler should be done')
 
-        mails = self.env['mail.mail'].sudo().search([('subject', 'ilike', 'TestEventMail'), ('date', '>=', now)], order='date DESC', limit=3)
+        mails = self.env['mail.mail'].sudo().search([('subject', 'ilike', 'TestEventMail'), ('date', '>=', self.now)], order='date DESC', limit=3)
         self.assertEqual(len(mails), 3, 'event: wrong number of reminders in outgoing mail queue')
+
+    @mute_logger('odoo.addons.base.models.ir_model', 'odoo.models')
+    def test_event_mail_schedule_trigger_stage(self):
+        """Test mail scheduling for events."""
+        stage_trigger = self.env['event.stage'].search([('name', '=', 'Announced')])
+
+        test_event_mail = self.env['event.mail'].with_user(self.user_eventmanager).create({
+            'event_id': self.test_event.id,
+            'interval_nbr': 3,
+            'interval_unit': 'days',
+            'interval_type': 'stage_update',
+            'trigger_stage_id': stage_trigger.id,
+        })
+
+        self.assertEqual(test_event_mail.trigger_stage_date, False)
+        self.test_event.stage_id = self.env['event.stage'].search([('name', '=', 'Booked')])
+        self.assertEqual(test_event_mail.trigger_stage_date, False)
+        self.test_event.stage_id = stage_trigger
+        self.assertAlmostEqual(test_event_mail.trigger_stage_date, self.now, delta=datetime.timedelta(minutes=1))
+        self.assertAlmostEqual(test_event_mail.scheduled_date, self.now + datetime.timedelta(days=3), delta=datetime.timedelta(minutes=1))
+
+        # changing the stage should not affect the `trigger_stage_date` if it's already set
+        test_event_mail.trigger_stage_date = self.now - relativedelta(days=1)
+        self.test_event.stage_id = self.env['event.stage'].search([('name', '=', 'Booked')])
+        self.test_event.stage_id = stage_trigger
+        self.assertAlmostEqual(test_event_mail.trigger_stage_date, self.now - relativedelta(days=1), delta=relativedelta(minutes=1))

--- a/addons/event/views/event_templates.xml
+++ b/addons/event/views/event_templates.xml
@@ -4,6 +4,7 @@
         <template id="assets_backend" name="event assets" inherit_id="web.assets_backend">
             <xpath expr="." position="inside">
                 <link rel="stylesheet" type="text/scss" href="/event/static/src/scss/event.scss"/>
+                <script type="text/javascript" src="/event/static/src/js/field_icon_selection.js"></script>
             </xpath>
         </template>
 

--- a/addons/event/views/event_views.xml
+++ b/addons/event/views/event_views.xml
@@ -271,7 +271,10 @@
                                         <field name="trigger_stage_id" options="{'no_create': True}"
                                             attrs="{'required': [('interval_type', '=', 'stage_update')], 'readonly':[('interval_type','!=','stage_update')]}"/>
                                         <field name="scheduled_date" groups="base.group_no_one" string="Schedule date"/>
-                                        <field name="done"/>
+                                        <field name="done" invisible="1"/>
+                                        <field name="contact_count"/>
+                                        <field name="event_mail_state" widget="icon_selection" string=" "
+                                            options="{'sent': 'fa-check', 'scheduled': 'fa-hourglass-half', 'running': 'fa-cogs'}"/>
                                     </tree>
                                 </field>
                             </page>
@@ -794,7 +797,10 @@
                     <field name="template_id" attrs="{'required': [('notification_type', '=', 'mail')]}"/>
                     <field name="scheduled_date"/>
                     <field name="mail_sent" string="Sent"/>
-                    <field name="done"/>
+                    <field name="done" invisible="1"/>
+                    <field name="contact_count"/>
+                    <field name="event_mail_state" widget="icon_selection" string=" "
+                        options="{'sent': 'fa-check', 'scheduled': 'fa-hourglass-half', 'running': 'fa-cogs'}"/>
                 </tree>
             </field>
         </record>

--- a/addons/event/views/event_views.xml
+++ b/addons/event/views/event_views.xml
@@ -48,6 +48,8 @@
                                                     <field name="interval_nbr" attrs="{'readonly':[('interval_unit', '=', 'now')]}"/>
                                                     <field name="interval_unit"/>
                                                     <field name="interval_type"/>
+                                                    <field name="trigger_stage_id" options="{'no_create': True}"
+                                                        attrs="{'required': [('interval_type', '=', 'stage_update')], 'readonly':[('interval_type','!=','stage_update')]}"/>
                                                 </tree>
                                             </field>
                                         </div>
@@ -266,6 +268,9 @@
                                         <field name="interval_nbr" attrs="{'readonly':[('interval_unit','=','now')]}"/>
                                         <field name="interval_unit"/>
                                         <field name="interval_type"/>
+                                        <field name="trigger_stage_id" options="{'no_create': True}"
+                                            attrs="{'required': [('interval_type', '=', 'stage_update')], 'readonly':[('interval_type','!=','stage_update')]}"/>
+                                        <field name="scheduled_date" groups="base.group_no_one" string="Schedule date"/>
                                         <field name="done"/>
                                     </tree>
                                 </field>
@@ -759,6 +764,7 @@
                                     <field name="interval_unit"/>
                                 </div>
                                 <field name="interval_type"/>
+                                <field name="trigger_stage_id"/>
                                 <field name="scheduled_date"/>
                             </group>
                         </group>

--- a/addons/event_sms/models/event_mail.py
+++ b/addons/event_sms/models/event_mail.py
@@ -43,6 +43,9 @@ class EventMailScheduler(models.Model):
                         mass_keep_log=True
                     )
                     mail.write({'mail_sent': True})
+
+                    mail.contact_count = len(mail.event_id.registration_ids.filtered(lambda reg: reg.state != 'cancel'))
+
         return super(EventMailScheduler, self).execute()
 
 


### PR DESCRIPTION
Purpose
=======
Be able to send event mail when we move an event to another stage.
e.g.: Sending "Sorry for canceling the event" when we move the event
in the stage "Canceled".

Show the state of the event mails (scheduled, running and sent).

Specifications
==============
If we specify "On stage update" on the event mail, the mail is sent
scheduled when we move the event into the specified stage.

If we specify a interval, the event mail will be sent "X times" after
moving the event into the specified stage.

Reset the `trigger_stage_id` if the interval type is not "stage_update".

Task 2127615
PR #45200
See odoo/upgrade/pull/858