### PR TITLE
[FIX] account_analytic_default_hr_expense : fix _onchange_product_id

### DIFF
--- a/addons/account_analytic_default_hr_expense/models/hr_expense.py
+++ b/addons/account_analytic_default_hr_expense/models/hr_expense.py
@@ -8,9 +8,7 @@ class HrExpense(models.Model):
     _inherit = 'hr.expense'
 
     @api.onchange('product_id', 'date', 'account_id')
-    def _onchange_product_id(self):
-        res = super(HrExpense, self)._onchange_product_id()
+    def _onchange_product_id_date_account_id(self):
         rec = self.env['account.analytic.default'].sudo().account_get(product_id=self.product_id.id, account_id=self.account_id.id, company_id=self.company_id.id, date=self.date)
-        self.analytic_account_id = rec.analytic_id.id
-        self.analytic_tag_ids = rec.analytic_tag_ids.ids
-        return res
+        self.analytic_account_id = self.analytic_account_id or rec.analytic_id.id
+        self.analytic_tag_ids = self.analytic_tag_ids or rec.analytic_tag_ids.ids


### PR DESCRIPTION
_onchange_product_id() used to always (re)set hr_expense analytic_account_id & analytic_tag_ids to default values.
Or set those to false if no default values are found.
Installing account_analytic_default_hr_expense made odoo/addons/hr_expense/tests/test_expenses.py tests fail

- changed function name (no need to be a _onchange_product_id override)
- removed super() & return
- only set default value to var if var is False

Task: 2205544