### PR TITLE
[FIX] gamification: fix karma tracking demo data

### DIFF
--- a/addons/gamification/data/gamification_karma_tracking_demo.xml
+++ b/addons/gamification/data/gamification_karma_tracking_demo.xml
@@ -26,9 +26,22 @@
         <field name="new_value">2050</field>
         <field name="tracking_date" eval="(DateTime.now() - relativedelta(day=20, months=1)).strftime('%Y-%m-%d')"/>
     </record>
+    <record id="karma_tracking_user_demo_today" model="gamification.karma.tracking">
+        <field name="user_id" ref="base.user_demo"/>
+        <field name="old_value">2050</field>
+        <field name="new_value">2500</field>
+        <field name="tracking_date" eval="(DateTime.now()).strftime('%Y-%m-%d')"/>
+    </record>
     <record id="base.user_demo" model="res.users">
         <field name="karma">2500</field>
     </record>
+    <function model="gamification.karma.tracking" name="unlink">
+        <value model="gamification.karma.tracking" eval="obj().search([
+                ('user_id', '=', ref('base.user_demo')),
+                ('old_value', '=', 0),
+                ('new_value', '=', 2500)
+            ]).id"/>
+    </function>
 
     <!--base.demo_user0 -->
     <record id="karma_tracking_user_portal_2nd_day_last_month" model="gamification.karma.tracking">
@@ -49,15 +62,28 @@
         <field name="new_value">20</field>
         <field name="tracking_date" eval="(DateTime.now() - relativedelta(day=10, months=1)).strftime('%Y-%m-%d')"/>
     </record>
-    <record id="karma_tracking_user_portal_today_0" model="gamification.karma.tracking">
+    <record id="karma_tracking_user_portal_yesterday" model="gamification.karma.tracking">
         <field name="user_id" ref="base.demo_user0"/>
         <field name="old_value">20</field>
         <field name="new_value">25</field>
-        <field name="tracking_date" eval="(DateTime.now()).strftime('%Y-%m-%d')"/>
+        <field name="tracking_date" eval="(DateTime.now() - relativedelta(day=1)).strftime('%Y-%m-%d')"/>
+    </record>
+    <record id="karma_tracking_user_portal_today" model="gamification.karma.tracking">
+        <field name="user_id" ref="base.demo_user0"/>
+        <field name="old_value">25</field>
+        <field name="new_value">30</field>
+        <field name="tracking_date" eval="DateTime.now()"/>
     </record>
     <record id="base.demo_user0" model="res.users">
         <field name="karma">30</field>
     </record>
+    <function model="gamification.karma.tracking" name="unlink">
+        <value model="gamification.karma.tracking" eval="obj().search([
+                ('user_id', '=', ref('base.demo_user0')),
+                ('old_value', '=', 0),
+                ('new_value', '=', 30)
+            ]).id"/>
+    </function>
 
     <!--base.user_admin (already have a tracking to 2500)-->
     <record id="karma_tracking_user_admin_1st_day_last_month" model="gamification.karma.tracking">
@@ -78,6 +104,13 @@
         <field name="new_value">2500</field>
         <field name="tracking_date" eval="(DateTime.now()).strftime('%Y-%m-%d')"/>
     </record>
+    <function model="gamification.karma.tracking" name="unlink">
+        <value model="gamification.karma.tracking" eval="obj().search([
+                ('user_id', '=', ref('base.user_admin')),
+                ('old_value', '=', 0),
+                ('new_value', '=', 2500)
+            ]).id"/>
+    </function>
 
 </data>
 </odoo>


### PR DESCRIPTION
Before this commit, when checking the gained karma per month or per week in
/profile/users route, the users gained more karma than they actually have.

This is due to the way demo data are loaded : karma tracking history is added
but when the final karma is set on the user, a new line of karma tracking is
created on the DB (via write or create method). But as the transaction with
karma tracking demo data is not commited yet, the old value is still 0.
That leads to add a new karma tracking line that have old_value = 0 and
new_value = user.karma. At the end the users 'gained' as addition the amount
of the karma they have.

E.g : Mitchell Admin has 2500 karma and his karma tracking history is the
following: 0 -> 1000 then 1000 -> 1500 then 1500 -> 2500.
In total, Mitchell should have gained 2500 XP: (2500-1500)+(1500-1000)+(1000-0)
But, before this commit, as there is an additional 0 to 2500 karma tracking
line, Mitchell Admin gain in total : (2500-0)+(2500-1500)+(1500-1000)+(1000-0)
= 5000 karma.

This commit clean that additional karma tracking line to get a correct karma
tracking history.

Task ID: 2209743