### PR TITLE
[IMP] web: shorten breadcrumb items if too long

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -490,7 +490,7 @@
                     <div class="oe_title pr-0">
                         <h1 class="d-flex flex-row justify-content-between">
                             <field name="priority" widget="priority" class="mr-3"/>
-                            <field name="name" class="o_task_name text-truncate" placeholder="Task Title..."/>
+                            <field name="name" class="o_task_name" placeholder="Task Title..."/>
                             <field name="kanban_state" widget="state_selection" class="ml-auto"/>
                         </h1>
                     </div>

--- a/addons/web/static/src/js/views/control_panel/control_panel_renderer.js
+++ b/addons/web/static/src/js/views/control_panel/control_panel_renderer.js
@@ -35,6 +35,8 @@ var ControlPanelRenderer = Renderer.extend({
      * @param {String} [params.template] the QWeb template to render the
      *   ControlPanel. By default, the template 'ControlPanel' will be used.
      * @param {string} [params.title=''] the title visible in control panel
+     * @param {integer} [params.maxBreadcrumbItemLength] the maximum length of
+     * a breadcrumb item before being shortened.
      */
     init: function (parent, state, params) {
         this._super.apply(this, arguments);
@@ -46,6 +48,7 @@ var ControlPanelRenderer = Renderer.extend({
             this.template = params.template;
         }
         this.context = params.context;
+        this.maxBreadcrumbItemLength = params.maxBreadcrumbItemLength || 64;
 
         this.$subMenus = null;
         this.action = params.action;
@@ -246,9 +249,20 @@ var ControlPanelRenderer = Renderer.extend({
         var self = this;
         var is_last = (index === length-1);
         var li_content = bc.title && _.escape(bc.title.trim()) || data.noDisplayContent;
+
+        // shorten the breadcrumb item if too long
+        if (li_content && li_content.length > this.maxBreadcrumbItemLength) {
+            li_content = li_content.slice(0, this.maxBreadcrumbItemLength - 3) + '...';
+        }
+
         var $bc = $('<li>', {class: 'breadcrumb-item'})
             .append(is_last ? li_content : $('<a>', {href: '#'}).html(li_content))
             .toggleClass('active', is_last);
+
+        if (bc.title) {
+            $bc.attr('title', bc.title);
+        }
+
         if (!is_last) {
             $bc.click(function (ev) {
                 ev.preventDefault();


### PR DESCRIPTION
If a breadcrumb item becomes too long, it is shortened and '...' is added at its end.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr