### PR TITLE
[IMP] web: owl component extension supports lazy loading of templates

### DIFF
--- a/addons/web/static/src/js/component_extension.js
+++ b/addons/web/static/src/js/component_extension.js
@@ -65,9 +65,15 @@
             });
             proms.push(templateProm);
         }
-        if (this.jsLibs || this.cssLibs || this.assetLibs) {
-            proms.push(this._loadLibs(this));
+        if (constructor.jsLibs || constructor.cssLibs || constructor.assetLibs) {
+            const libs = {
+                jsLibs: constructor.jsLibs,
+                cssLibs: constructor.cssLibs,
+                assetLibs: constructor.assetLibs,
+            }
+            proms.push(this.env.services.ajax.loadLibs(libs));
         }
+        await Promise.all(proms);
         return originalWillStart.apply(this, ...arguments);
     };
 })();

--- a/addons/web/static/src/js/component_extension.js
+++ b/addons/web/static/src/js/component_extension.js
@@ -39,4 +39,33 @@
         }
         originalTrigger.call(this, component, evType, payload);
     };
+    /**
+     * Patch owl.Component.willStart to handle
+     * xmlDependencies class member
+     * i.e. lazy loaded templates
+     * It may prove useful for Odoo's frontend
+     */
+    const originalWillStart = owl.Component.prototype.willStart;
+    owl.Component.prototype.willStart = async function() {
+        if (!(this.constructor.template in this.env.qweb.templates) && this.constructor.xmlDependencies) {
+            const proms = [];
+            for (const xml of this.constructor.xmlDependencies) {
+                const prom = owl.utils.loadFile(xml).then((doc) => {
+                    if (!doc) { return; }
+                    const frag = document.createElement('t');
+                    frag.innerHTML = doc;
+                    const owlTemplates = [];
+                    for (let child of frag.querySelectorAll("templates > [owl]")) {
+                        child.removeAttribute('owl');
+                        owlTemplates.push(child.outerHTML);
+                        child.remove();
+                    }
+                    this.env.qweb.addTemplates(`<templates> ${owlTemplates.join('\n')} </templates>`);
+                });
+                proms.push(prom);
+            }
+            await Promise.all(proms);
+        }
+        return originalWillStart.apply(this, ...arguments);
+    }
 })();

--- a/addons/web/static/src/js/core/ajax.js
+++ b/addons/web/static/src/js/core/ajax.js
@@ -562,6 +562,7 @@ _.extend(ajax, {
     loadLibs: loadLibs,
     get_file: get_file,
     post: post,
+    loadFile: owl.utils.loadFile,
 });
 
 return ajax;

--- a/addons/web/static/src/js/core/session.js
+++ b/addons/web/static/src/js/core/session.js
@@ -250,23 +250,6 @@ var Session = core.Class.extend(mixins.EventDispatcherMixin, {
         });
         return lock;
     },
-    loadFile: ajax.loadFile,
-    loadOwlXML: function(urls) {
-        this.globalProms = this.globalProms || {};
-        if (!urls) {
-            return Promise.all(Object.values(this.globalProms));
-        }
-        const currentProms = {};
-        for (const url of urls) {
-            let urlProm = this.globalProms[url];
-            if (!urlProm) {
-                urlProm = this.loadFile(url);
-                this.globalProms[url] = urlProm;
-            }
-            currentProms[url] = urlProm;
-        }
-        return Promise.all(Object.values(currentProms));
-    },
     get_currency: function (currency_id) {
         return this.currencies[currency_id];
     },

--- a/addons/web/static/src/js/core/session.js
+++ b/addons/web/static/src/js/core/session.js
@@ -250,6 +250,23 @@ var Session = core.Class.extend(mixins.EventDispatcherMixin, {
         });
         return lock;
     },
+    loadFile: ajax.loadFile,
+    loadOwlXML: function(urls) {
+        this.globalProms = this.globalProms || {};
+        if (!urls) {
+            return Promise.all(Object.values(this.globalProms));
+        }
+        const currentProms = {};
+        for (const url of urls) {
+            let urlProm = this.globalProms[url];
+            if (!urlProm) {
+                urlProm = this.loadFile(url);
+                this.globalProms[url] = urlProm;
+            }
+            currentProms[url] = urlProm;
+        }
+        return Promise.all(Object.values(currentProms));
+    },
     get_currency: function (currency_id) {
         return this.currencies[currency_id];
     },

--- a/addons/web/static/src/js/services/ajax_service.js
+++ b/addons/web/static/src/js/services/ajax_service.js
@@ -7,6 +7,23 @@ var core = require('web.core');
 var session = require('web.session');
 
 var AjaxService = AbstractService.extend({
+    loadFile: ajax.loadFile,
+    loadOwlXML: function(urls) {
+        this.globalProms = this.globalProms || {};
+        if (!urls) {
+            return Promise.all(Object.values(this.globalProms));
+        }
+        const currentProms = [];
+        for (const url of urls) {
+            let urlProm = this.globalProms[url];
+            if (!urlProm) {
+                urlProm = this.loadFile(url);
+                this.globalProms[url] = urlProm;
+            }
+            currentProms.push(urlProm);
+        }
+        return Promise.all(currentProms);
+    },
     /**
      * @param {Object} libs - @see ajax.loadLibs
      * @param {Object} [context] - @see ajax.loadLibs

--- a/addons/web/static/tests/component_extension_tests.js
+++ b/addons/web/static/tests/component_extension_tests.js
@@ -3,7 +3,7 @@ odoo.define('web.component_extension_tests', function (require) {
 
     const makeTestEnvironment = require("web.test_env");
     const testUtils = require("web.test_utils");
-    const session = require('web.session');
+    const AjaxService = require('web.AjaxService');
 
     const { Component, tags } = owl;
     const { xml } = tags;
@@ -47,35 +47,31 @@ odoo.define('web.component_extension_tests', function (require) {
         });
 
         QUnit.test("Component lazy load template", async function (assert) {
-            assert.expect(7);
+            assert.expect(6);
             const fixture = document.body.querySelector('#qunit-fixture');
+            const ajaxService = new AjaxService();
+            ajaxService.globalProms = null;
+            ajaxService.loadFile = function (url) {
+                assert.step(url);
+                let template;
+                if (url === 'dependency1') {
+                    template = `<templates>
+                        <div t-name="Parent.test1" owl="1">
+                            <t t-call="Parent.test2"/>
+                        </div>
+                    </templates>`;
+                } else if (url === 'dependency2') {
+                    template = `<templates>
+                        <div t-name="Parent.test2" owl="1">
+                            lazy loaded 2
+                        </div>
+                    </templates>`;
+                }
+                return Promise.resolve(template);
+            }
             const env = {
-                session: {
-                    loadOwlXML: session.loadOwlXML,
-                    loadFile: function (url) {
-                        assert.step(url);
-                        let template;
-                        if (url === 'dependency1') {
-                            template = `<templates>
-                                <div t-name="Parent.test1" owl="1">
-                                    <t t-call="Parent.test2"/>
-                                </div>
-                            </templates>`;
-                        } else if (url === 'dependency2') {
-                            template = `<templates>
-                                <div t-name="Parent.test2" owl="1">
-                                    lazy loaded 2
-                                </div>
-                            </templates>`;
-                        } else if (url === 'dependency3') {
-                            template = `<templates>
-                                <div t-name="Parent.test3" owl="1">
-                                    Parent3
-                                </div>
-                            </templates>`;
-                        }
-                        return Promise.resolve(template);
-                    }
+                services: {
+                    ajax: ajaxService,
                 }
             }
             class Parent extends Component {}
@@ -99,15 +95,9 @@ odoo.define('web.component_extension_tests', function (require) {
             );
 
             parent.destroy();
-
-            class Parent2 extends Parent {}
-            Parent2.xmlDependencies = ['dependency3'].concat(Parent.xmlDependencies);
-
-            const parent2 = new Parent2();
+            const parent2 = new Parent();
             await parent2.mount(fixture);
-            assert.verifySteps([
-                'dependency3',
-            ])
+            assert.verifySteps([]);
 
             assert.strictEqual(
                 fixture.innerHTML,

--- a/addons/web/static/tests/component_extension_tests.js
+++ b/addons/web/static/tests/component_extension_tests.js
@@ -45,6 +45,29 @@ odoo.define('web.component_extension_tests', function (require) {
             assert.ok(true, "Promise should still be pending");
         });
 
+        QUnit.test("Component lazy load template", async function (assert) {
+            assert.expect(1);
+            const fixture = document.body.querySelector('#qunit-fixture');
+
+            class Parent extends Component {}
+            Parent.env = makeTestEnvironment({}, () => Promise.reject());
+            Parent.template = 'Parent.test1';
+            Parent.xmlDependencies = [
+                '/web/static/tests/component_extension_tests_1.xml',
+                '/web/static/tests/component_extension_tests_2.xml',
+            ];
+
+            const parent = new Parent();
+            await parent.mount(fixture);
+
+            assert.strictEqual(
+                fixture.innerHTML,
+                `<div><div> lazy loaded 2 </div></div>`
+            );
+
+            parent.destroy();
+        });
+
         QUnit.module("Custom Hooks");
 
         QUnit.test("useListener handler type", async function (assert) {

--- a/addons/web/static/tests/component_extension_tests.js
+++ b/addons/web/static/tests/component_extension_tests.js
@@ -107,6 +107,45 @@ odoo.define('web.component_extension_tests', function (require) {
             parent2.destroy();
         });
 
+        QUnit.test("Component lazy load libs", async function (assert) {
+            assert.expect(4);
+            const fixture = document.body.querySelector('#qunit-fixture');
+            const ajaxService = new AjaxService();
+            ajaxService.loadLibs = function () {
+                assert.deepEqual(
+                    ...arguments,
+                    {
+                        assetLibs: ["asset"],
+                        cssLibs: ["css"],
+                        jsLibs: ["js"]
+                    }
+                )
+                assert.step('loadlibs');
+                return Promise.resolve();
+            }
+            const env = {
+                services: {
+                    ajax: ajaxService,
+                }
+            }
+            class Parent extends Component {}
+            Parent.jsLibs = ['js'];
+            Parent.cssLibs = ['css'];
+            Parent.assetLibs = ['asset'];
+            Parent.template = xml`<div>Parent</div>`;
+            Parent.env = makeTestEnvironment(env, () => Promise.reject());
+
+            const parent = new Parent();
+            await parent.mount(fixture);
+            assert.verifySteps(['loadlibs']);
+            assert.strictEqual(
+                fixture.innerHTML,
+                `<div>Parent</div>`
+            );
+
+            parent.destroy();
+        });
+
         QUnit.module("Custom Hooks");
 
         QUnit.test("useListener handler type", async function (assert) {

--- a/addons/web/static/tests/component_extension_tests_1.xml
+++ b/addons/web/static/tests/component_extension_tests_1.xml
@@ -1,0 +1,5 @@
+<templates>
+    <div t-name="Parent.test1" owl="1">
+        <t t-call="Parent.test2"/>
+    </div>
+</templates>

--- a/addons/web/static/tests/component_extension_tests_1.xml
+++ b/addons/web/static/tests/component_extension_tests_1.xml
@@ -1,5 +1,0 @@
-<templates>
-    <div t-name="Parent.test1" owl="1">
-        <t t-call="Parent.test2"/>
-    </div>
-</templates>

--- a/addons/web/static/tests/component_extension_tests_2.xml
+++ b/addons/web/static/tests/component_extension_tests_2.xml
@@ -1,0 +1,5 @@
+<templates>
+    <div t-name="Parent.test2" owl="1">
+        lazy loaded 2
+    </div>
+</templates>

--- a/addons/web/static/tests/component_extension_tests_2.xml
+++ b/addons/web/static/tests/component_extension_tests_2.xml
@@ -1,5 +1,0 @@
-<templates>
-    <div t-name="Parent.test2" owl="1">
-        lazy loaded 2
-    </div>
-</templates>


### PR DESCRIPTION
Useful for the frontend

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
