### PR TITLE
[IMP] account: automatic order payment term line

### DIFF
--- a/addons/account/data/account_data.xml
+++ b/addons/account/data/account_data.xml
@@ -42,44 +42,44 @@
         <record id="account_payment_term_15days" model="account.payment.term">
             <field name="name">15 Days</field>
             <field name="note">Payment terms: 15 Days</field>
-            <field name="line_ids" eval="[(5, 0), (0, 0, {'value': 'balance', 'value_amount': 0.0, 'sequence': 500, 'days': 15, 'option': 'day_after_invoice_date'})]"/>
+            <field name="line_ids" eval="[(5, 0), (0, 0, {'value': 'balance', 'value_amount': 0.0, 'days': 15, 'option': 'day_after_invoice_date'})]"/>
         </record>
 
         <record id="account_payment_term_21days" model="account.payment.term">
             <field name="name">21 Days</field>
             <field name="note">Payment terms: 21 Days</field>
-            <field name="line_ids" eval="[(5, 0), (0, 0, {'value': 'balance', 'value_amount': 0.0, 'sequence': 500, 'days': 21, 'option': 'day_after_invoice_date'})]"/>
+            <field name="line_ids" eval="[(5, 0), (0, 0, {'value': 'balance', 'value_amount': 0.0, 'days': 21, 'option': 'day_after_invoice_date'})]"/>
         </record>
 
         <record id="account_payment_term_30days" model="account.payment.term">
             <field name="name">30 Days</field>
             <field name="note">Payment terms: 30 Days</field>
-            <field name="line_ids" eval="[(5, 0), (0, 0, {'value': 'balance', 'value_amount': 0.0, 'sequence': 500, 'days': 30, 'option': 'day_after_invoice_date'})]"/>
+            <field name="line_ids" eval="[(5, 0), (0, 0, {'value': 'balance', 'value_amount': 0.0, 'days': 30, 'option': 'day_after_invoice_date'})]"/>
         </record>
 
         <record id="account_payment_term_45days" model="account.payment.term">
             <field name="name">45 Days</field>
             <field name="note">Payment terms: 45 Days</field>
-            <field name="line_ids" eval="[(5, 0), (0, 0, {'value': 'balance', 'value_amount': 0.0, 'sequence': 500, 'days': 45, 'option': 'day_after_invoice_date'})]"/>
+            <field name="line_ids" eval="[(5, 0), (0, 0, {'value': 'balance', 'value_amount': 0.0, 'days': 45, 'option': 'day_after_invoice_date'})]"/>
         </record>
 
         <record id="account_payment_term_2months" model="account.payment.term">
             <field name="name">2 Months</field>
             <field name="note">Payment terms: 2 Months</field>
-            <field name="line_ids" eval="[(5, 0), (0, 0, {'value': 'balance', 'value_amount': 0.0, 'sequence': 500, 'days': 60, 'option': 'day_after_invoice_date'})]"/>
+            <field name="line_ids" eval="[(5, 0), (0, 0, {'value': 'balance', 'value_amount': 0.0, 'days': 60, 'option': 'day_after_invoice_date'})]"/>
         </record>
 
         <record id="account_payment_term_end_following_month" model="account.payment.term">
             <field name="name">End of Following Month</field>
             <field name="note">Payment terms: End of Following Month</field>
-            <field name="line_ids" eval="[(5, 0), (0, 0, {'value': 'balance', 'value_amount': 0.0, 'sequence': 500, 'days': 31, 'option': 'day_following_month'})]"/>
+            <field name="line_ids" eval="[(5, 0), (0, 0, {'value': 'balance', 'value_amount': 0.0, 'days': 31, 'option': 'day_following_month'})]"/>
         </record>
 
         <record id="account_payment_term_advance_60days" model="account.payment.term">
             <field name="name">30% Now, Balance 60 Days</field>
             <field name="note">Payment terms: 30% Now, Balance 60 Days</field>
-            <field name="line_ids" eval="[(5, 0), (0, 0, {'value': 'percent', 'value_amount': 30.0, 'sequence': 400, 'days': 0, 'option': 'day_after_invoice_date'}),
-                    (0, 0, {'value': 'balance', 'value_amount': 0.0, 'sequence': 500, 'days': 60, 'option': 'day_after_invoice_date'})]"/>
+            <field name="line_ids" eval="[(5, 0), (0, 0, {'value': 'percent', 'value_amount': 30.0, 'days': 0, 'option': 'day_after_invoice_date'}),
+                    (0, 0, {'value': 'balance', 'value_amount': 0.0, 'days': 60, 'option': 'day_after_invoice_date'})]"/>
         </record>
 
         <!--

--- a/addons/account/demo/account_demo.xml
+++ b/addons/account/demo/account_demo.xml
@@ -24,8 +24,8 @@
         <record id="account_payment_term_advance" model="account.payment.term">
             <field name="name">30% Advance End of Following Month</field>
             <field name="note">Payment terms: 30% Advance End of Following Month</field>
-            <field name="line_ids" eval="[(5, 0), (0, 0, {'value': 'percent', 'value_amount': 30.0, 'sequence': 400, 'days': 0, 'option': 'day_after_invoice_date'}),
-                    (0, 0, {'value': 'balance', 'value_amount': 0.0, 'sequence': 500, 'days': 31, 'option': 'day_following_month'})]"/>
+            <field name="line_ids" eval="[(5, 0), (0, 0, {'value': 'percent', 'value_amount': 30.0, 'days': 0, 'option': 'day_after_invoice_date'}),
+                    (0, 0, {'value': 'balance', 'value_amount': 0.0, 'days': 31, 'option': 'day_following_month'})]"/>
         </record>
 
         <record id="base.user_demo" model="res.users">

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -674,14 +674,12 @@ class AccountTestInvoicingCommon(SavepointCase):
                 (0, 0, {
                     'value': 'percent',
                     'value_amount': 30.0,
-                    'sequence': 400,
                     'days': 0,
                     'option': 'day_after_invoice_date',
                 }),
                 (0, 0, {
                     'value': 'balance',
                     'value_amount': 0.0,
-                    'sequence': 500,
                     'days': 31,
                     'option': 'day_following_month',
                 }),

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -2414,15 +2414,13 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
                 (0, 0, {
                     'value': 'percent',
                     'value_amount': 100.0,
-                    'sequence': 10,
                     'days': 0,
                     'option': 'day_after_invoice_date',
                 }),
                 (0, 0, {
                     'value': 'balance',
                     'value_amount': 0.0,
-                    'sequence': 20,
-                    'days': 0,
+                    'days': 1,
                     'option': 'day_after_invoice_date',
                 }),
             ],

--- a/addons/account/views/account_view.xml
+++ b/addons/account/views/account_view.xml
@@ -1274,8 +1274,7 @@ action = model.setting_init_bank_account_action()
             <field name="model">account.payment.term.line</field>
             <field name="arch" type="xml">
                 <tree string="Payment Terms">
-                    <field name="sequence" widget="handle"/>
-                    <field name="value" string="Due Type"/>
+                    <field name="value" string="Due Type" attrs="{'readonly':[('value','=','balance')]}"/>
                     <field name="value_amount" attrs="{'readonly':[('value','=','balance')]}"/>
                     <field name="days"/>
                     <field name="option" string=""/>
@@ -1292,7 +1291,7 @@ action = model.setting_init_bank_account_action()
                     <h2>Term Type</h2>
                     <group>
                         <group>
-                            <field name="value" widget="radio"/>
+                            <field name="value" widget="radio" attrs="{'readonly':[('value','=','balance')]}"/>
                         </group>
 
                         <group>
@@ -1303,8 +1302,6 @@ action = model.setting_init_bank_account_action()
                             </div>
                         </group>
                     </group>
-
-                    <field name="sequence" invisible="1"/>
 
                     <h2>Due Date Computation</h2>
                     <div colspan="2">


### PR DESCRIPTION
Task [2026399](https://www.odoo.com/web?#id=2026399&action=333&active_id=967&model=project.task&view_type=form&cids=&menu_id=4720)
The user should not have to reorder payment term rules, we should order
by the number of days and put the balance at the end
automatically. (it's too advanced to know you should order lines).



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
