### PR TITLE
[FIX] account: Register multiple payments without grouping

### DIFF
--- a/addons/account/tests/test_payment.py
+++ b/addons/account/tests/test_payment.py
@@ -93,6 +93,7 @@ class TestPayment(AccountingTestCase):
             'payment_date': time.strftime('%Y') + '-07-15',
             'journal_id': self.bank_journal_euro.id,
             'payment_method_id': self.payment_method_manual_in.id,
+            'group_invoices': True,
         })
         register_payments.create_payments()
         payment = self.payment_model.search([], order="id desc", limit=1)
@@ -251,6 +252,7 @@ class TestPayment(AccountingTestCase):
             'payment_date': time.strftime('%Y') + '-07-15',
             'journal_id': self.bank_journal_euro.id,
             'payment_method_id': self.payment_method_manual_in.id,
+            'group_invoices': True,
         })
 
         # Perform the partial payment by setting the amount at 300 instead of 500
@@ -605,6 +607,7 @@ class TestPayment(AccountingTestCase):
 
         batch_payment = self.env['account.register.payments'].with_context(active_ids=(inv1 + inv2).ids).create({
             'amount': 70,
+            'group_invoices': True,
             'partner_id': inv1.partner_id.id,
             'journal_id': self.bank_journal_usd.id,
             'invoice_ids': [(6, False, (inv1 + inv2).ids)],


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a supplier S
- Create two vendor bills for S: B1 for an amount A1 and B2 for an amount A2
- In the list view of vendor bills select B1 and B2
- In the action, select "Register a payment" and untick "group invoices"
- Register the payments

Bug:

Only one payment had been done for B1 and B2 instead of two.

opw:2190086