### PR TITLE
[IMP] website_crm_livechat: update lead with utm source data

### DIFF
--- a/addons/utm/models/utm_mixin.py
+++ b/addons/utm/models/utm_mixin.py
@@ -31,7 +31,7 @@ class UtmMixin(models.AbstractModel):
                 value = False
                 if request:
                     # ir_http dispatch saves the url params in a cookie
-                    value = request.httprequest.cookies.get(cookie_name)
+                    value = request.httprequest.cookies.get(cookie_name) or request.params and request.params.get(url_param)
                 # if we receive a string for a many2one, we search/create the id
                 if field.type == 'many2one' and isinstance(value, str) and value:
                     Model = self.env[field.comodel_name]

--- a/addons/website_crm_livechat/models/__init__.py
+++ b/addons/website_crm_livechat/models/__init__.py
@@ -3,3 +3,4 @@
 
 from . import crm_lead
 from . import mail_channel
+from . import website_visitor

--- a/addons/website_crm_livechat/models/mail_channel.py
+++ b/addons/website_crm_livechat/models/mail_channel.py
@@ -15,4 +15,9 @@ class MailChannel(models.Model):
         visitor_sudo = self.livechat_visitor_id.sudo()
         if visitor_sudo:
             visitor_sudo.write({'lead_ids': [(4, lead.id)]})
+            lead.write({
+                'campaign_id': visitor_sudo.campaign_id.id or lead.campaign_id.id,
+                'medium_id': visitor_sudo.medium_id.id or lead.medium_id.id,
+                'source_id': visitor_sudo.source_id.id or lead.source_id.id
+            })
         return lead

--- a/addons/website_crm_livechat/models/website_visitor.py
+++ b/addons/website_crm_livechat/models/website_visitor.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class WebsiteVisitor(models.Model):
+    _name = 'website.visitor'
+    _inherit = ['website.visitor', 'utm.mixin']


### PR DESCRIPTION
**PURPOSE:**
- When we use the /lead command on a Live Chat session, it should pull the UTM data from the visitors browser, as this information could be useful in the long term for marketing traceability. 

**SPECIFICATION:**
- When using the /lead command, create an opportunity with the transcript of the conversation + the UTM data from where he came from. 


TaskID: 1938301
Closes https://github.com/odoo/odoo/pull/48306