### PR TITLE
[FIX] sale_timesheet: fix project_project_view_form button groups attribute name + value …

### DIFF
--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="project.edit_project"/>
         <field name="arch" type="xml">
             <xpath expr="//header" position="inside">
-                <button name="action_make_billable" string="Create Sales Order" type="object" attrs="{'invisible': [('billable_type', '!=', 'no')]}" group="sale.group_sale_salesman"/>
+                <button name="action_make_billable" string="Create Sales Order" type="object" attrs="{'invisible': [('billable_type', '!=', 'no')]}" groups="sales_team.group_sale_salesman"/>
             </xpath>
             <xpath expr="//page[@name='emails']" position="after">
                 <page name="billing_employee_rate" string="Invoicing" attrs="{'invisible': [('billable_type', '=', 'no')]}">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This pull request fixes the view sale_timesheet.project_project_view_form:
- the groups attribute of the button tag has a type : group instead of groups
- the xml_id of the group is sale.group_sale_salesman. However this external id does not exists. I have replaced it with sales_team.group_sale_salesman.

Current behavior before PR:
The button 'action_make_billable' was visible for every users

Desired behavior after PR is merged:
The button 'action_make_billable' is now visible only for users of the group 'User: Own Documents Only'


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
