### PR TITLE
[IMP] http: add a routing type

### DIFF
--- a/addons/website/tools.py
+++ b/addons/website/tools.py
@@ -15,7 +15,8 @@ def werkzeugRaiseNotFound(*args, **kwargs):
 def MockRequest(
         env, *, routing=True, multilang=True,
         context=None,
-        cookies=None, country_code=None, website=None, sale_order_id=None
+        cookies=None, country_code=None, website=None, sale_order_id=None,
+        request_type='http',
 ):
     router = MagicMock()
     match = router.return_value.bind.return_value.match
@@ -52,7 +53,8 @@ def MockRequest(
             geoip={'country_code': country_code},
             sale_order_id=sale_order_id,
         ),
-        website=website
+        website=website,
+        _request_type=request_type,
     )
 
     with contextlib.ExitStack() as s:

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -315,7 +315,7 @@ class WebRequest(object):
 
     def _call_function(self, *args, **kwargs):
         request = self
-        if self.endpoint.routing['type'] != self._request_type:
+        if self.endpoint.routing['type'] != self._request_type and self.endpoint.routing['type'] != '*':
             msg = "%s, %s: Function declared as capable of handling request of type '%s' but called with a request of type '%s'"
             params = (self.endpoint.original, self.httprequest.path, self.endpoint.routing['type'], self._request_type)
             _logger.info(msg, *params)
@@ -506,7 +506,7 @@ def route(route=None, **kw):
 
     """
     routing = kw.copy()
-    assert 'type' not in routing or routing['type'] in ("http", "json")
+    assert 'type' not in routing or routing['type'] in ("http", "json", "*")
     def decorator(f):
         if route:
             if isinstance(route, list):
@@ -517,7 +517,7 @@ def route(route=None, **kw):
         @functools.wraps(f)
         def response_wrap(*args, **kw):
             response = f(*args, **kw)
-            if isinstance(response, Response) or f.routing_type == 'json':
+            if isinstance(response, Response) or request._request_type == 'json':
                 return response
 
             if isinstance(response, (bytes, pycompat.text_type)):


### PR DESCRIPTION
Purpose
=======
Actually, there are only 2 routing types, `http` and `json`.
But, in some case, we might need to manage standard HTTP
requests and JSON requests, on the same endpoint.

That's the case with the Facebook webhook. They first make a
simple HTTP request to check if the endpoint is a valid webhook
endpoint and then events are sent in a JSON request.

Specifications
==============
Add a new routing type, which is `*`. If a route has this type,
all requests are manage as simple HTTP requests
(GET/POST params are sent in the parameters of the controller)
but you can get the JSON parameter in `request.jsonrequest`.

Task 2124457