### PR TITLE
[MERGE] project,* : introduce the possibility to create template projects

### DIFF
--- a/addons/hr_timesheet/data/hr_timesheet_demo.xml
+++ b/addons/hr_timesheet/data/hr_timesheet_demo.xml
@@ -16,6 +16,18 @@
         <field name="parent_id" ref="hr.employee_admin"/>
     </record>
 
+    <!-- Templates -->
+        <record id="project_template_3" model="project.project">
+            <field name="date_start" eval="time.strftime('%Y-%m-01 10:00:00')"/>
+            <field name="name">Legal consultancy template</field>
+            <field name="user_id" ref="base.user_demo"/>
+            <field name="type_ids" eval="[(4, ref('project.project_stage_0')), (4, ref('project.project_stage_1')), (4, ref('project.project_stage_2')), (4, ref('project.project_stage_3'))]"/>
+            <field name="partner_id" ref="base.partner_demo_portal"/>
+            <field name="is_template">True</field>
+            <field name="allow_timesheets">True</field>
+            <field name="privacy_visibility">portal</field>
+        </record>
+
     <!-- Projects -->
     <record id="account_analytic_account_project_1" model="account.analytic.account">
         <field name="name">Office Design</field>

--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -22,7 +22,7 @@ class AccountAnalyticLine(models.Model):
         return result
 
     def _domain_project_id(self):
-        domain = [('allow_timesheets', '=', True)]
+        domain = [('allow_timesheets', '=', True), ('is_template', '=', False)]
         if not self.user_has_groups('hr_timesheet.group_timesheet_manager'):
             return expression.AND([domain,
                 ['|', ('privacy_visibility', '!=', 'followers'), ('allowed_internal_user_ids', 'in', self.env.user.ids)]
@@ -41,7 +41,7 @@ class AccountAnalyticLine(models.Model):
 
     task_id = fields.Many2one(
         'project.task', 'Task', index=True,
-        domain="[('company_id', '=', company_id), ('project_id.allow_timesheets', '=', True), ('project_id', '=?', project_id)]"
+        domain="[('company_id', '=', company_id), ('project_id.allow_timesheets', '=', True), ('project_id', '=?', project_id), ('is_template', '=', False)]"
     )
     project_id = fields.Many2one('project.project', 'Project', domain=_domain_project_id)
 
@@ -58,6 +58,7 @@ class AccountAnalyticLine(models.Model):
 
     @api.onchange('project_id')
     def onchange_project_id(self):
+        # force domain on task when project is set
         if self.project_id and self.project_id != self.task_id.project_id:
             # reset task when changing project
             self.task_id = False

--- a/addons/hr_timesheet/models/project.py
+++ b/addons/hr_timesheet/models/project.py
@@ -74,6 +74,12 @@ class Project(models.Model):
             })
         return result
 
+    @api.onchange('project_template_id')
+    def _copy_template(self):
+        super(Project, self)._copy_template()
+        setattr(self, 'allow_timesheets', getattr(self.project_template_id, 'allow_timesheets'))
+        setattr(self, 'allow_timesheet_timer', getattr(self.project_template_id, 'allow_timesheet_timer'))
+
     @api.model
     def _init_data_analytic_account(self):
         self.search([('analytic_account_id', '=', False), ('allow_timesheets', '=', True)])._create_analytic_account()
@@ -104,7 +110,7 @@ class Task(models.Model):
         for task in self:
             displays = super()._compute_display_timer_buttons()
             start_p, start_s, stop, pause, resume = displays['start_p'], displays['start_p'], displays['stop'], displays['pause'], displays['resume']
-            if not task.display_timesheet_timer:
+            if not task.display_timesheet_timer or task.is_template:
                 start_p, start_s, stop, pause, resume = False, False, False, False, False
             else:
                 if not task.timer_start:

--- a/addons/hr_timesheet/views/project_views.xml
+++ b/addons/hr_timesheet/views/project_views.xml
@@ -39,44 +39,32 @@
             <field name="priority">24</field>
             <field name="arch" type="xml">
                 <div name="button_box" position="inside">
-                    <button class="oe_stat_button" name="%(act_hr_timesheet_line_by_project)d" type="action" icon="fa-calendar" string="Timesheets" attrs="{'invisible': [('allow_timesheets', '=', False)]}" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <button class="oe_stat_button" name="%(act_hr_timesheet_line_by_project)d" type="action" icon="fa-calendar" string="Timesheets" attrs="{'invisible': ['|', ('allow_timesheets', '=', False), ('is_template', '=', True)]}" groups="hr_timesheet.group_hr_timesheet_user"/>
                 </div>
-                <xpath expr="//div[@id='rating_settings']/.." position="before">
-                    <div class="row mt16 o_settings_container">
-                        <div class="col-lg-6 o_setting_box"  id="timesheet_settings">
-                            <div class="o_setting_left_pane">
-                                <field name="allow_timesheets"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="allow_timesheets" string="Timesheets"/>
-                                <div class="text-muted">
-                                    Log time on tasks
-                                </div>
+                <div id="rating_settings" position="before">
+                    <div class="col-lg-6 o_setting_box"  id="timesheet_settings">
+                        <div class="o_setting_left_pane">
+                            <field name="allow_timesheets"/>
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="allow_timesheets" string="Timesheets"/>
+                            <div class="text-muted">
+                                Log time on tasks
                             </div>
                         </div>
                     </div>
-                </xpath>
-            </field>
-        </record>
-
-        <record id="project_view_form_inherit" model="ir.ui.view">
-            <field name="name">project.view.form.inherit</field>
-            <field name="model">project.project</field>
-            <field name="inherit_id" ref="hr_timesheet.project_invoice_form"/>
-            <field name="arch" type="xml">
-                <xpath expr="//div[@id='timesheet_settings']" position="after">
-                        <div class="col-lg-6 o_setting_box"  attrs="{'invisible': [('allow_timesheets', '=', False)]}">
-                            <div class="o_setting_left_pane">
-                                <field name="allow_timesheet_timer"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="allow_timesheet_timer"/>
-                                <div class="text-muted">
-                                    Track your time using a timer
-                                </div>
+                    <div class="col-lg-6 o_setting_box" id="timesheet_timer_settings">
+                        <div class="o_setting_left_pane" attrs="{'invisible': [('allow_timesheets', '=', False)]}">
+                            <field name="allow_timesheet_timer"/>
+                        </div>
+                        <div class="o_setting_right_pane" attrs="{'invisible': [('allow_timesheets', '=', False)]}">
+                            <label for="allow_timesheet_timer"/>
+                            <div class="text-muted">
+                                Track your time using a timer
                             </div>
                         </div>
-                </xpath>
+                    </div>
+                </div>
             </field>
         </record>
 
@@ -120,7 +108,7 @@
                                 You can not log timesheets on this project since is linked to an inactive analytic account. Please change it, or reactivate the current one to timesheet on the project.
                             </div>
                         </group>
-                    <field name="timesheet_ids" mode="tree,kanban" attrs="{'invisible': [('analytic_account_active', '=', False)]}" context="{'default_project_id': project_id, 'default_name':''}">
+                    <field name="timesheet_ids" mode="tree,kanban" attrs="{'invisible': ['|', ('is_template', '=', True), ('analytic_account_active', '=', False)]}" context="{'default_project_id': project_id, 'default_name':''}">
                         <tree editable="bottom" string="Timesheet Activities" default_order="date">
                             <field name="date"/>
                             <field name="user_id" invisible="1"/>
@@ -176,7 +164,7 @@
                             </sheet>
                         </form>
                     </field>
-                    <group attrs="{'invisible': [('analytic_account_active', '=', False)]}">
+                    <group attrs="{'invisible': ['|', ('is_template', '=', True), ('analytic_account_active', '=', False)]}">
                         <group class="oe_subtotal_footer oe_right" name="project_hours">
                             <field name="effective_hours" widget="float_time" />
                             <button name="action_view_subtask_timesheet" string="Sub-tasks Hours Spent:" type="object" class="oe_inline oe_link pl-0" attrs="{'invisible' : ['|', ('allow_subtasks', '=', False), ('subtask_effective_hours', '=', 0.0)]}"/>

--- a/addons/pad_project/models/project.py
+++ b/addons/pad_project/models/project.py
@@ -25,3 +25,8 @@ class ProjectProject(models.Model):
     _inherit = "project.project"
 
     use_pads = fields.Boolean("Use collaborative pads", default=True, help="Use collaborative pad for the tasks on this project.")
+
+    @api.onchange('project_template_id')
+    def _copy_template(self):
+        super(ProjectProject, self)._copy_template()
+        setattr(self, 'use_pads', getattr(self.project_template_id, 'use_pads'))

--- a/addons/pad_project/views/project_views.xml
+++ b/addons/pad_project/views/project_views.xml
@@ -20,19 +20,19 @@
         <field name="model">project.project</field>
         <field name="inherit_id" ref="project.edit_project"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='rating_settings']" position="after">
-                <div class="col-lg-6 o_setting_box" id="pad_settings">
+            <div id="rating_settings" position="after">
+                <div class="col-lg-6 o_setting_box"  id="pad_settings">
                     <div class="o_setting_left_pane">
                         <field name="use_pads"/>
                     </div>
                     <div class="o_setting_right_pane">
-                        <label for="use_pads" string="Collaborative Pads"/>
+                        <label for="use_pads" string="Collaborative pads"/>
                         <div class="text-muted">
-                            Use collaborative rich text pads on tasks
+                            Use interactive pads on tasks
                         </div>
                     </div>
                 </div>
-            </xpath>
+            </div>
         </field>
     </record>
 

--- a/addons/project/__manifest__.py
+++ b/addons/project/__manifest__.py
@@ -38,7 +38,7 @@
         'data/project_mail_template_data.xml',
         'data/project_data.xml',
     ],
-    'demo': ['data/project_demo.xml'],
+    'demo': ['data/project_demo.xml', 'data/template_demo.xml'],
     'test': [
     ],
     'installable': True,

--- a/addons/project/data/project_demo.xml
+++ b/addons/project/data/project_demo.xml
@@ -46,6 +46,19 @@
             <field name="fold" eval="True"/>
         </record>
 
+        <!-- Templates -->
+        <record id="project_template_1" model="project.project">
+            <field name="date_start" eval="time.strftime('%Y-%m-01 10:00:00')"/>
+            <field name="name">Employee onboarding template</field>
+            <field name="color">5</field>
+            <field name="user_id" ref="base.user_demo"/>
+            <field name="type_ids" eval="[(4, ref('project_stage_0')), (4, ref('project_stage_1')), (4, ref('project_stage_2')), (4, ref('project_stage_3'))]"/>
+            <field name="partner_id" ref="base.partner_demo_portal"/>
+            <field name="is_template">True</field>
+            <field name="privacy_visibility">portal</field>
+        </record>
+
+        <!-- Projects -->
         <record id="project_project_1" model="project.project">
             <field name="date_start" eval="time.strftime('%Y-%m-01 10:00:00')"/>
             <field name="name">Office Design</field>
@@ -262,6 +275,36 @@
             <field name="stage_id" ref="project_stage_0"/>
         </record>
 
+        <record id="project_task_27" model="project.task">
+            <field name="sequence">20</field>
+            <field name="planned_hours">2</field>
+            <field name="user_id" eval="False"/>
+            <field name="project_id" ref="project.project_template_1"/>
+            <field name="name">Welcome speech</field>
+            <field name="stage_id" ref="project_stage_0"/>
+        </record>
+
+        <record id="project_task_28" model="project.task">
+            <field name="sequence">30</field>
+            <field name="planned_hours">40.0</field>
+            <field name="user_id" eval="False"/>
+            <field name="priority">1</field>
+            <field name="project_id" ref="project.project_template_1"/>
+            <field name="name">Online Training</field>
+            <field name="stage_id" ref="project_stage_0"/>
+        </record>
+
+        <record id="project_task_29" model="project.task">
+            <field name="sequence">40</field>
+            <field name="planned_hours">10.0</field>
+            <field name="user_id" eval="False"/>
+            <field name="project_id" ref="project.project_template_1"/>
+            <field name="name">Coaching</field>
+            <field name="stage_id" ref="project_stage_0"/>
+            <field name="tag_ids" eval="[(6, 0, [
+                    ref('project.project_tags_02')])]"/>
+        </record>
+
         <record id="message_task_1" model="mail.message">
             <field name="model">project.task</field>
             <field name="res_id" ref="project_task_22"/>
@@ -323,5 +366,6 @@ Send it ASAP, its urgent.</field>
         <function model="project.task" name="rating_apply" eval="([ref('project.project_task_3')], 10)"/>
         <function model="project.task" name="rating_apply" eval="([ref('project.project_task_24')], 10)"/>
         <function model="project.task" name="rating_apply" eval="([ref('project.project_task_8')], 1)"/>
+
     </data>
 </odoo>

--- a/addons/project/data/template_demo.xml
+++ b/addons/project/data/template_demo.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+
+        <!-- Creation of the projects based on a template -->
+        <function model="project.project" name="create" eval="[{'name': 'Employee On Boarding','project_template_id': ref('project.project_template_1')}]" />
+    </data>
+</odoo>

--- a/addons/project/models/res_partner.py
+++ b/addons/project/models/res_partner.py
@@ -8,11 +8,11 @@ class ResPartner(models.Model):
     """ Inherits partner and adds Tasks information in the partner form """
     _inherit = 'res.partner'
 
-    task_ids = fields.One2many('project.task', 'partner_id', string='Tasks')
+    task_ids = fields.One2many('project.task', 'partner_id', string='Tasks', domain="[('is_template', '=', False)]")
     task_count = fields.Integer(compute='_compute_task_count', string='# Tasks')
 
     def _compute_task_count(self):
-        fetch_data = self.env['project.task'].read_group([('partner_id', 'in', self.ids)], ['partner_id'], ['partner_id'])
+        fetch_data = self.env['project.task'].read_group([('is_template', '=', False), ('partner_id', 'in', self.ids)], ['partner_id'], ['partner_id'])
         result = dict((data['partner_id'][0], data['partner_id_count']) for data in fetch_data)
         for partner in self:
             partner.task_count = result.get(partner.id, 0) + sum(c.task_count for c in partner.child_ids)

--- a/addons/project/report/project_report.py
+++ b/addons/project/report/project_report.py
@@ -17,6 +17,7 @@ class ReportProjectTaskUser(models.Model):
     date_deadline = fields.Date(string='Deadline', readonly=True)
     date_last_stage_update = fields.Datetime(string='Last Stage Update', readonly=True)
     project_id = fields.Many2one('project.project', string='Project', readonly=True)
+    is_template = fields.Boolean(related="project_id.is_template", invisible="1")
     working_days_close = fields.Float(string='# Working Days to Close',
         digits=(16,2), readonly=True, group_operator="avg",
         help="Number of Working Days to close the task")

--- a/addons/project/report/project_report_views.xml
+++ b/addons/project/report/project_report_views.xml
@@ -86,6 +86,7 @@
             <field name="res_model">report.project.task.user</field>
             <field name="view_mode">graph,pivot</field>
             <field name="search_view_id" ref="view_task_project_user_search"/>
+            <field name="domain">[('is_template', '=', False)]</field>
             <field name="context">{'group_by_no_leaf':1,'group_by':[]}</field>
             <field name="help">This report allows you to analyse the performance of your projects and users. You can analyse the quantities of tasks, the hours spent compared to the planned hours, the average number of days to open or close a task, etc.</field>
         </record>

--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -52,6 +52,7 @@
         <field name="name">Project: Only invited users</field>
         <field name="model_id" ref="model_project_project"/>
         <field name="domain_force">[
+        ('is_template', '=', False),
         '|',
             ('privacy_visibility', '!=', 'followers'),
             ('allowed_internal_user_ids', 'in', user.ids),
@@ -70,6 +71,7 @@
         <field name="name">Project/Task: employees: follow required for follower-only projects</field>
         <field name="model_id" ref="model_project_task"/>
         <field name="domain_force">[
+        ('is_template', '=', False),
         '|',
             ('project_id.privacy_visibility', '!=', 'followers'),
             ('allowed_user_ids', 'in', user.ids),

--- a/addons/project/views/mail_activity_views.xml
+++ b/addons/project/views/mail_activity_views.xml
@@ -10,5 +10,5 @@
     </record>
     <menuitem id="project_menu_config_activity_type"
         action="mail_activity_type_action_config_project_types"
-        parent="menu_project_config"/>
+        parent="menu_project_config" sequence="50"/>
 </odoo>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -54,6 +54,28 @@
             </field>
         </record>
 
+        <record id="view_project_project_filter" model="ir.ui.view">
+            <field name="name">project.project.select</field>
+            <field name="model">project.project</field>
+            <field name="arch" type="xml">
+                <search string="Search Project">
+                    <field name="name" string="Project"/>
+                    <field name="user_id" string="Project Manager"/>
+                    <field name="partner_id" string="Customer" filter_domain="[('partner_id', 'child_of', self)]"/>
+                    <field name="project_template_id" string="Template"/>
+                    <filter string="My Favorites" name="my_projects" domain="[('favorite_user_ids', 'in', uid)]"/>
+                    <separator/>
+                    <filter string="Followed" name="followed_by_me" domain="[('message_is_follower', '=', True)]"/>
+                    <separator/>
+                    <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
+                    <group expand="0" string="Group By">
+                        <filter string="Project Manager" name="Manager" context="{'group_by': 'user_id'}"/>
+                        <filter string="Customer" name="Partner" context="{'group_by': 'partner_id'}"/>
+                    </group>
+                </search>
+            </field>
+        </record>
+
         <record id="act_project_project_2_project_task_all" model="ir.actions.act_window">
             <field name="name">Tasks</field>
             <field name="res_model">project.task</field>
@@ -64,6 +86,25 @@
                 'default_project_id': active_id,
             }</field>
             <field name="search_view_id" ref="view_task_search_form"/>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    Click <i>Create</i> to start a new task.
+                </p><p>
+                    To get things done, use activities and status on tasks.<br/>
+                    Chat in real time or by email to collaborate efficiently.
+                </p>
+            </field>
+        </record>
+
+        <record id="act_project_project_2_project_all" model="ir.actions.act_window">
+            <field name="name">Projects</field>
+            <field name="res_model">project.project</field>
+            <field name="view_mode">kanban,tree,form,pivot,graph</field>
+            <field name="context">{
+                'search_default_project_template_id': active_id,
+                'default_project_template_id': active_id
+            }</field>
+            <field name="search_view_id" ref="view_project_project_filter"/>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     Click <i>Create</i> to start a new task.
@@ -96,18 +137,22 @@
             <field name="arch" type="xml">
                 <form string="Project">
                     <header>
-                        <button name="%(portal.portal_share_action)d" string="Share" type="action" class="oe_highlight oe_read_only"/>
+                        <button name="%(portal.portal_share_action)d" string="Share" type="action" class="oe_highlight oe_read_only" attrs="{'invisible': [('is_template', '=', True)]}"/>
                     </header>
                 <sheet string="Project">
                     <div class="oe_button_box" name="button_box" groups="base.group_user">
-                        <button  class="oe_stat_button" name="attachment_tree_view" type="object" icon="fa-file-text-o">
+                        <button  class="oe_stat_button" name="attachment_tree_view" type="object" icon="fa-file-text-o" attrs="{'invisible': [('is_template', '=', True)]}">
                             <field string="Documents" name="doc_count" widget="statinfo"/>
                         </button>
                         <button class="oe_stat_button" type="action"
                             name="%(act_project_project_2_project_task_all)d" icon="fa-tasks">
                             <field string="Tasks" name="task_count" widget="statinfo" options="{'label_field': 'label_tasks'}"/>
                         </button>
-                        <button name="action_view_all_rating" type="object" attrs="{'invisible': ['|', ('rating_status', '=', 'no'), ('rating_percentage_satisfaction', '=', -1)]}" class="oe_stat_button oe_percent" icon="fa-smile-o" groups="project.group_project_rating">
+                        <button class="oe_stat_button" type="action"
+                            name="%(act_project_project_2_project_all)d" icon="fa-puzzle-piece" attrs="{'invisible': [('is_template', '=', False)]}">
+                            <field string="Projects" name="project_count" widget="statinfo" options="{'label_field': 'Projects'}"/>
+                        </button>
+                        <button name="action_view_all_rating" type="object" attrs="{'invisible': ['|', '|', ('rating_status', '=', 'no'), ('rating_percentage_satisfaction', '=', -1), ('is_template', '=', True)]}" class="oe_stat_button oe_percent" icon="fa-smile-o" groups="project.group_project_rating">
                             <div class="o_field_widget o_stat_info">
                                 <span class="o_stat_value">
                                     <field name="rating_percentage_satisfaction" nolabel="1"/>
@@ -137,6 +182,7 @@
                                     <field name="active" invisible="1"/>
                                     <field name="user_id" string="Project Manager" attrs="{'readonly':[('active','=',False)]}"/>
                                     <field name="partner_id" string="Customer"/>
+                                    <field name="project_template_id" string="Template" attrs="{'invisible': ['|', ('is_template', '=', True), '&amp;', ('id', '!=', False), ('project_template_id', '=', False)], 'readonly':[('id', '!=', False)]}"/>
                                 </group>
                                 <group>
                                     <field name="analytic_account_id" domain="['|', ('company_id', '=', company_id), ('company_id', '=', False)]" context="{'default_partner_id': partner_id}" groups="analytic.group_analytic_accounting"/>
@@ -145,11 +191,10 @@
                                     <field name="allowed_portal_user_ids" widget="many2many_tags" attrs="{'invisible': [('privacy_visibility', '!=', 'portal')]}"/>
 
                                     <field name="company_id" groups="base.group_multi_company"/>
-                                </group>
-                                <group name="extra_settings">
+                                    <field name="is_template" string="Project Template" groups="base.group_no_one"/>
                                 </group>
                             </group>
-                            <div class="row mt16 o_settings_container">
+                            <div class="row mt16 o_settings_container" id="project_settings">
                                 <div id="rating_settings" class="col-lg-6 o_setting_box" groups="project.group_project_rating">
                                     <div class="o_setting_right_pane">
                                         <label for="rating_status"/>
@@ -214,27 +259,6 @@
                     </div>
                 </sheet>
                 </form>
-            </field>
-        </record>
-
-        <record id="view_project_project_filter" model="ir.ui.view">
-            <field name="name">project.project.select</field>
-            <field name="model">project.project</field>
-            <field name="arch" type="xml">
-                <search string="Search Project">
-                    <field name="name" string="Project"/>
-                    <field name="user_id" string="Project Manager"/>
-                    <field name="partner_id" string="Customer" filter_domain="[('partner_id', 'child_of', self)]"/>
-                    <filter string="My Favorites" name="my_projects" domain="[('favorite_user_ids', 'in', uid)]"/>
-                    <separator/>
-                    <filter string="Followed" name="followed_by_me" domain="[('message_is_follower', '=', True)]"/>
-                    <separator/>
-                    <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
-                    <group expand="0" string="Group By">
-                        <filter string="Project Manager" name="Manager" context="{'group_by': 'user_id'}"/>
-                        <filter string="Customer" name="Partner" context="{'group_by': 'partner_id'}"/>
-                    </group>
-                </search>
             </field>
         </record>
 
@@ -430,7 +454,7 @@
         <record id="open_view_project_all" model="ir.actions.act_window">
             <field name="name">Projects</field>
             <field name="res_model">project.project</field>
-            <field name="domain">[]</field>
+            <field name="domain">[('is_template', '=', False)]</field>
             <field name="view_mode">kanban,form</field>
             <field name="view_id" ref="view_project_kanban"/>
             <field name="search_view_id" ref="view_project_project_filter"/>
@@ -447,13 +471,13 @@
         <record id="open_view_project_all_config" model="ir.actions.act_window">
             <field name="name">Projects</field>
             <field name="res_model">project.project</field>
-            <field name="domain">[]</field>
+            <field name="domain">[('is_template', '=', False)]</field>
             <field name="view_mode">tree,kanban,form</field>
             <field name="view_ids" eval="[(5, 0, 0),
                 (0, 0, {'view_mode': 'tree', 'view_id': ref('view_project')}),
                 (0, 0, {'view_mode': 'kanban', 'view_id': ref('project_view_kanban')})]"/>
             <field name="search_view_id" ref="view_project_project_filter"/>
-            <field name="context">{}</field>
+            <field name="context">{'default_is_template': False}</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_empty_folder">
                     Create a new project
@@ -462,6 +486,28 @@
                 </p>
             </field>
         </record>
+
+        <record id="open_view_project_template_all_config" model="ir.actions.act_window">
+            <field name="name">Project Templates</field>
+            <field name="res_model">project.project</field>
+            <field name="domain">[('is_template', '=', True)]</field>
+            <field name="view_mode">tree,kanban,form</field>
+            <field name="view_ids" eval="[(5, 0, 0),
+                (0, 0, {'view_mode': 'tree', 'view_id': ref('view_project')}),
+                (0, 0, {'view_mode': 'kanban', 'view_id': ref('project_view_kanban')})]"/>
+            <field name="search_view_id" ref="view_project_project_filter"/>
+            <field name="context">{
+                'default_is_template': True
+                }</field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_empty_folder">
+                    Create a new project template
+                </p><p>
+                    Organize your projects and tasks based on templates.
+                </p>
+            </field>
+        </record>
+
 
         <!-- Task -->
         <record id="view_task_form2" model="ir.ui.view">
@@ -473,7 +519,7 @@
                     <field name="allow_subtasks" invisible="1" />
                     <header>
                         <button name="action_assign_to_me" string="Assign to Me" type="object" class="oe_highlight"
-                            attrs="{'invisible' : [('user_id', '!=', False)]}"/>
+                            attrs="{'invisible' : ['|', ('is_template', '=', True), ('user_id', '!=', False)]}"/>
                         <field name="stage_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" attrs="{'invisible': [('project_id', '=', False)]}"/>
                     </header>
                     <sheet string="Task">
@@ -503,22 +549,29 @@
                             <field name="legend_blocked" invisible="1"/>
                             <field name="legend_normal" invisible="1"/>
                             <field name="legend_done" invisible="1"/>
+                            <field name="is_template" invisible="1"/>
                         </group>
                         <group>
-                            <field name="project_id" required="1" domain="[('active', '=', True), ('company_id', '=', company_id)]"/>
+                            <field name="project_id" domain="['|',
+                                                                    ('is_template', '=', context.get('all_task', 1)==0),
+                                                                    ('is_template', '=', False),
+                                                                ('active', '=', True),
+                                                                ('company_id', '=', company_id)]"/>
                             <field name="user_id"
                                 class="o_task_user_field"
-                                options='{"no_open": True}'/>
+                                options='{"no_open": True}'
+                                attrs="{'invisible': [('is_template', '=', True)]}"/>
                             <field
                                 name="parent_id"
-                                domain="[('parent_id', '=', False)]"
+                                domain="[('parent_id', '=', False), ('is_template', '=', False)]"
                                 attrs="{'invisible' : [('allow_subtasks', '=', False)]}"
                             />
                         </group>
                         <!-- YTI FIXME: Clean these fake groups -->
-                        <group name="sales_order_group"/>
+                        <group name="sales_order_group">
+                        </group>
                         <group name="dates">
-                            <field name="date_deadline"/>
+                            <field name="date_deadline" attrs="{'invisible': [('is_template', '=', True)]}"/>
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
                         </group>
                     </group>
@@ -532,7 +585,7 @@
                                 <group>
                                     <field name="sequence" groups="base.group_no_one"/>
                                     <field name="email_from" invisible="1"/>
-                                    <field name="email_cc" groups="base.group_no_one"/>
+                                    <field name="email_cc" groups="base.group_no_one" attrs="{'invisible': [('is_template', '=', True)]}"/>
                                     <field name="project_privacy_visibility" groups="base.group_no_one"/>
                                     <field name="allowed_user_ids" widget="many2many_tags"
                                            groups="base.group_no_one" attrs="{'invisible': [('project_privacy_visibility', 'not in', ('followers', 'portal'))]}"/>
@@ -541,15 +594,15 @@
                                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
                                     <field name="displayed_image_id" groups="base.group_no_one"/>
                                 </group>
-                                <group>
+                                <group attrs="{'invisible': [('is_template', '=', True)]}">
                                     <field name="date_assign" groups="base.group_no_one"/>
                                     <field name="date_last_stage_update" groups="base.group_no_one"/>
                                 </group>
-                                <group string="Working Time to Assign" attrs="{'invisible': [('working_hours_open', '=', 0.0)]}">
+                                <group string="Working Time to Assign" attrs="{'invisible': ['|', ('is_template', '=', True), ('working_hours_open', '=', 0.0)]}">
                                     <field name="working_hours_open" string="Hours"/>
                                     <field name="working_days_open" string="Days"/>
                                 </group>
-                                <group string="Working Time to Close" attrs="{'invisible': [('working_hours_close', '=', 0.0)]}">
+                                <group string="Working Time to Close" attrs="{'invisible': ['|', ('is_template', '=', True), ('working_hours_close', '=', 0.0)]}">
                                     <field name="working_hours_close" string="Hours"/>
                                     <field name="working_days_close" string="Days"/>
                                 </group>
@@ -584,7 +637,7 @@
                     <group>
                         <field name="name" string = "Task Title"/>
                         <field name="user_id" options="{'no_open': True,'no_create': True}"/>
-                        <field name="project_id" required="1" invisible="context.get('all_task', 1)"/>
+                        <field name="project_id" required="1" invisible="context.get('all_task', 1)" domain="[('is_template', '=', False)]"/>
                         <field name="company_id" invisible="1"/>
                         <field name="parent_id" invisible="1"/>
                     </group>
@@ -797,6 +850,7 @@
             <field name="res_model">project.task</field>
             <field name="view_mode">kanban,tree,form,calendar,pivot,graph,activity</field>
             <field name="context">{'search_default_my_tasks': 1}</field>
+            <field name="domain">[('project_id.is_template', '=', False), ('is_template', '=', False)]</field>
             <field name="search_view_id" ref="view_task_search_form"/>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
@@ -813,6 +867,7 @@
             <field name="res_model">project.task</field>
             <field name="view_mode">kanban,tree,form,calendar,pivot,graph,activity</field>
             <field name="context">{'search_default_my_tasks': 1, 'all_task': 0}</field>
+            <field name="domain">[('project_id.is_template', '=', False), ('is_template', '=', False)]</field>
             <field name="search_view_id" ref="view_task_search_form"/>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
@@ -842,6 +897,7 @@
             <field name="name">Tasks</field>
             <field name="res_model">project.task</field>
             <field name="view_mode">kanban,tree,form</field>
+            <field name="domain">[('project_id.is_template', '=', False)]</field>
             <field name="search_view_id" ref="view_task_search_form"/>
         </record>
 
@@ -981,10 +1037,11 @@
 
         <menuitem id="menu_tasks_config" name="GTD" parent="menu_project_config" sequence="2"/>
 
-        <menuitem action="open_task_type_form" id="menu_project_config_project" name="Stages" parent="menu_project_config" sequence="3" groups="base.group_no_one"/>
+        <menuitem action="open_task_type_form" id="menu_project_config_project" name="Stages" parent="menu_project_config" sequence="20" groups="base.group_no_one"/>
 
         <menuitem action="open_view_project_all" id="menu_projects" name="Projects" parent="menu_main_pm" sequence="1"/>
-        <menuitem action="open_view_project_all_config" id="menu_projects_config" name="Projects" parent="menu_project_config" sequence="10"/>
+        <menuitem action="open_view_project_all_config" id="menu_projects_config" name="Projects" parent="menu_project_config" sequence="30"/>
+        <menuitem action="open_view_project_template_all_config" id="menu_template_projects_config" name="Project Templates" parent="menu_project_config" sequence="40"/>
 
         <!-- User Form -->
         <act_window context="{'search_default_user_id': [active_id], 'default_user_id': active_id}"
@@ -1036,7 +1093,7 @@
               </p>
             </field>
         </record>
-        <menuitem action="project_tags_action" id="menu_project_tags_act" parent="menu_project_config"/>
+        <menuitem action="project_tags_action" id="menu_project_tags_act" parent="menu_project_config" sequence="60"/>
 
         <!-- Reporting menus -->
         <menuitem id="menu_project_report" name="Reporting"

--- a/addons/project/views/res_config_settings_views.xml
+++ b/addons/project/views/res_config_settings_views.xml
@@ -17,7 +17,7 @@
                                 <div class="o_setting_right_pane" name="pad_project_right_pane">
                                     <label for="module_pad"/>
                                     <div class="text-muted">
-                                        Use collaborative rich text pads on tasks
+                                        Use interactive pads on tasks
                                     </div>
                                 </div>
                             </div>

--- a/addons/project_timesheet_holidays/models/hr_holidays.py
+++ b/addons/project_timesheet_holidays/models/hr_holidays.py
@@ -17,8 +17,8 @@ class HolidaysType(models.Model):
         return company.leave_timesheet_task_id.id
 
     timesheet_generate = fields.Boolean('Generate Timesheet', default=True, help="If checked, when validating a time off, timesheet will be generated in the Vacation Project of the company.")
-    timesheet_project_id = fields.Many2one('project.project', string="Project", default=_default_project_id, domain="[('company_id', '=', company_id)]", help="The project will contain the timesheet generated when a time off is validated.")
-    timesheet_task_id = fields.Many2one('project.task', string="Task for timesheet", default=_default_task_id, domain="[('project_id', '=', timesheet_project_id), ('company_id', '=', company_id)]")
+    timesheet_project_id = fields.Many2one('project.project', string="Project", default=_default_project_id, domain="[('is_template', '=', False), ('company_id', '=', company_id)]", help="The project will contain the timesheet generated when a time off is validated.")
+    timesheet_task_id = fields.Many2one('project.task', string="Task for timesheet", default=_default_task_id, domain="[('is_template', '=', False), ('project_id', '=', timesheet_project_id), ('company_id', '=', company_id)]")
 
     @api.onchange('timesheet_task_id')
     def _onchange_timesheet_generate(self):

--- a/addons/project_timesheet_holidays/models/res_config_settings.py
+++ b/addons/project_timesheet_holidays/models/res_config_settings.py
@@ -7,5 +7,5 @@ from odoo import fields, models
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
-    leave_timesheet_project_id = fields.Many2one(related='company_id.leave_timesheet_project_id', string="Internal Project", domain="[('company_id', '=', company_id)]", readonly=False)
-    leave_timesheet_task_id = fields.Many2one(related='company_id.leave_timesheet_task_id', string="Time Off Task", domain="[('company_id', '=', company_id)]", readonly=False)
+    leave_timesheet_project_id = fields.Many2one(related='company_id.leave_timesheet_project_id', string="Internal Project", domain="[('is_template', '=', False), ('company_id', '=', company_id)]", readonly=False)
+    leave_timesheet_task_id = fields.Many2one(related='company_id.leave_timesheet_task_id', string="Time Off Task", domain="[('is_template', '=', False), ('company_id', '=', company_id)]", readonly=False)

--- a/addons/sale_project/models/product.py
+++ b/addons/sale_project/models/product.py
@@ -19,10 +19,10 @@ class ProductTemplate(models.Model):
         'In sale order\'s project': Will use the sale order\'s configured project if defined or fallback to \
         creating a new project based on the selected template.")
     project_id = fields.Many2one(
-        'project.project', 'Project', company_dependent=True,
+        'project.project', 'Project', company_dependent=True, domain=[('is_template', '=', False)],
         help='Select a non billable project on which tasks can be created. This setting must be set for each company.')
     project_template_id = fields.Many2one(
-        'project.project', 'Project Template', company_dependent=True, copy=True,
+        'project.project', 'Project Template', company_dependent=True, domain=[('is_template', '=', True)], copy=True,
         help='Select a non billable project to be the skeleton of the new created project when selling the current product. Its stages and tasks will be duplicated.')
 
     @api.constrains('project_id', 'project_template_id')

--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -178,7 +178,9 @@ class SaleOrderLine(models.Model):
         }
         if self.product_id.project_template_id:
             values['name'] = "%s - %s" % (values['name'], self.product_id.project_template_id.name)
-            project = self.product_id.project_template_id.copy(values)
+            values['partner_id'] = self.order_id.partner_id.id
+            values['project_template_id'] = self.product_id.project_template_id.id
+            project = self.product_id.project_template_id.create(values)
             project.tasks.write({
                 'sale_line_id': self.id,
                 'partner_id': self.order_id.partner_id.id,

--- a/addons/sale_project/views/product_views.xml
+++ b/addons/sale_project/views/product_views.xml
@@ -9,7 +9,7 @@
             <xpath expr="//field[@name='service_type']" position="after">
                 <field name="service_tracking" widget="radio" attrs="{'invisible': [('type','!=','service')]}"/>
                 <field name="project_id" attrs="{'invisible':[('service_tracking','!=','task_global_project')], 'required':[('service_tracking','==','task_global_project')]}"/>
-                <field name="project_template_id" context="{'active_test': False}" attrs="{'invisible':[('service_tracking','not in',['task_in_project', 'project_only'])]}"/>
+                <field name="project_template_id" context="{'active_test': False, 'default_is_template': True}" attrs="{'invisible':[('service_tracking','not in',['task_in_project', 'project_only'])]}"/>
             </xpath>
         </field>
     </record>

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -22,13 +22,13 @@
             <div name="button_box" position="inside">
                 <button class="d-none d-md-inline oe_stat_button"
                         type="object" name="action_view_so" icon="fa-dollar"
-                        attrs="{'invisible': [('sale_order_id', '=', False)]}"
+                        attrs="{'invisible': ['|', ('is_template', '=', True), ('sale_order_id', '=', False)]}"
                         string="Sales Order"
                         groups="sales_team.group_sale_salesman"/>
             </div>
             <xpath expr="//group[@name='sales_order_group']" position="inside">
-                <field name="sale_line_id" string="Sales Order Item" attrs="{'invisible': ['|', ('partner_id', '=', False), '&amp;', ('sale_order_id', '!=', False), ('sale_line_id', '=', False)]}" options='{"no_open": True}' readonly="1" context="{'create': False, 'edit': False, 'delete': False}" groups="sales_team.group_sale_salesman"/>
-                <field name="sale_order_id" attrs="{'invisible': [('project_id', '!=', False)]}" groups="sales_team.group_sale_salesman"/>
+                <field name="sale_line_id" string="Sales Order Item" attrs="{'invisible': ['|', '|', ('is_template', '=', True), ('partner_id', '=', False), '&amp;', ('sale_order_id', '!=', False), ('sale_line_id', '=', False)]}" options='{"no_open": True}' readonly="1" context="{'create': False, 'edit': False, 'delete': False}" groups="sales_team.group_sale_salesman"/>
+                <field name="sale_order_id" attrs="{'invisible': ['|', ('is_template', '=', True), ('project_id', '!=', False)]}" groups="sales_team.group_sale_salesman"/>
                 <field name="commercial_partner_id" invisible="1" />
                 <field name="project_sale_order_id" invisible="1"/>
             </xpath>

--- a/addons/sale_timesheet/data/sale_service_demo.xml
+++ b/addons/sale_timesheet/data/sale_service_demo.xml
@@ -18,6 +18,12 @@
             <field name="active" eval="True"/>
         </record>
 
+        <record id="account_analytic_account_project_service_template" model="account.analytic.account">
+            <field name="name">Services product</field>
+            <field name="code">INT1</field>
+            <field name="active" eval="True"/>
+        </record>
+
         <record id="project_support" model="project.project">
             <field name="date_start" eval="time.strftime('%Y-%m-01 10:00:00')"/>
             <field name="name">After-Sales Services</field>
@@ -25,11 +31,52 @@
             <field name="type_ids" eval="[(4, ref('project.project_stage_0')), (4, ref('project.project_stage_1')), (4, ref('project.project_stage_2'))]"/>
         </record>
 
+        <record id="project_service_template" model="project.project">
+            <field name="date_start" eval="time.strftime('%Y-%m-01 10:00:00')"/>
+            <field name="name">Design Service template</field>
+            <field name="is_template">True</field>
+            <field name="allow_timesheets">True</field>
+            <field name="billable_type">task_rate</field>
+            <field name="analytic_account_id" ref="account_analytic_account_project_service_template"/>
+            <field name="type_ids" eval="[(4, ref('project.project_stage_0')), (4, ref('project.project_stage_1')), (4, ref('project.project_stage_2'))]"/>
+        </record>
+
+        <record id="project_service_template" model="project.project">
+            <field name="date_start" eval="time.strftime('%Y-%m-01 10:00:00')"/>
+            <field name="name">Accounting services template</field>
+            <field name="is_template">True</field>
+            <field name="allow_timesheets">True</field>
+            <field name="allow_timesheet_timer">True</field>
+            <field name="billable_type">task_rate</field>
+            <field name="type_ids" eval="[(4, ref('project.project_stage_data_0')), (4, ref('project.project_stage_1')), (4, ref('project.project_stage_2'))]"/>
+        </record>
+
         <!-- Project Task -->
         <record id="project_task_internal" model="project.task">
             <field name="name">Internal training</field>
             <field name="user_id" ref="base.user_admin"/>
             <field name="project_id" ref="project.project_project_1"/>
+        </record>
+
+        <record id="project_task_service_1" model="project.task">
+            <field name="name">Consult client</field>
+            <field name="user_id" ref="base.user_admin"/>
+            <field name="project_id" ref="project_service_template"/>
+            <field name="stage_id" ref="project.project_stage_0"/>
+        </record>
+
+        <record id="project_task_service_2" model="project.task">
+            <field name="name">Mock up</field>
+            <field name="user_id" ref="base.user_admin"/>
+            <field name="project_id" ref="project_service_template"/>
+            <field name="stage_id" ref="project.project_stage_0"/>
+        </record>
+
+        <record id="project_task_service_3" model="project.task">
+            <field name="name">Build solution</field>
+            <field name="user_id" ref="base.user_admin"/>
+            <field name="project_id" ref="project_service_template"/>
+            <field name="stage_id" ref="project.project_stage_0"/>
         </record>
 
         <!-- Products -->
@@ -96,6 +143,19 @@
             <field name="service_tracking">no</field>
         </record>
 
+        <record id="product_service_deliver_timesheet_3" model="product.product">
+            <field name="name">Training</field>
+            <field name="categ_id" ref="product.product_category_3"/>
+            <field name="list_price">500</field>
+            <field name="standard_price">420.00</field>
+            <field name="type">service</field>
+            <field name="uom_id" ref="uom.product_uom_hour"/>
+            <field name="uom_po_id" ref="uom.product_uom_hour"/>
+            <field name="service_policy">delivered_timesheet</field>
+            <field name="service_tracking">project_only</field>
+            <field name="project_template_id" ref="project_service_template"/>
+        </record>
+
         <!-- Sales orders -->
         <record id="sale_order_1" model="sale.order">
             <field name="partner_id" ref="base.res_partner_2"/>
@@ -143,9 +203,24 @@
             <field name="product_uom_qty">10</field>
         </record>
 
+        <!-- Sale Order 'sale_order_3' (Training) -->
+        <record id="sale_order_3" model="sale.order">
+            <field name="partner_id" ref="base.res_partner_4"/>
+            <field name="client_order_ref">Trainee</field>
+            <field name="user_id" ref="base.user_admin"/>
+        </record>
+
+        <record id="sale_line_31" model="sale.order.line">
+            <field name="order_id" ref="sale_order_3"/>
+            <field name="sequence" eval="1"/>
+            <field name="product_id" ref="product_service_deliver_timesheet_3"/>
+            <field name="product_uom_qty">150</field>
+        </record>
+
         <!-- Confirm Sale Orders -->
         <function model="sale.order" name="action_confirm" eval="[[ref('sale_order_1')]]"/>
         <function model="sale.order" name="action_confirm" eval="[[ref('sale_order_2')]]"/>
+        <function model="sale.order" name="action_confirm" eval="[[ref('sale_order_3')]]"/>
 
         <!-- Timesheets on sale_order_1 -->
         <record id="timesheet_1" model="account.analytic.line">

--- a/addons/sale_timesheet/models/product.py
+++ b/addons/sale_timesheet/models/product.py
@@ -16,8 +16,8 @@ class ProductTemplate(models.Model):
         ('timesheet', 'Timesheets on project (one fare per SO/Project)'),
     ])
     # override domain
-    project_id = fields.Many2one(domain="[('billable_type', '=', 'no'), ('allow_timesheets', 'in', [service_policy == 'delivered_timesheet' or '', True])]")
-    project_template_id = fields.Many2one(domain="[('billable_type', '=', 'no'), ('allow_timesheets', 'in', [service_policy == 'delivered_timesheet' or '', True])]")
+    project_id = fields.Many2one(domain="[('billable_type', '=', 'no'), ('allow_timesheets', 'in', [service_policy == 'delivered_timesheet' or '', True]), ('is_template', '=', False)]")
+    project_template_id = fields.Many2one(domain="[('billable_type', '=', 'no'), ('allow_timesheets', 'in', [service_policy == 'delivered_timesheet' or '', True]), ('is_template', '=', True)]")
 
     def _default_visible_expense_policy(self):
         visibility = self.user_has_groups('project.group_project_user')

--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -50,7 +50,7 @@ class Project(models.Model):
     def _compute_display_create_order(self):
         for project in self:
             show = True
-            if not project.partner_id or project.billable_type != 'no' or project.allow_billable or project.sale_order_id:
+            if not project.partner_id or project.billable_type != 'no' or project.allow_billable or project.sale_order_id or project.is_template:
                 show = False
             project.display_create_order = show
 
@@ -154,6 +154,12 @@ class Project(models.Model):
                 'default_product_id': self.timesheet_product_id.id,
             },
         }
+
+    @api.onchange('project_template_id')
+    def _copy_template(self):
+        super(Project, self)._copy_template()
+        setattr(self, 'allow_billable', getattr(self.project_template_id, 'allow_billable'))
+        setattr(self, 'timesheet_product_id', getattr(self.project_template_id, 'timesheet_product_id'))
 
 
 class ProjectTask(models.Model):

--- a/addons/sale_timesheet/models/project_overview.py
+++ b/addons/sale_timesheet/models/project_overview.py
@@ -32,7 +32,7 @@ class Project(models.Model):
         uom_hour = self.env.ref('uom.product_uom_hour')
         hour_rounding = uom_hour.rounding
         billable_types = ['non_billable', 'non_billable_project', 'billable_time', 'billable_fixed']
-
+        self = self.search([('id', 'in', self.ids), ('is_template', '=', False)])
         values = {
             'projects': self,
             'currency': currency,

--- a/addons/sale_timesheet/models/sale_order.py
+++ b/addons/sale_timesheet/models/sale_order.py
@@ -12,7 +12,7 @@ class SaleOrder(models.Model):
     timesheet_count = fields.Float(string='Timesheet activities', compute='_compute_timesheet_ids', groups="hr_timesheet.group_hr_timesheet_user")
 
     # override domain
-    project_id = fields.Many2one(domain="[('billable_type', 'in', ('no', 'task_rate')), ('analytic_account_id', '!=', False), ('company_id', '=', company_id)]")
+    project_id = fields.Many2one(domain="[('is_template', '=', False), ('billable_type', 'in', ('no', 'task_rate')), ('analytic_account_id', '!=', False), ('company_id', '=', company_id)]")
     timesheet_encode_uom_id = fields.Many2one('uom.uom', related='company_id.timesheet_encode_uom_id')
     timesheet_total_duration = fields.Float("Timesheet Total Duration", compute='_compute_timesheet_total_duration', help="Total recorded duration, expressed in the encoding UoM")
 

--- a/addons/sale_timesheet/report/project_profitability_report_analysis.py
+++ b/addons/sale_timesheet/report/project_profitability_report_analysis.py
@@ -13,6 +13,7 @@ class ProfitabilityAnalysis(models.Model):
 
     analytic_account_id = fields.Many2one('account.analytic.account', string='Analytic Account', readonly=True)
     project_id = fields.Many2one('project.project', string='Project', readonly=True)
+    is_template = fields.Boolean(related="project_id.is_template")
     currency_id = fields.Many2one('res.currency', string='Project Currency', readonly=True)
     company_id = fields.Many2one('res.company', string='Project Company', readonly=True)
     user_id = fields.Many2one('res.users', string='Project Manager', readonly=True)

--- a/addons/sale_timesheet/report/project_profitability_report_analysis_views.xml
+++ b/addons/sale_timesheet/report/project_profitability_report_analysis_views.xml
@@ -55,6 +55,7 @@
         <field name="res_model">project.profitability.report</field>
         <field name="view_mode">pivot,graph</field>
         <field name="search_view_id" ref="project_profitability_report_view_search"/>
+        <field name="domain">[('is_template', '=', False)]</field>
         <field name="context">{
             'group_by_no_leaf':1,
             'group_by':[],

--- a/addons/sale_timesheet/security/sale_timesheet_security.xml
+++ b/addons/sale_timesheet/security/sale_timesheet_security.xml
@@ -12,5 +12,17 @@
         <record id="account.account_analytic_line_rule_billing_user" model="ir.rule">
             <field name="domain_force">[('project_id', '=', False)]</field>
         </record>
+
+        <record model="ir.rule" id="project_project_manager_rule">
+            <field name="name">Project: sale manager: see project templates</field>
+            <field name="model_id" ref="model_project_project"/>
+            <field name="domain_force">['|', ('is_template', '=', False), ('is_template', '=', True)]</field>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
+            <field name="perm_read" eval="True"/>
+            <field name="groups" eval="[(4,ref('sales_team.group_sale_manager'))]"/>
+        </record>
+
     </data>
 </odoo>

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -10,12 +10,12 @@
                 <button name="action_make_billable" string="Create Sales Order" type="object" attrs="{'invisible': [('display_create_order', '=', False)]}" groups="sales_team.group_sale_salesman"/>
             </xpath>
             <xpath expr="//page[@name='emails']" position="after">
-                <page name="billing_employee_rate" string="Invoicing" attrs="{'invisible': [('billable_type', '=', 'no')]}">
+                <page name="billing_employee_rate" string="Invoicing" attrs="{'invisible': ['|', ('billable_type', '=', 'no'), ('is_template', '=', True)]}">
                     <group>
                         <field name="display_create_order" invisible="1"/>
                         <field name="billable_type" invisible="1"/>
-                        <field name="sale_order_id" attrs="{'invisible': [('billable_type', '=', 'no')]}"/>
-                        <field name="sale_line_id" attrs="{'invisible': [('billable_type', '=', 'no')]}" context="{'create': False, 'edit': False, 'delete': False}"/>
+                        <field name="sale_order_id" attrs="{'invisible': ['|', ('billable_type', '=', 'no'), ('is_template', '=', True)]}"/>
+                        <field name="sale_line_id" attrs="{'invisible': ['|', ('billable_type', '=', 'no'), ('is_template', '=', True)]}" context="{'create': False, 'edit': False, 'delete': False}"/>
                     </group>
                     <field name="sale_line_employee_ids">
                         <tree editable="top">
@@ -26,22 +26,20 @@
                     </field>
                 </page>
             </xpath>
-            <xpath expr="//div[@id='timesheet_settings']/.." position="after">
-                <div class="row mt16 o_settings_container">
-                    <div class="col-lg-6 o_setting_box" id="allow_billable_container" attrs="{'invisible': [('billable_type', '=', 'employee_rate')]}">
-                        <div class="o_setting_left_pane">
-                            <field name="allow_billable" attrs="{'readonly': [('sale_order_id', '!=', False)]}"/>
+            <div id="timesheet_timer_settings" position="after">
+                <div class="col-lg-6 o_setting_box" id="allow_billable_settings" attrs="{'invisible': [('billable_type', '=', 'employee_rate')]}">
+                    <div class="o_setting_left_pane">
+                        <field name="allow_billable"/>
+                    </div>
+                    <div class="o_setting_right_pane" id="allow_billable_container_right_pane">
+                        <label for="allow_billable"/>
+                        <div class="text-muted" id="allow_billable_setting">
+                            Invoice your time and material from tasks
                         </div>
-                        <div class="o_setting_right_pane">
-                            <label for="allow_billable"/>
-                            <div class="text-muted" id="allow_billable_setting">
-                                Invoice your time and material from tasks
-                            </div>
-                            <field name="timesheet_product_id" attrs="{'invisible': ['|', ('allow_billable', '=', False), ('allow_timesheets', '=', False)], 'required': ['&amp;', ('allow_billable', '=', True), ('allow_timesheets', '=', True)]}"/>
-                        </div>
+                        <field name="timesheet_product_id" attrs="{'invisible': ['|', ('allow_billable', '=', False), ('allow_timesheets', '=', False)], 'required': ['&amp;', ('allow_billable', '=', True), ('allow_timesheets', '=', True)]}"/>
                     </div>
                 </div>
-            </xpath>
+            </div>
         </field>
     </record>
 
@@ -74,43 +72,43 @@
         </field>
     </record>
 
-        <record id="view_sale_service_inherit_form2" model="ir.ui.view">
-            <field name="name">sale.service.form.view.inherit</field>
-            <field name="model">project.task</field>
-            <field name="groups_id" eval="[(4, ref('base.group_user'))]"/>
-            <field name="inherit_id" ref="project.view_task_form2"/>
-            <field name="arch" type="xml">
-                <xpath expr="//header" position='inside'>
-                    <field name="allow_billable" invisible="1"/>
-                    <field name="display_create_order" invisible="1"/>
-                    <button name="action_make_billable" string="Create Sales Order" type="object" attrs="{'invisible': [('display_create_order', '=', False)]}" groups="sales_team.group_sale_salesman"/>
-                </xpath>
-                <xpath expr="//group[@name='sales_order_group']" position="inside">
-                    <field name="billable_type" invisible="1"/>
-                </xpath>
-                <xpath expr="//field[@name='email_cc']" position="after">
-                    <field name="analytic_account_id" groups="base.group_no_one"/>
-                </xpath>
-            </field>
-        </record>
+    <record id="view_sale_service_inherit_form2" model="ir.ui.view">
+        <field name="name">sale.service.form.view.inherit</field>
+        <field name="model">project.task</field>
+        <field name="groups_id" eval="[(4, ref('base.group_user'))]"/>
+        <field name="inherit_id" ref="project.view_task_form2"/>
+        <field name="arch" type="xml">
+            <xpath expr="//header" position='inside'>
+                <field name="allow_billable" invisible="1"/>
+                <field name="display_create_order" invisible="1"/>
+                <button name="action_make_billable" string="Create Sales Order" type="object" attrs="{'invisible': [('display_create_order', '=', False)]}" groups="sales_team.group_sale_salesman"/>
+            </xpath>
+            <xpath expr="//group[@name='sales_order_group']" position="inside">
+                <field name="billable_type" invisible="1"/>
+            </xpath>
+            <xpath expr="//field[@name='email_cc']" position="after">
+                <field name="analytic_account_id" groups="base.group_no_one"/>
+            </xpath>
+        </field>
+    </record>
 
-        <record id="project_task_view_form_inherit_sale_timesheet" model="ir.ui.view">
-            <field name="name">project.task.form.inherit.timesheet</field>
-            <field name="model">project.task</field>
-            <field name="inherit_id" ref="hr_timesheet.view_task_form2_inherited"/>
-            <field name="arch" type="xml">
-                <xpath expr="//field[@name='timesheet_ids']/tree" position="attributes">
-                    <attribute name="decoration-muted">timesheet_invoice_id != False</attribute>
-                </xpath>
-                <xpath expr="//field[@name='user_id']" position="after">
-                    <field name="is_project_map_empty" invisible="1"/>
-                </xpath>
-                <xpath expr="//field[@name='timesheet_ids']/tree" position="inside">
-                    <field name="timesheet_invoice_id" invisible="1"/>
-                    <field name="so_line" readonly="1" attrs="{'column_invisible': ['|', ('parent.is_project_map_empty', '=', True), ('parent.billable_type', '!=', 'employee_rate')]}"/>
-                </xpath>
-            </field>
-        </record>
+    <record id="project_task_view_form_inherit_sale_timesheet" model="ir.ui.view">
+        <field name="name">project.task.form.inherit.timesheet</field>
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="hr_timesheet.view_task_form2_inherited"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='timesheet_ids']/tree" position="attributes">
+                <attribute name="decoration-muted">timesheet_invoice_id != False</attribute>
+            </xpath>
+            <xpath expr="//field[@name='user_id']" position="after">
+                <field name="is_project_map_empty" invisible="1"/>
+            </xpath>
+            <xpath expr="//field[@name='timesheet_ids']/tree" position="inside">
+                <field name="timesheet_invoice_id" invisible="1"/>
+                <field name="so_line" readonly="1" attrs="{'column_invisible': ['|', ('parent.is_project_map_empty', '=', True), ('parent.billable_type', '!=', 'employee_rate')]}"/>
+            </xpath>
+        </field>
+    </record>
 
     <record id="project_timesheet_action_client_timesheet_plan" model="ir.actions.act_window">
         <field name="name">Overview</field>


### PR DESCRIPTION
Purpose
=======
The purpose of this is to allow the creation of template projects that
can be used as starting point for normal projects but don't appear
in reporting, on the dashboard, on the portal...

Tasks can also be created in those projects but no timesheets, quotations,
sale orders or invoices can be created from those tasks. We can link a
partner to template tasks. They don't appear on the partner form.

Specifications
==============
- Add a "Project Template" checkbox on the project form view beneath the company field.
  It is only visible in debug mode.

- Add a project_template_id field on the project form view to select a template
  with which you want to create your project. Once the project is saved you
  cannot change the template anymore.

- Add a "Project Templates" menu item in Project > Configuration.
  All projects created from this menu are templates by default.

- Display only non template projects on the dashboard

- Fields to be copied from a template to a project : 
     partner_id, company_id, currency_id, type_ids, label_tasks,  resource_calendar_id,
     color, user_id, privacy_visibility, display_name, use_pads, allow_billable, timesheet_product_id,
    allow_timesheets, allow_timesheet_timer

- Invisible fields on project.project form (non templates): 
     Project stat buttons, project_template_id

- Invisible fields on project.project form (templates): 
     Ratings stat button, sale_order_id, sale_line_id, SO stat button, Timesheets stat button


- Invisible fields on project.task form : 
     Assign to me button, user_id, parent_id, date_deadline, email_cc, date_assign, 
     date_last_stage_update, Working Time to Close, sale_order_id, sale_line_id,
     SO stat button, timer buttons, timesheet_ids

- Add demo data

Task-1975084
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
