### PR TITLE
[IMP] survey: add background image on survey sections

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -193,6 +193,8 @@ class Survey(http.Controller):
             values['token'] = token
         if survey.scoring_type != 'no_scoring' and survey.certification:
             values['graph_data'] = json.dumps(answer._prepare_statistics()[answer])
+        if survey.background_image:
+            values['background_image_url'] = survey.background_image_url
         return values
 
     # ------------------------------------------------------------
@@ -236,30 +238,29 @@ class Survey(http.Controller):
             :param post:
                 - previous_page_id : come from the breadcrumb or the back button and force the next questions to load
                                      to be the previous ones. """
+        triggering_answer_by_question, triggered_questions_by_answer, selected_answers = answer_sudo._get_conditional_values()
+
         data = {
             'is_html_empty': is_html_empty,
             'survey': survey_sudo,
             'answer': answer_sudo,
+            'questions_info': survey_sudo._get_questions_information(),
             'breadcrumb_pages': [{
                 'id': page.id,
                 'title': page.title,
             } for page in survey_sudo.page_ids],
             'format_datetime': lambda dt: format_datetime(request.env, dt, dt_format=False),
-            'format_date': lambda date: format_date(request.env, date)
+            'format_date': lambda date: format_date(request.env, date),
+            'triggering_answer_by_question': {
+                question.id: triggering_answer_by_question[question].id for question in triggering_answer_by_question.keys()
+                if triggering_answer_by_question[question]
+            },
+            'triggered_questions_by_answer': {
+                answer.id: triggered_questions_by_answer[answer].ids
+                for answer in triggered_questions_by_answer.keys()
+            },
+            'selected_answers': selected_answers.ids
         }
-        if survey_sudo.questions_layout != 'page_per_question':
-            triggering_answer_by_question, triggered_questions_by_answer, selected_answers = answer_sudo._get_conditional_values()
-            data.update({
-                'triggering_answer_by_question': {
-                    question.id: triggering_answer_by_question[question].id for question in triggering_answer_by_question.keys()
-                    if triggering_answer_by_question[question]
-                },
-                'triggered_questions_by_answer': {
-                    answer.id: triggered_questions_by_answer[answer].ids
-                    for answer in triggered_questions_by_answer.keys()
-                },
-                'selected_answers': selected_answers.ids
-            })
 
         if not answer_sudo.is_session_answer and survey_sudo.is_time_limited and answer_sudo.start_datetime:
             data.update({
@@ -279,6 +280,7 @@ class Survey(http.Controller):
                 'previous_page_id': new_previous_id,
                 'has_answered': answer_sudo.user_input_line_ids.filtered(lambda line: line.question_id.id == new_previous_id),
                 'can_go_back': survey_sudo._can_go_back(answer_sudo, page_or_question),
+                'background_image_url': page_or_question.background_image_url
             })
             return data
 
@@ -305,6 +307,7 @@ class Survey(http.Controller):
                 page_or_question_key: next_page_or_question,
                 'has_answered': answer_sudo.user_input_line_ids.filtered(lambda line: line.question_id == next_page_or_question),
                 'can_go_back': survey_sudo._can_go_back(answer_sudo, next_page_or_question),
+                'background_image_url': next_page_or_question.background_image_url
             })
             if survey_sudo.questions_layout != 'one_page':
                 data.update({
@@ -313,6 +316,9 @@ class Survey(http.Controller):
         elif answer_sudo.state == 'done' or answer_sudo.survey_time_limit_reached:
             # Display success message
             return self._prepare_survey_finished_values(survey_sudo, answer_sudo)
+        elif survey_sudo.background_image:
+            # If survey start, add background if any
+            data['background_image_url'] = survey_sudo.background_image_url
 
         return data
 
@@ -363,16 +369,22 @@ class Survey(http.Controller):
         return request.render('survey.survey_page_fill',
             self._prepare_survey_data(access_data['survey_sudo'], answer_sudo, **post))
 
-    @http.route('/survey/get_background_image/<string:survey_token>/<string:answer_token>', type='http', auth="public", website=True, sitemap=False)
-    def survey_get_background(self, survey_token, answer_token):
-        access_data = self._get_access_data(survey_token, answer_token, ensure_token=True)
-        if access_data['validity_code'] is not True:
-            return werkzeug.exceptions.Forbidden()
+    @http.route([
+        '/survey/get_background_image/<string:survey_token>',
+        '/survey/get_background_image/<string:survey_token>/<model("survey.question"):question>'
+    ], type='http', auth="public", website=True, sitemap=False)
+    def survey_get_background(self, survey_token, question=None):
+        survey_sudo, dummy = self._fetch_from_access_token(survey_token, False)
 
-        survey_sudo, answer_sudo = access_data['survey_sudo'], access_data['answer_sudo']
+        if question and question not in survey_sudo.question_and_page_ids:
+            # trying to access a question that is not in this survey
+            raise werkzeug.exceptions.Forbidden()
+
+        target_model = 'survey.question' if question else 'survey.survey'
+        target_id = question.id if question else survey_sudo.id
 
         status, headers, image_base64 = request.env['ir.http'].sudo().binary_content(
-            model='survey.survey', id=survey_sudo.id, field='background_image',
+            model=target_model, id=target_id, field='background_image',
             default_mimetype='image/png')
 
         return request.env['ir.http']._content_image_get_response(status, headers, image_base64)

--- a/addons/survey/controllers/survey_session_manage.py
+++ b/addons/survey/controllers/survey_session_manage.py
@@ -197,9 +197,8 @@ class UserInputSession(http.Controller):
     def _prepare_manage_session_values(self, survey):
         is_first_question, is_last_question = False, False
         if survey.question_ids:
-            most_voted_answers = survey._get_session_most_voted_answers()
             is_first_question = survey._is_first_page_or_question(survey.session_question_id)
-            is_last_question = survey._is_last_page_or_question(most_voted_answers, survey.session_question_id)
+            is_last_question = survey.session_question_id == survey.question_ids[-1]
 
         values = {
             'survey': survey,

--- a/addons/survey/controllers/survey_session_manage.py
+++ b/addons/survey/controllers/survey_session_manage.py
@@ -64,7 +64,8 @@ class UserInputSession(http.Controller):
                     'answer': request.env['survey.user_input'],
                 })
             return request.render('survey.user_input_session_open', {
-                'survey': survey
+                'survey': survey,
+                'background_image_url': survey.background_image_url
             })
         else:
             template_values = self._prepare_manage_session_values(survey)
@@ -93,7 +94,7 @@ class UserInputSession(http.Controller):
 
         if not survey or not survey.session_state:
             # no open session
-            return ''
+            return {}
 
         if survey.session_state == 'ready':
             survey._session_open()
@@ -114,9 +115,12 @@ class UserInputSession(http.Controller):
 
             template_values = self._prepare_manage_session_values(survey)
             template_values['is_rpc_call'] = True
-            return request.env.ref('survey.user_input_session_manage_content')._render(template_values)
+            return {
+                'background_image_url': next_question.background_image_url,
+                'question_html': request.env.ref('survey.user_input_session_manage_content')._render(template_values)
+            }
         else:
-            return False
+            return {}
 
     @http.route('/survey/session/results/<string:survey_token>', type='json', auth='user', website=True)
     def survey_session_results(self, survey_token, **kwargs):
@@ -248,4 +252,5 @@ class UserInputSession(http.Controller):
             'answers_validity': json.dumps(answers_validity),
             'answer_count': survey.session_question_answer_count,
             'attendees_count': survey.session_answer_count,
+            'background_image_url': survey.session_question_id.background_image_url
         }

--- a/addons/survey/static/src/scss/survey_templates_form.scss
+++ b/addons/survey/static/src/scss/survey_templates_form.scss
@@ -14,6 +14,10 @@ nav#oe_main_menu_navbar {
 /**********************************************************
                         Common Style
  **********************************************************/
+div#wrapwrap {
+    transition: box-shadow 0.3s ease-in-out;
+}
+
 .o_survey_wrap {
     min-height: 100%;
 }

--- a/addons/survey/views/survey_question_views.xml
+++ b/addons/survey/views/survey_question_views.xml
@@ -13,6 +13,7 @@
                 <field name="sequence" invisible="1"/>
                 <field name="scoring_type" invisible="1"/>
                 <sheet>
+                    <field name="background_image" widget="image" class="oe_avatar" attrs="{'invisible': [('is_page', '=', False)]}"/>
                     <div class="oe_title" style="width: 100%;">
                         <label for="title" string="Section" attrs="{'invisible': [('is_page', '=', False)]}"/>
                         <label for="title" string="Question" attrs="{'invisible': [('is_page', '=', True)]}"/>

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -65,6 +65,7 @@
                                 <tree decoration-bf="is_page" editable="bottom">
                                     <field name="sequence" widget="handle"/>
                                     <field name="title" widget="survey_description_page"/>
+                                    <field name="background_image" invisible="1"/>
                                     <field name="question_type" />
                                     <field name="is_page" invisible="1"/>
                                     <field name="questions_selection" invisible="1"/>

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -8,7 +8,11 @@
             <t t-set="no_livechat" t-value="True"/>
         </xpath>
         <xpath expr="//div[@id='wrapwrap']" position="attributes">
-            <attribute name="t-att-style" add="(('height: 100%; overflow: auto; background: url(' + '/survey/get_background_image/%s/%s' % (survey.access_token, answer.access_token) + ') no-repeat fixed center; box-shadow: inset 0 0 0 10000px rgba(255,255,255,.7); background-size: cover;') if survey and survey.background_image and answer else 'height: 100%; overflow: auto;')"/>
+            <attribute name="t-att-style"
+                       add="(('height: 100%; overflow: auto; box-shadow: inset 0 0 0 10000px rgba(255,255,255,.7); background-size: cover;
+                                background: url(' + background_image_url + ') no-repeat fixed center;')
+                             if background_image_url
+                             else 'height: 100%; overflow: auto; background-size: cover; background: no-repeat fixed center; box-shadow: inset 0 0 0 10000px rgba(255,255,255,.7);')"/>
         </xpath>
         <xpath expr="//head/t[@t-call-assets][last()]" position="after">
             <t t-call-assets="survey.survey_assets" lazy_load="True"/>
@@ -96,7 +100,8 @@
                 t-att-data-is-page-description="bool(question and question.is_page and not is_html_empty(question.description))"
                 t-att-data-questions-layout="survey.questions_layout"
                 t-att-data-triggered-questions-by-answer="json.dumps(triggered_questions_by_answer)"
-                t-att-data-selected-answers="json.dumps(selected_answers)">
+                t-att-data-selected-answers="json.dumps(selected_answers)"
+                t-att-data-questions-info="json.dumps(questions_info)">
             <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
             <input type="hidden" name="token" t-att-value="answer.access_token" />
             <div class="o_survey_error alert alert-danger d-none" role="alert">

--- a/addons/survey/views/survey_templates_user_input_session.xml
+++ b/addons/survey/views/survey_templates_user_input_session.xml
@@ -7,7 +7,11 @@
             <t t-set="no_livechat" t-value="True"/>
         </xpath>
         <xpath expr="//div[@id='wrapwrap']" position="attributes">
-            <attribute name="t-att-style" add="('height: 100%; overflow: auto; background: url(' + '/web/image/survey.survey/%s/background_image' % survey.id + ') no-repeat fixed center; box-shadow: inset 0 0 0 10000px rgba(255,255,255,.7); background-size: cover;') if survey and survey.background_image else 'height: 100%; overflow: auto;'"/>
+            <attribute name="t-att-style"
+                       add="(('height: 100%; overflow: auto; box-shadow: inset 0 0 0 10000px rgba(255,255,255,.7); background-size: cover;
+                                background: url(' + background_image_url + ') no-repeat fixed center;')
+                             if background_image_url
+                             else 'height: 100%; overflow: auto;')"/>
         </xpath>
         <xpath expr="//head/t[@t-call-assets][last()]" position="after">
             <t t-call-assets="survey.survey_assets" lazy_load="True"/>
@@ -76,7 +80,8 @@
             t-att-data-is-last-question="is_last_question"
             t-att-data-current-screen="'question' if is_scored_question else 'userInputs'"
             t-att-data-show-bar-chart="show_bar_chart"
-            t-att-data-show-text-answers="show_text_answers">
+            t-att-data-show-text-answers="show_text_answers"
+            t-att-data-current-background-image-url="background_image_url">
             <div class="o_survey_question_header flex-wrap px-3 w-100 d-flex justify-content-between align-items-center position-absolute">
                 <h3>
                     <span>Go to <a t-att-href="survey.session_link" t-esc="survey.session_link" target="_blank" /></span>


### PR DESCRIPTION
Purpose
=======

Allow the user to configure a background per section. 
Can be useful to illustrate a selected theme, especially for survey with 
conditional questions (e.g.: burger quiz).

Specifications
==============

This merge adds the background per section feature.
If the section to display has a background image configured, the background
will be refreshed using that section background image.
If the section has no background, the survey background is used.
The background is refreshed only if the previous and the next sections are
different. The background is refreshed at the same time that the next question
is loaded.

The next section to display depends on free text (section with description)
configuration and on conditional questions.
The next section to display can be the next question's section or directly
the next question itself (if the question is a section).

Link
====

Task ID: 2225393