### PR TITLE
Highlight error for onchange/compute in abstract models

### DIFF
--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -708,6 +708,64 @@ class ComputeOnchangeLine(models.Model):
             line.bar = (line.foo or "") + "r"
 
 
+class ComputeOnchangeAbstract(models.AbstractModel):
+    _name = 'test_new_api.compute.onchange.abstract'
+    _description = "Compute method as an onchange on abstract model"
+
+    active = fields.Boolean()
+    foo = fields.Char()
+    bar = fields.Char(compute='_compute_bar', store=True)
+    baz = fields.Char(compute='_compute_baz', store=True, readonly=False)
+    count = fields.Integer(default=0)
+    line_ids = fields.One2many(
+        'test_new_api.compute.onchange.line.abstract', 'record_id',
+        compute='_compute_line_ids', store=True, readonly=False
+    )
+
+    @api.onchange('foo')
+    def _onchange_foo(self):
+        self.count += 1
+
+    @api.depends('foo')
+    def _compute_bar(self):
+        for record in self:
+            record.bar = (record.foo or "") + "r"
+
+    @api.depends('active', 'foo')
+    def _compute_baz(self):
+        for record in self:
+            if record.active:
+                record.baz = (record.foo or "") + "z"
+
+    @api.depends('foo')
+    def _compute_line_ids(self):
+        for record in self:
+            if not record.foo:
+                continue
+            if any(line.foo == record.foo for line in record.line_ids):
+                continue
+            # add a line with the same value as 'foo'
+            record.line_ids = [Command.create({'foo': record.foo})]
+
+    def copy(self, default=None):
+        default = dict(default or {}, foo="%s (copy)" % (self.foo or ""))
+        return super().copy(default)
+
+
+class ComputeOnchangeLineAbstract(models.AbstractModel):
+    _name = 'test_new_api.compute.onchange.line.abstract'
+    _description = "Line-like model for test_new_api.compute.onchange.abstract"
+
+    record_id = fields.Many2one('test_new_api.compute.onchange.abstract', ondelete='cascade')
+    foo = fields.Char()
+    bar = fields.Char(compute='_compute_bar')
+
+    @api.depends('foo')
+    def _compute_bar(self):
+        for line in self:
+            line.bar = (line.foo or "") + "r"
+
+
 class ComputeDynamicDepends(models.Model):
     _name = 'test_new_api.compute.dynamic.depends'
     _description = "Computed field with dynamic dependencies"

--- a/odoo/addons/test_new_api/tests/test_onchange.py
+++ b/odoo/addons/test_new_api/tests/test_onchange.py
@@ -960,3 +960,89 @@ class TestComputeOnchange(common.TransactionCase):
             {'name': 'foo', 'count': 1},
             {'name': 'bar', 'count': 1},
         ])
+
+
+class TestComputeOnchangeAbstract(common.TransactionCase):
+
+    def test_set_new(self):
+        model = self.env['test_new_api.compute.onchange.abstract']
+        record = model.new({'active': True})
+        self.assertEqual(record.bar, "r")
+        self.assertEqual(record.baz, "z")
+
+        # recompute 'bar' (readonly) and 'baz' (editable)
+        record.foo = "foo1"
+        self.assertEqual(record.bar, "foo1r")
+        self.assertEqual(record.baz, "foo1z")
+
+        # do not recompute 'baz'
+        record.baz = "baz2"
+        self.assertEqual(record.bar, "foo1r")
+        self.assertEqual(record.baz, "baz2")
+
+        # recompute 'baz', but do not change its value
+        record.active = False
+        self.assertEqual(record.bar, "foo1r")
+        self.assertEqual(record.baz, "baz2")
+
+        # recompute 'baz', but do not change its value
+        record.foo = "foo3"
+        self.assertEqual(record.bar, "foo3r")
+        self.assertEqual(record.baz, "baz2")
+
+        # do not recompute 'baz'
+        record.baz = "baz4"
+        self.assertEqual(record.bar, "foo3r")
+        self.assertEqual(record.baz, "baz4")
+
+    def test_onchange(self):
+        # check computations of 'bar' (readonly) and 'baz' (editable)
+        form = common.Form(self.env['test_new_api.compute.onchange.abstract'])
+        self.assertEqual(form.bar, "r")
+        self.assertEqual(form.baz, False)
+        form.active = True
+        self.assertEqual(form.bar, "r")
+        self.assertEqual(form.baz, "z")
+        form.foo = "foo1"
+        self.assertEqual(form.bar, "foo1r")
+        self.assertEqual(form.baz, "foo1z")
+        form.baz = "baz2"
+        self.assertEqual(form.bar, "foo1r")
+        self.assertEqual(form.baz, "baz2")
+        form.active = False
+        self.assertEqual(form.bar, "foo1r")
+        self.assertEqual(form.baz, "baz2")
+        form.foo = "foo3"
+        self.assertEqual(form.bar, "foo3r")
+        self.assertEqual(form.baz, "baz2")
+        form.active = True
+        self.assertEqual(form.bar, "foo3r")
+        self.assertEqual(form.baz, "foo3z")
+
+        with form.line_ids.new() as line:
+            # check computation of 'bar' (readonly)
+            self.assertEqual(line.foo, False)
+            self.assertEqual(line.bar, "r")
+            line.foo = "foo"
+            self.assertEqual(line.foo, "foo")
+            self.assertEqual(line.bar, "foor")
+
+        record = form.save()
+        self.assertEqual(record.bar, "foo3r")
+        self.assertEqual(record.baz, "foo3z")
+
+        form = common.Form(record)
+        self.assertEqual(form.bar, "foo3r")
+        self.assertEqual(form.baz, "foo3z")
+        form.foo = "foo4"
+        self.assertEqual(form.bar, "foo4r")
+        self.assertEqual(form.baz, "foo4z")
+        form.baz = "baz5"
+        self.assertEqual(form.bar, "foo4r")
+        self.assertEqual(form.baz, "baz5")
+        form.active = False
+        self.assertEqual(form.bar, "foo4r")
+        self.assertEqual(form.baz, "baz5")
+        form.foo = "foo6"
+        self.assertEqual(form.bar, "foo6r")
+        self.assertEqual(form.baz, "baz5")


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Abstract models (or non-abstract models but with _auto = False) are usually used in reports and such.
But when the model is abstract, the onchange/compute doesn't work as in a non-abstract model, and thus testing them is a nightmare. Not sure if it's expected or an error.

Not tested in transient models, but could also be a nice addition.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr