### PR TITLE
[IMP] purchase_stock: price diff as val. layer

### DIFF
--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -120,7 +120,6 @@ class SequenceMixin(models.AbstractModel):
         would only work when the numbering makes a new start (domain returns by
         _get_last_sequence_domain is [], i.e: a new year).
 
-        :param field_name: the field that contains the sequence.
         :param relaxed: this should be set to True when a previous request didn't find
             something without. This allows to find a pattern from a previous period, and
             try to adapt it for the new period.
@@ -214,8 +213,6 @@ class SequenceMixin(models.AbstractModel):
         This method ensures that the field is set both in the ORM and in the database.
         This is necessary because we use a database query to get the previous sequence,
         and we need that query to always be executed on the latest data.
-
-        :param field_name: the field that contains the sequence.
         """
         self.ensure_one()
         self[self._sequence_field] = self._get_next_sequence()

--- a/addons/purchase/views/product_views.xml
+++ b/addons/purchase/views/product_views.xml
@@ -60,17 +60,6 @@
             </field>
         </record>
 
-        <record id="view_category_property_form" model="ir.ui.view">
-            <field name="name">product.category.property.form.inherit.stock</field>
-            <field name="model">product.category</field>
-            <field name="inherit_id" ref="account.view_category_property_form"/>
-            <field name="arch" type="xml">
-                <field name="property_account_income_categ_id" position="before">
-                    <field name="property_account_creditor_price_difference_categ" domain="[('deprecated','=',False)]" groups="account.group_account_readonly"/>
-                </field>
-            </field>
-        </record>
-
         <record id="view_product_account_purchase_ok_form" model="ir.ui.view">
             <field name="name">product.template.account.purchase.ok.form.inherit</field>
             <field name="model">product.template</field>
@@ -103,17 +92,6 @@
                         </div>
                     </button>
                 </div>
-            </field>
-        </record>
-
-        <record id="product_template_form_view" model="ir.ui.view">
-            <field name="name">product.normal.form.inherit.stock</field>
-            <field name="model">product.template</field>
-            <field name="inherit_id" ref="account.product_template_form_view"/>
-            <field name="arch" type="xml">
-                <field name="property_account_expense_id" position="after">
-                    <field name="property_account_creditor_price_difference" domain="[('deprecated','=',False)]" attrs="{'readonly':[('purchase_ok', '=', 0)]}" groups="account.group_account_readonly"/>
-                </field>
             </field>
         </record>
 

--- a/addons/purchase_stock/models/__init__.py
+++ b/addons/purchase_stock/models/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import account_invoice
+from . import account_move_line
 from . import product
 from . import purchase
 from . import res_company

--- a/addons/purchase_stock/models/account_invoice.py
+++ b/addons/purchase_stock/models/account_invoice.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
-from odoo.tools.float_utils import float_compare
+from odoo import fields, models, _
+from odoo.tools.float_utils import float_compare, float_is_zero
 
 
 class AccountMove(models.Model):
@@ -46,11 +46,6 @@ class AccountMove(models.Model):
                 # Filter out lines being not eligible for price difference.
                 if line.product_id.type != 'product' or line.product_id.valuation != 'real_time':
                     continue
-
-                # Retrieve accounts needed to generate the price difference.
-                debit_pdiff_account = line.product_id.property_account_creditor_price_difference \
-                                or line.product_id.categ_id.property_account_creditor_price_difference_categ
-                debit_pdiff_account = move.fiscal_position_id.map_account(debit_pdiff_account)
 
                 if line.product_id.cost_method != 'standard' and line.purchase_line_id:
                     po_currency = line.purchase_line_id.currency_id
@@ -114,49 +109,159 @@ class AccountMove(models.Model):
                     price_unit = line.tax_ids.compute_all(
                         price_unit, currency=move.currency_id, quantity=1.0, is_refund=move.move_type == 'in_refund')['total_excluded']
 
-                if float_compare(valuation_price_unit, price_unit, precision_digits=invoice_cur_prec) != 0 \
+                if line.quantity and float_compare(valuation_price_unit, price_unit, precision_digits=invoice_cur_prec) != 0 \
                         and float_compare(line['price_unit'], line.price_unit, precision_digits=invoice_cur_prec) == 0:
 
                     price_unit_val_dif = price_unit - valuation_price_unit
 
-                    if move.currency_id.compare_amounts(price_unit, valuation_price_unit) != 0 and debit_pdiff_account:
-                        # Add price difference account line.
-                        vals = {
-                            'name': line.name[:64],
-                            'move_id': move.id,
-                            'currency_id': line.currency_id.id,
-                            'product_id': line.product_id.id,
-                            'product_uom_id': line.product_uom_id.id,
-                            'quantity': line.quantity,
-                            'price_unit': price_unit_val_dif,
-                            'price_subtotal': line.quantity * price_unit_val_dif,
-                            'account_id': debit_pdiff_account.id,
-                            'analytic_account_id': line.analytic_account_id.id,
-                            'analytic_tag_ids': [(6, 0, line.analytic_tag_ids.ids)],
-                            'exclude_from_invoice_tab': True,
-                            'is_anglo_saxon_line': True,
-                        }
-                        vals.update(line._get_fields_onchange_subtotal(price_subtotal=vals['price_subtotal']))
-                        lines_vals_list.append(vals)
+                    if move.currency_id.compare_amounts(price_unit, valuation_price_unit) != 0:
+                        accounts = line.product_id.product_tmpl_id.get_product_accounts()
+                        stock_valuation_account = accounts.get('stock_valuation')
 
-                        # Correct the amount of the current line.
-                        vals = {
-                            'name': line.name[:64],
-                            'move_id': move.id,
-                            'currency_id': line.currency_id.id,
-                            'product_id': line.product_id.id,
-                            'product_uom_id': line.product_uom_id.id,
-                            'quantity': line.quantity,
-                            'price_unit': -price_unit_val_dif,
-                            'price_subtotal': line.quantity * -price_unit_val_dif,
-                            'account_id': line.account_id.id,
-                            'analytic_account_id': line.analytic_account_id.id,
-                            'analytic_tag_ids': [(6, 0, line.analytic_tag_ids.ids)],
-                            'exclude_from_invoice_tab': True,
-                            'is_anglo_saxon_line': True,
-                        }
-                        vals.update(line._get_fields_onchange_subtotal(price_subtotal=vals['price_subtotal']))
-                        lines_vals_list.append(vals)
+                        # Retrieve stock valuation moves.
+                        valuation_stock_moves = self.env['stock.move'].search([
+                            ('purchase_line_id', '=', line.purchase_line_id.id),
+                            ('product_qty', '!=', 0.0),
+                        ])
+                        if move.move_type == 'in_refund':
+                            valuation_stock_moves = valuation_stock_moves.filtered(lambda stock_move: stock_move._is_out())
+                        else:
+                            valuation_stock_moves = valuation_stock_moves.filtered(lambda stock_move: stock_move._is_in())
+                        valuation_stock_moves = valuation_stock_moves.filtered(lambda stock_move: stock_move.state == 'done')
+
+                        if valuation_stock_moves.stock_valuation_layer_ids:
+                            qty_invoiced = line.purchase_line_id.qty_invoiced
+                            qty_received = line.purchase_line_id.qty_received
+                            qty_to_diff = qty_received - (qty_invoiced - line.quantity)
+                            if qty_to_diff <= 0:
+                                continue
+                            product = line.product_id
+                            linked_layer = valuation_stock_moves.stock_valuation_layer_ids[-1]
+                            svl_vals = []
+                            price_unit_val_dif = line.price_unit - linked_layer.unit_cost
+                            price_subtotal = qty_to_diff * price_unit_val_dif
+                            if price_unit_val_dif == 0:
+                                continue
+
+                            # Create a new stock valuation layer for the price difference.
+                            svl_vals.append({
+                                'company_id': line.company_id.id,
+                                'product_id': product.id,
+                                'description': _('Price difference between %s and %s') % (move.purchase_id.name, move._get_next_sequence()),
+                                'value': price_subtotal,
+                                'quantity': 0,
+                                'account_move_id': move.id,
+                                'stock_valuation_layer_id': linked_layer.id
+                            })
+                            # Update the standard price if product cost method is AVCO.
+                            if product.cost_method == 'average' and not float_is_zero(product.quantity_svl, precision_rounding=product.uom_id.rounding):
+                                product.with_company(self.company_id).sudo().with_context(disable_auto_svl=True).standard_price += price_unit_val_dif / product.quantity_svl
+
+                            # If the product already left the stock, create a
+                            # negative counter part for the stock valuation layer.
+                            product_already_out = float_is_zero(linked_layer.remaining_qty, precision_rounding=product.uom_id.rounding)
+                            if product_already_out:
+                                svl_vals[0]['quantity'] = 1
+                                svl_out_vals = dict(svl_vals[0], **{
+                                    'quantity': -1,
+                                    'description': _('Adjustment of price difference between %s and %s as the product is already out') % (move.purchase_id.name, move._get_next_sequence()),
+                                    'value': -price_subtotal,
+                                })
+                                svl_vals.append(svl_out_vals)
+                            else:
+                                linked_layer.remaining_value += price_subtotal
+
+                            self.env['stock.valuation.layer'].sudo().create(svl_vals)
+
+                            # Add an account line for the price difference.
+                            common_vals = {
+                                'name': line.name[:64],
+                                'move_id': move.id,
+                                'currency_id': line.currency_id.id,
+                                'product_id': product.id,
+                                'product_uom_id': line.product_uom_id.id,
+                                'quantity': line.quantity,
+                                'analytic_account_id': line.analytic_account_id.id,
+                                'analytic_tag_ids': [(6, 0, line.analytic_tag_ids.ids)],
+                                'exclude_from_invoice_tab': True,
+                                'is_anglo_saxon_line': True,
+                            }
+                            vals = dict(common_vals, **{
+                                'price_unit': price_unit_val_dif,
+                                'price_subtotal': price_subtotal,
+                                'account_id': stock_valuation_account.id,
+                            })
+                            vals.update(line._get_fields_onchange_subtotal(price_subtotal=vals['price_subtotal']))
+                            lines_vals_list.append(vals)
+
+                            # Correct the amount of the current line.
+                            vals = dict(common_vals, **{
+                                'price_unit': -price_unit_val_dif,
+                                'price_subtotal': -price_subtotal,
+                                'account_id': line.account_id.id,
+                            })
+                            vals.update(line._get_fields_onchange_subtotal(price_subtotal=vals['price_subtotal']))
+                            lines_vals_list.append(vals)
+
+                            # Creates the journal entries for the output.
+                            if product_already_out:
+                                # Add also an account line for the price difference for the output side.
+                                common_vals['name'] = common_vals['name'] + (_(": %s already out") % line.quantity)
+                                vals = dict(common_vals, **{
+                                    'price_unit': -price_unit_val_dif,
+                                    'price_subtotal': -price_subtotal,
+                                    'account_id': stock_valuation_account.id,
+                                })
+                                vals.update(line._get_fields_onchange_subtotal(price_subtotal=vals['price_subtotal']))
+                                lines_vals_list.append(vals)
+
+                                # Retrieve accounts needed.
+                                accounts = line.product_id.product_tmpl_id.get_product_accounts(fiscal_pos=move.fiscal_position_id)
+                                debit_interim_account = accounts['stock_output']
+                                credit_expense_account = accounts['expense']
+
+                                vals = dict(common_vals, **{
+                                    'price_unit': price_unit_val_dif,
+                                    'price_subtotal': price_subtotal,
+                                    'account_id': debit_interim_account.id,
+                                })
+                                vals.update(line._get_fields_onchange_subtotal(price_subtotal=vals['price_subtotal']))
+                                lines_vals_list.append(vals)
+
+                                # Add interim account line.
+                                vals = {
+                                    'name': line.name[:64] + (_(": %s already out") % line.quantity),
+                                    'move_id': move.id,
+                                    'product_id': line.product_id.id,
+                                    'product_uom_id': line.product_uom_id.id,
+                                    'quantity': line.quantity,
+                                    'price_unit': -price_unit_val_dif,
+                                    'price_subtotal': -price_subtotal,
+                                    'account_id': debit_interim_account.id,
+                                    'exclude_from_invoice_tab': True,
+                                    'is_anglo_saxon_line': True,
+                                }
+                                vals.update(line._get_fields_onchange_subtotal(price_subtotal=vals['price_subtotal']))
+                                lines_vals_list.append(vals)
+
+                                # Add the price diff. in the expense account line.
+                                vals = {
+                                    'name': line.name[:64] + (_(": %s already out") % line.quantity),
+                                    'move_id': move.id,
+                                    'product_id': line.product_id.id,
+                                    'product_uom_id': line.product_uom_id.id,
+                                    'quantity': line.quantity,
+                                    'price_unit': price_unit_val_dif,
+                                    'price_subtotal': price_subtotal,
+                                    'account_id': credit_expense_account.id,
+                                    'analytic_account_id': line.analytic_account_id.id,
+                                    'analytic_tag_ids': [(6, 0, line.analytic_tag_ids.ids)],
+                                    'exclude_from_invoice_tab': True,
+                                    'is_anglo_saxon_line': True,
+                                }
+                                vals.update(line._get_fields_onchange_subtotal(price_subtotal=vals['price_subtotal']))
+                                lines_vals_list.append(vals)
+
         return lines_vals_list
 
     def _post(self, soft=True):
@@ -165,6 +270,7 @@ class AccountMove(models.Model):
         if self._context.get('move_reverse_cancel'):
             return super()._post(soft)
         self.env['account.move.line'].create(self._stock_account_prepare_anglo_saxon_in_lines_vals())
+        self.invoice_line_ids._update_qty_waiting_for_receipt()
         return super()._post(soft)
 
     def _stock_account_get_last_step_stock_moves(self):

--- a/addons/purchase_stock/models/account_move_line.py
+++ b/addons/purchase_stock/models/account_move_line.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = 'account.move.line'
+
+    qty_waiting_for_receipt = fields.Float(
+        default=0, help="Quantity invoiced but not received yet.")
+
+    def _update_qty_waiting_for_receipt(self):
+        # TODO: Could be set directly in `_stock_account_prepare_anglo_saxon_in_lines_vals` ?
+        for line in self:
+            po_line = line.purchase_line_id
+            line.qty_waiting_for_receipt = min(line.quantity, po_line.qty_invoiced - po_line.qty_received)

--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -47,6 +47,9 @@ class AccountMove(models.Model):
 
         # Unlink the COGS lines generated during the 'post' method.
         self.mapped('line_ids').filtered(lambda line: line.is_anglo_saxon_line).unlink()
+
+        # Deletes stock valuation layers generated during the 'post' method.
+        self.stock_valuation_layer_ids.sudo().unlink()
         return res
 
     def button_cancel(self):
@@ -93,7 +96,7 @@ class AccountMove(models.Model):
         '''
         lines_vals_list = []
         for move in self:
-            if not move.is_sale_document(include_receipts=True) or not move.company_id.anglo_saxon_accounting:
+            if (not move.is_sale_document(include_receipts=True) or not move.company_id.anglo_saxon_accounting):
                 continue
 
             for line in move.invoice_line_ids:


### PR DESCRIPTION
Removes the price difference account field on product template and product category, and instead of using this account, in case of price difference between the purchase order and the bill, creates a stock valuation layer about this price diff.

task-2081607