### PR TITLE
[FIX] web: prevent wrong date selection from datepicker widget

### DIFF
--- a/addons/web/static/src/js/widgets/date_picker.js
+++ b/addons/web/static/src/js/widgets/date_picker.js
@@ -91,13 +91,6 @@ var DateWidget = Widget.extend({
      * set datetime value
      */
     changeDatetime: function () {
-        if (this.__libInput > 0) {
-            if (this.options.warn_future) {
-                this._warnFuture(this.getValue());
-            }
-            this.trigger("datetime_changed");
-            return;
-        }
         var oldValue = this.getValue();
         if (this.isValid()) {
             this._setValueFromUi();

--- a/addons/web/static/tests/widgets/datetime_tests.js
+++ b/addons/web/static/tests/widgets/datetime_tests.js
@@ -1,38 +1,49 @@
 odoo.define('web.datetime_tests', function (require) {
 "use strict";
 
-var datepicker = require("web.datepicker");
-var testUtils = require("web.test_utils");
+const datepicker = require("web.datepicker");
+const testUtils = require("web.test_utils");
 
 QUnit.module('DatePicker', {}, function () {
 
     QUnit.module('DateTimeWidget', {}, function () {
 
-        QUnit.test("in date time widget, changing a date and then clicking on input", async function (assert) {
-            assert.expect(2);
+        QUnit.test("date time widget, selecting a date and clicking on input to close datepicker", async function (assert) {
+            assert.expect(4);
 
-            var $target = $("#qunit-fixture");
-
-            var parent = testUtils.createParent({});
-            var dateTimeWidget = new datepicker.DateTimeWidget(parent);
-
+            let counter = 0;
             testUtils.mock.patch(datepicker.DateTimeWidget, {
                 _setValueFromUi: function () {
-                    assert.ok(true, "should have triggered _setValueFromUi");
+                    counter++;
                     return this._super.apply(this, arguments);
                 },
             });
 
+            const $target = $("#qunit-fixture");
+
+            const parent = testUtils.createParent({});
+            const dateTimeWidget = new datepicker.DateTimeWidget(parent);
             await dateTimeWidget.appendTo($target);
+
             // opening the datepicker
             await testUtils.dom.openDatepicker($target.find('.o_datepicker'));
+
+            assert.strictEqual($('.bootstrap-datetimepicker-widget:visible').length, 1,
+                "datepicker should be opened");
+            assert.strictEqual(counter, 0, "counter should be 0");
             // selecting today's date (no date has been selected yet)
-            testUtils.dom.click(document.querySelector(".datepicker-days > table > tbody > tr > td.day.today"));
+            testUtils.dom.click($('.day:contains(22)'));
             // now click on the input element, this should invoke _setValueFromUi() 2 times
             testUtils.dom.click(document.querySelector(".o_datepicker_input"));
+            assert.strictEqual(counter, 2, "counter should be 0");
 
-            testUtils.mock.unpatch(datepicker.DateTimeWidget);
+            // re-open datepicker
+            testUtils.dom.openDatepicker($target.find('.o_datepicker'));
+            assert.strictEqual($('.day.active').text(), '22',
+                "datepicker should be highlight with 22nd day of month");
+
             dateTimeWidget.destroy();
+            testUtils.mock.unpatch(datepicker.DateTimeWidget);
         });
     });
 });

--- a/addons/web/static/tests/widgets/datetime_tests.js
+++ b/addons/web/static/tests/widgets/datetime_tests.js
@@ -1,0 +1,39 @@
+odoo.define('web.datetime_tests', function (require) {
+"use strict";
+
+var datepicker = require("web.datepicker");
+var testUtils = require("web.test_utils");
+
+QUnit.module('DatePicker', {}, function () {
+
+    QUnit.module('DateTimeWidget', {}, function () {
+
+        QUnit.test("in date time widget, changing a date and then clicking on input", async function (assert) {
+            assert.expect(2);
+
+            var $target = $("#qunit-fixture");
+
+            var parent = testUtils.createParent({});
+            var dateTimeWidget = new datepicker.DateTimeWidget(parent);
+
+            testUtils.mock.patch(datepicker.DateTimeWidget, {
+                _setValueFromUi: function () {
+                    assert.ok(true, "should have triggered _setValueFromUi");
+                    return this._super.apply(this, arguments);
+                },
+            });
+
+            await dateTimeWidget.appendTo($target);
+            // opening the datepicker
+            await testUtils.dom.openDatepicker($target.find('.o_datepicker'));
+            // selecting today's date (no date has been selected yet)
+            testUtils.dom.click(document.querySelector(".datepicker-days > table > tbody > tr > td.day.today"));
+            // now click on the input element, this should invoke _setValueFromUi() 2 times
+            testUtils.dom.click(document.querySelector(".o_datepicker_input"));
+
+            testUtils.mock.unpatch(datepicker.DateTimeWidget);
+            dateTimeWidget.destroy();
+        });
+    });
+});
+});

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -706,6 +706,7 @@
                 <script type="text/javascript" src="/web/static/tests/widgets/domain_selector_tests.js"/>
                 <script type="text/javascript" src="/web/static/tests/widgets/model_field_selector_tests.js"/>
                 <script type="text/javascript" src="/web/static/tests/widgets/rainbow_man_tests.js"/>
+                <script type="text/javascript" src="/web/static/tests/widgets/datetime_tests.js"/>
 
                 <script type="text/javascript" src="/web/static/tests/tools/debug_manager_tests.js"/>
 


### PR DESCRIPTION
To reproduce the bug,
1. Go to a searchview with a relatively long list of filters (like the account.move.line one)
2. Add a custom filter
3. Select a datetime field (e.g. 'Created on')
4. Select operator 'is after'
5. Open the datetime widget
6. Select a date in 2019 (e.g. 21/12/2019)
7. IMPORTANT: click on the input itself while the datetime widget is still open
8. IMPORTANT: apply the filter while the datetime widget is still open

It'll select today's date instead of 21/12/2019.

task-2181446