### PR TITLE
[FIX] stock_sms : SMS confirmation

### DIFF
--- a/addons/stock_sms/models/res_config_settings.py
+++ b/addons/stock_sms/models/res_config_settings.py
@@ -9,6 +9,6 @@ class ResConfigSettings(models.TransientModel):
 
     stock_move_sms_validation = fields.Boolean(
         related='company_id.stock_move_sms_validation',
-        string='SMS Validation with stock move', readonly=False)
+        string='SMS Validation', readonly=False)
     stock_sms_confirmation_template_id = fields.Many2one(
         related='company_id.stock_sms_confirmation_template_id', readonly=False)


### PR DESCRIPTION
PURPOSE

The SMS confirmation settings have the right and meaning full name.

SPECIFICATIONS

Currently, SMS confirmation settings have name looks like a technical name so, user can not understand the feature what is it dose and what is its use.

The main goal is to give a correct and meaning full name to SMS confirmation settings.

To do that we modify the name of SMS confirmation settings "SMS Validation with stock move" to "SMS Validation".

LINKS
PR#46016
Task 2185325




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
