### PR TITLE
[FIX] account: raise a warning when attempting to reconcile multiple f…

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -10243,7 +10243,9 @@ msgid "View"
 msgstr ""
 
 #. module: account
+#: code:addons/account/models/account_payment.py:146
 #: selection:res.partner,invoice_warn:0
+#, python-format
 msgid "Warning"
 msgstr ""
 
@@ -10294,6 +10296,12 @@ msgstr ""
 #. module: account
 #: model:ir.ui.view,arch_db:account.account_planner
 msgid "Welcome"
+msgstr ""
+
+#. module: account
+#: code:addons/account/models/account_payment.py:147
+#, python-format
+msgid "When creating a payment for multiple invoices, the payment should have the same currency as the invoices."
 msgstr ""
 
 #. module: account


### PR DESCRIPTION
…oreign currency invoices

Steps to reproduce:
- install sales
- go to settings and activate multi-currency
- go to invoicing > sales > customer invoice > create 2 invoices with
any amount in a foreign currency
- go to invoicing > sales > customer invoice > select the invoices
you previously created > action > register payment > select any journal
- validate

Previous behavior:
only one of the invoices selected would be reconciled properly, the
remaining amounts are considered as a currency exchange difference
the remaining invoices remain open

Current behavior:
an UserError is raised when the user attempts to reconcile multiple
invoices with foreign currencies

opw-2206285