### PR TITLE
[FIX] website_event: fix 'ir.ui.view' duplicates when activating submenu

### DIFF
--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -96,6 +96,7 @@ class Event(models.Model):
 
     def _create_menu(self, sequence, name, url, xml_id):
         if not url:
+            self.env['ir.ui.view'].search([('name', '=', name + ' ' + self.name)]).unlink()
             newpath = self.env['website'].new_page(name + ' ' + self.name, template=xml_id, ispage=False)['url']
             url = "/event/" + slug(self) + "/page/" + newpath[1:]
         menu = self.env['website.menu'].create({


### PR DESCRIPTION
PURPOSE

Before this commit when updating an event with website_menu activated
it created an 'ir.ui.view' which wasn't deleted with the website_menu
thus creating another one when activating it again. This commit fix
this issue.

SPECIFICATION

Delete the corresponding 'ir.ui.view' before creating a menu.

LINK

Task ID : 2210427


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
