### PR TITLE
[FIX] mail: livechat message are not always of type mail.mt_comment

### DIFF
--- a/addons/mail/static/src/js/models/threads/document_thread.js
+++ b/addons/mail/static/src/js/models/threads/document_thread.js
@@ -328,10 +328,14 @@ var DocumentThread = Thread.extend({
         var resID = this.getDocumentID();
         return this._super.apply(this, arguments)
             .then(function (messageData) {
+                var lastMessageSubtype = "mail.mt_comment"
+                if (self._messages.length) {
+                    lastMessageSubtype = self._messages[self._messages.length -1]._isNote ? "mail.mt_note" : "mail.mt_comment";
+                }
                 _.extend(messageData, {
                     context: data.context,
                     message_type: data.message_type,
-                    subtype: data.subtype || "mail.mt_comment",
+                    subtype: data.subtype || lastMessageSubtype,
                     subtype_id: data.subtype_id,
                 });
                 return self._rpc({


### PR DESCRIPTION
Steps to reproduce:
- install sales, contact, discuss
- go to Settings > Users > marc demo > and change the notification
type from "Handle by Emails" to "Handle in Odoo"
- (optional) give marc demo "Administrator" rights on the sales app
for easier testing
- go to sales > create a quotation and either e-mail the customer
or add him as a follower on the quote
- log an internal note to Marc Demo (with an @ so he gets a message)
- login with the user Marc Demo and open the messages from the top
- answer the message in the livechat window

Previous behavior:
messages sent trough the livechat are always set as comments
even if they are preceded by a note

Current behavior:
new messages follow the same implied rules as in the chatter.
answering a note produces a note, answering a comment
produces a comment

opw-2194944