### PR TITLE
[FIX] website_(blog/slides/sale),project,crm: allow portal to use attachments

### DIFF
--- a/addons/portal/controllers/mail.py
+++ b/addons/portal/controllers/mail.py
@@ -61,6 +61,8 @@ def _message_post_helper(res_model, res_id, message, token='', _hash=False, pid=
             record = record.sudo()
         else:
             raise Forbidden()
+    elif getattr(request.env[res_model], '_mail_post_sudo', False):
+        record = record.sudo()
 
     # deduce author of message
     author_id = request.env.user.partner_id.id if request.env.user.partner_id else False

--- a/addons/portal/models/mail_thread.py
+++ b/addons/portal/models/mail_thread.py
@@ -11,6 +11,7 @@ class MailThread(models.AbstractModel):
     _inherit = 'mail.thread'
 
     _mail_post_token_field = 'access_token' # token field for external posts, to be overridden
+    _mail_post_sudo = False  # all record of the model are sudo-ed before posting, to be overridden
 
     website_message_ids = fields.One2many('mail.message', 'res_id', string='Website Messages',
         domain=lambda self: [('model', '=', self._name), '|', ('message_type', '=', 'comment'), ('message_type', '=', 'email')], auto_join=True,

--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -117,6 +117,7 @@ class BlogPost(models.Model):
     _inherit = ['mail.thread', 'website.seo.metadata', 'website.published.multi.mixin']
     _order = 'id DESC'
     _mail_post_access = 'read'
+    _mail_post_sudo = True
 
     def _compute_website_url(self):
         super(BlogPost, self)._compute_website_url()

--- a/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
+++ b/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
@@ -492,6 +492,7 @@
                 <div class="col-lg-10 offset-lg-1 mt16">
                     <t t-call="portal.message_thread">
                         <t t-set="object" t-value="lead"/>
+                        <t t-set="token" t-value="lead.access_token"/>
                     </t>
                 </div>
             </div>
@@ -809,6 +810,7 @@
                 <div class="mt16">
                     <t t-call="portal.message_thread">
                         <t t-set="object" t-value="opportunity"/>
+                        <t t-set="token" t-value="opportunity.access_token"/>
                     </t>
                 </div>
             </div>

--- a/addons/website_sale/models/product.py
+++ b/addons/website_sale/models/product.py
@@ -169,6 +169,7 @@ class ProductTemplate(models.Model):
     _inherit = ["product.template", "website.seo.metadata", 'website.published.multi.mixin', 'rating.mixin']
     _name = 'product.template'
     _mail_post_access = 'read'
+    _mail_post_sudo = True
     _check_company_auto = True
 
     website_description = fields.Html('Description for the website', sanitize_attributes=False, translate=html_translate)

--- a/addons/website_slides/controllers/mail.py
+++ b/addons/website_slides/controllers/mail.py
@@ -57,7 +57,7 @@ class SlidesPortalChatter(PortalChatter):
         message = request.env['mail.message'].search(domain, limit=1)
         if not message:
             raise NotFound()
-        message.write({
+        message.sudo().write({
             'body': message_body,
             'attachment_ids': [(4, aid) for aid in attachment_ids],
         })

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -439,7 +439,7 @@ class WebsiteSlides(WebsiteProfile):
                 last_message_values = last_message.read(['body', 'rating_value', 'attachment_ids'])[0]
                 last_message_attachment_ids = last_message_values.pop('attachment_ids', [])
                 if last_message_attachment_ids:
-                    last_message_attachment_ids = json.dumps(request.env['ir.attachment'].browse(last_message_attachment_ids).read(
+                    last_message_attachment_ids = json.dumps(request.env['ir.attachment'].browse(last_message_attachment_ids).sudo().read(
                         ['id', 'name', 'mimetype', 'file_size', 'access_token']
                     ))
             else:

--- a/doc/reference/mixins.rst
+++ b/doc/reference/mixins.rst
@@ -479,6 +479,8 @@ including (but not limited to):
     the required access rights to be able to post a message on the model; by
     default a ``write`` access is needed, can be set to ``read`` as well
 
+``_mail_post_sudo`` - :bool: post the message on the record under SUDO rights
+
 Context keys:
     These context keys can be used to somewhat control ``mail.thread`` features
     like auto-subscription or field tracking during calls to ``create()`` or


### PR DESCRIPTION
Bug
===
When a portal user want to send an attachment on blog/eshop/slide,
he get an 403 error.

In `mail.message`, during the create operation, we check the read
access right on the attachment. As this access is restricted to
only the internal user, since #38358, an error is raised.

Task-2214795
PR #47661