### PR TITLE
[FIX] project_forecast: Forecast in multi company

### DIFF
--- a/addons/hr/security/hr_security.xml
+++ b/addons/hr/security/hr_security.xml
@@ -39,7 +39,7 @@
         <field name="name">Employee multi company rule</field>
         <field name="model_id" ref="model_hr_employee"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
+        <field name="domain_force">['|', '|', ('company_id','=',False),('company_id','child_of',[user.company_id.id]), ('user_id', '=', user.id)]</field>
     </record>
 
 </data>


### PR DESCRIPTION
    Steps to reproduce the bug:

    - Let's consider two companies C1 and C2
    - Let's consider the user U where U has C1 and C2 as allowed companies
    - Let's consider an employee E linked to U in C1
    - In C2, go to Project app > Forecast
    - Add a new line

    Bug:

    An access error was raised

opw:2211258