### PR TITLE
[REV] mrp: unit_factor as computed field

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -600,6 +600,7 @@ class MrpProduction(models.Model):
             'product_uom': product_uom,
             'operation_id': operation_id,
             'byproduct_id': byproduct_id,
+            'unit_factor': product_uom_qty / self.product_qty,
             'name': self.name,
             'date': self.date_planned_start,
             'date_expected': date_planned_finished,
@@ -688,16 +689,19 @@ class MrpProduction(models.Model):
         self.ensure_one()
         move = self.move_raw_ids.filtered(lambda x: x.bom_line_id.id == bom_line.id and x.state not in ('done', 'cancel'))
         if move:
-            old_qty = move[0].product_uom_qty
+            move = move[0]
+            remaining_qty = move.raw_material_production_id.product_qty - move.raw_material_production_id.qty_produced
+            old_qty = move.product_uom_qty
             if quantity > 0:
-                move[0].write({'product_uom_qty': quantity})
-                move[0]._action_assign()
-                return move[0], old_qty, quantity
+                move.write({'product_uom_qty': quantity})
+                move._action_assign()
+                move.unit_factor = remaining_qty and (quantity - move.quantity_done) / remaining_qty or 1.0
+                return move, old_qty, quantity
             else:
-                if move[0].quantity_done > 0:
+                if move.quantity_done > 0:
                     raise UserError(_('Lines need to be deleted, but can not as you still have some quantities to consume in them. '))
-                move[0]._action_cancel()
-                move[0].unlink()
+                move._action_cancel()
+                move.unlink()
                 return self.env['stock.move'], old_qty, quantity
         else:
             operation = bom_line.operation_id.id or line_data['parent_line'] and line_data['parent_line'].operation_id.id
@@ -710,6 +714,15 @@ class MrpProduction(models.Model):
             )
             move = self.env['stock.move'].create(move_values)
             return move, 0, quantity
+
+    def _update_non_bom_moves(self):
+        """Update additional stock move, not created from a bom line."""
+        self.ensure_one()
+        additional_moves = self.move_raw_ids.filtered(lambda move: move.additional and move.state not in ('done', 'cancel'))
+        for move in additional_moves:
+            quantity = self.product_qty * move.unit_factor
+            remaining_qty = move.raw_material_production_id.product_qty - move.raw_material_production_id.qty_produced
+            move.unit_factor = remaining_qty and (quantity - move.quantity_done) / remaining_qty or 1.0
 
     def _get_ready_to_produce_state(self):
         """ returns 'assigned' if enough components are reserved in order to complete
@@ -750,6 +763,8 @@ class MrpProduction(models.Model):
                 'group_id': production.procurement_group_id.id,
                 'reference': production.name,  # set reference when MO name is different than 'New'
             })
+            for move in additional_moves:
+                move.unit_factor = move.product_uom_qty / (production.product_qty - production.qty_produced)
             additional_moves._adjust_procure_method()
             moves_to_confirm |= additional_moves
             moves_to_confirm |= production.move_finished_ids.filtered(
@@ -804,6 +819,12 @@ class MrpProduction(models.Model):
             production.consumption = production.bom_id.consumption
             if not production.move_raw_ids:
                 raise UserError(_("Add some materials to consume before marking this MO as to do."))
+            for move_raw in production.move_raw_ids:
+                move_raw.write({
+                    'group_id': production.procurement_group_id.id,
+                    'unit_factor': move_raw.product_uom_qty / production.product_qty,
+                    'reference': production.name,  # set reference when MO name is different than 'New'
+                })
             production._generate_finished_moves()
             production.move_raw_ids._adjust_procure_method()
             (production.move_raw_ids | production.move_finished_ids)._action_confirm()

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -87,7 +87,7 @@ class StockMove(models.Model):
     byproduct_id = fields.Many2one(
         'mrp.bom.byproduct', 'By-products', check_company=True,
         help="By-product line that generated the move in a manufacturing order")
-    unit_factor = fields.Float('Unit Factor', compute='_compute_unit_factor', store=True)
+    unit_factor = fields.Float('Unit Factor', default=1)
     is_done = fields.Boolean(
         'Done', compute='_compute_is_done',
         store=True,
@@ -134,15 +134,6 @@ class StockMove(models.Model):
     def _compute_is_done(self):
         for move in self:
             move.is_done = (move.state in ('done', 'cancel'))
-
-    @api.depends('product_uom_qty')
-    def _compute_unit_factor(self):
-        for move in self:
-            mo = move.raw_material_production_id or move.production_id
-            if mo:
-                move.unit_factor = (move.product_uom_qty - move.quantity_done) / ((mo.product_qty - mo.qty_produced) or 1)
-            else:
-                move.unit_factor = 1.0
 
     @api.model
     def default_get(self, fields_list):

--- a/addons/mrp/wizard/change_production_qty.py
+++ b/addons/mrp/wizard/change_production_qty.py
@@ -76,7 +76,7 @@ class ChangeProductionQty(models.TransientModel):
                             documents[key] = [value]
 
                 production._update_raw_move(line, line_data)
-
+            production._update_non_bom_moves()
             production._log_manufacture_exception(documents)
             operation_bom_qty = {}
             for bom, bom_data in boms:


### PR DESCRIPTION
This reverts commit 96b17a82cf1ea1287e0a52c52c78166ef817ce7b.

The issue appears at post inventory. As the reservation on the
stock_move is updated (because the move are split to set some
quantity done), The reserved quantity on quant are so. This is done
via a savepoint. The savepoint will flush the current snapshot. This
flush will recompute all the computed field. This is the unwanted
behavior because all the stock move ready to be validated will have
their unit factor set to 0.

This commit is not exactly the original revert because of the flexible
consumption feature (896352e53b77df2f42de39c0fed897d10ae947b0)

Task : 2212001

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
