### PR TITLE
[FIX] website_hr_recruitment: fix demo data images layout

### DIFF
--- a/addons/website_hr_recruitment/data/hr_job_demo.xml
+++ b/addons/website_hr_recruitment/data/hr_job_demo.xml
@@ -114,16 +114,16 @@
                 <h3 class="text-muted">Pictures of smart and enthusiastic people</h3>
             </div>
             <div class="col-lg-12 text-center">
-                <div class="col-lg-5 mt16">
+                <div class="col-lg-5 mt16 float-left">
                     <img alt="" class="img img-fluid" style="height:355px;" src="/website_hr_recruitment/static/src/img/882207_10151545507603963_1381082528_o.jpg"/>
                 </div>
-                <div class="col-lg-3 mt16">
+                <div class="col-lg-3 mt16 float-left">
                     <img alt="" class="img img-fluid" style="height:355px;" src="/website_hr_recruitment/static/src/img/1010054_10151543538268963_186969588_n.jpg"/>
                 </div>
-                <div class="col-lg-3 mt16">
+                <div class="col-lg-3 mt16 float-left">
                     <img alt="" class="img img-fluid" src="/website_hr_recruitment/static/src/img/1017407_10151536656083963_857938319_n.jpg"/>
                 </div>
-                <div class="col-lg-3 mt16">
+                <div class="col-lg-3 mt16 float-left">
                     <img alt="" class="img img-fluid" src="/website_hr_recruitment/static/src/img/1044326_10151536655788963_587131144_n.jpg"/>
                 </div>
             </div>
@@ -247,16 +247,16 @@
                 <h3 class="text-muted">Pictures of smart and enthusiastic people</h3>
             </div>
             <div class="col-lg-12 text-center">
-                <div class="col-lg-5 mt16">
+                <div class="col-lg-5 mt16 float-left">
                     <img alt="" class="img img-fluid" style="height:355px;" src="/website_hr_recruitment/static/src/img/882207_10151545507603963_1381082528_o.jpg"/>
                 </div>
-                <div class="col-lg-3 mt16">
+                <div class="col-lg-3 mt16 float-left">
                     <img alt="" class="img img-fluid" style="height:355px;" src="/website_hr_recruitment/static/src/img/1010054_10151543538268963_186969588_n.jpg"/>
                 </div>
-                <div class="col-lg-3 mt16">
+                <div class="col-lg-3 mt16 float-left">
                     <img alt="" class="img img-fluid" src="/website_hr_recruitment/static/src/img/1017407_10151536656083963_857938319_n.jpg"/>
                 </div>
-                <div class="col-lg-3 mt16">
+                <div class="col-lg-3 mt16 float-left">
                     <img alt="" class="img img-fluid" src="/website_hr_recruitment/static/src/img/1044326_10151536655788963_587131144_n.jpg"/>
                 </div>
             </div>
@@ -381,16 +381,16 @@
                 <h3 class="text-muted">Pictures of smart and enthusiastic people</h3>
             </div>
             <div class="col-lg-12 text-center">
-                <div class="col-lg-5 mt16">
+                <div class="col-lg-5 mt16 float-left">
                     <img alt="" class="img img-fluid" style="height:355px;" src="/website_hr_recruitment/static/src/img/882207_10151545507603963_1381082528_o.jpg"/>
                 </div>
-                <div class="col-lg-3 mt16">
+                <div class="col-lg-3 mt16 float-left">
                     <img alt="" class="img img-fluid" style="height:355px;" src="/website_hr_recruitment/static/src/img/1010054_10151543538268963_186969588_n.jpg"/>
                 </div>
-                <div class="col-lg-3 mt16">
+                <div class="col-lg-3 mt16 float-left">
                     <img alt="" class="img img-fluid" src="/website_hr_recruitment/static/src/img/1017407_10151536656083963_857938319_n.jpg"/>
                 </div>
-                <div class="col-lg-3 mt16">
+                <div class="col-lg-3 mt16 float-left">
                     <img alt="" class="img img-fluid" src="/website_hr_recruitment/static/src/img/1044326_10151536655788963_587131144_n.jpg"/>
                 </div>
             </div>
@@ -510,16 +510,16 @@
                 <h3 class="text-muted">Pictures of smart and enthusiastic people</h3>
             </div>
             <div class="col-lg-12 text-center">
-                <div class="col-lg-5 mt16">
+                <div class="col-lg-5 mt16 float-left">
                     <img alt="" class="img img-fluid" style="height:355px;" src="/website_hr_recruitment/static/src/img/882207_10151545507603963_1381082528_o.jpg"/>
                 </div>
-                <div class="col-lg-3 mt16">
+                <div class="col-lg-3 mt16 float-left">
                     <img alt="" class="img img-fluid" style="height:355px;" src="/website_hr_recruitment/static/src/img/1010054_10151543538268963_186969588_n.jpg"/>
                 </div>
-                <div class="col-lg-3 mt16">
+                <div class="col-lg-3 mt16 float-left">
                     <img alt="" class="img img-fluid" src="/website_hr_recruitment/static/src/img/1017407_10151536656083963_857938319_n.jpg"/>
                 </div>
-                <div class="col-lg-3 mt16">
+                <div class="col-lg-3 mt16 float-left">
                     <img alt="" class="img img-fluid" src="/website_hr_recruitment/static/src/img/1044326_10151536655788963_587131144_n.jpg"/>
                 </div>
             </div>
@@ -638,16 +638,16 @@
                 <h3 class="text-muted">Pictures of smart and enthusiastic people</h3>
             </div>
             <div class="col-lg-12 text-center">
-                <div class="col-lg-5 mt16">
+                <div class="col-lg-5 mt16 float-left">
                     <img alt="" class="img img-fluid" style="height:355px;" src="/website_hr_recruitment/static/src/img/882207_10151545507603963_1381082528_o.jpg"/>
                 </div>
-                <div class="col-lg-3 mt16">
+                <div class="col-lg-3 mt16 float-left">
                     <img alt="" class="img img-fluid" style="height:355px;" src="/website_hr_recruitment/static/src/img/1010054_10151543538268963_186969588_n.jpg"/>
                 </div>
-                <div class="col-lg-3 mt16">
+                <div class="col-lg-3 mt16 float-left">
                     <img alt="" class="img img-fluid" src="/website_hr_recruitment/static/src/img/1017407_10151536656083963_857938319_n.jpg"/>
                 </div>
-                <div class="col-lg-3 mt16">
+                <div class="col-lg-3 mt16 float-left">
                     <img alt="" class="img img-fluid" src="/website_hr_recruitment/static/src/img/1044326_10151536655788963_587131144_n.jpg"/>
                 </div>
             </div>
@@ -766,16 +766,16 @@
                 <h3 class="text-muted">Pictures of smart and enthusiastic people</h3>
             </div>
             <div class="col-lg-12 text-center">
-                <div class="col-lg-5 mt16">
+                <div class="col-lg-5 mt16 float-left">
                     <img alt="" class="img img-fluid" style="height:355px;" src="/website_hr_recruitment/static/src/img/882207_10151545507603963_1381082528_o.jpg"/>
                 </div>
-                <div class="col-lg-3 mt16">
+                <div class="col-lg-3 mt16 float-left">
                     <img alt="" class="img img-fluid" style="height:355px;" src="/website_hr_recruitment/static/src/img/1010054_10151543538268963_186969588_n.jpg"/>
                 </div>
-                <div class="col-lg-3 mt16">
+                <div class="col-lg-3 mt16 float-left">
                     <img alt="" class="img img-fluid" src="/website_hr_recruitment/static/src/img/1017407_10151536656083963_857938319_n.jpg"/>
                 </div>
-                <div class="col-lg-3 mt16">
+                <div class="col-lg-3 mt16 float-left">
                     <img alt="" class="img img-fluid" src="/website_hr_recruitment/static/src/img/1044326_10151536655788963_587131144_n.jpg"/>
                 </div>
             </div>
@@ -895,16 +895,16 @@
                 <h3 class="text-muted">Pictures of smart and enthusiastic people</h3>
             </div>
             <div class="col-lg-12 text-center">
-                <div class="col-lg-5 mt16">
+                <div class="col-lg-5 mt16 float-left">
                     <img alt="" class="img img-fluid" style="height:355px;" src="/website_hr_recruitment/static/src/img/882207_10151545507603963_1381082528_o.jpg"/>
                 </div>
-                <div class="col-lg-3 mt16">
+                <div class="col-lg-3 mt16 float-left">
                     <img alt="" class="img img-fluid" style="height:355px;" src="/website_hr_recruitment/static/src/img/1010054_10151543538268963_186969588_n.jpg"/>
                 </div>
-                <div class="col-lg-3 mt16">
+                <div class="col-lg-3 mt16 float-left">
                     <img alt="" class="img img-fluid" src="/website_hr_recruitment/static/src/img/1017407_10151536656083963_857938319_n.jpg"/>
                 </div>
-                <div class="col-lg-3 mt16">
+                <div class="col-lg-3 mt16 float-left">
                     <img alt="" class="img img-fluid" src="/website_hr_recruitment/static/src/img/1044326_10151536655788963_587131144_n.jpg"/>
                 </div>
             </div>


### PR DESCRIPTION
### Issue

	- Install Online Jobs
	- Go on your website > Jobs
	- Click on any job

	The images are inline

### Cause

	Bootstrap migration
	Old bootstrap added `float: left;` on `.col-x-x`
	Now it doesn't

### Solution

	Add float-left classes on the `col-x-x` containing
	the images.

**OPW-2197772**

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
