### PR TITLE
[FIX] A follower must be either a partner or a channel

### DIFF
--- a/addons/mail/models/mail_followers.py
+++ b/addons/mail/models/mail_followers.py
@@ -48,6 +48,10 @@ class Followers(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
+        if any("channel_id" in vals for vals in vals_list):
+            ctx = dict(self.env.context)
+            ctx.pop('default_partner_id', None)
+            self = self.with_context(ctx)
         res = super(Followers, self).create(vals_list)
         res._invalidate_documents()
         return res


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In some situation, the environment was defining default value for partner_id on mail.followers creation. However, if the channel is given, a SQL constraint prevent the creation. In consequences, a traceback was thrown. 

After this commit:
The environment partner_id default value is remove if channel_id is given in the creation

OPW-2200219




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
