### PR TITLE
[IMP] base: index optimization on ir.translation

### DIFF
--- a/odoo/addons/base/models/ir_translation.py
+++ b/odoo/addons/base/models/ir_translation.py
@@ -157,7 +157,7 @@ class IrTranslation(models.Model):
     _log_access = False
 
     name = fields.Char(string='Translated field', required=True)
-    res_id = fields.Integer(string='Record ID')
+    res_id = fields.Integer(string='Record ID', index=True)
     lang = fields.Selection(selection='_get_languages', string='Language', validate=False)
     type = fields.Selection(TRANSLATION_TYPE, string='Type', index=True)
     src = fields.Text(string='Internal Source')  # stored in database, kept for backward compatibility

--- a/odoo/addons/base/models/ir_translation.py
+++ b/odoo/addons/base/models/ir_translation.py
@@ -187,6 +187,8 @@ class IrTranslation(models.Model):
         res = super(IrTranslation, self)._auto_init()
         # Add separate hash index on src (no size limit on values, and good performance).
         tools.create_index_using(self._cr, 'ir_translation_src_hash', self._table, ['src'], 'hash')
+        if not tools.index_exists(self._cr, 'ir_translation_value_set_idx'):
+            self._cr.execute("CREATE INDEX ir_translation_value_set_idx ON ir_translation (name, lang, res_id, id DESC) WHERE value != ''")
 
         if not tools.index_exists(self._cr, 'ir_translation_unique'):
             self._cr.execute("CREATE UNIQUE INDEX ir_translation_unique ON ir_translation (type, name, lang, res_id, md5(src)) WHERE type = 'model_terms'")
@@ -194,6 +196,7 @@ class IrTranslation(models.Model):
             self._cr.execute("CREATE UNIQUE INDEX ir_translation_code_unique ON ir_translation (type, lang, md5(src)) WHERE type = 'code'")
         if not tools.index_exists(self._cr, 'ir_translation_model_unique'):
             self._cr.execute("CREATE UNIQUE INDEX ir_translation_model_unique ON ir_translation (type, lang, name, res_id) WHERE type = 'model'")
+
 
         return res
 

--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -204,6 +204,14 @@ def create_unique_index(cr, indexname, tablename, expressions):
     cr.execute('CREATE UNIQUE INDEX "{}" ON "{}" ({})'.format(indexname, tablename, args))
     _schema.debug("Table %r: created index %r (%s)", tablename, indexname, args)
 
+def create_index_using(cr, indexname, tablename, expressions, using='btree'):
+    """ Create the given index unless it exists. """
+    if index_exists(cr, indexname):
+        return
+    args = ', '.join(expressions)
+    cr.execute('CREATE INDEX "{}" ON "{}" USING {} ({})'.format(indexname, tablename, using, args))
+    _schema.debug("Table %r: created %s index %r (%s)", tablename, using, indexname, args)
+
 def drop_index(cr, indexname, tablename):
     """ Drop the given index if it exists. """
     cr.execute('DROP INDEX IF EXISTS "{}"'.format(indexname))

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -343,11 +343,11 @@ def html_translate(callback, value):
 #
 def translate(cr, name, source_type, lang, source=None):
     if source and name:
-        cr.execute('select value from ir_translation where lang=%s and type=%s and name=%s and src=%s and md5(src)=md5(%s)', (lang, source_type, str(name), source, source))
+        cr.execute('select value from ir_translation where lang=%s and type=%s and name=%s and md5(src)=md5(%s)', (lang, source_type, str(name), source, source))
     elif name:
         cr.execute('select value from ir_translation where lang=%s and type=%s and name=%s', (lang, source_type, str(name)))
     elif source:
-        cr.execute('select value from ir_translation where lang=%s and type=%s and src=%s and md5(src)=md5(%s)', (lang, source_type, source, source))
+        cr.execute('select value from ir_translation where lang=%s and type=%s and md5(src)=md5(%s)', (lang, source_type, source, source))
     res_trans = cr.fetchone()
     res = res_trans and res_trans[0] or False
     return res


### PR DESCRIPTION
Since postgresql 10.0, hash indexes are safe to be used
https://www.postgresql.org/docs/10/release-10.html#id-1.11.6.17.5.3.3

> - Add write-ahead logging support to hash indexes (Amit Kapila)
>   - This makes hash indexes crash-safe and replicatable. The former warning message about their use is removed.
> - Improve hash index performance (Amit Kapila, Mithun Cy, Ashutosh Sharma)

Hash indexes [are faster](http://amitkapila16.blogspot.com/2017/03/hash-indexes-are-faster-than-btree.html) but only works on `=` operator. So ideal for translations where we do exact match searches.

A standard ir_translation table with 138k records (67 modules installed and 7 languages activated), after a vacuum analyze.
```
 table_size | indexes_size | total_size 
------------+--------------+------------
 24 MB      | 59 MB        | 71 MB
```

With this branch, same modules and languages:

```
 table_size | indexes_size | total_size 
------------+--------------+------------
 24 MB      | 47 MB        | 71 MB
```

Remove index on `res_id` and `comments` as not useful.

Switching from `md5` index to native hash index reduced the size of the index from 11MB to 5MB.
Switching `ir_translation_unique` to a partial index reduced the size of the index from 21MB to 8MB.

Unique hash index is not (yet?) possible so need to maintain the other `md5` unique indexes.

Remove the `order='module'`, we don't care of the order in this specific case.

PS: to extrapolate, on odoo.com, the ir_translation takes 380MB for data and 2023MB for indexes.