### PR TITLE
[WIP] project : add recurrence on project tasks

### DIFF
--- a/addons/project/__manifest__.py
+++ b/addons/project/__manifest__.py
@@ -37,6 +37,7 @@
         'data/digest_data.xml',
         'data/project_mail_template_data.xml',
         'data/project_data.xml',
+        'wizard/project_edit_recurrence_views.xml',
     ],
     'demo': ['data/project_demo.xml'],
     'test': [

--- a/addons/project/data/project_data.xml
+++ b/addons/project/data/project_data.xml
@@ -261,4 +261,25 @@
             <field name="description">In the chatter, sending an email with an attachment will display the picture on the card. When there are several image attachments, you can choose which one you want to display.</field>
         </record>
 
+        <!-- Recurrency cron -->
+        <record id="project_recurring_task" model="ir.cron">
+            <field name="name">Tasks: Generate recurring tasks</field>
+            <field name="model_id" ref="project.model_project_task"/>
+            <field name="active" eval="False"/>
+            <field name="state">code</field>
+            <field name="code">model._cron_create_recurring_tasks()</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="numbercall">-1</field>
+            <field name="nextcall" eval="(datetime.now() + timedelta(days=1)).strftime('%Y-%m-%d %H:%M:%S')"/>
+        </record>
+
+        <template id="project_recurring_task_template">
+            <span>This task has been generated from 
+                <a href="#" data-oe-model="project.task" t-att-data-oe-id="task.id">
+                    <t t-esc="task.name"/>
+                </a>
+            </span>
+        </template>
+
 </odoo>

--- a/addons/project/data/project_demo.xml
+++ b/addons/project/data/project_demo.xml
@@ -38,12 +38,14 @@
             <field name="sequence">20</field>
             <field name="name">Done</field>
             <field name="fold" eval="True"/>
+            <field name="is_closed" eval="True"/>
         </record>
         <record id="project_stage_3" model="project.task.type">
             <field name="sequence">30</field>
             <field name="name">Cancelled</field>
             <field name="legend_done">Ready to reopen</field>
             <field name="fold" eval="True"/>
+            <field name="is_closed" eval="True"/>
         </record>
 
         <record id="project_project_1" model="project.project">

--- a/addons/project/models/res_config_settings.py
+++ b/addons/project/models/res_config_settings.py
@@ -11,12 +11,12 @@ class ResConfigSettings(models.TransientModel):
     module_hr_timesheet = fields.Boolean(string="Task Logs")
     group_subtask_project = fields.Boolean("Sub-tasks", implied_group="project.group_subtask_project")
     group_project_rating = fields.Boolean("Use Rating on Project", implied_group='project.group_project_rating')
+    group_recurring_task_project = fields.Boolean(string="Recurring Tasks", implied_group="project.group_recurring_task_project")
 
     def _get_subtasks_projects_domain(self):
         return []
 
     def execute(self):
-        res = super(ResConfigSettings, self).execute()
         if self.group_project_rating:
             # Change the rating status on existing projects from 'no' to 'stage'
             self.env['project.project'].search([('rating_status', '=', 'no')]).write({
@@ -24,4 +24,9 @@ class ResConfigSettings(models.TransientModel):
         if self.group_subtask_project:
             domain = self._get_subtasks_projects_domain()
             self.env['project.project'].search(domain).write({'allow_subtasks': True})
-        return res
+        cron = self.sudo().with_context(active_test=False).env.ref('project.project_recurring_task', raise_if_not_found=False)
+        if cron and cron.active != self.group_recurring_task_project:
+            cron.active = self.group_recurring_task_project
+            cron.flush(['active'])
+            self.env['project.project'].search([]).write({'allow_recurring_tasks': self.group_recurring_task_project})
+        return super(ResConfigSettings, self).execute()

--- a/addons/project/security/ir.model.access.csv
+++ b/addons/project/security/ir.model.access.csv
@@ -23,3 +23,4 @@ access_mail_activity_type_project_manager,mail.activity.type.project.manager,mai
 access_account_analytic_account_user,account.analytic.account,analytic.model_account_analytic_account,project.group_project_user,1,0,0,0
 access_account_analytic_account_manager,account.analytic.account,analytic.model_account_analytic_account,project.group_project_manager,1,1,1,1
 access_account_analytic_line_project,account.analytic.line project,analytic.model_account_analytic_line,project.group_project_manager,1,1,1,1
+access_project_task_edit_recurrence,access.project.task.edit.recurrence,model_project_task_edit_recurrence,project.group_project_user,1,1,1,0

--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -29,6 +29,11 @@
         <field name="category_id" ref="base.module_category_hidden"/>
     </record>
 
+    <record id="group_recurring_task_project" model="res.groups">
+            <field name="name">Auto-generate tasks for regular activities</field>
+            <field name="category_id" ref="base.module_category_hidden"/>
+        </record>
+
 <data noupdate="1">
     <record id="base.default_user" model="res.users">
         <field name="groups_id" eval="[(4,ref('project.group_project_manager'))]"/>

--- a/addons/project/static/src/css/project.css
+++ b/addons/project/static/src/css/project.css
@@ -65,3 +65,7 @@
 .o_kanban_project_tasks .badge-danger {
   border-color: var(--danger);
 }
+
+.o_label {
+  font-weight: bold;
+}

--- a/addons/project/static/src/js/project_form_controller.js
+++ b/addons/project/static/src/js/project_form_controller.js
@@ -1,0 +1,122 @@
+odoo.define('project.ProjectFormController', function (require) {
+    "use strict";
+
+    var BasicController = require('web.BasicController');
+    var core = require('web.core');
+    var Dialog = require('web.Dialog');
+    var QWeb = core.qweb;
+    var _t = core._t;
+
+    Dialog.confirmRecurring = function (owner, message, options) {
+        var buttons = [
+            {
+                text: _t("Ok"),
+                classes: 'btn-primary',
+                close: true,
+                click: options && options.confirm_callback,
+            },
+            {
+                text: _t("Cancel"),
+                close: true,
+                click: options && options.cancel_callback
+            }
+        ];
+        return new Dialog(owner, _.extend({
+            size: 'medium',
+            buttons: buttons,
+            $content: $('<main/>', {
+                role: 'alert',
+            }).append($('<input>', {type: 'radio', name:'recurrence_modification', id:'only', checked:true}))
+            .append($('<label>', {for: 'only', text: 'This task'}))
+            .append($('<br>')).append($('<input>', {type: 'radio', name:'recurrence_modification', id:'all'}))
+            .append($('<label>', {for: 'all', text: 'All tasks'}))
+            .append($('<br>')).append($('<input>', {type: 'radio', name:'recurrence_modification', id:'future'}))
+            .append($('<label>', {for: 'future', text: 'This task and the following ones'})),
+            title: message,
+            onForceClose: options && (options.onForceClose || options.cancel_callback),
+        }, options)).open({shouldFocusButtons:true});
+    };
+
+    var ProjectController = BasicController.extend({
+    /**
+     * @override
+     *
+     * @param {string[]} ids
+     */
+    _deleteRecords: function (ids) {
+        var self = this;
+        function doIt() {
+            return self.model
+                .deleteRecords(ids, self.modelName)
+                .then(self._onDeletedRecords.bind(self, ids));
+        }
+        function doIt2() {
+            let value = ""
+            const array = this.$content.find('input')
+            $.each(array, function(key, object){
+                if (object.checked) {
+                    console.log('true')
+                    value = object.id
+                }
+            })
+            switch (value) {
+                case 'all':
+                    console.log('get ids of all tasks linked to this recurrence');
+                    var promise = self._rpc({
+                        model: 'project.task',
+                        method: 'get_all_tasks_from_this_recurrence',
+                        args: [self.model.get(self.handle).res_id],
+                    });
+                    promise.then(function (result) {
+                        console.log(result)
+                        return self._rpc({
+                            model: 'project.task',
+                            method: 'unlink',
+                            args: [result]
+                        });
+                    });
+                    break;
+                case 'only':
+                    console.log('only this one so apply doIt()');
+                    doIt();
+                    break;
+                case 'future':
+                    console.log('get ids of all following tasks linked to this recurrence');
+                    var promise = self._rpc({
+                        model: self.model.get(self.handle).model,
+                        method: 'get_all_following_tasks_from_this_recurrence',
+                        args: [self.model.get(self.handle).res_id],
+                    });
+                    promise.then(function (result) {
+                        console.log('res' + result)
+                        // debugger;
+                        // return self.model
+                        //     .deleteRecords(result, self.modelName)
+                        //     .then(self._onDeletedRecords.bind(self, result));
+                    })
+                    console.log(promise)
+                    // return self.model
+                    //     .deleteRecords(ids, self.modelName)
+                    //     .then(self._onDeletedRecords.bind(self, ids));
+                    console.log(ids)
+                    break;
+            }
+        }
+        console.log(self)
+        if (self.modelName == 'project.task' && self.model.localData[ids].data.recurrency) {
+            Dialog.confirmRecurring(this, _t("Delete recurring task"), {
+                confirm_callback: doIt2,
+            });
+        }
+        else if (this.confirmOnDelete) {
+            Dialog.confirm(this, _t("Are you sure you want to delete this record ?"), {
+                confirm_callback: doIt,
+            });
+        } else {
+            doIt();
+        }
+    },
+    });
+
+    return ProjectController;
+});

--- a/addons/project/static/src/js/project_form_view.js
+++ b/addons/project/static/src/js/project_form_view.js
@@ -1,0 +1,18 @@
+odoo.define('project.ProjectFormView', function (require) {
+    "use strict";
+
+
+    var ProjectFormController = require('project.ProjectFormController');
+    var FormView = require('web.FormView');
+    var viewRegistry = require('web.view_registry');
+
+    var ProjectFormView = FormView.extend({
+        config: _.extend({}, FormView.prototype.config, {
+            Controller: ProjectFormController,
+        }),
+    });
+
+    viewRegistry.add('project_form', ProjectFormView);
+
+    return ProjectFormView;
+    });

--- a/addons/project/tests/__init__.py
+++ b/addons/project/tests/__init__.py
@@ -2,3 +2,4 @@
 
 from . import test_project_base, test_project_flow, test_access_rights, test_project_ui
 from . import test_multicompany
+# from . import test_project_recurrency

--- a/addons/project/tests/test_project_recurrency.py
+++ b/addons/project/tests/test_project_recurrency.py
@@ -1,0 +1,191 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from dateutil.relativedelta import relativedelta
+
+from odoo import fields
+from odoo.tests.common import SavepointCase
+from unittest.mock import patch
+
+
+class TestProjectRecurrency(SavepointCase):
+
+    # 1) create a project with allow_recurring_tasks true
+    # 2) create a first_task with recurrency true, + parameters
+    # 3) mark the task as done
+    # 4) run the cron
+    # 5) check if the child task has been created task with parent_id = first_task.id 
+    # 6) mark the child task as done and check if the recurrency_next_date of the first_task has been set accordingly
+    # 7) run the cron 1 day later and repeat step 5 and 6
+    # 8) run the cron again, no child task should have been created
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.stage1 = cls.env['project.task.type'].create({
+            'name': 'New',
+            'sequence': 1,
+            'is_closed': False
+        })
+
+        cls.stage2 = cls.env['project.task.type'].create({
+            'name': 'Done',
+            'sequence': 2,
+            'is_closed': True
+        })
+
+        project = cls.env['project.project'].create({
+            'name': 'Test',
+            'type_ids': [cls.stage1.id, cls.stage2.id],
+            'allow_recurring_tasks': True})
+
+        cls.task = cls.env['project.task'].create({
+            'name': 'Recurrent Task',
+            'project_id': project.id,
+        })
+
+    # def test_project_recurrency_count(self):
+    #     # recurrency parameters : every week for 2 repetitions. The task is to be created 6 days before it has to be completed
+    #     # 4a) check that no task as been created
+    #     # 4b) set date_end of task date to yesterday
+    #     # 4c) run the cron again
+
+    #     self.task.write({
+    #         'recurrency': True,
+    #         'recurrency_interval': 1,
+    #         'recurrency_type': 'weeks',
+    #         'recurrency_end_type': 'count',
+    #         'recurrency_count': 2,
+    #         'recurrency_before_interval': 6,
+    #         'recurrency_before_type': 'days'
+    #     })
+    #     self.assertFalse(self.task.recurring_next_date)
+
+    #     self.task.write({
+    #         'stage_id': self.stage2.id,
+    #     })
+    #     self.assertEqual(self.task.recurring_next_date, fields.Date.today() + relativedelta(days=7))
+    #     self.env['project.task']._cron_create_recurring_tasks()
+    #     self.assertFalse(self.env['project.task'].search([('recurring_parent_id', '=', self.task.id)]))
+
+    #     self.task.write({
+    #         'date_end': self.task.date_end - relativedelta(days=1)
+    #     })
+
+    #     self.env['project.task']._cron_create_recurring_tasks()
+    #     child_task = self.env['project.task'].search([('recurring_parent_id', '=', self.task.id)])
+    #     self.assertTrue(child_task)
+    #     self.assertEqual(child_task.recurring_parent_id, self.task)
+
+    #     # recurring_next_date is False as long as the last task in the chain isn't marked as done
+    #     self.assertFalse(self.task.recurring_next_date)
+
+    #     child_task.write({
+    #         'stage_id': self.stage2.id,
+    #     })
+
+    #     self.assertEqual(self.task.recurring_next_date, fields.Date.today() + relativedelta(days=7))
+    #     self.assertEqual(child_task.recurring_next_date, fields.Date.today() + relativedelta(days=7))
+
+    #     child_task.write({
+    #         'date_end': child_task.date_end - relativedelta(days=1)
+    #     })
+    #     self.assertEqual(self.task.recurring_next_date, fields.Date.today() + relativedelta(days=6))
+    #     self.env['project.task']._cron_create_recurring_tasks()
+    #     self.assertEqual(len(self.env['project.task'].search([('recurring_parent_id', '=', self.task.id)])), 2)
+
+    #     child_task = self.env['project.task'].search([('recurring_parent_id', '=', self.task.id), ('date_end', '=', False)])
+    #     self.assertEqual(child_task.recurring_parent_id, self.task)
+
+    #     # recurring_next_date is False as long as the last task in the chain isn't marked as done
+    #     self.assertFalse(self.task.recurring_next_date)
+
+    #     child_task.write({
+    #         'stage_id': self.stage2.id,
+    #     })
+
+    #     # The number of children tasks is 2 so the repetion should stop and no more recurring_next_date is set
+    #     self.assertFalse(self.task.recurring_next_date)
+
+    #     # No next date is set so the cron shouldn't create a new task
+    #     self.env['project.task']._cron_create_recurring_tasks()
+    #     self.assertEqual(len(self.env['project.task'].search([('recurring_parent_id', '=', self.task.id)])), 2)
+
+    # def test_project_recurrency_until(self):
+    #     # recurrency parameters : every 2 days until today()+5. The task is to be created 1 days before it has to be completed
+    #     # 4a) check that no task as been created
+    #     # 4b) set date.today() to tomorrow
+    #     # 4c) run the cron again
+
+    #     self.patcher = patch('odoo.addons.project.models.project.fields.Date', wraps=fields.Date)
+    #     self.mock_date = self.patcher.start()
+
+    #     self.task.write({
+    #         'recurrency': True,
+    #         'recurrency_interval': 2,
+    #         'recurrency_type': 'days',
+    #         'recurrency_end_type': 'last_date',
+    #         'recurrency_until_date': fields.Date.today() + relativedelta(days=5),
+    #         'recurrency_before_interval': 1,
+    #         'recurrency_before_type': 'days'
+    #     })
+    #     self.assertFalse(self.task.recurring_next_date)
+
+    #     self.task.write({
+    #         'stage_id': self.stage2.id,
+    #     })
+    #     self.assertEqual(self.task.recurring_next_date, fields.Date.today() + relativedelta(days=2))
+    #     self.env['project.task']._cron_create_recurring_tasks()
+    #     self.assertFalse(self.env['project.task'].search([('recurring_parent_id', '=', self.task.id)]))
+
+    #     # today = set to +1
+    #     self.mock_date.today.return_value = fields.Date.today() + relativedelta(days=1)
+    #     self.env['project.task']._cron_create_recurring_tasks()
+    #     child_task = self.env['project.task'].search([('recurring_parent_id', '=', self.task.id)])
+    #     self.assertTrue(child_task)
+    #     self.assertEqual(child_task.recurring_parent_id, self.task)
+
+    #     # recurring_next_date is False as long as the last task in the chain isn't marked as done
+    #     self.assertFalse(self.task.recurring_next_date)
+
+    #     # today = set to +2
+    #     self.mock_date.today.return_value = fields.Date.today() + relativedelta(days=1)
+    #     child_task.write({
+    #         'stage_id': self.stage2.id,
+    #     })
+    #     child_task.write({
+    #         'date_end': fields.Date.today()
+    #     })
+    #     self.assertEqual(self.task.recurring_next_date, fields.Date.today() + relativedelta(days=2))
+    #     self.assertEqual(child_task.recurring_next_date, fields.Date.today() + relativedelta(days=2))
+
+    #     # today = set to +3
+    #     self.mock_date.today.return_value = fields.Date.today() + relativedelta(days=1)
+    #     self.env['project.task']._cron_create_recurring_tasks()
+    #     self.assertEqual(len(self.env['project.task'].search([('recurring_parent_id', '=', self.task.id)])), 2)
+
+    #     child_task = self.env['project.task'].search([('recurring_parent_id', '=', self.task.id), ('date_end', '=', False)])
+    #     self.assertEqual(child_task.recurring_parent_id, self.task)
+
+    #     # recurring_next_date is False as long as the last task in the chain isn't marked as done
+    #     self.assertFalse(self.task.recurring_next_date)
+
+    #     # today = set to +4
+    #     self.mock_date.today.return_value = fields.Date.today() + relativedelta(days=1)
+
+    #     child_task.write({
+    #         'stage_id': self.stage2.id,
+    #     })
+    #     child_task.write({
+    #         'date_end': fields.Date.today()
+    #     })
+
+    #     # The number of children tasks is 2 so the repetion should stop and no more recurring_next_date is set
+    #     self.assertFalse(self.task.recurring_next_date)
+
+    #     # today = set to +5
+    #     self.mock_date.today.return_value = fields.Date.today() + relativedelta(days=1)
+    #     # No next date is set so the cron shouldn't create a new task
+    #     self.env['project.task']._cron_create_recurring_tasks()
+    #     self.assertEqual(len(self.env['project.task'].search([('recurring_parent_id', '=', self.task.id)])), 2)
+    #     self.patcher.stop()

--- a/addons/project/views/project_assets.xml
+++ b/addons/project/views/project_assets.xml
@@ -4,6 +4,8 @@
             <xpath expr="." position="inside">
                 <link rel="stylesheet" href="/project/static/src/css/project.css"/>
                 <script type="text/javascript" src="/project/static/src/js/project.js"></script>
+                <!-- <script type="text/javascript" src="/project/static/src/js/project_form_controller.js"></script>
+                <script type="text/javascript" src="/project/static/src/js/project_form_view.js"></script> -->
                 <script type="text/javascript" src="/project/static/src/js/project_task_kanban_examples.js"></script>
                 <script type="text/javascript" src="/project/static/src/js/tours/project.js"></script>
                 <link rel="stylesheet" type="text/scss" href="/project/static/src/scss/project_dashboard.scss"/>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -187,6 +187,17 @@
                                         </div>
                                     </div>
                                 </div>
+                                <div class="col-lg-6 o_setting_box"  id="recurrency_settings" groups="project.group_recurring_task_project">
+                                    <div class="o_setting_left_pane">
+                                        <field name="allow_recurring_tasks" />
+                                    </div>
+                                    <div class="o_setting_right_pane">
+                                        <label for="allow_recurring_tasks" />
+                                        <div class="text-muted">
+                                            Auto-generate tasks for regular activities
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                             <group name="misc">
                                 <group string="Time Scheduling">
@@ -305,6 +316,7 @@
                             <div name="alias_def" attrs="{'invisible': [('alias_domain', '=', False)]}">
                                 <field name="alias_name" class="oe_inline"/>@<field name="alias_domain" class="oe_inline" readonly="1"/>
                             </div>
+                            <field name="allow_recurring_tasks" groups="project.group_recurring_task_project"/>
                         </group>
                     </group>
                 </form>
@@ -471,6 +483,7 @@
             <field name="arch" type="xml">
                 <form string="Task" class="o_form_project_tasks">
                     <field name="allow_subtasks" invisible="1" />
+                    <field name="allow_recurring_tasks" invisible="1"/>
                     <header>
                         <button name="action_assign_to_me" string="Assign to Me" type="object" class="oe_highlight"
                             attrs="{'invisible' : [('user_id', '!=', False)]}"/>
@@ -553,6 +566,40 @@
                                     <field name="working_hours_close" string="Hours"/>
                                     <field name="working_days_close" string="Days"/>
                                 </group>
+                            </group>
+                        </page>
+                        <page name="Recurrency" string="Recurrency" attrs="{'invisible': [('allow_recurring_tasks', '=', False)]}">
+                            <group>
+                                <field name="recurrency"/>
+                                <field name="recurring_parent_id" attrs="{'invisible': ['|', ('recurrency', '=', False), ('recurring_parent_id', '=', False)]}"/>
+                                <field name="recurring_next_date" groups="base.group_no_one" attrs="{'invisible': [('recurrency', '=', False)]}"/>
+                            </group>
+                            <group>
+                                <div class="o_row" attrs="{'invisible': [('recurrency', '=', False)]}">
+                                    <span class="o_label">Every</span>
+                                    <field name="recurrency_interval" attrs="{'required': [('recurrency','=', True)]}"/>
+                                    <field name="recurrency_type" attrs="{'required': [('recurrency','=', True)]}"/>
+                                </div>
+                                <div class="o_row" attrs="{'invisible': ['|', ('recurrency', '=', False), ('recurrency_type', '!=', 'weeks')]}">
+                                    <span class="o_label">on</span>
+                                    <group>
+                                        <field name="mo"/>
+                                        <field name="tu"/>
+                                        <field name="we"/>
+                                        <field name="th"/>
+                                        <field name="fr"/>
+                                        <field name="sa"/>
+                                        <field name="su"/>
+                                    </group>
+                                </div>
+                                <div class="o_row" attrs="{'invisible': [('recurrency', '=', False)]}">
+                                    <span class="o_label">until</span>
+                                    <field name="recurrency_end_type" attrs="{'required': [('recurrency','=', True)]}"/>
+                                    <field name="recurrency_until_date" attrs="{'invisible': [('recurrency_end_type', '!=', 'last_date')], 'required': [('recurrency','=', True), ('recurrency_end_type', '=', 'last_date')]}"/>
+                                </div>
+                            </group>
+                            <group attrs="{'invisible': [('recurrency', '=', False)]}">
+                                <field name="recurrency_stage_id"/>
                             </group>
                         </page>
                     </notebook>
@@ -889,6 +936,7 @@
                             </group>
                             <group>
                                 <field name="fold"/>
+                                <field name="is_closed" groups="base.group_no_one"/>
                                 <field name="project_ids" widget="many2many_tags" groups="base.group_no_one"/>
                                 <field name="sequence" groups="base.group_no_one"/>
                             </group>

--- a/addons/project/views/res_config_settings_views.xml
+++ b/addons/project/views/res_config_settings_views.xml
@@ -49,6 +49,17 @@
                                     </div>
                                 </div>
                             </div>
+                            <div class="col-12 col-lg-6 o_setting_box" name="group_recurring_task_project">
+                                <div class="o_setting_left_pane">
+                                    <field name="group_recurring_task_project"/>
+                                </div>
+                                <div class="o_setting_right_pane">
+                                    <label for="group_recurring_task_project"/>
+                                    <div class="text-muted">
+                                        Auto-generate tasks for regular activities
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                         <h2>Time Management</h2>
                         <div class="row mt16 o_settings_container" name="project_time">

--- a/addons/project/wizard/__init__.py
+++ b/addons/project/wizard/__init__.py
@@ -1,7 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import controllers
-from . import models
-from . import report
-from . import wizard
+from . import project_edit_recurrence

--- a/addons/project/wizard/project_edit_recurrence.py
+++ b/addons/project/wizard/project_edit_recurrence.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, api, _
+from odoo.exceptions import UserError
+
+
+class ProjectTaskEditRecurrence(models.TransientModel):
+    _name = 'project.task.edit.recurrence'
+    _description = "Edit task recurrence"
+
+    """
+        If the user:
+            1) deletes a task
+            2) archives a task
+            3) edits a field kept when copying a task
+            4) edits the recurrency parameters
+            5) switches 'recurring task' to false
+        Raise a modal so that the user can select whether to delete/archive/modify:
+        this task (except for scenario 4)
+        this and the following tasks
+        all tasks
+        For scenario 5, archive the selected tasks
+    """
+
+    def _get_editing_style_selection_fields(self):
+        if self._context.get('editing_type', False) == 'edit_recurrence_settings':
+            return [
+                ('all', 'All Tasks'),
+                ('future', 'Current and following tasks')
+            ]
+        if self._context.get('editing_type', False) == 'edit_recurrence':
+            return [
+                ('all', 'All Tasks')
+            ]
+        return [
+            ('current', 'Current Task'),
+            ('all', 'All Tasks'),
+            ('future', 'Current and following tasks')
+        ]
+
+
+    @api.model
+    def default_get(self, fields):
+        result = super().default_get(fields)
+        result['task_id'] = self._context.get('task_id', False)
+        result['editing_type'] = self._context.get('editing_type', False)
+        if result['editing_type'] == 'edit_recurrence_settings':
+            result['editing_style'] = 'future'
+        elif result['editing_type'] == 'edit_recurrence':
+            result['editing_style'] = 'all'
+        else:
+            result['editing_style'] = 'current'
+        return result
+
+    task_id = fields.Many2one("project.task")
+    editing_type = fields.Selection([
+        ('unlink', 'Delete'),
+        ('archive', 'Archive'),
+        ('edit', 'Edit'),
+        ('edit_recurrence_settings', 'Edit the recurrence settings')
+    ])
+    editing_style = fields.Selection(selection=lambda self: self._get_editing_style_selection_fields())
+
+    def action_edit_recurrence(self):
+        if self.editing_type == 'unlink':
+            if self.editing_style == 'all':
+                self.env['project.task'].browse(self.task_id._get_all_tasks_from_this_recurrence()).with_context(force_delete=True).unlink()
+            elif self.editing_style == 'future':
+                self.env['project.task'].browse(self.task_id._get_all_following_tasks_from_this_recurrence()).with_context(force_delete=True).unlink()
+            else:
+                self.task_id.with_context(force_delete=True).unlink()
+            context = self.env.context.copy()
+            del context['task_id']
+            del context['editing_type']
+            action = self.env.ref('project.act_project_project_2_project_task_all').read()[0]
+            action.update({
+                'context': context,
+                'target': 'main'
+            })
+            return action
+        elif self.editing_type == 'archive':
+            active = self.task_id.active
+            print(active)
+            if self.editing_style == 'all':
+                self.env['project.task'].browse(self.task_id._get_all_tasks_from_this_recurrence()).with_context(archive=True).write({'active': not active})
+            elif self.editing_style == 'future':
+                self.env['project.task'].browse(self.task_id._get_all_following_tasks_from_this_recurrence()).with_context(archive=True).write({'active': not active})
+            else:
+                self.task_id.with_context(archive=True).write({'active': not active})
+            context = self.env.context.copy()
+            del context['task_id']
+            del context['editing_type']
+            action = self.env.ref('project.act_project_project_2_project_task_all').read()[0]
+            action.update({
+                'context': context,
+                'target': 'main'
+            })
+            return action
+        elif self.editing_type == 'edit':
+            if self.editing_style == 'all':
+                self.env['project.task'].browse(self.task_id._get_all_tasks_from_this_recurrence()).with_context(edit=True).write(self.env.context.get('modified_values'))
+            elif self.editing_style == 'future':
+                self.env['project.task'].browse(self.task_id._get_all_following_tasks_from_this_recurrence()).with_context(edit=True).write(self.env.context.get('modified_values'))
+            else:
+                self.task_id.with_context(edit=True).write(self.env.context.get('modified_values'))
+            context = self.env.context.copy()
+            del context['task_id']
+            del context['editing_type']
+            del context['modified_values']
+            action = self.env.ref('project.act_project_project_2_project_task_all').read()[0]
+            action.update({
+                'context': context,
+                'target': 'main'
+            })
+            return action
+        elif self.editing_type == 'edit_recurrence_settings':
+            if self.editing_style == 'all':
+                self.env['project.task'].browse(self.task_id._get_all_tasks_from_this_recurrence()).with_context(edit=True).write(self.env.context.get('modified_values'))
+            elif self.editing_style == 'future':
+                self.env['project.task'].browse(self.task_id._get_all_following_tasks_from_this_recurrence()).with_context(edit=True).write(self.env.context.get('modified_values'))
+            # else:
+            #     self.task_id.with_context(edit=True).write(self.env.context.get('values'))
+            context = self.env.context.copy()
+            del context['task_id']
+            del context['editing_type']
+            del context['modified_values']
+            action = self.env.ref('project.act_project_project_2_project_task_all').read()[0]
+            action.update({
+                'context': context,
+                'target': 'main'
+            })
+            return action
+        else:
+            raise UserError(_('Please choose one of the options'))

--- a/addons/project/wizard/project_edit_recurrence_views.xml
+++ b/addons/project/wizard/project_edit_recurrence_views.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="project_task_edit_recurrence_view_form" model="ir.ui.view">
+        <field name="name">project.task.edit.recurrence.wizard.form</field>
+        <field name="model">project.task.edit.recurrence</field>
+        <field name="arch" type="xml">
+            <form string="Edit the recurrence">
+                <group>
+                    <field name="task_id" readonly="1"/>
+                </group>
+                <group>
+                    <field name="editing_type" invisible="1"/>
+                    <field name="editing_style" required="1" widget="radio"/>
+                </group>
+                <footer>
+                    <button string="Edit recurrence" type="object" name="action_edit_recurrence" class="oe_highlight"/>
+                    <button string="Cancel" special="cancel" type="object" class="btn btn-secondary oe_inline"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="project_task_action_edit_recurrence" model="ir.actions.act_window">
+        <field name="name">Edit the recurrence</field>
+        <field name="res_model">project.task.edit.recurrence</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="project_task_edit_recurrence_view_form"/>
+        <field name="target">new</field>
+    </record>
+</odoo>

--- a/addons/web/static/src/js/services/crash_manager.js
+++ b/addons/web/static/src/js/services/crash_manager.js
@@ -357,17 +357,15 @@ var RedirectWarningHandler = Widget.extend(ExceptionHandler, {
     display: function() {
         var self = this;
         var error = this.error;
-
+        var additional_context = this.context
+        if (error.data.arguments.length > 3) {
+            additional_context = _.extend({}, additional_context, error.data.arguments[3]);
+        };
         new WarningDialog(this, {
             title: _.str.capitalize(error.type) || _t("Odoo Warning"),
             buttons: [
                 {text: error.data.arguments[2], classes : "btn-primary", click: function() {
-                    $.bbq.pushState({
-                        'action': error.data.arguments[1],
-                        'cids': $.bbq.getState().cids,
-                    }, 2);
-                    self.destroy();
-                    location.reload();
+                    self.do_action(error.data.arguments[1], {additional_context:additional_context});
                 }},
                 {text: _t("Cancel"), click: function() { self.destroy(); }, close: true}
             ]


### PR DESCRIPTION
Purpose
=======
Some activities are repeated regularly. Having the possibility
to auto-generate those would be great.

Specifications
==============
Add the recurrence feature to the settings of project. When
it's enabled, enable it by default on all existing and future
projects.

Add a 'Recurring tasks' checkbox to the project view form
to enable/disable the feature on a project.

When Recurring tasks is True on a project, show a new tab
on project task form.

In this tab you have the recurrency settings for the task:
Every X days/weeks/months/years until
-forever
-last date
-numper of repetitions

You also have the possibility to choose how long before
the deadline the task should be created.

Task-2172156
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
