### PR TITLE
[WIP] account: Wrong behavior with taxes on accounts

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -521,7 +521,7 @@ class AccountMove(models.Model):
         self.line_ids -= to_remove
 
         # ==== Mount base lines ====
-        for line in self.line_ids.filtered(lambda line: not line.tax_repartition_line_id):
+        for line in self.line_ids[-1].filtered(lambda line: not line.tax_repartition_line_id):
             # Don't call compute_all if there is no tax.
             if not line.tax_ids:
                 line.tag_ids = [(5, 0, 0)]


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider that l10n_be is installed for company C
- Create a journal entry for C
- Add a line L1 with account = 700000 and set a debit of 100€
- Automatically a new tax line L2 is created with debit 21€ and tax grids 54
- Tax Grids of L1 is set to 3
- Remove L2 and Tax Grids 3 from L1
- Add a new line L3 with account = 130000

Bug:

Tax grids of L1 was set to 3 and L2 was recreated.

PS: Try to only recompute the base line tax on the last added line

opw:2224161