### PR TITLE
[FIX] website_event: Ordering more tickets than available seats

### DIFF
--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -244,6 +244,15 @@ class WebsiteEventController(http.Controller):
     @http.route(['/event/<model("event.event"):event>/registration/new'], type='json', auth="public", methods=['POST'], website=True)
     def registration_new(self, event, **post):
         tickets = self._process_tickets_details(post)
+        if event.seats_availability != 'unlimited':
+            ordered_seats = 0
+            index = 0
+            for ticket in tickets:
+                if event.seats_available < ordered_seats + ticket['quantity']:
+                    tickets.pop(index)
+                else:
+                    ordered_seats += ticket['quantity']
+                index += 1
         if not tickets:
             return False
         return request.env['ir.ui.view'].render_template("website_event.registration_attendee_details", {'tickets': tickets, 'event': event})

--- a/addons/website_event/i18n/website_event.pot
+++ b/addons/website_event/i18n/website_event.pot
@@ -239,6 +239,11 @@ msgid "Attendee #%s"
 msgstr ""
 
 #. module: website_event
+#: model_terms:ir.ui.view,arch_db:website_event.registration_template
+msgid "Available seats: "
+msgstr ""
+
+#. module: website_event
 #: model_terms:ir.ui.view,arch_db:website_event.registration_attendee_details
 msgid "Cancel Registration"
 msgstr ""

--- a/addons/website_event/views/event_templates.xml
+++ b/addons/website_event/views/event_templates.xml
@@ -444,6 +444,7 @@
             <div class="card-footer">
                 <div class="row">
                     <div class="col-lg-4 offset-lg-8 col-xl-3 offset-xl-9">
+                        <span t-if="event.seats_availability != 'unlimited'">Available seats: <t t-esc="event.seats_available"/></span>
                         <button type="submit" class="btn btn-primary btn-lg btn-block a-submit" t-attf-id="#{event.id}">
                             Register Now
                         </button>


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider an event E with Maximum Attendees = 2 and Autoconfirm
- Create two kind of tickets Premium with Maximum available seats = 2 and Normal with Maximum available seats = 2
- Go to the website and register for E
- Take two tickets Premium and two tickets Normal

Bug:

Odoo gave the possibility to buy for tickets for E even if the Maximum Attendees was 2
and Odoo never autoconfirm these tickets.

opw:2214576