### PR TITLE
[FIX] account: Reference in Account Journa Entry is empty

### DIFF
--- a/addons/account/models/account_invoice.py
+++ b/addons/account/models/account_invoice.py
@@ -1374,7 +1374,7 @@ class AccountInvoice(models.Model):
                 invoice.message_subscribe([invoice.partner_id.id])
 
             # Auto-compute reference, if not already existing and if configured on company
-            if not invoice.reference and invoice.type == 'out_invoice':
+            if not invoice.reference and (invoice.type == 'out_invoice' or invoice.type == 'out_refund'):
                 invoice.reference = invoice._get_computed_reference()
 
             # DO NOT FORWARD-PORT.


### PR DESCRIPTION
Steps to reproduce the bug:

- Create a customer invoice I
- Validate I
- Create credit note CN of I
- Validate CN

Bug:

For I, a journal entry has been created with the invoice number of I as reference
For CN, a journal entry has been created with no reference

opw:2201320