### PR TITLE
Master base import exact row new jip

### DIFF
--- a/addons/base_import/static/src/js/import_action.js
+++ b/addons/base_import/static/src/js/import_action.js
@@ -789,31 +789,21 @@ var DataImport = AbstractAction.extend({
         this.$('.oe_import_error_report').html(
             QWeb.render('ImportView.error', {
                 errors: messagesSorted,
-                at: function (rows) {
-                    var from = rows.from + offset;
-                    var to = rows.to + offset;
+                at: function (rows, rawIndex, batchSkip) {
+                    var row = rows.from + offset + batchSkip + rawIndex;
                     var rowName = '';
                     if (results.name.length > rows.from && results.name[rows.from] !== '') {
                         rowName = _.str.sprintf(' (%s)', results.name[rows.from]);
                     }
-                    if (from === to) {
-                        return _.str.sprintf(_t("at row %d%s"), from, rowName);
-                    }
-                    return _.str.sprintf(_t("between rows %d and %d"),
-                                         from, to);
+                    return _.str.sprintf(_t("at row %d%s"), row, rowName);
                 },
-                at_multi: function (rows) {
-                    var from = rows.from + offset;
-                    var to = rows.to + offset;
+                at_multi: function (rows, rawIndex, batchSkip) {
+                    var row = rows.from + offset + batchSkip + rawIndex;
                     var rowName = '';
                     if (results.name.length > rows.from && results.name[rows.from] !== '') {
                         rowName = _.str.sprintf(' (%s)', results.name[rows.from]);
                     }
-                    if (from === to) {
-                        return _.str.sprintf(_t("Row %d%s"), from, rowName);
-                    }
-                    return _.str.sprintf(_t("Between rows %d and %d"),
-                                         from, to);
+                    return _.str.sprintf(_t("at row %d%s"), row, rowName);
                 },
                 at_multi_header: function (numberLines) {
                     return _.str.sprintf(_t("at %d different rows:"),

--- a/addons/base_import/static/src/xml/base_import.xml
+++ b/addons/base_import/static/src/xml/base_import.xml
@@ -215,14 +215,18 @@
     </t>
     <t t-name="ImportView.error.multi.body">
         <span class="oe_import_report_message">
-            <t t-esc="at_multi(error.rows)"/>
+            <t t-set="raw_index" t-value="error.index ? error.index : 0"/>
+            <t t-set="batch_skip" t-value="errors.skip ? errors.skip : 0"/>
+            <t t-esc="at_multi(error.rows, raw_index, batch_skip)"/>
         </span>
     </t>
     <t t-name="ImportView.error.single">
         <span class="oe_import_report_message">
             <t t-esc="error.message"/>
         </span>
-        <t t-if="error.rows"  t-esc="at(error.rows)"/>
+        <t t-set="raw_index" t-value="error.index ? error.index : 0"/>
+        <t t-set="batch_skip" t-value="errors.skip ? errors.skip : 0"/>
+        <t t-if="error.rows"  t-esc="at(error.rows, raw_index, batch_skip)"/>
         <t t-if="error.moreinfo" t-raw="info(error.moreinfo)"/>
     </t>
 </templates>

--- a/odoo/addons/test_impex/tests/test_load.py
+++ b/odoo/addons/test_impex/tests/test_load.py
@@ -905,10 +905,19 @@ class test_o2m(ImporterCase):
     def test_subfields_fail_by_implicit_id(self):
         result = self.import_(['value/parent_id'], [['noxidforthat']])
         self.assertEqual(result['messages'], [message(
-            u"No matching record found for name 'noxidforthat' in field 'Value/Parent'",
+            u"No matching record found for name 'noxidforthat' in field 'Value/Parent'", index=0,
             moreinfo=moreaction(res_model='export.one2many')
             )])
         self.assertIs(result['ids'], False)
+
+    def test_subfields_fail_with_multi_rows(self):
+        result = self.import_(['value/parent_id'], [['noxidforthat'], ['noxidforthat1'], ['noxidforthat2']])
+        self.assertEqual(result['messages'], [message(
+            u"No matching record found for name 'noxidforthat' in field 'Value/Parent'", from_=0, to_=2, index=0,
+            moreinfo=moreaction(res_model='export.one2many',),
+            )])
+        self.assertIs(result['ids'], False)
+        self.assertEqual(result['messages'][0]['index'], 0)
 
     def test_link_inline(self):
         """ m2m-style specification for o2ms
@@ -1104,7 +1113,7 @@ class test_realworld(SavepointCaseWithUserDemo):
             [['5'],],
         )
         self.assertEqual(result['messages'], [message(
-            u"No matching record found for name '5' in field 'Child/Child1/Parent'", field='child',
+            u"No matching record found for name '5' in field 'Child/Child1/Parent'", field='child', index=0,
             moreinfo=moreaction(res_model='export.one2many.multiple'))])
         self.assertIs(result['ids'], False)
 


### PR DESCRIPTION
Purpose:
Display exact row in import errors on one2many 'subfield'.

Specification:
Improve the error message to the following:
No matching record found for name 'XXX' in field YYY at [EXACT ROW]

Task: 1924916

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
