### PR TITLE
[FIX] base_setup: Add DOM id to license link

### DIFF
--- a/addons/base_setup/static/src/xml/res_config_edition.xml
+++ b/addons/base_setup/static/src/xml/res_config_edition.xml
@@ -14,7 +14,7 @@
                 <div>
                     <div class="tab-content">
                         <div role="tabpanel" id="settings" class="tab-pane active text-muted o_web_settings_compact_subtitle">
-                            <small>Copyright © 2004 <a target="_blank" href="https://www.odoo.com" style="text-decoration: underline;">Odoo S.A.</a> <a target="_blank" href="http://www.gnu.org/licenses/lgpl.html" style="text-decoration: underline;">GNU LGPL Licensed</a></small>
+                            <small>Copyright © 2004 <a target="_blank" href="https://www.odoo.com" style="text-decoration: underline;">Odoo S.A.</a> <a id="license" target="_blank" href="http://www.gnu.org/licenses/lgpl.html" style="text-decoration: underline;">GNU LGPL Licensed</a></small>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
With Odoo Enterprise Edition, the license is still GNU LGPL.
A DOM id is added here to allow targeting the license link in `web_enterprise`

Task 2198484


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
