### PR TITLE
[FIX] website_sale: Uncheck Common Product Catalog in multi websites

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -162,6 +162,9 @@ class WebsiteSale(ProductConfiguratorController):
 
     def _get_search_domain(self, search, category, attrib_values):
         domain = request.website.sale_product_domain()
+        # if company_share_product is false then only displays the products of the website's company
+        if request.env.ref('product.product_comp_rule').sudo().active:
+            domain += [('company_id', 'in', (False, request.website.company_id.id))]
         if search:
             for srch in search.split(" "):
                 domain += [


### PR DESCRIPTION
Steps to reproduce the bug:

-  Install website_sale and sale_margin (to show the cost in a SO line)
- Let's consider two companies C1 and C2 and uncheck Common Product Catalog (in General Settings)
- Let's consider a website W in C2
- Let's consider a user U in C1
- Let's consider a product P in C1 with cost(standard price) = 100€
- Log as U and go to the shop of W
- The product P appears in the shop, add P in the cart and process the SO

Bug:

The cost of P in the created SO was 0€ instead of 100€

PS:

- When creating a SO line, the function _get_purchase_price is called to get the purchase_price
- The purchase_price is computed with the standard_price
- The field standard_price is company dependent so a force_company is needed to ensure that
the standard_price is taken in the right company.
- The function sale_get_order forces the company of the website in the context.

So the cost of P is always computed in the company of the website. That's why only the products
in the website's company must be displayed when the product catalog is not shared.

opw:2187870