### PR TITLE
[FIX] web: Filter menu in search bar responsive issue

### DIFF
--- a/addons/web/static/src/scss/search_view.scss
+++ b/addons/web/static/src/scss/search_view.scss
@@ -156,7 +156,6 @@
 // Filters
 .o_filters_menu {
     .o_filter_condition {
-        @include o-search-options-dropdown-custom-item;
         margin-bottom: 8px;
         .o_or_filter { // or between conditions
             display: none;  // hidden for the first condition
@@ -183,7 +182,9 @@
     }
     .o_add_filter_menu { // apply and add buttons
         display: none;  // Needed by the webclient
-        @include o-search-options-dropdown-custom-item;
+    }
+    .o_add_filter_menu, .o_filter_condition {
+        padding-left: 3rem;
     }
 }
 


### PR DESCRIPTION
PURPOSE:

In Filter dropdown pop-up, If the buttons named "Apply" & "Add a custom filter"
have larger text then the width of the dropdown menu then it will hide the
overflowed text and it will cause the horizontal scroll in the pop-up.

Ex :  in French language "Add a custom filter" is translated into
"Ajouter un filtre personnalisé" so it is quite larger than the fixed width
dropdown pop-up.

SPEC:

So with this commit, we have removed the constraint of the width from the pop-up
to display the filter buttons perfect.

Task : 1964133


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
