### PR TITLE
[FIX] l10n_multilang : Translation not working when load COA

### DIFF
--- a/addons/l10n_multilang/models/l10n_multilang.py
+++ b/addons/l10n_multilang/models/l10n_multilang.py
@@ -12,8 +12,8 @@ _logger = logging.getLogger(__name__)
 class AccountChartTemplate(models.Model):
     _inherit = 'account.chart.template'
 
-    def load_for_current_company(self, sale_tax_rate, purchase_tax_rate):
-        res = super(AccountChartTemplate, self).load_for_current_company(sale_tax_rate, purchase_tax_rate)
+    def _load(self, sale_tax_rate, purchase_tax_rate, company):
+        res = super(AccountChartTemplate, self)._load(sale_tax_rate, purchase_tax_rate, company)
         # Copy chart of account translations when loading chart of account
         for chart_template in self.filtered('spoken_languages'):
             external_id = self.env['ir.model.data'].search([


### PR DESCRIPTION
https://github.com/odoo/odoo/commit/f8d4bf4499e1e21cbce853c3a5f78fe5574abe6c in this commit account.chart.template model method "load_for_current_company is" changed to "_load" but forgot to change in l10n_multilang where this method is inherited

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
