### PR TITLE
[IMP] account,l10n_*: default tax label on invoice

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -89,7 +89,7 @@
                                             <span t-field="line.discount"/>
                                         </td>
                                         <td t-attf-class="text-left {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
-                                            <span t-esc="', '.join(map(lambda x: (x.description or x.name), line.tax_ids))" id="line_tax_ids"/>
+                                            <span t-esc="', '.join(map(lambda x: (x.description or '{:g} %'.format(x.amount)), line.tax_ids))" id="line_tax_ids"/>
                                         </td>
                                         <td class="text-right o_price_total">
                                             <span t-field="line.price_subtotal" groups="account.group_show_line_subtotals_tax_excluded"/>

--- a/addons/l10n_ae/data/account_tax_template_data.xml
+++ b/addons/l10n_ae/data/account_tax_template_data.xml
@@ -5,7 +5,6 @@
         <field name="type_tax_use">sale</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
-        <field name="description">VAT 5%</field>
         <field name="tax_group_id" ref="ae_tax_group_5"/>
         <field name="chart_template_id" ref="uae_chart_template_standard"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -40,7 +39,6 @@
         <field name="type_tax_use">sale</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
-        <field name="description">VAT 5%</field>
         <field name="tax_group_id" ref="ae_tax_group_5"/>
         <field name="chart_template_id" ref="uae_chart_template_standard"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -75,7 +73,6 @@
         <field name="type_tax_use">sale</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
-        <field name="description">VAT 5%</field>
         <field name="tax_group_id" ref="ae_tax_group_5"/>
         <field name="chart_template_id" ref="uae_chart_template_standard"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -110,7 +107,6 @@
         <field name="type_tax_use">sale</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
-        <field name="description">VAT 5%</field>
         <field name="tax_group_id" ref="ae_tax_group_5"/>
         <field name="chart_template_id" ref="uae_chart_template_standard"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -145,7 +141,6 @@
         <field name="type_tax_use">sale</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
-        <field name="description">VAT 5%</field>
         <field name="tax_group_id" ref="ae_tax_group_5"/>
         <field name="chart_template_id" ref="uae_chart_template_standard"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -180,7 +175,6 @@
         <field name="type_tax_use">sale</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
-        <field name="description">VAT 5%</field>
         <field name="tax_group_id" ref="ae_tax_group_5"/>
         <field name="chart_template_id" ref="uae_chart_template_standard"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -215,7 +209,6 @@
         <field name="type_tax_use">sale</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
-        <field name="description">VAT 5%</field>
         <field name="tax_group_id" ref="ae_tax_group_5"/>
         <field name="chart_template_id" ref="uae_chart_template_standard"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -250,7 +243,6 @@
         <field name="type_tax_use">sale</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
-        <field name="description">Exempted</field>
         <field name="tax_group_id" ref="ae_tax_group_exempted"/>
         <field name="chart_template_id" ref="uae_chart_template_standard"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -281,7 +273,6 @@
         <field name="type_tax_use">sale</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
-        <field name="description">VAT 0%</field>
         <field name="tax_group_id" ref="ae_tax_group_0"/>
         <field name="chart_template_id" ref="uae_chart_template_standard"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -312,7 +303,6 @@
         <field name="type_tax_use">sale</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
-        <field name="description">Export Tax</field>
         <field name="chart_template_id" ref="uae_chart_template_standard"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
@@ -340,7 +330,6 @@
         <field name="type_tax_use">sale</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
-        <field name="description">Supplies subject to reverse charge provisions</field>
         <field name="chart_template_id" ref="uae_chart_template_standard"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
@@ -386,7 +375,6 @@
         <field name="type_tax_use">sale</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
-        <field name="description">Supplies subject to reverse charge provisions</field>
         <field name="chart_template_id" ref="uae_chart_template_standard"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
@@ -432,7 +420,6 @@
         <field name="type_tax_use">sale</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
-        <field name="description">Supplies subject to reverse charge provisions</field>
         <field name="chart_template_id" ref="uae_chart_template_standard"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
@@ -478,7 +465,6 @@
         <field name="type_tax_use">sale</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
-        <field name="description">Supplies subject to reverse charge provisions</field>
         <field name="chart_template_id" ref="uae_chart_template_standard"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
@@ -524,7 +510,6 @@
         <field name="type_tax_use">sale</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
-        <field name="description">Supplies subject to reverse charge provisions</field>
         <field name="chart_template_id" ref="uae_chart_template_standard"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
@@ -570,7 +555,6 @@
         <field name="type_tax_use">sale</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
-        <field name="description">Supplies subject to reverse charge provisions</field>
         <field name="chart_template_id" ref="uae_chart_template_standard"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
@@ -616,7 +600,6 @@
         <field name="type_tax_use">sale</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
-        <field name="description">Supplies subject to reverse charge provisions</field>
         <field name="chart_template_id" ref="uae_chart_template_standard"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
@@ -662,7 +645,6 @@
         <field name="type_tax_use">sale</field>
         <field name="amount">5.0</field>
         <field name="amount_type">percent</field>
-        <field name="description">Tax Refunds provided to Tourists under the Tax Refunds for Tourists Scheme</field>
         <field name="chart_template_id" ref="uae_chart_template_standard"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
@@ -697,7 +679,6 @@
         <field name="type_tax_use">purchase</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
-        <field name="description">VAT 5%</field>
         <field name="tax_group_id" ref="ae_tax_group_5"/>
         <field name="chart_template_id" ref="uae_chart_template_standard"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -732,7 +713,6 @@
         <field name="type_tax_use">purchase</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
-        <field name="description">Exempted Tax</field>
         <field name="tax_group_id" ref="ae_tax_group_exempted"/>
         <field name="chart_template_id" ref="uae_chart_template_standard"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -761,7 +741,6 @@
         <field name="type_tax_use">purchase</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
-        <field name="description">VAT 0%</field>
         <field name="tax_group_id" ref="ae_tax_group_0"/>
         <field name="chart_template_id" ref="uae_chart_template_standard"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -790,7 +769,6 @@
         <field name="type_tax_use">purchase</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
-        <field name="description">Import Tax</field>
         <field name="chart_template_id" ref="uae_chart_template_standard"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
@@ -822,7 +800,6 @@
         <field name="type_tax_use">purchase</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
-        <field name="description">Supplies subject to reverse charge provisions</field>
         <field name="chart_template_id" ref="uae_chart_template_standard"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {

--- a/addons/l10n_ar/data/account_tax_template_data.xml
+++ b/addons/l10n_ar/data/account_tax_template_data.xml
@@ -4,7 +4,6 @@
     <record id="ri_tax_percepcion_iva_aplicada" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
         <field name="name">Percepción IVA Aplicada</field>
-        <field name="description">Perc IVA A</field>
         <field name="sequence">4</field>
         <field name="active" eval="False"/>
         <field name="amount_type">fixed</field>
@@ -40,7 +39,6 @@
     <record id="ri_tax_percepcion_ganancias_aplicada" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
         <field name="name">Percepción Ganancias Aplicada</field>
-        <field name="description">Perc Ganancias A</field>
         <field name="sequence">4</field>
         <field name="active" eval="False"/>
         <field name="amount_type">fixed</field>
@@ -76,7 +74,6 @@
     <record id="ri_tax_percepcion_ganancias_sufrida" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
         <field name="name">Percepción Ganancias Sufrida</field>
-        <field name="description">Perc Ganancias S</field>
         <field name="sequence">4</field>
         <field name="amount_type">fixed</field>
         <field eval="1.0" name="amount"/>
@@ -111,7 +108,6 @@
     <record id="ri_tax_percepcion_iibb_caba_sufrida" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_base_chart_template"/>
         <field name="name">Percepción IIBB CABA Sufrida</field>
-        <field name="description">Perc IIBB CABA S</field>
         <field name="sequence">4</field>
         <field name="amount_type">fixed</field>
         <field eval="1.0" name="amount"/>
@@ -146,7 +142,6 @@
     <record id="ri_tax_percepcion_iibb_ba_sufrida" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_base_chart_template"/>
         <field name="name">Percepción IIBB ARBA Sufrida</field>
-        <field name="description">Perc IIBB ARBA S</field>
         <field name="sequence">4</field>
         <field name="amount_type">fixed</field>
         <field eval="1.0" name="amount"/>
@@ -181,7 +176,6 @@
     <record id="ri_tax_percepcion_iibb_co_sufrida" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_base_chart_template"/>
         <field name="name">Percepción IIBB Córdoba Sufrida</field>
-        <field name="description">Perc IIBB Córdoba S</field>
         <field name="sequence">4</field>
         <field name="amount_type">fixed</field>
         <field eval="1.0" name="amount"/>
@@ -216,7 +210,6 @@
     <record id="ri_tax_percepcion_iibb_sf_sufrida" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_base_chart_template"/>
         <field name="name">Percepción IIBB Santa Fé Sufrida</field>
-        <field name="description">Perc IIBB Santa Fé S</field>
         <field name="sequence">4</field>
         <field name="amount_type">fixed</field>
         <field eval="1.0" name="amount"/>
@@ -251,7 +244,6 @@
     <record id="ri_tax_percepcion_iibb_aplicada" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_ex_chart_template"/>
         <field name="name">Percepción IIBB Aplicada</field>
-        <field name="description">Perc IIBB A</field>
         <field name="sequence">4</field>
         <field name="active" eval="False"/>
         <field name="amount_type">fixed</field>
@@ -289,7 +281,6 @@
     <!-- Remove this record in V14 -->
     <record id="ri_tax_vat_no_corresponde_ventas" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_ri_chart_template"/>
-        <field name="description">IVA No Corresponde</field>
         <field name="name">IVA No Corresponde</field>
         <field name="active" eval="False"/>
         <field name="sequence">2</field>
@@ -325,7 +316,6 @@
 
     <record id="ri_tax_vat_no_corresponde_compras" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_ri_chart_template"/>
-        <field name="description">IVA No Corresponde</field>
         <field name="name">IVA No Corresponde</field>
         <field name="sequence">2</field>
         <field name="amount_type">fixed</field>
@@ -360,7 +350,6 @@
 
     <record id="ri_tax_vat_no_gravado_ventas" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_ri_chart_template"/>
-        <field name="description">IVA No Gravado</field>
         <field name="name">IVA No Gravado</field>
         <field name="sequence">2</field>
         <field name="amount_type">fixed</field>
@@ -395,7 +384,6 @@
 
     <record id="ri_tax_vat_no_gravado_compras" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_ri_chart_template"/>
-        <field name="description">IVA No Gravado</field>
         <field name="name">IVA No Gravado</field>
         <field name="sequence">2</field>
         <field name="amount_type">fixed</field>
@@ -430,7 +418,6 @@
 
     <record id="ri_tax_vat_exento_ventas" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_ri_chart_template"/>
-        <field name="description">IVA Exento</field>
         <field name="name">IVA Exento</field>
         <field name="sequence">2</field>
         <field name="amount_type">fixed</field>
@@ -465,7 +452,6 @@
 
     <record id="ri_tax_vat_exento_compras" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_ri_chart_template"/>
-        <field name="description">IVA Exento</field>
         <field name="name">IVA Exento</field>
         <field name="sequence">2</field>
         <field name="amount_type">fixed</field>
@@ -500,7 +486,6 @@
 
     <record id="ri_tax_vat_0_ventas" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_ri_chart_template"/>
-        <field name="description">IVA 0%</field>
         <field name="name">IVA 0%</field>
         <field name="sequence">2</field>
         <field eval="0.0" name="amount"/>
@@ -535,7 +520,6 @@
 
     <record id="ri_tax_vat_0_compras" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_ri_chart_template"/>
-        <field name="description">IVA 0%</field>
         <field name="name">IVA 0%</field>
         <field name="sequence">2</field>
         <field eval="0.0" name="amount"/>
@@ -570,7 +554,6 @@
 
     <record id="ri_tax_vat_10_ventas" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_ri_chart_template"/>
-        <field name="description">IVA 10.5%</field>
         <field name="name">IVA 10.5%</field>
         <field name="sequence">2</field>
         <field eval="10.5" name="amount"/>
@@ -605,7 +588,6 @@
 
     <record id="ri_tax_vat_10_compras" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_ri_chart_template"/>
-        <field name="description">IVA 10.5%</field>
         <field name="name">IVA 10.5%</field>
         <field name="sequence">2</field>
         <field eval="10.5" name="amount"/>
@@ -641,7 +623,6 @@
     <record id="ri_tax_vat_21_ventas" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_ri_chart_template"/>
         <field name="name">IVA 21%</field>
-        <field name="description">IVA 21%</field>
         <field name="sequence">1</field>
         <field eval="21" name="amount"/>
         <field name="amount_type">percent</field>
@@ -676,7 +657,6 @@
     <record id="ri_tax_vat_21_compras" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_ri_chart_template"/>
         <field name="name">IVA 21%</field>
-        <field name="description">IVA 21%</field>
         <field name="sequence">1</field>
         <field eval="21" name="amount"/>
         <field name="amount_type">percent</field>
@@ -711,7 +691,6 @@
     <record id="ri_tax_vat_27_ventas" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_ri_chart_template"/>
         <field name="name">IVA 27%</field>
-        <field name="description">IVA 27%</field>
         <field name="sequence">3</field>
         <field eval="27" name="amount"/>
         <field name="amount_type">percent</field>
@@ -746,7 +725,6 @@
     <record id="ri_tax_vat_27_compras" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_ri_chart_template"/>
         <field name="name">IVA 27%</field>
-        <field name="description">IVA 27%</field>
         <field name="sequence">3</field>
         <field eval="27" name="amount"/>
         <field name="amount_type">percent</field>
@@ -781,7 +759,6 @@
     <record id="ri_tax_vat_25_ventas" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_ri_chart_template"/>
         <field name="name">IVA 2,5%</field>
-        <field name="description">IVA 2,5%</field>
         <field name="sequence">9</field>
         <field name="active" eval="False"/>
         <field eval="2.5" name="amount"/>
@@ -817,7 +794,6 @@
     <record id="ri_tax_vat_25_compras" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_ri_chart_template"/>
         <field name="name">IVA 2,5%</field>
-        <field name="description">IVA 2,5%</field>
         <field name="sequence">9</field>
         <field name="active" eval="False"/>
         <field eval="2.5" name="amount"/>
@@ -853,7 +829,6 @@
     <record id="ri_tax_vat_5_ventas" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_ri_chart_template"/>
         <field name="name">IVA 5%</field>
-        <field name="description">IVA 5%</field>
         <field name="sequence">10</field>
         <field name="active" eval="False"/>
         <field eval="5" name="amount"/>
@@ -889,7 +864,6 @@
     <record id="ri_tax_vat_5_compras" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_ri_chart_template"/>
         <field name="name">IVA 5%</field>
-        <field name="description">IVA 5%</field>
         <field name="sequence">10</field>
         <field name="active" eval="False"/>
         <field eval="5" name="amount"/>
@@ -925,7 +899,6 @@
     <record id="ri_tax_percepcion_iva_sufrida" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_ri_chart_template"/>
         <field name="name">Percepción IVA Sufrida</field>
-        <field name="description">Perc IVA S</field>
         <field name="sequence">4</field>
         <field name="amount_type">fixed</field>
         <field eval="1.0" name="amount"/>
@@ -960,7 +933,6 @@
     <record id="ri_tax_ganancias_iva_adicional" model="account.tax.template">
         <field name="chart_template_id" ref="l10nar_ri_chart_template"/>
         <field name="name">IVA Adicional 20%</field>
-        <field name="description">IVA Adicional 20%</field>
         <field name="sequence">4</field>
         <field eval="20.0" name="amount"/>
         <field name="amount_type">percent</field>

--- a/addons/l10n_at/data/account_tax_template.xml
+++ b/addons/l10n_at/data/account_tax_template.xml
@@ -24,7 +24,6 @@
             auf den Leistungsempfänger übergegangen ist. -->
         <record id="account_tax_template_sales_rev_charge_0_code021" model="account.tax.template">
             <field name="name">UST_021 Steuerschuld betrifft Leistungsempfänger</field>
-            <field name="description">USt. 0%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">400</field>
             <field name="type_tax_use">sale</field>
@@ -64,7 +63,6 @@
         <!-- Ausfuhrlieferungen (§ 6 Abs. 1 Z 1 iVm § 7) -->
         <record id="account_tax_template_sales_non_eu_0_code011" model="account.tax.template">
             <field name="name">UST_011 Export 0%</field>
-            <field name="description">USt. 0%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">300</field>
             <field name="type_tax_use">sale</field>
@@ -100,7 +98,6 @@
         <!-- Lohnveredelungen (§ 6 Abs. 1 Z 1 iVm § 8) -->
         <record id="account_tax_template_sales_non_eu_0_code012" model="account.tax.template">
             <field name="name">UST_012 Lohnveredelung 0%</field>
-            <field name="description">USt. 0%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">200</field>
             <field name="type_tax_use">sale</field>
@@ -139,7 +136,6 @@
             im Drittlandsgebiet usw.) -->
         <record id="account_tax_template_sales_non_eu_0_code015" model="account.tax.template">
             <field name="name">UST_015 Export 0% (§ 6 Abs. 1 Z 2 bis 6)</field>
-            <field name="description">USt. 0%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">300</field>
             <field name="type_tax_use">sale</field>
@@ -177,7 +173,6 @@
             (Art. 6 Abs. 1) -->
         <record id="account_tax_template_sales_eu_0_code017" model="account.tax.template">
             <field name="name">UST_017 IGL 0% (ohne Art. 6 Abs. 1)</field>
-            <field name="description">USt. 0%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">200</field>
             <field name="type_tax_use">sale</field>
@@ -213,7 +208,6 @@
         <!-- EU Fahrzeuglieferungen (Art. 6 Abs. 1) -->
         <record id="account_tax_template_sales_eu_0_code018" model="account.tax.template">
             <field name="name">UST_018 IGL 0% (Art. 6 Abs. 1)</field>
-            <field name="description">USt. 0%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">200</field>
             <field name="type_tax_use">sale</field>
@@ -250,7 +244,6 @@
         <!-- § 6 Abs. 1 Z 9 lit. a (Grundstücksumsätze) -->
         <record id="account_tax_template_sales_0_code019" model="account.tax.template">
             <field name="name">UST_019 Grundstücksumsätze 0% (§ 6 Abs. 1 Z 9 lit. a)</field>
-            <field name="description">USt. 0%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">100</field>
             <field name="type_tax_use">sale</field>
@@ -287,7 +280,6 @@
         <!-- § 6 Abs. 1 Z 27 (Kleinunternehmer) -->
         <record id="account_tax_template_sales_0_code016" model="account.tax.template">
             <field name="name">UST_016 Kleinunternehmer 0% (§ 6 Abs. 1 Z 27)</field>
-            <field name="description">USt. 0%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">100</field>
             <field name="type_tax_use">sale</field>
@@ -325,7 +317,6 @@
             Vorsteuerabzug) -->
         <record id="account_tax_template_sales_0_code020" model="account.tax.template">
             <field name="name">UST_020 Übrige steuerfreie Umsätze 0%</field>
-            <field name="description">USt. 0%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">100</field>
             <field name="type_tax_use">sale</field>
@@ -363,7 +354,6 @@
         <!-- Soll-Umsatzsteuern (=normale Umsatzsteuer) -->
         <record id="account_tax_template_sales_20_code022" model="account.tax.template">
             <field name="name">UST_022 Normalsteuersatz 20%</field>
-            <field name="description">USt. 20%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">100</field>
             <field name="type_tax_use">sale</field>
@@ -402,7 +392,6 @@
         </record>
         <record id="account_tax_template_sales_20_katalog022" model="account.tax.template">
             <field name="name">UST_022 Normalsteuersatz 20% (Sonstige Leistungen)</field>
-            <field name="description">USt. 20%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">100</field>
             <field name="type_tax_use">sale</field>
@@ -441,7 +430,6 @@
         </record>
         <record id="account_tax_template_sales_10_code029" model="account.tax.template">
             <field name="name">UST_029 ermäßigter Steuersatz 10%</field>
-            <field name="description">USt. 10%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">100</field>
             <field name="type_tax_use">sale</field>
@@ -481,7 +469,6 @@
         </record>
         <record id="account_tax_template_sales_13_code006" model="account.tax.template">
             <field name="name">UST_006 ermäßigter Steuersatz 13%</field>
-            <field name="description">USt. 13%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">100</field>
             <field name="type_tax_use">sale</field>
@@ -521,7 +508,6 @@
         <!-- 19% für Gemeinden Jungholz und Mittelberg -->
         <record id="account_tax_template_sales_19_code037" model="account.tax.template">
             <field name="name">UST_037 Steuersatz 19%</field>
-            <field name="description">USt. 19%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">100</field>
             <field name="type_tax_use">sale</field>
@@ -562,7 +548,6 @@
             Betriebe -->
         <record id="account_tax_template_sales_add10_code052" model="account.tax.template">
             <field name="name">UST_052 Zusatzsteuersatz 10% (LWB/FWB)</field>
-            <field name="description">USt. 10%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">100</field>
             <field name="type_tax_use">sale</field>
@@ -601,7 +586,6 @@
         </record>
         <record id="account_tax_template_sales_add7_code007" model="account.tax.template">
             <field name="name">UST_007 Zusatzsteuersatz 7% (LWB/FWB)</field>
-            <field name="description">USt. 7%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">100</field>
             <field name="type_tax_use">sale</field>
@@ -642,7 +626,6 @@
             +052, +007 -->
         <record id="account_tax_template_sales_self_20_code022" model="account.tax.template">
             <field name="name">UST_022 Normalsteuersatz 20% (Eigenverbrauch)</field>
-            <field name="description">USt. 20%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">100</field>
             <field name="type_tax_use">sale</field>
@@ -681,7 +664,6 @@
         </record>
         <record id="account_tax_template_sales_self_10_code029" model="account.tax.template">
             <field name="name">UST_029 ermäßigter Steuersatz 10% (Eigenverbrauch)</field>
-            <field name="description">USt. 10%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">100</field>
             <field name="type_tax_use">sale</field>
@@ -720,7 +702,6 @@
         </record>
         <record id="account_tax_template_sales_self_19_code037" model="account.tax.template">
             <field name="name">UST_037 Steuersatz 19% (Eigenverbrauch) </field>
-            <field name="description">USt. 19%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">100</field>
             <field name="type_tax_use">sale</field>
@@ -759,7 +740,6 @@
         </record>
         <record id="account_tax_template_sales_self_add10_code052" model="account.tax.template">
             <field name="name">UST_052 Zusatzsteuersatz 10% (LWB/FWB - Eigenverbrauch)</field>
-            <field name="description">USt. 10%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">100</field>
             <field name="type_tax_use">sale</field>
@@ -798,7 +778,6 @@
         </record>
         <record id="account_tax_template_sales_self_add7_code007" model="account.tax.template">
             <field name="name">UST_007 Zusatzsteuersatz 7% (LWB/FWB - Eigenverbrauch)</field>
-            <field name="description">USt. 7%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">100</field>
             <field name="type_tax_use">sale</field>
@@ -840,7 +819,6 @@
             Art. 7 Abs. 4 -->
         <record id="account_tax_template_purchase_tax_invoiced_accepted_code056" model="account.tax.template">
             <field name="name">UST_056 Tax invoiced accepted (§ 11 Abs. 12 und 14, § 16 Abs. 2 sowie gemäß Art. 7 Abs. 4)</field>
-            <field name="description">USt. 20%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">100</field>
             <field name="type_tax_use">purchase</field>
@@ -877,7 +855,6 @@
 
         <record id="account_tax_template_sales_eu_0_services" model="account.tax.template">
             <field name="name">UST_EU Dienstleistung (Sonstige Leistungen) 0%</field>
-            <field name="description">USt. 0%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">200</field>
             <field name="type_tax_use">sale</field>
@@ -913,7 +890,6 @@
 
         <record id="account_tax_template_sales_non_eu_0_services" model="account.tax.template">
             <field name="name">UST_NON_EU Dienstleistung (Drittstaaten) 0%</field>
-            <field name="description">USt. 0%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">300</field>
             <field name="type_tax_use">sale</field>
@@ -951,7 +927,6 @@
         <!-- Davon steuerfrei gemäß Art. 6 Abs. 2 (IGE-UST) -->
         <record id="account_tax_template_purchase_eu_0_code071" model="account.tax.template">
             <field name="name">UST_071 IGE 0% (Art. 6 Abs. 2)</field>
-            <field name="description">USt. 0%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">200</field>
             <field name="type_tax_use">purchase</field>
@@ -989,7 +964,6 @@
 
         <record id="account_tax_template_purchase_eu_20" model="account.tax.template">
             <field name="name">IGE 20%</field>
-            <field name="description">IGE 20%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">500</field>
             <field name="type_tax_use">purchase</field>
@@ -1041,7 +1015,6 @@
 
         <record id="account_tax_template_purchase_eu_10" model="account.tax.template">
             <field name="name">IGE 10%</field>
-            <field name="description">IGE 10%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">500</field>
             <field name="type_tax_use">purchase</field>
@@ -1093,7 +1066,6 @@
 
         <record id="account_tax_template_purchase_eu_13" model="account.tax.template">
             <field name="name">IGE 13%</field>
-            <field name="description">IGE 13%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">500</field>
             <field name="type_tax_use">purchase</field>
@@ -1145,7 +1117,6 @@
 
         <record id="account_tax_template_purchase_eu_19" model="account.tax.template">
             <field name="name">IGE 19%</field>
-            <field name="description">IGE 19%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">500</field>
             <field name="type_tax_use">purchase</field>
@@ -1196,7 +1167,6 @@
                 <!-- Reverse Charge (§ 19 Abs. 1a - Bauleistungen) -->
         <record id="account_tax_template_purchase_rev_charge_1a" model="account.tax.template">
             <field name="name">Reverse Charge 20% (§ 19 Abs. 1a - Bauleistungen)</field>
-            <field name="description">RC 20% § 19 Abs. 1a</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">550</field>
             <field name="type_tax_use">purchase</field>
@@ -1245,7 +1215,6 @@
         <!-- Reverse Charge gemäß § 19 Abs. 1b (Sicherungseigentum, Vorbehaltseigentum  und Grundstücke im Zwangsversteigerungsverfahren) -->
         <record id="account_tax_template_purchase_rev_charge_1b" model="account.tax.template">
             <field name="name">Reverse Charge 20% (§ 19 Abs. 1b - Sicherungseigentum)</field>
-            <field name="description">RC 20% § 19 Abs. 1b</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">550</field>
             <field name="type_tax_use">purchase</field>
@@ -1294,7 +1263,6 @@
         <!-- Reverse Charge gemäß § 19 Abs. 1 zweiter Satz, § 19 Abs. 1c sowie  gemäß Art. 25 Abs. 5 -->
         <record id="account_tax_template_purchase_rev_charge_1c" model="account.tax.template">
             <field name="name">Reverse Charge 20% (§ 19 Abs. 1c - Sonstige Leistungen)</field>
-            <field name="description">RC 20% § 19 Abs. 1c</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">550</field>
             <field name="type_tax_use">purchase</field>
@@ -1346,7 +1314,6 @@
             Verordnung BGBl. II Nr. 369/2013) -->
         <record id="account_tax_template_purchase_rev_charge_1d" model="account.tax.template">
             <field name="name">Reverse Charge 20% (§ 19 Abs. 1d - Schrott und Abfallstoffe)</field>
-            <field name="description">RC 20% § 19 Abs. 1d</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">550</field>
             <field name="type_tax_use">purchase</field>
@@ -1393,7 +1360,6 @@
         </record>
         <record id="account_tax_template_purchase_eu_xx_code076" model="account.tax.template">
             <field name="name">Erwerbe gemäß Art. 3 Abs. 8 zweiter Satz, die im Mitgliedstaat des Bestimmungslandes besteuert worden sind (IGE-UST)</field>
-            <field name="description">UST_076 IGE (im Bestimmungsland besteuert)</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field eval="0.0" name="amount" />
             <field name="sequence">200</field>
@@ -1431,7 +1397,6 @@
         </record>
         <record id="account_tax_template_purchase_eu_xx_code077" model="account.tax.template">
             <field name="name">Erwerbe gemäß Art. 3 Abs. 8 zweiter Satz, die gemäß Art. 25 Abs. 2 im Inland als besteuert gelten (IGE-UST)</field>
-            <field name="description">UST_077 IGE (im Inland besteuert)</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field eval="0.0" name="amount" />
             <field name="sequence">200</field>
@@ -1460,7 +1425,6 @@
             -089, !-064, +062, -063, -067! -->
         <record id="account_tax_template_purchase_20_code060" model="account.tax.template">
             <field name="name">VST_060 Normalsteuersatz 20%</field>
-            <field name="description">VSt. 20%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">400</field>
             <field name="type_tax_use">purchase</field>
@@ -1496,7 +1460,6 @@
         <record
             id="account_tax_template_purchase_20_misc_code060" model="account.tax.template">
             <field name="name">VST_060 sonstige Leistungen 20%</field>
-            <field name="description">VSt. 20%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">400</field>
             <field name="type_tax_use">purchase</field>
@@ -1531,7 +1494,6 @@
         </record>
         <record id="account_tax_template_purchase_10_code060" model="account.tax.template">
             <field name="name">VST_060 ermäßigter Steuersatz 10%</field>
-            <field name="description">VSt. 10%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">400</field>
             <field name="type_tax_use">purchase</field>
@@ -1566,7 +1528,6 @@
         </record>
         <record id="account_tax_template_purchase_13_code060" model="account.tax.template">
             <field name="name">VST_060 ermäßigter Steuersatz 13%</field>
-            <field name="description">VSt. 13%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">400</field>
             <field name="type_tax_use">purchase</field>
@@ -1601,7 +1562,6 @@
         </record>
         <record id="account_tax_template_purchase_19_code060" model="account.tax.template">
             <field name="name">VST_060 Jungholz und Mittelberg 19%</field>
-            <field name="description">VSt. 19%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">400</field>
             <field name="type_tax_use">purchase</field>
@@ -1636,7 +1596,6 @@
         </record>
         <record id="account_tax_template_purchase_12_code060" model="account.tax.template">
             <field name="name">VST_060 Weineinkauf 12% (LWB)</field>
-            <field name="description">VSt. 12%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">400</field>
             <field name="type_tax_use">purchase</field>
@@ -1673,7 +1632,6 @@
             12 Abs. 1 Z 2 lit. a) -->
         <record id="account_tax_template_purchase_xx_code061" model="account.tax.template">
             <field name="name">VST_061 entrichtete EUst (§ 12 Abs. 1 Z 2 lit. a)</field>
-            <field name="description">VSt. 20%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">400</field>
             <field name="type_tax_use">purchase</field>
@@ -1708,7 +1666,6 @@
             verbuchte Einfuhrumsatzsteuer (§ 12 Abs. 1 Z 2 lit. b) -->
         <record id="account_tax_template_purchase_xx_code083" model="account.tax.template">
             <field name="name">VST_083 verbuchte EUst. (§ 12 Abs. 1 Z 2 lit. b)</field>
-            <field name="description">VSt. 20%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">400</field>
             <field name="type_tax_use">none</field>
@@ -1746,7 +1703,6 @@
         <record
             id="account_tax_template_purchase_correct_code063" model="account.tax.template">
             <field name="name">VST_063 (§12 Abs. 10 und 11 - Berichtigung)</field>
-            <field name="description">VSt. 0%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field eval="0.00" name="amount" />
             <field name="sequence">400</field>
@@ -1781,7 +1737,6 @@
         <record
             id="account_tax_template_purchase_correct_code067" model="account.tax.template">
             <field name="name">VST_067 (§ 16 - Berichtigung)</field>
-            <field name="description">VSt. 0%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field eval="0.00" name="amount" />
             <field name="sequence">400</field>
@@ -1817,7 +1772,6 @@
         <!-- Sonstige Berichtigungen -->
         <record id="account_tax_template_purchase_correct_code090" model="account.tax.template">
             <field name="name">VST_090 (Sonstige Berichtigungen)</field>
-            <field name="description">VSt. 0%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field eval="0.00" name="amount" />
             <field name="sequence">600</field>
@@ -1854,7 +1808,6 @@
         <!-- Vorsteuern betreffend KFZ nach EKR 063, 064, 732-733 und 744-747 -->
         <record id="account_tax_template_purchase_cars_buildings_code027" model="account.tax.template">
             <field name="name">VST_027 betreffend KFZ nach EKR 063, 064, 732-733 und 744-747</field>
-            <field name="description">VSt. 20%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">400</field>
             <field name="type_tax_use">purchase</field>
@@ -1888,7 +1841,6 @@
         <!-- Vorsteuern betreffend Gebäude nach EKR 030-037 und 070, 071 -->
         <record id="account_tax_template_purchase_cars_buildings_code028" model="account.tax.template">
             <field name="name">VST_028 betreffend Gebäude nach EKR 030-037 und 070, 071</field>
-            <field name="description">VSt. 20%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field eval="20" name="amount" />
             <field name="sequence">400</field>
@@ -1922,7 +1874,6 @@
         <!-- Innergemeinschaftlicher Erwerb 070 abzgl. 071 ! -->
         <record id="account_tax_template_purchase_eu_0_vst_071" model="account.tax.template">
             <field name="name">VST_071 IGE 0%</field>
-            <field name="description">VST_071 IGE 0% (Art. 6 Abs. 2)</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field eval="0" name="amount" />
             <field name="sequence">500</field>
@@ -1960,7 +1911,6 @@
             des Bestimmungslandes besteuert worden sind (IGE-VST) -->
         <record id="account_tax_template_purchase_eu_xx_vst_076" model="account.tax.template">
             <field name="name">VST_076 IGE (im Bestimmungsland besteuert)</field>
-            <field name="description">VSt. 20%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">500</field>
             <field name="type_tax_use">purchase</field>
@@ -1999,7 +1949,6 @@
             Abs. 2 im Inland als besteuert gelten (IGE-VST) -->
         <record id="account_tax_template_purchase_eu_xx_vst_077" model="account.tax.template">
             <field name="name">VST_077 IGE (im Inland besteuert)</field>
-            <field name="description">VSt. 20%</field>
             <field name="chart_template_id" ref="l10n_at_chart_template" />
             <field name="sequence">500</field>
             <field name="type_tax_use">purchase</field>

--- a/addons/l10n_au/data/account_tax_template_data.xml
+++ b/addons/l10n_au/data/account_tax_template_data.xml
@@ -5,7 +5,6 @@
         <field name="chart_template_id" ref="l10n_au_chart_template"/>
         <field name="name">Sale (10%)</field>
         <field name="sequence">1</field>
-        <field name="description">GST Sales</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">percent</field>
         <field name="amount">10.0</field>
@@ -44,7 +43,6 @@
         <field name="chart_template_id" ref="l10n_au_chart_template"/>
         <field name="name">GST Inc Sale (10%)</field>
         <field name="sequence">2</field>
-        <field name="description">GST Inclusive Sales</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">percent</field>
         <field name="amount">10.0</field>
@@ -83,7 +81,6 @@
         <field name="chart_template_id" ref="l10n_au_chart_template"/>
         <field name="name">Zero (Export) Sale</field>
         <field name="sequence">3</field>
-        <field name="description">Zero Rated (Export) Sales</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
@@ -116,7 +113,6 @@
         <field name="chart_template_id" ref="l10n_au_chart_template"/>
         <field name="name">Exempt Sale</field>
         <field name="sequence">4</field>
-        <field name="description">Exempt Sales</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
@@ -149,7 +145,6 @@
         <field name="chart_template_id" ref="l10n_au_chart_template"/>
         <field name="name">Input Taxed</field>
         <field name="sequence">5</field>
-        <field name="description">Input Taxed Sales</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
@@ -182,7 +177,6 @@
         <field name="chart_template_id" ref="l10n_au_chart_template"/>
         <field name="name">Sale Adj (10%)</field>
         <field name="sequence">6</field>
-        <field name="description">Tax Adjustments (Sales)</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">percent</field>
         <field name="amount">10.0</field>
@@ -221,7 +215,6 @@
         <field name="chart_template_id" ref="l10n_au_chart_template"/>
         <field name="name">Purch (10%)</field>
         <field name="sequence">1</field>
-        <field name="description">GST Purchases</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
         <field name="amount">10.0</field>
@@ -258,7 +251,6 @@
         <field name="chart_template_id" ref="l10n_au_chart_template"/>
         <field name="name">GST Inc Purch (10%)</field>
         <field name="sequence">2</field>
-        <field name="description">GST Inclusive Purchases</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
         <field name="amount">10.0</field>
@@ -295,7 +287,6 @@
         <field name="chart_template_id" ref="l10n_au_chart_template"/>
         <field name="name">Capital (10.0%)</field>
         <field name="sequence">3</field>
-        <field name="description">Capital Purchases</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
         <field name="amount">10.0</field>
@@ -332,7 +323,6 @@
         <field name="chart_template_id" ref="l10n_au_chart_template"/>
         <field name="name">Zero Rated Purch</field>
         <field name="sequence">4</field>
-        <field name="description">Capital Purchases</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
@@ -365,7 +355,6 @@
         <field name="chart_template_id" ref="l10n_au_chart_template"/>
         <field name="name">Purch (Taxable Imports)</field>
         <field name="sequence">5</field>
-        <field name="description">Purchase (Taxable Imports) - Tax Paid Separately</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
@@ -398,7 +387,6 @@
         <field name="chart_template_id" ref="l10n_au_chart_template"/>
         <field name="name">Purch for Input Sales</field>
         <field name="sequence">6</field>
-        <field name="description">Purchases for Input Taxed Sales</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
         <field name="amount">10.0</field>
@@ -433,7 +421,6 @@
         <field name="chart_template_id" ref="l10n_au_chart_template"/>
         <field name="name">Purch Private (10%)</field>
         <field name="sequence">7</field>
-        <field name="description">Purchases for Private use or not deductible</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
         <field name="amount">10.0</field>
@@ -468,7 +455,6 @@
         <field name="chart_template_id" ref="l10n_au_chart_template"/>
         <field name="name">GST Only on Imports</field>
         <field name="sequence">8</field>
-        <field name="description">GST Only on Imports</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
         <field name="amount">100000000</field>
@@ -503,7 +489,6 @@
         <field name="chart_template_id" ref="l10n_au_chart_template"/>
         <field name="name">Purch Adj (10%)</field>
         <field name="sequence">9</field>
-        <field name="description">Tax Adjustments (Purchases)</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
         <field name="amount">10.0</field>

--- a/addons/l10n_be/data/account_tax_template_data.xml
+++ b/addons/l10n_be/data/account_tax_template_data.xml
@@ -3,7 +3,6 @@
 
         <record id="attn_VAT-OUT-21-L" model="account.tax.template">
             <field name="sequence">10</field>
-            <field name="description">TVA 21%</field>
             <field name="name">21%</field>
             <field name="price_include" eval="0"/>
             <field name="amount">21</field>
@@ -44,7 +43,6 @@
 
         <record id="attn_VAT-OUT-21-S" model="account.tax.template">
             <field name="sequence">11</field>
-            <field name="description">TVA 21%</field>
             <field name="name">21% S.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">21</field>
@@ -85,7 +83,6 @@
 
         <record id="attn_VAT-OUT-12-S" model="account.tax.template">
             <field name="sequence">20</field>
-            <field name="description">TVA 12%</field>
             <field name="name">12% S.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">12</field>
@@ -126,7 +123,6 @@
 
         <record id="attn_VAT-OUT-12-L" model="account.tax.template">
             <field name="sequence">21</field>
-            <field name="description">TVA 12%</field>
             <field name="name">12%</field>
             <field name="price_include" eval="0"/>
             <field name="amount">12</field>
@@ -166,7 +162,6 @@
 
         <record id="attn_VAT-OUT-06-S" model="account.tax.template">
             <field name="sequence">30</field>
-            <field name="description">TVA 6%</field>
             <field name="name">6% S.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">6</field>
@@ -207,7 +202,6 @@
 
         <record id="attn_VAT-OUT-06-L" model="account.tax.template">
             <field name="sequence">31</field>
-            <field name="description">TVA 6%</field>
             <field name="name">6%</field>
             <field name="price_include" eval="0"/>
             <field name="amount">6</field>
@@ -247,7 +241,6 @@
 
         <record id="attn_VAT-OUT-00-S" model="account.tax.template">
             <field name="sequence">40</field>
-            <field name="description">TVA 0%</field>
             <field name="name">0% S.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0</field>
@@ -284,7 +277,6 @@
 
         <record id="attn_VAT-OUT-00-L" model="account.tax.template">
             <field name="sequence">41</field>
-            <field name="description">TVA 0%</field>
             <field name="name">0%</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0</field>
@@ -320,7 +312,6 @@
 
         <record id="attn_VAT-OUT-00-CC" model="account.tax.template">
             <field name="sequence">50</field>
-            <field name="description">TVA 0% Cocont.</field>
             <field name="name">0% Cocont.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0</field>
@@ -356,7 +347,6 @@
 
         <record id="attn_VAT-OUT-00-EU-S" model="account.tax.template">
             <field name="sequence">60</field>
-            <field name="description">TVA 0% EU</field>
             <field name="name">0% EU S.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0</field>
@@ -393,7 +383,6 @@
 
         <record id="attn_VAT-OUT-00-EU-L" model="account.tax.template">
             <field name="sequence">61</field>
-            <field name="description">TVA 0% EU</field>
             <field name="name">0% EU M.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0</field>
@@ -429,7 +418,6 @@
 
         <record id="attn_VAT-OUT-00-EU-T" model="account.tax.template">
             <field name="sequence">62</field>
-            <field name="description">TVA 0% EU</field>
             <field name="name">0% EU T.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0</field>
@@ -466,7 +454,6 @@
 
         <record id="attn_VAT-OUT-00-ROW" model="account.tax.template">
             <field name="sequence">70</field>
-            <field name="description">TVA 0% Non EU</field>
             <field name="name">0% Non EU</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0</field>
@@ -502,7 +489,6 @@
 
         <record id="attn_VAT-IN-V81-21" model="account.tax.template">
             <field name="sequence">110</field>
-            <field name="description">TVA 21%</field>
             <field name="name">21% M.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">21</field>
@@ -543,7 +529,6 @@
 
         <record id="attn_VAT-IN-V81-12" model="account.tax.template">
             <field name="sequence">120</field>
-            <field name="description">TVA 12%</field>
             <field name="name">12% M.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">12</field>
@@ -584,7 +569,6 @@
 
         <record id="attn_VAT-IN-V81-06" model="account.tax.template">
             <field name="sequence">130</field>
-            <field name="description">TVA 6%</field>
             <field name="name">6% M.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">6</field>
@@ -625,7 +609,6 @@
 
         <record id="attn_VAT-IN-V81-00" model="account.tax.template">
             <field name="sequence">140</field>
-            <field name="description">TVA 0%</field>
             <field name="name">0% M.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0</field>
@@ -662,7 +645,6 @@
 
          <record id="attn_TVA-21-inclus-dans-prix" model="account.tax.template">
             <field name="sequence">150</field>
-            <field name="description">TVA 21% TTC</field>
             <field name="name">21% S. TTC</field>
             <field name="price_include" eval="1"/>
             <field name="amount">21</field>
@@ -703,7 +685,6 @@
 
         <record id="attn_VAT-IN-V82-21-S" model="account.tax.template">
             <field name="sequence">210</field>
-            <field name="description">TVA 21%</field>
             <field name="name">21% S.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">21</field>
@@ -745,7 +726,6 @@
 
         <record id="attn_VAT-IN-V82-21-G" model="account.tax.template">
             <field name="sequence">220</field>
-            <field name="description">TVA 21%</field>
             <field name="name">21% Biens divers</field>
             <field name="price_include" eval="0"/>
             <field name="amount">21</field>
@@ -787,7 +767,6 @@
 
         <record id="attn_VAT-IN-V82-12-S" model="account.tax.template">
             <field name="sequence">230</field>
-            <field name="description">TVA 12%</field>
             <field name="name">12% S.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">12</field>
@@ -829,7 +808,6 @@
 
         <record id="attn_VAT-IN-V82-12-G" model="account.tax.template">
             <field name="sequence">240</field>
-            <field name="description">TVA 12%</field>
             <field name="name">12% Biens divers</field>
             <field name="price_include" eval="0"/>
             <field name="amount">12</field>
@@ -871,7 +849,6 @@
 
         <record id="attn_VAT-IN-V82-06-S" model="account.tax.template">
             <field name="sequence">250</field>
-            <field name="description">TVA 6%</field>
             <field name="name">6% S.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">6</field>
@@ -913,7 +890,6 @@
 
         <record id="attn_VAT-IN-V82-06-G" model="account.tax.template">
             <field name="sequence">260</field>
-            <field name="description">TVA 6%</field>
             <field name="name">6% Biens divers</field>
             <field name="price_include" eval="0"/>
             <field name="amount">6</field>
@@ -955,7 +931,6 @@
 
         <record id="attn_VAT-IN-V82-00-S" model="account.tax.template">
             <field name="sequence">270</field>
-            <field name="description">TVA 0%</field>
             <field name="name">0% S.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0</field>
@@ -993,7 +968,6 @@
 
         <record id="attn_VAT-IN-V82-00-G" model="account.tax.template">
             <field name="sequence">280</field>
-            <field name="description">TVA 0%</field>
             <field name="name">0% Biens divers</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0</field>
@@ -1031,7 +1005,6 @@
 
         <record id="attn_VAT-IN-V83-21" model="account.tax.template">
             <field name="sequence">310</field>
-            <field name="description">TVA 21%</field>
             <field name="name">21% Biens d'investissement</field>
             <field name="price_include" eval="0"/>
             <field name="amount">21</field>
@@ -1073,7 +1046,6 @@
 
         <record id="attn_VAT-IN-V83-12" model="account.tax.template">
             <field name="sequence">320</field>
-            <field name="description">TVA 12%</field>
             <field name="name">12% Biens d'investissement</field>
             <field name="price_include" eval="0"/>
             <field name="amount">12</field>
@@ -1115,7 +1087,6 @@
 
         <record id="attn_VAT-IN-V83-06" model="account.tax.template">
             <field name="sequence">330</field>
-            <field name="description">TVA 6%</field>
             <field name="name">6% Biens d'investissement</field>
             <field name="price_include" eval="0"/>
             <field name="amount">6</field>
@@ -1157,7 +1128,6 @@
 
         <record id="attn_VAT-IN-V83-00" model="account.tax.template">
             <field name="sequence">340</field>
-            <field name="description">TVA 0%</field>
             <field name="name">0% Biens d'investissement</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0</field>
@@ -1195,7 +1165,6 @@
 
         <record id="attn_VAT-IN-V81-21-CC" model="account.tax.template">
             <field name="sequence">410</field>
-            <field name="description">TVA 21% Cocont.</field>
             <field name="name">21% Cocont. M.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">21</field>
@@ -1247,7 +1216,6 @@
 
         <record id="attn_VAT-IN-V81-12-CC" model="account.tax.template">
             <field name="sequence">420</field>
-            <field name="description">TVA 12% Cocont.</field>
             <field name="name">12% Cocont. M.</field>
             <field name="price_include" eval="0"/>
             <field name="amount_type">percent</field>
@@ -1300,7 +1268,6 @@
 
         <record id="attn_VAT-IN-V81-06-CC" model="account.tax.template">
             <field name="sequence">430</field>
-            <field name="description">TVA 6% Cocont.</field>
             <field name="name">6% Cocont. M.</field>
             <field name="price_include" eval="0"/>
             <field name="amount_type">percent</field>
@@ -1353,7 +1320,6 @@
 
         <record id="attn_VAT-IN-V81-00-CC" model="account.tax.template">
             <field name="sequence">440</field>
-            <field name="description">TVA 0% Cocont.</field>
             <field name="name">0% Cocont. M.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0</field>
@@ -1391,7 +1357,6 @@
 
         <record id="attn_VAT-IN-V82-21-CC" model="account.tax.template">
             <field name="sequence">510</field>
-            <field name="description">TVA 21% Cocont.</field>
             <field name="name">21% Cocont .S.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">21</field>
@@ -1444,7 +1409,6 @@
 
         <record id="attn_VAT-IN-V82-12-CC" model="account.tax.template">
             <field name="sequence">520</field>
-            <field name="description">TVA 12% Cocont.</field>
             <field name="name">12% Cocont. S.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">12</field>
@@ -1497,7 +1461,6 @@
 
         <record id="attn_VAT-IN-V82-06-CC" model="account.tax.template">
             <field name="sequence">530</field>
-            <field name="description">TVA 6% Cocont.</field>
             <field name="name">6% Cocont. S.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">6</field>
@@ -1550,7 +1513,6 @@
 
         <record id="attn_VAT-IN-V82-00-CC" model="account.tax.template">
             <field name="sequence">540</field>
-            <field name="description">TVA 0% Cocont.</field>
             <field name="name">0% Cocont. S.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0</field>
@@ -1588,7 +1550,6 @@
 
         <record id="attn_VAT-IN-V83-21-CC" model="account.tax.template">
             <field name="sequence">610</field>
-            <field name="description">TVA 21% Cocont.</field>
             <field name="name">21% Cocont. - Biens d'investissement</field>
             <field name="price_include" eval="0"/>
             <field name="amount">21</field>
@@ -1641,7 +1602,6 @@
 
         <record id="attn_VAT-IN-V83-12-CC" model="account.tax.template">
             <field name="sequence">620</field>
-            <field name="description">TVA 12% Cocont.</field>
             <field name="name">12% Cocont. - Biens d'investissement</field>
             <field name="price_include" eval="0"/>
             <field name="amount">12</field>
@@ -1694,7 +1654,6 @@
 
         <record id="attn_VAT-IN-V83-06-CC" model="account.tax.template">
             <field name="sequence">630</field>
-            <field name="description">TVA 6% Cocont.</field>
             <field name="name">6% Cocont. - Biens d'investissement</field>
             <field name="price_include" eval="0"/>
             <field name="amount">6</field>
@@ -1747,7 +1706,6 @@
 
         <record id="attn_VAT-IN-V83-00-CC" model="account.tax.template">
             <field name="sequence">640</field>
-            <field name="description">TVA 0% Cocont.</field>
             <field name="name">0% Cocont. - Biens d'investissement</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0</field>
@@ -1785,7 +1743,6 @@
 
         <record id="attn_VAT-IN-V82-CAR-EXC" model="account.tax.template">
             <field name="sequence">720</field>
-            <field name="description">TVA 50% Non Déductible - Frais de voiture (Prix Excl.)</field>
             <field name="name">50% Non Déductible - Frais de voiture (Prix Excl.)</field>
             <field name="price_include" eval="0"/>
             <field name="amount">21</field>
@@ -1841,7 +1798,6 @@
 
         <record id="attn_VAT-IN-V81-21-EU" model="account.tax.template">
             <field name="sequence">1110</field>
-            <field name="description">TVA 21% EU</field>
             <field name="name">21% EU M.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">21</field>
@@ -1893,7 +1849,6 @@
 
         <record id="attn_VAT-IN-V81-12-EU" model="account.tax.template">
             <field name="sequence">1120</field>
-            <field name="description">TVA 12% EU</field>
             <field name="name">12% EU M.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">12</field>
@@ -1946,7 +1901,6 @@
 
         <record id="attn_VAT-IN-V81-06-EU" model="account.tax.template">
             <field name="sequence">1130</field>
-            <field name="description">TVA 6% EU</field>
             <field name="name">6% EU M.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">6</field>
@@ -1999,7 +1953,6 @@
 
         <record id="attn_VAT-IN-V81-00-EU" model="account.tax.template">
             <field name="sequence">1140</field>
-            <field name="description">TVA 0% EU</field>
             <field name="name">0% EU M.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0.0</field>
@@ -2037,7 +1990,6 @@
 
         <record id="attn_VAT-IN-V82-21-EU-S" model="account.tax.template">
             <field name="sequence">1210</field>
-            <field name="description">TVA 21% EU</field>
             <field name="name">21% EU S.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">21</field>
@@ -2090,7 +2042,6 @@
 
         <record id="attn_VAT-IN-V82-21-EU-G" model="account.tax.template">
             <field name="sequence">1220</field>
-            <field name="description">TVA 21% EU</field>
             <field name="name">21% EU - Biens divers</field>
             <field name="price_include" eval="0"/>
             <field name="amount">21</field>
@@ -2143,7 +2094,6 @@
 
         <record id="attn_VAT-IN-V82-12-EU-S" model="account.tax.template">
             <field name="sequence">1230</field>
-            <field name="description">TVA 12% EU</field>
             <field name="name">12% EU S.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">12</field>
@@ -2196,7 +2146,6 @@
 
         <record id="attn_VAT-IN-V82-12-EU-G" model="account.tax.template">
             <field name="sequence">1240</field>
-            <field name="description">TVA 12% EU</field>
             <field name="name">12% EU - Biens divers</field>
             <field name="price_include" eval="0"/>
             <field name="amount">12</field>
@@ -2249,7 +2198,6 @@
 
         <record id="attn_VAT-IN-V82-06-EU-S" model="account.tax.template">
             <field name="sequence">1250</field>
-            <field name="description">TVA 6% EU</field>
             <field name="name">6% EU S.</field>
             <field name="price_include" eval="0"/>
             <field name="amount_type">percent</field>
@@ -2302,7 +2250,6 @@
 
         <record id="attn_VAT-IN-V82-06-EU-G" model="account.tax.template">
             <field name="sequence">1260</field>
-            <field name="description">TVA 6% EU</field>
             <field name="name">6% EU - Biens divers</field>
             <field name="price_include" eval="0"/>
             <field name="amount">6</field>
@@ -2355,7 +2302,6 @@
 
         <record id="attn_VAT-IN-V82-00-EU-S" model="account.tax.template">
             <field name="sequence">1270</field>
-            <field name="description">TVA 0% EU</field>
             <field name="name">0% EU S.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0.0</field>
@@ -2393,7 +2339,6 @@
 
         <record id="attn_VAT-IN-V83-21-EU" model="account.tax.template">
             <field name="sequence">1310</field>
-            <field name="description">TVA 21% EU</field>
             <field name="name">21% EU - Biens d'investissement</field>
             <field name="price_include" eval="0"/>
             <field name="amount">21</field>
@@ -2446,7 +2391,6 @@
 
         <record id="attn_VAT-IN-V82-00-EU-G" model="account.tax.template">
             <field name="sequence">1280</field>
-            <field name="description">TVA 0% EU</field>
             <field name="name">0% EU - Biens divers</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0</field>
@@ -2484,7 +2428,6 @@
 
         <record id="attn_VAT-IN-V83-12-EU" model="account.tax.template">
             <field name="sequence">1320</field>
-            <field name="description">TVA 12% EU</field>
             <field name="name">12% EU - Biens d'investissement</field>
             <field name="price_include" eval="0"/>
             <field name="amount_type">percent</field>
@@ -2537,7 +2480,6 @@
 
         <record id="attn_VAT-IN-V83-06-EU" model="account.tax.template">
             <field name="sequence">1330</field>
-            <field name="description">TVA 6% EU</field>
             <field name="name">6% EU - Biens d'investissement</field>
             <field name="price_include" eval="0"/>
             <field name="amount_type">percent</field>
@@ -2590,7 +2532,6 @@
 
         <record id="attn_VAT-IN-V83-00-EU" model="account.tax.template">
             <field name="sequence">1340</field>
-            <field name="description">TVA 0% EU</field>
             <field name="name">0% EU - Biens d'investissement</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0.0</field>
@@ -2628,7 +2569,6 @@
 
         <record id="attn_VAT-IN-V81-21-ROW-CC" model="account.tax.template">
             <field name="sequence">2110</field>
-            <field name="description">TVA 21% Non EU</field>
             <field name="name">21% Non EU M.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">21</field>
@@ -2680,7 +2620,6 @@
 
         <record id="attn_VAT-IN-V81-12-ROW-CC" model="account.tax.template">
             <field name="sequence">2120</field>
-            <field name="description">TVA 12% Non EU</field>
             <field name="name">12% Non EU M.</field>
             <field name="amount">12</field>
             <field name="price_include" eval="0"/>
@@ -2733,7 +2672,6 @@
 
         <record id="attn_VAT-IN-V81-06-ROW-CC" model="account.tax.template">
             <field name="sequence">2130</field>
-            <field name="description">TVA 6% Non EU</field>
             <field name="name">6% Non EU M.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">6</field>
@@ -2786,7 +2724,6 @@
 
         <record id="attn_VAT-IN-V81-00-ROW-CC" model="account.tax.template">
             <field name="sequence">2140</field>
-            <field name="description">TVA 0% Non EU</field>
             <field name="name">0% Non EU M.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0.0</field>
@@ -2824,7 +2761,6 @@
 
         <record id="attn_VAT-IN-V82-21-ROW-CC" model="account.tax.template">
             <field name="sequence">2210</field>
-            <field name="description">TVA 21% Non EU</field>
             <field name="name">21% Non EU S.</field>
             <field name="amount">21</field>
             <field name="price_include" eval="0"/>
@@ -2877,7 +2813,6 @@
 
         <record id="attn_VAT-IN-V82-12-ROW-CC" model="account.tax.template">
             <field name="sequence">2220</field>
-            <field name="description">TVA 12% Non EU</field>
             <field name="name">12% Non EU S.</field>
             <field name="price_include" eval="0"/>
             <field name="amount_type">percent</field>
@@ -2930,7 +2865,6 @@
 
         <record id="attn_VAT-IN-V82-06-ROW-CC" model="account.tax.template">
             <field name="sequence">2230</field>
-            <field name="description">TVA 6% Non EU</field>
             <field name="name">6% Non EU S.</field>
             <field name="price_include" eval="0"/>
             <field name="amount_type">percent</field>
@@ -2983,7 +2917,6 @@
 
         <record id="attn_VAT-IN-V82-00-ROW-CC" model="account.tax.template">
             <field name="sequence">2240</field>
-            <field name="description">TVA 0% Non EU</field>
             <field name="name">0% Non EU S.</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0.0</field>
@@ -3021,7 +2954,6 @@
 
         <record id="attn_VAT-IN-V83-21-ROW-CC" model="account.tax.template">
             <field name="sequence">2310</field>
-            <field name="description">TVA 21% Non EU</field>
             <field name="name">21% Non EU - Biens d'investissement</field>
             <field name="amount">21</field>
             <field name="price_include" eval="0"/>
@@ -3074,7 +3006,6 @@
 
         <record id="attn_VAT-IN-V83-12-ROW-CC" model="account.tax.template">
             <field name="sequence">2320</field>
-            <field name="description">TVA 12% Non EU</field>
             <field name="name">12% Non EU - Biens d'investissement</field>
             <field name="price_include" eval="0"/>
             <field name="amount_type">percent</field>
@@ -3127,7 +3058,6 @@
 
         <record id="attn_VAT-IN-V83-06-ROW-CC" model="account.tax.template"> <!--merged group-->
             <field name="sequence">2330</field>
-            <field name="description">TVA 6% Non EU</field>
             <field name="name">6% Non EU - Biens d'investissement</field>
             <field name="price_include" eval="0"/>
             <field name="amount_type">percent</field>
@@ -3180,7 +3110,6 @@
 
         <record id="attn_VAT-IN-V83-00-ROW-CC" model="account.tax.template">
             <field name="sequence">2340</field>
-            <field name="description">TVA 0% Non EU</field>
             <field name="name">0% Non EU - Biens d'investissement</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0.0</field>

--- a/addons/l10n_br/data/account_tax_template_data.xml
+++ b/addons/l10n_br/data/account_tax_template_data.xml
@@ -25,7 +25,6 @@
 		</record>
 
 		<record id="tax_template_out_ipi" model="account.tax.template">
-			<field name="description">IPI </field>
 			<field name="name">IPI Saída</field>
 			<field name="amount">0.00</field>
 			<field name="type_tax_use">sale</field>
@@ -58,7 +57,6 @@
        	</record>
 
 		<record id="tax_template_out_ipi2" model="account.tax.template">
-			<field name="description">IPI 2%</field>
 			<field name="name">IPI Saída 2%</field>
 			<field name="amount">2</field>
 			<field name="type_tax_use">sale</field>
@@ -95,7 +93,6 @@
        	</record>
 
 		<record id="tax_template_out_ipi3" model="account.tax.template">
-			<field name="description">IPI 3%</field>
 			<field name="name">IPI Saída 3%</field>
 			<field name="amount">3</field>
 			<field name="type_tax_use">sale</field>
@@ -132,7 +129,6 @@
        	</record>
 
 		<record id="tax_template_out_ipi4" model="account.tax.template">
-			<field name="description">IPI 4%</field>
 			<field name="name">IPI Saída 4%</field>
 			<field name="amount">4</field>
 			<field name="type_tax_use">sale</field>
@@ -169,7 +165,6 @@
        	</record>
 
 		<record id="tax_template_out_ipi5" model="account.tax.template">
-			<field name="description">IPI 5%</field>
 			<field name="name">IPI Saída 5%</field>
 			<field name="amount">5</field>
 			<field name="type_tax_use">sale</field>
@@ -206,7 +201,6 @@
        	</record>
 
 		<record id="tax_template_out_ipi7" model="account.tax.template">
-			<field name="description">IPI 7%</field>
 			<field name="name">IPI Saída 7%</field>
 			<field name="amount">7</field>
 			<field name="type_tax_use">sale</field>
@@ -243,7 +237,6 @@
         </record>
 
 		<record id="tax_template_out_ipi8" model="account.tax.template">
-			<field name="description">IPI 8%</field>
 			<field name="name">IPI Saída 8%</field>
 			<field name="amount">8</field>
 			<field name="type_tax_use">sale</field>
@@ -280,7 +273,6 @@
        	</record>
 
 		<record id="tax_template_out_ipi10" model="account.tax.template">
-			<field name="description">IPI 10%</field>
 			<field name="name">IPI Saída 10%</field>
 			<field name="amount">10</field>
 			<field name="type_tax_use">sale</field>
@@ -317,7 +309,6 @@
        	</record>
 
 		<record id="tax_template_out_ipi12" model="account.tax.template">
-			<field name="description">IPI 12%</field>
 			<field name="name">IPI Saída 12%</field>
 			<field name="amount">12</field>
 			<field name="type_tax_use">sale</field>
@@ -354,7 +345,6 @@
        	</record>
 
 		<record id="tax_template_out_ipi13" model="account.tax.template">
-			<field name="description">IPI 13%</field>
 			<field name="name">IPI Saída 13%</field>
 			<field name="amount">13</field>
 			<field name="type_tax_use">sale</field>
@@ -391,7 +381,6 @@
        	</record>
 
 		<record id="tax_template_out_ipi15" model="account.tax.template">
-			<field name="description">IPI 15%</field>
 			<field name="name">IPI Saída 15%</field>
 			<field name="amount">15</field>
 			<field name="type_tax_use">sale</field>
@@ -428,7 +417,6 @@
        	</record>
 
 		<record id="tax_template_out_ipi16" model="account.tax.template">
-			<field name="description">IPI 16%</field>
 			<field name="name">IPI Saída 16%</field>
 			<field name="amount">16</field>
 			<field name="type_tax_use">sale</field>
@@ -465,7 +453,6 @@
        	</record>
 
 		<record id="tax_template_out_ipi18" model="account.tax.template">
-			<field name="description">IPI 18%</field>
 			<field name="name">IPI Saída 18%</field>
 			<field name="amount">18</field>
 			<field name="type_tax_use">sale</field>
@@ -502,7 +489,6 @@
        	</record>
 
 		<record id="tax_template_out_ipi20" model="account.tax.template">
-			<field name="description">IPI 20%</field>
 			<field name="name">IPI Saída 20%</field>
 			<field name="amount">20</field>
 			<field name="type_tax_use">sale</field>
@@ -539,7 +525,6 @@
 		</record>
 
 		<record id="tax_template_out_ipi22" model="account.tax.template">
-			<field name="description">IPI 22%</field>
 			<field name="name">IPI Saída 22%</field>
 			<field name="amount">22</field>
 			<field name="type_tax_use">sale</field>
@@ -576,7 +561,6 @@
        	</record>
 
 		<record id="tax_template_out_ipi24" model="account.tax.template">
-			<field name="description">IPI 24%</field>
 			<field name="name">IPI Saída 24%</field>
 			<field name="amount">24</field>
 			<field name="type_tax_use">sale</field>
@@ -613,7 +597,6 @@
        	</record>
 
 		<record id="tax_template_out_ipi25" model="account.tax.template">
-			<field name="description">IPI 25%</field>
 			<field name="name">IPI Saída 25%</field>
 			<field name="amount">25</field>
 			<field name="type_tax_use">sale</field>
@@ -650,7 +633,6 @@
        	</record>
 
 		<record id="tax_template_out_ipi27" model="account.tax.template">
-			<field name="description">IPI 27%</field>
 			<field name="name">IPI Saída 27%</field>
 			<field name="amount">27</field>
 			<field name="type_tax_use">sale</field>
@@ -687,7 +669,6 @@
        	</record>
 
 		<record id="tax_template_out_ipi30" model="account.tax.template">
-			<field name="description">IPI 30%</field>
 			<field name="name">IPI Saída 30%</field>
 			<field name="amount">30</field>
 			<field name="type_tax_use">sale</field>
@@ -724,7 +705,6 @@
        	</record>
 
 		<record id="tax_template_out_ipi35" model="account.tax.template">
-			<field name="description">IPI 35%</field>
 			<field name="name">IPI Saída 35%</field>
 			<field name="amount">35</field>
 			<field name="type_tax_use">sale</field>
@@ -761,7 +741,6 @@
 		</record>
 
 		<record id="tax_template_out_ipi40" model="account.tax.template">
-			<field name="description">IPI 40%</field>
 			<field name="name">IPI Saída 40%</field>
 			<field name="amount">40</field>
 			<field name="type_tax_use">sale</field>
@@ -798,7 +777,6 @@
        	</record>
 
 		<record id="tax_template_out_ipi42" model="account.tax.template">
-			<field name="description">IPI 42%</field>
 			<field name="name">IPI Saída 42%</field>
 			<field name="amount">42</field>
 			<field name="type_tax_use">sale</field>
@@ -835,7 +813,6 @@
        	</record>
 
 		<record id="tax_template_out_ipi45" model="account.tax.template">
-			<field name="description">IPI 45%</field>
 			<field name="name">IPI Saída 45%</field>
 			<field name="amount">45</field>
 			<field name="type_tax_use">sale</field>
@@ -872,7 +849,6 @@
        	</record>
 
 		<record id="tax_template_out_ipi50" model="account.tax.template">
-			<field name="description">IPI 50%</field>
 			<field name="name">IPI Saída 50%</field>
 			<field name="amount">50</field>
 			<field name="type_tax_use">sale</field>
@@ -909,7 +885,6 @@
        	</record>
 
 		<record id="tax_template_out_ipi60" model="account.tax.template">
-			<field name="description">IPI 60%</field>
 			<field name="name">IPI Saída 60%</field>
 			<field name="amount">60</field>
 			<field name="type_tax_use">sale</field>
@@ -946,7 +921,6 @@
        	</record>
 
 		<record id="tax_template_out_ipi300" model="account.tax.template">
-			<field name="description">IPI 300%</field>
 			<field name="name">IPI Saída 300%</field>
 			<field name="amount">300</field>
 			<field name="type_tax_use">sale</field>
@@ -983,7 +957,6 @@
        	</record>
 
 		<record id="tax_template_out_ipi330" model="account.tax.template">
-			<field name="description">IPI 330%</field>
 			<field name="name">IPI Saída 330%</field>
 			<field name="amount">330</field>
 			<field name="type_tax_use">sale</field>
@@ -1020,7 +993,6 @@
        	</record>
 
        	<record id="tax_template_in_ipi" model="account.tax.template">
-			<field name="description">IPI</field>
 			<field name="name">IPI Entrada</field>
 			<field name="amount">0.00</field>
 			<field name="type_tax_use">purchase</field>
@@ -1053,7 +1025,6 @@
        	</record>
 
 		<record id="tax_template_in_ipi2" model="account.tax.template">
-			<field name="description">IPI 2%</field>
 			<field name="name">IPI Entrada 2%</field>
 			<field name="amount">2</field>
 			<field name="type_tax_use">purchase</field>
@@ -1090,7 +1061,6 @@
        	</record>
 
 		<record id="tax_template_in_ipi3" model="account.tax.template">
-			<field name="description">IPI 3%</field>
 			<field name="name">IPI Entrada 3%</field>
 			<field name="amount">3</field>
 			<field name="type_tax_use">purchase</field>
@@ -1127,7 +1097,6 @@
        	</record>
 
 		<record id="tax_template_in_ipi4" model="account.tax.template">
-			<field name="description">IPI 4%</field>
 			<field name="name">IPI Entrada 4%</field>
 			<field name="amount">4</field>
 			<field name="type_tax_use">purchase</field>
@@ -1164,7 +1133,6 @@
        	</record>
 
 		<record id="tax_template_in_ipi5" model="account.tax.template">
-			<field name="description">IPI 5%</field>
 			<field name="name">IPI Entrada 5%</field>
 			<field name="amount">5</field>
 			<field name="type_tax_use">purchase</field>
@@ -1201,7 +1169,6 @@
        	</record>
 
 		<record id="tax_template_in_ipi7" model="account.tax.template">
-			<field name="description">IPI 7%</field>
 			<field name="name">IPI Entrada 7%</field>
 			<field name="amount">7</field>
 			<field name="type_tax_use">purchase</field>
@@ -1238,7 +1205,6 @@
         	</record>
 
 		<record id="tax_template_in_ipi8" model="account.tax.template">
-			<field name="description">IPI 8%</field>
 			<field name="name">IPI Entrada 8%</field>
 			<field name="amount">8</field>
 			<field name="type_tax_use">purchase</field>
@@ -1275,7 +1241,6 @@
        	</record>
 
 		<record id="tax_template_in_ipi10" model="account.tax.template">
-			<field name="description">IPI 10%</field>
 			<field name="name">IPI Entrada 10%</field>
 			<field name="amount">10</field>
 			<field name="type_tax_use">purchase</field>
@@ -1312,7 +1277,6 @@
        	</record>
 
 		<record id="tax_template_in_ipi12" model="account.tax.template">
-			<field name="description">IPI 12%</field>
 			<field name="name">IPI Entrada 12%</field>
 			<field name="amount">12</field>
 			<field name="type_tax_use">purchase</field>
@@ -1349,7 +1313,6 @@
        	</record>
 
 		<record id="tax_template_in_ipi13" model="account.tax.template">
-			<field name="description">IPI 13%</field>
 			<field name="name">IPI Entrada 13%</field>
 			<field name="amount">13</field>
 			<field name="type_tax_use">purchase</field>
@@ -1386,7 +1349,6 @@
        	</record>
 
 		<record id="tax_template_in_ipi15" model="account.tax.template">
-			<field name="description">IPI 15%</field>
 			<field name="name">IPI Entrada 15%</field>
 			<field name="amount">15</field>
 			<field name="type_tax_use">purchase</field>
@@ -1423,7 +1385,6 @@
        	</record>
 
 		<record id="tax_template_in_ipi16" model="account.tax.template">
-			<field name="description">IPI 16%</field>
 			<field name="name">IPI Entrada 16%</field>
 			<field name="amount">16</field>
 			<field name="type_tax_use">purchase</field>
@@ -1460,7 +1421,6 @@
        	</record>
 
 		<record id="tax_template_in_ipi18" model="account.tax.template">
-			<field name="description">IPI 18%</field>
 			<field name="name">IPI Entrada 18%</field>
 			<field name="amount">18</field>
 			<field name="type_tax_use">purchase</field>
@@ -1497,7 +1457,6 @@
        	</record>
 
 		<record id="tax_template_in_ipi20" model="account.tax.template">
-			<field name="description">IPI 20%</field>
 			<field name="name">IPI Entrada 20%</field>
 			<field name="amount">20</field>
 			<field name="type_tax_use">purchase</field>
@@ -1534,7 +1493,6 @@
         </record>
 
 		<record id="tax_template_in_ipi22" model="account.tax.template">
-			<field name="description">IPI 22%</field>
 			<field name="name">IPI Entrada 22%</field>
 			<field name="amount">22</field>
 			<field name="type_tax_use">purchase</field>
@@ -1571,7 +1529,6 @@
        	</record>
 
 		<record id="tax_template_in_ipi24" model="account.tax.template">
-			<field name="description">IPI 24%</field>
 			<field name="name">IPI Entrada 24%</field>
 			<field name="amount">24</field>
 			<field name="type_tax_use">purchase</field>
@@ -1608,7 +1565,6 @@
        	</record>
 
 		<record id="tax_template_in_ipi25" model="account.tax.template">
-			<field name="description">IPI 25%</field>
 			<field name="name">IPI Entrada 25%</field>
 			<field name="amount">25</field>
 			<field name="type_tax_use">purchase</field>
@@ -1645,7 +1601,6 @@
        	</record>
 
 		<record id="tax_template_in_ipi27" model="account.tax.template">
-			<field name="description">IPI 27%</field>
 			<field name="name">IPI Entrada 27%</field>
 			<field name="amount">27</field>
 			<field name="type_tax_use">purchase</field>
@@ -1682,7 +1637,6 @@
        	</record>
 
 		<record id="tax_template_in_ipi30" model="account.tax.template">
-			<field name="description">IPI 30%</field>
 			<field name="name">IPI Entrada 30%</field>
 			<field name="amount">30</field>
 			<field name="type_tax_use">purchase</field>
@@ -1719,7 +1673,6 @@
        	</record>
 
 		<record id="tax_template_in_ipi35" model="account.tax.template">
-			<field name="description">IPI 35%</field>
 			<field name="name">IPI Entrada 35%</field>
 			<field name="amount">35</field>
 			<field name="type_tax_use">purchase</field>
@@ -1756,7 +1709,6 @@
 		</record>
 
 		<record id="tax_template_in_ipi40" model="account.tax.template">
-			<field name="description">IPI 40%</field>
 			<field name="name">IPI Entrada 40%</field>
 			<field name="amount">40</field>
 			<field name="type_tax_use">purchase</field>
@@ -1793,7 +1745,6 @@
        	</record>
 
 		<record id="tax_template_in_ipi42" model="account.tax.template">
-			<field name="description">IPI 42%</field>
 			<field name="name">IPI Entrada 42%</field>
 			<field name="amount">42</field>
 			<field name="type_tax_use">purchase</field>
@@ -1830,7 +1781,6 @@
        	</record>
 
 		<record id="tax_template_in_ipi45" model="account.tax.template">
-			<field name="description">IPI 45%</field>
 			<field name="name">IPI Entrada 45%</field>
 			<field name="amount">45</field>
 			<field name="type_tax_use">purchase</field>
@@ -1867,7 +1817,6 @@
        	</record>
 
 		<record id="tax_template_in_ipi50" model="account.tax.template">
-			<field name="description">IPI 50%</field>
 			<field name="name">IPI Entrada 50%</field>
 			<field name="amount">50</field>
 			<field name="type_tax_use">purchase</field>
@@ -1904,7 +1853,6 @@
        	</record>
 
 		<record id="tax_template_in_ipi60" model="account.tax.template">
-			<field name="description">IPI 60%</field>
 			<field name="name">IPI Entrada 60%</field>
 			<field name="amount">60</field>
 			<field name="type_tax_use">purchase</field>
@@ -1941,7 +1889,6 @@
        	</record>
 
 		<record id="tax_template_in_ipi300" model="account.tax.template">
-			<field name="description">IPI 300%</field>
 			<field name="name">IPI Entrada 300%</field>
 			<field name="amount">300</field>
 			<field name="type_tax_use">purchase</field>
@@ -1978,7 +1925,6 @@
        	</record>
 
 		<record id="tax_template_in_ipi330" model="account.tax.template">
-			<field name="description">IPI 330%</field>
 			<field name="name">IPI Entrada 330%</field>
 			<field name="amount">330</field>
 			<field name="type_tax_use">purchase</field>
@@ -2015,7 +1961,6 @@
        	</record>
 
 		<record id="tax_template_out_icms_interno" model="account.tax.template">
-			<field name="description">ICMS Interno</field>
 			<field name="name">ICMS Saida Interno</field>
 			<field name="amount">0.00</field>
 			<field name="type_tax_use">sale</field>
@@ -2048,7 +1993,6 @@
        	</record>
 
 		<record id="tax_template_out_icms_externo" model="account.tax.template">
-			<field name="description">ICMS Externo</field>
 			<field name="name">ICMS Saida Externo</field>
 			<field name="amount">0.00</field>
 			<field name="type_tax_use">sale</field>
@@ -2081,7 +2025,6 @@
        	</record>
 
 		<record id="tax_template_out_icms_subist" model="account.tax.template">
-			<field name="description">ICMS Subist</field>
 			<field name="name">ICMS Saida Subist</field>
 			<field name="amount">0.00</field>
 			<field name="type_tax_use">sale</field>
@@ -2114,7 +2057,6 @@
        	</record>
 
 		<record id="tax_template_out_icms_externo7" model="account.tax.template">
-			<field name="description">ICMS Externo 7%</field>
 			<field name="name">ICMS Saida Externo 7%</field>
 			<field name="amount">7</field>
 			<field name="type_tax_use">sale</field>
@@ -2151,7 +2093,6 @@
        	</record>
 
 		<record id="tax_template_out_icms_externo12" model="account.tax.template">
-			<field name="description">ICMS Externo 12%</field>
 			<field name="name">ICMS Saida Externo 12%</field>
 			<field name="amount">12</field>
 			<field name="type_tax_use">sale</field>
@@ -2188,7 +2129,6 @@
        	</record>
 
 		<record id="tax_template_out_icms_interno19" model="account.tax.template">
-			<field name="description">ICMS Interno 19%</field>
 			<field name="name">ICMS Saida Interno 19%</field>
 			<field name="amount">19</field>
 			<field name="type_tax_use">sale</field>
@@ -2225,7 +2165,6 @@
        	</record>
 
 		<record id="tax_template_out_icms_interno26" model="account.tax.template">
-			<field name="description">ICMS Interno 26%</field>
 			<field name="name">ICMS Saida Interno 26%</field>
 			<field name="amount">26</field>
 			<field name="type_tax_use">sale</field>
@@ -2262,7 +2201,6 @@
        	</record>
 
        	<record id="tax_template_in_icms_interno" model="account.tax.template">
-			<field name="description">ICMS Interno</field>
 			<field name="name">ICMS Entrada Interno</field>
 			<field name="amount">0.00</field>
 			<field name="type_tax_use">purchase</field>
@@ -2295,7 +2233,6 @@
        	</record>
 
 		<record id="tax_template_in_icms_externo" model="account.tax.template">
-			<field name="description">ICMS Externo</field>
 			<field name="name">ICMS Entrada Externo</field>
 			<field name="amount">0.00</field>
 			<field name="type_tax_use">purchase</field>
@@ -2328,7 +2265,6 @@
        	</record>
 
 		<record id="tax_template_in_icms_subist" model="account.tax.template">
-			<field name="description">ICMS Subist</field>
 			<field name="name">ICMS Entrada Subist</field>
 			<field name="amount">0.00</field>
 			<field name="type_tax_use">purchase</field>
@@ -2361,7 +2297,6 @@
        	</record>
 
 		<record id="tax_template_in_icms_externo7" model="account.tax.template">
-			<field name="description">ICMS Externo 7%</field>
 			<field name="name">ICMS Entrada Externo 7%</field>
 			<field name="amount">7</field>
 			<field name="type_tax_use">purchase</field>
@@ -2398,7 +2333,6 @@
        	</record>
 
 		<record id="tax_template_in_icms_externo12" model="account.tax.template">
-			<field name="description">ICMS Externo 12%</field>
 			<field name="name">ICMS Entrada Externo 12%</field>
 			<field name="amount">12</field>
 			<field name="type_tax_use">purchase</field>
@@ -2435,7 +2369,6 @@
        	</record>
 
 		<record id="tax_template_in_icms_interno19" model="account.tax.template">
-			<field name="description">ICMS Interno 19%</field>
 			<field name="name">ICMS Entrada Interno 19%</field>
 			<field name="amount">19</field>
 			<field name="type_tax_use">purchase</field>
@@ -2472,7 +2405,6 @@
        	</record>
 
 		<record id="tax_template_in_icms_interno26" model="account.tax.template">
-			<field name="description">ICMS Interno 26%</field>
 			<field name="name">ICMS Entrada Interno 26%</field>
 			<field name="amount">26</field>
 			<field name="type_tax_use">purchase</field>
@@ -2509,7 +2441,6 @@
        	</record>
 
 		<record id="tax_template_out_pis" model="account.tax.template">
-			<field name="description">PIS</field>
 			<field name="name">PIS Saida</field>
 			<field name="amount">0.00</field>
 			<field name="type_tax_use">sale</field>
@@ -2542,7 +2473,6 @@
        	</record>
 
 		<record id="tax_template_out_pis065" model="account.tax.template">
-			<field name="description">PIS 0,65%</field>
 			<field name="name">PIS Saida 0,65%</field>
 			<field name="amount">0.65</field>
 			<field name="type_tax_use">sale</field>
@@ -2579,7 +2509,6 @@
        	</record>
 
        	<record id="tax_template_in_pis" model="account.tax.template">
-			<field name="description">PIS</field>
 			<field name="name">PIS Entrada</field>
 			<field name="amount">0.00</field>
 			<field name="type_tax_use">purchase</field>
@@ -2612,7 +2541,6 @@
        	</record>
 
 		<record id="tax_template_in_pis065" model="account.tax.template">
-			<field name="description">PIS 0,65%</field>
 			<field name="name">PIS Entrada 0,65%</field>
 			<field name="amount">0.65</field>
 			<field name="type_tax_use">purchase</field>
@@ -2649,7 +2577,6 @@
        	</record>
 
 		<record id="tax_template_out_cofins" model="account.tax.template">
-			<field name="description">COFINS</field>
 			<field name="name">COFINS Saida</field>
 			<field name="amount">0.00</field>
 			<field name="type_tax_use">sale</field>
@@ -2682,7 +2609,6 @@
        	</record>
 
 		<record id="tax_template_out_cofins3" model="account.tax.template">
-			<field name="description">COFINS 3%</field>
 			<field name="name">COFINS Saida 3%</field>
 			<field name="amount">3</field>
 			<field name="type_tax_use">sale</field>
@@ -2719,7 +2645,6 @@
         </record>
 
         <record id="tax_template_in_cofins" model="account.tax.template">
-			<field name="description">COFINS</field>
 			<field name="name">COFINS Entrada</field>
 			<field name="amount">0.00</field>
 			<field name="type_tax_use">purchase</field>
@@ -2752,7 +2677,6 @@
        	</record>
 
 		<record id="tax_template_in_cofins3" model="account.tax.template">
-			<field name="description">COFINS 3%</field>
 			<field name="name">COFINS Entrada 3%</field>
 			<field name="amount">3</field>
 			<field name="type_tax_use">purchase</field>
@@ -2789,7 +2713,6 @@
         </record>
 
 		<record id="tax_template_out_irpj" model="account.tax.template">
-			<field name="description">IRPJ</field>
 			<field name="name">IRPJ</field>
 			<field name="amount">0.00</field>
 			<field name="type_tax_use">sale</field>
@@ -2822,7 +2745,6 @@
         </record>
 
 		<record id="tax_template_out_ir" model="account.tax.template">
-			<field name="description">IR</field>
 			<field name="name">IR</field>
 			<field name="amount">0.00</field>
 			<field name="type_tax_use">sale</field>
@@ -2855,7 +2777,6 @@
         </record>
 
 		<record id="tax_template_out_issqn" model="account.tax.template">
-			<field name="description">ISSQN</field>
 			<field name="name">ISSQN Saida</field>
 			<field name="amount">0.00</field>
 			<field name="type_tax_use">sale</field>
@@ -2888,7 +2809,6 @@
         </record>
 
         <record id="tax_template_out_issqn1" model="account.tax.template">
-			<field name="description">ISSQN 1%</field>
 			<field name="name">ISSQN Saida 1%</field>
 			<field name="amount">1</field>
 			<field name="type_tax_use">sale</field>
@@ -2923,7 +2843,6 @@
         </record>
 
         <record id="tax_template_out_issqn2" model="account.tax.template">
-			<field name="description">ISSQN 2%</field>
 			<field name="name">ISSQN Saida 2%</field>
 			<field name="amount">2</field>
             <field name="type_tax_use">sale</field>
@@ -2957,7 +2876,6 @@
 	        ]"/>
         </record>
 		<record id="tax_template_in_issqn2" model="account.tax.template">
-			<field name="description">ISSQN 2%</field>
 			<field name="name">ISSQN Entrada 2%</field>
 			<field name="amount">2</field>
 			<field name="type_tax_use">purchase</field>
@@ -2992,7 +2910,6 @@
 		</record>
 
         <record id="tax_template_out_issqn3" model="account.tax.template">
-			<field name="description">ISSQN 3%</field>
 			<field name="name">ISSQN Saida 3%</field>
 			<field name="amount">3</field>
 			<field name="type_tax_use">sale</field>
@@ -3027,7 +2944,6 @@
         </record>
 
         <record id="tax_template_out_issqn4" model="account.tax.template">
-			<field name="description">ISS 4%</field>
 			<field name="name">ISSQN Saida 4%</field>
 			<field name="amount">4</field>
 			<field name="type_tax_use">sale</field>
@@ -3062,7 +2978,6 @@
         </record>
 
         <record id="tax_template_out_issqn5" model="account.tax.template">
-			<field name="description">ISSQN 5%</field>
 			<field name="name">ISSQN Saida 5%</field>
 			<field name="amount">5</field>
 			<field name="type_tax_use">sale</field>
@@ -3097,7 +3012,6 @@
         </record>
 
 		<record id="tax_template_out_csll" model="account.tax.template">
-			<field name="description">CSLL</field>
 			<field name="name">CSLL</field>
 			<field name="amount">0.00</field>
 			<field name="type_tax_use">sale</field>

--- a/addons/l10n_ca/data/account_tax_data.xml
+++ b/addons/l10n_ca/data/account_tax_data.xml
@@ -9,7 +9,6 @@
     <record id="gstpst_sale_bc_gst_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">GST for sales - 5% (BC)</field>
-        <field name="description">GST 5%</field>
         <field name="type_tax_use">sale</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
@@ -44,7 +43,6 @@
     <record id="pst_bc_sale_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">PST for sales - 7% (BC)</field>
-        <field name="description">PST 7%</field>
         <field name="type_tax_use">none</field>
         <field name="amount">7</field>
         <field name="amount_type">percent</field>
@@ -79,7 +77,6 @@
     <record id="gstpst_bc_sale_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">GST + PST for sales (BC)</field>
-        <field name="description">GST + PST</field>
         <field name="type_tax_use">sale</field>
         <field name="amount">100</field>
         <field name="amount_type">group</field>
@@ -92,7 +89,6 @@
     <record id="gstpst_sale_mb_gst_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">GST for sales - 5% (MB)</field>
-        <field name="description">GST 5%</field>
         <field name="type_tax_use">none</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
@@ -129,7 +125,6 @@
     <record id="pst_mb_sale_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">PST for sales - 8% (MB)</field>
-        <field name="description">PST 8%</field>
         <field name="type_tax_use">none</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
@@ -165,7 +160,6 @@
     <record id="gstpst_mb_sale_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">GST + PST for sales (MB)</field>
-        <field name="description">GST + PST</field>
         <field name="type_tax_use">sale</field>
         <field name="amount">100</field>
         <field name="amount_type">group</field>
@@ -178,7 +172,6 @@
     <record id="gstqst_sale_gst_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">GST for sales - 5% (QC)</field>
-        <field name="description">GST 5%</field>
         <field name="type_tax_use">none</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
@@ -214,7 +207,6 @@
     <record id="qst_sale_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">QST for sales - 9.975%</field>
-        <field name="description">QST 9.975%</field>
         <field name="type_tax_use">none</field>
         <field name="amount">9.9750</field>
         <field name="amount_type">percent</field>
@@ -250,7 +242,6 @@
     <record id="gstqst_sale_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">GST + QST for sales</field>
-        <field name="description">GST + QST</field>
         <field name="type_tax_use">sale</field>
         <field name="amount">100</field>
         <field name="amount_type">group</field>
@@ -263,7 +254,6 @@
     <record id="gstpst_sale_sk_gst_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">GST for sales - 5% (SK)</field>
-        <field name="description">GST 5%</field>
         <field name="type_tax_use">none</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
@@ -300,7 +290,6 @@
     <record id="pst_sk_sale_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">PST for sales - 5% (SK)</field>
-        <field name="description">PST 5%</field>
         <field name="type_tax_use">none</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
@@ -336,7 +325,6 @@
     <record id="gstpst_sk_sale_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">GST + PST for sales (SK)</field>
-        <field name="description">GST + PST</field>
         <field name="type_tax_use">sale</field>
         <field name="amount">100</field>
         <field name="amount_type">group</field>
@@ -349,7 +337,6 @@
     <record id="hst13_sale_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">HST for sales - 13%</field>
-        <field name="description">HST 13%</field>
         <field name="type_tax_use">sale</field>
         <field name="amount">13</field>
         <field name="amount_type">percent</field>
@@ -384,7 +371,6 @@
     <record id="hst14_sale_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">HST for sales - 14%</field>
-        <field name="description">HST 14%</field>
         <field name="type_tax_use">sale</field>
         <field name="amount">14</field>
         <field name="amount_type">percent</field>
@@ -419,7 +405,6 @@
     <record id="hst15_sale_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">HST for sales - 15%</field>
-        <field name="description">HST 15%</field>
         <field name="type_tax_use">sale</field>
         <field name="amount">15</field>
         <field name="amount_type">percent</field>
@@ -456,7 +441,6 @@
     <record id="gst_sale_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">GST for sales - 5%</field>
-        <field name="description">GST 5%</field>
         <field name="type_tax_use">sale</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
@@ -495,7 +479,6 @@
     <record id="gstpst_purc_bc_gst_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">GST for purchases - 5% (BC)</field>
-        <field name="description">GST 5%</field>
         <field name="type_tax_use">none</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
@@ -532,7 +515,6 @@
     <record id="pst_bc_purc_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">PST for purchases - 7% (BC)</field>
-        <field name="description">PST 7%</field>
         <field name="type_tax_use">none</field>
         <field name="amount">7</field>
         <field name="amount_type">percent</field>
@@ -568,7 +550,6 @@
     <record id="gstpst_bc_purc_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">GST + PST for purchases (BC)</field>
-        <field name="description">GST + PST</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount">100</field>
         <field name="amount_type">group</field>
@@ -581,7 +562,6 @@
     <record id="gstpst_purc_mb_gst_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">GST for purchases - 5% (MB)</field>
-        <field name="description">GST 5%</field>
         <field name="type_tax_use">none</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
@@ -618,7 +598,6 @@
     <record id="pst_mb_purc_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">PST for purchases - 8% (MB)</field>
-        <field name="description">PST 8%</field>
         <field name="type_tax_use">none</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
@@ -654,7 +633,6 @@
     <record id="gstpst_mb_purc_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">GST + PST for purchases (MB)</field>
-        <field name="description">GST + PST</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount">100</field>
         <field name="amount_type">group</field>
@@ -667,7 +645,6 @@
     <record id="gstqst_purc_gst_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">GST for purchases - 5% (QC)</field>
-        <field name="description">GST 5%</field>
         <field name="type_tax_use">none</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
@@ -703,7 +680,6 @@
     <record id="qst_purc_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">QST for purchases - 9.975%</field>
-        <field name="description">QST 9.975%</field>
         <field name="type_tax_use">none</field>
         <field name="amount">9.9750</field>
         <field name="amount_type">percent</field>
@@ -739,7 +715,6 @@
     <record id="gstqst_purc_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">GST + QST for purchases</field>
-        <field name="description">GST + QST</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount">100</field>
         <field name="amount_type">group</field>
@@ -752,7 +727,6 @@
     <record id="gstpst_purc_sk_gst_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">GST for purchases - 5% (SK)</field>
-        <field name="description">GST 5%</field>
         <field name="type_tax_use">none</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
@@ -789,7 +763,6 @@
     <record id="pst_sk_purc_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">PST for purchases - 5% (SK)</field>
-        <field name="description">PST 5%</field>
         <field name="type_tax_use">none</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
@@ -825,7 +798,6 @@
     <record id="gstpst_sk_purc_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">GST + PST for purchases (SK)</field>
-        <field name="description">GST + PST</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount">1</field>
         <field name="amount_type">group</field>
@@ -838,7 +810,6 @@
     <record id="hst13_purc_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">HST for purchases - 13%</field>
-        <field name="description">HST 13%</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount">13</field>
         <field name="amount_type">percent</field>
@@ -873,7 +844,6 @@
     <record id="hst14_purc_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">HST for purchases - 14%</field>
-        <field name="description">HST 14%</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount">14</field>
         <field name="amount_type">percent</field>
@@ -908,7 +878,6 @@
     <record id="hst15_purc_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">HST for purchases - 15%</field>
-        <field name="description">HST 15%</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount">15</field>
         <field name="amount_type">percent</field>
@@ -945,7 +914,6 @@
     <record id="gst_purc_en" model="account.tax.template">
         <field name="chart_template_id" ref="ca_en_chart_template_en"/>
         <field name="name">GST for purchases - 5%</field>
-        <field name="description">GST 5%</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>

--- a/addons/l10n_ch/data/account_vat2011_data.xml
+++ b/addons/l10n_ch/data/account_vat2011_data.xml
@@ -5,7 +5,6 @@
         -->
         <record model="account.tax.template" id="vat_25">
             <field name="name">TVA due a 2.5% (TR)</field>
-            <field name="description">2.5%</field>
             <field name="amount" eval="2.5"/>
             <field name="amount_type">percent</field>
             <field name="chart_template_id" ref="l10nch_chart_template"/>
@@ -41,7 +40,6 @@
 
         <record model="account.tax.template" id="vat_25_incl">
             <field name="name">TVA due à 2.5% (Incl. TR)</field>
-            <field name="description">2.5% Incl.</field>
             <field name="price_include" eval="1"/>
             <field name="amount" eval="2.5"/>
             <field name="amount_type">percent</field>
@@ -78,7 +76,6 @@
 
         <record model="account.tax.template" id="vat_25_purchase">
             <field name="name">TVA 2.5% sur achat B&amp;S (TR)</field>
-            <field name="description">2.5% achat</field>
             <field name="amount" eval="2.5"/>
             <field name="amount_type">percent</field>
             <field name="chart_template_id" ref="l10nch_chart_template"/>
@@ -112,7 +109,6 @@
 
         <record model="account.tax.template" id="vat_25_purchase_incl">
             <field name="name">TVA 2.5% sur achat B&amp;S (Incl. TR)</field>
-            <field name="description">2.5% achat Incl.</field>
             <field name="price_include" eval="1"/>
             <field name="amount" eval="2.5"/>
             <field name="amount_type">percent</field>
@@ -147,7 +143,6 @@
 
         <record model="account.tax.template" id="vat_25_invest">
             <field name="name">TVA 2.5% sur invest. et autres ch. (TR)</field>
-            <field name="description">2.5% invest.</field>
             <field name="amount" eval="2.5"/>
             <field name="amount_type">percent</field>
             <field name="chart_template_id" ref="l10nch_chart_template"/>
@@ -181,7 +176,6 @@
 
         <record model="account.tax.template" id="vat_25_invest_incl">
             <field name="name">TVA 2.5% sur invest. et autres ch. (Incl. TR)</field>
-            <field name="description">2.5% invest. Incl.</field>
             <field name="price_include" eval="1"/>
             <field name="amount" eval="2.5"/>
             <field name="amount_type">percent</field>
@@ -216,7 +210,6 @@
 
         <record model="account.tax.template" id="vat_37">
             <field name="name">TVA due a 3.7% (TS)</field>
-            <field name="description">3.7%</field>
             <field name="amount" eval="3.7"/>
             <field name="amount_type">percent</field>
             <field name="chart_template_id" ref="l10nch_chart_template"/>
@@ -252,7 +245,6 @@
 
         <record model="account.tax.template" id="vat_37_incl">
             <field name="name">TVA due à 3.7% (Incl. TS)</field>
-            <field name="description">3.7% Incl.</field>
             <field name="price_include" eval="1"/>
             <field name="amount" eval="3.7"/>
             <field name="amount_type">percent</field>
@@ -289,7 +281,6 @@
 
         <record model="account.tax.template" id="vat_37_purchase">
             <field name="name">TVA 3.7% sur achat B&amp;S (TS)</field>
-            <field name="description">3.7% achat</field>
             <field name="amount" eval="3.7"/>
             <field name="amount_type">percent</field>
             <field name="chart_template_id" ref="l10nch_chart_template"/>
@@ -323,7 +314,6 @@
 
         <record model="account.tax.template" id="vat_37_purchase_incl">
             <field name="name">TVA 3.7% sur achat B&amp;S (Incl. TS)</field>
-            <field name="description">3.7% achat Incl.</field>
             <field name="price_include" eval="1"/>
             <field name="amount" eval="3.7"/>
             <field name="amount_type">percent</field>
@@ -358,7 +348,6 @@
 
         <record model="account.tax.template" id="vat_37_invest">
             <field name="name">TVA 3.7% sur invest. et autres ch. (TS)</field>
-            <field name="description">3.7% invest</field>
             <field name="amount" eval="3.7"/>
             <field name="amount_type">percent</field>
             <field name="chart_template_id" ref="l10nch_chart_template"/>
@@ -392,7 +381,6 @@
 
         <record model="account.tax.template" id="vat_37_invest_incl">
             <field name="name">TVA 3.7% sur invest. et autres ch. (Incl. TS)</field>
-            <field name="description">3.7% invest Incl.</field>
             <field name="price_include" eval="1"/>
             <field name="amount" eval="3.7"/>
             <field name="amount_type">percent</field>
@@ -427,7 +415,6 @@
 
         <record model="account.tax.template" id="vat_77">
             <field name="name">TVA due a 7.7% (TN)</field>
-            <field name="description">7.7%</field>
             <field name="amount" eval="7.7"/>
             <field name="sequence" eval="0"/>
             <field name="amount_type">percent</field>
@@ -464,7 +451,6 @@
 
         <record model="account.tax.template" id="vat_77_incl">
             <field name="name">TVA due à 7.7% (Incl. TN)</field>
-            <field name="description">7.7% Incl.</field>
             <field name="price_include" eval="1"/>
             <field name="amount" eval="7.7"/>
             <field name="sequence" eval="0"/>
@@ -502,7 +488,6 @@
 
         <record model="account.tax.template" id="vat_77_purchase_incl">
             <field name="name">TVA 7.7% sur achat B&amp;S (Incl. TN)</field>
-            <field name="description">7.7% achat Incl.</field>
             <field name="price_include" eval="1"/>
             <field name="amount" eval="7.7"/>
             <field name="amount_type">percent</field>
@@ -538,7 +523,6 @@
 
         <record model="account.tax.template" id="vat_77_invest">
             <field name="name">TVA 7.7% sur invest. et autres ch. (TN)</field>
-            <field name="description">7.7% invest.</field>
             <field name="amount" eval="7.7"/>
             <field name="amount_type">percent</field>
             <field name="chart_template_id" ref="l10nch_chart_template"/>
@@ -572,7 +556,6 @@
 
         <record model="account.tax.template" id="vat_77_invest_incl">
             <field name="name">TVA 7.7% sur invest. et autres ch. (Incl. TN)</field>
-            <field name="description">7.7% invest. Incl.</field>
             <field name="price_include" eval="1"/>
             <field name="amount" eval="7.7"/>
             <field name="amount_type">percent</field>
@@ -608,7 +591,6 @@
         <record model="account.tax.template" id="vat_XO">
             <field name="name">TVA due a 0% (Exportations)</field>
             <field name="amount" eval="0.00"/>
-            <field name="description">0%</field>
             <field name="amount_type">percent</field>
             <field name="chart_template_id" ref="l10nch_chart_template"/>
             <field name="type_tax_use">sale</field>
@@ -639,7 +621,6 @@
 
         <record model="account.tax.template" id="vat_O_exclude">
             <field name="name">TVA 0% exclue</field>
-            <field name="description">0% excl.</field>
             <field name="amount" eval="0.00"/>
             <field name="amount_type">percent</field>
             <field name="chart_template_id" ref="l10nch_chart_template"/>
@@ -671,7 +652,6 @@
 
         <record model="account.tax.template" id="vat_O_import">
             <field name="name">TVA 0% Importations de biens et services</field>
-            <field name="description">0% import.</field>
             <field name="amount" eval="0.00"/>
             <field name="amount_type">percent</field>
             <field name="chart_template_id" ref="l10nch_chart_template"/>
@@ -682,7 +662,6 @@
         <!--# 100% on import !! the tax percentage is 00-->
         <record model="account.tax.template" id="vat_100_import">
             <field name="name">100% dédouanement TVA</field>
-            <field name="description">100% imp.</field>
             <field name="amount" eval="0.0"/>
             <field name="amount_type">percent</field>
             <field name="chart_template_id" ref="l10nch_chart_template"/>
@@ -714,7 +693,6 @@
 
         <record model="account.tax.template" id="vat_77_purchase_return">
             <field name="name">TVA due a 7.7% (TN) (return)</field>
-            <field name="description">7.7% achat (return)</field>
             <field name="amount" eval="-7.7"/>
             <field name="amount_type">percent</field>
             <field name="sequence" eval="0"/>
@@ -750,7 +728,6 @@
 
         <record model="account.tax.template" id="vat_77_purchase">
             <field name="name">TVA 7.7% sur achat B&amp;S (TN)</field>
-            <field name="description">7.7% achat</field>
             <field name="amount" eval="7.7"/>
             <field name="amount_type">percent</field>
             <field name="sequence" eval="0"/>
@@ -784,7 +761,6 @@
 
          <!--# for reverse charge or VAT on Acquisition (group of taxes)-->
         <record model="account.tax.template" id="vat_77_purchase_reverse">
-            <field name="description">7.7% achat</field>
             <field name="name">TVA 7.7% sur achat service a l'etranger (reverse charge)</field>
             <field name="amount_type">group</field>
             <field name="type_tax_use">purchase</field>
@@ -797,7 +773,6 @@
         <record model="account.tax.template" id="vat_other_movements_900">
             <field name="name">Subventions, taxes touristiques à 0%</field>
             <field name="amount" eval="0.00"/>
-            <field name="description">0% subventions</field>
             <field name="amount_type">percent</field>
             <field name="chart_template_id" ref="l10nch_chart_template"/>
             <field name="type_tax_use">sale</field>
@@ -821,7 +796,6 @@
         <record model="account.tax.template" id="vat_other_movements_910">
             <field name="name">Dons, dividendes, dédommagements à 0%</field>
             <field name="amount" eval="0.00"/>
-            <field name="description">0% dons</field>
             <field name="amount_type">percent</field>
             <field name="chart_template_id" ref="l10nch_chart_template"/>
             <field name="type_tax_use">sale</field>

--- a/addons/l10n_cl/data/account_tax_data.xml
+++ b/addons/l10n_cl/data/account_tax_data.xml
@@ -5,7 +5,6 @@
     <record id="ITAX_19" model="account.tax.template">
         <field name="chart_template_id" ref="cl_chart_template"/>
         <field name="name">IVA 19% Venta</field>
-        <field name="description">IVA 19% Venta</field>
         <field name="amount">19</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -42,7 +41,6 @@
     <record id="OTAX_19" model="account.tax.template">
       <field name="chart_template_id" ref="cl_chart_template"/>
       <field name="name">IVA 19% Compra</field>
-      <field name="description">IVA 19% Compra</field>
       <field name="amount">19</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">purchase</field>
@@ -79,7 +77,6 @@
     <record id="I_IU2C" model="account.tax.template">
         <field name="chart_template_id" ref="cl_chart_template"/>
         <field name="name">Retención de Segunda Categoría</field>
-        <field name="description">Retención de Segunda Categoría</field>
         <field name="amount">-10</field>
         <field name="sequence" eval="2"/>
         <field name="amount_type">percent</field>
@@ -117,7 +114,6 @@
     <record id="especifico_compra" model="account.tax.template">
         <field name="chart_template_id" ref="cl_chart_template"/>
         <field name="name">Específico Compra</field>
-        <field name="description">Especifico</field>
         <field name="amount">63</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -151,7 +147,6 @@
     <record id="iva_activo_fijo" model="account.tax.template">
         <field name="chart_template_id" ref="cl_chart_template"/>
         <field name="name">IVA Compra - 19% Activo Fijo</field>
-        <field name="description">IVA 19% ActF</field>
         <field name="amount">19</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -189,7 +184,6 @@
     <record id="iva_activo_fijo_uso_comun" model="account.tax.template">
         <field name="chart_template_id" ref="cl_chart_template"/>
         <field name="name">IVA Compra - 19% Activo Fijo Uso Común</field>
-        <field name="description">IVA 19% ActFUC</field>
         <field name="amount">19</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -227,7 +221,6 @@
     <record id="iva_activo_fijo_uso_no_recup" model="account.tax.template">
         <field name="chart_template_id" ref="cl_chart_template"/>
         <field name="name">IVA Compra - 19% Activo Fijo No Recuperable</field>
-        <field name="description">IVA 19% ActFNR</field>
         <field name="amount">19</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>

--- a/addons/l10n_cl/data/product_data.xml
+++ b/addons/l10n_cl/data/product_data.xml
@@ -5,7 +5,6 @@
         <field name="name">Ad-Valorem</field>
         <field name="type">service</field>
         <field name="default_code">AD_VALOREM</field>
-        <field name="description">Cargo para calculo de Ad-Valorem en DIN</field>
         <field name="sale_ok" eval="False"/>
         <field name="uom_id" ref="uom.product_uom_unit"/>
     </record>

--- a/addons/l10n_cn/data/account_tax_template_data.xml
+++ b/addons/l10n_cn/data/account_tax_template_data.xml
@@ -5,7 +5,6 @@
     <record id="l10n_cn_sales_included_13" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_chart_china_small_business"/>
         <field name="name">税收13％（含)</field>
-        <field name="description">税收13％</field>
         <field name="amount">13</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -37,7 +36,6 @@
     <record id="l10n_cn_sales_included_9" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_chart_china_small_business"/>
         <field name="name">税收9％（含)</field>
-        <field name="description">税收9％</field>
         <field name="amount">9</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -69,7 +67,6 @@
     <record id="l10n_cn_sales_included_6" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_chart_china_small_business"/>
         <field name="name">税收6％（含)</field>
-        <field name="description">税收6％</field>
         <field name="amount">6</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -104,7 +101,6 @@
     <record id="l10n_cn_sales_excluded_13" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_chart_china_small_business"/>
         <field name="name">税收13%</field>
-        <field name="description">税收13%</field>
         <field name="amount">13</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -136,7 +132,6 @@
     <record id="l10n_cn_sales_excluded_9" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_chart_china_small_business"/>
         <field name="name">税收9%</field>
-        <field name="description">税收9%</field>
         <field name="amount">9</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -168,7 +163,6 @@
     <record id="l10n_cn_sales_excluded_6" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_chart_china_small_business"/>
         <field name="name">税收6%</field>
-        <field name="description">税收6％</field>
         <field name="amount">6</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -202,7 +196,6 @@
     <record id="l10n_cn_purchase_excluded_13" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_chart_china_small_business"/>
         <field name="name">税收13%</field>
-        <field name="description">税收13%</field>
         <field name="amount">13</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -234,7 +227,6 @@
     <record id="l10n_cn_purchase_excluded_9" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_chart_china_small_business"/>
         <field name="name">税收9%</field>
-        <field name="description">税收9%</field>
         <field name="amount">9</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -266,7 +258,6 @@
     <record id="l10n_cn_purchase_excluded_6" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_chart_china_small_business"/>
         <field name="name">税收6%</field>
-        <field name="description">税收6％</field>
         <field name="amount">6</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>

--- a/addons/l10n_cr/data/account_tax_template_data.xml
+++ b/addons/l10n_cr/data/account_tax_template_data.xml
@@ -3,7 +3,6 @@
         <!-- Account Tax Template -->
         <record id="account_tax_template_IV_0" model="account.tax.template">
             <field name="name">Sales Tax</field>
-            <field name="description">IV</field>
             <field name="sequence">10</field>
             <field name="amount">13</field>
             <field name="amount_type">percent</field>
@@ -37,7 +36,6 @@
         </record>
         <record id="account_tax_template_IV_1" model="account.tax.template">
             <field name="name">Purchase Tax</field>
-            <field name="description">IV</field>
             <field name="sequence">10</field>
             <field name="amount">13</field>
             <field name="amount_type">percent</field>

--- a/addons/l10n_de_skr03/data/account_tax_fiscal_position_data.xml
+++ b/addons/l10n_de_skr03/data/account_tax_fiscal_position_data.xml
@@ -5,7 +5,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">Innergem. Erwerb 19%USt/19%VSt</field>
-            <field name="description">innergem. Erwerb 19%</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -60,7 +59,6 @@
             <field name="sequence">25</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">Innergem. Erwerb 7%USt/7%VSt</field>
-            <field name="description">innergem. Erwerb 7%</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="type_tax_use">purchase</field>
@@ -115,7 +113,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">Innergem. Erwerb 19%USt/0%VSt</field>
-            <field name="description">innergem. Erwerb 19% - 0% Vorsteuer</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -164,7 +161,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">Innergem. Erwerb 7%USt/0%VSt</field>
-            <field name="description">innergem. Erwerb 7% - 0% Vorsteuer</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="type_tax_use">purchase</field>
@@ -213,7 +209,6 @@
             <field name="sequence">23</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">Innergem. Erwerb Neufahrzeug 19%USt/19%VSt</field>
-            <field name="description">innergem. Erwerb Neufahrzeug 19%</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -266,7 +261,6 @@
             <field name="sequence">21</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">Steuerfreie innergem. Lieferung (§4 Abs. 1b UStG)</field>
-            <field name="description">steuerfreie innergem. Lieferung</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
@@ -303,7 +297,6 @@
             <field name="sequence">22</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">Steuerfreie Ausfuhr (§4 Nr. 1a UStG)</field>
-            <field name="description">steuerfreie Ausfuhr</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
@@ -340,7 +333,6 @@
             <field name="sequence">23</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">Steuerfreier Umsatz mit Vorsteuerabzug (§ 4 Nr. 2-7)</field>
-            <field name="description">Steuerfr. Umsatz(§ 4 Nr. 2-7)</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
@@ -377,7 +369,6 @@
             <field name="sequence">24</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">Steuerfreier Umsatz ohne Vorsteuerabzug (§ 4 Nr. 8-28)</field>
-            <field name="description">Steuerfr. Umsatz(§ 4 Nr. 8-28)</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
@@ -414,7 +405,6 @@
             <field name="sequence">21</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">19% Einfuhrumsatzsteuer (§21 Abs.3 UstG)</field>
-            <field name="description">Einfuhrumsatzsteuer 19%</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -463,7 +453,6 @@
             <field name="sequence">21</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">7% Einfuhrumsatzsteuer (§21 Abs.3 UstG)</field>
-            <field name="description">Einfuhrumsatzsteuer 7%</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="type_tax_use">purchase</field>
@@ -512,7 +501,6 @@
             <field name="sequence">22</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">Steuerfr. innergem. Erwerb (§§ 4b und 25c UStG)</field>
-            <field name="description">Steuerfr. innergem. Erwerb (§§ 4b und 25c UStG)</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
@@ -549,7 +537,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">nicht steuerbare Umsätze</field>
-            <field name="description">nicht steuerbare Umsätze</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
@@ -587,7 +574,6 @@
             <field name="sequence">10</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">19% Umsatzsteuer</field>
-            <field name="description">19% USt</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="l10n_de_datev_code">13</field>
@@ -629,7 +615,6 @@
             <field name="sequence">15</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">7% Umsatzsteuer</field>
-            <field name="description">7% USt</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="l10n_de_datev_code">12</field>
@@ -671,7 +656,6 @@
             <field name="sequence">16</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">0% USt (Pflichtbefreit z.B. als Kleinunt. oder bei med. Leistg.)</field>
-            <field name="description">0% USt (Pflichtbefreit)</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
@@ -706,7 +690,6 @@
             <field name="sequence">17</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">19% Umsatzsteuer (inkludiert in Preis)</field>
-            <field name="description">19% USt (inkludiert in Preis)</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">sale</field>
@@ -748,7 +731,6 @@
             <field name="sequence">18</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">7% Umsatzsteuer (inkludiert in Preis)</field>
-            <field name="description">7% USt (inkludiert in Preis)</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="type_tax_use">sale</field>
@@ -790,7 +772,6 @@
             <field name="sequence">26</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">5,5 % Umsatzsteuer Land-/Forstwirtschaft</field>
-            <field name="description">5,5% USt Land-/Forstwirtschaft</field>
             <field name="amount_type">percent</field>
             <field name="amount">5.5</field>
             <field name="type_tax_use">sale</field>
@@ -829,7 +810,6 @@
             <field name="sequence">27</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">10,7 % Umsatzsteuer Land-/Forstwirtschaft</field>
-            <field name="description">10,7% USt Land-/Forstwirtschaft</field>
             <field name="amount_type">percent</field>
             <field name="amount">10.7</field>
             <field name="type_tax_use">sale</field>
@@ -868,7 +848,6 @@
             <field name="sequence">28</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">19% Umsatzsteuer Land-/Forstwirtschaft (Alkohol u.a.)</field>
-            <field name="description">19% USt Land-/Forstwirtschaft (Alkohol u.a.)</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">sale</field>
@@ -907,7 +886,6 @@
             <field name="sequence">21</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">x% Umsatzsteuer (zu anderen Steuersätzen)</field>
-            <field name="description">x% USt (zu anderen Steuersätzen)</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
@@ -944,7 +922,6 @@
             <field name="sequence">10</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">19% Vorsteuer</field>
-            <field name="description">19% VSt</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="l10n_de_datev_code">19</field>
@@ -984,7 +961,6 @@
             <field name="sequence">15</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">7% Vorsteuer</field>
-            <field name="description">7% VSt</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="l10n_de_datev_code">18</field>
@@ -1024,7 +1000,6 @@
             <field name="sequence">16</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">0% VSt (Pflichtbefreit z.B. als Kleinunt. oder bei med. Leistg.)</field>
-            <field name="description">0% VSt (Pflichtbefreit)</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
@@ -1059,7 +1034,6 @@
             <field name="sequence">16</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">19% Vorsteuer (inkludiert in Preis)</field>
-            <field name="description">19% VSt (inkludiert in Preis)</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -1098,7 +1072,6 @@
             <field name="sequence">17</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">7% Vorsteuer (inkludiert in Preis)</field>
-            <field name="description">7% VSt (inkludiert in Preis)</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="type_tax_use">purchase</field>
@@ -1137,7 +1110,6 @@
             <field name="sequence">26</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">5,5% Vorsteuer Land-/Forstwirtschaft</field>
-            <field name="description">5,5% VSt Land-/Forstwirtschaft</field>
             <field name="amount_type">percent</field>
             <field name="amount">5.5</field>
             <field name="type_tax_use">purchase</field>
@@ -1176,7 +1148,6 @@
             <field name="sequence">27</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">10,7% Vorsteuer Land-/Forstwirtschaft</field>
-            <field name="description">10,7% VSt Land-/Forstwirtschaft</field>
             <field name="amount_type">percent</field>
             <field name="amount">10.7</field>
             <field name="type_tax_use">purchase</field>
@@ -1215,7 +1186,6 @@
             <field name="sequence">21</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">19 % Umsatzsteuer EU Lieferung</field>
-            <field name="description">19% USt EU</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">sale</field>
@@ -1256,7 +1226,6 @@
             <field name="sequence">22</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">7% Umsatzsteuer EU Lieferung</field>
-            <field name="description">7% USt EU</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="type_tax_use">sale</field>
@@ -1297,7 +1266,6 @@
             <field name="sequence">23</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">19% USt gem. §13b UStG - ohne VSt. - (ausländ. Werklieferungen u.ä.)</field>
-            <field name="description">19% USt EU gem. §13b UStG - ohne VSt. - (ausländ. Werklieferungen u.ä.)</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -1336,7 +1304,6 @@
             <field name="sequence">24</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">7% USt gem. §13b UStG - ohne VSt. - (ausländ. Werklieferungen u.ä.)</field>
-            <field name="description">7% USt EU gem. §13b UStG - ohne VSt. - (ausländ. Werklieferungen u.ä.)</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="type_tax_use">purchase</field>
@@ -1375,7 +1342,6 @@
             <field name="sequence">25</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">19% USt gem. §13b UStG - ohne VSt. - (sonst. Leistungen EU)</field>
-            <field name="description">19% USt EU gem. §13b UStG - ohne VSt. - (sonst. Leistungen EU)</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -1414,7 +1380,6 @@
             <field name="sequence">26</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">7% USt gem. §13b UStG - ohne VSt. - (sonst. Leistungen EU)</field>
-            <field name="description">7% USt EU gem. §13b UStG - ohne VSt. - (sonst. Leistungen EU)</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="type_tax_use">purchase</field>
@@ -1453,7 +1418,6 @@
             <field name="sequence">27</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">19% USt gem. §13b UStG - ohne VSt. - (empf. Bauleistungen)</field>
-            <field name="description">19% USt EU gem. §13b UStG - ohne VSt. - (empf. Bauleistungen)</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -1492,7 +1456,6 @@
             <field name="sequence">28</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">7% USt gem. §13b UStG - ohne VSt. - (empf. Bauleistungen)</field>
-            <field name="description">7% USt EU gem. §13b UStG - ohne VSt. - (empf. Bauleistungen)</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="type_tax_use">purchase</field>
@@ -1531,7 +1494,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">0% Steuerfreie Leistung EU</field>
-            <field name="description">0% USt EU</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
@@ -1568,7 +1530,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">0% Steuerfreie Leistung Drittland</field>
-            <field name="description">0% USt Drittland</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
@@ -1605,7 +1566,6 @@
             <field name="sequence">30</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">0% Steuerfreie Neufahrzeuglieferung EU</field>
-            <field name="description">0% USt Neufahrzeug EU</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
@@ -1642,7 +1602,6 @@
             <field name="sequence">40</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">0% Umsatzsteuer Dreiecksgeschäft erster Abnehmer</field>
-            <field name="description">0% USt Dreiecksgeschäft erster Abnehmer</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
@@ -1679,7 +1638,6 @@
             <field name="sequence">50</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">0% Umsatzsteuer Bauleistung (Erbringer §13b)</field>
-            <field name="description">0% Umsatzsteuer Bauleistung (Erbringer §13b)</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
@@ -1716,7 +1674,6 @@
             <field name="sequence">50</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">0% Umsatzsteuer Lieferung von Mobilfunkgeräten u.a. (§13b)</field>
-            <field name="description">0% USt Lieferung von Mobilfunkgeräten u.a. (§13b)</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
@@ -1753,7 +1710,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">Steuerpflichtige sonstige Leistungen EU 19%USt/19%VSt</field>
-            <field name="description">Leistungen EU 19%Ust/19%VSt</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -1808,7 +1764,6 @@
             <field name="sequence">21</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">Steuerpflichtige sonstige Leistungen EU 7%USt/7%VSt</field>
-            <field name="description">Steuerpfl. sonst. Leistg. EU 7%Ust/7%VSt</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="type_tax_use">purchase</field>
@@ -1863,7 +1818,6 @@
             <field name="sequence">22</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">Steuer gem. §13b UStG 19%USt/19%VSt (Bauleistung Empfänger)</field>
-            <field name="description">Steuer gem. §13b UStG 19%USt/19%VSt (Bauleistung Empfänger)</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -1918,7 +1872,6 @@
             <field name="sequence">23</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">Steuer gem. §13b UStG 7%USt/7%VSt (Bauleistung Empfänger)</field>
-            <field name="description">Steuer gem. §13b UStG 7%USt/7%VSt (Bauleistung Empfänger)</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="type_tax_use">purchase</field>
@@ -1973,7 +1926,6 @@
             <field name="sequence">24</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">Steuer gem. §13b 19%USt/19%VSt (Empfang von Mobilfunkgeräten u.a.)</field>
-            <field name="description">Steuer gem. §13b 19%Ust/19%VSt (Empfang von Mobilfunkgeräten u.a.)</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -2028,7 +1980,6 @@
             <field name="sequence">105</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">Dreiecksgeschäft Erwerb letzter Abnehmer 19%USt/19%VSt</field>
-            <field name="description">Dreiecksgeschäft Erwerb letzter Abnehmer 19%Ust/19%VSt</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -2081,7 +2032,6 @@
             <field name="sequence">25</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">Steuer gem. §13b 19%USt/19%VSt (ausländ. Werklieferungen u.ä.)</field>
-            <field name="description">Steuer gem. §13b 19%USt/19%VSt (ausländ. Werklieferungen u.ä.)</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -2136,7 +2086,6 @@
             <field name="sequence">26</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">Steuer gem. §13b 7%USt/7%VSt (ausländ. Werklieferungen u.ä.)</field>
-            <field name="description">Steuer gem. §13b 7%USt/7%VSt (ausländ. Werklieferungen u.ä.)</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="type_tax_use">purchase</field>
@@ -2191,7 +2140,6 @@
             <field name="sequence">27</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">Steuer gem. §13a Abs. 1 Nr. 6 UStG 19%USt/19%VSt (Auslagerung)</field>
-            <field name="description">Steuer gem. §13a Abs. 1 Nr. 6 UStG 19%USt/19%VSt (Auslagerung)</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -2244,7 +2192,6 @@
             <field name="sequence">28</field>
             <field name="chart_template_id" ref="l10n_de_chart_template"/>
             <field name="name">Steuer gem. §13a Abs. 1 Nr. 6 UStG 7%USt/7%VSt (Auslagerung)</field>
-            <field name="description">Steuer gem. §13a Abs. 1 Nr. 6 UStG 7%USt/7VSt (Auslagerung)</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="type_tax_use">purchase</field>

--- a/addons/l10n_de_skr04/data/account_tax_fiscal_position_data.xml
+++ b/addons/l10n_de_skr04/data/account_tax_fiscal_position_data.xml
@@ -5,7 +5,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">Innergem. Erwerb 19%USt/19%VSt</field>
-            <field name="description">innergem. Erwerb 19%</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -62,7 +61,6 @@
             <field name="sequence">25</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">Innergem. Erwerb 7%USt/7%VSt</field>
-            <field name="description">innergem. Erwerb 7%</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="type_tax_use">purchase</field>
@@ -119,7 +117,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">Innergem. Erwerb 19%USt/0%VSt</field>
-            <field name="description">innergem. Erwerb 19% - 0% Vorsteuer</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -170,7 +167,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">Innergem. Erwerb 7%USt/0%VSt</field>
-            <field name="description">innergem. Erwerb 7% - 0% Vorsteuer</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="type_tax_use">purchase</field>
@@ -221,7 +217,6 @@
             <field name="sequence">23</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">Innergem. Erwerb Neufahrzeug 19%USt/19%VSt</field>
-            <field name="description">innergem. Erwerb Neufahrzeug 19%</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -276,7 +271,6 @@
             <field name="sequence">21</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">Steuerfreie innergem. Lieferung (§4 Abs. 1b UStG)</field>
-            <field name="description">steuerfreie innergem. Lieferung</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
@@ -315,7 +309,6 @@
             <field name="sequence">22</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">Steuerfreie Ausfuhr (§4 Nr. 1a UStG)</field>
-            <field name="description">steuerfreie Ausfuhr</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
@@ -354,7 +347,6 @@
             <field name="sequence">23</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">Steuerfreier Umsatz mit Vorsteuerabzug (§ 4 Nr. 2-7)</field>
-            <field name="description">Steuerfr. Umsatz(§ 4 Nr. 2-7)</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
@@ -393,7 +385,6 @@
             <field name="sequence">24</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">Steuerfreier Umsatz ohne Vorsteuerabzug (§ 4 Nr. 8-28)</field>
-            <field name="description">Steuerfr. Umsatz(§ 4 Nr. 8-28)</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
@@ -432,7 +423,6 @@
             <field name="sequence">21</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">19% Einfuhrumsatzsteuer (§21 Abs.3 UstG)</field>
-            <field name="description">Einfuhrumsatzsteuer 19%</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -481,7 +471,6 @@
             <field name="sequence">21</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">7% Einfuhrumsatzsteuer (§21 Abs.3 UstG)</field>
-            <field name="description">Einfuhrumsatzsteuer 7%</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="type_tax_use">purchase</field>
@@ -530,7 +519,6 @@
             <field name="sequence">22</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">Steuerfr. innergem. Erwerb (§§ 4b und 25c UStG)</field>
-            <field name="description">Steuerfr. innergem. Erwerb (§§ 4b und 25c UStG)</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
@@ -569,7 +557,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">nicht steuerbare Umsätze</field>
-            <field name="description">nicht steuerbare Umsätze</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
@@ -608,7 +595,6 @@
             <field name="sequence">10</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">19% Umsatzsteuer</field>
-            <field name="description">19% USt</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="l10n_de_datev_code">13</field>
@@ -652,7 +638,6 @@
             <field name="sequence">15</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">7% Umsatzsteuer</field>
-            <field name="description">7% USt</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="l10n_de_datev_code">12</field>
@@ -696,7 +681,6 @@
             <field name="sequence">16</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">0% USt (Pflichtbefreit z.B. als Kleinunt. oder bei med. Leistg.)</field>
-            <field name="description">0% USt (Pflichtbefreit)</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
@@ -733,7 +717,6 @@
             <field name="sequence">17</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">19% Umsatzsteuer (inkludiert in Preis)</field>
-            <field name="description">19% USt (inkludiert in Preis)</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">sale</field>
@@ -777,7 +760,6 @@
             <field name="sequence">18</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">7% Umsatzsteuer (inkludiert in Preis)</field>
-            <field name="description">7% USt (inkludiert in Preis)</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="type_tax_use">sale</field>
@@ -821,7 +803,6 @@
             <field name="sequence">26</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">5,5 % Umsatzsteuer Land-/Forstwirtschaft</field>
-            <field name="description">5,5% USt Land-/Forstwirtschaft</field>
             <field name="amount_type">percent</field>
             <field name="amount">5.5</field>
             <field name="type_tax_use">sale</field>
@@ -862,7 +843,6 @@
             <field name="sequence">27</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">10,7 % Umsatzsteuer Land-/Forstwirtschaft</field>
-            <field name="description">10,7% USt Land-/Forstwirtschaft</field>
             <field name="amount_type">percent</field>
             <field name="amount">10.7</field>
             <field name="type_tax_use">sale</field>
@@ -903,7 +883,6 @@
             <field name="sequence">28</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">19% Umsatzsteuer Land-/Forstwirtschaft (Alkohol u.a.)</field>
-            <field name="description">19% USt Land-/Forstwirtschaft (Alkohol u.a.)</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">sale</field>
@@ -944,7 +923,6 @@
             <field name="sequence">21</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">x% Umsatzsteuer (zu anderen Steuersätzen)</field>
-            <field name="description">x% USt (zu anderen Steuersätzen)</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
@@ -983,7 +961,6 @@
             <field name="sequence">10</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">19% Vorsteuer</field>
-            <field name="description">19% VSt</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="l10n_de_datev_code">19</field>
@@ -1025,7 +1002,6 @@
             <field name="sequence">15</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">7% Vorsteuer</field>
-            <field name="description">7% VSt</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="l10n_de_datev_code">18</field>
@@ -1067,7 +1043,6 @@
             <field name="sequence">16</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">0% VSt (Pflichtbefreit z.B. als Kleinunt. oder bei med. Leistg.)</field>
-            <field name="description">0% VSt (Pflichtbefreit)</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
@@ -1104,7 +1079,6 @@
             <field name="sequence">16</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">19% Vorsteuer (inkludiert in Preis)</field>
-            <field name="description">19% VSt (inkludiert in Preis)</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -1145,7 +1119,6 @@
             <field name="sequence">17</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">7% Vorsteuer (inkludiert in Preis)</field>
-            <field name="description">7% VSt (inkludiert in Preis)</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="type_tax_use">purchase</field>
@@ -1186,7 +1159,6 @@
             <field name="sequence">26</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">5,5% Vorsteuer Land-/Forstwirtschaft</field>
-            <field name="description">5,5% VSt Land-/Forstwirtschaft</field>
             <field name="amount_type">percent</field>
             <field name="amount">5.5</field>
             <field name="type_tax_use">purchase</field>
@@ -1227,7 +1199,6 @@
             <field name="sequence">27</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">10,7% Vorsteuer Land-/Forstwirtschaft</field>
-            <field name="description">10,7% VSt Land-/Forstwirtschaft</field>
             <field name="amount_type">percent</field>
             <field name="amount">10.7</field>
             <field name="type_tax_use">purchase</field>
@@ -1268,7 +1239,6 @@
             <field name="sequence">21</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">19 % Umsatzsteuer EU Lieferung</field>
-            <field name="description">19% USt EU</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">sale</field>
@@ -1311,7 +1281,6 @@
             <field name="sequence">22</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">7% Umsatzsteuer EU Lieferung</field>
-            <field name="description">7% USt EU</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="type_tax_use">sale</field>
@@ -1354,7 +1323,6 @@
             <field name="sequence">23</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">19% USt gem. §13b UStG - ohne VSt. - (ausländ. Werklieferungen u.ä.)</field>
-            <field name="description">19% USt EU gem. §13b UStG - ohne VSt. - (ausländ. Werklieferungen u.ä.)</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -1395,7 +1363,6 @@
             <field name="sequence">24</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">7% USt gem. §13b UStG - ohne VSt. - (ausländ. Werklieferungen u.ä.)</field>
-            <field name="description">7% USt EU gem. §13b UStG - ohne VSt. - (ausländ. Werklieferungen u.ä.)</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="type_tax_use">purchase</field>
@@ -1436,7 +1403,6 @@
             <field name="sequence">25</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">19% USt gem. §13b UStG - ohne VSt. - (sonst. Leistungen EU)</field>
-            <field name="description">19% USt EU gem. §13b UStG - ohne VSt. - (sonst. Leistungen EU)</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -1477,7 +1443,6 @@
             <field name="sequence">26</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">7% USt gem. §13b UStG - ohne VSt. - (sonst. Leistungen EU)</field>
-            <field name="description">7% USt EU gem. §13b UStG - ohne VSt. - (sonst. Leistungen EU)</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="type_tax_use">purchase</field>
@@ -1518,7 +1483,6 @@
             <field name="sequence">27</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">19% USt gem. §13b UStG - ohne VSt. - (empf. Bauleistungen)</field>
-            <field name="description">19% USt EU gem. §13b UStG - ohne VSt. - (empf. Bauleistungen)</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -1559,7 +1523,6 @@
             <field name="sequence">28</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">7% USt gem. §13b UStG - ohne VSt. - (empf. Bauleistungen)</field>
-            <field name="description">7% USt EU gem. §13b UStG - ohne VSt. - (empf. Bauleistungen)</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="type_tax_use">purchase</field>
@@ -1600,7 +1563,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">0% Steuerfreie Leistung EU</field>
-            <field name="description">0% USt EU</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
@@ -1639,7 +1601,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">0% Steuerfreie Leistung Drittland</field>
-            <field name="description">0% USt Drittland</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
@@ -1678,7 +1639,6 @@
             <field name="sequence">30</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">0% Steuerfreie Neufahrzeuglieferung EU</field>
-            <field name="description">0% USt Neufahrzeug EU</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
@@ -1717,7 +1677,6 @@
             <field name="sequence">40</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">0% Umsatzsteuer Dreiecksgeschäft erster Abnehmer</field>
-            <field name="description">0% USt Dreiecksgeschäft erster Abnehmer</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
@@ -1756,7 +1715,6 @@
             <field name="sequence">50</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">0% Umsatzsteuer Bauleistung (Erbringer §13b)</field>
-            <field name="description">0% Umsatzsteuer Bauleistung (Erbringer §13b)</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
@@ -1795,7 +1753,6 @@
             <field name="sequence">50</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">0% Umsatzsteuer Lieferung von Mobilfunkgeräten u.a. (§13b)</field>
-            <field name="description">0% USt Lieferung von Mobilfunkgeräten u.a. (§13b)</field>
             <field name="amount_type">percent</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
@@ -1833,7 +1790,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">Steuerpflichtige sonstige Leistungen EU 19%USt/19%VSt</field>
-            <field name="description">Leistungen EU 19%Ust/19%VSt</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -1890,7 +1846,6 @@
             <field name="sequence">21</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">Steuerpflichtige sonstige Leistungen EU 7%USt/7%VSt</field>
-            <field name="description">Steuerpfl. sonst. Leistg. EU 7%Ust/7%VSt</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="type_tax_use">purchase</field>
@@ -1947,7 +1902,6 @@
             <field name="sequence">22</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">Steuer gem. §13b UStG 19%USt/19%VSt (Bauleistung Empfänger)</field>
-            <field name="description">Steuer gem. §13b UStG 19%USt/19%VSt (Bauleistung Empfänger)</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -2004,7 +1958,6 @@
             <field name="sequence">23</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">Steuer gem. §13b UStG 7%USt/7%VSt (Bauleistung Empfänger)</field>
-            <field name="description">Steuer gem. §13b UStG 7%USt/7%VSt (Bauleistung Empfänger)</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="type_tax_use">purchase</field>
@@ -2061,7 +2014,6 @@
             <field name="sequence">24</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">Steuer gem. §13b 19%USt/19%VSt (Empfang von Mobilfunkgeräten u.a.)</field>
-            <field name="description">Steuer gem. §13b 19%Ust/19%VSt (Empfang von Mobilfunkgeräten u.a.)</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -2118,7 +2070,6 @@
             <field name="sequence">25</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">Dreiecksgeschäft Erwerb letzter Abnehmer 19%USt/19%VSt</field>
-            <field name="description">Dreiecksgeschäft Erwerb letzter Abnehmer 19%Ust/19%VSt</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -2173,7 +2124,6 @@
             <field name="sequence">25</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">Steuer gem. §13b 19%USt/19%VSt (ausländ. Werklieferungen u.ä.)</field>
-            <field name="description">Steuer gem. §13b 19%USt/19%VSt (ausländ. Werklieferungen u.ä.)</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -2230,7 +2180,6 @@
             <field name="sequence">26</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">Steuer gem. §13b 7%USt/7%VSt (ausländ. Werklieferungen u.ä.)</field>
-            <field name="description">Steuer gem. §13b 7%USt/7%VSt (ausländ. Werklieferungen u.ä.)</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="type_tax_use">purchase</field>
@@ -2287,7 +2236,6 @@
             <field name="sequence">27</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">Steuer gem. §13a Abs. 1 Nr. 6 UStG 19%USt/19%VSt (Auslagerung)</field>
-            <field name="description">Steuer gem. §13a Abs. 1 Nr. 6 UStG 19%USt/19%VSt (Auslagerung)</field>
             <field name="amount_type">percent</field>
             <field name="amount">19</field>
             <field name="type_tax_use">purchase</field>
@@ -2342,7 +2290,6 @@
             <field name="sequence">28</field>
             <field name="chart_template_id" ref="l10n_chart_de_skr04"/>
             <field name="name">Steuer gem. §13a Abs. 1 Nr. 6 UStG 7%USt/7%VSt (Auslagerung)</field>
-            <field name="description">Steuer gem. §13a Abs. 1 Nr. 6 UStG 7%USt/7VSt (Auslagerung)</field>
             <field name="amount_type">percent</field>
             <field name="amount">7</field>
             <field name="type_tax_use">purchase</field>

--- a/addons/l10n_dk/data/account_tax_template_data.xml
+++ b/addons/l10n_dk/data/account_tax_template_data.xml
@@ -6,7 +6,6 @@
         <field name="chart_template_id" ref="dk_chart_template"/>
         <field name="sequence">110</field>
         <field name="name">Salgsmoms 25%</field>
-        <field name="description">25%</field>
         <field name="amount">25</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -37,7 +36,6 @@
         <field name="chart_template_id" ref="dk_chart_template"/>
         <field name="sequence">120</field>
         <field name="name">Salgsmoms 25%, ydelser</field>
-        <field name="description">25%</field>
         <field name="amount">25</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -68,7 +66,6 @@
         <field name="chart_template_id" ref="dk_chart_template"/>
         <field name="sequence">140</field>
         <field name="name">Salg omvendt betalingspligt</field>
-        <field name="description"></field>
         <field name="price_include" eval="0"/>
         <field name="amount">100</field>
         <field name="amount_type">percent</field>
@@ -112,7 +109,6 @@
         <field name="chart_template_id" ref="dk_chart_template"/>
         <field name="sequence">210</field>
         <field name="name">EU Varesalg (Virksomheder)</field>
-        <field name="description"></field>
         <field name="price_include" eval="0"/>
         <field name="amount">100</field>
         <field name="amount_type">percent</field>
@@ -154,7 +150,6 @@
         <field name="chart_template_id" ref="dk_chart_template"/>
         <field name="sequence">220</field>
         <field name="name">EU Ydelsessalg (Virksomheder)</field>
-        <field name="description"></field>
         <field name="price_include" eval="0"/>
         <field name="amount">100</field>
         <field name="amount_type">percent</field>
@@ -198,7 +193,6 @@
         <field name="chart_template_id" ref="dk_chart_template"/>
         <field name="sequence">310</field>
         <field name="name">3. Land Salg Vare / Ydelser</field>
-        <field name="description"></field>
         <field name="amount">100</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -242,7 +236,6 @@
         <field name="chart_template_id" ref="dk_chart_template"/>
         <field name="sequence">400</field>
         <field name="name">Købsmoms 25%</field>
-        <field name="description">25%</field>
         <field name="amount">25</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -273,7 +266,6 @@
         <field name="chart_template_id" ref="dk_chart_template"/>
         <field name="sequence">410</field>
         <field name="name">Købsmoms 25% indeholdt</field>
-        <field name="description">25% indeholdt</field>
         <field name="amount">25</field>
         <field name="amount_type">percent</field>
         <field name="price_include" eval="True"/>
@@ -305,7 +297,6 @@
         <field name="chart_template_id" ref="dk_chart_template"/>
         <field name="sequence">420</field>
         <field name="name">Købsmoms 25%, ydelser</field>
-        <field name="description">25%</field>
         <field name="amount">25</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -336,7 +327,6 @@
         <field name="chart_template_id" ref="dk_chart_template"/>
         <field name="sequence">430</field>
         <field name="name">Køb omvendt betalingspligt</field>
-        <field name="description"></field>
         <field name="price_include" eval="0"/>
         <field name="amount">25</field>
         <field name="amount_type">percent</field>
@@ -378,7 +368,6 @@
         <field name="chart_template_id" ref="dk_chart_template"/>
         <field name="sequence">450</field>
         <field name="name">Restaurationsmoms 6,25%, købsmoms</field>
-        <field name="description">6,25%</field>
         <field name="amount">6.25</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -411,7 +400,6 @@
         <field name="chart_template_id" ref="dk_chart_template"/>
         <field name="sequence">510</field>
         <field name="name">EU Varekøb</field>
-        <field name="description"></field>
         <field name="price_include" eval="0"/>
         <field name="amount">100</field>
         <field name="amount_type">percent</field>
@@ -474,7 +462,6 @@
         <field name="chart_template_id" ref="dk_chart_template"/>
         <field name="sequence">520</field>
         <field name="name">EU Ydelseskøb</field>
-        <field name="description"></field>
         <field name="price_include" eval="0"/>
         <field name="amount">100</field>
         <field name="amount_type">percent</field>
@@ -538,7 +525,6 @@
         <field name="chart_template_id" ref="dk_chart_template"/>
         <field name="sequence">610</field>
         <field name="name">3. Land Varekøb</field>
-        <field name="description"></field>
         <field name="price_include" eval="0"/>
         <field name="amount">25</field>
         <field name="amount_type">percent</field>
@@ -580,7 +566,6 @@
         <field name="chart_template_id" ref="dk_chart_template"/>
         <field name="sequence">620</field>
         <field name="name">3. Land Ydelseskøb</field>
-        <field name="description"></field>
         <field name="amount">25</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>

--- a/addons/l10n_do/data/account.tax.template.xml
+++ b/addons/l10n_do/data/account.tax.template.xml
@@ -7,7 +7,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="sequence">4</field>
             <field name="name">Exento ITBIS Ventas</field>
-            <field name="description">Exento</field>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -41,7 +40,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="sequence">10</field>
             <field name="name">Exento ITBIS Compras</field>
-            <field name="description">Exento</field>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -73,7 +71,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="sequence">1</field>
             <field name="name">18% ITBIS Ventas</field>
-            <field name="description">18% ITBIS</field>
             <field name="amount">18</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -111,7 +108,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="sequence">2</field>
             <field name="name">18% ITBIS Incl. Ventas</field>
-            <field name="description">18% ITBIS</field>
             <field name="amount">18</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -149,7 +145,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="sequence">3</field>
             <field name="name">10% Propina Legal</field>
-            <field name="description">10% Legal</field>
             <field name="amount">10</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -183,7 +178,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="name">18% ITBIS Compras</field>
             <field name="sequence">11</field>
-            <field name="description">18% ITBIS (B)</field>
             <field name="amount">18</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -219,7 +213,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="sequence">12</field>
             <field name="name">18% ITBIS Incl. Compras</field>
-            <field name="description">18% ITBIS (Incl B)</field>
             <field name="amount">18</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -255,7 +248,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="name">16% ITBIS Compras</field>
             <field name="sequence">13</field>
-            <field name="description">16% ITBIS (B)</field>
             <field name="amount">16</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -289,7 +281,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="name">16% ITBIS Incl. Compras</field>
             <field name="sequence">14</field>
-            <field name="description">16% ITBIS (Incl B)</field>
             <field name="amount">16</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -323,7 +314,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="name">9% ITBIS Compras</field>
             <field name="sequence">15</field>
-            <field name="description">9% ITBIS (L690-16)</field>
             <field name="amount">9</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -357,7 +347,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="name">9% ITBIS Incl. Compras</field>
             <field name="sequence">16</field>
-            <field name="description">9% ITBIS (L690-16)</field>
             <field name="amount">9</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -391,7 +380,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="name">8% ITBIS Compras</field>
             <field name="sequence">17</field>
-            <field name="description">8% ITBIS (L690-16)</field>
             <field name="amount">8</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -425,7 +413,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="name">8% ITBIS Incl. Compras</field>
             <field name="sequence">18</field>
-            <field name="description">8% ITBIS (L690-16)</field>
             <field name="amount">8</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -459,7 +446,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="sequence">19</field>
             <field name="name">10% Propina Legal</field>
-            <field name="description">10% Legal</field>
             <field name="amount">10</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -493,7 +479,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="sequence">20</field>
             <field name="name">18% ITBIS Compras - Servicios</field>
-            <field name="description">18% ITBIS (S)</field>
             <field name="amount">18</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -529,7 +514,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="sequence">20</field>
             <field name="name">18% ITBIS Incl. Compras - Servicios</field>
-            <field name="description">18% ITBIS (Incl S)</field>
             <field name="amount">18</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -565,7 +549,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="sequence">20</field>
             <field name="name">18% ITBIS - Importaciones</field>
-            <field name="description">18% ITBIS (IMP)</field>
             <field name="amount">18</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -601,7 +584,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="sequence">20</field>
             <field name="name">18% ITBIS sobre el 10% del Monto Total</field>
-            <field name="description">18% del 10%</field>
             <field name="amount">1.8</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -635,7 +617,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="sequence">30</field>
             <field name="name">0.15% Transferencia Bancaria</field>
-            <field name="description">0.15% Trans</field>
             <field name="amount">0.0015</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">none</field>
@@ -669,7 +650,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="sequence">30</field>
             <field name="name">10% ISC Telecomunicaciones</field>
-            <field name="description">10% ISC</field>
             <field name="amount">10</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -703,7 +683,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="sequence">30</field>
             <field name="name">2% CDT Telecomunicaciones</field>
-            <field name="description">2% CDT</field>
             <field name="amount">2</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -748,7 +727,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="sequence">40</field>
             <field name="name">Retención 100% ITBIS Servicios de Seguridad (N07-09)</field>
-            <field name="description">-100% ITBIS (N07-09)</field>
             <field name="amount">-18</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -782,7 +760,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="sequence">41</field>
             <field name="name">Retención 100% ITBIS Servicios No Lucrativas (N01-11)</field>
-            <field name="description">-100% ITBIS (N01-11)</field>
             <field name="amount">-18</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -820,7 +797,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="sequence">42</field>
             <field name="name">Retención 100% ITBIS Servicios a Físicas (R293-11)</field>
-            <field name="description">-100% ITBIS (R293-11)</field>
             <field name="amount">-18</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -858,7 +834,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="sequence">43</field>
             <field name="name">Retención 30% ITBIS Servicios a Jurídicas (N02-05)</field>
-            <field name="description">-30% ITBIS (N02-05)</field>
             <field name="amount">-5.4</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -893,7 +868,6 @@
             <field name="active">False</field>
             <field name="sequence">43</field>
             <field name="name">Retención 30% ITBIS Servicios Profesionales (N02-05)</field>
-            <field name="description">-30% ITBIS (N02-05)</field>
             <field name="amount">-5.4</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">none</field>
@@ -927,7 +901,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="sequence">44</field>
             <field name="name">Retención 75% ITBIS Bienes a Informales (N08-10)</field>
-            <field name="description">-75% ITBIS (N08-10)</field>
             <field name="amount">-13.5</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -961,7 +934,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="sequence">40</field>
             <field name="name">Retención 10% ISR Honorarios a Físicas</field>
-            <field name="description">-10% ISR</field>
             <field name="amount">-10</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -995,7 +967,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="sequence">50</field>
             <field name="name">Retención 10% ISR Alquileres a Físicas</field>
-            <field name="description">-10% ISR</field>
             <field name="amount">-10</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -1029,7 +1000,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="sequence">51</field>
             <field name="name">Retención 10% ISR por Dividendos (L253-12)</field>
-            <field name="description">-10% ISR</field>
             <field name="amount">-10</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -1063,7 +1033,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="sequence">52</field>
             <field name="name">Retención 2% ISR a Física (con Materiales)</field>
-            <field name="description">-2% ISR (N07-07)</field>
             <field name="amount">-2</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -1097,7 +1066,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="sequence">53</field>
             <field name="name">Retención 2% ISR por Transferencia de Títulos</field>
-            <field name="description">-2% ISR</field>
             <field name="amount">-2</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -1131,7 +1099,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="sequence">49</field>
             <field name="name">Retención 27% ISR por Remesas al Exterior (L253-12)</field>
-            <field name="description">-27% ISR</field>
             <field name="amount">-27</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -1165,7 +1132,6 @@
             <field name="chart_template_id" ref="do_chart_template"/>
             <field name="sequence">50</field>
             <field name="name">Retención 5% ISR Gubernamentales</field>
-            <field name="description">-5% ISR</field>
             <field name="amount">-5</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>

--- a/addons/l10n_ec/data/account_tax_data.xml
+++ b/addons/l10n_ec/data/account_tax_data.xml
@@ -4,7 +4,6 @@
     <record id="salevat1" model="account.tax.template">
         <field name="chart_template_id" ref="ec_chart_template"/>
         <field name="name">Sale IVA Cobrado (12%)(12.0%)</field>
-        <field name="description">IVA Cobrado 12%</field>
         <field name="amount">12</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -38,7 +37,6 @@
     <record id="salevat2" model="account.tax.template">
         <field name="chart_template_id" ref="ec_chart_template"/>
         <field name="name">Sale IVA Pagado (12%)(12.0%)</field>
-        <field name="description">IVA Pagado 12%</field>
         <field name="amount">12</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -72,7 +70,6 @@
     <record id="saleret1" model="account.tax.template">
         <field name="chart_template_id" ref="ec_chart_template"/>
         <field name="name">Sale Retencion (8%)(8.0%)</field>
-        <field name="description">Retencion 8%</field>
         <field name="amount">-8.0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -106,7 +103,6 @@
     <record id="saleret2" model="account.tax.template">
         <field name="chart_template_id" ref="ec_chart_template"/>
         <field name="name">Sale Retencion (30%)(30.0%)</field>
-        <field name="description">Retencion 30%</field>
         <field name="amount">-30.0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -140,7 +136,6 @@
     <record id="saleret3" model="account.tax.template">
         <field name="chart_template_id" ref="ec_chart_template"/>
         <field name="name">Sale Retencion (70%)(70.0%)</field>
-        <field name="description">Retencion 70%</field>
         <field name="amount">-70.0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -174,7 +169,6 @@
     <record id="saleret4" model="account.tax.template">
         <field name="chart_template_id" ref="ec_chart_template"/>
         <field name="name">Sale Retencion (100%)(100.0%)</field>
-        <field name="description">Retencion 100%</field>
         <field name="amount">-100.0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -208,7 +202,6 @@
     <record id="purchasevat1" model="account.tax.template">
         <field name="chart_template_id" ref="ec_chart_template"/>
         <field name="name">Purchase IVA Cobrado (12%)(12.0%)</field>
-        <field name="description">IVA Cobrado 12%</field>
         <field name="amount">12</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -242,7 +235,6 @@
     <record id="purchasevat2" model="account.tax.template">
         <field name="chart_template_id" ref="ec_chart_template"/>
         <field name="name">Purchase IVA Pagado (12%)(12.0%)</field>
-        <field name="description">IVA Pagado 12%</field>
         <field name="amount">12</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -276,7 +268,6 @@
     <record id="purchaseret1" model="account.tax.template">
         <field name="chart_template_id" ref="ec_chart_template"/>
         <field name="name">Purchase Retencion (8%)(8.0%)</field>
-        <field name="description">Retencion 8%</field>
         <field name="amount">-8.0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -310,7 +301,6 @@
     <record id="purchaseret2" model="account.tax.template">
         <field name="chart_template_id" ref="ec_chart_template"/>
         <field name="name">Purchase Retencion (30%)(30.0%)</field>
-        <field name="description">Retencion 30%</field>
         <field name="amount">-30.0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -344,7 +334,6 @@
     <record id="purchaseret3" model="account.tax.template">
         <field name="chart_template_id" ref="ec_chart_template"/>
         <field name="name">Purchase Retencion (70%)(70.0%)</field>
-        <field name="description">Retencion 70%</field>
         <field name="amount">-70.0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -378,7 +367,6 @@
     <record id="purchaseret4" model="account.tax.template">
         <field name="chart_template_id" ref="ec_chart_template"/>
         <field name="name">Purchase Retencion (100%)(100.0%)</field>
-        <field name="description">Retencion 100%</field>
         <field name="amount">-100.0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>

--- a/addons/l10n_es/data/account_tax_data.xml
+++ b/addons/l10n_es/data/account_tax_data.xml
@@ -250,7 +250,6 @@
 
     <record id="account_tax_template_s_iva21b" model="account.tax.template">
         <field name="sequence" eval="0"/> <!-- Para que sea el impuesto por defecto de ventas -->
-        <field name="description">S_IVA21B</field>
         <field name="type_tax_use">sale</field>
         <field name="name">IVA 21% (Bienes)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -288,7 +287,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_iva21s" model="account.tax.template">
-        <field name="description">S_IVA21S</field>
         <field name="type_tax_use">sale</field>
         <field name="name">IVA 21% (Servicios)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -326,7 +324,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_iva21isp" model="account.tax.template">
-        <field name="description">S_IVA21ISP</field>
         <field name="type_tax_use">sale</field>
         <field name="name">IVA 21% (ISP)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -365,7 +362,6 @@
     </record>
     <record id="account_tax_template_p_iva21_bc" model="account.tax.template">
         <field name="sequence" eval="0"/> <!-- Para que sea el impuesto por defecto de compras -->
-        <field name="description">P_IVA21_BC</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">21% IVA soportado (bienes corrientes)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -403,7 +399,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_iva21_sc" model="account.tax.template">
-        <field name="description">P_IVA21_SC</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">21% IVA soportado (servicios corrientes)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -442,7 +437,6 @@
     </record>
     <record id="account_tax_template_p_iva21_sp_in" model="account.tax.template">
         <field name="name">IVA 21% Adquisición de servicios intracomunitarios</field>
-        <field name="description">P_IVA21_SP_IN</field>
         <field name="type_tax_use">purchase</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount_type">percent</field>
@@ -493,7 +487,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_iva21_ic_bc" model="account.tax.template">
-        <field name="description">P_IVA21_IC_BC</field>
         <field name="amount_type">percent</field>
         <field name="amount" eval="21"/>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -546,7 +539,6 @@
     </record>
     <record id="account_tax_template_p_iva21_ic_bi" model="account.tax.template">
         <field name="name">IVA 21% Adquisición Intracomunitaria. Bienes de inversión</field>
-        <field name="description">P_IVA21_IC_BI</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
         <field name="amount" eval="21"/>
@@ -597,7 +589,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_iva21_ibc" model="account.tax.template">
-        <field name="description">P_IVA21_IBC</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">IVA 21% Importaciones bienes corrientes</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -635,7 +626,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_iva21_ibi" model="account.tax.template">
-        <field name="description">P_IVA21_IBI</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">IVA 21% Importaciones bienes de inversión</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -673,7 +663,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_irpf21td" model="account.tax.template">
-        <field name="description">P_IRPFTD</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">Retenciones IRPF (Trabajadores) dinerarios</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -712,7 +701,6 @@
     </record>
     <record id="account_tax_template_p_iva4_sp_ex" model="account.tax.template">
         <field name="amount" eval="4"/>
-        <field name="description">P_IVA4_SP_EX</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -764,7 +752,6 @@
     </record>
     <record id="account_tax_template_p_iva10_sp_ex" model="account.tax.template">
         <field name="amount" eval="10"/>
-        <field name="description">P_IVA10_SP_EX</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -816,7 +803,6 @@
     </record>
     <record id="account_tax_template_p_iva21_sp_ex" model="account.tax.template">
         <field name="name">IVA 21% Adquisición de servicios extracomunitarios</field>
-        <field name="description">P_IVA21_SP_EX</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount" eval="21"/>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -867,7 +853,6 @@
     </record>
     <record id="account_tax_template_p_iva4_ic_bc" model="account.tax.template">
         <field name="amount" eval="4"/>
-        <field name="description">P_IVA4_IC_BC</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -919,7 +904,6 @@
     </record>
     <record id="account_tax_template_p_iva4_ic_bi" model="account.tax.template">
         <field name="amount" eval="4"/>
-        <field name="description">P_IVA4_IC_BI</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -970,7 +954,6 @@
     </record>
     <record id="account_tax_template_p_iva10_ic_bc" model="account.tax.template">
         <field name="amount" eval="10"/>
-        <field name="description">P_IVA10_IC_BC</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -1021,7 +1004,6 @@
     </record>
     <record id="account_tax_template_p_iva10_ic_bi" model="account.tax.template">
         <field name="amount" eval="10"/>
-        <field name="description">P_IVA10_IC_BI</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -1071,7 +1053,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_iva0_sp_i" model="account.tax.template">
-        <field name="description">S_IVA0_SP_I</field>
         <field name="type_tax_use">sale</field>
         <field name="name">IVA 0% Prestación de servicios intracomunitario</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -1105,7 +1086,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_iva_ns" model="account.tax.template">
-        <field name="description">S_IVA_NS</field>
         <field name="type_tax_use">sale</field>
         <field name="name">No sujeto Repercutido</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -1139,7 +1119,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_iva_e" model="account.tax.template">
-        <field name="description">S_IVA_SP_E</field>
         <field name="type_tax_use">sale</field>
         <field name="name">IVA 0% Prestación de servicios extracomunitaria</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -1173,7 +1152,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_iva4_ibc" model="account.tax.template">
-        <field name="description">P_IVA4_IBC</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">IVA 4% Importaciones bienes corrientes</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -1211,7 +1189,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_iva4_ibi" model="account.tax.template">
-        <field name="description">P_IVA4_IBI</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">IVA 4% Importaciones bienes de inversión</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -1249,7 +1226,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_iva10_ibc" model="account.tax.template">
-        <field name="description">P_IVA10_IBC</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">IVA 10% Importaciones bienes corrientes</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -1287,7 +1263,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_iva10_ibi" model="account.tax.template">
-        <field name="description">P_IVA10_IBI</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">IVA 10% Importaciones bienes de inversión</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -1325,7 +1300,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_iva4_bi" model="account.tax.template">
-        <field name="description">P_IVA4_BI</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">4% IVA Soportado (bienes de inversión)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -1363,7 +1337,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_iva4_sc" model="account.tax.template">
-        <field name="description">P_IVA4_SC</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">4% IVA soportado (servicios corrientes)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -1401,7 +1374,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_iva10_bi" model="account.tax.template">
-        <field name="description">P_IVA10_BI</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">10% IVA Soportado (bienes de inversión)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -1439,7 +1411,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_iva21_bi" model="account.tax.template">
-        <field name="description">P_IVA21_BI</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">21% IVA Soportado (bienes de inversión)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -1477,7 +1448,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_iva10_bc" model="account.tax.template">
-        <field name="description">P_IVA10_BC</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">10% IVA soportado (bienes corrientes)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -1515,7 +1485,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_iva4_bc" model="account.tax.template">
-        <field name="description">P_IVA4_BC</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">4% IVA soportado (bienes corrientes)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -1553,7 +1522,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_iva10_sc" model="account.tax.template">
-        <field name="description">P_IVA10_SC</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">10% IVA soportado (servicios corrientes)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -1591,7 +1559,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_iva0" model="account.tax.template">
-        <field name="description">S_IVA0</field>
         <field name="type_tax_use">sale</field>
         <field name="name">IVA Exento Repercutido</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -1623,7 +1590,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_req05" model="account.tax.template">
-        <field name="description">S_REQ05</field>
         <field name="type_tax_use">sale</field>
         <field name="name">0.50% Recargo Equivalencia Ventas</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -1661,7 +1627,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_iva4b" model="account.tax.template">
-        <field name="description">S_IVA4B</field>
         <field name="type_tax_use">sale</field>
         <field name="name">IVA 4% (Bienes)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -1699,7 +1664,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_iva10b" model="account.tax.template">
-        <field name="description">S_IVA10B</field>
         <field name="type_tax_use">sale</field>
         <field name="name">IVA 10% (Bienes)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -1737,7 +1701,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_iva0_nd" model="account.tax.template">
-        <field name="description">P_IVA0_ND</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">IVA Soportado no deducible</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -1769,7 +1732,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_iva4s" model="account.tax.template">
-        <field name="description">S_IVA4S</field>
         <field name="type_tax_use">sale</field>
         <field name="name">IVA 4% (Servicios)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -1807,7 +1769,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_iva10s" model="account.tax.template">
-        <field name="description">S_IVA10S</field>
         <field name="type_tax_use">sale</field>
         <field name="name">IVA 10% (Servicios)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -1845,7 +1806,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_req014" model="account.tax.template">
-        <field name="description">S_REQ014</field>
         <field name="type_tax_use">sale</field>
         <field name="name">1.4% Recargo Equivalencia Ventas</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -1883,7 +1843,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_req52" model="account.tax.template">
-        <field name="description">S_REQ52</field>
         <field name="type_tax_use">sale</field>
         <field name="name">5.2% Recargo Equivalencia Ventas</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -1921,7 +1880,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_iva0_bc" model="account.tax.template">
-        <field name="description">P_IVA0_BC</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">IVA Soportado exento (operaciones corrientes)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -1953,7 +1911,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_iva0_ns" model="account.tax.template">
-        <field name="description">P_IVA0_NS</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">IVA Soportado no sujeto</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -1985,7 +1942,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_irpf9" model="account.tax.template">
-        <field name="description">S_IRPF9</field>
         <field name="type_tax_use">sale</field>
         <field name="name">Retenciones a cuenta IRPF 9%</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2019,7 +1975,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_irpf18" model="account.tax.template">
-        <field name="description">S_IRPF18</field>
         <field name="type_tax_use">sale</field>
         <field name="name">Retenciones a cuenta IRPF 18%</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2053,7 +2008,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_irpf19" model="account.tax.template">
-        <field name="description">S_IRPF19</field>
         <field name="type_tax_use">sale</field>
         <field name="name">Retenciones a cuenta IRPF 19%</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2087,7 +2041,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_irpf19a" model="account.tax.template">
-        <field name="description">S_RAC19A</field>
         <field name="type_tax_use">sale</field>
         <field name="name">Retenciones a cuenta 19% (Arrendamientos)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2121,7 +2074,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_irpf195a" model="account.tax.template">
-        <field name="description">S_RAC195A</field>
         <field name="type_tax_use">sale</field>
         <field name="name">Retenciones a cuenta 19,5% (Arrendamientos)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2155,7 +2107,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_irpf19" model="account.tax.template">
-        <field name="description">P_IRPF19</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">Retenciones IRPF 19%</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2193,7 +2144,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_irpf20a" model="account.tax.template">
-        <field name="description">P_RAC20A</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">Retenciones 20% (Arrendamientos)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2231,7 +2181,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_irpf18" model="account.tax.template">
-        <field name="description">P_IRPF18</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">Retenciones IRPF 18%</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2269,7 +2218,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_irpf19a" model="account.tax.template">
-        <field name="description">P_RAC19A</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">Retenciones 19% (Arrendamientos)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2307,7 +2255,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_irpf195a" model="account.tax.template">
-        <field name="description">P_RAC195A</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">Retenciones 19,5% (Arrendamientos)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2345,7 +2292,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_irpf7" model="account.tax.template">
-        <field name="description">P_IRPF7</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">Retenciones IRPF 7%</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2383,7 +2329,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_irpf9" model="account.tax.template">
-        <field name="description">P_IRPF9</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">Retenciones IRPF 9%</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2421,7 +2366,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_irpf20" model="account.tax.template">
-        <field name="description">S_IRPF20</field>
         <field name="type_tax_use">sale</field>
         <field name="name">Retenciones a cuenta IRPF 20%</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2455,7 +2399,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_irpf20a" model="account.tax.template">
-        <field name="description">S_RAC20A</field>
         <field name="type_tax_use">sale</field>
         <field name="name">Retenciones a cuenta 20% (Arrendamientos)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2489,7 +2432,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_iva12_agr" model="account.tax.template">
-        <field name="description">P_IVA12_AGR</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">12% IVA Soportado régimen agricultura</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2526,7 +2468,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_iva105_gan" model="account.tax.template">
-        <field name="description">P_IVA105_GAN</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">10,5% IVA Soportado régimen ganadero o pesca</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2563,7 +2504,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_iva0_e" model="account.tax.template">
-        <field name="description">S_IVA0_E</field>
         <field name="type_tax_use">sale</field>
         <field name="name">IVA 0% Exportaciones</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2597,7 +2537,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_iva0_ic" model="account.tax.template">
-        <field name="description">S_IVA0_IC</field>
         <field name="type_tax_use">sale</field>
         <field name="name">IVA 0% Entregas Intracomunitarias exentas</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2631,7 +2570,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_req014" model="account.tax.template">
-        <field name="description">P_REQ014</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">1.4% Recargo Equivalencia Compras</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2669,7 +2607,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_req05" model="account.tax.template">
-        <field name="description">P_REQ05</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">0.50% Recargo Equivalencia Compras</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2707,7 +2644,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_req52" model="account.tax.template">
-        <field name="description">P_REQ5.2</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">5.2% Recargo Equivalencia Compras</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2745,7 +2681,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_irpf1" model="account.tax.template">
-        <field name="description">S_IRPF1</field>
         <field name="type_tax_use">sale</field>
         <field name="name">Retenciones a cuenta IRPF 1%</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2779,7 +2714,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_irpf2" model="account.tax.template">
-        <field name="description">S_IRPF2</field>
         <field name="type_tax_use">sale</field>
         <field name="name">Retenciones a cuenta IRPF 2%</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2813,7 +2747,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_irpf21" model="account.tax.template">
-        <field name="description">S_IRPF21</field>
         <field name="type_tax_use">sale</field>
         <field name="name">Retenciones a cuenta IRPF 21%</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2847,7 +2780,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_irpf21a" model="account.tax.template">
-        <field name="description">S_RAC21A</field>
         <field name="type_tax_use">sale</field>
         <field name="name">Retenciones a cuenta 21% (Arrendamientos)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2881,7 +2813,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_irpf7" model="account.tax.template">
-        <field name="description">S_IRPF7</field>
         <field name="type_tax_use">sale</field>
         <field name="name">Retenciones a cuenta IRPF 7%</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2915,7 +2846,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_irpf15" model="account.tax.template">
-        <field name="description">S_IRPF15</field>
         <field name="type_tax_use">sale</field>
         <field name="name">Retenciones a cuenta IRPF 15%</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2949,7 +2879,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_irpf1" model="account.tax.template">
-        <field name="description">P_IRPF1</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">Retenciones IRPF 1%</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -2987,7 +2916,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_irpf15" model="account.tax.template">
-        <field name="description">P_IRPF15</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">Retenciones IRPF 15%</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -3025,7 +2953,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_irpf21t" model="account.tax.template">
-        <field name="description">P_IRPFT</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">Retenciones IRPF 21% (Trabajadores)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -3064,7 +2991,6 @@
     </record>
     <record id="account_tax_template_p_iva10_sp_in" model="account.tax.template">
         <field name="amount" eval="10"/>
-        <field name="description">P_IVA10_SP_IN</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -3115,7 +3041,6 @@
     </record>
     <record id="account_tax_template_p_iva4_sp_in" model="account.tax.template">
         <field name="amount" eval="4"/>
-        <field name="description">P_IVA4_SP_IN</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -3165,7 +3090,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_irpf21te" model="account.tax.template">
-        <field name="description">P_IRPFTE</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">Retenciones IRPF (Trabajadores) en especie</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -3203,7 +3127,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_irpf20" model="account.tax.template">
-        <field name="description">P_IRPF20</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">Retenciones IRPF 20%</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -3241,7 +3164,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_irpf21a" model="account.tax.template">
-        <field name="description">P_RAC21A</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">Retenciones 21% (Arrendamientos)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -3279,7 +3201,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_irpf21p" model="account.tax.template">
-        <field name="description">P_IRPF21P</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">Retenciones IRPF 21%</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -3317,7 +3238,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_irpf2" model="account.tax.template">
-        <field name="description">P_IRPF2</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">Retenciones IRPF 2%</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
@@ -3356,7 +3276,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_s_iva0_isp" model="account.tax.template">
-        <field name="description">S_IVA0_ISP</field>
         <field name="name">IVA 0% Venta con Inversión del Sujeto Pasivo</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">percent</field>
@@ -3390,7 +3309,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_iva4_isp" model="account.tax.template">
-        <field name="description">P_IVA4_ISP</field>
         <field name="name">IVA 4% Compra con Inversión del Sujeto Pasivo Nacional</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
@@ -3441,7 +3359,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_iva10_isp" model="account.tax.template">
-        <field name="description">P_IVA10_ISP</field>
         <field name="name">IVA 10% Compra con Inversión del Sujeto Pasivo Nacional</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
@@ -3492,7 +3409,6 @@
         ]"/>
     </record>
     <record id="account_tax_template_p_iva21_isp" model="account.tax.template">
-        <field name="description">P_IVA21_ISP</field>
         <field name="name">IVA 21% Compra con Inversión del Sujeto Pasivo Nacional</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
@@ -3544,7 +3460,6 @@
     </record>
     <record id="account_tax_template_p_rp19" model="account.tax.template">
         <field name="type_tax_use">purchase</field>
-        <field name="description">P_RP19</field>
         <field name="name">Retenciones 19% (préstamos)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount" eval="-19"/>
@@ -3578,7 +3493,6 @@
     </record>
     <record id="account_tax_template_p_rrD19" model="account.tax.template">
         <field name="type_tax_use">purchase</field>
-        <field name="description">P_RRD19</field>
         <field name="name">Retenciones 19% (reparto de dividendos)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount" eval="-19"/>

--- a/addons/l10n_et/data/account_tax_data.xml
+++ b/addons/l10n_et/data/account_tax_data.xml
@@ -5,7 +5,6 @@
         <record id="id_tax03" model="account.tax.template">
             <field name="chart_template_id" ref="l10n_et"/>
             <field name="name">VAT 15% rated sales</field>
-            <field name="description">tax03</field>
             <field name="amount">15</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -41,7 +40,6 @@
         <record id="id_tax04" model="account.tax.template">
             <field name="chart_template_id" ref="l10n_et"/>
             <field name="name">VAT 0% rated sales</field>
-            <field name="description">tax04</field>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -73,7 +71,6 @@
         <record id="id_tax06" model="account.tax.template">
             <field name="chart_template_id" ref="l10n_et"/>
             <field name="name">VAT Exempt rated sales</field>
-            <field name="description">tax06</field>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -105,7 +102,6 @@
         <record id="id_tax11" model="account.tax.template">
             <field name="chart_template_id" ref="l10n_et"/>
             <field name="name">VAT Out of Scope rated sales</field>
-            <field name="description">tax11</field>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -139,7 +135,6 @@
             <field name="name">Withholding 2% rated sales</field>
             <field name="amount">-2</field>
             <field name="amount_type">percent</field>
-            <field name="description">tax02</field>
             <field name="type_tax_use">sale</field>
             <field name="tax_group_id" ref="tax_group_withh_2"/>
             <field name="invoice_repartition_line_ids" eval="[(5,0,0),
@@ -173,7 +168,6 @@
         <record id="id_tax13" model="account.tax.template">
             <field name="chart_template_id" ref="l10n_et"/>
             <field name="name">Withholding 35% rated sales</field>
-            <field name="description">tax13</field>
             <field name="amount">-35</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -209,7 +203,6 @@
         <record id="id_tax14" model="account.tax.template">
             <field name="chart_template_id" ref="l10n_et"/>
             <field name="name">Withholding VAT 15% rated sales</field>
-            <field name="description">tax14</field>
             <field name="amount">-15</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -245,7 +238,6 @@
         <record id="id_tax08" model="account.tax.template">
             <field name="chart_template_id" ref="l10n_et"/>
             <field name="name">VAT 15% rated purchases</field>
-            <field name="description">tax08</field>
             <field name="amount">15</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -281,7 +273,6 @@
         <record id="id_tax07" model="account.tax.template">
             <field name="chart_template_id" ref="l10n_et"/>
             <field name="name">VAT 0% rated purchases</field>
-            <field name="description">tax07</field>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -313,7 +304,6 @@
         <record id="id_tax10" model="account.tax.template">
             <field name="chart_template_id" ref="l10n_et"/>
             <field name="name">VAT Exempt rated purchases</field>
-            <field name="description">tax10</field>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -345,7 +335,6 @@
         <record id="id_tax09" model="account.tax.template">
             <field name="chart_template_id" ref="l10n_et"/>
             <field name="name">VAT Out of Scope rated purchases</field>
-            <field name="description">tax09</field>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -377,7 +366,6 @@
         <record id="id_tax05" model="account.tax.template">
             <field name="chart_template_id" ref="l10n_et"/>
             <field name="name">Withholding 2% rated purchases</field>
-            <field name="description">tax05</field>
             <field name="amount">-2</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -413,7 +401,6 @@
         <record id="id_tax12" model="account.tax.template">
             <field name="chart_template_id" ref="l10n_et"/>
             <field name="name">Withholding 35% rated purchases</field>
-            <field name="description">tax12</field>
             <field name="amount">-35</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>

--- a/addons/l10n_fr/data/account_tax_data.xml
+++ b/addons/l10n_fr/data/account_tax_data.xml
@@ -10,7 +10,6 @@
     <record model="account.tax.template" id="tva_normale">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA collectée (vente) 20,0%</field>
-        <field name="description">TVA 20%</field>
         <field name="amount" eval="20.0"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="9"/>
@@ -49,7 +48,6 @@
     <record model="account.tax.template" id="tva_intermediaire_encaissement">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA à l'encaissement (vente) 10,0%</field>
-        <field name="description">TVA 10%</field>
         <field name="amount" eval="10.0"/>
         <field name="amount_type">percent</field>
         <field name="tax_exigibility">on_payment</field>
@@ -90,7 +88,6 @@
     <record model="account.tax.template" id="tva_normale_encaissement">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA à l'encaissement (vente) 20,0%</field>
-        <field name="description">TVA à l'encaissement 20%</field>
         <field name="amount" eval="20.0"/>
         <field name="amount_type">percent</field>
         <field name="tax_exigibility">on_payment</field>
@@ -131,7 +128,6 @@
     <record model="account.tax.template" id="tva_specifique">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA collectée (vente) 8,5%</field>
-        <field name="description">TVA 8,5%</field>
         <field name="amount" eval="8.5"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
@@ -170,7 +166,6 @@
     <record model="account.tax.template" id="tva_intermediaire">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA collectée (vente) 10,0%</field>
-        <field name="description">TVA 10%</field>
         <field name="amount" eval="10.0"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
@@ -209,7 +204,6 @@
     <record model="account.tax.template" id="tva_reduite">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA collectée (vente) 5,5%</field>
-        <field name="description">TVA 5,5%</field>
         <field name="amount" eval="5.5"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
@@ -248,7 +242,6 @@
     <record model="account.tax.template" id="tva_reduite_encaissement">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA réduite à l'encaissement (vente) 5.5%</field>
-        <field name="description">TVA réduite à l'encaissement 5,5%</field>
         <field name="amount" eval="5.5"/>
         <field name="amount_type">percent</field>
         <field name="tax_exigibility">on_payment</field>
@@ -289,7 +282,6 @@
     <record model="account.tax.template" id="tva_super_reduite">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA collectée (vente) 2,1%</field>
-        <field name="description">TVA 2,1%</field>
         <field name="amount" eval="2.1"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
@@ -328,7 +320,6 @@
     <record model="account.tax.template" id="tva_super_reduite_encaissement">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA réduite à l'encaissement (vente) 2.1%</field>
-        <field name="description">TVA réduite à l'encaissement 2,1%</field>
         <field name="amount" eval="2.1"/>
         <field name="amount_type">percent</field>
         <field name="tax_exigibility">on_payment</field>
@@ -371,7 +362,6 @@
     <record model="account.tax.template" id="tva_normale_ttc">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA collectée (vente) 20,0% TTC</field>
-        <field name="description">TVA 20% TTC</field>
         <field name="price_include" eval="1"/>
         <field name="amount" eval="20.0"/>
         <field name="amount_type">percent</field>
@@ -411,7 +401,6 @@
     <record model="account.tax.template" id="tva_intermediaire_encaissement_ttc">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA à l'encaissement (vente) 10,0% TTC</field>
-        <field name="description">TVA 10% TTC</field>
         <field name="price_include" eval="1"/>
         <field name="amount" eval="10"/>
         <field name="amount_type">percent</field>
@@ -453,7 +442,6 @@
     <record model="account.tax.template" id="tva_normale_encaissement_ttc">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA à l'encaissement (vente) 20,0% TTC</field>
-        <field name="description">TVA 20% TTC</field>
         <field name="price_include" eval="1"/>
         <field name="amount" eval="20"/>
         <field name="amount_type">percent</field>
@@ -495,7 +483,6 @@
     <record model="account.tax.template" id="tva_specifique_ttc">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA collectée (vente) 8,5% TTC</field>
-        <field name="description">TVA 8,5% TTC</field>
         <field name="price_include" eval="1"/>
         <field name="amount" eval="8.5"/>
         <field name="amount_type">percent</field>
@@ -535,7 +522,6 @@
     <record model="account.tax.template" id="tva_intermediaire_ttc">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA collectée (vente) 10,0% TTC</field>
-        <field name="description">TVA 10% TTC</field>
         <field name="price_include" eval="1"/>
         <field name="amount" eval="10.0"/>
         <field name="amount_type">percent</field>
@@ -575,7 +561,6 @@
     <record model="account.tax.template" id="tva_reduite_ttc">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA collectée (vente) 5,5% TTC</field>
-        <field name="description">TVA 5,5% TTC</field>
         <field name="price_include" eval="1"/>
         <field name="amount" eval="5.5"/>
         <field name="amount_type">percent</field>
@@ -615,7 +600,6 @@
     <record model="account.tax.template" id="tva_reduite_encaissement_ttc">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA réduite à l'encaissement (vente) 5.5% TTC</field>
-        <field name="description">TVA réduite à l'encaissement 5,5% TTC</field>
         <field name="price_include" eval="1"/>
         <field name="amount" eval="5.5"/>
         <field name="amount_type">percent</field>
@@ -657,7 +641,6 @@
     <record model="account.tax.template" id="tva_super_reduite_ttc">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA collectée (vente) 2,1% TTC</field>
-        <field name="description">TVA 2,1% TTC</field>
         <field name="price_include" eval="1"/>
         <field name="amount" eval="2.1"/>
         <field name="amount_type">percent</field>
@@ -697,7 +680,6 @@
     <record model="account.tax.template" id="tva_super_reduite_encaissement_ttc">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA réduite à l'encaissement (vente) 2.1% TTC</field>
-        <field name="description">TVA réduite à l'encaissement 2,1% TTC</field>
         <field name="price_include" eval="1"/>
         <field name="amount" eval="2.1"/>
         <field name="amount_type">percent</field>
@@ -740,7 +722,6 @@
     <record model="account.tax.template" id="tva_acq_normale">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA déductible (achat) 20,0%</field>
-        <field name="description">TVA 20%</field>
         <field name="amount" eval="20.0"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="9"/>
@@ -779,7 +760,6 @@
     <record model="account.tax.template" id="tva_acq_encaissement">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA à l'encaissement (achat) 20,0%</field>
-        <field name="description">TVA 20%</field>
         <field name="amount" eval="20.0"/>
         <field name="amount_type">percent</field>
         <field name="tax_exigibility">on_payment</field>
@@ -820,7 +800,6 @@
     <record model="account.tax.template" id="tva_acq_intermediaire_encaissement">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA à l'encaissement (achat) 10,0%</field>
-        <field name="description">TVA 10%</field>
         <field name="amount" eval="10.0"/>
         <field name="amount_type">percent</field>
         <field name="tax_exigibility">on_payment</field>
@@ -861,7 +840,6 @@
     <record model="account.tax.template" id="tva_acq_specifique">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA déductible (achat) 8,5%</field>
-        <field name="description">TVA 8,5%</field>
         <field name="amount" eval="8.5"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
@@ -900,7 +878,6 @@
     <record model="account.tax.template" id="tva_acq_intermediaire">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA déductible (achat) 10,0%</field>
-        <field name="description">TVA 10%</field>
         <field name="amount" eval="10.0"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
@@ -939,7 +916,6 @@
     <record model="account.tax.template" id="tva_acq_reduite">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA déductible (achat) 5,5%</field>
-        <field name="description">TVA 5,5%</field>
         <field name="amount" eval="5.5"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
@@ -978,7 +954,6 @@
     <record model="account.tax.template" id="tva_acq_encaissement_reduite">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA à l'encaissement (achat) 5,5%</field>
-        <field name="description">TVA 5,5%</field>
         <field name="amount" eval="5.5"/>
         <field name="amount_type">percent</field>
         <field name="tax_exigibility">on_payment</field>
@@ -1019,7 +994,6 @@
     <record model="account.tax.template" id="tva_acq_super_reduite">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA déductible (achat) 2,1%</field>
-        <field name="description">TVA 2,1%</field>
         <field name="amount" eval="2.1"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
@@ -1060,7 +1034,6 @@
     <record model="account.tax.template" id="tva_acq_encaissement_super_reduite">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA à l'encaissement (achat) 2,1% </field>
-        <field name="description">TVA 2,1%</field>
         <field name="amount" eval="2.1"/>
         <field name="amount_type">percent</field>
         <field name="tax_exigibility">on_payment</field>
@@ -1101,7 +1074,6 @@
     <record model="account.tax.template" id="tva_acq_normale_TTC">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA déductible (achat) 20,0% TTC</field>
-        <field name="description">TVA 20% TTC</field>
         <field name="price_include" eval="1"/>
         <field name="amount" eval="20.0"/>
         <field name="amount_type">percent</field>
@@ -1141,7 +1113,6 @@
     <record model="account.tax.template" id="tva_acq_encaissement_TTC">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA à l'encaissement (achat) 20,0% TTC</field>
-        <field name="description">TVA 20% TTC</field>
         <field name="price_include" eval="1"/>
         <field name="amount" eval="20.0"/>
         <field name="amount_type">percent</field>
@@ -1183,7 +1154,6 @@
     <record model="account.tax.template" id="tva_acq_specifique_TTC">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA déductible (achat) 8,5% TTC</field>
-        <field name="description">TVA 8,5% TTC</field>
         <field name="price_include" eval="1"/>
         <field name="amount" eval="8.5"/>
         <field name="amount_type">percent</field>
@@ -1223,7 +1193,6 @@
     <record model="account.tax.template" id="tva_acq_intermediaire_encaissement_TTC">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA à l'encaissement (achat) 10,0% TTC</field>
-        <field name="description">TVA 10% TTC</field>
         <field name="price_include" eval="1"/>
         <field name="amount" eval="10.0"/>
         <field name="amount_type">percent</field>
@@ -1265,7 +1234,6 @@
     <record model="account.tax.template" id="tva_acq_intermediaire_TTC">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA déductible (achat) 10,0% TTC</field>
-        <field name="description">TVA 10% TTC</field>
         <field name="price_include" eval="1"/>
         <field name="amount" eval="10.0"/>
         <field name="amount_type">percent</field>
@@ -1305,7 +1273,6 @@
     <record model="account.tax.template" id="tva_acq_reduite_TTC">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA déductible (achat) 5,5% TTC</field>
-        <field name="description">TVA 5,5% TTC</field>
         <field name="price_include" eval="1"/>
         <field name="amount" eval="5.5"/>
         <field name="amount_type">percent</field>
@@ -1345,7 +1312,6 @@
     <record model="account.tax.template" id="tva_acq_encaissement_reduite_TTC">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA à l'encaissement (achat) 5,5% TTC</field>
-        <field name="description">TVA 5,5% TTC</field>
         <field name="price_include" eval="1"/>
         <field name="amount" eval="5.5"/>
         <field name="amount_type">percent</field>
@@ -1387,7 +1353,6 @@
     <record model="account.tax.template" id="tva_acq_super_reduite_TTC">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA déductible (achat) 2,1% TTC</field>
-        <field name="description">TVA 2,1% TTC</field>
         <field name="price_include" eval="1"/>
         <field name="amount" eval="2.1"/>
         <field name="amount_type">percent</field>
@@ -1427,7 +1392,6 @@
     <record model="account.tax.template" id="tva_acq_encaissement_super_reduite_TTC">
       <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
       <field name="name">TVA à l'encaissement (achat) 2,1% TTC</field>
-      <field name="description">TVA 2,1% TTC</field>
       <field name="price_include" eval="1"/>
       <field name="amount" eval="2.1"/>
       <field name="amount_type">percent</field>
@@ -1472,7 +1436,6 @@
     <record model="account.tax.template" id="tva_imm_normale">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA déd./immobilisation (achat) 20,0%</field>
-        <field name="description">TVA immo 20%</field>
         <field name="amount" eval="20.0"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
@@ -1511,7 +1474,6 @@
     <record model="account.tax.template" id="tva_imm_specifique">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA déd./immobilisation (achat) 8,5%</field>
-        <field name="description">TVA immo 8,5%</field>
         <field name="amount" eval="8.5"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
@@ -1550,7 +1512,6 @@
     <record model="account.tax.template" id="tva_imm_intermediaire">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA déd./immobilisation (achat) 10,0%</field>
-        <field name="description">TVA immo 10%</field>
         <field name="amount" eval="10.0"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
@@ -1589,7 +1550,6 @@
     <record model="account.tax.template" id="tva_imm_reduite">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA déd./immobilisation (achat) 5,5%</field>
-        <field name="description">TVA immo 5,5%</field>
         <field name="amount" eval="5.5"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
@@ -1628,7 +1588,6 @@
     <record model="account.tax.template" id="tva_imm_super_reduite">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA déd./immobilisation (achat) 2,1%</field>
-        <field name="description">TVA immo 2,1%</field>
         <field name="amount" eval="2.1"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
@@ -1669,7 +1628,6 @@
     <record model="account.tax.template" id="tva_intra_normale">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA due s/ acq. intracommunautaire (achat) 20,0%</field>   <!-- ventes -->
-        <field name="description">TVA 20% EU</field>
         <field name="amount" eval="-20.0"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
@@ -1708,7 +1666,6 @@
     <record model="account.tax.template" id="tva_intra_specifique">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA due s/ acq. intracommunautaire (achat) 8,5%</field>
-        <field name="description">TVA 8,5% EU</field>
         <field name="amount" eval="-8.5"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
@@ -1747,7 +1704,6 @@
     <record model="account.tax.template" id="tva_intra_intermediaire">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA due s/ acq. intracommunautaire (achat) 10,0%</field>
-        <field name="description">TVA 10% EU</field>
         <field name="amount" eval="-10.0"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
@@ -1786,7 +1742,6 @@
     <record model="account.tax.template" id="tva_intra_reduite">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA due s/ acq. intracommunautaire (achat) 5,5%</field>
-        <field name="description">TVA 5,5% EU</field>
         <field name="amount" eval="-5.5"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
@@ -1825,7 +1780,6 @@
     <record model="account.tax.template" id="tva_intra_super_reduite">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA due s/ acq. intracommunautaire (achat) 2,1%</field>
-        <field name="description">TVA 2,1% EU</field>
         <field name="amount" eval="-2.1"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
@@ -1866,7 +1820,6 @@
     <record model="account.tax.template" id="tva_acq_intra_normale">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA déd. s/ acq. intracommunautaire (achat) 20,0%</field>
-        <field name="description">TVA 20% EU</field>
         <field name="amount" eval="20.0"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
@@ -1905,7 +1858,6 @@
     <record model="account.tax.template" id="tva_acq_intra_specifique">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA déd. s/ acq. intracommunautaire (achat) 8,5%</field>
-        <field name="description">TVA 8,5% EU</field>
         <field name="amount" eval="8.5"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
@@ -1944,7 +1896,6 @@
     <record model="account.tax.template" id="tva_acq_intra_intermediaire">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA déd. s/ acq. intracommunautaire (achat) 10,0%</field>
-        <field name="description">TVA 10% EU</field>
         <field name="amount" eval="10.0"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
@@ -1983,7 +1934,6 @@
     <record model="account.tax.template" id="tva_acq_intra_reduite">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA déd. s/ acq. intracommunautaire (achat) 5,5%</field>
-        <field name="description">TVA 5,5% EU</field>
         <field name="amount" eval="5.5"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
@@ -2022,7 +1972,6 @@
     <record model="account.tax.template" id="tva_acq_intra_super_reduite">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA déd. s/ acq. intracommunautaire (achat) 2,1%</field>
-        <field name="description">TVA 2,1% EU</field>
         <field name="amount" eval="2.1"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
@@ -2063,7 +2012,6 @@
     <record model="account.tax.template" id="tva_0">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA 0% autres opérations non imposables (vente)</field>
-        <field name="description">TVA 0%</field>
         <field name="amount" eval="0.00"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
@@ -2098,7 +2046,6 @@
     <record model="account.tax.template" id="tva_export_0">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA 0% export (vente)</field>
-        <field name="description">TVA 0% Export</field>
         <field name="amount" eval="0.00"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
@@ -2133,7 +2080,6 @@
     <record model="account.tax.template" id="tva_intra_0">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA 0% livraisons intracommunautaires (vente)</field>
-        <field name="description">TVA 0% EU</field>
         <field name="amount" eval="0.00"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>
@@ -2168,7 +2114,6 @@
     <record model="account.tax.template" id="tva_import_0">
         <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
         <field name="name">TVA 0% import (achat)</field>
-        <field name="description">TVA 0% Import</field>
         <field name="amount" eval="0.00"/>
         <field name="amount_type">percent</field>
         <field name="sequence" eval="10"/>

--- a/addons/l10n_gr/data/account_tax_data.xml
+++ b/addons/l10n_gr/data/account_tax_data.xml
@@ -5,7 +5,6 @@
     <record id="ivat19" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_gr_chart_template"/>
         <field name="name">Πωλήσεις ΦΠΑ 19%</field>
-        <field name="description">Πωλήσεις ΦΠΑ 19%</field>
         <field eval="19" name="amount"/>
         <field name="sequence" eval="3" />
         <field name="amount_type">percent</field>
@@ -40,7 +39,6 @@
     <record id="ivat21" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_gr_chart_template"/>
         <field name="name">Πωλήσεις ΦΠΑ 21%</field>
-        <field name="description">Πωλήσεις ΦΠΑ 21%</field>
         <field eval="21" name="amount"/>
         <field name="sequence" eval="2" />
         <field name="amount_type">percent</field>
@@ -75,7 +73,6 @@
     <record id="ivat23" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_gr_chart_template"/>
         <field name="name">Πωλήσεις ΦΠΑ 23%</field>
-        <field name="description">Πωλήσεις ΦΠΑ 23%</field>
         <field eval="23" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -110,7 +107,6 @@
     <record id="pvat19" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_gr_chart_template"/>
         <field name="name">Αγορές ΦΠΑ19%</field>
-        <field name="description">Αγορές ΦΠΑ19%</field>
         <field eval="19" name="amount"/>
         <field name="sequence" eval="3" />
         <field name="amount_type">percent</field>
@@ -146,7 +142,6 @@
     <record id="pvat21" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_gr_chart_template"/>
         <field name="name">Αγορές ΦΠΑ21%</field>
-        <field name="description">Αγορές ΦΠΑ21%</field>
         <field eval="21" name="amount"/>
         <field name="sequence" eval="2" />
         <field name="amount_type">percent</field>
@@ -181,7 +176,6 @@
     <record id="pvat23" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_gr_chart_template"/>
         <field name="name">Αγορές ΦΠΑ23%</field>
-        <field name="description">Αγορές ΦΠΑ23%</field>
         <field eval="23" name="amount"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -216,7 +210,6 @@
     <record id="evat19" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_gr_chart_template"/>
         <field name="name">Δαπάνες ΦΠΑ19%</field>
-        <field name="description">Δαπάνες ΦΠΑ19%</field>
         <field eval="19" name="amount"/>
         <field name="sequence" eval="3" />
         <field name="amount_type">percent</field>
@@ -251,7 +244,6 @@
     <record id="evat21" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_gr_chart_template"/>
         <field name="name">Δαπάνες ΦΠΑ21%</field>
-        <field name="description">Δαπάνες ΦΠΑ21%</field>
         <field eval="21" name="amount"/>
         <field name="sequence" eval="2" />
         <field name="amount_type">percent</field>
@@ -286,7 +278,6 @@
     <record id="evat23" model="account.tax.template">
         <field name="chart_template_id" ref="l10n_gr_chart_template"/>
         <field name="name">Δαπάνες ΦΠΑ23%</field>
-        <field name="description">Δαπάνες ΦΠΑ23%</field>
         <field eval="23" name="amount"/>
         <field name="sequence" eval="2" />
         <field name="amount_type">percent</field>

--- a/addons/l10n_gt/data/account_chart_template_data.xml
+++ b/addons/l10n_gt/data/account_chart_template_data.xml
@@ -7,7 +7,6 @@
         <record id="impuestos_plantilla_iva_por_cobrar" model="account.tax.template">
             <field name="chart_template_id" ref="cuentas_plantilla"/>
             <field name="name">IVA por Cobrar</field>
-            <field name="description">IVA por Cobrar</field>
             <field name="amount" eval="12"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -42,7 +41,6 @@
         <record id="impuestos_plantilla_iva_por_pagar" model="account.tax.template">
             <field name="chart_template_id" ref="cuentas_plantilla"/>
             <field name="name">IVA por Pagar</field>
-            <field name="description">IVA por Pagar</field>
             <field name="amount" eval="12"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>

--- a/addons/l10n_hn/data/account_chart_template_data.xml
+++ b/addons/l10n_hn/data/account_chart_template_data.xml
@@ -7,7 +7,6 @@
         <record id="impuestos_plantilla_isv_por_cobrar" model="account.tax.template">
             <field name="chart_template_id" ref="cuentas_plantilla"/>
             <field name="name">ISV por Cobrar</field>
-            <field name="description">ISV por Cobrar</field>
             <field name="amount" eval="15"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -42,7 +41,6 @@
         <record id="impuestos_plantilla_isv_por_pagar" model="account.tax.template">
             <field name="chart_template_id" ref="cuentas_plantilla"/>
             <field name="name">ISV por Pagar</field>
-            <field name="description">ISV por Pagar</field>
             <field name="amount" eval="15"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>

--- a/addons/l10n_hr/data/account_tax_template_data.xml
+++ b/addons/l10n_hr/data/account_tax_template_data.xml
@@ -3,7 +3,6 @@
 
 
     <record id="rrif_pdv_25" model="account.tax.template">
-        <field name="description">PDV 25%</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">25% PDV</field>
         <field name="amount">25</field>
@@ -40,7 +39,6 @@
     </record>
 
     <record id="rrif_pdv_25usl" model="account.tax.template">
-        <field name="description">PDV 25% Usluge</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">25% PDV usluge</field>
         <field name="amount">25</field>
@@ -77,7 +75,6 @@
     </record>
 
     <record id="rrif_pdv_10" model="account.tax.template">
-        <field name="description">PDV 10%</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">10% PDV</field>
         <field name="amount">10</field>
@@ -114,7 +111,6 @@
     </record>
 
     <record id="rrif_pdv_0" model="account.tax.template">
-        <field name="description">PDV  0%</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">0% PDV</field>
         <field name="amount">0</field>
@@ -147,7 +143,6 @@
     </record>
 
     <record id="rrif_pdv_avans_25" model="account.tax.template">
-        <field name="description">PDV za predujam 25%</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">25% PDV (za predujam)</field>
         <field name="amount">25</field>
@@ -184,7 +179,6 @@
     </record>
 
     <record id="rrif_pdv_avans_10" model="account.tax.template">
-        <field name="description">PDV za predujam 10%</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">10% PDV (za predujam)</field>
         <field name="amount">10</field>
@@ -221,7 +215,6 @@
     </record>
 
     <record id="rrif_pdv_avans_0" model="account.tax.template">
-        <field name="description">PDV za predujam 0%</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">0% PDV (za predujam)</field>
         <field name="amount">0</field>
@@ -254,7 +247,6 @@
     </record>
 
     <record id="rrif_pdv_nezar_isp_25" model="account.tax.template">
-        <field name="description">PDV po nezaračunanim isporukama 25%</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">25% PDV za nezaračunane isp.</field>
         <field name="amount">25</field>
@@ -291,7 +283,6 @@
     </record>
 
     <record id="rrif_pdv_nezar_isp_10" model="account.tax.template">
-        <field name="description">PDV po nezaračunanim isporukama 10%</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">10% PDV za nezaračunane isp.</field>
         <field name="amount">10</field>
@@ -328,7 +319,6 @@
     </record>
 
     <record id="rrif_pdv_nezar_isp_0" model="account.tax.template">
-        <field name="description">PDV po nezaračunanim isporukama 0%</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">0% PDV za nezaračunane isp.</field>
         <field name="amount">0</field>
@@ -361,7 +351,6 @@
     </record>
 
     <record id="rrif_pdv_nepod_0" model="account.tax.template">
-        <field name="description">1. KOJE NE PODLIJEŽU OPOREZIVANJU (čl. 2. u svezi s čl. 5 i čl. 8 st. 7 Zakona)</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">0% Ne podliježe op.</field>
         <field name="amount">0</field>
@@ -394,7 +383,6 @@
     </record>
 
     <record id="rrif_pdv_osl_izvoz_0" model="account.tax.template">
-        <field name="description">2.1. IZVOZNE - s pravom na odbitak pretporeza (čl. 13. st. 1. toč. 1. i čl. 14. Zakona)</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">0% osl. izvozne</field>
         <field name="amount">0</field>
@@ -427,7 +415,6 @@
     </record>
 
     <record id="rrif_pdv_osl_medpri_0" model="account.tax.template">
-        <field name="description">2.2. U VEZI S MEĐUNARODNIM PRIJEVOZOM  (čl. 13.b Zakona)</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">0% osl. međ. prijevoz</field>
         <field name="amount">0</field>
@@ -460,7 +447,6 @@
     </record>
 
     <record id="rrif_pdv_osl_tuz_0" model="account.tax.template">
-        <field name="description">2.3. TUZEMNE - bez prava na odbitak pretporeza (čl. 11. i čl. 11a Zakona)</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">0% osl tuzemne</field>
         <field name="amount">0</field>
@@ -493,7 +479,6 @@
     </record>
 
     <record id="rrif_pdv_osl_ost_0" model="account.tax.template">
-        <field name="description">2.4. OSTALO (čl. 13. st. 1. toč. 2. I čl. 13a Zakona) </field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">0% osl. ostalo</field>
         <field name="amount">0</field>
@@ -526,7 +511,6 @@
     </record>
 
     <record id="rrif_pp_25" model="account.tax.template">
-        <field name="description">Pretporez 25% PDV</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">25% PDV pretporez</field>
         <field name="amount">25</field>
@@ -561,7 +545,6 @@
     </record>
 
     <record id="rrif_pp_25usl" model="account.tax.template">
-        <field name="description">Pretporez 25% PDV Usluge</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">25% PDV pretporez usluge</field>
         <field name="amount">25</field>
@@ -596,7 +579,6 @@
     </record>
 
     <record id="rrif_pp_10" model="account.tax.template">
-        <field name="description">Pretporez 10% PDV</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">10% PDV pretporez</field>
         <field name="amount">10</field>
@@ -633,7 +615,6 @@
     </record>
 
     <record id="rrif_pp_0" model="account.tax.template">
-        <field name="description">Pretporez 0% PDV</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">0% PDV pretporez</field>
         <field name="amount">0</field>
@@ -666,7 +647,6 @@
     </record>
 
     <record id="rrif_pp_avans_25" model="account.tax.template">
-        <field name="description">Pretporez za predujam 25% PDV</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">25% PDV pretporez za predujam</field>
         <field name="amount">25</field>
@@ -701,7 +681,6 @@
     </record>
 
     <record id="rrif_pp_avans_0" model="account.tax.template">
-        <field name="description">Pretporez za predujam 0% PDV</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">0% PDV pretporez za predujam</field>
         <field name="amount">0</field>
@@ -734,7 +713,6 @@
     </record>
 
     <record id="rrif_pp_uvoz_25" model="account.tax.template">
-        <field name="description">Plaćeni PDV 25% pri uvozu dobara</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">25% uvoz dobara</field>
         <field name="amount">25</field>
@@ -771,7 +749,6 @@
     </record>
 
     <record id="rrif_pp_uvoz_10" model="account.tax.template">
-        <field name="description">Plaćeni PDV 10% pri uvozu dobara</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">10% uvoz dobara</field>
         <field name="amount">10</field>
@@ -808,7 +785,6 @@
     </record>
 
     <record id="rrif_pp_uvoz_0" model="account.tax.template">
-        <field name="description">Plaćeni PDV 0% pri uvozu dobara</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">0% uvoz dobara</field>
         <field name="amount">0</field>
@@ -842,7 +818,6 @@
 
 
      <record id="rrif_pp_ino_25" model="account.tax.template">
-        <field name="description">Plaćeni PDV 25% na usluge inozemnih poduzetnika</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">25% ino. usluge</field>
         <field name="amount">25</field>
@@ -879,7 +854,6 @@
     </record>
 
     <record id="rrif_pp_ino_10" model="account.tax.template">
-        <field name="description">Plaćeni PDV 10% na usluge inozemnih poduzetnika</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">10% ino. usluge</field>
         <field name="amount">10</field>
@@ -916,7 +890,6 @@
     </record>
 
     <record id="rrif_ppr2_25" model="account.tax.template">
-        <field name="description">25% R-2 dobavljač</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">25% R-2 dobavljač</field>
         <field name="amount">25</field>
@@ -953,7 +926,6 @@
     </record>
 
     <record id="rrif_pp_uvoz_samopdv_25" model="account.tax.template">
-        <field name="description">Samo PDV kod uvoza 25%</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">Samo PDV kod uvoza 25%</field>
         <field name="amount">25</field>
@@ -990,7 +962,6 @@
     </record>
 
     <record id="rrif_pp_uvoz_samopdv_25usl" model="account.tax.template">
-        <field name="description">Samo PDV kod uvoza 25% usluge</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">Samo PDV kod uvoza 25% usluge</field>
         <field name="amount">25</field>
@@ -1027,7 +998,6 @@
     </record>
 
     <record id="rrif_ppdnp1_3070_1" model="account.tax.template">
-        <field name="description">pp 30% Nepriznat 70% Priznat</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">pp 30% Nepriznat 70% Priznat</field>
         <field name="amount">25</field>
@@ -1076,7 +1046,6 @@
     </record>
 
     <record id="rrif_ppdnp1_7030_1" model="account.tax.template">
-        <field name="description">pp 70% Nepriznat 30% Priznat</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">pp 70% Nepriznat 30% Priznat</field>
         <field name="amount">25</field>
@@ -1125,7 +1094,6 @@
     </record>
 
     <record id="rrif_ppdnp1_3070_1_r2" model="account.tax.template">
-        <field name="description">R2 pp 30% Nepriznat 70% Priznat</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">R2 pp 30% Nepriznat 70% Priznat</field>
         <field name="amount">25</field>
@@ -1174,7 +1142,6 @@
     </record>
 
     <record id="rrif_ppdnp1_7030_1_r2" model="account.tax.template">
-        <field name="description">R2 pp 70% Nepriznat 30% Priznat</field>
         <field name="chart_template_id" ref="l10n_hr_chart_template_rrif"/>
         <field name="name">R2 pp 70% Nepriznat 30% Priznat</field>
         <field name="amount">25</field>

--- a/addons/l10n_hu/data/account_tax_template_data.xml
+++ b/addons/l10n_hu/data/account_tax_template_data.xml
@@ -2,7 +2,6 @@
 <odoo>
 
     <record id="F27" model="account.tax.template">
-        <field name="description">27%</field>
         <field name="chart_template_id" ref="hungarian_chart_template"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Fizetendő - 27%</field>
@@ -40,7 +39,6 @@
     </record>
 
     <record id="F18" model="account.tax.template">
-        <field name="description">18%</field>
         <field name="chart_template_id" ref="hungarian_chart_template"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Fizetendő – 18%</field>
@@ -78,7 +76,6 @@
     </record>
 
     <record id="F5" model="account.tax.template">
-        <field name="description">5%</field>
         <field name="chart_template_id" ref="hungarian_chart_template"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Fizetendő – 5%</field>
@@ -116,7 +113,6 @@
     </record>
 
     <record id="FA" model="account.tax.template">
-        <field name="description">AAM</field>
         <field name="chart_template_id" ref="hungarian_chart_template"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Fizetendő – Alanyi Adómentes</field>
@@ -150,7 +146,6 @@
     </record>
 
     <record id="FT" model="account.tax.template">
-        <field name="description">TAM</field>
         <field name="chart_template_id" ref="hungarian_chart_template"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Fizetendő – Tárgyi Adómentes</field>
@@ -184,7 +179,6 @@
     </record>
 
     <record id="FF" model="account.tax.template">
-        <field name="description">FORD</field>
         <field name="chart_template_id" ref="hungarian_chart_template"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Fizetendő – Fordított ÁFA</field>
@@ -218,7 +212,6 @@
     </record>
 
     <record id="FEUO" model="account.tax.template">
-        <field name="description">Export</field>
         <field name="chart_template_id" ref="hungarian_chart_template"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Fizetendő – Export</field>
@@ -252,7 +245,6 @@
     </record>
 
     <record id="FEU" model="account.tax.template">
-        <field name="description">EU</field>
         <field name="chart_template_id" ref="hungarian_chart_template"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Fizetendő – EU</field>
@@ -286,7 +278,6 @@
     </record>
 
     <record id="V18" model="account.tax.template">
-        <field name="description">18%</field>
         <field name="chart_template_id" ref="hungarian_chart_template"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Visszaigényelhető – 18%</field>
@@ -324,7 +315,6 @@
     </record>
 
     <record id="V27" model="account.tax.template">
-        <field name="description">27%</field>
         <field name="chart_template_id" ref="hungarian_chart_template"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Visszaigényelhető – 27%</field>
@@ -362,7 +352,6 @@
     </record>
 
     <record id="V5" model="account.tax.template">
-        <field name="description">5%</field>
         <field name="chart_template_id" ref="hungarian_chart_template"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Visszaigényelhető – 5%</field>
@@ -400,7 +389,6 @@
     </record>
 
     <record id="VA" model="account.tax.template">
-        <field name="description">AAM</field>
         <field name="chart_template_id" ref="hungarian_chart_template"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Visszaigényelhető – Alanyi Adómentes</field>
@@ -434,7 +422,6 @@
     </record>
 
     <record id="VT" model="account.tax.template">
-        <field name="description">TAM</field>
         <field name="chart_template_id" ref="hungarian_chart_template"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Visszaigényelhető – Tárgyi Adómentes</field>
@@ -468,7 +455,6 @@
     </record>
 
     <record id="VAHT" model="account.tax.template">
-        <field name="description">ÁHT</field>
         <field name="chart_template_id" ref="hungarian_chart_template"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Visszaigényelhető – ÁFA hatályán kívüli</field>
@@ -500,7 +486,6 @@
     </record>
 
     <record id="VEU" model="account.tax.template">
-        <field name="description">EU</field>
         <field name="chart_template_id" ref="hungarian_chart_template"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Visszaigényelhető – EU</field>
@@ -534,7 +519,6 @@
     </record>
 
     <record id="VEUO" model="account.tax.template">
-        <field name="description">Import</field>
         <field name="chart_template_id" ref="hungarian_chart_template"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Visszaigényelhető – Import</field>
@@ -568,7 +552,6 @@
     </record>
 
     <record id="VF" model="account.tax.template">
-        <field name="description">FORD</field>
         <field name="chart_template_id" ref="hungarian_chart_template"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Visszaigényelhető – Fordított ÁFA</field>

--- a/addons/l10n_id/data/account_tax_template_data.xml
+++ b/addons/l10n_id/data/account_tax_template_data.xml
@@ -2,7 +2,6 @@
 <odoo>
 
     <record id="tax_ST1" model="account.tax.template">
-        <field name="description">ST1</field>
         <field name="chart_template_id" ref="l10n_id_chart"/>
         <field name="type_tax_use">sale</field>
         <field name="name">10%</field>
@@ -33,7 +32,6 @@
     </record>
 
     <record id="tax_PT1" model="account.tax.template">
-        <field name="description">PT1</field>
         <field name="chart_template_id" ref="l10n_id_chart"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">10%</field>
@@ -64,7 +62,6 @@
     </record>
 
     <record id="tax_ST0" model="account.tax.template">
-        <field name="description">ST0</field>
         <field name="chart_template_id" ref="l10n_id_chart"/>
         <field name="type_tax_use">sale</field>
         <field name="name">0%</field>
@@ -95,7 +92,6 @@
         </record>
 
     <record id="tax_ST2" model="account.tax.template">
-        <field name="description">ST2</field>
         <field name="chart_template_id" ref="l10n_id_chart"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Exempt</field>
@@ -126,7 +122,6 @@
     </record>
 
     <record id="tax_PT0" model="account.tax.template">
-        <field name="description">PT0</field>
         <field name="chart_template_id" ref="l10n_id_chart"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Exempt</field>
@@ -157,7 +152,6 @@
     </record>
 
     <record id="tax_PT2" model="account.tax.template">
-        <field name="description">PT2</field>
         <field name="chart_template_id" ref="l10n_id_chart"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">0%</field>

--- a/addons/l10n_ie/data/account_tax_data.xml
+++ b/addons/l10n_ie/data/account_tax_data.xml
@@ -2,7 +2,6 @@
 <odoo>
 
     <record id="l10n_ie_tax_st0" model="account.tax.template">
-        <field name="description">ST0</field>
         <field name="chart_template_id" ref="l10n_ie"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Zero rated sales (IE)</field>
@@ -31,7 +30,6 @@
     </record>
 
     <record id="l10n_ie_tax_st1" model="account.tax.template">
-        <field name="description">ST1</field>
         <field name="chart_template_id" ref="l10n_ie"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Standard rate sales (13.5%) (IE)</field>
@@ -62,7 +60,6 @@
     </record>
 
     <record id="l10n_ie_tax_st2" model="account.tax.template">
-        <field name="description">ST2</field>
         <field name="chart_template_id" ref="l10n_ie"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Exempt sales (IE)</field>
@@ -91,7 +88,6 @@
     </record>
 
     <record id="l10n_ie_tax_pt0" model="account.tax.template">
-        <field name="description">PT0</field>
         <field name="chart_template_id" ref="l10n_ie"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Zero rated purchases (IE)</field>
@@ -120,7 +116,6 @@
     </record>
 
     <record id="l10n_ie_tax_pt1" model="account.tax.template">
-        <field name="description">PT1</field>
         <field name="chart_template_id" ref="l10n_ie"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Standard rate purchases (13.5%) (IE)</field>
@@ -151,7 +146,6 @@
     </record>
 
     <record id="l10n_ie_tax_pt2" model="account.tax.template">
-        <field name="description">PT2</field>
         <field name="chart_template_id" ref="l10n_ie"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Exempt purchases (IE)</field>
@@ -180,7 +174,6 @@
     </record>
 
     <record id="l10n_ie_tax_pt8" model="account.tax.template">
-        <field name="description">PT8</field>
         <field name="chart_template_id" ref="l10n_ie"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Standard rated purchases from EU (IE)</field>
@@ -221,7 +214,6 @@
     </record>
 
     <record id="l10n_ie_tax_pt9" model="account.tax.template">
-        <field name="description">PT9</field>
         <field name="chart_template_id" ref="l10n_ie"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Lower rate purchases (9%) (IE)</field>
@@ -252,7 +244,6 @@
     </record>
 
     <record id="l10n_ie_tax_st4" model="account.tax.template">
-        <field name="description">ST4</field>
         <field name="chart_template_id" ref="l10n_ie"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Sales to customers in EU (IE)</field>
@@ -281,7 +272,6 @@
     </record>
 
     <record id="l10n_ie_tax_pt7" model="account.tax.template">
-        <field name="description">PT7</field>
         <field name="chart_template_id" ref="l10n_ie"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Zero rated purchases from EU (IE)</field>
@@ -310,7 +300,6 @@
     </record>
 
     <record id="l10n_ie_tax_st11" model="account.tax.template">
-        <field name="description">ST11</field>
         <field name="chart_template_id" ref="l10n_ie"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Standard rate sales (23%) (IE)</field>
@@ -341,7 +330,6 @@
     </record>
 
     <record id="l10n_ie_tax_pt11" model="account.tax.template">
-        <field name="description">PT11</field>
         <field name="chart_template_id" ref="l10n_ie"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Standard rate purchases (23%) (IE)</field>
@@ -372,7 +360,6 @@
     </record>
 
     <record id="l10n_ie_tax_st9" model="account.tax.template">
-        <field name="description">ST9</field>
         <field name="chart_template_id" ref="l10n_ie"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Lower rate sale (9%) (IE)</field>
@@ -403,7 +390,6 @@
     </record>
 
     <record id="l10n_ie_tax_pt6" model="account.tax.template">
-        <field name="description">PT6</field>
         <field name="chart_template_id" ref="l10n_ie"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Lower rate purchases (4.8%) (IE)</field>
@@ -434,7 +420,6 @@
     </record>
 
     <record id="l10n_ie_tax_st6" model="account.tax.template">
-        <field name="description">ST6</field>
         <field name="chart_template_id" ref="l10n_ie"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Lower rate sale (4.8%) (IE)</field>

--- a/addons/l10n_il/data/account_tax_template_data.xml
+++ b/addons/l10n_il/data/account_tax_template_data.xml
@@ -4,7 +4,6 @@
     <!-- Sales Taxes -->
     <record id="il_vat_sales_17" model="account.tax.template">
         <field name="sequence">1</field>
-        <field name="description">17%</field>
         <field name="name">VAT Sales</field>
         <field name="amount">17</field>
         <field name="amount_type">percent</field>
@@ -37,7 +36,6 @@
 
     <record id="il_vat_pa_sales_17" model="account.tax.template">
         <field name="sequence">8</field>
-        <field name="description">17%</field>
         <field name="name">VAT PA Sales</field>
         <field name="amount">17</field>
         <field name="amount_type">percent</field>
@@ -70,7 +68,6 @@
 
     <record id="il_vat_sales_exempt" model="account.tax.template">
         <field name="sequence">9</field>
-        <field name="description">0%</field>
         <field name="name">VAT exempt</field>
         <field name="price_include" eval="1"/>
         <field name="amount">0</field>
@@ -106,7 +103,6 @@
     <!-- Purchase Taxes -->
     <record id="il_vat_inputs_17" model="account.tax.template">
         <field name="sequence">2</field>
-        <field name="description">17%</field>
         <field name="name">VAT inputs</field>
         <field name="amount">17</field>
         <field name="amount_type">percent</field>
@@ -139,7 +135,6 @@
 
     <record id="il_vat_pa_purchase_16" model="account.tax.template">
         <field name="sequence">3</field>
-        <field name="description">16%</field>
         <field name="name">VAT 16% (PA)</field>
         <field name="amount">16</field>
         <field name="amount_type">percent</field>
@@ -172,7 +167,6 @@
 
     <record id="il_vat_inputs_2_3_17" model="account.tax.template">
         <field name="sequence">4</field>
-        <field name="description">17%</field>
         <field name="name">VAT Inputs 2/3</field>
         <field name="price_include" eval="1"/>
         <field name="amount">9.6866</field>
@@ -206,7 +200,6 @@
 
     <record id="il_vat_inputs_1_4_17" model="account.tax.template">
         <field name="sequence">5</field>
-        <field name="description">17%</field>
         <field name="name">VAT Inputs 1/4</field>
         <field name="price_include" eval="1"/>
         <field name="amount">3.6325</field>
@@ -240,7 +233,6 @@
 
     <record id="il_vat_inputs_fa_17" model="account.tax.template">
         <field name="sequence">6</field>
-        <field name="description">17%</field>
         <field name="name">VAT inputs for fixed assets</field>
         <field name="amount">17</field>
         <field name="amount_type">percent</field>
@@ -273,7 +265,6 @@
 
     <record id="il_vat_purchase_exempt" model="account.tax.template">
         <field name="sequence">7</field>
-        <field name="description">0%</field>
         <field name="name">VAT exempt</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>

--- a/addons/l10n_in/data/account_tax_template_data.xml
+++ b/addons/l10n_in/data/account_tax_template_data.xml
@@ -80,7 +80,6 @@
 
     <record id="cess_sale_5" model="account.tax.template">
         <field name="name">CESS Sale 5%</field>
-        <field name="description">CESS 5%</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">percent</field>
         <field name="amount">5</field>
@@ -116,7 +115,6 @@
 
     <record id="cess_sale_1591" model="account.tax.template">
         <field name="name">CESS Sale 1591 Per Thousand</field>
-        <field name="description">1591 PER THOUSAND</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">fixed</field>
         <field name="amount">1.591</field>
@@ -152,7 +150,6 @@
 
     <record id="cess_5_plus_1591_sale" model="account.tax.template">
         <field name="name">CESS 5% + RS.1591/THOUSAND</field>
-        <field name="description">CESS 5% + RS.1591/THOUSAND</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">group</field>
         <field name="amount">0</field>
@@ -163,7 +160,6 @@
 
     <record id="cess_21_4170_higer_sale" model="account.tax.template">
         <field name="name">CESS 21% or RS.4170/THOUSAND</field>
-        <field name="description">CESS 21% or RS.4170/THOUSAND</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">code</field>
         <field name="amount">0</field>
@@ -204,7 +200,6 @@ if tax > result:result=tax</field>
 
     <record id="exempt_sale" model="account.tax.template">
         <field name="name">Exempt Sale</field>
-        <field name="description">Exempt</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
@@ -241,7 +236,6 @@ if tax > result:result=tax</field>
 
     <record id="nil_rated_sale" model="account.tax.template">
         <field name="name">Nil Rated</field>
-        <field name="description">Nil Rated</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
@@ -278,7 +272,6 @@ if tax > result:result=tax</field>
 
     <record id="igst_sale_0" model="account.tax.template">
         <field name="name">IGST 0%</field>
-        <field name="description">IGST 0%</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
@@ -312,7 +305,6 @@ if tax > result:result=tax</field>
 
     <record id="igst_sale_1" model="account.tax.template">
         <field name="name">IGST 1%</field>
-        <field name="description">IGST 1%</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">percent</field>
         <field name="amount">1</field>
@@ -348,7 +340,6 @@ if tax > result:result=tax</field>
 
     <record id="igst_sale_2" model="account.tax.template">
         <field name="name">IGST 2%</field>
-        <field name="description">IGST 2%</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">percent</field>
         <field name="amount">2</field>
@@ -384,7 +375,6 @@ if tax > result:result=tax</field>
 
     <record id="igst_sale_28" model="account.tax.template">
         <field name="name">IGST 28%</field>
-        <field name="description">IGST 28%</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">percent</field>
         <field name="amount">28</field>
@@ -420,7 +410,6 @@ if tax > result:result=tax</field>
 
     <record id="igst_sale_18" model="account.tax.template">
         <field name="name">IGST 18%</field>
-        <field name="description">IGST 18%</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">percent</field>
         <field name="amount">18</field>
@@ -456,7 +445,6 @@ if tax > result:result=tax</field>
 
     <record id="igst_sale_12" model="account.tax.template">
         <field name="name">IGST 12%</field>
-        <field name="description">IGST 12%</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">percent</field>
         <field name="amount">12</field>
@@ -492,7 +480,6 @@ if tax > result:result=tax</field>
 
     <record id="igst_sale_5" model="account.tax.template">
         <field name="name">IGST 5%</field>
-        <field name="description">IGST 5%</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">percent</field>
         <field name="amount">5</field>
@@ -530,7 +517,6 @@ if tax > result:result=tax</field>
 
     <record id="sgst_sale_0_5" model="account.tax.template">
         <field name="name">SGST Sale 0.5%</field>
-        <field name="description">SGST 0.5%</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">percent</field>
         <field name="amount">0.5</field>
@@ -566,7 +552,6 @@ if tax > result:result=tax</field>
 
     <record id="cgst_sale_0_5" model="account.tax.template">
         <field name="name">CGST Sale 0.5%</field>
-        <field name="description">CGST 0.5%</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">percent</field>
         <field name="amount">0.5</field>
@@ -600,7 +585,6 @@ if tax > result:result=tax</field>
 
     <record id="sgst_sale_1" model="account.tax.template">
         <field name="name">GST 1%</field>
-        <field name="description">GST 1%</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">group</field>
         <field name="amount">1.0</field>
@@ -611,7 +595,6 @@ if tax > result:result=tax</field>
 
     <record id="sgst_sale_1_2" model="account.tax.template">
         <field name="name">SGST Sale 1%</field>
-        <field name="description">SGST 1%</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">percent</field>
         <field name="amount">1</field>
@@ -647,7 +630,6 @@ if tax > result:result=tax</field>
 
     <record id="cgst_sale_1_2" model="account.tax.template">
         <field name="name">CGST Sale 1%</field>
-        <field name="description">CGST 1%</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">percent</field>
         <field name="amount">1</field>
@@ -681,7 +663,6 @@ if tax > result:result=tax</field>
 
     <record id="sgst_sale_2" model="account.tax.template">
         <field name="name">GST 2%</field>
-        <field name="description">GST 2%</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">group</field>
         <field name="amount">2.0</field>
@@ -692,7 +673,6 @@ if tax > result:result=tax</field>
 
     <record id="sgst_sale_14" model="account.tax.template">
         <field name="name">SGST Sale 14%</field>
-        <field name="description">SGST 14%</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">percent</field>
         <field name="amount">14</field>
@@ -728,7 +708,6 @@ if tax > result:result=tax</field>
 
     <record id="cgst_sale_14" model="account.tax.template">
         <field name="name">CGST Sale 14%</field>
-        <field name="description">CGST 14%</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">percent</field>
         <field name="amount">14</field>
@@ -762,7 +741,6 @@ if tax > result:result=tax</field>
 
     <record id="sgst_sale_28" model="account.tax.template">
         <field name="name">GST 28%</field>
-        <field name="description">GST 28%</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">group</field>
         <field name="amount">28.0</field>
@@ -773,7 +751,6 @@ if tax > result:result=tax</field>
 
     <record id="sgst_sale_9" model="account.tax.template">
         <field name="name">SGST Sale 9%</field>
-        <field name="description">SGST 9%</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">percent</field>
         <field name="amount">9</field>
@@ -809,7 +786,6 @@ if tax > result:result=tax</field>
 
     <record id="cgst_sale_9" model="account.tax.template">
         <field name="name">CGST Sale 9%</field>
-        <field name="description">CGST 9%</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">percent</field>
         <field name="amount">9</field>
@@ -843,7 +819,6 @@ if tax > result:result=tax</field>
 
     <record id="sgst_sale_18" model="account.tax.template">
         <field name="name">GST 18%</field>
-        <field name="description">GST 18%</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">group</field>
         <field name="amount">18.0</field>
@@ -854,7 +829,6 @@ if tax > result:result=tax</field>
 
      <record id="sgst_sale_6" model="account.tax.template">
         <field name="name">SGST Sale 6%</field>
-        <field name="description">SGST 6%</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">percent</field>
         <field name="amount">6</field>
@@ -888,7 +862,6 @@ if tax > result:result=tax</field>
 
     <record id="cgst_sale_6" model="account.tax.template">
         <field name="name">CGST Sale 6%</field>
-        <field name="description">CGST 6%</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">percent</field>
         <field name="amount">6</field>
@@ -922,7 +895,6 @@ if tax > result:result=tax</field>
 
     <record id="sgst_sale_12" model="account.tax.template">
         <field name="name">GST 12%</field>
-        <field name="description">GST 12%</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">group</field>
         <field name="amount">12.0</field>
@@ -933,7 +905,6 @@ if tax > result:result=tax</field>
 
     <record id="sgst_sale_2_5" model="account.tax.template">
         <field name="name">SGST Sale 2.5%</field>
-        <field name="description">SGST 2.5%</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">percent</field>
         <field name="amount">2.5</field>
@@ -969,7 +940,6 @@ if tax > result:result=tax</field>
 
     <record id="cgst_sale_2_5" model="account.tax.template">
         <field name="name">CGST Sale 2.5%</field>
-        <field name="description">CGST 2.5%</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">percent</field>
         <field name="amount">2.5</field>
@@ -1003,7 +973,6 @@ if tax > result:result=tax</field>
 
     <record id="sgst_sale_5" model="account.tax.template">
         <field name="name">GST 5%</field>
-        <field name="description">GST 5%</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">group</field>
         <field name="amount">5.0</field>
@@ -1019,7 +988,6 @@ if tax > result:result=tax</field>
 
     <record id="cess_purchase_5" model="account.tax.template">
         <field name="name">CESS Purchase 5%</field>
-        <field name="description">CESS 5%</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">percent</field>
         <field name="amount">5</field>
@@ -1055,7 +1023,6 @@ if tax > result:result=tax</field>
 
     <record id="cess_purchase_1591" model="account.tax.template">
         <field name="name">CESS Purchase 1591 Per Thousand</field>
-        <field name="description">1591 PER THOUSAND</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">fixed</field>
         <field name="amount">1.591</field>
@@ -1091,7 +1058,6 @@ if tax > result:result=tax</field>
 
     <record id="cess_5_plus_1591_purchase" model="account.tax.template">
         <field name="name">CESS 5% + RS.1591/THOUSAND</field>
-        <field name="description">CESS 5% + RS.1591/THOUSAND</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">group</field>
         <field name="amount">0</field>
@@ -1102,7 +1068,6 @@ if tax > result:result=tax</field>
 
     <record id="cess_21_4170_higer_purchase" model="account.tax.template">
         <field name="name">CESS 21% or RS.4170/THOUSAND</field>
-        <field name="description">CESS 21% or RS.4170/THOUSAND</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">code</field>
         <field name="amount">0</field>
@@ -1143,7 +1108,6 @@ if tax > result:result=tax</field>
 
     <record id="exempt_purchase" model="account.tax.template">
         <field name="name">Exempt purchase</field>
-        <field name="description">Exempt</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
@@ -1178,7 +1142,6 @@ if tax > result:result=tax</field>
 
     <record id="nil_rated_purchase" model="account.tax.template">
         <field name="name">Nil Rated</field>
-        <field name="description">Nil Rat</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
@@ -1215,7 +1178,6 @@ if tax > result:result=tax</field>
 
     <record id="igst_purchase_0" model="account.tax.template">
         <field name="name">IGST 0%</field>
-        <field name="description">IGST 0%</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
@@ -1249,7 +1211,6 @@ if tax > result:result=tax</field>
 
     <record id="igst_purchase_1" model="account.tax.template">
         <field name="name">IGST 1%</field>
-        <field name="description">IGST 1%</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
         <field name="amount">1</field>
@@ -1285,7 +1246,6 @@ if tax > result:result=tax</field>
 
     <record id="igst_purchase_2" model="account.tax.template">
         <field name="name">IGST 2%</field>
-        <field name="description">IGST 2%</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
         <field name="amount">2</field>
@@ -1321,7 +1281,6 @@ if tax > result:result=tax</field>
 
     <record id="igst_purchase_28" model="account.tax.template">
         <field name="name">IGST 28%</field>
-        <field name="description">IGST 28%</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
         <field name="amount">28</field>
@@ -1357,7 +1316,6 @@ if tax > result:result=tax</field>
 
     <record id="igst_purchase_18" model="account.tax.template">
         <field name="name">IGST 18%</field>
-        <field name="description">IGST 18%</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
         <field name="amount">18</field>
@@ -1393,7 +1351,6 @@ if tax > result:result=tax</field>
 
     <record id="igst_purchase_12" model="account.tax.template">
         <field name="name">IGST 12%</field>
-        <field name="description">IGST 12%</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
         <field name="amount">12</field>
@@ -1429,7 +1386,6 @@ if tax > result:result=tax</field>
 
     <record id="igst_purchase_5" model="account.tax.template">
         <field name="name">IGST 5%</field>
-        <field name="description">IGST 5%</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
         <field name="amount">5</field>
@@ -1467,7 +1423,6 @@ if tax > result:result=tax</field>
 
     <record id="sgst_purchase_0_5" model="account.tax.template">
         <field name="name">SGST Purchase 0.5%</field>
-        <field name="description">SGST 0.5%</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">percent</field>
         <field name="amount">0.5</field>
@@ -1501,7 +1456,6 @@ if tax > result:result=tax</field>
 
     <record id="cgst_purchase_0_5" model="account.tax.template">
         <field name="name">CGST Purchase 0.5%</field>
-        <field name="description">CGST 0.5%</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">percent</field>
         <field name="amount">0.5</field>
@@ -1535,7 +1489,6 @@ if tax > result:result=tax</field>
 
     <record id="sgst_purchase_1" model="account.tax.template">
         <field name="name">GST 1%</field>
-        <field name="description">GST 1%</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">group</field>
         <field name="amount">1.0</field>
@@ -1546,7 +1499,6 @@ if tax > result:result=tax</field>
 
     <record id="sgst_purchase_1_2" model="account.tax.template">
         <field name="name">SGST Purchase 1%</field>
-        <field name="description">SGST 1%</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">percent</field>
         <field name="amount">1</field>
@@ -1582,7 +1534,6 @@ if tax > result:result=tax</field>
 
     <record id="cgst_purchase_1_2" model="account.tax.template">
         <field name="name">CGST Purchase 1%</field>
-        <field name="description">CGST 1%</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">percent</field>
         <field name="amount">1</field>
@@ -1617,7 +1568,6 @@ if tax > result:result=tax</field>
 
     <record id="sgst_purchase_2" model="account.tax.template">
         <field name="name">GST 2%</field>
-        <field name="description">GST 2%</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">group</field>
         <field name="amount">2.0</field>
@@ -1628,7 +1578,6 @@ if tax > result:result=tax</field>
 
     <record id="sgst_purchase_14" model="account.tax.template">
         <field name="name">SGST Purchase 14%</field>
-        <field name="description">SGST 14%</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">percent</field>
         <field name="amount">14</field>
@@ -1662,7 +1611,6 @@ if tax > result:result=tax</field>
 
     <record id="cgst_purchase_14" model="account.tax.template">
         <field name="name">CGST Purchase 14%</field>
-        <field name="description">CGST 14%</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">percent</field>
         <field name="amount">14</field>
@@ -1696,7 +1644,6 @@ if tax > result:result=tax</field>
 
     <record id="sgst_purchase_28" model="account.tax.template">
         <field name="name">GST 28%</field>
-        <field name="description">GST 28%</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">group</field>
         <field name="amount">28.0</field>
@@ -1707,7 +1654,6 @@ if tax > result:result=tax</field>
 
     <record id="sgst_purchase_9" model="account.tax.template">
         <field name="name">SGST Purchase 9%</field>
-        <field name="description">SGST 9%</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">percent</field>
         <field name="amount">9</field>
@@ -1743,7 +1689,6 @@ if tax > result:result=tax</field>
 
     <record id="cgst_purchase_9" model="account.tax.template">
         <field name="name">CGST Purchase 9%</field>
-        <field name="description">CGST 9%</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">percent</field>
         <field name="amount">9</field>
@@ -1777,7 +1722,6 @@ if tax > result:result=tax</field>
 
     <record id="sgst_purchase_18" model="account.tax.template">
         <field name="name">GST 18%</field>
-        <field name="description">GST 18%</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">group</field>
         <field name="amount">18.0</field>
@@ -1788,7 +1732,6 @@ if tax > result:result=tax</field>
 
     <record id="sgst_purchase_6" model="account.tax.template">
         <field name="name">SGST Purchase 6%</field>
-        <field name="description">SGST 6%</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">percent</field>
         <field name="amount">6</field>
@@ -1824,7 +1767,6 @@ if tax > result:result=tax</field>
 
     <record id="cgst_purchase_6" model="account.tax.template">
         <field name="name">CGST Purchase 6%</field>
-        <field name="description">CGST 6%</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">percent</field>
         <field name="amount">6</field>
@@ -1858,7 +1800,6 @@ if tax > result:result=tax</field>
 
     <record id="sgst_purchase_12" model="account.tax.template">
         <field name="name">GST 12%</field>
-        <field name="description">GST 12%</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">group</field>
         <field name="amount">12.0</field>
@@ -1869,7 +1810,6 @@ if tax > result:result=tax</field>
 
     <record id="sgst_purchase_2_5" model="account.tax.template">
         <field name="name">SGST Purchase 2.5%</field>
-        <field name="description">SGST 2.5%</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">percent</field>
         <field name="amount">2.5</field>
@@ -1905,7 +1845,6 @@ if tax > result:result=tax</field>
 
     <record id="cgst_purchase_2_5" model="account.tax.template">
         <field name="name">CGST Purchase 2.5%</field>
-        <field name="description">CGST 2.5%</field>
         <field name="type_tax_use">none</field>
         <field name="amount_type">percent</field>
         <field name="amount">2.5</field>
@@ -1939,7 +1878,6 @@ if tax > result:result=tax</field>
 
     <record id="sgst_purchase_5" model="account.tax.template">
         <field name="name">GST 5%</field>
-        <field name="description">GST 5%</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">group</field>
         <field name="amount">5.0</field>

--- a/addons/l10n_it/data/account_tax_template.xml
+++ b/addons/l10n_it/data/account_tax_template.xml
@@ -2,7 +2,6 @@
 <odoo>
 
     <record id="22v" model="account.tax.template">
-        <field name="description">22v</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 22% (debito)</field>
         <field name="sequence">1</field>
@@ -36,7 +35,6 @@
     </record>
 
     <record id="22a" model="account.tax.template">
-        <field name="description">22a</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 22% (credito)</field>
         <field name="sequence">2</field>
@@ -70,7 +68,6 @@
     </record>
 
     <record id="21v" model="account.tax.template">
-        <field name="description">21v</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 21% (debito)</field>
         <field name="sequence">3</field>
@@ -104,7 +101,6 @@
     </record>
 
     <record id="21a" model="account.tax.template">
-        <field name="description">21a</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 21% (credito)</field>
         <field name="sequence">4</field>
@@ -138,7 +134,6 @@
     </record>
 
     <record id="20v" model="account.tax.template">
-        <field name="description">20v</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 20% (debito)</field>
         <field name="sequence">3</field>
@@ -172,7 +167,6 @@
     </record>
 
     <record id="20a" model="account.tax.template">
-        <field name="description">20a</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 20% (credito)</field>
         <field name="sequence">4</field>
@@ -206,7 +200,6 @@
     </record>
 
     <record id="5v" model="account.tax.template">
-        <field name="description">5v</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 5% (debito)</field>
         <field name="sequence">5</field>
@@ -240,7 +233,6 @@
     </record>
 
      <record id="5a" model="account.tax.template">
-        <field name="description">5a</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 5% (credito)</field>
         <field name="sequence">6</field>
@@ -274,7 +266,6 @@
     </record>
 
     <record id="10v" model="account.tax.template">
-        <field name="description">10v</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 10% (debito)</field>
         <field name="sequence">5</field>
@@ -308,7 +299,6 @@
     </record>
 
     <record id="10a" model="account.tax.template">
-        <field name="description">10a</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 10% (credito)</field>
         <field name="sequence">6</field>
@@ -342,7 +332,6 @@
     </record>
 
     <record id="10AO" model="account.tax.template">
-        <field name="description">10AO</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 10% indetraibile</field>
         <field name="sequence">7</field>
@@ -374,7 +363,6 @@
     </record>
 
     <record id="12v" model="account.tax.template">
-        <field name="description">12v</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva 12% (debito)</field>
         <field name="sequence">8</field>
@@ -408,7 +396,6 @@
     </record>
 
     <record id="12a" model="account.tax.template">
-        <field name="description">12a</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva 12% (credito)</field>
         <field name="sequence">9</field>
@@ -442,7 +429,6 @@
     </record>
 
     <record id="2010" model="account.tax.template">
-        <field name="description">2010</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 20% detraibile 10%</field>
         <field name="sequence">10</field>
@@ -484,7 +470,6 @@
     </record>
 
     <record id="2015" model="account.tax.template">
-        <field name="description">2015</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 20% detraibile 15%</field>
         <field name="sequence">11</field>
@@ -526,7 +511,6 @@
     </record>
 
     <record id="2040" model="account.tax.template">
-        <field name="description">2040</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 20% detraibile 40%</field>
         <field name="sequence">12</field>
@@ -568,7 +552,6 @@
     </record>
 
     <record id="20AO" model="account.tax.template">
-        <field name="description">20AO</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 20% indetraibile</field>
         <field name="sequence">13</field>
@@ -600,7 +583,6 @@
     </record>
 
     <record id="20I5" model="account.tax.template">
-        <field name="description">20I5</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">IVA al 20% detraibile al 50%</field>
         <field name="sequence">14</field>
@@ -642,7 +624,6 @@
     </record>
 
     <record id="2v" model="account.tax.template">
-        <field name="description">2v</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva 2% (debito)</field>
         <field name="sequence">15</field>
@@ -676,7 +657,6 @@
     </record>
 
     <record id="2a" model="account.tax.template">
-        <field name="description">2a</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva 2% (credito)</field>
         <field name="sequence">16</field>
@@ -710,7 +690,6 @@
     </record>
 
     <record id="4v" model="account.tax.template">
-        <field name="description">4v</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva 4% (debito)</field>
         <field name="sequence">17</field>
@@ -744,7 +723,6 @@
     </record>
 
     <record id="4a" model="account.tax.template">
-        <field name="description">4a</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva 4% (credito)</field>
         <field name="sequence">18</field>
@@ -778,7 +756,6 @@
     </record>
 
     <record id="4AO" model="account.tax.template">
-        <field name="description">4AO</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 4% indetraibile</field>
         <field name="sequence">19</field>
@@ -810,7 +787,6 @@
     </record>
 
     <record id="10I5" model="account.tax.template">
-        <field name="description">10I5</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">IVA al 10% detraibile al 50%</field>
         <field name="sequence">20</field>
@@ -852,7 +828,6 @@
     </record>
 
     <record id="4I5" model="account.tax.template">
-        <field name="description">4I5</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">IVA al 4% detraibile al 50%</field>
         <field name="sequence">21</field>
@@ -894,7 +869,6 @@
     </record>
 
     <record id="00v" model="account.tax.template">
-        <field name="description">00v</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Fuori Campo IVA (debito)</field>
         <field name="sequence">22</field>
@@ -926,7 +900,6 @@
     </record>
 
     <record id="00a" model="account.tax.template">
-        <field name="description">00a</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Fuori Campo IVA (credito)</field>
         <field name="sequence">23</field>
@@ -958,7 +931,6 @@
     </record>
 
     <record id="00art15v" model="account.tax.template">
-        <field name="description">00art15v</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Imponibile Escluso Art.15 (debito)</field>
         <field name="sequence">22</field>
@@ -990,7 +962,6 @@
     </record>
 
     <record id="00art15a" model="account.tax.template">
-        <field name="description">00art15a</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Imponibile Escluso Art.15 (credito)</field>
         <field name="sequence">23</field>
@@ -1022,7 +993,6 @@
     </record>
 
     <record id="22v_INC" model="account.tax.template">
-        <field name="description">22v INC</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 22% (debito) INC</field>
         <field name="sequence">24</field>
@@ -1056,7 +1026,6 @@
     </record>
 
     <record id="21v_INC" model="account.tax.template">
-        <field name="description">21v INC</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 21% (debito) INC</field>
         <field name="sequence">25</field>
@@ -1090,7 +1059,6 @@
     </record>
 
     <record id="20v_INC" model="account.tax.template">
-        <field name="description">20v INC</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 20% (debito) INC</field>
         <field name="sequence">25</field>
@@ -1124,7 +1092,6 @@
     </record>
 
     <record id="10v_INC" model="account.tax.template">
-        <field name="description">10v INC</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 10% (debito) INC</field>
         <field name="sequence">26</field>
@@ -1158,7 +1125,6 @@
     </record>
 
     <record id="12v_INC" model="account.tax.template">
-        <field name="description">12v INC</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva 12% (debito) INC</field>
         <field name="sequence">27</field>
@@ -1192,7 +1158,6 @@
     </record>
 
     <record id="2v_INC" model="account.tax.template">
-        <field name="description">2v INC</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva 2% (debito) INC</field>
         <field name="sequence">28</field>
@@ -1226,7 +1191,6 @@
     </record>
 
     <record id="4v_INC" model="account.tax.template">
-        <field name="description">4v INC</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva 4% (debito) INC</field>
         <field name="sequence">29</field>
@@ -1260,7 +1224,6 @@
     </record>
 
     <record id="00v_INC" model="account.tax.template">
-        <field name="description">00v INC</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Fuori Campo IVA (debito) INC</field>
         <field name="sequence">30</field>
@@ -1292,7 +1255,6 @@
     </record>
 
     <record id="2110" model="account.tax.template">
-        <field name="description">2110</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 21% detraibile 10%</field>
         <field name="sequence">31</field>
@@ -1334,7 +1296,6 @@
     </record>
 
     <record id="2115" model="account.tax.template">
-        <field name="description">2115</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 21% detraibile 15%</field>
         <field name="sequence">32</field>
@@ -1376,7 +1337,6 @@
     </record>
 
     <record id="2140" model="account.tax.template">
-        <field name="description">2140</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 21% detraibile 40%</field>
         <field name="sequence">33</field>
@@ -1418,7 +1378,6 @@
     </record>
 
     <record id="21AO" model="account.tax.template">
-        <field name="description">21AO</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 21% indetraibile</field>
         <field name="sequence">34</field>
@@ -1450,7 +1409,6 @@
     </record>
 
     <record id="21I5" model="account.tax.template">
-        <field name="description">21I5</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">IVA al 21% detraibile al 50%</field>
         <field name="sequence">35</field>
@@ -1492,7 +1450,6 @@
     </record>
 
     <record id="2210" model="account.tax.template">
-        <field name="description">2210</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 22% detraibile 10%</field>
         <field name="sequence">31</field>
@@ -1534,7 +1491,6 @@
     </record>
 
     <record id="2215" model="account.tax.template">
-        <field name="description">2215</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 22% detraibile 15%</field>
         <field name="sequence">32</field>
@@ -1576,7 +1532,6 @@
     </record>
 
     <record id="2240" model="account.tax.template">
-        <field name="description">2240</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 22% detraibile 40%</field>
         <field name="sequence">33</field>
@@ -1618,7 +1573,6 @@
     </record>
 
     <record id="22AO" model="account.tax.template">
-        <field name="description">22AO</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">Iva al 22% indetraibile</field>
         <field name="sequence">34</field>
@@ -1650,7 +1604,6 @@
     </record>
 
     <record id="22I5" model="account.tax.template">
-        <field name="description">22I5</field>
         <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
         <field name="name">IVA al 22% detraibile al 50%</field>
         <field name="sequence">35</field>

--- a/addons/l10n_jp/data/account_tax_template_data.xml
+++ b/addons/l10n_jp/data/account_tax_template_data.xml
@@ -5,7 +5,6 @@
         <field name="sequence">1</field>
         <field name="chart_template_id" ref="l10n_jp1"/>
         <field name="name">仮受消費税(外) 8%</field>
-        <field name="description">仮受消費税(外) 8%</field>
         <field name="amount_type">percent</field>
         <field name="amount">8</field>
         <field name="type_tax_use">sale</field>
@@ -43,7 +42,6 @@
         <field name="sequence">1</field>
         <field name="chart_template_id" ref="l10n_jp1"/>
         <field name="name">仮受消費税(外) 10%</field>
-        <field name="description">仮受消費税(外) 10%</field>
         <field name="amount_type">percent</field>
         <field name="amount">10</field>
         <field name="type_tax_use">sale</field>
@@ -81,7 +79,6 @@
         <field name="sequence">1</field>
         <field name="chart_template_id" ref="l10n_jp1"/>
         <field name="name">仮受消費税(内) 8%</field>
-        <field name="description">仮受消費税(内) 8%</field>
         <field name="amount_type">percent</field>
         <field name="amount">8</field>
         <field name="type_tax_use">sale</field>
@@ -119,7 +116,6 @@
         <field name="sequence">1</field>
         <field name="chart_template_id" ref="l10n_jp1"/>
         <field name="name">仮受消費税(内) 10%</field>
-        <field name="description">仮受消費税(内) 10%</field>
         <field name="amount_type">percent</field>
         <field name="amount">10</field>
         <field name="type_tax_use">sale</field>
@@ -157,7 +153,6 @@
         <field name="sequence">1</field>
         <field name="chart_template_id" ref="l10n_jp1"/>
         <field name="name">輸出免税</field>
-        <field name="description">輸出免税</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
         <field name="type_tax_use">sale</field>
@@ -191,7 +186,6 @@
         <field name="sequence">1</field>
         <field name="chart_template_id" ref="l10n_jp1"/>
         <field name="name">非課税販売</field>
-        <field name="description">非課税販売</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
         <field name="type_tax_use">sale</field>
@@ -225,7 +219,6 @@
         <field name="sequence">1</field>
         <field name="chart_template_id" ref="l10n_jp1"/>
         <field name="name">仮払消費税(外) 8%</field>
-        <field name="description">仮払消費税(外) 8%</field>
         <field name="amount_type">percent</field>
         <field name="amount">8</field>
         <field name="type_tax_use">purchase</field>
@@ -263,7 +256,6 @@
         <field name="sequence">1</field>
         <field name="chart_template_id" ref="l10n_jp1"/>
         <field name="name">仮払消費税(外) 10%</field>
-        <field name="description">仮払消費税(外) 10%</field>
         <field name="amount_type">percent</field>
         <field name="amount">10</field>
         <field name="type_tax_use">purchase</field>
@@ -301,7 +293,6 @@
         <field name="sequence">1</field>
         <field name="chart_template_id" ref="l10n_jp1"/>
         <field name="name">仮払消費税(内) 8%</field>
-        <field name="description">仮払消費税(内) 8%</field>
         <field name="amount_type">percent</field>
         <field name="amount">8</field>
         <field name="type_tax_use">purchase</field>
@@ -339,7 +330,6 @@
         <field name="sequence">1</field>
         <field name="chart_template_id" ref="l10n_jp1"/>
         <field name="name">仮払消費税(内) 10%</field>
-        <field name="description">仮払消費税(内) 10%</field>
         <field name="amount_type">percent</field>
         <field name="amount">10</field>
         <field name="type_tax_use">purchase</field>
@@ -377,7 +367,6 @@
         <field name="sequence">1</field>
         <field name="chart_template_id" ref="l10n_jp1"/>
         <field name="name">海外仕入</field>
-        <field name="description">海外仕入</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
         <field name="type_tax_use">purchase</field>
@@ -411,7 +400,6 @@
         <field name="sequence">1</field>
         <field name="chart_template_id" ref="l10n_jp1"/>
         <field name="name">非課税購買</field>
-        <field name="description">非課税購買</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
         <field name="type_tax_use">purchase</field>

--- a/addons/l10n_lt/data/account_tax_template_data.xml
+++ b/addons/l10n_lt/data/account_tax_template_data.xml
@@ -38,7 +38,6 @@
     <record id="account_tax_template_sales_0_vat12" model="account.tax.template">
         <field name="tax_group_id" ref="tax_group_vat_0"/>
         <field name="name">Sale 0% (VAT12) export</field>
-        <field name="description">0% VAT</field>
         <field name="type_tax_use">sale</field>
         <field name="amount" eval="0.0"/>
         <field name="amount_type">percent</field>
@@ -72,7 +71,6 @@
     <record id="account_tax_template_sales_0_vat13" model="account.tax.template">
         <field name="tax_group_id" ref="tax_group_vat_0"/>
         <field name="name">Sale 0% (VAT13)</field>
-        <field name="description">0% VAT</field>
         <field name="type_tax_use">sale</field>
         <field name="amount" eval="0.0"/>
         <field name="amount_type">percent</field>
@@ -140,7 +138,6 @@
     <record id="account_tax_template_sales_5" model="account.tax.template">
         <field name="tax_group_id" ref="tax_group_vat_5"/>
         <field name="name">Sale 5% (VAT3)</field>
-        <field name="description">5% VAT</field>
         <field name="type_tax_use">sale</field>
         <field name="amount" eval="5.0"/>
         <field name="amount_type">percent</field>
@@ -175,7 +172,6 @@
     <record id="account_tax_template_sales_21" model="account.tax.template">
         <field name="tax_group_id" ref="tax_group_vat_21"/>
         <field name="name">Sale 21% (VAT1)</field>
-        <field name="description">21% VAT</field>
         <field name="type_tax_use">sale</field>
         <field name="amount" eval="21.0"/>
         <field name="amount_type">percent</field>
@@ -210,7 +206,6 @@
     <record id="account_tax_template_sales_reversed_21" model="account.tax.template">
         <field name="tax_group_id" ref="tax_group_vat_21"/>
         <field name="name">Reversed Sale 21% (VAT25)</field>
-        <field name="description">21% VAT</field>
         <field name="type_tax_use">sale</field>
         <field name="amount" eval="21.0"/>
         <field name="amount_type">group</field>
@@ -289,7 +284,6 @@
     <record id="account_tax_template_purchase_0_vat14" model="account.tax.template">
         <field name="tax_group_id" ref="tax_group_vat_0"/>
         <field name="name">Purchase 0% (VAT14) export, transportation</field>
-        <field name="description">0% VAT</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount" eval="0.0"/>
         <field name="amount_type">percent</field>
@@ -323,7 +317,6 @@
     <record id="account_tax_template_purchase_0" model="account.tax.template">
         <field name="tax_group_id" ref="tax_group_vat_0"/>
         <field name="name">Purchase 0% (VAT15)</field>
-        <field name="description">0% VAT</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount" eval="0.0"/>
         <field name="amount_type">percent</field>
@@ -424,7 +417,6 @@
     <record id="account_tax_template_purchase_5" model="account.tax.template">
         <field name="tax_group_id" ref="tax_group_vat_5"/>
         <field name="name">Purchase 5% (VAT3)</field>
-        <field name="description">5% VAT</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount" eval="5.0"/>
         <field name="amount_type">percent</field>
@@ -459,7 +451,6 @@
     <record id="account_tax_template_purchase_not_deductible_9" model="account.tax.template">
         <field name="tax_group_id" ref="tax_group_vat_9"/>
         <field name="name">Purchase 9% (VAT2) not deductible</field>
-        <field name="description">9% VAT</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount" eval="9.0"/>
         <field name="amount_type">percent</field>
@@ -493,7 +484,6 @@
     <record id="account_tax_template_purchase_9" model="account.tax.template">
         <field name="tax_group_id" ref="tax_group_vat_9"/>
         <field name="name">Purchase 9% (VAT2)</field>
-        <field name="description">9% VAT</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount" eval="9.0"/>
         <field name="amount_type">percent</field>
@@ -528,7 +518,6 @@
     <record id="account_tax_template_purchase_not_deductible_21" model="account.tax.template">
         <field name="tax_group_id" ref="tax_group_vat_21"/>
         <field name="name">Purchase 21% (VAT1) not deductible</field>
-        <field name="description">21% VAT</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount" eval="21.0"/>
         <field name="amount_type">percent</field>
@@ -562,7 +551,6 @@
     <record id="account_tax_template_purchase_21" model="account.tax.template">
         <field name="tax_group_id" ref="tax_group_vat_21"/>
         <field name="name">Purchase 21% (VAT1)</field>
-        <field name="description">21% VAT</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount" eval="21.0"/>
         <field name="amount_type">percent</field>
@@ -597,7 +585,6 @@
     <record id="account_tax_template_purchase_reversed_21" model="account.tax.template">
         <field name="tax_group_id" ref="tax_group_vat_21"/>
         <field name="name">Reversed Purchase 21% (VAT25)</field>
-        <field name="description">21% VAT</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount" eval="21.0"/>
         <field name="amount_type">group</field>
@@ -643,7 +630,6 @@
     <record id="account_tax_template_purchase_assumed_21_vat16" model="account.tax.template">
         <field name="tax_group_id" ref="tax_group_vat_21"/>
         <field name="name">Assumed Purchase 21% (VAT16) from EU</field>
-        <field name="description">Assumed 21% VAT</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount" eval="21"/>
         <field name="amount_type">group</field>
@@ -688,7 +674,6 @@
     <record id="account_tax_template_purchase_assumed_21_vat20" model="account.tax.template">
         <field name="tax_group_id" ref="tax_group_vat_21"/>
         <field name="name">Assumed Purchase 21% (VAT20)</field>
-        <field name="description">Assumed 21% VAT</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount" eval="21.0"/>
         <field name="amount_type">group</field>
@@ -733,7 +718,6 @@
     <record id="account_tax_template_purchase_assumed_21" model="account.tax.template">
         <field name="tax_group_id" ref="tax_group_vat_21"/>
         <field name="name">Assumed Purchase 21% (VAT21) Goods/Services</field>
-        <field name="description">Assumed 21% VAT</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount" eval="21.0"/>
         <field name="amount_type">group</field>

--- a/addons/l10n_lu/data/account_tax_template_2015.xml
+++ b/addons/l10n_lu/data/account_tax_template_2015.xml
@@ -1,7 +1,6 @@
 <odoo>
 	<record id="lu_2011_tax_AB-EC-0" model="account.tax.template">
 		<field name="sequence">171</field>
-        <field name="description">0%</field>
         <field name="name">EX-EC-P-G</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -34,7 +33,6 @@
 
 	<record id="lu_2015_tax_AB-EC-14" model="account.tax.template">
 		<field name="sequence">105</field>
-        <field name="description">14%</field>
         <field name="name">14-EC-P-G</field>
         <field name="amount">14</field>
         <field name="amount_type">percent</field>
@@ -83,7 +81,6 @@
 
 	<record id="lu_2015_tax_AB-EC-17" model="account.tax.template">
 		<field name="sequence">111</field>
-        <field name="description">17%</field>
         <field name="name">17-EC-P-G</field>
         <field name="amount">17</field>
         <field name="amount_type">percent</field>
@@ -132,7 +129,6 @@
 
 	<record id="lu_2011_tax_AB-EC-3" model="account.tax.template">
 		<field name="sequence">114</field>
-        <field name="description">3%</field>
         <field name="name">3-EC-P-G</field>
         <field name="amount">3</field>
         <field name="amount_type">percent</field>
@@ -181,7 +177,6 @@
 
 	<record id="lu_2015_tax_AB-EC-8" model="account.tax.template">
 		<field name="sequence">120</field>
-        <field name="description">8%</field>
         <field name="name">8-EC-P-G</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
@@ -230,7 +225,6 @@
 
 	<record id="lu_2015_tax_AB-ECP-0" model="account.tax.template">
 		<field name="sequence">123</field>
-        <field name="description">0%</field>
         <field name="name">EX-EC(P)-P-G</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -263,7 +257,6 @@
 
 	<record id="lu_2015_tax_AB-ECP-14" model="account.tax.template">
 		<field name="sequence">127</field>
-        <field name="description">14%</field>
         <field name="name">14-EC(P)-P-G</field>
         <field name="amount">14</field>
         <field name="amount_type">percent</field>
@@ -312,7 +305,6 @@
 
 	<record id="lu_2015_tax_AB-ECP-17" model="account.tax.template">
 		<field name="sequence">133</field>
-        <field name="description">17%</field>
         <field name="name">17-EC(P)-P-G</field>
         <field name="amount">17</field>
         <field name="amount_type">percent</field>
@@ -361,7 +353,6 @@
 
 	<record id="lu_2015_tax_AB-ECP-3" model="account.tax.template">
 		<field name="sequence">136</field>
-        <field name="description">3%</field>
         <field name="name">3-EC(P)-P-G</field>
         <field name="amount">3</field>
         <field name="amount_type">percent</field>
@@ -410,7 +401,6 @@
 
 	<record id="lu_2015_tax_AB-ECP-8" model="account.tax.template">
 		<field name="sequence">142</field>
-        <field name="description">8%</field>
         <field name="name">8-EC(P)-P-G</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
@@ -459,7 +449,6 @@
 
 	<record id="lu_2011_tax_AB-IC-0" model="account.tax.template">
 		<field name="sequence">145</field>
-        <field name="description">0%</field>
         <field name="name">EX-IC-P-G</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -492,7 +481,6 @@
 
 	<record id="lu_2015_tax_AB-IC-14" model="account.tax.template">
 		<field name="sequence">149</field>
-        <field name="description">14%</field>
         <field name="name">14-IC-P-G</field>
         <field name="amount">14</field>
         <field name="amount_type">percent</field>
@@ -541,7 +529,6 @@
 
 	<record id="lu_2015_tax_AB-IC-17" model="account.tax.template">
 		<field name="sequence">155</field>
-        <field name="description">17%</field>
         <field name="name">17-IC-P-G</field>
         <field name="amount">17</field>
         <field name="amount_type">percent</field>
@@ -590,7 +577,6 @@
 
 	<record id="lu_2011_tax_AB-IC-3" model="account.tax.template">
 		<field name="sequence">158</field>
-        <field name="description">3%</field>
         <field name="name">3-IC-P-G</field>
         <field name="amount">3</field>
         <field name="amount_type">percent</field>
@@ -639,7 +625,6 @@
 
 	<record id="lu_2015_tax_AB-IC-8" model="account.tax.template">
 		<field name="sequence">164</field>
-        <field name="description">8%</field>
         <field name="name">8-IC-P-G</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
@@ -688,7 +673,6 @@
 
 	<record id="lu_2011_tax_AB-PA-0" model="account.tax.template">
 		<field name="sequence">167</field>
-        <field name="description">0%</field>
         <field name="name">0-P-G</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -719,7 +703,6 @@
 
 	<record id="lu_2015_tax_AB-PA-14" model="account.tax.template">
 		<field name="sequence">169</field>
-        <field name="description">14%</field>
         <field name="name">14-P-G</field>
         <field name="amount">14</field>
         <field name="amount_type">percent</field>
@@ -754,7 +737,6 @@
 
 	<record id="lu_2015_tax_AB-PA-17" model="account.tax.template">
 		<field name="sequence">101</field>
-        <field name="description">17%</field>
         <field name="name">17-P-G</field>
         <field name="amount">17</field>
         <field name="amount_type">percent</field>
@@ -790,7 +772,6 @@
 
 	<record id="lu_2011_tax_AB-PA-3" model="account.tax.template">
 		<field name="sequence">172</field>
-        <field name="description">3%</field>
         <field name="name">3-P-G</field>
         <field name="amount">3</field>
         <field name="amount_type">percent</field>
@@ -825,7 +806,6 @@
 
 	<record id="lu_2015_tax_AB-PA-8" model="account.tax.template">
 		<field name="sequence">174</field>
-        <field name="description">8%</field>
         <field name="name">8-P-G</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
@@ -860,7 +840,6 @@
 
 	<record id="lu_2011_tax_AP-EC-0" model="account.tax.template">
 		<field name="sequence">175</field>
-        <field name="description">0%</field>
         <field name="name">EX-EC-P-S</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -893,7 +872,6 @@
 
 	<record id="lu_2015_tax_AP-EC-14" model="account.tax.template">
 		<field name="sequence">179</field>
-        <field name="description">14%</field>
         <field name="name">14-EC-P-S</field>
         <field name="amount">14</field>
         <field name="amount_type">percent</field>
@@ -942,7 +920,6 @@
 
 	<record id="lu_2015_tax_AP-EC-17" model="account.tax.template">
 		<field name="sequence">185</field>
-        <field name="description">17%</field>
         <field name="name">17-EC-P-S</field>
         <field name="amount">17</field>
         <field name="amount_type">percent</field>
@@ -991,7 +968,6 @@
 
 	<record id="lu_2011_tax_AP-EC-3" model="account.tax.template">
 		<field name="sequence">188</field>
-        <field name="description">3%</field>
         <field name="name">3-EC-P-S</field>
         <field name="amount">3</field>
         <field name="amount_type">percent</field>
@@ -1040,7 +1016,6 @@
 
 	<record id="lu_2015_tax_AP-EC-8" model="account.tax.template">
 		<field name="sequence">194</field>
-        <field name="description">8%</field>
         <field name="name">8-EC-P-S</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
@@ -1089,7 +1064,6 @@
 
 	<record id="lu_2011_tax_AP-IC-0" model="account.tax.template">
 		<field name="sequence">197</field>
-        <field name="description">0%</field>
         <field name="name">EX-IC-P-S</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -1122,7 +1096,6 @@
 
 	<record id="lu_2015_tax_AP-IC-14" model="account.tax.template">
 		<field name="sequence">201</field>
-        <field name="description">14%</field>
         <field name="name">14-IC-P-S</field>
         <field name="amount">14</field>
         <field name="amount_type">percent</field>
@@ -1171,7 +1144,6 @@
 
 	<record id="lu_2015_tax_AP-IC-17" model="account.tax.template">
 		<field name="sequence">207</field>
-        <field name="description">17%</field>
         <field name="name">17-IC-P-S</field>
         <field name="amount">17</field>
         <field name="amount_type">percent</field>
@@ -1220,7 +1192,6 @@
 
 	<record id="lu_2011_tax_AP-IC-3" model="account.tax.template">
 		<field name="sequence">210</field>
-        <field name="description">3%</field>
         <field name="name">3-IC-P-S</field>
         <field name="amount">3</field>
         <field name="amount_type">percent</field>
@@ -1269,7 +1240,6 @@
 
 	<record id="lu_2015_tax_AP-IC-8" model="account.tax.template">
 		<field name="sequence">216</field>
-        <field name="description">8%</field>
         <field name="name">8-IC-P-S</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
@@ -1318,7 +1288,6 @@
 
 	<record id="lu_2011_tax_AP-PA-0" model="account.tax.template">
 		<field name="sequence">219</field>
-        <field name="description">0%</field>
         <field name="name">0-P-S</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -1349,7 +1318,6 @@
 
 	<record id="lu_2015_tax_AP-PA-14" model="account.tax.template">
 		<field name="sequence">221</field>
-        <field name="description">14%</field>
         <field name="name">14-P-S</field>
         <field name="amount">14</field>
         <field name="amount_type">percent</field>
@@ -1384,7 +1352,6 @@
 
 	<record id="lu_2015_tax_AP-PA-17" model="account.tax.template">
 		<field name="sequence">223</field>
-        <field name="description">17%</field>
         <field name="name">17-P-S</field>
         <field name="amount">17</field>
         <field name="amount_type">percent</field>
@@ -1419,7 +1386,6 @@
 
 	<record id="lu_2011_tax_AP-PA-3" model="account.tax.template">
 		<field name="sequence">224</field>
-        <field name="description">3%</field>
         <field name="name">3-P-S</field>
         <field name="amount">3</field>
         <field name="amount_type">percent</field>
@@ -1454,7 +1420,6 @@
 
 	<record id="lu_2015_tax_AP-PA-8" model="account.tax.template">
 		<field name="sequence">226</field>
-        <field name="description">8%</field>
         <field name="name">8-P-S</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
@@ -1489,7 +1454,6 @@
 
 	<record id="lu_2011_tax_FB-EC-0" model="account.tax.template">
 		<field name="sequence">227</field>
-        <field name="description">0%</field>
         <field name="name">EX-EC-E-G</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -1523,7 +1487,6 @@
 
 	<record id="lu_2015_tax_FB-EC-14" model="account.tax.template">
 		<field name="sequence">231</field>
-        <field name="description">14%</field>
         <field name="name">14-EC-E-G</field>
         <field name="amount">14</field>
         <field name="amount_type">percent</field>
@@ -1573,7 +1536,6 @@
 
 	<record id="lu_2015_tax_FB-EC-17" model="account.tax.template">
 		<field name="sequence">237</field>
-        <field name="description">17%</field>
         <field name="name">17-EC-E-G</field>
         <field name="amount">17</field>
         <field name="amount_type">percent</field>
@@ -1623,7 +1585,6 @@
 
 	<record id="lu_2011_tax_FB-EC-3" model="account.tax.template">
 		<field name="sequence">240</field>
-        <field name="description">3%</field>
         <field name="name">3-EC-E-G</field>
         <field name="amount">3</field>
         <field name="amount_type">percent</field>
@@ -1673,7 +1634,6 @@
 
 	<record id="lu_2015_tax_FB-EC-8" model="account.tax.template">
 		<field name="sequence">246</field>
-        <field name="description">8%</field>
         <field name="name">8-EC-E-G</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
@@ -1723,7 +1683,6 @@
 
 	<record id="lu_2015_tax_FB-ECP-0" model="account.tax.template">
 		<field name="sequence">249</field>
-        <field name="description">0%</field>
         <field name="name">EX-EC(P)-E-G</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -1757,7 +1716,6 @@
 
 	<record id="lu_2015_tax_FB-ECP-14" model="account.tax.template">
 		<field name="sequence">253</field>
-        <field name="description">14%</field>
         <field name="name">14-EC(P)-E-G</field>
         <field name="amount">14</field>
         <field name="amount_type">percent</field>
@@ -1807,7 +1765,6 @@
 
 	<record id="lu_2015_tax_FB-ECP-17" model="account.tax.template">
 		<field name="sequence">259</field>
-        <field name="description">17%</field>
         <field name="name">17-EC(P)-E-G</field>
         <field name="amount">17</field>
         <field name="amount_type">percent</field>
@@ -1857,7 +1814,6 @@
 
 	<record id="lu_2015_tax_FB-ECP-3" model="account.tax.template">
 		<field name="sequence">262</field>
-        <field name="description">3%</field>
         <field name="name">3-EC(P)-E-G</field>
         <field name="amount">3</field>
         <field name="amount_type">percent</field>
@@ -1907,7 +1863,6 @@
 
 	<record id="lu_2015_tax_FB-ECP-8" model="account.tax.template">
 		<field name="sequence">268</field>
-        <field name="description">8%</field>
         <field name="name">8-EC(P)-E-G</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
@@ -1957,7 +1912,6 @@
 
 	<record id="lu_2011_tax_FB-IC-0" model="account.tax.template">
 		<field name="sequence">271</field>
-        <field name="description">0%</field>
         <field name="name">EX-IC-E-G</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -1991,7 +1945,6 @@
 
 	<record id="lu_2015_tax_FB-IC-14" model="account.tax.template">
 		<field name="sequence">275</field>
-        <field name="description">14%</field>
         <field name="name">14-IC-E-G</field>
         <field name="amount">14</field>
         <field name="amount_type">percent</field>
@@ -2041,7 +1994,6 @@
 
 	<record id="lu_2015_tax_FB-IC-17" model="account.tax.template">
 		<field name="sequence">281</field>
-        <field name="description">17%</field>
         <field name="name">17-IC-E-G</field>
         <field name="amount">17</field>
         <field name="amount_type">percent</field>
@@ -2091,7 +2043,6 @@
 
 	<record id="lu_2011_tax_FB-IC-3" model="account.tax.template">
 		<field name="sequence">284</field>
-        <field name="description">3%</field>
         <field name="name">3-IC-E-G</field>
         <field name="amount">3</field>
         <field name="amount_type">percent</field>
@@ -2141,7 +2092,6 @@
 
 	<record id="lu_2015_tax_FB-IC-8" model="account.tax.template">
 		<field name="sequence">290</field>
-        <field name="description">8%</field>
         <field name="name">8-IC-E-G</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
@@ -2191,7 +2141,6 @@
 
 	<record id="lu_2011_tax_FB-PA-0" model="account.tax.template">
 		<field name="sequence">293</field>
-        <field name="description">0%</field>
         <field name="name">0-E-G</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -2223,7 +2172,6 @@
 
 	<record id="lu_2015_tax_FB-PA-14" model="account.tax.template">
 		<field name="sequence">295</field>
-        <field name="description">14%</field>
         <field name="name">14-E-G</field>
         <field name="amount">14</field>
         <field name="amount_type">percent</field>
@@ -2259,7 +2207,6 @@
 
 	<record id="lu_2015_tax_FB-PA-17" model="account.tax.template">
 		<field name="sequence">297</field>
-        <field name="description">17%</field>
         <field name="name">17-E-G</field>
         <field name="amount">17</field>
         <field name="amount_type">percent</field>
@@ -2295,7 +2242,6 @@
 
 	<record id="lu_2011_tax_FB-PA-3" model="account.tax.template">
 		<field name="sequence">298</field>
-        <field name="description">3%</field>
         <field name="name">3-E-G</field>
         <field name="amount">3</field>
         <field name="amount_type">percent</field>
@@ -2331,7 +2277,6 @@
 
 	<record id="lu_2015_tax_FB-PA-8" model="account.tax.template">
 		<field name="sequence">300</field>
-        <field name="description">8%</field>
         <field name="name">8-E-G</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
@@ -2367,7 +2312,6 @@
 
 	<record id="lu_2011_tax_FP-EC-0" model="account.tax.template">
 		<field name="sequence">301</field>
-        <field name="description">0%</field>
         <field name="name">0-EC-E-S</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -2401,7 +2345,6 @@
 
 	<record id="lu_2015_tax_FP-EC-14" model="account.tax.template">
 		<field name="sequence">305</field>
-        <field name="description">14%</field>
         <field name="name">14-EC-E-S</field>
         <field name="amount">14</field>
         <field name="amount_type">percent</field>
@@ -2451,7 +2394,6 @@
 
 	<record id="lu_2015_tax_FP-EC-17" model="account.tax.template">
 		<field name="sequence">311</field>
-        <field name="description">17%</field>
         <field name="name">17-EC-E-S</field>
         <field name="amount">17</field>
         <field name="amount_type">percent</field>
@@ -2501,7 +2443,6 @@
 
 	<record id="lu_2011_tax_FP-EC-3" model="account.tax.template">
 		<field name="sequence">314</field>
-        <field name="description">3%</field>
         <field name="name">3-EC-E-S</field>
         <field name="amount">3</field>
         <field name="amount_type">percent</field>
@@ -2551,7 +2492,6 @@
 
 	<record id="lu_2015_tax_FP-EC-8" model="account.tax.template">
 		<field name="sequence">320</field>
-        <field name="description">8%</field>
         <field name="name">8-EC-E-S</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
@@ -2601,7 +2541,6 @@
 
     <record id="lu_2011_tax_FP-IC-0" model="account.tax.template">
 		<field name="sequence">323</field>
-        <field name="description">0%</field>
         <field name="name">EX-IC-E-S</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -2635,7 +2574,6 @@
 
 	<record id="lu_2015_tax_FP-IC-14" model="account.tax.template">
 		<field name="sequence">327</field>
-        <field name="description">14%</field>
         <field name="name">14-IC-E-S</field>
         <field name="amount">14</field>
         <field name="amount_type">percent</field>
@@ -2685,7 +2623,6 @@
 
 	<record id="lu_2015_tax_FP-IC-17" model="account.tax.template">
 		<field name="sequence">333</field>
-        <field name="description">17%</field>
         <field name="name">17-IC-E-S</field>
         <field name="amount">17</field>
         <field name="amount_type">percent</field>
@@ -2735,7 +2672,6 @@
 
 	<record id="lu_2011_tax_FP-IC-3" model="account.tax.template">
 		<field name="sequence">336</field>
-        <field name="description">3%</field>
         <field name="name">3-IC-E-S</field>
         <field name="amount">3</field>
         <field name="amount_type">percent</field>
@@ -2785,7 +2721,6 @@
 
 	<record id="lu_2015_tax_FP-IC-8" model="account.tax.template">
 		<field name="sequence">342</field>
-        <field name="description">8%</field>
         <field name="name">8-IC-E-S</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
@@ -2835,7 +2770,6 @@
 
 	<record id="lu_2011_tax_FP-PA-0" model="account.tax.template">
 		<field name="sequence">345</field>
-        <field name="description">0%</field>
         <field name="name">0-E-S</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -2867,7 +2801,6 @@
 
 	<record id="lu_2015_tax_FP-PA-14" model="account.tax.template">
 		<field name="sequence">347</field>
-        <field name="description">14%</field>
         <field name="name">14-E-S</field>
         <field name="amount">14</field>
         <field name="amount_type">percent</field>
@@ -2903,7 +2836,6 @@
 
 	<record id="lu_2015_tax_FP-PA-17" model="account.tax.template">
 		<field name="sequence">349</field>
-        <field name="description">17%</field>
         <field name="name">17-E-S</field>
         <field name="amount">17</field>
         <field name="amount_type">percent</field>
@@ -2939,7 +2871,6 @@
 
 	<record id="lu_2011_tax_FP-PA-3" model="account.tax.template">
 		<field name="sequence">350</field>
-        <field name="description">3%</field>
         <field name="name">3-E-S</field>
         <field name="amount">3</field>
         <field name="amount_type">percent</field>
@@ -2975,7 +2906,6 @@
 
 	<record id="lu_2015_tax_FP-PA-8" model="account.tax.template">
 		<field name="sequence">352</field>
-        <field name="description">8%</field>
         <field name="name">8-E-S</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
@@ -3011,7 +2941,6 @@
 
 	<record id="lu_2011_tax_IB-EC-0" model="account.tax.template">
 		<field name="sequence">353</field>
-        <field name="description">0%</field>
         <field name="name">0-EC-IG</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -3045,7 +2974,6 @@
 
 	<record id="lu_2015_tax_IB-EC-14" model="account.tax.template">
 		<field name="sequence">357</field>
-        <field name="description">14%</field>
         <field name="name">14-EC-IG</field>
         <field name="amount">14</field>
         <field name="amount_type">percent</field>
@@ -3095,7 +3023,6 @@
 
 	<record id="lu_2015_tax_IB-EC-17" model="account.tax.template">
 		<field name="sequence">363</field>
-        <field name="description">17%</field>
         <field name="name">17-EC-IG</field>
         <field name="amount">17</field>
         <field name="amount_type">percent</field>
@@ -3145,7 +3072,6 @@
 
 	<record id="lu_2011_tax_IB-EC-3" model="account.tax.template">
 		<field name="sequence">366</field>
-        <field name="description">3%</field>
         <field name="name">3-EC-IG</field>
         <field name="amount">3</field>
         <field name="amount_type">percent</field>
@@ -3195,7 +3121,6 @@
 
 	<record id="lu_2015_tax_IB-EC-8" model="account.tax.template">
 		<field name="sequence">372</field>
-        <field name="description">8%</field>
         <field name="name">8-EC-IG</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
@@ -3245,7 +3170,6 @@
 
 	<record id="lu_2015_tax_IB-ECP-0" model="account.tax.template">
 		<field name="sequence">375</field>
-        <field name="description">5%</field>
         <field name="name">0-EC(P)-IG</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -3279,7 +3203,6 @@
 
 	<record id="lu_2015_tax_IB-ECP-14" model="account.tax.template">
 		<field name="sequence">379</field>
-        <field name="description">14%</field>
         <field name="name">14-EC(P)-IG</field>
         <field name="amount">14</field>
         <field name="amount_type">percent</field>
@@ -3329,7 +3252,6 @@
 
 	<record id="lu_2015_tax_IB-ECP-17" model="account.tax.template">
 		<field name="sequence">385</field>
-        <field name="description">17%</field>
         <field name="name">17-EC(P)-IG</field>
         <field name="amount">17</field>
         <field name="amount_type">percent</field>
@@ -3379,7 +3301,6 @@
 
 	<record id="lu_2015_tax_IB-ECP-3" model="account.tax.template">
 		<field name="sequence">388</field>
-        <field name="description">3%</field>
         <field name="name">3-EC(P)-IG</field>
         <field name="amount">3</field>
         <field name="amount_type">percent</field>
@@ -3429,7 +3350,6 @@
 
 	<record id="lu_2015_tax_IB-ECP-8" model="account.tax.template">
 		<field name="sequence">394</field>
-        <field name="description">8%</field>
         <field name="name">8-EC(P)-IG</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
@@ -3479,7 +3399,6 @@
 
 	<record id="lu_2011_tax_IB-IC-0" model="account.tax.template">
 		<field name="sequence">397</field>
-        <field name="description">0%</field>
         <field name="name">0-IC-IG</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -3513,7 +3432,6 @@
 
 	<record id="lu_2015_tax_IB-IC-14" model="account.tax.template">
 		<field name="sequence">401</field>
-        <field name="description">14%</field>
         <field name="name">14-IC-IG</field>
         <field name="amount">14</field>
         <field name="amount_type">percent</field>
@@ -3563,7 +3481,6 @@
 
 	<record id="lu_2015_tax_IB-IC-17" model="account.tax.template">
 		<field name="sequence">407</field>
-        <field name="description">17%</field>
         <field name="name">17-IC-IG</field>
         <field name="amount">17</field>
         <field name="amount_type">percent</field>
@@ -3613,7 +3530,6 @@
 
 	<record id="lu_2011_tax_IB-IC-3" model="account.tax.template">
 		<field name="sequence">410</field>
-        <field name="description">3%</field>
         <field name="name">3-IC-IG</field>
         <field name="amount">3</field>
         <field name="amount_type">percent</field>
@@ -3663,7 +3579,6 @@
 
 	<record id="lu_2015_tax_IB-IC-8" model="account.tax.template">
 		<field name="sequence">416</field>
-        <field name="description">8%</field>
         <field name="name">8-IC-IG</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
@@ -3713,7 +3628,6 @@
 
 	<record id="lu_2011_tax_IB-PA-0" model="account.tax.template">
 		<field name="sequence">419</field>
-        <field name="description">0%</field>
         <field name="name">0-IG</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -3745,7 +3659,6 @@
 
 	<record id="lu_2015_tax_IB-PA-14" model="account.tax.template">
 		<field name="sequence">421</field>
-        <field name="description">14%</field>
         <field name="name">14-IG</field>
         <field name="amount">14</field>
         <field name="amount_type">percent</field>
@@ -3781,7 +3694,6 @@
 
 	<record id="lu_2015_tax_IB-PA-17" model="account.tax.template">
 		<field name="sequence">423</field>
-        <field name="description">17%</field>
         <field name="name">17-IG</field>
         <field name="amount">17</field>
         <field name="amount_type">percent</field>
@@ -3817,7 +3729,6 @@
 
 	<record id="lu_2011_tax_IB-PA-3" model="account.tax.template">
 		<field name="sequence">424</field>
-        <field name="description">3%</field>
         <field name="name">3-IG</field>
         <field name="amount">3</field>
         <field name="amount_type">percent</field>
@@ -3853,7 +3764,6 @@
 
 	<record id="lu_2015_tax_IB-PA-8" model="account.tax.template">
 		<field name="sequence">426</field>
-        <field name="description">8%</field>
         <field name="name">8-IG</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
@@ -3889,7 +3799,6 @@
 
 	<record id="lu_2011_tax_IP-EC-0" model="account.tax.template">
 		<field name="sequence">427</field>
-        <field name="description">0%</field>
         <field name="name">0-EC-IS</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -3923,7 +3832,6 @@
 
 	<record id="lu_2015_tax_IP-EC-14" model="account.tax.template">
 		<field name="sequence">431</field>
-        <field name="description">14%</field>
         <field name="name">14-EC-IS</field>
         <field name="amount">14</field>
         <field name="amount_type">percent</field>
@@ -3973,7 +3881,6 @@
 
 	<record id="lu_2015_tax_IP-EC-17" model="account.tax.template">
 		<field name="sequence">437</field>
-        <field name="description">17%</field>
         <field name="name">17-EC-IS</field>
         <field name="amount">17</field>
         <field name="amount_type">percent</field>
@@ -4023,7 +3930,6 @@
 
 	<record id="lu_2011_tax_IP-EC-3" model="account.tax.template">
 		<field name="sequence">440</field>
-        <field name="description">3%</field>
         <field name="name">3-EC-IS</field>
         <field name="amount">3</field>
         <field name="amount_type">percent</field>
@@ -4073,7 +3979,6 @@
 
 	<record id="lu_2015_tax_IP-EC-8" model="account.tax.template">
 		<field name="sequence">446</field>
-        <field name="description">8%</field>
         <field name="name">8-EC-IS</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
@@ -4123,7 +4028,6 @@
 
 	<record id="lu_2011_tax_IP-IC-0" model="account.tax.template">
 		<field name="sequence">449</field>
-        <field name="description">0%</field>
         <field name="name">0-IC-IS</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -4157,7 +4061,6 @@
 
 	<record id="lu_2015_tax_IP-IC-14" model="account.tax.template">
 		<field name="sequence">453</field>
-        <field name="description">14%</field>
         <field name="name">14-IC-IS</field>
         <field name="amount">14</field>
         <field name="amount_type">percent</field>
@@ -4207,7 +4110,6 @@
 
 	<record id="lu_2015_tax_IP-IC-17" model="account.tax.template">
 		<field name="sequence">459</field>
-        <field name="description">17%</field>
         <field name="name">17-IC-IS</field>
         <field name="amount">17</field>
         <field name="amount_type">percent</field>
@@ -4257,7 +4159,6 @@
 
 	<record id="lu_2011_tax_IP-IC-3" model="account.tax.template">
 		<field name="sequence">462</field>
-        <field name="description">3%</field>
         <field name="name">3-IC-IS</field>
         <field name="amount">3</field>
         <field name="amount_type">percent</field>
@@ -4307,7 +4208,6 @@
 
 	<record id="lu_2015_tax_IP-IC-8" model="account.tax.template">
 		<field name="sequence">468</field>
-        <field name="description">8%</field>
         <field name="name">8-IC-IS</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
@@ -4357,7 +4257,6 @@
 
 	<record id="lu_2011_tax_IP-PA-0" model="account.tax.template">
 		<field name="sequence">471</field>
-        <field name="description">0%</field>
         <field name="name">0-IS</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -4389,7 +4288,6 @@
 
 	<record id="lu_2015_tax_IP-PA-14" model="account.tax.template">
 		<field name="sequence">473</field>
-        <field name="description">14%</field>
         <field name="name">14-IS</field>
         <field name="amount">14</field>
         <field name="amount_type">percent</field>
@@ -4425,7 +4323,6 @@
 
 	<record id="lu_2015_tax_IP-PA-17" model="account.tax.template">
 		<field name="sequence">475</field>
-        <field name="description">17%</field>
         <field name="name">17-IS</field>
         <field name="amount">17</field>
         <field name="amount_type">percent</field>
@@ -4461,7 +4358,6 @@
 
 	<record id="lu_2011_tax_IP-PA-3" model="account.tax.template">
 		<field name="sequence">476</field>
-        <field name="description">3%</field>
         <field name="name">3-IS</field>
         <field name="amount">3</field>
         <field name="amount_type">percent</field>
@@ -4497,7 +4393,6 @@
 
 	<record id="lu_2015_tax_IP-PA-8" model="account.tax.template">
 		<field name="sequence">478</field>
-        <field name="description">8%</field>
         <field name="name">8-IS</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
@@ -4533,7 +4428,6 @@
 
 	<record id="lu_2015_tax_V-ART-43_60b" model="account.tax.template">
 		<field name="sequence">489</field>
-        <field name="description">0%</field>
         <field name="name">0-E-Art.43&amp;60b</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -4567,7 +4461,6 @@
 
 	<record id="lu_2015_tax_V-ART-44_56q" model="account.tax.template">
 		<field name="sequence">480</field>
-        <field name="description">0%</field>
         <field name="name">0-E-Art.44&amp;56q</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -4601,7 +4494,6 @@
 
 	<record id="lu_2011_tax_VB-EC-0" model="account.tax.template">
 		<field name="sequence">481</field>
-        <field name="description">0%</field>
         <field name="name">0-EC-S-G</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -4635,7 +4527,6 @@
 
 	<record id="lu_2011_tax_VB-EC-Tab" model="account.tax.template">
 		<field name="sequence">482</field>
-        <field name="description">0%</field>
         <field name="name">0-EC-ST-G</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -4669,7 +4560,6 @@
 
 	<record id="lu_2011_tax_VB-IC-0" model="account.tax.template">
 		<field name="sequence">483</field>
-        <field name="description">0%</field>
         <field name="name">0-IC-S-G</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -4703,7 +4593,6 @@
 
 	<record id="lu_2011_tax_VB-IC-Tab" model="account.tax.template">
 		<field name="sequence">484</field>
-        <field name="description">0%</field>
         <field name="name">0-IC-ST-G</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -4737,7 +4626,6 @@
 
 	<record id="lu_2011_tax_VB-PA-0" model="account.tax.template">
 		<field name="sequence">485</field>
-        <field name="description">0%</field>
         <field name="name">0-S-G</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -4771,7 +4659,6 @@
 
 	<record id="lu_2015_tax_VB-PA-14" model="account.tax.template">
 		<field name="sequence">487</field>
-        <field name="description">14%</field>
         <field name="name">14-S-G</field>
         <field name="amount">14</field>
         <field name="amount_type">percent</field>
@@ -4809,7 +4696,6 @@
 
 	<record id="lu_2015_tax_VB-PA-17" model="account.tax.template">
 		<field name="sequence">502</field>
-        <field name="description">17%</field>
         <field name="name">17-S-G</field>
         <field name="amount">17</field>
         <field name="amount_type">percent</field>
@@ -4847,7 +4733,6 @@
 
 	<record id="lu_2011_tax_VB-PA-3" model="account.tax.template">
 		<field name="sequence">490</field>
-        <field name="description">3%</field>
         <field name="name">3-S-G</field>
         <field name="amount">3</field>
         <field name="amount_type">percent</field>
@@ -4885,7 +4770,6 @@
 
 	<record id="lu_2015_tax_VB-PA-8" model="account.tax.template">
 		<field name="sequence">492</field>
-        <field name="description">8%</field>
         <field name="name">8-S-G</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
@@ -4923,7 +4807,6 @@
 
 	<record id="lu_2011_tax_VB-PA-Tab" model="account.tax.template">
 		<field name="sequence">493</field>
-        <field name="description">0%</field>
         <field name="name">0-ST-G</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -4957,7 +4840,6 @@
 
 	<record id="lu_2015_tax_VB-TR-0" model="account.tax.template">
 		<field name="sequence">494</field>
-        <field name="description">0%</field>
         <field name="name">0-ICT-S-G</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -4991,7 +4873,6 @@
 
 	<record id="lu_2011_tax_VP-EC-0" model="account.tax.template">
 		<field name="sequence">495</field>
-        <field name="description">0%</field>
         <field name="name">0-EC-S-S</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -5024,7 +4905,6 @@
 
 	<record id="lu_2011_tax_VP-IC-0" model="account.tax.template">
 		<field name="sequence">496</field>
-        <field name="description">0%</field>
         <field name="name">0-IC-S-S</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -5057,7 +4937,6 @@
 
 	<record id="lu_2011_tax_VP-IC-EX" model="account.tax.template">
 		<field name="sequence">497</field>
-        <field name="description">0%</field>
         <field name="name"> EX-IC-S-S</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -5090,7 +4969,6 @@
 
 	<record id="lu_2011_tax_VP-PA-0" model="account.tax.template">
 		<field name="sequence">498</field>
-        <field name="description">0%</field>
         <field name="name">0-S-S</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -5123,7 +5001,6 @@
 
 	<record id="lu_2015_tax_VP-PA-14" model="account.tax.template">
 		<field name="sequence">500</field>
-        <field name="description">14%</field>
         <field name="name">14-S-S</field>
         <field name="amount">14</field>
         <field name="amount_type">percent</field>
@@ -5160,7 +5037,6 @@
 
 	<record id="lu_2015_tax_VP-PA-17" model="account.tax.template">
 		<field name="sequence">479</field>
-        <field name="description">17%</field>
         <field name="name">17-S-S</field>
         <field name="amount">17</field>
         <field name="amount_type">percent</field>
@@ -5197,7 +5073,6 @@
 
 	<record id="lu_2011_tax_VP-PA-3" model="account.tax.template">
 		<field name="sequence">503</field>
-        <field name="description">3%</field>
         <field name="name">3-S-S</field>
         <field name="amount">3</field>
         <field name="amount_type">percent</field>
@@ -5234,7 +5109,6 @@
 
 	<record id="lu_2015_tax_VP-PA-8" model="account.tax.template">
 		<field name="sequence">505</field>
-        <field name="description">8%</field>
         <field name="name">8-S-S</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
@@ -5271,7 +5145,6 @@
 
 	<record id="lu_2015_tax_SANS" model="account.tax.template">
 		<field name="sequence">506</field>
-        <field name="description">0%</field>
         <field name="name">0-P-Tax-Free</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -5302,7 +5175,6 @@
 
 	<record id="lu_2015_tax_SANS_sale" model="account.tax.template">
 		<field name="sequence">507</field>
-        <field name="description">0%</field>
         <field name="name">0-S-Tax-Free</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>

--- a/addons/l10n_ma/data/account_tax_data.xml
+++ b/addons/l10n_ma/data/account_tax_data.xml
@@ -14,7 +14,6 @@
     <!-- Account Tax Template -->
     <record model="account.tax.template" id="tva_exo">
         <field name="name">Exonere de TVA VENTES</field>
-        <field name="description">Exonere de TVA VENTES</field>
         <field name="type_tax_use">sale</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -44,7 +43,6 @@
 
     <record model="account.tax.template" id="tva_exo1">
         <field name="name">Exonere de TVA ACHATS</field>
-        <field name="description">Exonere de TVA ACHATS</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -74,7 +72,6 @@
 
     <record model="account.tax.template" id="tva_vt20">
         <field name="name">TVA 20% VENTES</field>
-        <field name="description">TVA 20% VENTES</field>
         <field name="type_tax_use">sale</field>
         <field name="amount">20</field>
         <field name="amount_type">percent</field>
@@ -110,7 +107,6 @@
 
     <record model="account.tax.template" id="tva_vt14">
         <field name="name">TVA 14% VENTES</field>
-        <field name="description">TVA 14% VENTES</field>
         <field name="type_tax_use">sale</field>
         <field name="amount">14</field>
         <field name="amount_type">percent</field>
@@ -145,7 +141,6 @@
 
     <record model="account.tax.template" id="tva_vt10">
         <field name="name">TVA 10% VENTES</field>
-        <field name="description">TVA 10% VENTES</field>
         <field name="type_tax_use">sale</field>
         <field name="amount">10</field>
         <field name="amount_type">percent</field>
@@ -181,7 +176,6 @@
 
     <record model="account.tax.template" id="tva_vt07">
         <field name="name">TVA 7% VENTES</field>
-        <field name="description">TVA 7% VENTES</field>
         <field name="type_tax_use">sale</field>
         <field name="amount">7</field>
         <field name="amount_type">percent</field>
@@ -217,7 +211,6 @@
 
     <record model="account.tax.template" id="tva_ac20">
         <field name="name">TVA 20% ACHATS</field>
-        <field name="description">TVA 20% ACHATS</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount">20</field>
         <field name="amount_type">percent</field>
@@ -253,7 +246,6 @@
 
     <record model="account.tax.template" id="tva_acim">
         <field name="name">TVA 20% ACHATS (immobilisation)</field>
-        <field name="description">TVA 20% ACHATS (immobilisation)</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount">20</field>
         <field name="amount_type">percent</field>
@@ -289,7 +281,6 @@
 
     <record model="account.tax.template" id="tva_ac14">
         <field name="name">TVA 14% ACHATS</field>
-        <field name="description">TVA 14% ACHATS</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount">14</field>
         <field name="amount_type">percent</field>
@@ -325,7 +316,6 @@
 
     <record model="account.tax.template" id="tva_ac10">
         <field name="name">TVA 10% ACHATS</field>
-        <field name="description">TVA 10% ACHATS</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount">10</field>
         <field name="amount_type">percent</field>
@@ -361,7 +351,6 @@
 
     <record model="account.tax.template" id="tva_ac07">
         <field name="name">TVA 7% ACHATS</field>
-        <field name="description">TVA 7% ACHATS</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount">7</field>
         <field name="amount_type">percent</field>

--- a/addons/l10n_mn/data/account_tax_template_data.xml
+++ b/addons/l10n_mn/data/account_tax_template_data.xml
@@ -8,7 +8,6 @@
         <field name="sequence">1</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group1"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -46,7 +45,6 @@
         <field name="sequence">1</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group4"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -84,7 +82,6 @@
         <field name="sequence">10</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
-        <field name="description">0%</field>
         <field name="tax_group_id" ref="account_tax_group4"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -118,7 +115,6 @@
         <field name="sequence">10</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="description">0%</field>
         <field name="tax_group_id" ref="account_tax_group6"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -152,7 +148,6 @@
         <field name="sequence">10</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="description">0%</field>
         <field name="tax_group_id" ref="account_tax_group6"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -186,7 +181,6 @@
         <field name="sequence">20</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group1"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -224,7 +218,6 @@
         <field name="sequence">20</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group1"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -262,7 +255,6 @@
         <field name="sequence">20</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group1"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -300,7 +292,6 @@
         <field name="sequence">20</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group1"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -338,7 +329,6 @@
         <field name="sequence">20</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group2"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -376,7 +366,6 @@
         <field name="sequence">20</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group2"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -414,7 +403,6 @@
         <field name="sequence">20</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group2"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -452,7 +440,6 @@
         <field name="sequence">20</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group2"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -490,7 +477,6 @@
         <field name="sequence">20</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group2"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -528,7 +514,6 @@
         <field name="sequence">20</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group2"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -566,7 +551,6 @@
         <field name="sequence">20</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group2"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -604,7 +588,6 @@
         <field name="sequence">20</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group2"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -642,7 +625,6 @@
         <field name="sequence">20</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group2"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -680,7 +662,6 @@
         <field name="sequence">20</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group2"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -718,7 +699,6 @@
         <field name="sequence">20</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group2"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -756,7 +736,6 @@
         <field name="sequence">20</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group2"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -794,7 +773,6 @@
         <field name="sequence">20</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group2"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -832,7 +810,6 @@
         <field name="sequence">20</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group2"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -870,7 +847,6 @@
         <field name="sequence">20</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group2"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -908,7 +884,6 @@
         <field name="sequence">30</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="description">0%</field>
         <field name="tax_group_id" ref="account_tax_group3"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -942,7 +917,6 @@
         <field name="sequence">30</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="description">0%</field>
         <field name="tax_group_id" ref="account_tax_group3"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -976,7 +950,6 @@
         <field name="sequence">40</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group4"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -1014,7 +987,6 @@
         <field name="sequence">40</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group4"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -1052,7 +1024,6 @@
         <field name="sequence">40</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group4"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -1090,7 +1061,6 @@
         <field name="sequence">40</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group4"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -1128,7 +1098,6 @@
         <field name="sequence">40</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group4"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -1166,7 +1135,6 @@
         <field name="sequence">40</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group4"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -1204,7 +1172,6 @@
         <field name="sequence">40</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group4"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -1242,7 +1209,6 @@
         <field name="sequence">40</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group4"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -1280,7 +1246,6 @@
         <field name="sequence">40</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group4"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -1318,7 +1283,6 @@
         <field name="sequence">50</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group5"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -1356,7 +1320,6 @@
         <field name="sequence">50</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group5"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -1394,7 +1357,6 @@
         <field name="sequence">50</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group5"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -1432,7 +1394,6 @@
         <field name="sequence">50</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
-        <field name="description">10%</field>
         <field name="tax_group_id" ref="account_tax_group5"/>
         <field name="chart_template_id" ref="mn_chart_1"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),

--- a/addons/l10n_mx/data/account_tax_data.xml
+++ b/addons/l10n_mx/data/account_tax_data.xml
@@ -64,7 +64,6 @@
         <field name="sequence" eval="10"/>
         <field name="chart_template_id" ref="mx_coa"/>
         <field name="name">IVA(0%) VENTAS</field>
-        <field name="description">IVA(0%)</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -104,7 +103,6 @@
         <field name="sequence" eval="1"/>
         <field name="chart_template_id" ref="mx_coa"/>
         <field name="name">IVA(16%) VENTAS</field>
-        <field name="description">IVA(16%)</field>
         <field name="amount">16</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -144,7 +142,6 @@
         <field name="sequence" eval="10"/>
         <field name="chart_template_id" ref="mx_coa"/>
         <field name="name">RET IVA FLETES 4%</field>
-        <field name="description">Retención IVA(-4%)</field>
         <field name="amount">-4</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -184,7 +181,6 @@
         <field name="sequence" eval="10"/>
         <field name="chart_template_id" ref="mx_coa"/>
         <field name="name">RET IVA ARRENDAMIENTO 10%</field>
-        <field name="description">Retención IVA(-10%)</field>
         <field name="amount">-10</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -224,7 +220,6 @@
         <field name="sequence" eval="10"/>
         <field name="chart_template_id" ref="mx_coa"/>
         <field name="name">RET ISR ARRENDAMIENTO 10%</field>
-        <field name="description">Retención ISR(-10%)</field>
         <field name="amount">-10</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -259,7 +254,6 @@
         <field name="sequence" eval="10"/>
         <field name="chart_template_id" ref="mx_coa"/>
         <field name="name">RET ISR HONORARIOS 10%</field>
-        <field name="description">Retención ISR(-10%)</field>
         <field name="amount">-10</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -294,7 +288,6 @@
         <field name="sequence" eval="10"/>
         <field name="chart_template_id" ref="mx_coa"/>
         <field name="name">RETENCION IVA ARRENDAMIENTO 10.67%</field>
-        <field name="description">Retención IVA(-10.67%)</field>
         <field name="amount">-10.67</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -334,7 +327,6 @@
         <field name="sequence" eval="10"/>
         <field name="chart_template_id" ref="mx_coa"/>
         <field name="name">RETENCION IVA HONORARIOS 10.67%</field>
-        <field name="description">Retención IVA(-10.67%)</field>
         <field name="amount">-10.67</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -374,7 +366,6 @@
         <field name="sequence" eval="10"/>
         <field name="chart_template_id" ref="mx_coa"/>
         <field name="name">IVA(0%) COMPRAS</field>
-        <field name="description">IVA(0%)</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -412,7 +403,6 @@
         <field name="sequence" eval="1"/>
         <field name="chart_template_id" ref="mx_coa"/>
         <field name="name">IVA(16%) COMPRAS</field>
-        <field name="description">IVA(16%)</field>
         <field name="amount">16</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -451,7 +441,6 @@
     <record id="tax16" model="account.tax.template">
         <field name="chart_template_id" ref="mx_coa"/>
         <field name="name">IVA(8%) COMPRAS</field>
-        <field name="description">IVA(8%)</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -490,7 +479,6 @@
     <record id="tax17" model="account.tax.template">
         <field name="chart_template_id" ref="mx_coa"/>
         <field name="name">IVA(8%) VENTAS</field>
-        <field name="description">IVA(8%)</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>

--- a/addons/l10n_nl/data/account_tax_template.xml
+++ b/addons/l10n_nl/data/account_tax_template.xml
@@ -7,7 +7,6 @@
             <field name="sequence">10</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Verkopen/omzet onbelast (nul-tarief)</field>
-            <field name="description">0% BTW</field>
             <field eval="0" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -39,7 +38,6 @@
             <field name="sequence">10</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Verkopen/omzet laag 6%</field>
-            <field name="description">6% BTW</field>
             <field eval="6" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -75,7 +73,6 @@
             <field name="sequence">10</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Verkopen/omzet laag 9%</field>
-            <field name="description">9% BTW</field>
             <field eval="9" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -111,7 +108,6 @@
             <field name="sequence">5</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Verkopen/omzet hoog</field>
-            <field name="description">21% BTW</field>
             <field eval="21" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -147,7 +143,6 @@
             <field name="sequence">15</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Verkopen/omzet overig</field>
-            <field name="description">variabel BTW</field>
             <field eval="21" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -184,7 +179,6 @@
             <field name="sequence">10</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Verkopen/omzet onbelast (nul-tarief) diensten</field>
-            <field name="description">0% BTW diensten</field>
             <field eval="0" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -216,7 +210,6 @@
             <field name="sequence">10</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Verkopen/omzet laag diensten 6%</field>
-            <field name="description">6% BTW diensten</field>
             <field eval="6" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -252,7 +245,6 @@
             <field name="sequence">10</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Verkopen/omzet laag diensten 9%</field>
-            <field name="description">9% BTW diensten</field>
             <field eval="9" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -288,7 +280,6 @@
             <field name="sequence">6</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Verkopen/omzet hoog diensten</field>
-            <field name="description">21% BTW diensten</field>
             <field eval="21" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -324,7 +315,6 @@
             <field name="sequence">15</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Verkopen/omzet overig diensten</field>
-            <field name="description">variabel BTW diensten</field>
             <field eval="21" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -361,7 +351,6 @@
             <field name="sequence">10</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">BTW te vorderen laag (inkopen) 6%</field>
-            <field name="description">6% BTW</field>
             <field eval="6" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -395,7 +384,6 @@
             <field name="sequence">10</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">BTW te vorderen laag (inkopen) 9%</field>
-            <field name="description">9% BTW</field>
             <field eval="9" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -430,7 +418,6 @@
             <field name="sequence">10</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">BTW te vorderen laag (inkopen incl. BTW) 6%</field>
-            <field name="description">6% BTW Incl.</field>
             <field eval="6" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="price_include">True</field>
@@ -465,7 +452,6 @@
             <field name="sequence">10</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">BTW te vorderen laag (inkopen incl. BTW) 9%</field>
-            <field name="description">9% BTW Incl.</field>
             <field eval="9" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="price_include">True</field>
@@ -500,7 +486,6 @@
             <field name="sequence">5</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">BTW te vorderen hoog (inkopen)</field>
-            <field name="description">21% BTW</field>
             <field eval="21" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -534,7 +519,6 @@
             <field name="sequence">7</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">BTW te vorderen hoog (inkopen incl. BTW)</field>
-            <field name="description">21% BTW Incl.</field>
             <field eval="21" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="price_include">True</field>
@@ -569,7 +553,6 @@
             <field name="sequence">15</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">BTW te vorderen overig (inkopen)</field>
-            <field name="description">variabel BTW</field>
             <field eval="21" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -604,7 +587,6 @@
             <field name="sequence">10</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">BTW te vorderen laag (inkopen) diensten 6%</field>
-            <field name="description">6% BTW diensten</field>
             <field eval="6" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -638,7 +620,6 @@
             <field name="sequence">10</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">BTW te vorderen laag (inkopen) diensten 9%</field>
-            <field name="description">9% BTW diensten</field>
             <field eval="9" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -672,7 +653,6 @@
             <field name="sequence">6</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">BTW te vorderen hoog (inkopen) diensten</field>
-            <field name="description">21% BTW diensten</field>
             <field eval="21" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -706,7 +686,6 @@
             <field name="sequence">15</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">BTW te vorderen overig (inkopen) diensten</field>
-            <field name="description">variabel BTW diensten</field>
             <field eval="21" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -741,7 +720,6 @@
             <field name="sequence">15</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">BTW af te dragen verlegd (verkopen)</field>
-            <field name="description">0% BTW verlegd</field>
             <field eval="0" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -773,7 +751,6 @@
             <field name="sequence">15</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">BTW af te dragen verlegd (inkopen)</field>
-            <field name="description">21% BTW verlegd</field>
             <field eval="21" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -823,7 +800,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Inkopen import binnen EU laag 6%</field>
-            <field name="description">6% BTW import binnen EU</field>
             <field eval="6" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -871,7 +847,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Inkopen import binnen EU laag 9%</field>
-            <field name="description">9% BTW import binnen EU</field>
             <field eval="9" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -919,7 +894,6 @@
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="sequence">20</field>
             <field name="name">Inkopen import binnen EU hoog</field>
-            <field name="description">21% BTW import binnen EU</field>
             <field eval="21" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -967,7 +941,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Inkopen import binnen EU overig</field>
-            <field name="description">0% BTW import binnen EU</field>
             <field eval="0" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -1000,7 +973,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Verkopen export binnen EU (producten)</field>
-            <field name="description">BTW export binnen EU (producten)</field>
             <field eval="0" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -1032,7 +1004,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Verkopen export binnen EU (diensten)</field>
-            <field name="description">BTW export binnen EU (diensten)</field>
             <field eval="0" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -1064,7 +1035,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Installatie/afstandsverkopen binnen EU</field>
-            <field name="description">Inst./afst.verkopen binnen EU</field>
             <field eval="0" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -1097,7 +1067,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Inkopen import binnen EU laag diensten 6%</field>
-            <field name="description">6% BTW import binnen EU diensten</field>
             <field eval="6" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -1145,7 +1114,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Inkopen import binnen EU laag diensten 9%</field>
-            <field name="description">9% BTW import binnen EU diensten</field>
             <field eval="9" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -1193,7 +1161,6 @@
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="sequence">20</field>
             <field name="name">Inkopen import binnen EU hoog diensten</field>
-            <field name="description">21% BTW import binnen EU diensten</field>
             <field eval="21" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -1241,7 +1208,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Inkopen import binnen EU overig diensten</field>
-            <field name="description">0% BTW import binnen EU diensten</field>
             <field eval="0" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -1276,7 +1242,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Inkopen import buiten EU laag 6%</field>
-            <field name="description">BTW import buiten EU laag inkopen</field>
             <field eval="6" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -1324,7 +1289,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Inkopen import buiten EU laag 9%</field>
-            <field name="description">BTW import buiten EU laag inkopen</field>
             <field eval="9" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -1372,7 +1336,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Inkopen import buiten EU hoog</field>
-            <field name="description">BTW import buiten EU hoog inkopen</field>
             <field eval="21" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -1420,7 +1383,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Inkopen import buiten EU overig</field>
-            <field name="description">BTW import buiten EU overig inkopen</field>
             <field eval="21" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -1469,7 +1431,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Verkopen export buiten EU</field>
-            <field name="description">BTW export buiten EU</field>
             <field eval="0" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -1501,7 +1462,6 @@
             <field name="sequence">21</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Installatie/afstandsverkopen buiten EU</field>
-            <field name="description">Inst./afst.verkopen buiten EU</field>
             <field eval="0" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -1534,7 +1494,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Inkopen import buiten EU laag diensten 6%</field>
-            <field name="description">BTW import buiten EU laag inkopen diensten</field>
             <field eval="6" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -1582,7 +1541,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Inkopen import buiten EU laag diensten 9%</field>
-            <field name="description">BTW import buiten EU laag inkopen diensten</field>
             <field eval="9" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -1630,7 +1588,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Inkopen import buiten EU hoog diensten</field>
-            <field name="description">BTW import buiten EU hoog inkopen diensten</field>
             <field eval="21" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -1678,7 +1635,6 @@
             <field name="sequence">20</field>
             <field name="chart_template_id" ref="l10nnl_chart_template"/>
             <field name="name">Inkopen import buiten EU overig diensten</field>
-            <field name="description">BTW import buiten EU overig inkopen diensten</field>
             <field eval="21" name="amount"/>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>

--- a/addons/l10n_no/data/account_tax_data.xml
+++ b/addons/l10n_no/data/account_tax_data.xml
@@ -4,7 +4,6 @@
        <record id="tax1" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">0 Ingen mvabehandling 0%</field>
-            <field name="description">Ingen mvabehandling(anskaffelser)</field>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -34,7 +33,6 @@
         <record id="tax2" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">1 Inngående mva høy sats 25%</field>
-            <field name="description">Fradrag for inngående mva</field>
             <field name="amount">25</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -68,7 +66,6 @@
         <record id="tax3" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">3 Utgående mva høy sats 25%</field>
-            <field name="description">Utgående mva</field>
             <field name="amount">25</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -104,7 +101,6 @@
         <record id="tax4" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">5 Mvafritt salg 0%</field>
-            <field name="description">Mvafritt salg</field>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -136,7 +132,6 @@
         <record id="tax5" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">6 Omsetning utenfor mvaloven 0%</field>
-            <field name="description">Omsetning utenfor merverdiavgiftsloven</field>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -168,7 +163,6 @@
         <record id="tax6" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">7 Ingen mvabehandling(inntekter) 0%</field>
-            <field name="description">Ingen mvabehandling(inntekter)</field>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -198,7 +192,6 @@
         <record id="tax7" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">11 Inngående mva middel sats 15%</field>
-            <field name="description">Fradrag for inngående mva</field>
             <field name="amount">15</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -232,7 +225,6 @@
         <record id="tax8" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">12 Inngående mva råfisk 11%</field>
-            <field name="description">Fradrag for inngående mva</field>
             <field name="amount">11</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -266,7 +258,6 @@
         <record id="tax9" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">13 Inngående mva lav sats 12%</field>
-            <field name="description">Fradrag for inngående mva</field>
             <field name="amount">12</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -300,7 +291,6 @@
         <record id="tax10" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">14 Innførselsmva høy sats 25%</field>
-            <field name="description">Fradrag for innførselsmva</field>
             <field name="amount">25</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -334,7 +324,6 @@
         <record id="tax11" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">15 Innførselsmva middel sats 15%</field>
-            <field name="description">Fradrag for innførselsmva</field>
             <field name="amount">15</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -368,7 +357,6 @@
         <record id="tax12" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">20 Grunnlag ved innførsel av varer nullsats 0%</field>
-            <field name="description">Grunnlag ved innførsel av varer</field>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -398,7 +386,6 @@
         <record id="tax13" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">21 Grunnlag ved innførsel av varer høy sats 25%</field>
-            <field name="description">Grunnlag ved innførsel av varer</field>
             <field name="amount">25</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -428,7 +415,6 @@
         <record id="tax14" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">22 Grunnlag ved innførsel av varer middel sats 15%</field>
-            <field name="description">Grunnlag ved innførsel av varer</field>
             <field name="amount">15</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -458,7 +444,6 @@
         <record id="tax15" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">31 Utgående mva middel sats 15%</field>
-            <field name="description">Utgående mva</field>
             <field name="amount">15</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -494,7 +479,6 @@
         <record id="tax16" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">32 Utgående mva råfisk 11%</field>
-            <field name="description">Utgående mva</field>
             <field name="amount">11</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -530,7 +514,6 @@
         <record id="tax17" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">33 Utgående mva lav sats 12%</field>
-            <field name="description">Utgående mva</field>
             <field name="amount">12</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -566,7 +549,6 @@
         <record id="tax18" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">51 Innenlands omsetning med omvendt avgiftsplikt nullsats 0%</field>
-            <field name="description">Innlands omsetning med omvendt avgiftsplikt</field>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -598,7 +580,6 @@
         <record id="tax19" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">52 Utførsel av varer og tjenester nullsats 0%</field>
-            <field name="description">Utførsel av varer og tjenester</field>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -630,7 +611,6 @@
         <record id="tax20" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">81 Innførsel av varer med fradrag for innførselsmva høy sats 25%</field>
-            <field name="description">Innførsel av varer med fradrag for innførselsmva</field>
             <field name="amount">25</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -666,7 +646,6 @@
         <record id="tax21" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">82 Innførsel av varer uten fradrag for innførselsmva høy sats 25%</field>
-            <field name="description">Innførsel av varer uten fradrag for innførselsmva</field>
             <field name="amount">25</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -702,7 +681,6 @@
         <record id="tax22" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">83 Innførsel av varer med fradrag for innførselsmva middel sats 15%</field>
-            <field name="description">Innførsel av varer med fradrag for innførselsmva</field>
             <field name="amount">15</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -738,7 +716,6 @@
         <record id="tax23" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">84 Innførsel av varer uten fradrag for innførselsmva middel sats 15%</field>
-            <field name="description">Innførsel av varer uten fradrag for innførselsmva</field>
             <field name="amount">15</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -774,7 +751,6 @@
         <record id="tax24" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">85 Innførsel av varer uten mva beregning 0%</field>
-            <field name="description">Innførsel av varer som det ikke skal beregnes mervediavgift av</field>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -806,7 +782,6 @@
         <record id="tax25" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">86 Tjenester kjøpt fra utlandet med fradrag for mva høy sats 25%</field>
-            <field name="description">Tjenester kjøpt fra utlandet med fradrag for mva</field>
             <field name="amount">25</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -842,7 +817,6 @@
         <record id="tax26" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">87 Tjenester kjøpt fra utlandet uten fradrag for mva høy sats 25%</field>
-            <field name="description">Tjenester kjøpt fra utlandet uten fradrag for mva</field>
             <field name="amount">25</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -878,7 +852,6 @@
         <record id="tax27" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">88 Tjenester kjøpt fra utlandet med fradrag for mva lav sats 12%</field>
-            <field name="description">Tjenester kjøpt fra utlandet med fradrag for mva</field>
             <field name="amount">12</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -914,7 +887,6 @@
         <record id="tax28" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">89 Tjenester kjøpt fra utlandet uten fradrag for mva lav sats 12%</field>
-            <field name="description">Tjenester kjøpt fra utlandet uten fradrag for mva</field>
             <field name="amount">12</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -950,7 +922,6 @@
         <record id="tax29" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">91 Kjøp av klimakvoter eller gull med fradrag for mva høy sats 25%</field>
-            <field name="description">Kjøp av klimakvoter eller gull med fradrag for mva</field>
             <field name="amount">25</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -986,7 +957,6 @@
         <record id="tax30" model="account.tax.template">
             <field name="chart_template_id" ref="no_chart_template"/>
             <field name="name">92 Kjøp av klimakvoter eller gull uten fradrag for mva høy sats 25%</field>
-            <field name="description">Kjøp av klimakvoter eller gull uten fradrag for mva</field>
             <field name="amount">25</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>

--- a/addons/l10n_nz/data/account_tax_template_data.xml
+++ b/addons/l10n_nz/data/account_tax_template_data.xml
@@ -4,7 +4,6 @@
         <field name="chart_template_id" ref="l10n_nz_chart_template"/>
         <field name="name">Sale (15%)</field>
         <field name="sequence">1</field>
-        <field name="description">GST Sales</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">percent</field>
         <field name="amount">15</field>
@@ -43,7 +42,6 @@
         <field name="chart_template_id" ref="l10n_nz_chart_template"/>
         <field name="name">GST Inc Sale (15%)</field>
         <field name="sequence">2</field>
-        <field name="description">GST Inclusive Sales</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">percent</field>
         <field name="amount">15</field>
@@ -82,7 +80,6 @@
         <field name="chart_template_id" ref="l10n_nz_chart_template"/>
         <field name="name">Zero/Export (0%) Sale</field>
         <field name="sequence">3</field>
-        <field name="description">Zero Rated (Export) Sales</field>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
@@ -117,7 +114,6 @@
         <field name="chart_template_id" ref="l10n_nz_chart_template"/>
         <field name="name">Purch (15%)</field>
         <field name="sequence">1</field>
-        <field name="description">GST Purchases</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
         <field name="amount">15</field>
@@ -156,7 +152,6 @@
         <field name="chart_template_id" ref="l10n_nz_chart_template"/>
         <field name="name">GST Inc Purch (15%)</field>
         <field name="sequence">2</field>
-        <field name="description">GST Inclusive Purchases</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
         <field name="amount">15</field>
@@ -195,7 +190,6 @@
         <field name="chart_template_id" ref="l10n_nz_chart_template"/>
         <field name="name">Zero/Import (0%) Purch</field>
         <field name="sequence">3</field>
-        <field name="description">Zero Rated Purchases</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
@@ -228,7 +222,6 @@
         <field name="chart_template_id" ref="l10n_nz_chart_template"/>
         <field name="name">Purch (Imports Taxable)</field>
         <field name="sequence">4</field>
-        <field name="description">Purchase (Taxable Imports) - Tax Paid Separately</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
@@ -261,7 +254,6 @@
         <field name="chart_template_id" ref="l10n_nz_chart_template"/>
         <field name="name">GST Only – Imports</field>
         <field name="sequence">5</field>
-        <field name="description">GST Only on Imports</field>
         <field name="type_tax_use">purchase</field>
         <field name="amount_type">percent</field>
         <field name="amount">100000000</field>

--- a/addons/l10n_pa/data/account_tax_data.xml
+++ b/addons/l10n_pa/data/account_tax_data.xml
@@ -3,7 +3,6 @@
     <record id="ITAX_19" model="account.tax.template">
         <field name="chart_template_id" ref="l10npa_chart_template"/>
         <field name="name">ITBMS 7% Venta</field>
-        <field name="description">ITBMS 7% Venta</field>
         <field name="amount">7</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -37,7 +36,6 @@
     <record id="OTAX_19" model="account.tax.template">
         <field name="chart_template_id" ref="l10npa_chart_template"/>
         <field name="name">ITBMS 7% Compra</field>
-        <field name="description">ITBMS 7% Compra</field>
         <field name="amount">7</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>

--- a/addons/l10n_pe/data/account_tax_data.xml
+++ b/addons/l10n_pe/data/account_tax_data.xml
@@ -44,7 +44,6 @@
     <record id="sale_tax_igv_18" model="account.tax.template">
         <field name="chart_template_id" ref="pe_chart_template"/>
         <field name="name">18%</field>
-        <field name="description">IGV</field>
         <field name="l10n_pe_edi_tax_code">1000</field>
         <field name="l10n_pe_edi_unece_category">S</field>
         <field name="amount">18.0</field>
@@ -81,7 +80,6 @@
     <record id="sale_tax_igv_18_included" model="account.tax.template">
         <field name="chart_template_id" ref="pe_chart_template"/>
         <field name="name">18% (Included in price)</field>
-        <field name="description">IGV</field>
         <field name="l10n_pe_edi_tax_code">1000</field>
         <field name="l10n_pe_edi_unece_category">S</field>
         <field name="amount">18.0</field>
@@ -119,7 +117,6 @@
     <record id="sale_tax_exo" model="account.tax.template">
         <field name="chart_template_id" ref="pe_chart_template"/>
         <field name="name">0% Exonerated</field>
-        <field name="description">EXO</field>
         <field name="l10n_pe_edi_tax_code">9997</field>
         <field name="l10n_pe_edi_unece_category">E</field>
         <field name="amount">0.0</field>
@@ -155,7 +152,6 @@
     <record id="sale_tax_ina" model="account.tax.template">
         <field name="chart_template_id" ref="pe_chart_template"/>
         <field name="name">0% Unaffected</field>
-        <field name="description">INA</field>
         <field name="l10n_pe_edi_tax_code">9998</field>
         <field name="l10n_pe_edi_unece_category">Z</field>
         <field name="amount">0.0</field>
@@ -191,7 +187,6 @@
     <record id="sale_tax_gra" model="account.tax.template">
         <field name="chart_template_id" ref="pe_chart_template"/>
         <field name="name">0% Free</field>
-        <field name="description">GRA</field>
         <field name="l10n_pe_edi_tax_code">9997</field>
         <field name="l10n_pe_edi_unece_category">E</field>
         <field name="amount">0.0</field>
@@ -228,7 +223,6 @@
     <record id="purchase_tax_igv_18" model="account.tax.template">
         <field name="chart_template_id" ref="pe_chart_template"/>
         <field name="name">18%</field>
-        <field name="description">IGV</field>
         <field name="l10n_pe_edi_tax_code">1000</field>
         <field name="l10n_pe_edi_unece_category">S</field>
         <field name="amount">18.0</field>
@@ -265,7 +259,6 @@
     <record id="purchase_tax_igv_18_included" model="account.tax.template">
         <field name="chart_template_id" ref="pe_chart_template"/>
         <field name="name">18% (Included in price)</field>
-        <field name="description">IGV</field>
         <field name="l10n_pe_edi_tax_code">1000</field>
         <field name="l10n_pe_edi_unece_category">S</field>
         <field name="amount">18.0</field>
@@ -303,7 +296,6 @@
     <record id="purchase_tax_exo" model="account.tax.template">
         <field name="chart_template_id" ref="pe_chart_template"/>
         <field name="name">0% Exonerated</field>
-        <field name="description">EXO</field>
         <field name="l10n_pe_edi_tax_code">9997</field>
         <field name="l10n_pe_edi_unece_category">E</field>
         <field name="amount">0.0</field>
@@ -339,7 +331,6 @@
     <record id="purchase_tax_ina" model="account.tax.template">
         <field name="chart_template_id" ref="pe_chart_template"/>
         <field name="name">0% Unaffected</field>
-        <field name="description">INA</field>
         <field name="l10n_pe_edi_tax_code">9998</field>
         <field name="l10n_pe_edi_unece_category">Z</field>
         <field name="amount">0.0</field>
@@ -375,7 +366,6 @@
     <record id="purchase_tax_gra" model="account.tax.template">
         <field name="chart_template_id" ref="pe_chart_template"/>
         <field name="name">0% Free</field>
-        <field name="description">GRA</field>
         <field name="l10n_pe_edi_tax_code">9997</field>
         <field name="l10n_pe_edi_unece_category">E</field>
         <field name="amount">0.0</field>

--- a/addons/l10n_pl/data/account_tax_data.xml
+++ b/addons/l10n_pl/data/account_tax_data.xml
@@ -7,7 +7,6 @@
     <record id="vs_kraj_23" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">VAT-23%</field>
-      <field name="description">V23</field>
       <field name="amount">23</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">sale</field>
@@ -44,7 +43,6 @@
     <record id="vs_kraj_22" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">VAT-22%</field>
-      <field name="description">V22</field>
       <field name="amount">22</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">sale</field>
@@ -80,7 +78,6 @@
     <record id="vs_kraj_8" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">VAT-8%</field>
-      <field name="description">V8</field>
       <field name="amount">8</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">sale</field>
@@ -116,7 +113,6 @@
     <record id="vs_kraj_7" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">VAT-7%</field>
-      <field name="description">V7</field>
       <field name="amount">7</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">sale</field>
@@ -152,7 +148,6 @@
     <record id="vs_kraj_5" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">VAT-5%</field>
-      <field name="description">V5</field>
       <field name="amount">5</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">sale</field>
@@ -188,7 +183,6 @@
     <record id="vs_kraj_3" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">VAT-3%</field>
-      <field name="description">V3</field>
       <field name="amount">3</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">sale</field>
@@ -224,7 +218,6 @@
     <record id="vs_kraj_0" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">VAT-0%</field>
-      <field name="description">V0</field>
       <field name="amount">0</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">sale</field>
@@ -256,7 +249,6 @@
     <record id="vs_kraj_zw" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">VAT-ZW</field>
-      <field name="description">VZW</field>
       <field name="amount">0</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">sale</field>
@@ -288,7 +280,6 @@
     <record id="vs_kraj_usl_23" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">VAT usł-23%</field>
-      <field name="description">VU23</field>
       <field name="amount">23</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">sale</field>
@@ -324,7 +315,6 @@
     <record id="vs_kraj_usl_22" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">VAT usł-22%</field>
-      <field name="description">VU22</field>
       <field name="amount">22</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">sale</field>
@@ -362,7 +352,6 @@
     <record id="vz_kraj_23" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">VAT naliczony-23%</field>
-      <field name="description">Z23</field>
       <field name="amount">23</field>
       <field name="amount_type">percent</field>
       <field name="sequence" eval="0"/>
@@ -399,7 +388,6 @@
     <record id="vz_kraj_22" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">VAT naliczony-22%</field>
-      <field name="description">Z22</field>
       <field name="amount">22</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">purchase</field>
@@ -435,7 +423,6 @@
     <record id="vz_kraj_8" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">VAT naliczony-8%</field>
-      <field name="description">Z8</field>
       <field name="amount">8</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">purchase</field>
@@ -471,7 +458,6 @@
     <record id="vz_kraj_7" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">VAT naliczony-7%</field>
-      <field name="description">Z7</field>
       <field name="amount">7</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">purchase</field>
@@ -507,7 +493,6 @@
     <record id="vz_kraj_5" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">VAT naliczony-5%</field>
-      <field name="description">Z5</field>
       <field name="amount">5</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">purchase</field>
@@ -543,7 +528,6 @@
     <record id="vz_kraj_3" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">VAT naliczony-3%</field>
-      <field name="description">Z3</field>
       <field name="amount">3</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">purchase</field>
@@ -579,7 +563,6 @@
     <record id="vz_kraj_0" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">VAT naliczony-0%</field>
-      <field name="description">Z0</field>
       <field name="amount">0</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">purchase</field>
@@ -611,7 +594,6 @@
     <record id="vz_kraj_zw" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">VAT naliczony-ZW</field>
-      <field name="description">ZZW</field>
       <field name="amount">0</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">purchase</field>
@@ -643,7 +625,6 @@
     <record id="vz_kraj_usl_23" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">VAT usł nalicz-23%</field>
-      <field name="description">ZU23</field>
       <field name="amount">23</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">purchase</field>
@@ -679,7 +660,6 @@
     <record id="vz_kraj_usl_22" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">VAT usł nalicz-22%</field>
-      <field name="description">ZU22</field>
       <field name="amount">22</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">purchase</field>
@@ -718,7 +698,6 @@
     <record id="vp_leas_sale" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">VAT - leasing pojazdu(sale)</field>
-      <field name="description">VLP</field>
       <field name="amount">23.00</field>
       <field name="sequence" eval="1"/>
       <field name="amount_type">percent</field>
@@ -765,7 +744,6 @@
     <record id="vp_leas_purchase" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">VAT - leasing pojazdu(purchase)</field>
-      <field name="description">VLP</field>
       <field name="amount">23.00</field>
       <field name="sequence" eval="1"/>
       <field name="amount_type">percent</field>
@@ -814,7 +792,6 @@
     <record id="vs_stal" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">Sprzedaż stali</field>
-      <field name="description">VST</field>
       <field name="amount">0</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">sale</field>
@@ -846,7 +823,6 @@
     <record id="vz_stal" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">Zakup stali</field>
-      <field name="description">ZST</field>
       <field name="amount">23.0</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">purchase</field>
@@ -897,7 +873,6 @@
     <record id="vs_unia" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">Dost tow. unia</field>
-      <field name="description">UDT</field>
       <field name="amount">0</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">sale</field>
@@ -929,7 +904,6 @@
     <record id="vz_unia" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">Nab tow unia</field>
-      <field name="description">UNT</field>
       <field name="amount">23.0</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">purchase</field>
@@ -977,7 +951,6 @@
     <record id="vs_dostu" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">Świad Usł</field>
-      <field name="description">UDU</field>
       <field name="amount">0</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">sale</field>
@@ -1009,7 +982,6 @@
     <record id="vz_nabu" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">Nab Usł</field>
-      <field name="description">UNU</field>
       <field name="amount">23.0</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">purchase</field>
@@ -1061,7 +1033,6 @@
     <record id="vs_eksp_tow" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">Eksp Tow</field>
-      <field name="description">EXT</field>
       <field name="amount">0</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">sale</field>
@@ -1093,7 +1064,6 @@
     <record id="vz_imp_tow" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">Imp Tow</field>
-      <field name="description">IMT</field>
       <field name="amount">23.0</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">purchase</field>
@@ -1141,7 +1111,6 @@
     <record id="vs_ekspu" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">Eksp Usł</field>
-      <field name="description">EXU</field>
       <field name="amount">0</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">sale</field>
@@ -1173,7 +1142,6 @@
     <record id="vz_impu" model="account.tax.template">
       <field name="chart_template_id" ref="pl_chart_template"/>
       <field name="name">Imp Usł</field>
-      <field name="description">IMU</field>
       <field name="amount">23.00</field>
       <field name="amount_type">percent</field>
       <field name="type_tax_use">purchase</field>

--- a/addons/l10n_pt/data/account_tax_data.xml
+++ b/addons/l10n_pt/data/account_tax_data.xml
@@ -5,7 +5,6 @@
         <record id="iva23" model="account.tax.template">
             <field name="chart_template_id" ref="pt_chart_template"/>
             <field name="name">IVA23</field>
-            <field name="description">IVA23</field>
             <field name="amount">23</field>
             <field name="amount_type">percent</field>
             <field name="tax_group_id" ref="tax_group_iva_23"/>
@@ -36,7 +35,6 @@
         <record id="iva13" model="account.tax.template">
             <field name="chart_template_id" ref="pt_chart_template"/>
             <field name="name">IVA13</field>
-            <field name="description">IVA13</field>
             <field name="amount">13</field>
             <field name="amount_type">percent</field>
             <field name="tax_group_id" ref="tax_group_iva_13"/>
@@ -67,7 +65,6 @@
         <record id="iva6" model="account.tax.template">
             <field name="chart_template_id" ref="pt_chart_template"/>
             <field name="name">IVA6</field>
-            <field name="description">IVA6</field>
             <field name="amount">6</field>
             <field name="amount_type">percent</field>
             <field name="tax_group_id" ref="tax_group_iva_6"/>
@@ -98,7 +95,6 @@
         <record id="iva0" model="account.tax.template">
             <field name="chart_template_id" ref="pt_chart_template"/>
             <field name="name">IVA0</field>
-            <field name="description">IVA0</field>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
             <field name="tax_group_id" ref="tax_group_iva_0"/>
@@ -129,7 +125,6 @@
         <record id="compiva23" model="account.tax.template">
             <field name="chart_template_id" ref="pt_chart_template"/>
             <field name="name">IVA23 compra</field>
-            <field name="description">IVA23 compra</field>
             <field name="amount">23</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -161,7 +156,6 @@
         <record id="compiva13" model="account.tax.template">
             <field name="chart_template_id" ref="pt_chart_template"/>
             <field name="name">IVA13 compra</field>
-            <field name="description">IVA13 compra</field>
             <field name="amount">13</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -193,7 +187,6 @@
         <record id="compiva6" model="account.tax.template">
             <field name="chart_template_id" ref="pt_chart_template"/>
             <field name="name">IVA6 compra</field>
-            <field name="description">IVA6 compra</field>
             <field name="amount">6</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -225,7 +218,6 @@
         <record id="compiva0" model="account.tax.template">
             <field name="chart_template_id" ref="pt_chart_template"/>
             <field name="name">IVA0 compra</field>
-            <field name="description">IVA0 compra</field>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>

--- a/addons/l10n_ro/data/account_tax_data.xml
+++ b/addons/l10n_ro/data/account_tax_data.xml
@@ -3,7 +3,6 @@
     <record id="tvac_00" model="account.tax.template">
         <field name="chart_template_id" ref="ro_chart_template"/>
         <field name="sequence">13</field>
-        <field name="description">TVA colectat 0%</field>
         <field name="name">TVA colectat 0%</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
@@ -37,7 +36,6 @@
         <field name="chart_template_id" ref="ro_chart_template"/>
         <field name="sequence">12</field>
         <field name="name">TVA colectat 5%</field>
-        <field name="description">TVA colectat 5%</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -74,7 +72,6 @@
         <field name="chart_template_id" ref="ro_chart_template"/>
         <field name="sequence">14</field>
         <field name="name">TVA colectat 9%</field>
-        <field name="description">TVA colectat 9%</field>
         <field name="amount">9</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -111,7 +108,6 @@
         <field name="chart_template_id" ref="ro_chart_template"/>
         <field name="sequence">9</field>
         <field name="name">TVA colectat 19%</field>
-        <field name="description">TVA colectat 19%</field>
         <field name="amount">19</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -148,7 +144,6 @@
         <field name="chart_template_id" ref="ro_chart_template"/>
         <field name="sequence">10</field>
         <field name="name">TVA colectat 20%</field>
-        <field name="description">TVA colectat 20%</field>
         <field name="amount">20</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -181,7 +176,6 @@
         <field name="chart_template_id" ref="ro_chart_template"/>
         <field name="sequence">11</field>
         <field name="name">TVA colectat 24%</field>
-        <field name="description">TVA colectat 24%</field>
         <field name="amount">24</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -218,7 +212,6 @@
         <field name="chart_template_id" ref="ro_chart_template"/>
         <field name="sequence">23</field>
         <field name="name">TVA deductibil 0%</field>
-        <field name="description">TVA deductibil 0%</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -251,7 +244,6 @@
         <field name="chart_template_id" ref="ro_chart_template"/>
         <field name="sequence">22</field>
         <field name="name">TVA deductibil 5%</field>
-        <field name="description">TVA deductibil 5%</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -288,7 +280,6 @@
         <field name="chart_template_id" ref="ro_chart_template"/>
         <field name="sequence">21</field>
         <field name="name">TVA deductibil 9%</field>
-        <field name="description">TVA deductibil 9%</field>
         <field name="amount">9</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -325,7 +316,6 @@
         <field name="chart_template_id" ref="ro_chart_template"/>
         <field name="sequence">19</field>
         <field name="name">TVA deductibil 19%</field>
-        <field name="description">TVA deductibil 19%</field>
         <field name="amount">19</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -362,7 +352,6 @@
         <field name="chart_template_id" ref="ro_chart_template"/>
         <field name="sequence">20</field>
         <field name="name">TVA deductibil 20%</field>
-        <field name="description">TVA deductibil 20%</field>
         <field name="amount">20</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -395,7 +384,6 @@
         <field name="chart_template_id" ref="ro_chart_template"/>
         <field name="sequence">23</field>
         <field name="name">TVA deductibil 24%</field>
-        <field name="description">TVA deductibil 24%</field>
         <field name="amount">24</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -432,7 +420,6 @@
         <field name="chart_template_id" ref="ro_chart_template"/>
         <field name="sequence">30</field>
         <field name="name">TVA Taxare Inversa</field>
-        <field name="description">TVA Taxare Inversa</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -465,7 +452,6 @@
         <field name="chart_template_id" ref="ro_chart_template"/>
         <field name="sequence">34</field>
         <field name="name">TVA Taxare Inversa 0%</field>
-        <field name="description">TVA Taxare Inversa 0%</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -500,7 +486,6 @@
         <field name="chart_template_id" ref="ro_chart_template"/>
         <field name="sequence">33</field>
         <field name="name">TVA Taxare Inversa 5%</field>
-        <field name="description">TVA Taxare Inversa 5%</field>
         <field name="amount">5</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -551,7 +536,6 @@
         <field name="chart_template_id" ref="ro_chart_template"/>
         <field name="sequence">32</field>
         <field name="name">TVA Taxare Inversa 9%</field>
-        <field name="description">TVA Taxare Inversa 9%</field>
         <field name="amount">9</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -602,7 +586,6 @@
         <field name="chart_template_id" ref="ro_chart_template"/>
         <field name="sequence">32</field>
         <field name="name">TVA Taxare Inversa 19%</field>
-        <field name="description">TVA Taxare Inversa 19%</field>
         <field name="amount">19</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -645,7 +628,6 @@
         <field name="chart_template_id" ref="ro_chart_template"/>
         <field name="sequence">31</field>
         <field name="name">TVA Taxare Inversa 20%</field>
-        <field name="description">TVA Taxare Inversa 20%</field>
         <field name="amount">20</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -688,7 +670,6 @@
         <field name="chart_template_id" ref="ro_chart_template"/>
         <field name="sequence">30</field>
         <field name="name">TVA Taxare Inversa 24%</field>
-        <field name="description">TVA Taxare Inversa 24%</field>
         <field name="amount">24</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -738,7 +719,6 @@
         <field name="chart_template_id" ref="ro_chart_template"/>
         <field name="sequence">40</field>
         <field name="name">TVA Taxare Scutita Livrari</field>
-        <field name="description">Scutit-L</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -771,7 +751,6 @@
         <field name="chart_template_id" ref="ro_chart_template"/>
         <field name="sequence">41</field>
         <field name="name">TVA Taxare Scutita Achizitii</field>
-        <field name="description">Scutit-A</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -806,7 +785,6 @@
         <field name="chart_template_id" ref="ro_chart_template"/>
         <field name="sequence">50</field>
         <field name="name">TVA Taxare Neimpozabila Livrari</field>
-        <field name="description">Neimpozabil-L</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -839,7 +817,6 @@
         <field name="chart_template_id" ref="ro_chart_template"/>
         <field name="sequence">51</field>
         <field name="name">TVA Taxare Neimpozabila Achizitii</field>
-        <field name="description">Neimpozabil-A</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>

--- a/addons/l10n_se/data/account_tax_template.xml
+++ b/addons/l10n_se/data/account_tax_template.xml
@@ -4,7 +4,6 @@
         <record id="sale_tax_25_goods" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Utgående moms 25%</field>
-            <field name="description">ST25</field>
             <field name="amount">25</field>
             <field name="type_tax_use">sale</field>
             <field name="tax_group_id" ref="tax_group_25"/>
@@ -36,7 +35,6 @@
         <record id="sale_tax_25_services" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Utgående moms Tjänst 25%</field>
-            <field name="description">ST25</field>
             <field name="amount">25</field>
             <field name="type_tax_use">sale</field>
             <field name="tax_group_id" ref="tax_group_25"/>
@@ -68,7 +66,6 @@
         <record id="purchase_tax_25_goods" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Ingående moms 25%</field>
-            <field name="description">PT25</field>
             <field name="amount">25</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_25"/>
@@ -98,7 +95,6 @@
         <record id="purchase_tax_25_services" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Ingående moms Tjänst 25%</field>
-            <field name="description">PT25</field>
             <field name="amount">25</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_25"/>
@@ -128,7 +124,6 @@
         <record id="sale_tax_12_goods" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Utgående moms 12%</field>
-            <field name="description">ST12</field>
             <field name="amount">12</field>
             <field name="type_tax_use">sale</field>
             <field name="tax_group_id" ref="tax_group_12"/>
@@ -160,7 +155,6 @@
         <record id="sale_tax_12_services" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Utgående moms Tjänst 12%</field>
-            <field name="description">ST12</field>
             <field name="amount">12</field>
             <field name="type_tax_use">sale</field>
             <field name="tax_group_id" ref="tax_group_12"/>
@@ -192,7 +186,6 @@
         <record id="purchase_tax_12_goods" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Ingående moms 12%</field>
-            <field name="description">PT12</field>
             <field name="amount">12</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_12"/>
@@ -222,7 +215,6 @@
         <record id="purchase_tax_12_services" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Ingående moms Tjänst 12%</field>
-            <field name="description">PT12</field>
             <field name="amount">12</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_12"/>
@@ -252,7 +244,6 @@
         <record id="sale_tax_6_goods" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Utgående moms 6%</field>
-            <field name="description">ST6</field>
             <field name="amount">6</field>
             <field name="type_tax_use">sale</field>
             <field name="tax_group_id" ref="tax_group_6"/>
@@ -284,7 +275,6 @@
         <record id="sale_tax_6_services" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Utgående moms Tjänst 6%</field>
-            <field name="description">ST6</field>
             <field name="amount">6</field>
             <field name="type_tax_use">sale</field>
             <field name="tax_group_id" ref="tax_group_6"/>
@@ -316,7 +306,6 @@
         <record id="purchase_tax_6_goods" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Ingående moms 6%</field>
-            <field name="description">PT6</field>
             <field name="amount">6</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_6"/>
@@ -346,7 +335,6 @@
         <record id="purchase_tax_6_services" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Ingående moms Tjänst 6%</field>
-            <field name="description">PT6</field>
             <field name="amount">6</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_6"/>
@@ -377,7 +365,6 @@
         <record id="sale_tax_services_EC" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Momsfri försäljning av tjänst EU</field>
-            <field name="description">SE0</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
             <field name="tax_group_id" ref="tax_group_0"/>
@@ -405,7 +392,6 @@
         <record id="sale_tax_goods_EC" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Momsfri Försäljning av varor EU</field>
-            <field name="description">SE0</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
             <field name="tax_group_id" ref="tax_group_0"/>
@@ -433,7 +419,6 @@
         <record id="purchase_goods_tax_25_EC" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Inköp av varor EU moms 25%</field>
-            <field name="description">PE25</field>
             <field name="amount">25</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_25"/>
@@ -477,7 +462,6 @@
         <record id="purchase_goods_tax_12_EC" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Inköp av varor EU moms 12%</field>
-            <field name="description">PE12</field>
             <field name="amount">12</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_12"/>
@@ -521,7 +505,6 @@
         <record id="purchase_goods_tax_6_EC" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Inköp av varor EU moms 6%</field>
-            <field name="description">PE6</field>
             <field name="amount">6</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_6"/>
@@ -566,7 +549,6 @@
         <record id="purchase_services_tax_25_EC" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Inköp av tjänst EU moms 25%</field>
-            <field name="description">PE25</field>
             <field name="amount">25</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_25"/>
@@ -610,7 +592,6 @@
         <record id="purchase_services_tax_12_EC" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Inköp av tjänst EU moms 12%</field>
-            <field name="description">PE12</field>
             <field name="amount">12</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_12"/>
@@ -654,7 +635,6 @@
         <record id="purchase_services_tax_6_EC" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Inköp av tjänst EU moms 6%</field>
-            <field name="description">PE6</field>
             <field name="amount">6</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_6"/>
@@ -699,7 +679,6 @@
         <record id="purchase_construction_services_tax_25_EC" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Inköpta tjänster i Sverige, omvändskattskyldighet, 25 %</field>
-            <field name="description">PCS25</field>
             <field name="amount">25</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_25"/>
@@ -743,7 +722,6 @@
         <record id="purchase_construction_services_tax_12_EC" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Inköpta tjänster i Sverige, omvändskattskyldighet, 12 %</field>
-            <field name="description">PCS12</field>
             <field name="amount">12</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_12"/>
@@ -787,7 +765,6 @@
         <record id="purchase_construction_services_tax_6_EC" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Inköpta tjänster i Sverige, omvändskattskyldighet, 6 %</field>
-            <field name="description">PCS6</field>
             <field name="amount">6</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_6"/>
@@ -832,7 +809,6 @@
         <record id="sale_tax_services_NEC" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Momsfri försäljning av tjänst utanför EU</field>
-            <field name="description">SE0</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
             <field name="tax_group_id" ref="tax_group_0"/>
@@ -860,7 +836,6 @@
         <record id="sale_tax_goods_NEC" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Momsfri försäljning av varor utanför EU</field>
-            <field name="description">SE0</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
             <field name="tax_group_id" ref="tax_group_0"/>
@@ -888,7 +863,6 @@
         <record id="purchase_goods_tax_25_NEC" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Beskattningsunderlag vid import 25%</field>
-            <field name="description">PN25</field>
             <field name="amount">25</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_25"/>
@@ -930,7 +904,6 @@
         <record id="purchase_goods_tax_12_NEC" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Beskattningsunderlag vid import 12%</field>
-            <field name="description">PN12</field>
             <field name="amount">12</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_12"/>
@@ -972,7 +945,6 @@
         <record id="purchase_goods_tax_6_NEC" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Beskattningsunderlag vid import 6%</field>
-            <field name="description">PN6</field>
             <field name="amount">6</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_6"/>
@@ -1014,7 +986,6 @@
         <record id="purchase_services_tax_25_NEC" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Inköp av tjänster utanför EU 25%</field>
-            <field name="description">PN25</field>
             <field name="amount">25</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_25"/>
@@ -1058,7 +1029,6 @@
         <record id="purchase_services_tax_12_NEC" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Inköp av tjänster utanför EU 12%</field>
-            <field name="description">PN12</field>
             <field name="amount">12</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_12"/>
@@ -1102,7 +1072,6 @@
         <record id="purchase_services_tax_6_NEC" model="account.tax.template">
             <field name="chart_template_id" ref="l10nse_chart_template"/>
             <field name="name">Inköp av tjänster utanför EU 6%</field>
-            <field name="description">PN6</field>
             <field name="amount">6</field>
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_6"/>

--- a/addons/l10n_sg/data/account_tax_data.xml
+++ b/addons/l10n_sg/data/account_tax_data.xml
@@ -4,7 +4,6 @@
         <!-- Sales Tax -->
         <record id="sg_sale_tax_es_0" model="account.tax.template">
             <field name="name">Sales Tax 0% ES33</field>
-            <field name="description">0% ES33</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
@@ -37,7 +36,6 @@
 
         <record id="sg_sale_tax_ds_7" model="account.tax.template">
             <field name="name">Sales Tax 7% DS</field>
-            <field name="description">7% DS</field>
             <field name="price_include" eval="0"/>
             <field name="amount">7</field>
             <field name="amount_type">percent</field>
@@ -74,7 +72,6 @@
 
         <record id="sg_sale_tax_esn_0" model="account.tax.template">
             <field name="name">Sales Tax 0% ESN33</field>
-            <field name="description">0% ESN33</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
@@ -107,7 +104,6 @@
 
         <record id="sg_sale_tax_os_0" model="account.tax.template">
             <field name="name">Sales Tax 0% OS</field>
-            <field name="description">0% OS</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
@@ -138,7 +134,6 @@
 
         <record id="sg_sale_tax_zr_0" model="account.tax.template">
             <field name="name">Sales Tax 0% ZR</field>
-            <field name="description">0% ZR</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
@@ -171,7 +166,6 @@
 
         <record id="sg_sale_tax_sr_7" model="account.tax.template">
             <field name="name">Sales Tax 7% SR</field>
-            <field name="description">7% SR</field>
             <field name="price_include" eval="0"/>
             <field name="amount">7</field>
             <field name="amount_type">percent</field>
@@ -208,7 +202,6 @@
 
         <record id="sg_sale_tax_srca_s_na" model="account.tax.template">
             <field name="name">Sales Tax SRCA-S</field>
-            <field name="description">SRCA-S</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
@@ -241,7 +234,6 @@
 
         <record id="sg_sale_tax_srca_c_7" model="account.tax.template">
             <field name="name">Sales Tax 7% SRCA-C</field>
-            <field name="description">7% SRCA-C</field>
             <field name="price_include" eval="0"/>
             <field name="amount">7</field>
             <field name="amount_type">percent</field>
@@ -280,7 +272,6 @@
 
         <record id="sg_purchase_tax_txn33_7" model="account.tax.template">
             <field name="name">Purchase Tax 7% TX-N33</field>
-            <field name="description">7% TX-N33</field>
             <field name="price_include" eval="0"/>
             <field name="amount">7</field>
             <field name="amount_type">percent</field>
@@ -317,7 +308,6 @@
 
         <record id="sg_purchase_tax_txe33_7" model="account.tax.template">
             <field name="name">Purchase Tax 7% TX-E33</field>
-            <field name="description">7% TX-E33</field>
             <field name="price_include" eval="0"/>
             <field name="amount">7</field>
             <field name="amount_type">percent</field>
@@ -354,7 +344,6 @@
 
         <record id="sg_purchase_tax_bl_7" model="account.tax.template">
             <field name="name">Purchase Tax 7% BL</field>
-            <field name="description">7% BL</field>
             <field name="price_include" eval="0"/>
             <field name="amount">7</field>
             <field name="amount_type">percent</field>
@@ -387,7 +376,6 @@
 
         <record id="sg_purchase_tax_im_7" model="account.tax.template">
             <field name="name">Purchase Tax 7% IM</field>
-            <field name="description">7% IM</field>
             <field name="price_include" eval="0"/>
             <field name="amount">7</field>
             <field name="amount_type">percent</field>
@@ -424,7 +412,6 @@
 
         <record id="sg_purchase_tax_txre_7" model="account.tax.template">
             <field name="name">Purchase Tax 7% TX-RE</field>
-            <field name="description">7% TX-RE</field>
             <field name="price_include" eval="0"/>
             <field name="amount">7</field>
             <field name="amount_type">percent</field>
@@ -461,7 +448,6 @@
 
         <record id="sg_purchase_tax_me_0" model="account.tax.template">
             <field name="name">Purchase Tax 7% IGDS</field>
-            <field name="description">7% IGDS</field>
             <field name="price_include" eval="0"/>
             <field name="amount">7</field>
             <field name="amount_type">percent</field>
@@ -498,7 +484,6 @@
 
         <record id="sg_purchase_tax_nr_0" model="account.tax.template">
             <field name="name">Purchase Tax 0% NR</field>
-            <field name="description">0% NR</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
@@ -529,7 +514,6 @@
 
         <record id="sg_purchase_tax_zp_0" model="account.tax.template">
             <field name="name">Purchase Tax 0% ZP</field>
-            <field name="description">0% ZP</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
@@ -562,7 +546,6 @@
 
         <record id="sg_purchase_tax_op_0" model="account.tax.template">
             <field name="name">Purchase Tax 0% OP</field>
-            <field name="description">0% OP</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
@@ -593,7 +576,6 @@
 
         <record id="sg_purchase_tax_ep_0" model="account.tax.template">
             <field name="name">Purchase Tax 0% EP</field>
-            <field name="description">0% EP</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
@@ -624,7 +606,6 @@
 
         <record id="sg_purchase_tax_mes_0" model="account.tax.template">
             <field name="name">Purchase Tax MES</field>
-            <field name="description">0% MES</field>
             <field name="price_include" eval="0"/>
             <field name="amount">0</field>
             <field name="amount_type">percent</field>
@@ -657,7 +638,6 @@
 
         <record id="sg_purchase_tax_tx7_7" model="account.tax.template">
             <field name="name">Purchase Tax 7% TX7</field>
-            <field name="description">7% TX7</field>
             <field name="price_include" eval="0"/>
             <field name="amount">7</field>
             <field name="amount_type">percent</field>
@@ -694,7 +674,6 @@
 
         <record id="sg_purchase_tax_txca_7" model="account.tax.template">
             <field name="name">Purchase Tax 7% TXCA</field>
-            <field name="description">7% TXCA</field>
             <field name="price_include" eval="0"/>
             <field name="amount">7</field>
             <field name="amount_type">percent</field>

--- a/addons/l10n_si/data/account_tax_data.xml
+++ b/addons/l10n_si/data/account_tax_data.xml
@@ -4,7 +4,6 @@
     <record id="gd_taxr_1" model="account.tax.template">
         <field name="chart_template_id" ref="gd_chart"/>
         <field name="name">Izstopni DDV 0%</field>
-        <field name="description">DDV-I-0</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
         <field name="type_tax_use">sale</field>
@@ -37,7 +36,6 @@
     <record id="gd_taxr_2" model="account.tax.template">
         <field name="chart_template_id" ref="gd_chart"/>
         <field name="name">Izstopni DDV 9.5%</field>
-        <field name="description">DDV-I-9.5</field>
         <field name="amount_type">percent</field>
         <field name="amount">9.5</field>
         <field name="type_tax_use">sale</field>
@@ -74,7 +72,6 @@
     <record id="gd_taxr_3" model="account.tax.template">
         <field name="chart_template_id" ref="gd_chart"/>
         <field name="name">Izstopni DDV 22%</field>
-        <field name="description">DDV-I-22</field>
         <field name="amount_type">percent</field>
         <field name="amount">22</field>
         <field name="type_tax_use">sale</field>
@@ -111,7 +108,6 @@
     <record id="gd_taxp_1" model="account.tax.template">
         <field name="chart_template_id" ref="gd_chart"/>
         <field name="name">Vstopni DDV 0%</field>
-        <field name="description">DDV-V-0</field>
         <field name="amount_type">percent</field>
         <field name="amount">0</field>
         <field name="type_tax_use">purchase</field>
@@ -144,7 +140,6 @@
     <record id="gd_taxp_2" model="account.tax.template">
         <field name="chart_template_id" ref="gd_chart"/>
         <field name="name">Vstopni DDV 9.5%</field>
-        <field name="description">DDV-V-9.5</field>
         <field name="amount_type">percent</field>
         <field name="amount">9.5</field>
         <field name="type_tax_use">purchase</field>
@@ -181,7 +176,6 @@
     <record id="gd_taxp_3" model="account.tax.template">
         <field name="chart_template_id" ref="gd_chart"/>
         <field name="name">Vstopni DDV 22%</field>
-        <field name="description">DDV-V-22</field>
         <field name="amount_type">percent</field>
         <field name="amount">22</field>
         <field name="type_tax_use">purchase</field>
@@ -218,7 +212,6 @@
     <record id="gd_taxp_nr_1" model="account.tax.template">
         <field name="chart_template_id" ref="gd_chart"/>
         <field name="name">Vstopni DDV 9.5% - neodbitni</field>
-        <field name="description">DDV-V-9.5-NE</field>
         <field name="amount_type">percent</field>
         <field name="amount">9.5</field>
         <field name="type_tax_use">purchase</field>
@@ -255,7 +248,6 @@
     <record id="gd_taxp_nr_2" model="account.tax.template">
         <field name="chart_template_id" ref="gd_chart"/>
         <field name="name">Vstopni DDV 22% - neodbitni</field>
-        <field name="description">DDV-V-22-NE</field>
         <field name="amount_type">percent</field>
         <field name="amount">22</field>
         <field name="type_tax_use">purchase</field>
@@ -292,7 +284,6 @@
     <record id="gd_taxp_st_1" model="account.tax.template">
         <field name="chart_template_id" ref="gd_chart"/>
         <field name="name">Vstopni DDV 9.5% - samoobdavčitev</field>
-        <field name="description">DDV-V-9.5-SO</field>
         <field name="amount_type">percent</field>
         <field name="amount">9.5</field>
         <field name="type_tax_use">purchase</field>
@@ -341,7 +332,6 @@
     <record id="gd_taxp_st_2" model="account.tax.template">
         <field name="chart_template_id" ref="gd_chart"/>
         <field name="name">Vstopni DDV 22% - samoobdavčitev</field>
-        <field name="description">DDV-V-22-SO</field>
         <field name="amount_type">percent</field>
         <field name="amount">22</field>
         <field name="type_tax_use">purchase</field>

--- a/addons/l10n_tr/data/account_tax_template_data.xml
+++ b/addons/l10n_tr/data/account_tax_template_data.xml
@@ -3,7 +3,6 @@
     <!-- account.tax.template -->
     <record id="tr_kdv_satis_sale_18" model="account.tax.template">
         <field name="sequence">11</field>
-        <field name="description">KDV %18(sale)</field>
         <field name="name">KDV %18(sale)</field>
         <field name="price_include" eval="0"/>
         <field name="amount">18</field>
@@ -37,7 +36,6 @@
 
     <record id="tr_kdv_satis_purchase_18" model="account.tax.template">
         <field name="sequence">11</field>
-        <field name="description">KDV %18(purchase)</field>
         <field name="name">KDV %18(purchase)</field>
         <field name="price_include" eval="0"/>
         <field name="amount">18</field>

--- a/addons/l10n_ua/data/account_tax_template.xml
+++ b/addons/l10n_ua/data/account_tax_template.xml
@@ -10,7 +10,6 @@
             <field name="chart_template_id" ref="l10n_ua_psbo_chart_template"/>
             <field name="sequence">10</field>
             <field name="name">Реалізація ПДВ 20%</field>
-            <field name="description">+ ПДВ 20%</field>
             <field name="amount">20</field>
             <field name="type_tax_use">sale</field>
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -41,7 +40,6 @@
             <field name="chart_template_id" ref="l10n_ua_psbo_chart_template"/>
             <field name="sequence">10</field>
             <field name="name">Реалізація в т. ч. ПДВ 20%</field>
-            <field name="description">в т. ч. ПДВ 20%</field>
             <field name="amount">20</field>
             <field name="type_tax_use">sale</field>
             <field name="price_include" eval="1"/>
@@ -73,7 +71,6 @@
             <field name="chart_template_id" ref="l10n_ua_psbo_chart_template"/>
             <field name="sequence">11</field>
             <field name="name">Реалізація ПДВ 7%</field>
-            <field name="description">+ ПДВ 7%</field>
             <field name="amount">7</field>
             <field name="type_tax_use">sale</field>
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -104,7 +101,6 @@
             <field name="chart_template_id" ref="l10n_ua_psbo_chart_template"/>
             <field name="sequence">11</field>
             <field name="name">Реалізація в т. ч. ПДВ 7%</field>
-            <field name="description">в т .ч. ПДВ 7%</field>
             <field name="amount">7</field>
             <field name="type_tax_use">sale</field>
             <field name="price_include" eval="1"/>
@@ -136,7 +132,6 @@
             <field name="chart_template_id" ref="l10n_ua_psbo_chart_template"/>
             <field name="sequence">12</field>
             <field name="name">Реалізація ПДВ 0%</field>
-            <field name="description">ПДВ 0%</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -164,7 +159,6 @@
             <field name="chart_template_id" ref="l10n_ua_psbo_chart_template"/>
             <field name="sequence">13</field>
             <field name="name">Реалізація звільнена від  ПДВ</field>
-            <field name="description">Звільнено від ПДВ</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -192,7 +186,6 @@
             <field name="chart_template_id" ref="l10n_ua_psbo_chart_template"/>
             <field name="sequence">14</field>
             <field name="name">Реалізація Не є об'єктом ПДВ</field>
-            <field name="description">Не є об'єктом ПДВ</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -221,7 +214,6 @@
             <field name="chart_template_id" ref="l10n_ua_psbo_chart_template"/>
             <field name="sequence">20</field>
             <field name="name">Придбання ПДВ 20%</field>
-            <field name="description">+ ПДВ 20%</field>
             <field name="amount">20</field>
             <field name="type_tax_use">purchase</field>
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -252,7 +244,6 @@
             <field name="chart_template_id" ref="l10n_ua_psbo_chart_template"/>
             <field name="sequence">20</field>
             <field name="name">Придбання в т. ч. ПДВ 20%</field>
-            <field name="description">в т. ч. ПДВ 20%</field>
             <field name="amount">20</field>
             <field name="type_tax_use">purchase</field>
             <field name="price_include" eval="1"/>
@@ -284,7 +275,6 @@
             <field name="chart_template_id" ref="l10n_ua_psbo_chart_template"/>
             <field name="sequence">21</field>
             <field name="name">Придбання ПДВ 7%</field>
-            <field name="description">+ ПДВ 7%</field>
             <field name="amount">7</field>
             <field name="type_tax_use">purchase</field>
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -315,7 +305,6 @@
             <field name="chart_template_id" ref="l10n_ua_psbo_chart_template"/>
             <field name="sequence">21</field>
             <field name="name">Придбання в т. ч. ПДВ 7%</field>
-            <field name="description">в т. ч. ПДВ 7%</field>
             <field name="amount">7</field>
             <field name="type_tax_use">purchase</field>
             <field name="price_include" eval="1"/>
@@ -347,7 +336,6 @@
             <field name="chart_template_id" ref="l10n_ua_psbo_chart_template"/>
             <field name="sequence">22</field>
             <field name="name">Придбання ПДВ 0%</field>
-            <field name="description">ПДВ 0%</field>
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -375,7 +363,6 @@
             <field name="chart_template_id" ref="l10n_ua_psbo_chart_template"/>
             <field name="sequence">23</field>
             <field name="name">Придбання звільнене від  ПДВ</field>
-            <field name="description">Звільнено від ПДВ</field>
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -403,7 +390,6 @@
             <field name="chart_template_id" ref="l10n_ua_psbo_chart_template"/>
             <field name="sequence">24</field>
             <field name="name">Придбання Не є об'єктом ПДВ</field>
-            <field name="description">Не є об'єктом ПДВ</field>
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -433,7 +419,6 @@
             <field name="chart_template_id" ref="l10n_ua_psbo_chart_template"/>
             <field name="sequence">30</field>
             <field name="name">Дохід від продажу  товарів</field>
-            <field name="description">Дохід від продажу товарів</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
         </record>
@@ -441,7 +426,6 @@
             <field name="chart_template_id" ref="l10n_ua_psbo_chart_template"/>
             <field name="sequence">31</field>
             <field name="name">Дохід від безоплатно отриманих  товарів</field>
-            <field name="description">Дохід від безоплатно отриманих товарів</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
         </record>
@@ -449,7 +433,6 @@
             <field name="chart_template_id" ref="l10n_ua_psbo_chart_template"/>
             <field name="sequence">32</field>
             <field name="name">Дохід від заборгованності за якою минув строк позивної давності</field>
-            <field name="description">Дохід від заборгованності, за якою минув строк позивної давності</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
         </record>
@@ -457,7 +440,6 @@
             <field name="chart_template_id" ref="l10n_ua_psbo_chart_template"/>
             <field name="sequence">33</field>
             <field name="name">Дохід, за ставкою 15%</field>
-            <field name="description">Дохід за ставкою 15%</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
         </record>
@@ -466,7 +448,6 @@
             <field name="chart_template_id" ref="l10n_ua_psbo_chart_template"/>
             <field name="sequence">40</field>
             <field name="name">Витрати від продажу  товарів</field>
-            <field name="description">Витрати від продажу товарів</field>
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
         </record>
@@ -474,7 +455,6 @@
             <field name="chart_template_id" ref="l10n_ua_psbo_chart_template"/>
             <field name="sequence">41</field>
             <field name="name">Витрати на оплату праці</field>
-            <field name="description">Витрати на оплату праці найманих працівників</field>
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
         </record>
@@ -482,7 +462,6 @@
             <field name="chart_template_id" ref="l10n_ua_psbo_chart_template"/>
             <field name="sequence">42</field>
             <field name="name">Витрати ЄСВ</field>
-            <field name="description">Витрати на ЄСВ</field>
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
         </record>
@@ -490,7 +469,6 @@
             <field name="chart_template_id" ref="l10n_ua_psbo_chart_template"/>
             <field name="sequence">43</field>
             <field name="name">Витрати  інші</field>
-            <field name="description">Витрати інші</field>
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
         </record>
@@ -505,7 +483,6 @@
             <field name="chart_template_id" ref="l10n_ua_ias_chart_template"/>
             <field name="sequence">10</field>
             <field name="name">Реалізація з ПДВ 20%</field>
-            <field name="description">+ ПДВ 20%</field>
             <field name="amount">20</field>
             <field name="type_tax_use">sale</field>
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -536,7 +513,6 @@
             <field name="chart_template_id" ref="l10n_ua_ias_chart_template"/>
             <field name="sequence">10</field>
             <field name="name">Реалізація в т. ч. ПДВ 20%</field>
-            <field name="description">в т. ч. ПДВ 20%</field>
             <field name="amount">20</field>
             <field name="type_tax_use">sale</field>
             <field name="price_include" eval="1"/>
@@ -568,7 +544,6 @@
             <field name="chart_template_id" ref="l10n_ua_ias_chart_template"/>
             <field name="sequence">11</field>
             <field name="name">Реалізація з ПДВ 7%</field>
-            <field name="description">+ ПДВ 7%</field>
             <field name="amount">7</field>
             <field name="type_tax_use">sale</field>
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -599,7 +574,6 @@
             <field name="chart_template_id" ref="l10n_ua_ias_chart_template"/>
             <field name="sequence">11</field>
             <field name="name">Реалізація в т. ч. ПДВ 7%</field>
-            <field name="description">в т .ч. ПДВ 7%</field>
             <field name="amount">7</field>
             <field name="type_tax_use">sale</field>
             <field name="price_include" eval="1"/>
@@ -631,7 +605,6 @@
             <field name="chart_template_id" ref="l10n_ua_ias_chart_template"/>
             <field name="sequence">12</field>
             <field name="name">Реалізація з ПДВ 0%</field>
-            <field name="description">ПДВ 0%</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -659,7 +632,6 @@
             <field name="chart_template_id" ref="l10n_ua_ias_chart_template"/>
             <field name="sequence">13</field>
             <field name="name">Реалізація звільнена від ПДВ</field>
-            <field name="description">Звільнено від ПДВ</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -687,7 +659,6 @@
             <field name="chart_template_id" ref="l10n_ua_ias_chart_template"/>
             <field name="sequence">14</field>
             <field name="name">Реалізація не є об'єктом ПДВ</field>
-            <field name="description">Не є об'єктом ПДВ</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -716,7 +687,6 @@
             <field name="chart_template_id" ref="l10n_ua_ias_chart_template"/>
             <field name="sequence">20</field>
             <field name="name">Придбання з ПДВ 20%</field>
-            <field name="description">+ ПДВ 20%</field>
             <field name="amount">20</field>
             <field name="type_tax_use">purchase</field>
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -747,7 +717,6 @@
             <field name="chart_template_id" ref="l10n_ua_ias_chart_template"/>
             <field name="sequence">20</field>
             <field name="name">Придбання в т. ч. ПДВ 20%</field>
-            <field name="description">в т. ч. ПДВ 20%</field>
             <field name="amount">20</field>
             <field name="type_tax_use">purchase</field>
             <field name="price_include" eval="1"/>
@@ -779,7 +748,6 @@
             <field name="chart_template_id" ref="l10n_ua_ias_chart_template"/>
             <field name="sequence">21</field>
             <field name="name">Придбання з ПДВ 7%</field>
-            <field name="description">+ ПДВ 7%</field>
             <field name="amount">7</field>
             <field name="type_tax_use">purchase</field>
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -810,7 +778,6 @@
             <field name="chart_template_id" ref="l10n_ua_ias_chart_template"/>
             <field name="sequence">21</field>
             <field name="name">Придбання в т. ч. ПДВ 7%</field>
-            <field name="description">в т. ч. ПДВ 7%</field>
             <field name="amount">7</field>
             <field name="type_tax_use">purchase</field>
             <field name="price_include" eval="1"/>
@@ -842,7 +809,6 @@
             <field name="chart_template_id" ref="l10n_ua_ias_chart_template"/>
             <field name="sequence">22</field>
             <field name="name">Придбання з ПДВ 0%</field>
-            <field name="description">ПДВ 0%</field>
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -870,7 +836,6 @@
             <field name="chart_template_id" ref="l10n_ua_ias_chart_template"/>
             <field name="sequence">23</field>
             <field name="name">Придбання звільнене від ПДВ</field>
-            <field name="description">Звільнено від ПДВ</field>
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -898,7 +863,6 @@
             <field name="chart_template_id" ref="l10n_ua_ias_chart_template"/>
             <field name="sequence">24</field>
             <field name="name">Придбання не є об'єктом ПДВ</field>
-            <field name="description">Не є об'єктом ПДВ</field>
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
             <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
@@ -928,7 +892,6 @@
             <field name="chart_template_id" ref="l10n_ua_ias_chart_template"/>
             <field name="sequence">30</field>
             <field name="name">Дохід від продажу товарів</field>
-            <field name="description">Дохід від продажу товарів</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
         </record>
@@ -936,7 +899,6 @@
             <field name="chart_template_id" ref="l10n_ua_ias_chart_template"/>
             <field name="sequence">31</field>
             <field name="name">Дохід від безоплатно отриманих товарів</field>
-            <field name="description">Дохід від безоплатно отриманих товарів</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
         </record>
@@ -944,7 +906,6 @@
             <field name="chart_template_id" ref="l10n_ua_ias_chart_template"/>
             <field name="sequence">32</field>
             <field name="name">Дохід від заборгованності, за якою минув строк позивної давності</field>
-            <field name="description">Дохід від заборгованності, за якою минув строк позивної давності</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
         </record>
@@ -952,7 +913,6 @@
             <field name="chart_template_id" ref="l10n_ua_ias_chart_template"/>
             <field name="sequence">33</field>
             <field name="name">Дохід, що оподатковується за ставкою 15%</field>
-            <field name="description">Дохід за ставкою 15%</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
         </record>
@@ -961,7 +921,6 @@
             <field name="chart_template_id" ref="l10n_ua_ias_chart_template"/>
             <field name="sequence">40</field>
             <field name="name">Витрати від продажу товарів</field>
-            <field name="description">Витрати від продажу товарів</field>
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
         </record>
@@ -969,7 +928,6 @@
             <field name="chart_template_id" ref="l10n_ua_ias_chart_template"/>
             <field name="sequence">41</field>
             <field name="name">Витрати на оплату праці найманих працівників</field>
-            <field name="description">Витрати на оплату праці найманих працівників</field>
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
         </record>
@@ -977,7 +935,6 @@
             <field name="chart_template_id" ref="l10n_ua_ias_chart_template"/>
             <field name="sequence">42</field>
             <field name="name">Витрати на ЄСВ</field>
-            <field name="description">Витрати на ЄСВ</field>
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
         </record>
@@ -985,7 +942,6 @@
             <field name="chart_template_id" ref="l10n_ua_ias_chart_template"/>
             <field name="sequence">43</field>
             <field name="name">Витрати інші</field>
-            <field name="description">Витрати інші</field>
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
         </record>

--- a/addons/l10n_uk/data/account_tax_data.xml
+++ b/addons/l10n_uk/data/account_tax_data.xml
@@ -2,7 +2,6 @@
 <odoo>
 
     <record id="ST0" model="account.tax.template">
-        <field name="description">ST0</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Zero rated sales</field>
@@ -34,7 +33,6 @@
     </record>
 
     <record id="ST2" model="account.tax.template">
-        <field name="description">ST2</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Exempt sales</field>
@@ -66,7 +64,6 @@
     </record>
 
     <record id="PT0" model="account.tax.template">
-        <field name="description">PT0</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Zero rated purchases</field>
@@ -98,7 +95,6 @@
     </record>
 
     <record id="PT2" model="account.tax.template">
-        <field name="description">PT2</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Exempt purchases</field>
@@ -130,7 +126,6 @@
     </record>
 
     <record id="PT8" model="account.tax.template">
-        <field name="description">PT8</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Standard rated purchases from EC</field>
@@ -178,7 +173,6 @@
     </record>
 
     <record id="PT5" model="account.tax.template">
-        <field name="description">PT5</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Lower rate purchases (5%)</field>
@@ -214,7 +208,6 @@
     </record>
 
 	<record id="ST5" model="account.tax.template">
-        <field name="description">ST5</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Lower rate sales (5%)</field>
@@ -250,7 +243,6 @@
     </record>
 
     <record id="ST4" model="account.tax.template">
-        <field name="description">ST4</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Sales to customers in EC</field>
@@ -282,7 +274,6 @@
     </record>
 
     <record id="PT7" model="account.tax.template">
-        <field name="description">PT7</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Zero rated purchases from EC</field>
@@ -314,7 +305,6 @@
     </record>
 
     <record id="ST11" model="account.tax.template">
-        <field name="description">ST11</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Standard rate sales (20%)</field>
@@ -350,7 +340,6 @@
     </record>
 
     <record id="PT11" model="account.tax.template">
-        <field name="description">PT11</field>
         <field name="chart_template_id" ref="l10n_uk"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Standard rate purchases (20%)</field>

--- a/addons/l10n_uy/data/account_tax_data.xml
+++ b/addons/l10n_uy/data/account_tax_data.xml
@@ -6,7 +6,6 @@
         <record id="vat1" model="account.tax.template">
             <field name="chart_template_id" ref="uy_chart_template"/>
             <field name="name">IVA Ventas (22%)</field>
-            <field name="description">IVA Ventas (22%)</field>
             <field name="amount">22</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -42,7 +41,6 @@
         <record id="vat2" model="account.tax.template">
             <field name="chart_template_id" ref="uy_chart_template"/>
             <field name="name">IVA Ventas (10%)</field>
-            <field name="description">IVA Ventas (10%)</field>
             <field name="amount">10</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">sale</field>
@@ -78,7 +76,6 @@
         <record id="vat3" model="account.tax.template">
             <field name="chart_template_id" ref="uy_chart_template"/>
             <field name="name">Ventas Exentos IVA</field>
-            <field name="description">Ventas Exentos IVA</field>
             <field name="amount">0</field>
             <field name="amount_type">fixed</field>
             <field name="type_tax_use">sale</field>
@@ -110,7 +107,6 @@
         <record id="vat4" model="account.tax.template">
             <field name="chart_template_id" ref="uy_chart_template"/>
             <field name="name">IVA Compras (22%)</field>
-            <field name="description">IVA Compras (22%)</field>
             <field name="amount">22</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -146,7 +142,6 @@
         <record id="vat5" model="account.tax.template">
             <field name="chart_template_id" ref="uy_chart_template"/>
             <field name="name">IVA Compras (10%)</field>
-            <field name="description">IVA Compras (10%)</field>
             <field name="amount">10</field>
             <field name="amount_type">percent</field>
             <field name="type_tax_use">purchase</field>
@@ -182,7 +177,6 @@
         <record id="vat6" model="account.tax.template">
             <field name="chart_template_id" ref="uy_chart_template"/>
             <field name="name">Compras Exentos IVA</field>
-            <field name="description">Compras Exentos IVA</field>
             <field name="amount">0</field>
             <field name="amount_type">fixed</field>
             <field name="type_tax_use">purchase</field>

--- a/addons/l10n_ve/data/account_tax_data.xml
+++ b/addons/l10n_ve/data/account_tax_data.xml
@@ -5,7 +5,6 @@
     <record id="tax0sale" model="account.tax.template">
         <field name="chart_template_id" ref="ve_chart_template_amd"/>
         <field name="name">Exento (ventas)</field>
-        <field name="description">Exento (ventas)</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -34,7 +33,6 @@
     <record id="tax1sale" model="account.tax.template">
         <field name="chart_template_id" ref="ve_chart_template_amd"/>
         <field name="name">IVA (12.0%) ventas</field>
-        <field name="description">IVA (12.0%) ventas</field>
         <field name="amount">12</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -65,7 +63,6 @@
     <record id="tax2sale" model="account.tax.template">
         <field name="chart_template_id" ref="ve_chart_template_amd"/>
         <field name="name">IVA (8.0%) ventas</field>
-        <field name="description">IVA (8.0%) ventas</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -96,7 +93,6 @@
     <record id="tax3sale" model="account.tax.template">
         <field name="chart_template_id" ref="ve_chart_template_amd"/>
         <field name="name">IVA (22.0%) ventas</field>
-        <field name="description">IVA (22.0%) ventas</field>
         <field name="amount">22</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -127,7 +123,6 @@
     <record id="tax0purchase" model="account.tax.template">
         <field name="chart_template_id" ref="ve_chart_template_amd"/>
         <field name="name">Exento (compras)</field>
-        <field name="description">Exento (compras)</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -156,7 +151,6 @@
     <record id="tax1purchase" model="account.tax.template">
         <field name="chart_template_id" ref="ve_chart_template_amd"/>
         <field name="name">IVA (12.0%) compras</field>
-        <field name="description">IVA (12.0%) compras</field>
         <field name="amount">12</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -187,7 +181,6 @@
     <record id="tax2purchase" model="account.tax.template">
         <field name="chart_template_id" ref="ve_chart_template_amd"/>
         <field name="name">IVA (8.0%) compras</field>
-        <field name="description">IVA (8.0%) compras</field>
         <field name="amount">8</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -218,7 +211,6 @@
     <record id="tax3purchase" model="account.tax.template">
         <field name="chart_template_id" ref="ve_chart_template_amd"/>
         <field name="name">IVA (22.0%) compras</field>
-        <field name="description">IVA (22.0%) compras</field>
         <field name="amount">22</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>

--- a/addons/l10n_vn/data/account_tax_data.xml
+++ b/addons/l10n_vn/data/account_tax_data.xml
@@ -5,7 +5,6 @@
     <record id="tax_purchase_vat10" model="account.tax.template">
         <field name="chart_template_id" ref="vn_template"/>
         <field name="name">Thuế GTGT được khấu trừ 10%</field>
-        <field name="description">Thuế GTGT được khấu trừ 10%</field>
         <field name="amount" eval="10"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -40,7 +39,6 @@
     <record id="tax_purchase_vat5" model="account.tax.template">
         <field name="chart_template_id" ref="vn_template"/>
         <field name="name">Thuế GTGT được khấu trừ 5%</field>
-        <field name="description">Thuế GTGT được khấu trừ 5%</field>
         <field name="amount" eval="5"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -75,7 +73,6 @@
     <record id="tax_purchase_vat0" model="account.tax.template">
         <field name="chart_template_id" ref="vn_template"/>
         <field name="name">Thuế GTGT được khấu trừ 0%</field>
-        <field name="description">Thuế GTGT được khấu trừ 0%</field>
         <field name="amount" eval="0"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
@@ -108,7 +105,6 @@
     <record id="tax_sale_vat10" model="account.tax.template">
         <field name="chart_template_id" ref="vn_template"/>
         <field name="name">Thuế GTGT phải nộp 10%</field>
-        <field name="description">Thuế GTGT phải nộp 10%</field>
         <field name="amount" eval="10"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -143,7 +139,6 @@
     <record id="tax_sale_vat5" model="account.tax.template">
         <field name="chart_template_id" ref="vn_template"/>
         <field name="name">Thuế GTGT phải nộp 5%</field>
-        <field name="description">Thuế GTGT phải nộp 5%</field>
         <field name="amount" eval="5"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -178,7 +173,6 @@
     <record id="tax_sale_vat0" model="account.tax.template">
         <field name="chart_template_id" ref="vn_template"/>
         <field name="name">Thuế GTGT phải nộp 0%</field>
-        <field name="description">Thuế GTGT phải nộp 0%</field>
         <field name="amount" eval="0"/>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>

--- a/addons/l10n_za/data/account_tax_template_data.xml
+++ b/addons/l10n_za/data/account_tax_template_data.xml
@@ -2,7 +2,6 @@
 <odoo>
 
     <record id="ST1" model="account.tax.template">
-        <field name="description">15%</field>
         <field name="chart_template_id" ref="default_chart_template"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Standard Rate</field>
@@ -38,7 +37,6 @@
     </record>
 
     <record id="ST1A" model="account.tax.template">
-        <field name="description">15%</field>
         <field name="chart_template_id" ref="default_chart_template"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Standard Rate (Capital Goods)</field>
@@ -74,7 +72,6 @@
     </record>
 
     <record id="ST2" model="account.tax.template">
-        <field name="description">0%</field>
         <field name="chart_template_id" ref="default_chart_template"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Zero Rate</field>
@@ -106,7 +103,6 @@
     </record>
 
     <record id="ST2A" model="account.tax.template">
-        <field name="description">0%</field>
         <field name="chart_template_id" ref="default_chart_template"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Zero Rate Exports</field>
@@ -138,7 +134,6 @@
     </record>
 
     <record id="ST3" model="account.tax.template">
-        <field name="description">0%</field>
         <field name="chart_template_id" ref="default_chart_template"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Exempt and Non-Supplies</field>
@@ -170,7 +165,6 @@
     </record>
 
     <record id="ST5" model="account.tax.template">
-        <field name="description">15%</field>
         <field name="chart_template_id" ref="default_chart_template"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Accommodation (28+ days)</field>
@@ -206,7 +200,6 @@
     </record>
 
     <record id="ST7" model="account.tax.template">
-        <field name="description">15%</field>
         <field name="chart_template_id" ref="default_chart_template"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Accommodation (Under 28 days)</field>
@@ -242,7 +235,6 @@
     </record>
 
     <record id="ST10" model="account.tax.template">
-        <field name="description">15%</field>
         <field name="chart_template_id" ref="default_chart_template"/>
         <field name="type_tax_use">sale</field>
         <field name="name">Export of Second-hand Goods/ Change in Use</field>
@@ -278,7 +270,6 @@
     </record>
 
     <record id="ST12" model="account.tax.template">
-        <field name="description">15%</field>
         <field name="chart_template_id" ref="default_chart_template"/>
         <field name="type_tax_use">sale</field>
         <field name="name">VAT Adjustments and Manual VAT</field>
@@ -312,7 +303,6 @@
     </record>
 
     <record id="PT15" model="account.tax.template">
-        <field name="description">15%</field>
         <field name="chart_template_id" ref="default_chart_template"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Standard Rate</field>
@@ -346,7 +336,6 @@
     </record>
 
     <record id="PT14" model="account.tax.template">
-        <field name="description">15%</field>
         <field name="chart_template_id" ref="default_chart_template"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Standard Rate (Capital Goods)</field>
@@ -380,7 +369,6 @@
     </record>
 
     <record id="PT14A" model="account.tax.template">
-        <field name="description">15%</field>
         <field name="chart_template_id" ref="default_chart_template"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Capital Goods Imported</field>
@@ -414,7 +402,6 @@
     </record>
 
     <record id="PT15A" model="account.tax.template">
-        <field name="description">15%</field>
         <field name="chart_template_id" ref="default_chart_template"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Goods and Services Imported</field>
@@ -448,7 +435,6 @@
     </record>
 
     <record id="PT16" model="account.tax.template">
-        <field name="description">15%</field>
         <field name="chart_template_id" ref="default_chart_template"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Change in Use</field>
@@ -482,7 +468,6 @@
     </record>
 
     <record id="PT17" model="account.tax.template">
-        <field name="description">15%</field>
         <field name="chart_template_id" ref="default_chart_template"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Bad Debts</field>
@@ -516,7 +501,6 @@
     </record>
 
     <record id="PT18" model="account.tax.template">
-        <field name="description">15%</field>
         <field name="chart_template_id" ref="default_chart_template"/>
         <field name="type_tax_use">purchase</field>
         <field name="name">Other Adjustments</field>


### PR DESCRIPTION
Task [2222127](https://www.odoo.com/web#id=2222127&action=333&active_id=1691&model=project.task&view_type=form&cids=&menu_id=4720)

The label of the taxes printed on the invoice was often a technical name
that was not interesting to the customer receiving the invoice.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
