### PR TITLE
[IMP] point_of_sale: Manual discount.

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -217,6 +217,7 @@ class PosConfig(models.Model):
     rounding_method = fields.Many2one('account.cash.rounding', string="Cash rounding")
     cash_rounding = fields.Boolean(string="Cash Rounding")
     only_round_cash_method = fields.Boolean(string="Only apply rounding on cash")
+    manual_discount = fields.Boolean(string="Manual Discounts", default=True)
 
     @api.depends('use_pricelist', 'available_pricelist_ids')
     def _compute_allowed_pricelist_ids(self):

--- a/addons/point_of_sale/static/src/js/screens.js
+++ b/addons/point_of_sale/static/src/js/screens.js
@@ -433,6 +433,9 @@ var NumpadWidget = PosBaseWidget.extend({
         this.$el.find('.numpad-minus').click(_.bind(this.clickSwitchSign, this));
         this.$el.find('.number-char').click(_.bind(this.clickAppendNewChar, this));
         this.$el.find('.mode-button').click(_.bind(this.clickChangeMode, this));
+        if (!this.pos.config.manual_discount) {
+            this.$el.find('.mode-button[data-mode=discount]').prop("disabled",true);
+        }
     },
     applyAccessRights: function() {
         var cashier = this.pos.get('cashier') || this.pos.get_cashier();
@@ -544,7 +547,7 @@ var OrderWidget = PosBaseWidget.extend({
             var mode = this.numpad_state.get('mode');
             if( mode === 'quantity'){
                 order.get_selected_orderline().set_quantity(val);
-            }else if( mode === 'discount'){
+            }else if( mode === 'discount' && this.pos.config.manual_discount){
                 order.get_selected_orderline().set_discount(val);
             }else if( mode === 'price'){
                 var selected_orderline = order.get_selected_orderline();

--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -309,6 +309,17 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="col-xs-12 col-lg-6 o_setting_box" >
+                            <div class="o_setting_left_pane">
+                                <field name="manual_discount"/>
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label for="manual_discount"/>
+                                <div class="text-muted">
+                                    Allow discounts per line
+                                </div>
+                            </div>
+                        </div>
                         <div class="col-12 col-lg-6 o_setting_box">
                             <div class="o_setting_left_pane">
                                 <field name="module_pos_loyalty" widget="upgrade_boolean" nolabel="1"/>


### PR DESCRIPTION
The user is now able to select if he wants to use the manual discount or not.
Now we have an option in the pos config, by default True so enable the manual discout (discount per line).
If the option is false, the numpad button is disabled.

task-id: 2082140
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
