### PR TITLE
[ADD] pos_unbalanced_force_close: Allow closing unbalanced session

### DIFF
--- a/addons/pos_unbalanced_force_close/__init__.py
+++ b/addons/pos_unbalanced_force_close/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models
+from . import wizard

--- a/addons/pos_unbalanced_force_close/__manifest__.py
+++ b/addons/pos_unbalanced_force_close/__manifest__.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'Point of Sale Force Close Unbalanced Session',
+    'version': '1.0.0',
+    'category': 'Sales/Point Of Sale',
+    'sequence': 20,
+    'summary': 'Allow Force closing an unbalanced session.',
+    'description': """
+    This module allows closing unbalanced session by adding an account_move_line with the amount
+    of the difference between credit and debit.
+    Be carefull as this can cause discrepancies in your accounting.
+    Use it on your own will.
+    No support will be provided for unbalanced sessions closed with this module.
+    """,
+    'depends': ['point_of_sale'],
+    'data': [
+        'security/account_security.xml',
+        'views/res_config_settings_view.xml',
+        'views/pos_config_view.xml',
+        'views/pos_session_view.xml',
+        'wizard/confirmation_wizard.xml',
+    ],
+    'installable': True,
+}

--- a/addons/pos_unbalanced_force_close/i18n/pos_unbalanced_force_close.pot
+++ b/addons/pos_unbalanced_force_close/i18n/pos_unbalanced_force_close.pot
@@ -1,0 +1,183 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* pos_unbalanced_force_close
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 13.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-03-18 14:08+0000\n"
+"PO-Revision-Date: 2020-03-18 14:08+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: pos_unbalanced_force_close
+#: model_terms:ir.ui.view,arch_db:pos_unbalanced_force_close.form
+msgid ""
+"<strong>Force close the session.</strong><br/>\n"
+"                                    The difference will be posted in the specified account."
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: model_terms:ir.ui.view,arch_db:pos_unbalanced_force_close.form
+msgid ""
+"<strong>Set the session into the \"Recovery\" modus.</strong><br/>\n"
+"                                    This will allow you to open a new session.\n"
+"                                    Don't forget to contact"
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: model_terms:ir.ui.view,arch_db:pos_unbalanced_force_close.form
+msgid "<strong>This session has an unbalanced journal entry.</strong><br/>"
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: model:ir.model.fields,field_description:pos_unbalanced_force_close.field_pos_config__allow_force_close
+#: model:ir.model.fields,field_description:pos_unbalanced_force_close.field_pos_session___allow_force_close
+msgid "Allow closing unbalanced sessions"
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: model:res.groups,name:pos_unbalanced_force_close.group_force_close_unbalanced
+msgid "Allow the closing of an unbalanced POS session"
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: model_terms:ir.ui.view,arch_db:pos_unbalanced_force_close.res_config_view_form_inherit_pos_force_close
+msgid ""
+"Allow to force the closing of a POS session that has\n"
+"                                    an unbalanced journal entry by posting the difference."
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: model_terms:ir.ui.view,arch_db:pos_unbalanced_force_close.pos_config_view_form_inherit_cash_rounding
+msgid ""
+"Allow to force the closing of the session that has\n"
+"                                        an unbalanced journal entry by posting the difference."
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: model_terms:ir.ui.view,arch_db:pos_unbalanced_force_close.form
+msgid "Cancel"
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: model:ir.model,name:pos_unbalanced_force_close.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: model:ir.model.fields,field_description:pos_unbalanced_force_close.field_pos_unbalanced_force_close_wizard__force_close_unbalanced_difference
+msgid "Difference"
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: model:ir.model.fields,field_description:pos_unbalanced_force_close.field_pos_config__difference_credit_account
+msgid "Difference Credit Account"
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: model:ir.model.fields,field_description:pos_unbalanced_force_close.field_pos_config__difference_debit_account
+msgid "Difference Debit Account"
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: code:addons/pos_unbalanced_force_close/wizard/confirmation_wizard.py:0
+#, python-format
+msgid ""
+"Difference Debit Account and Difference Credit account must be defined in "
+"the POS configuration."
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: model:ir.model.fields,field_description:pos_unbalanced_force_close.field_pos_session___force_close_unbalanced_difference
+msgid "Difference debit/credit"
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: model_terms:ir.ui.view,arch_db:pos_unbalanced_force_close.form
+msgid "Force Close"
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: model:ir.model.fields,field_description:pos_unbalanced_force_close.field_res_config_settings__group_force_close_unbalanced
+#: model_terms:ir.ui.view,arch_db:pos_unbalanced_force_close.view_pos_session_form_inherit
+msgid "Force Close Unbalanced Session"
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: model:ir.model.fields,field_description:pos_unbalanced_force_close.field_pos_session___force_close_unbalanced
+msgid "Has been forced closed after unbalanced journal entry"
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: model:ir.model,name:pos_unbalanced_force_close.model_account_move
+msgid "Journal Entries"
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: model_terms:ir.ui.view,arch_db:pos_unbalanced_force_close.form
+msgid "Odoo Support"
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: code:addons/pos_unbalanced_force_close/models/pos_session.py:0
+#, python-format
+msgid "Only administrators can force close the session."
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: model:ir.model,name:pos_unbalanced_force_close.model_pos_config
+msgid "Point of Sale Configuration"
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: model:ir.model,name:pos_unbalanced_force_close.model_pos_session
+msgid "Point of Sale Session"
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: model:ir.model.fields,field_description:pos_unbalanced_force_close.field_pos_unbalanced_force_close_wizard__session_id
+msgid "Session"
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: code:addons/pos_unbalanced_force_close/wizard/confirmation_wizard.py:0
+#, python-format
+msgid "Session already in \"Recovery\" modus."
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: model_terms:ir.ui.view,arch_db:pos_unbalanced_force_close.form
+msgid "Set Recovery Modus"
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: model_terms:ir.ui.view,arch_db:pos_unbalanced_force_close.pos_config_view_form_inherit_cash_rounding
+#: model_terms:ir.ui.view,arch_db:pos_unbalanced_force_close.res_config_view_form_inherit_pos_force_close
+msgid "Support"
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: model:ir.model.fields,field_description:pos_unbalanced_force_close.field_pos_session___is_unbalanced
+msgid "Unbalanced Journal Entry"
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: model:ir.model,name:pos_unbalanced_force_close.model_pos_unbalanced_force_close_wizard
+msgid "Wizard: Confirmation of force close"
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: model_terms:ir.ui.view,arch_db:pos_unbalanced_force_close.form
+msgid "You have multiple options:"
+msgstr ""
+
+#. module: pos_unbalanced_force_close
+#: model_terms:ir.ui.view,arch_db:pos_unbalanced_force_close.form
+msgid "to investigate the issue and close this session."
+msgstr ""

--- a/addons/pos_unbalanced_force_close/models/__init__.py
+++ b/addons/pos_unbalanced_force_close/models/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import account_move
+from . import res_config_settings
+from . import pos_config
+from . import pos_session

--- a/addons/pos_unbalanced_force_close/models/account_move.py
+++ b/addons/pos_unbalanced_force_close/models/account_move.py
@@ -1,0 +1,22 @@
+from odoo import fields, models, api
+from odoo.exceptions import UserError
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    # Check whether a pos_session is being closed.
+    # If it is a pos_session and it is unbalanced
+    #   -> rollback operation
+    #   -> set unbalanced flag on the session
+
+    def _check_balanced(self):
+        try:
+            super(AccountMove, self)._check_balanced()
+        except UserError:
+            if self.env.context.get('pos_session_id'):
+                self.env.cr.rollback()
+                session = self.env['pos.session'].browse(self.env.context.get('pos_session_id'))
+                session._is_unbalanced = True
+                self.env.cr.commit()
+            raise

--- a/addons/pos_unbalanced_force_close/models/pos_config.py
+++ b/addons/pos_unbalanced_force_close/models/pos_config.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, fields, api, _
+from odoo.exceptions import ValidationError
+
+
+class PosConfig(models.Model):
+    _inherit = 'pos.config'
+
+    allow_force_close = fields.Boolean("Allow closing unbalanced sessions")
+    difference_debit_account = fields.Many2one("account.account", string='Difference Debit Account')
+    difference_credit_account = fields.Many2one("account.account", string='Difference Credit Account')

--- a/addons/pos_unbalanced_force_close/models/pos_session.py
+++ b/addons/pos_unbalanced_force_close/models/pos_session.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import _, fields, models
+from odoo.tools import float_is_zero, float_round, float_compare
+from odoo.exceptions import AccessError, UserError
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+class PosSession(models.Model):
+    _inherit = "pos.session"
+
+    _allow_force_close = fields.Boolean(related='config_id.allow_force_close', readonly=True, store=False)
+    _is_unbalanced = fields.Boolean('Unbalanced Journal Entry', readonly=True)
+
+    # The 2 following fields are mainly for Support purpose, to keep an history of what have been done with the session.
+    _force_close_unbalanced = fields.Boolean('Has been forced closed after unbalanced journal entry', readonly=True)
+    _force_close_unbalanced_difference = fields.Float('Difference debit/credit', readonly=True)
+
+    def _get_rounding_difference_vals(self, amount, amount_converted):
+        partial_args = {
+            'name':    'Rounding line',
+            'move_id': self.move_id.id,
+        }
+        if amount > 0:  # loss
+            partial_args['account_id'] = self.config_id.difference_credit_account.id
+            return self._credit_amounts(partial_args, amount, amount_converted)
+        else:  # profit
+            partial_args['account_id'] = self.config_id.difference_debit_account.id
+            return self._debit_amounts(partial_args, -amount, -amount_converted)
+
+    def _get_extra_move_lines_vals(self):
+        res = super(PosSession, self)._get_extra_move_lines_vals()
+        if not self._allow_force_close or \
+                not self._is_unbalanced or \
+                not self.env.user._is_admin() or \
+                not self.env.context.get('force_close_unbalanced'):
+            return res
+        rounding_difference = {'amount': 0.0, 'amount_converted': 0.0}
+        rounding_vals = []
+        rounding_difference['amount'] = sum(self.move_id.line_ids.mapped('debit')) - sum(self.move_id.line_ids.mapped('credit'))
+        rounding_difference['amount_converted'] = rounding_difference['amount']
+        if not float_is_zero(rounding_difference['amount_converted'], precision_rounding=self.company_id.currency_id.rounding):
+            value = self._get_rounding_difference_vals(rounding_difference['amount'], rounding_difference['amount_converted'])
+            self._force_close_unbalanced_difference = value['debit'] or value['credit']
+            rounding_vals += [value]
+            _logger.warning('Force Close Unbalanced POS Session. uid: {} - session_id:{} - difference:{}'.format(self.env.user.id, self.id, self._force_close_unbalanced_difference))
+        return res + rounding_vals
+
+    def action_pos_session_closing_control(self):
+        # Only the admin can force close the session
+        if self.env.context.get('force_close_unbalanced') and not self.env.user._is_admin():
+            raise AccessError(_("Only administrators can force close the session."))
+
+        super(PosSession, self.with_context(pos_session_id=self.id)).action_pos_session_closing_control()
+
+        if self.env.context.get('force_close_unbalanced'):
+            self._force_close_unbalanced = True
+
+    def action_pos_session_unbalanced_force_close(self):
+        # Wizard
+        return {
+            'name':      'Force close',
+            'type':      'ir.actions.act_window',
+            'view_type': 'form',
+            'view_mode': 'form',
+            'res_model': 'pos_unbalanced_force_close.wizard',
+            'views':     [(False, 'form')],
+            'view_id':   'pos_unbalanced_force_close.open_confirmation_wizard',
+            'target':    'new',
+            'context':   self.env.context,
+        }

--- a/addons/pos_unbalanced_force_close/models/res_config_settings.py
+++ b/addons/pos_unbalanced_force_close/models/res_config_settings.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models, _
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    group_force_close_unbalanced = fields.Boolean("Force Close Unbalanced Session", implied_group='pos_unbalanced_force_close.group_force_close_unbalanced')

--- a/addons/pos_unbalanced_force_close/security/account_security.xml
+++ b/addons/pos_unbalanced_force_close/security/account_security.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+<data noupdate="0">
+    <record id="group_force_close_unbalanced" model="res.groups">
+        <field name="name">Allow the closing of an unbalanced POS session</field>
+        <field name="category_id" ref="base.module_category_hidden"/>
+    </record>
+</data>
+</odoo>

--- a/addons/pos_unbalanced_force_close/views/pos_config_view.xml
+++ b/addons/pos_unbalanced_force_close/views/pos_config_view.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="pos_config_view_form_inherit_force_close" model="ir.ui.view">
+        <field name="name">pos.config.form.inherit.force_close</field>
+        <field name="model">pos.config</field>
+        <field name="inherit_id" ref="point_of_sale.pos_config_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='accounting_section']" position="after">
+                <div groups="base.group_no_one">
+                    <div groups="pos_unbalanced_force_close.group_force_close_unbalanced">
+                        <h2 name="support">Support</h2>
+                        <div class="row mt16 o_settings_container">
+                            <div class="col-12 col-lg-6 o_setting_box">
+                                <div class="o_setting_left_pane">
+                                    <field name="allow_force_close"/>
+                                </div>
+                                <div class="o_setting_right_pane">
+                                    <label for="allow_force_close"/>
+                                    <div class="text-muted">
+                                        Allow to force the closing of the session that has
+                                        an unbalanced journal entry by posting the difference.
+                                    </div>
+                                    <div class="content-group"
+                                         attrs="{'invisible': [('allow_force_close', '=', False)]}">
+                                        <label for="difference_debit_account"/>
+                                        <field name="difference_debit_account"
+                                               attrs="{'required': [('allow_force_close', '=', True)]}"/>
+                                        <label for="difference_credit_account"/>
+                                        <field name="difference_credit_account"
+                                               attrs="{'required': [('allow_force_close', '=', True)]}"/>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/pos_unbalanced_force_close/views/pos_session_view.xml
+++ b/addons/pos_unbalanced_force_close/views/pos_session_view.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="view_pos_session_form_inherit" model="ir.ui.view">
+            <field name="name">pos_unbalanced_force_close.pos.session.form.view</field>
+            <field name="model">pos.session</field>
+            <field name="inherit_id" ref="point_of_sale.view_pos_session_form"/>
+            <field name="priority" eval="8"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='state']" position="before">
+                    <field name="_is_unbalanced" invisible="1"/>
+                    <field name="_allow_force_close" invisible="1"/>
+                    <button id="force_close" name="action_pos_session_unbalanced_force_close" type="object"
+                            string="Force Close Unbalanced Session"
+                            class="oe_highlight"
+                            attrs="{'invisible' : ['|', '|', ('_is_unbalanced', '=', False),
+                                               ('_allow_force_close', '=', False),
+                                               ('state', 'in', ['opening_control', 'closed'])]}"
+                            groups="pos_unbalanced_force_close.group_force_close_unbalanced"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/pos_unbalanced_force_close/views/res_config_settings_view.xml
+++ b/addons/pos_unbalanced_force_close/views/res_config_settings_view.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_config_view_form_inherit_pos_force_close" model="ir.ui.view">
+        <field name="name">res.config.form.inherit.pos.force_close</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="point_of_sale.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@data-key='point_of_sale']" position="inside" >
+                <div groups="base.group_no_one">
+                    <h2>Support</h2>
+                    <div class="row mt16 o_settings_container">
+                        <div class="col-12 col-lg-6 o_setting_box">
+                            <div class="o_setting_left_pane">
+                                <field name="group_force_close_unbalanced"/>
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label for="group_force_close_unbalanced"/>
+                                <div class="text-muted">
+                                    Allow to force the closing of a POS session that has
+                                    an unbalanced journal entry by posting the difference.
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/pos_unbalanced_force_close/wizard/__init__.py
+++ b/addons/pos_unbalanced_force_close/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import confirmation_wizard

--- a/addons/pos_unbalanced_force_close/wizard/confirmation_wizard.py
+++ b/addons/pos_unbalanced_force_close/wizard/confirmation_wizard.py
@@ -1,0 +1,27 @@
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+
+
+class ModelName (models.TransientModel):
+    _name = 'pos_unbalanced_force_close.wizard'
+    _description = 'Wizard: Confirmation of force close'
+
+    def _default_session(self):
+        return self.env['pos.session'].browse(self._context.get('active_id'))
+
+    session_id = fields.Many2one('pos.session', default=_default_session)
+    force_close_unbalanced_difference = fields.Float('Difference', related='session_id._force_close_unbalanced_difference')
+
+    def force_close(self):
+        if not all([
+            self.session_id.config_id.difference_debit_account,
+            self.session_id.config_id.difference_credit_account,
+        ]):
+            raise UserError(_('Difference Debit Account and Difference Credit account must be defined in the POS configuration.'))
+        self.session_id.with_context(force_close_unbalanced=True).action_pos_session_closing_control()
+
+    def set_rescue(self):
+        if self.session_id.rescue:
+            raise UserError(_('Session already in "Recovery" modus.'))
+
+        self.session_id.rescue = True

--- a/addons/pos_unbalanced_force_close/wizard/confirmation_wizard.xml
+++ b/addons/pos_unbalanced_force_close/wizard/confirmation_wizard.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record model="ir.ui.view" id="pos_unbalanced_force_close.form">
+            <field name="name">pos_unbalanced_force_close_wizard.form</field>
+            <field name="model">pos_unbalanced_force_close.wizard</field>
+            <field name="arch" type="xml">
+                <form>
+                    <group>
+                        <div>
+                            <strong>This session has an unbalanced journal entry.</strong><br/>
+                        </div>
+                        <div>
+                            You have multiple options:
+                            <ul>
+                                <li>
+                                    <strong>Force close the session.</strong><br/>
+                                    The difference will be posted in the specified account.
+                                </li>
+                                <li>
+                                    <strong>Set the session into the "Recovery" modus.</strong><br/>
+                                    This will allow you to open a new session.
+                                    Don't forget to contact <a href="www.odoo.com/help" target="_blank">Odoo Support</a>
+                                    to investigate the issue and close this session.
+                                </li>
+                            </ul>
+                        </div>
+                    </group>
+                    <footer>
+                        <button name="force_close" type="object" string="Force Close" class="oe_highlight"/>
+                        <button name="set_rescue" type="object" string="Set Recovery Modus" class="oe_highlight"/>
+                        <button special="cancel" string="Cancel"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
This module is intended to help customers who do not care
about accounting to not be blocked by an unbalanced journal entry.

Can also be used for support purpose.

To test this:
- Have a fresh V13
- Install module pos_unbalanced_force_close
- Activate "Force Close Unbalanced Session" under "Support"
  in General Settings (debug mode only)
- Activate "Allow closing unbalanced Sessions" in pos_config PC and
  specify difference credit and debit account
- Start a new session S from PC
- Sells anything
- Register payment P
- With SQL or server action, modify P up or down for a few cents
- Try to close S -> Unbalanced journal entry
- Refresh the page
- Be logged as admin and debug mode to see the button
- Click "Force Close Unbalanced Session"
- You have 3 choices:
  * Force close the session
  * Set the session into recovery modus (rescue)
  * Cancel

Have fun testing ;)