### PR TITLE
[IMP] mrp: Prevent to delete WO from Gantt

### DIFF
--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -374,6 +374,7 @@
         <field name="model">mrp.workorder</field>
         <field name="arch" type="xml">
             <gantt class="o_mrp_workorder_gantt" date_stop="date_planned_finished" date_start="date_planned_start" string="Operations" default_group_by="workcenter_id" create="0"
+                delete="0"
                 progress="progress" plan="0"
                 decoration-danger="date_planned_start &lt; current_date and state in ['pending', 'ready']"
                 decoration-success="state == 'done'"


### PR DESCRIPTION
PURPOSE
Shouldn't be possible to delete a work order from any Gantt

SPECIFICATIONS

Currently, the remove button is displayed on Planning by Workcenter so
the user can able to delete a work order form Gantt view. 

This is the goal of this commit.
Once a work order is created is shouldn't be possible to delete it.

To do that, add an attribute "delete" in mrp work order Gantt view to disable
 the Remove button on "Planning by Workcenter".

LINKS

PR #46684
Task 2206166