### PR TITLE
[FIX] stock: reserverd quantity readonly

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -27,7 +27,9 @@ class StockMoveLine(models.Model):
     product_qty = fields.Float(
         'Real Reserved Quantity', digits=0,
         compute='_compute_product_qty', inverse='_set_product_qty', store=True)
-    product_uom_qty = fields.Float('Reserved', default=0.0, digits=dp.get_precision('Product Unit of Measure'), required=True)
+    product_uom_qty = fields.Float(
+        'Reserved', default=0.0, digits=dp.get_precision('Product Unit of Measure'),
+        required=True, readonly=True)
     ordered_qty = fields.Float('Ordered Quantity', digits=dp.get_precision('Product Unit of Measure'))
     qty_done = fields.Float('Done', default=0.0, digits=dp.get_precision('Product Unit of Measure'), copy=False)
     package_id = fields.Many2one('stock.quant.package', 'Source Package', ondelete='restrict')


### PR DESCRIPTION
Some users modify the stock.move.line views with studio in order
to add the product_uom_qty fields. However it's suppose to be
manage by the system and write on it directly introduce inconcistencies
in the system as quants are not updated.

Set the field as readonly even if it could be remove but it's a small safeguard

opw-2211981
