### PR TITLE
[FIX] website_profile: fix all users' page back button height

### DIFF
--- a/addons/website_profile/static/src/scss/website_profile.scss
+++ b/addons/website_profile/static/src/scss/website_profile.scss
@@ -148,7 +148,6 @@ $owprofile-color-bg: mix($body-bg, #efeff4);
             @include o-hover-text-color(white, $gray-800);
             margin-top: -1px;
             border-radius: 0;
-            min-height: 35px;
 
             &:hover {
                 background-color: white;


### PR DESCRIPTION
## Issue

	- Install Forum
	- Go to All Users

	The back button height is greater than the navbar height

### Cause

	There is a min-height 35px and it seems not needed

### Solution

	Remove it

Additional bug fix asked by SBU in:
**OPW-2198011**

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
