### PR TITLE
[FIX] stock: Report forecast has incorrect quantity

### DIFF
--- a/addons/stock/report/report_stock_quantity.py
+++ b/addons/stock/report/report_stock_quantity.py
@@ -72,7 +72,8 @@ FROM
 LEFT JOIN stock_location l on (l.id=q.location_id)
 LEFT JOIN stock_warehouse wh ON l.parent_path like concat('%/', wh.view_location_id, '/%')
 WHERE
-    l.usage = 'internal'
+    l.usage = 'internal' AND
+    wh.id IS NOT NULL
 UNION
 SELECT
     m.id,


### PR DESCRIPTION
Usecase to reproduce:
- Create an internal location outside your warehouse (e.g. renting)
- Create a product with 10 units in stock
- Deliver to the location outside your warehouse
- Product stat button show 9 forecasted unit
- Open report -> It shows 10 units

It happens because the sql view take all the quant linked to
an internal location. However the compute_quantities on product.product
rejects quantity outside your warehouses.

Adapt query in order to respect the condition on warehouse for quants.

Task: 2206785
