### PR TITLE
[IMP] website_slides: Allow to make a review with stars only

### DIFF
--- a/addons/portal/controllers/mail.py
+++ b/addons/portal/controllers/mail.py
@@ -130,7 +130,7 @@ class PortalChatter(http.Controller):
         attachment_tokens = [attachment_token for attachment_token in attachment_tokens.split(',') if attachment_token]
         self._portal_post_check_attachments(attachment_ids, attachment_tokens)
 
-        if message or attachment_ids:
+        if message or attachment_ids or kw.get('force'):
             # message is received in plaintext and saved in html
             if message:
                 message = plaintext2html(message)

--- a/addons/portal_rating/controllers/portal_chatter.py
+++ b/addons/portal_rating/controllers/portal_chatter.py
@@ -17,6 +17,9 @@ class PortalChatter(PortalChatter):
     @http.route()
     def portal_chatter_post(self, res_model, res_id, message, redirect=None, attachment_ids='', attachment_tokens='', **kwargs):
         if kwargs.get('rating_value'):
+            if not message and kwargs.get('rating_value') != '0' and 'false':
+                # Ensuring the rating is created even if there's no message
+                kwargs['force'] = True
             kwargs['rating_feedback'] = kwargs.pop('rating_feedback', message)
         return super(PortalChatter, self).portal_chatter_post(res_model, res_id, message, redirect=redirect, attachment_ids=attachment_ids, attachment_tokens=attachment_tokens, **kwargs)
 

--- a/addons/portal_rating/static/src/js/portal_chatter.js
+++ b/addons/portal_rating/static/src/js/portal_chatter.js
@@ -43,9 +43,13 @@ PortalChatter.include({
             this.options = _.defaults(this.options, {
                 'display_rating': false,
                 'rating_default_value': 0.0,
+                'rating_count': 0,
+                'disable_count': false,
+                'disable_messages': false,
             });
         }
         // rating card
+        this.set('rating_count', this.options.rating_count);
         this.set('rating_card_values', {});
         this.set('rating_value', false);
         this.on("change:rating_value", this, this._onChangeRatingDomain);
@@ -117,7 +121,7 @@ PortalChatter.include({
                 'percent': [],
             };
             _.each(_.keys(result['rating_stats']['percent']).reverse(), function (rating) {
-                if (rating % 2 === 0) {
+                if (rating <= 5) {
                     ratingData['percent'].push({
                         'num': rating,
                         'percent': utils.round_precision(result['rating_stats']['percent'][rating], 0.01),
@@ -208,6 +212,9 @@ PortalChatter.include({
      * @param {MouseEvent} ev
      */
     _onClickStarDomain: function (ev) {
+        if (this.options.disable_messages) {
+            return false;
+        }
         var $tr = this.$(ev.currentTarget);
         var num = $tr.data('star');
         if ($tr.css('opacity') === '1') {

--- a/addons/portal_rating/static/src/js/portal_rating_composer.js
+++ b/addons/portal_rating/static/src/js/portal_rating_composer.js
@@ -23,7 +23,7 @@ var RatingPopupComposer = publicWidget.Widget.extend({
 
     init: function (parent, options) {
         this._super.apply(this, arguments);
-        this.rating_avg = Math.round(options['ratingAvg'] / 100) / 100 || 0.0;
+        this.rating_avg = Math.round(options['ratingAvg'] * 100) / 100 || 0.0;
         this.rating_total = options['ratingTotal'] || 0.0;
 
         this.options = _.defaults({}, options, {

--- a/addons/portal_rating/static/src/xml/portal_chatter.xml
+++ b/addons/portal_rating/static/src/xml/portal_chatter.xml
@@ -37,11 +37,16 @@
 
     <t t-extend="portal.Chatter">
         <t t-jquery="t[t-call='portal.chatter_message_count']" t-operation="replace">
-            <t t-if="widget.options['display_rating']">
+            <t t-if="widget.options['display_rating'] and !widget.options['disable_count']">
                 <t t-call="portal_rating.rating_card"/>
             </t>
-            <t t-if="!widget.options['display_rating']">
+            <t t-elif="!widget.options['disable_count']">
                 <t t-call="portal.chatter_message_count"/>
+            </t>
+        </t>
+        <t t-jquery="t[t-call='portal.chatter_messages']" t-operation="replace">
+            <t t-if="!widget.options['disable_messages']">
+                <t t-call="portal.chatter_messages"/>
             </t>
         </t>
     </t>

--- a/addons/portal_rating/static/src/xml/portal_tools.xml
+++ b/addons/portal_rating/static/src/xml/portal_tools.xml
@@ -17,6 +17,20 @@
         </div>
     </t>
 
+    <t t-name="portal_rating.chatter_rating_count">
+        <t t-set="count" t-value="widget.get('rating_count')"/>
+        <div class="o_rating_counter">
+            <t t-if="count > 0">
+                <span class="o_message_count"> <t t-esc="count"/></span>
+                <t t-if="count == 1">rating</t>
+                <t t-else="">ratings</t>
+            </t>
+            <t t-else="">
+                There are no ratings for now.
+            </t>
+        </div>
+    </t>
+
     <t t-name="portal_rating.rating_card">
         <div class="row o_website_rating_card_container">
             <div class="col-lg-3 offset-lg-2" t-if="!_.isEmpty(widget.get('rating_card_values'))">
@@ -26,7 +40,7 @@
                     <t t-call="portal_rating.rating_stars_static">
                         <t t-set="val" t-value="widget.get('rating_card_values')['avg'] || 0"/>
                     </t>
-                    <t t-call="portal.chatter_message_count"/>
+                    <t t-call="portal_rating.chatter_rating_count"/>
                 </div>
             </div>
             <div class="col-lg-6" t-if="!_.isEmpty(widget.get('rating_card_values'))">

--- a/addons/portal_rating/views/portal_templates.xml
+++ b/addons/portal_rating/views/portal_templates.xml
@@ -3,6 +3,10 @@
     <template id="message_thread" inherit_id="portal.message_thread">
         <xpath expr="//div[@id='discussion']" position="attributes">
             <attribute name="t-att-data-display_rating">display_rating or False</attribute>
+            <attribute name="t-att-data-domain">json.dumps(reviews_domain)</attribute>
+            <attribute name="t-att-data-rating_count">rating_count</attribute>
+            <attribute name="t-att-data-disable_count">disable_count or False</attribute>
+            <attribute name="t-att-data-disable_messages">disable_messages or False</attribute>
         </xpath>
     </template>
 </odoo>

--- a/addons/rating/models/mail_thread.py
+++ b/addons/rating/models/mail_thread.py
@@ -18,7 +18,7 @@ class MailThread(models.AbstractModel):
         if rating_value:
             ir_model = self.env['ir.model'].sudo().search([('model', '=', self._name)])
             self.env['rating.rating'].sudo().create({
-                'rating': float(rating_value) if rating_value is not None else False,
+                'rating': float(rating_value) if rating_value is not None and rating_value != 'false' else False,
                 'feedback': rating_feedback,
                 'res_model_id': ir_model.id,
                 'res_id': self.id,

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -347,6 +347,7 @@ class WebsiteSale(http.Controller):
             'categories': categs,
             'main_object': product,
             'product': product,
+            'rating_count': product.rating_count,
             'add_qty': add_qty,
             'view_track': view_track,
         }

--- a/addons/website_slides/controllers/mail.py
+++ b/addons/website_slides/controllers/mail.py
@@ -67,7 +67,7 @@ class SlidesPortalChatter(PortalChatter):
             domain = [('res_model', '=', res_model), ('res_id', '=', res_id), ('is_internal', '=', False), ('message_id', '=', message.id)]
             rating = request.env['rating.rating'].sudo().search(domain, order='write_date DESC', limit=1)
             rating.write({
-                'rating': float(post['rating_value']),
+                'rating': post['rating_value'] != 'false' and float(post['rating_value']) or False,
                 'feedback': html2plaintext(message.body),
             })
 

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -444,6 +444,8 @@ class WebsiteSlides(WebsiteProfile):
             # chatter
             'rating_avg': channel.rating_avg,
             'rating_count': channel.rating_count,
+            'review_count': channel.rating_review_count,
+            'reviews_domain': [('body_is_empty', '=', False)],
             # display data
             'user': request.env.user,
             'pager': pager,

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -584,7 +584,7 @@ class Channel(models.Model):
     def action_view_ratings(self):
         action = self.env.ref('website_slides.rating_rating_action_slide_channel').read()[0]
         action['name'] = _('Rating of %s') % (self.name)
-        action['domain'] = [('res_id', 'in', self.ids)]
+        action['domain'] = self._rating_domain()
         return action
 
     # ---------------------------------------------------------

--- a/addons/website_slides/static/src/scss/rating_rating_views.scss
+++ b/addons/website_slides/static/src/scss/rating_rating_views.scss
@@ -1,10 +1,19 @@
 $o-kanban-large-record-width: 350px;
+$o-kanban-medium-record-width: 200px;
 
 .o_kanban_view.o_slide_rating_kanban {
     .o_kanban_record {
+        width: $o-kanban-medium-record-width
+    }
+}
+
+.o_kanban_view.o_slide_review_kanban{
+    .o_kanban_record{
         width: $o-kanban-large-record-width
     }
+}
 
+.o_kanban_view.o_slide_rating_kanban,.o_kanban_view.o_slide_review_kanban{
     .o_slide_rating_kanban_left {
         min-width: 80px;
 

--- a/addons/website_slides/views/rating_rating_views.xml
+++ b/addons/website_slides/views/rating_rating_views.xml
@@ -3,7 +3,6 @@
     <record id="rating_rating_view_kanban_slide_channel" model="ir.ui.view">
         <field name="name">rating.rating.view.kanban.slides</field>
         <field name="model">rating.rating</field>
-        <field name="priority">20</field>
         <field name="arch" type="xml">
             <kanban create="false" class="o_slide_rating_kanban">
                 <field name="rating"/>
@@ -17,8 +16,8 @@
                         <t t-set="val_decimal" t-value="val_stars - val_integer"/>
                         <t t-set="empty_star" t-value="5 - (val_integer + Math.ceil(val_decimal))"/>
                         <div class="oe_kanban_card oe_kanban_global_click">
-                            <div class="d-flex flex-row">
-                                <div class="o_slide_rating_kanban_left mr-3">
+                            <div class="d-flex flex-row text-center">
+                                <div class="o_slide_rating_kanban_left w-100">
                                     <h1 class="o_slide_rating_value text-center text-primary" t-esc="val_stars"/>
                                     <t t-foreach="_.range(0, val_integer)" t-as="num">
                                         <i class="fa fa-star" aria-label="A star" role="img"></i>
@@ -29,28 +28,16 @@
                                     <t t-foreach="_.range(0, empty_star)" t-as="num" role="img">
                                         <i class="fa fa-star text-black-25" aria-label="A star"></i>
                                     </t>
-                                </div>
-                                <div>
-                                    <div class="o_kanban_card_header">
-                                        <div class="o_kanban_card_header_title">
-                                            <span class="font-weight-bold"><field name="partner_id"/></span>
-                                        </div>
-                                    </div>
-                                    <div class="o_kanban_card_content mt0 d-flex flex-column">
-                                        <span>
-                                            <i class="fa fa-folder mr-2" aria-label="Open folder"></i>
-                                            <a type="object" name="action_open_rated_object" t-att-title="record.res_name.raw_value">
-                                                <field name="res_name" />
-                                            </a>
-                                        </span>
-                                        <span><i class="fa fa-clock-o mr-2" aria-label="Create date"/> <field name="create_date" /></span>
-                                        <div class="d-flex mt-2">
-                                            <span t-esc="record.feedback.raw_value"/>
-                                        </div>
+                                    <div class="font-weight-bold"><field name="partner_id"/></div>
+                                    <div>
+                                        <i class="fa fa-folder mr-2" aria-label="Open folder"></i>
+                                        <a type="object" name="action_open_rated_object" t-att-title="record.res_name.raw_value">
+                                            <field name="res_name"/>
+                                        </a>
                                     </div>
                                 </div>
-                             </div>
-                         </div>
+                            </div>
+                        </div>
                     </t>
                 </templates>
             </kanban>
@@ -86,6 +73,17 @@
         </field>
     </record>
 
+    <record id="rating_rating_view_tree_slides" model="ir.ui.view">
+        <field name="name">rating.rating.view.tree.slides.channel</field>
+        <field name="model">rating.rating</field>
+        <field name="mode">primary</field>
+        <field name="priority" eval="5"/>
+        <field name="inherit_id" ref="rating.rating_rating_view_tree"/>
+        <field name="arch" type="xml">
+            <field name="feedback" position="replace"/>
+        </field>
+    </record>
+
     <record id="rating_rating_view_pivot_slide_channel" model="ir.ui.view">
         <field name="name">rating.rating.view.pivot.slides</field>
         <field name="model">rating.rating</field>
@@ -99,6 +97,48 @@
         </field>
     </record>
 
+    <record id="rating_rating_view_kanban_slide_channel_review" model="ir.ui.view">
+        <field name="name">rating.review.view.kanban.slides</field>
+        <field name="model">rating.rating</field>
+        <field name="mode">primary</field>
+        <field name="priority" eval="25"/>
+        <field name="inherit_id" ref="rating_rating_view_kanban_slide_channel"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[1]/div[1]/div[1]/div[2]" position="replace" />
+            <xpath expr="//div[1]/div[1]/div[1]/div[1]" position="replace" />
+            <xpath expr="//div[1]/div[1]" position="attributes">
+                <attribute name="class">d-flex flex-row</attribute>
+            </xpath>
+            <xpath expr="//kanban" position="attributes">
+                <attribute name="class">o_slide_review_kanban</attribute>
+            </xpath>
+            <xpath expr="//div[1]/div[1]/div[1]" position="attributes">
+                <attribute name="class">o_slide_rating_kanban_left mr-3</attribute>
+            </xpath>
+            <xpath expr="//div[1]/div[1]/div[1]" position="after">
+                <div>
+                    <div class="o_kanban_card_header">
+                        <div class="o_kanban_card_header_title">
+                            <span class="font-weight-bold"><field name="partner_id"/></span>
+                        </div>
+                    </div>
+                    <div class="o_kanban_card_content mt0 d-flex flex-column">
+                        <span>
+                            <i class="fa fa-folder mr-2" aria-label="Open folder"></i>
+                            <a type="object" name="action_open_rated_object" t-att-title="record.res_name.raw_value">
+                                <field name="res_name"/>
+                            </a>
+                        </span>
+                        <span><i class="fa fa-clock-o mr-2" aria-label="Create date"/> <field name="create_date" /></span>
+                        <div class="d-flex mt-2">
+                            <span t-esc="record.feedback.raw_value"/>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
     <record id="rating_rating_action_slide_channel" model="ir.actions.act_window">
         <field name="name">Rating</field>
         <field name="res_model">rating.rating</field>
@@ -107,6 +147,23 @@
         <field name="context">{}</field>
         <field name="search_view_id" ref="rating_rating_view_search_slide_channel"/>
         <field name="view_id" ref="rating_rating_view_kanban_slide_channel"/>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_empty_folder">
+                There are no ratings for these courses at the moment
+            </p>
+        </field>
+    </record>
+
+    <record id="rating_rating_action_slide_channel_review" model="ir.actions.act_window">
+        <field name="name">Review</field>
+        <field name="res_model">rating.rating</field>
+        <field name="view_mode">kanban,tree,graph,pivot,form</field>
+        <field name="domain">[('consumed', '=', True), ('res_model', '=', 'slide.channel'), ('feedback', '!=', '')]</field>
+        <field name="context">{}</field>
+        <field name="search_view_id" ref="rating_rating_view_search_slide_channel"/>
+        <field name="view_ids" eval="[(5, 0, 0),
+            (0, 0, {'view_mode': 'kanban', 'view_id': ref('rating_rating_view_kanban_slide_channel_review')}),
+            (0, 0, {'view_mode': 'tree', 'view_id': ref('rating.rating_rating_view_tree')}),]"/>
         <field name="help" type="html">
             <p class="o_view_nocontent_empty_folder">
                 There are no ratings for these courses at the moment

--- a/addons/website_slides/views/slide_channel_views.xml
+++ b/addons/website_slides/views/slide_channel_views.xml
@@ -45,7 +45,7 @@
                                 class="oe_stat_button"
                                 groups="website_slides.group_website_slides_officer"
                                 attrs="{'invisible': [('allow_comment', '=', False)]}">
-                                <field name="rating_count" string="Reviews" widget="statinfo"/>
+                                <field name="rating_count" string="Ratings" widget="statinfo"/>
                             </button>
                             <field name="is_published" widget="website_redirect_button"/>
                         </div>
@@ -258,7 +258,7 @@
                                         </div>
                                         <div class="col-6 o_kanban_primary_right">
                                             <div class="d-flex" t-if="record.rating_count.raw_value">
-                                                <a name="action_view_ratings" type="object" class="mr-auto"><field name="rating_count"/> reviews</a>
+                                                <a name="action_view_ratings" type="object" class="mr-auto"><field name="rating_count"/>ratings</a>
                                                 <span><field name="rating_avg_stars"/> / 5</span>
                                             </div>
                                             <div class="d-flex">

--- a/addons/website_slides/views/website_slides_menu_views.xml
+++ b/addons/website_slides/views/website_slides_menu_views.xml
@@ -32,11 +32,16 @@
         parent="website_slides_menu_courses"
         sequence="2"
         action="slide_slide_action"/>
-    <menuitem name="Reviews"
-        id="website_slides_menu_courses_reviews"
+    <menuitem name="Ratings"
+        id="website_slides_menu_courses_ratings"
         parent="website_slides_menu_courses"
         sequence="3"
         action="rating_rating_action_slide_channel"/>
+    <menuitem name="Reviews"
+        id="website_slides_menu_courses_reviews"
+        parent="website_slides_menu_courses"
+        sequence="4"
+        action="rating_rating_action_slide_channel_review"/>
 
     <!-- Reporting sub-menu -->
     <menuitem name="Courses"

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -158,11 +158,6 @@
                 </div>
             </div>
 
-            <!-- Share modal : here to avoid having text-white from o_wslides_course_header -->
-            <t t-call="website_slides.slide_share_modal" t-if="channel.channel_type == 'documentation'">
-                <t t-set="record" t-value="channel"/>
-            </t>
-
             <div class="o_wslides_course_main">
                 <!-- ========== TRAINING COURSE ========== -->
                 <div t-if="channel.channel_type == 'training'" class="container">
@@ -183,10 +178,17 @@
                                     </a>
                                 </li>
                                 <li t-if="channel.allow_comment" class="nav-item o_wslides_course_header_nav_review_training">
+                                    <a t-att-class="'nav-link %s' % ('active' if active_tab == 'rating' else '')"
+                                        id="rating-tab" data-toggle="pill" href="#rating" role="tab" aria-controls="rating"
+                                        t-att-aria-selected="'true' if active_tab == 'rating' else 'false'">
+                                        Rating
+                                    </a>
+                                </li>
+                                <li t-if="channel.allow_comment and review_count > 0" class="nav-item o_wslides_course_header_nav_review_training">
                                     <a t-att-class="'nav-link %s' % ('active' if active_tab == 'review' else '')"
                                         id="review-tab" data-toggle="pill" href="#review" role="tab" aria-controls="review"
                                         t-att-aria-selected="'true' if active_tab == 'review' else 'false'">
-                                        Reviews<t t-if="rating_count"> (<t t-esc="rating_count"/>)</t>
+                                        Reviews<t t-if="review_count"> (<t t-esc="review_count"/>)</t>
                                     </a>
                                 </li>
                             </ul>
@@ -211,6 +213,16 @@
                                     </div>
                                     <t t-if="channel.channel_type == 'training'" t-call="website_slides.course_slides_list"/>
                                 </div>
+                                <div t-if="channel.allow_comment" t-att-class="'tab-pane fade %s' % ('show active' if active_tab == 'rating' else '')" id="rating" role="tabpanel" aria-labelledby="rating-tab">
+                                    <t t-call="portal.message_thread">
+                                        <t t-set="object" t-value="channel"/>
+                                        <t t-set="hash" t-value="message_post_hash"/>
+                                        <t t-set="pid" t-value="message_post_pid"/>
+                                        <t t-set="display_rating" t-value="True"/>
+                                        <t t-set="disable_composer" t-value="True"/>
+                                        <t t-set="disable_messages" t-value="True"/>
+                                    </t>
+                                </div>
                                 <div t-if="channel.allow_comment" t-att-class="'tab-pane fade %s' % ('show active' if active_tab == 'review' else '')" id="review" role="tabpanel" aria-labelledby="review-tab">
                                     <t t-call="portal.message_thread">
                                         <t t-set="object" t-value="channel"/>
@@ -218,6 +230,7 @@
                                         <t t-set="pid" t-value="message_post_pid"/>
                                         <t t-set="display_rating" t-value="True"/>
                                         <t t-set="disable_composer" t-value="True"/>
+                                        <t t-set="disable_count" t-value="True"/>
                                     </t>
                                 </div>
                             </div>
@@ -239,11 +252,18 @@
                                             Course
                                         </a>
                                     </li>
-                                    <li t-if="channel.allow_comment" class="nav-item o_wslides_course_header_nav_review_documentation">
+                                    <li t-if="channel.allow_comment" class="nav-item o_wslides_course_header_nav_review_training">
+                                        <a t-att-class="'nav-link %s' % ('active' if active_tab == 'rating' else '')"
+                                            id="rating-tab" data-toggle="pill" href="#rating" role="tab" aria-controls="rating"
+                                            t-att-aria-selected="'true' if active_tab == 'rating' else 'false'">
+                                            Rating
+                                        </a>
+                                    </li>
+                                    <li t-if="channel.allow_comment and review_count > 0" class="nav-item o_wslides_course_header_nav_review_documentation">
                                         <a t-att-class="'nav-link %s' % ('active' if active_tab == 'review' else '')"
                                             id="review-tab" data-toggle="pill" href="#review" role="tab" aria-controls="review"
                                             t-att-aria-selected="'true' if active_tab == 'review' else 'false'">
-                                            Reviews<t t-if="rating_count"> (<t t-esc="rating_count"/>)</t>
+                                            Reviews<t t-if="review_count"> (<t t-esc="review_count"/>)</t>
                                         </a>
                                     </li>
                                 </ul>
@@ -251,9 +271,21 @@
                         </div>
                     </div>
 
-                    <div class="tab-content pb-5" id="courseMainTabContent">
+                    <div class="tab-content pb-5 o_wslides_tabs_content" id="courseMainTabContent">
                         <div t-att-class="'tab-pane fade %s' % ('show active' if active_tab == 'home' else '')" id="home" role="tabpanel" aria-labelledby="home-tab">
                             <t t-if="channel.channel_type == 'documentation'" t-call="website_slides.course_slides_cards"/>
+                        </div>
+                        <div t-if="channel.allow_comment" t-att-class="'tab-pane fade %s' % ('show active' if active_tab == 'rating' else '')" id="rating" role="tabpanel" aria-labelledby="rating-tab">
+                            <div class="container pt-4">
+                                <t t-call="portal.message_thread">
+                                    <t t-set="object" t-value="channel"/>
+                                    <t t-set="hash" t-value="message_post_hash"/>
+                                    <t t-set="pid" t-value="message_post_pid"/>
+                                    <t t-set="display_rating" t-value="True"/>
+                                    <t t-set="disable_composer" t-value="True"/>
+                                    <t t-set="disable_messages" t-value="True"/>
+                                </t>
+                            </div>
                         </div>
                         <div t-if="channel.allow_comment" t-att-class="'tab-pane fade %s' % ('show active' if active_tab == 'review' else '')" id="review" role="tabpanel" aria-labelledby="review-tab">
                             <div class="container pt-4">
@@ -263,6 +295,7 @@
                                     <t t-set="pid" t-value="message_post_pid"/>
                                     <t t-set="display_rating" t-value="True"/>
                                     <t t-set="disable_composer" t-value="True"/>
+                                    <t t-set="disable_count" t-value="True"/>
                                 </t>
                             </div>
                         </div>


### PR DESCRIPTION
Remove the message constraint to rate a course on the review popup.
Split Ratings from reviews so that we have
        rating: which  only require rating value
        review: which is a rating value and a comment

task-2184038

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
