### PR TITLE
[IMP] website_event: improve the event dates edition on website

### DIFF
--- a/addons/web_editor/models/ir_qweb.py
+++ b/addons/web_editor/models/ir_qweb.py
@@ -273,7 +273,11 @@ class DateTime(models.AbstractModel):
 
         # parse from string to datetime
         lg = self.env['res.lang']._lang_get(self.env.user.lang) or get_lang(self.env)
-        dt = datetime.strptime(value, '%s %s' % (lg.date_format, lg.time_format))
+
+        if re.match(r'^[0-9]+$', value):
+            dt = datetime.fromtimestamp(int(value))
+        else:
+            dt = datetime.strptime(value, '%s %s' % (lg.date_format, lg.time_format))
 
         # convert back from user's timezone to UTC
         tz_name = element.attrib.get('data-oe-original-tz') or self.env.context.get('tz') or self.env.user.tz

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -6,6 +6,7 @@ import json
 
 from odoo import api, fields, models, _
 from odoo.addons.http_routing.models.ir_http import slug
+from odoo.addons.base.models.res_partner import _tz_get
 
 GOOGLE_CALENDAR_URL = 'https://www.google.com/calendar/render?'
 
@@ -99,6 +100,11 @@ class Event(models.Model):
                         event.menu_id = root_menu
                     for sequence, (name, url, xml_id) in enumerate(event._get_menu_entries()):
                         event._create_menu(sequence, name, url, xml_id)
+
+    @api.model
+    def _event_tz_get(self):
+        # to be able to get the timezone list from the snippet template
+        return _tz_get(self)
 
     def _create_menu(self, sequence, name, url, xml_id):
         if not url:

--- a/addons/website_event/static/src/js/website_event_dates.js
+++ b/addons/website_event/static/src/js/website_event_dates.js
@@ -1,0 +1,69 @@
+odoo.define('website_event.dates', function (require) {
+'use strict';
+
+var options = require('web_editor.snippets.options');
+
+options.registry.s_website_event_dates = options.Class.extend({
+    selector: ".event_dates",
+    disabledInEditableMode: false,
+
+    /**
+     * @override
+     */
+    start: function () {
+        // elements in the options
+        this.$startDate = this.$target.find('.o_website_event_date_begin');
+        this.$endDate = this.$target.find('.o_website_event_date_end');
+        this.$timezone = this.$target.find('*[data-oe-field="date_tz"]');
+
+        this._initValues();
+
+        return this._super.apply(this, arguments);
+    },
+
+    _onUserValueUpdate: async function (event) {
+        await this._super.apply(this, arguments);
+
+        let attributeName = event.target.getMethodsParams().attributeName;
+        let data = this.$target[0].dataset;
+
+        switch (attributeName) {
+            case 'startDate': {
+                // for visual purpose, update the UI
+                this.$target.find('*[data-oe-field="date_begin"]').html(moment.unix(data.startDate).format("LL"));
+                // insert the timestamp to save it in the back-end
+                this.$startDate.html(data.startDate).addClass('o_dirty');
+                break;
+            }
+            case 'endDate': {
+                // for visual purpose, update the UI
+                this.$target.find('*[data-oe-field="date_end"]').html(moment.unix(data.endDate).format("LL"));
+                // insert the timestamp to save it in the back-end
+                this.$endDate.html(data.endDate).addClass('o_dirty');
+                break;
+            }
+            case 'timezone': {
+                this.$timezone.html(data.timezone).addClass('o_dirty');
+                break;
+            }
+        }
+
+        // warn the users if the dates are not coherent
+        if (data.startDate && data.endDate && parseInt(data.endDate) < parseInt(data.startDate)) {
+            this.$el.find('input').addClass('text-danger');
+        } else {
+            this.$el.find('input.text-danger').removeClass('text-danger');
+        }
+
+    },
+
+    /**
+     * Set the initial value into the snippet options
+     */
+    _initValues: function () {
+        this.$target[0].dataset['startDate'] = parseInt(this.$startDate.data('timestamp'));
+        this.$target[0].dataset['endDate'] = parseInt(this.$endDate.data('timestamp'));
+        this.$target[0].dataset['timezone'] = this.$timezone.text();
+    },
+});
+});

--- a/addons/website_event/static/src/scss/website_event.scss
+++ b/addons/website_event/static/src/scss/website_event.scss
@@ -241,3 +241,8 @@
         z-index: $zindex-dropdown - 1;
     }
 }
+
+.o_website_event_dates * {
+    // do not allows to click on elements inside the snippet
+    pointer-events: none;
+}

--- a/addons/website_event/views/assets.xml
+++ b/addons/website_event/views/assets.xml
@@ -14,6 +14,7 @@
     <template id="assets_editor" inherit_id="website.assets_editor" name="Event Assets Editor">
         <xpath expr="." position="inside">
             <script type="text/javascript" src="/website_event/static/src/js/website_event.editor.js"></script>
+            <script type="text/javascript" src="/website_event/static/src/js/website_event_dates.js"></script>
             <script type="text/javascript" src="/website_event/static/src/js/tours/website_event.js"></script>
         </xpath>
     </template>

--- a/addons/website_event/views/event_snippets.xml
+++ b/addons/website_event/views/event_snippets.xml
@@ -46,6 +46,34 @@
     </div>
 </template>
 
+<!-- Snippet - Event dates -->
+<template id="event_dates" name="Event Dates">
+    <div class="o_website_event_dates p-1" t-if="event">
+        <h6 class="o_wevent_sidebar_title">Date &amp; Time</h6>
+        <div class="d-flex">
+            <h5 t-field="event.with_context(tz=event.date_tz).date_begin" class="my-1 mr-1" t-options="{'date_only': 'true', 'format': 'full'}"/>
+        </div>
+        <t t-if="not event.is_one_day">Start -</t>
+        <span t-field="event.with_context(tz=event.date_tz).date_begin" t-options="{'time_only': 'true', 'format': 'short'}"/>
+        <t t-if="event.is_one_day">
+            <i class="fa fa-long-arrow-right mx-1"/>
+            <span t-field="event.with_context(tz=event.date_tz).date_end" t-options="{'time_only': 'true', 'format': 'short'}"/>
+        </t>
+        <t t-else="">
+            <i class="fa fa-long-arrow-down d-block text-muted mx-3 my-2" style="font-size: 1.5rem"/>
+            <div class="d-flex">
+                <h5 t-field="event.with_context(tz=event.date_tz).date_end" class="my-1 mr-1" t-options="{'date_only': 'true', 'format': 'full'}"/>
+            </div>
+            <t t-if="not event.is_one_day">End -</t>
+            <span t-field="event.with_context(tz=event.date_tz).date_end" t-options="{'time_only': 'true', 'format': 'short'}"/>
+        </t>
+        <small t-field="event.date_tz" class="d-block my-3 text-muted"/>
+        <!-- Used to store the timestamp of the dates and to save the new values (need a different DOM element because we use the timestamp) -->
+        <div class="o_website_event_date_begin d-none" t-field="event.date_begin" t-att-data-timestamp="event.date_begin.timestamp()"/>
+        <div class="o_website_event_date_end d-none"   t-field="event.date_end"   t-att-data-timestamp="event.date_end.timestamp()"/>
+    </div>
+</template>
+
 <!-- Snippets and options -->
 <template id="snippets" inherit_id="website.snippets">
     <xpath expr="//t[@id='event_local_events_hook']" position="replace">
@@ -58,6 +86,16 @@
 
 <template id="snippet_options" inherit_id="website.snippet_options">
     <xpath expr="//*[@t-set='so_content_addition_selector']" position="inside">, .oe_country_events, .s_speaker_bio</xpath>
+    <xpath expr="." position="inside">
+        <div data-js="s_website_event_dates" data-selector=".o_website_event_dates" data-no-check="true">
+            <h4>Event</h4>
+            <we-datetimepicker string="Start Date" data-select-data-attribute="" data-attribute-name="startDate"/>
+            <we-datetimepicker string="End Date" data-select-data-attribute=""   data-attribute-name="endDate"/>
+            <we-select string="Timezone" data-attribute-name="timezone">
+                <we-button t-foreach="env['event.event']._event_tz_get()" t-as="timezone" t-att-data-select-data-attribute="timezone[0]" t-esc="timezone[1]"/>
+            </we-select>
+        </div>
+    </xpath>
 </template>
 
 <!-- Snippet - Speaker Bio -->

--- a/addons/website_event/views/event_templates.xml
+++ b/addons/website_event/views/event_templates.xml
@@ -190,8 +190,8 @@
                     <main t-attf-class="#{opt_events_list_cards and 'card-body' or (opt_events_list_columns and 'py-3' or 'px-4')}">
                         <!-- Title -->
                         <h5 t-attf-class="card-title mt-2 mb-0 text-truncate #{(not event.website_published) and 'text-danger'}">
-                            <a t-attf-href="/event/#{ slug(event) }/#{(not event.menu_id) and 'register'}" 
-                                class="text-reset text-decoration-none" 
+                            <a t-attf-href="/event/#{ slug(event) }/#{(not event.menu_id) and 'register'}"
+                                class="text-reset text-decoration-none"
                                 itemprop="url">
                                 <span t-field="event.name" itemprop="name"/>
                             </a>
@@ -420,29 +420,9 @@
                     <div class="col-lg-4 bg-light shadow-sm d-print-none">
                         <!-- Date & Time -->
                         <div class="o_wevent_sidebar_block">
-                            <h6 class="o_wevent_sidebar_title">Date &amp; Time</h6>
-                            <div class="d-flex">
-                                <h5 t-field="event.with_context(tz=event.date_tz).date_begin" class="my-1 mr-1" t-options="{'date_only': 'true', 'format': 'EEEE'}"/>
-                                <h5 class="my-1" t-field="event.with_context(tz=event.date_tz).date_begin" t-options="{'date_only': 'true', 'format': 'long'}" itemprop="startDate" t-att-datetime="event.date_begin"/>
-                            </div>
-                            <t t-if="not event.is_one_day">Start -</t>
-                            <span t-field="event.with_context(tz=event.date_tz).date_begin" t-options="{'time_only': 'true', 'format': 'short'}"/>
-                            <t t-if="event.is_one_day">
-                                <i class="fa fa-long-arrow-right mx-1"/>
-                                <span t-field="event.with_context(tz=event.date_tz).date_end" t-options="{'time_only': 'true', 'format': 'short'}"/>
+                            <t t-call="website_event.event_dates">
+                                <t t-set="event" t-value="event"/>
                             </t>
-                            <t t-else="">
-                                <i class="fa fa-long-arrow-down d-block text-muted mx-3 my-2" style="font-size: 1.5rem"/>
-                                <div class="d-flex">
-                                    <h5 t-field="event.with_context(tz=event.date_tz).date_end" class="my-1 mr-1" t-options="{'date_only': 'true', 'format': 'EEEE'}"/>
-                                    <h5 class="my-1" t-field="event.with_context(tz=event.date_tz).date_end" t-options="{'date_only': 'true', 'format': 'long'}"/>
-                                </div>
-                                <t t-if="not event.is_one_day">End -</t>
-                                <span t-field="event.with_context(tz=event.date_tz).date_end" t-options="{'time_only': 'true', 'format': 'short'}"/>
-                            </t>
-                            <!-- Timezone -->
-                            <small t-esc="event.date_tz" class="d-block my-3 text-muted"/>
-
                             <div class="dropdown">
                                 <i class="fa fa-calendar mr-1"/>
                                 <a href="#" role="button" data-toggle="dropdown">Add to Calendar</a>
@@ -526,7 +506,7 @@
 
             <t t-set="tickets" t-value="event.event_ticket_ids.filtered(lambda ticket: not ticket.is_expired)"/>
             <!-- If some tickets expired and there is only one type left, we keep the same layout -->
-            <t t-if="len(event.event_ticket_ids) &gt; 1"> 
+            <t t-if="len(event.event_ticket_ids) &gt; 1">
                 <div class="d-flex align-items-center py-2 pl-3 pr-2 border-bottom">
                     <span t-if="not event.event_registrations_open" class="text-danger">
                         <i class="fa fa-ban mr-2"/>Sold Out


### PR DESCRIPTION
Purpose
========
Allow the user to edit both dates (start/end) of the event on website
with a "datetime picker" widget.

Specifications
==============
Add a new snippet option to be able to edit the dates of the events.

Modify the datetime field in QWeb to be able to save datetime with the
timestamp (as python and javascript don't have the same format for the
dates, it's easier and less errors prone to send the timestamp).

Task 2202935
