### PR TITLE
[FIX] hr_payroll, hr_holidays: Fix constrains

### DIFF
--- a/addons/hr_contract/models/hr_contract.py
+++ b/addons/hr_contract/models/hr_contract.py
@@ -164,7 +164,7 @@ class Contract(models.Model):
     @api.multi
     def write(self, vals):
         if vals.get('state') == 'open':
-            for contract in self:
+            for contract in self.filtered('employee_id'):
                 contract.employee_id.contract_id = contract
         return super(Contract, self).write(vals)
 

--- a/addons/hr_contract/models/hr_contract.py
+++ b/addons/hr_contract/models/hr_contract.py
@@ -109,7 +109,7 @@ class Contract(models.Model):
     @api.constrains('employee_id', 'state', 'date_start', 'date_end')
     def _check_current_contract(self):
         """ Two contracts in state [incoming | pending | open] cannot overlap """
-        for contract in self.filtered(lambda c: c.state not in ['draft', 'cancel', 'close']):
+        for contract in self.filtered(lambda c: c.state not in ['draft', 'cancel', 'close'] and c.employee_id):
             domain = [
                 ('id', '!=', contract.id),
                 ('employee_id', '=', contract.employee_id.id),

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -440,7 +440,7 @@ class HolidaysRequest(models.Model):
 
     @api.constrains('date_from', 'date_to', 'state', 'employee_id')
     def _check_date(self):
-        for holiday in self:
+        for holiday in self.filtered('employee_id'):
             domain = [
                 ('date_from', '<', holiday.date_to),
                 ('date_to', '>', holiday.date_from),


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fix constrains on contract and time off.

Current behavior before PR:

- When we change a contract to stage 'open', we write this contract
   on employee. But it causes error when it's a template contract
  (without employee).
- We check for all contract that there are no overlapping for a
  same employee.
- We can't create company (or team) time off if you have 2 or more
  template contract in your database.
- We can't create multiple company or team time off that overlaps.


Desired behavior after PR is merged:

- When we change a contract to stage 'open', we write this contract
  on employee only if contract has an employee.
- We check that there are no overlapping for contract with
  employee.
- We can create company (or team) time off if you have 2 or more
  template contract in your database.
- If a time off is set across multiple contract, print those contracts
  in error message.
- We can create multiple company or team time off that overlaps.


taskID: 2196185

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
