### PR TITLE
[FIX] point_of_sale: don't print invoice message on receipts

### DIFF
--- a/addons/point_of_sale/static/src/css/pos.css
+++ b/addons/point_of_sale/static/src/css/pos.css
@@ -1488,6 +1488,7 @@ td {
     .pos .keyboard_frame,
     .pos .receipt-screen header,
     .pos .receipt-screen .top-content,
+    .pos .receipt-screen .centered-content h2,
     .pos .receipt-screen .centered-content .button {
         display: none !important;
     }


### PR DESCRIPTION
Current behavior:

- A customer without ESC/POS printer prints a receipt
- It says "The order has been synchronized earlier..." at the top

Just like the old "Print Invoice" button this message should be hidden
when printing.

Introduced by f55349f30520562fbe4bd0f07761e705e9966491.

opw-2213129