### PR TITLE
[FIX] base: Cache-Control header with `unique` query string

### DIFF
--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -413,7 +413,7 @@ class IrHttp(models.AbstractModel):
             headers.append(('ETag', filehash))
             if etag == filehash and status == 200:
                 status = 304
-        headers.append(('Cache-Control', 'max-age=%s' % (http.STATIC_CACHE_LONG if unique else 0)))
+        headers.append(('Cache-Control', 'max-age=%s' % (http.STATIC_CACHE_LONG if (not unique) else 0)))
         # content-disposition default name
         if download:
             headers.append(('Content-Disposition', content_disposition(filename)))


### PR DESCRIPTION
Issue:

Scene 1 (described in steps)
1. Fetch an image with /web/image?model=product.product&field=image_128&id=1
2. In SPA, we most of the time rely on the cached image, that is
the reason why `unique` query string is recognize by our controller.
(IMO)
3. Now, another part of the dom asks for the same image reference in 1.
4. In the current version of the code, since we don't have `unique` in
the query string, the Cache-Control will have max-age=0, which I think
is not correct because from what I understood, if you don't put unique
in the url, it implicitly means that you don't care about the new
version of the image, so the cached image is fine.

Scene 2
There are instances as well, e.g. in Lunch, that product images are
fetched with url having changing `unique` value. With the current
version, Cache-Control is set to max-age=1year for each url. But even
though the image is supposed to be cached for 1 year, the browser asks
again and again for new images because the urls of the cached ones are
different from the new urls.

Fix:

The fix is to establish the meaning of `unique` parameter. IMHO, if it
is specified (regardless of value), it means that we are asking for the
updated version of the image, and if not, then the image is not unique,
which means that we are okay with the cached version.

This fix assumes the correctness of the above paragraph.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
