### PR TITLE
[FIX] l10n_cn*: updated tax rates effective from April, 2019

### DIFF
--- a/addons/l10n_cn_small_business/data/account_tax_template_data.xml
+++ b/addons/l10n_cn_small_business/data/account_tax_template_data.xml
@@ -1,16 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="1">
+    <record id="l10n_cn_small_business_tax_group_vat_9" model="account.tax.group">
+        <field name="name">VAT 9%</field>
+    </record>
+    <record id="l10n_cn_small_business_tax_group_vat_13" model="account.tax.group">
+        <field name="name">VAT 13%</field>
+    </record>
 
     <!-- sales tax included -->
-    <record id="l10n_cn_small_business_sales_included_17" model="account.tax.template">
+    <record id="l10n_cn_small_business_sales_included_13" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_chart_china_small_business"/>
-        <field name="name">税收17％（含） - 中国小企业会计科目表</field>
-        <field name="description">税收17％</field>
-        <field name="amount">17</field>
+        <field name="name">税收13％（含） - 中国小企业会计科目表</field>
+        <field name="description">税收13％</field>
+        <field name="sequence">0</field>
+        <field name="amount">13</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
         <field name="price_include" eval="1"/>
-        <field name="tax_group_id" ref="l10n_cn.l10n_cn_tax_group_vat_17"/>
+        <field name="tax_group_id" ref="l10n_cn_small_business_tax_group_vat_13"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
@@ -34,15 +41,15 @@
             }),
         ]"/>
     </record>
-    <record id="l10n_cn_small_business_sales_included_11" model="account.tax.template">
+    <record id="l10n_cn_small_business_sales_included_9" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_chart_china_small_business"/>
-        <field name="name">税收11％（含） - 中国小企业会计科目表</field>
-        <field name="description">税收11％</field>
-        <field name="amount">11</field>
+        <field name="name">税收9％（含） - 中国小企业会计科目表</field>
+        <field name="description">税收9％</field>
+        <field name="amount">9</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
         <field name="price_include" eval="1"/>
-        <field name="tax_group_id" ref="l10n_cn.l10n_cn_tax_group_vat_11"/>
+        <field name="tax_group_id" ref="l10n_cn_small_business_tax_group_vat_9"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
@@ -132,15 +139,15 @@
     </record>
 
     <!-- sales tax excluded -->
-    <record id="l10n_cn_small_business_sales_excluded_17" model="account.tax.template">
+    <record id="l10n_cn_small_business_sales_excluded_13" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_chart_china_small_business"/>
-        <field name="name">税收17％ - 中国小企业会计科目表</field>
-        <field name="description">税收17％</field>
-        <field name="amount">17</field>
+        <field name="name">税收13％ - 中国小企业会计科目表</field>
+        <field name="description">税收13％</field>
+        <field name="amount">13</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
         <field name="price_include" eval="0"/>
-        <field name="tax_group_id" ref="l10n_cn.l10n_cn_tax_group_vat_17"/>
+        <field name="tax_group_id" ref="l10n_cn_small_business_tax_group_vat_13"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
@@ -164,15 +171,15 @@
             }),
         ]"/>
     </record>
-    <record id="l10n_cn_small_business_sales_excluded_11" model="account.tax.template">
+    <record id="l10n_cn_small_business_sales_excluded_9" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_chart_china_small_business"/>
-        <field name="name">税收11％ - 中国小企业会计科目表</field>
-        <field name="description">税收11％</field>
-        <field name="amount">11</field>
+        <field name="name">税收9％ - 中国小企业会计科目表</field>
+        <field name="description">税收9％</field>
+        <field name="amount">9</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
         <field name="price_include" eval="0"/>
-        <field name="tax_group_id" ref="l10n_cn.l10n_cn_tax_group_vat_11"/>
+        <field name="tax_group_id" ref="l10n_cn_small_business_tax_group_vat_9"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
@@ -263,15 +270,16 @@
 
 
     <!-- purchase tax excluded -->
-    <record id="l10n_cn_small_business_purchase_excluded_17" model="account.tax.template">
+    <record id="l10n_cn_small_business_purchase_excluded_13" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_chart_china_small_business"/>
-        <field name="name">税收17％ - 中国小企业会计科目表</field>
-        <field name="description">税收17％</field>
-        <field name="amount">17</field>
+        <field name="name">税收13％ - 中国小企业会计科目表</field>
+        <field name="description">税收13％</field>
+        <field name="sequence">0</field>
+        <field name="amount">13</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
         <field name="price_include" eval="0"/>
-        <field name="tax_group_id" ref="l10n_cn.l10n_cn_tax_group_vat_17"/>
+        <field name="tax_group_id" ref="l10n_cn_small_business_tax_group_vat_13"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
@@ -295,15 +303,15 @@
             }),
         ]"/>
     </record>
-    <record id="l10n_cn_small_business_purchase_excluded_11" model="account.tax.template">
+    <record id="l10n_cn_small_business_purchase_excluded_9" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_chart_china_small_business"/>
-        <field name="name">税收11％ - 中国小企业会计科目表</field>
-        <field name="description">税收11％</field>
-        <field name="amount">11</field>
+        <field name="name">税收9％ - 中国小企业会计科目表</field>
+        <field name="description">税收9％</field>
+        <field name="amount">9</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
         <field name="price_include" eval="0"/>
-        <field name="tax_group_id" ref="l10n_cn.l10n_cn_tax_group_vat_11"/>
+        <field name="tax_group_id" ref="l10n_cn_small_business_tax_group_vat_9"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,

--- a/addons/l10n_cn_small_business/i18n_extra/en_US.po
+++ b/addons/l10n_cn_small_business/i18n_extra/en_US.po
@@ -172,68 +172,68 @@ msgid "壞賬準備"
 msgstr "Bad Debt Provisions"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_11
-#: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_11
-msgid "税收11％"
-msgstr "Tax 11%"
+#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_9
+#: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_9
+msgid "税收9％"
+msgstr "Tax 9%"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_11
-#: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_11
-msgid "税收11％ - 中国小企业会计科目表"
-msgstr "Tax 11%"
+#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_9
+#: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_9
+msgid "税收9％ - 中国小企业会计科目表"
+msgstr "Tax 9%"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_11
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_11
-#: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_11
-#: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_included_11
-msgid "税收11％"
-msgstr "Tax 11%"
+#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_9
+#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_9
+#: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_9
+#: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_included_9
+msgid "税收9％"
+msgstr "Tax 9%"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_11
-#: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_11
-msgid "税收11％ - 中国小企业会计科目表"
-msgstr "Tax 11%"
+#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_9
+#: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_9
+msgid "税收9％ - 中国小企业会计科目表"
+msgstr "Tax 9%"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_11
-#: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_included_11
-msgid "税收11％（含） - 中国小企业会计科目表"
-msgstr "Tax 11% (Incl.)"
+#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_9
+#: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_included_9
+msgid "税收9％（含） - 中国小企业会计科目表"
+msgstr "Tax 9% (Incl.)"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_17
-#: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_17
-msgid "税收17％"
-msgstr "Tax 17%"
+#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_13
+#: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_13
+msgid "税收13％"
+msgstr "Tax 13%"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_17
-#: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_17
-msgid "税收17％ - 中国小企业会计科目表"
-msgstr "Tax 17%"
+#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_13
+#: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_13
+msgid "税收13％ - 中国小企业会计科目表"
+msgstr "Tax 13%"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_17
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_17
-#: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_17
-#: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_included_17
-msgid "税收17％"
-msgstr "Tax 17%"
+#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_13
+#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_13
+#: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_13
+#: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_included_13
+msgid "税收13％"
+msgstr "Tax 13%"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_17
-#: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_17
-msgid "税收17％ - 中国小企业会计科目表"
-msgstr "Tax 17%"
+#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_13
+#: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_13
+msgid "税收13％ - 中国小企业会计科目表"
+msgstr "Tax 13%"
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_17
-#: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_included_17
-msgid "税收17％（含） - 中国小企业会计科目表"
-msgstr "Tax 17% (Incl.)"
+#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_13
+#: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_included_13
+msgid "税收13％（含） - 中国小企业会计科目表"
+msgstr "Tax 13% (Incl.)"
 
 #. module: l10n_cn_small_business
 #: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_3

--- a/addons/l10n_cn_small_business/i18n_extra/l10n_cn_small_business.pot
+++ b/addons/l10n_cn_small_business/i18n_extra/l10n_cn_small_business.pot
@@ -172,67 +172,67 @@ msgid "壞賬準備"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_11
-#: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_11
-msgid "税收11％"
+#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_9
+#: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_9
+msgid "税收9％"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_11
-#: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_11
-msgid "税收11％ - 中国小企业会计科目表"
+#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_9
+#: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_9
+msgid "税收9％ - 中国小企业会计科目表"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_11
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_11
-#: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_11
-#: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_included_11
-msgid "税收11％"
+#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_9
+#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_9
+#: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_9
+#: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_included_9
+msgid "税收9％"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_11
-#: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_11
-msgid "税收11％ - 中国小企业会计科目表"
+#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_9
+#: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_9
+msgid "税收9％ - 中国小企业会计科目表"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_11
-#: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_included_11
-msgid "税收11％（含） - 中国小企业会计科目表"
+#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_9
+#: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_included_9
+msgid "税收9％（含） - 中国小企业会计科目表"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_17
-#: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_17
-msgid "税收17％"
+#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_13
+#: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_13
+msgid "税收13％"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_17
-#: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_17
-msgid "税收17％ - 中国小企业会计科目表"
+#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_purchase_excluded_13
+#: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_purchase_excluded_13
+msgid "税收13％ - 中国小企业会计科目表"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_17
-#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_17
-#: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_17
-#: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_included_17
-msgid "税收17％"
+#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_13
+#: model:account.tax,description:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_13
+#: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_13
+#: model:account.tax.template,description:l10n_cn_small_business.l10n_cn_small_business_sales_included_13
+msgid "税收13％"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_17
-#: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_17
-msgid "税收17％ - 中国小企业会计科目表"
+#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_excluded_13
+#: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_excluded_13
+msgid "税收13％ - 中国小企业会计科目表"
 msgstr ""
 
 #. module: l10n_cn_small_business
-#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_17
-#: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_included_17
-msgid "税收17％（含） - 中国小企业会计科目表"
+#: model:account.tax,name:l10n_cn_small_business.1_l10n_cn_small_business_sales_included_13
+#: model:account.tax.template,name:l10n_cn_small_business.l10n_cn_small_business_sales_included_13
+msgid "税收13％（含） - 中国小企业会计科目表"
 msgstr ""
 
 #. module: l10n_cn_small_business

--- a/addons/l10n_cn_standard/data/account_tax_template_data.xml
+++ b/addons/l10n_cn_standard/data/account_tax_template_data.xml
@@ -1,16 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="1">
+    <record id="l10n_cn_standard_tax_group_vat_9" model="account.tax.group">
+        <field name="name">VAT 9%</field>
+    </record>
+    <record id="l10n_cn_standard_tax_group_vat_13" model="account.tax.group">
+        <field name="name">VAT 13%</field>
+    </record>
 
     <!-- sales tax included -->
-    <record id="l10n_cn_standard_sales_included_17" model="account.tax.template">
+    <record id="l10n_cn_standard_sales_included_13" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_chart_china_standard_business"/>
-        <field name="name">税收17％（含） - 中国会计科目表-企业会计准则</field>
-        <field name="description">税收17％</field>
-        <field name="amount">17</field>
+        <field name="name">税收13％（含） - 中国会计科目表-企业会计准则</field>
+        <field name="description">税收13％</field>
+        <field name="sequence">0</field>
+        <field name="amount">13</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
         <field name="price_include" eval="1"/>
-        <field name="tax_group_id" ref="l10n_cn.l10n_cn_tax_group_vat_17"/>
+        <field name="tax_group_id" ref="l10n_cn_standard_tax_group_vat_13"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
@@ -34,15 +41,15 @@
             }),
         ]"/>
     </record>
-    <record id="l10n_cn_standard_sales_included_11" model="account.tax.template">
+    <record id="l10n_cn_standard_sales_included_9" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_chart_china_standard_business"/>
-        <field name="name">税收11％（含） - 中国会计科目表-企业会计准则</field>
-        <field name="description">税收11％</field>
-        <field name="amount">11</field>
+        <field name="name">税收9％（含） - 中国会计科目表-企业会计准则</field>
+        <field name="description">税收9％</field>
+        <field name="amount">9</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
         <field name="price_include" eval="1"/>
-        <field name="tax_group_id" ref="l10n_cn.l10n_cn_tax_group_vat_11"/>
+        <field name="tax_group_id" ref="l10n_cn_standard_tax_group_vat_9"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
@@ -133,15 +140,15 @@
     </record>
 
     <!-- sales tax excluded -->
-    <record id="l10n_cn_standard_sales_excluded_17" model="account.tax.template">
+    <record id="l10n_cn_standard_sales_excluded_13" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_chart_china_standard_business"/>
-        <field name="name">税收17％ - 中国会计科目表-企业会计准则</field>
-        <field name="description">税收17％</field>
-        <field name="amount">17</field>
+        <field name="name">税收13％ - 中国会计科目表-企业会计准则</field>
+        <field name="description">税收13％</field>
+        <field name="amount">13</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
         <field name="price_include" eval="0"/>
-        <field name="tax_group_id" ref="l10n_cn.l10n_cn_tax_group_vat_17"/>
+        <field name="tax_group_id" ref="l10n_cn_standard_tax_group_vat_13"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
@@ -165,15 +172,15 @@
             }),
         ]"/>
     </record>
-    <record id="l10n_cn_standard_sales_excluded_11" model="account.tax.template">
+    <record id="l10n_cn_standard_sales_excluded_9" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_chart_china_standard_business"/>
-        <field name="name">税收11％ - 中国会计科目表-企业会计准则</field>
-        <field name="description">税收11％</field>
-        <field name="amount">11</field>
+        <field name="name">税收9％ - 中国会计科目表-企业会计准则</field>
+        <field name="description">税收9％</field>
+        <field name="amount">9</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
         <field name="price_include" eval="0"/>
-        <field name="tax_group_id" ref="l10n_cn.l10n_cn_tax_group_vat_11"/>
+        <field name="tax_group_id" ref="l10n_cn_standard_tax_group_vat_9"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
@@ -264,15 +271,16 @@
 
 
     <!-- purchase tax excluded -->
-    <record id="l10n_cn_standard_purchase_excluded_17" model="account.tax.template">
+    <record id="l10n_cn_standard_purchase_excluded_13" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_chart_china_standard_business"/>
-        <field name="name">税收17％ - 中国会计科目表-企业会计准则</field>
-        <field name="description">税收17％</field>
-        <field name="amount">17</field>
+        <field name="name">税收13％ - 中国会计科目表-企业会计准则</field>
+        <field name="description">税收13％</field>
+        <field name="sequence">0</field>
+        <field name="amount">13</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
         <field name="price_include" eval="0"/>
-        <field name="tax_group_id" ref="l10n_cn.l10n_cn_tax_group_vat_17"/>
+        <field name="tax_group_id" ref="l10n_cn_standard_tax_group_vat_13"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
@@ -296,15 +304,15 @@
             }),
         ]"/>
     </record>
-    <record id="l10n_cn_standard_purchase_excluded_11" model="account.tax.template">
+    <record id="l10n_cn_standard_purchase_excluded_9" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_chart_china_standard_business"/>
-        <field name="name">税收11％ - 中国会计科目表-企业会计准则</field>
-        <field name="description">税收11％</field>
-        <field name="amount">11</field>
+        <field name="name">税收9％ - 中国会计科目表-企业会计准则</field>
+        <field name="description">税收9％</field>
+        <field name="amount">9</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
         <field name="price_include" eval="0"/>
-        <field name="tax_group_id" ref="l10n_cn.l10n_cn_tax_group_vat_11"/>
+        <field name="tax_group_id" ref="l10n_cn_standard_tax_group_vat_9"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,

--- a/addons/l10n_cn_standard/i18n_extra/en_US.po
+++ b/addons/l10n_cn_standard/i18n_extra/en_US.po
@@ -333,68 +333,68 @@ msgid "坏账准备"
 msgstr "Bad Debt Provisions"
 
 #. module: l10n_cn_standard
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_11
-#: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_purchase_excluded_11
-msgid "税收11％"
-msgstr "Tax 11%"
+#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_9
+#: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_purchase_excluded_9
+msgid "税收9％"
+msgstr "Tax 9%"
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_11
-#: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_purchase_excluded_11
-msgid "税收11％ - 中国会计科目表-企业会计准则"
-msgstr "Tax 11%"
+#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_9
+#: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_purchase_excluded_9
+msgid "税收9％ - 中国会计科目表-企业会计准则"
+msgstr "Tax 9%"
 
 #. module: l10n_cn_standard
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_11
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_included_11
-#: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_excluded_11
-#: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_included_11
-msgid "税收11％"
-msgstr "Tax 11%"
+#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_9
+#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_included_9
+#: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_excluded_9
+#: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_included_9
+msgid "税收9％"
+msgstr "Tax 9%"
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_11
-#: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_excluded_11
-msgid "税收11％ - 中国会计科目表-企业会计准则"
-msgstr "Tax 11%"
+#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_9
+#: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_excluded_9
+msgid "税收9％ - 中国会计科目表-企业会计准则"
+msgstr "Tax 9%"
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_included_11
-#: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_included_11
-msgid "税收11％（含） - 中国会计科目表-企业会计准则"
-msgstr "Tax 11% (Incl.)"
+#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_included_9
+#: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_included_9
+msgid "税收9％（含） - 中国会计科目表-企业会计准则"
+msgstr "Tax 9% (Incl.)"
 
 #. module: l10n_cn_standard
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_17
-#: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_purchase_excluded_17
-msgid "税收17％"
-msgstr "Tax 17%"
+#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_13
+#: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_purchase_excluded_13
+msgid "税收13％"
+msgstr "Tax 13%"
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_17
-#: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_purchase_excluded_17
-msgid "税收17％ - 中国会计科目表-企业会计准则"
-msgstr "Tax 17%"
+#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_13
+#: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_purchase_excluded_13
+msgid "税收13％ - 中国会计科目表-企业会计准则"
+msgstr "Tax 13%"
 
 #. module: l10n_cn_standard
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_17
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_included_17
-#: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_excluded_17
-#: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_included_17
-msgid "税收17％"
-msgstr "Tax 17%"
+#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_13
+#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_included_13
+#: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_excluded_13
+#: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_included_13
+msgid "税收13％"
+msgstr "Tax 13%"
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_17
-#: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_excluded_17
-msgid "税收17％ - 中国会计科目表-企业会计准则"
-msgstr "Tax 17%"
+#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_13
+#: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_excluded_13
+msgid "税收13％ - 中国会计科目表-企业会计准则"
+msgstr "Tax 13%"
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_included_17
-#: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_included_17
-msgid "税收17％（含） - 中国会计科目表-企业会计准则"
-msgstr "Tax 17% (Incl.)"
+#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_included_13
+#: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_included_13
+msgid "税收13％（含） - 中国会计科目表-企业会计准则"
+msgstr "Tax 13% (Incl.)"
 
 #. module: l10n_cn_standard
 #: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_3

--- a/addons/l10n_cn_standard/i18n_extra/l10n_cn_standard.pot
+++ b/addons/l10n_cn_standard/i18n_extra/l10n_cn_standard.pot
@@ -333,67 +333,67 @@ msgid "坏账准备"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_11
-#: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_purchase_excluded_11
-msgid "税收11％"
+#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_9
+#: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_purchase_excluded_9
+msgid "税收9％"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_11
-#: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_purchase_excluded_11
-msgid "税收11％ - 中国会计科目表-企业会计准则"
+#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_9
+#: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_purchase_excluded_9
+msgid "税收9％ - 中国会计科目表-企业会计准则"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_11
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_included_11
-#: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_excluded_11
-#: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_included_11
-msgid "税收11％"
+#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_9
+#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_included_9
+#: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_excluded_9
+#: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_included_9
+msgid "税收9％"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_11
-#: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_excluded_11
-msgid "税收11％ - 中国会计科目表-企业会计准则"
+#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_9
+#: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_excluded_9
+msgid "税收9％ - 中国会计科目表-企业会计准则"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_included_11
-#: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_included_11
-msgid "税收11％（含） - 中国会计科目表-企业会计准则"
+#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_included_9
+#: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_included_9
+msgid "税收9％（含） - 中国会计科目表-企业会计准则"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_17
-#: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_purchase_excluded_17
-msgid "税收17％"
+#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_13
+#: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_purchase_excluded_13
+msgid "税收13％"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_17
-#: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_purchase_excluded_17
-msgid "税收17％ - 中国会计科目表-企业会计准则"
+#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_purchase_excluded_13
+#: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_purchase_excluded_13
+msgid "税收13％ - 中国会计科目表-企业会计准则"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_17
-#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_included_17
-#: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_excluded_17
-#: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_included_17
-msgid "税收17％"
+#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_13
+#: model:account.tax,description:l10n_cn_standard.1_l10n_cn_standard_sales_included_13
+#: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_excluded_13
+#: model:account.tax.template,description:l10n_cn_standard.l10n_cn_standard_sales_included_13
+msgid "税收13％"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_17
-#: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_excluded_17
-msgid "税收17％ - 中国会计科目表-企业会计准则"
+#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_excluded_13
+#: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_excluded_13
+msgid "税收13％ - 中国会计科目表-企业会计准则"
 msgstr ""
 
 #. module: l10n_cn_standard
-#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_included_17
-#: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_included_17
-msgid "税收17％（含） - 中国会计科目表-企业会计准则"
+#: model:account.tax,name:l10n_cn_standard.1_l10n_cn_standard_sales_included_13
+#: model:account.tax.template,name:l10n_cn_standard.l10n_cn_standard_sales_included_13
+msgid "税收13％（含） - 中国会计科目表-企业会计准则"
 msgstr ""
 
 #. module: l10n_cn_standard


### PR DESCRIPTION
Task: 2209514

Note: I did not define account.tax.group records in l10n_cn module, instead, I defined them in both l10n_cn_standard and l10n_cn_small_business modules. This is because if user tries to upgrade any of the above modules without upgrading l10n_cn, it does not crash.
Also, I did not remove `account.tax` model's translation terms from po/pot files considering this is stable version where we do not apply unnecessary changes.