### PR TITLE
[FIX] fields: make the cache of a monetary field consistent with the db

### DIFF
--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -530,21 +530,21 @@ class TestFields(common.TransactionCase):
         # determine the possible roundings of amount
         if currency:
             ramount = currency.round(amount)
-            samount = float(float_repr(ramount, currency.decimal_places))
+            ramount = float(float_repr(ramount, currency.decimal_places))
         else:
-            ramount = samount = amount
+            ramount = amount
 
         # check the currency on record
         self.assertEqual(record.currency_id, currency)
 
         # check the value on the record
-        self.assertIn(record.amount, [ramount, samount], msg)
+        self.assertEqual(record.amount, ramount, msg)
 
         # check the value in the database
         record.flush()
         self.cr.execute('SELECT amount FROM test_new_api_mixed WHERE id=%s', [record.id])
         value = self.cr.fetchone()[0]
-        self.assertEqual(value, samount, msg)
+        self.assertEqual(value, ramount, msg)
 
     def test_20_monetary(self):
         """ test monetary fields """

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1305,7 +1305,7 @@ class Monetary(Field):
             if len(currency) > 1:
                 raise ValueError("Got multiple currencies while assigning values of monetary field %s" % str(self))
             elif currency:
-                value = currency.round(value)
+                value = round(currency.round(value), currency.decimal_places)
         return value
 
     def convert_to_record(self, value, record):


### PR DESCRIPTION
To reproduce:

```
>>> tx = env['payment.transaction'].create({
   'amount': 10.87,
   'acquirer_id': env['payment.acquirer'].search([], limit=1).id,
   'currency_id': env.ref('base.USD').id,
   'reference': 'test'
})
>>> tx.id
130
>>> tx.amount
10.870000000000001

<Restart odoo>
>>> env['payment.transaction'].browse(130).amount
10.87
```

The issue is due to float_round (called by currency.round) not
guaranteeing a number will have the specified decimals.

This causes issues when users use these monetary values in
transactions to payment acquirers.

Solve it by rounding to exactly the digits specified by the
currency. This is analogous to what is done by float_repr in
convert_to_column.

opw-2188889