### PR TITLE
[FIX] Multiple carrier tracking on web preview

### DIFF
--- a/addons/delivery/views/delivery_portal_template.xml
+++ b/addons/delivery/views/delivery_portal_template.xml
@@ -3,11 +3,20 @@
         <xpath expr="//div[hasclass('o_sale_stock_picking')]/div" position="after">
             <div t-if="i.carrier_tracking_ref" class="small d-lg-inline-block">
                 Tracking:
-                <t t-if="i.carrier_tracking_url">
-                    <a t-att-href="i.carrier_tracking_url" target="_blank"><span t-field="i.carrier_tracking_ref"/></a>
+                <t t-set="multiple_carrier_tracking" t-value="i.get_multiple_carrier_tracking()"/>
+                <t t-if="multiple_carrier_tracking">
+                     <t t-foreach="multiple_carrier_tracking" t-as="line">
+                         <a t-att-href="line[1]" target="_blank"><span t-esc="line[0]"/></a>
+                         <span t-if="not line_last"> + </span>
+                     </t>
                 </t>
                 <t t-else="">
-                     <span t-field="i.carrier_id.name"/> <span t-field="i.carrier_tracking_ref"/>
+                    <t t-if="i.carrier_tracking_url">
+                        <a t-att-href="i.carrier_tracking_url" target="_blank"><span t-field="i.carrier_tracking_ref"/></a>
+                    </t>
+                    <t t-else="">
+                        <span t-field="i.carrier_id.name"/> <span t-field="i.carrier_tracking_ref"/>
+                    </t>
                 </t>
             </div>
             <t t-if="i.carrier_id.get_return_label_from_portal and i.return_label_ids">


### PR DESCRIPTION
Current behavior before PR:
Incorrect URL links on web preview when there were several multiple carrier tracking.
The multiple tracking was already fixed in https://github.com/odoo/odoo/commit/5ed27d470cd76d0a742c25e2be473124428d0798
But only in the mail template and translation, the web preview wasn't corrected.

OPW-2199339
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
