### PR TITLE
[FIX] sale: transaction fees computation mismatch at payment

### DIFF
--- a/addons/sale/models/payment.py
+++ b/addons/sale/models/payment.py
@@ -166,8 +166,7 @@ class PaymentTransaction(models.Model):
 
     def render_sale_button(self, order, submit_txt=None, render_values=None):
         values = {
-            'partner_id': order.partner_shipping_id.id or order.partner_invoice_id.id,
-            'billing_partner_id': order.partner_invoice_id.id,
+            'partner_id': order.partner_id.id,
         }
         if render_values:
             values.update(render_values)


### PR DESCRIPTION
There is a discrepancy between what country is used to compute the
fees for a transaction depending on where we are in the payment flow.

At rendering, the country of the order's shipping partner is used (since
it is set as the main partner in the rendering values dict through
`render_sale_button`).

At creation, the country of the partner is used (since the
payment.transaction record is created with the order's main partner_id
in _create_payment_transaction).

This is unfortunate and can cause issues with payment flows if there is
a mismatch between countries of the shipping/invoice/main partner, as
the fees may be computed as 'international' in one case and 'domestic'
in another - this causes the values sent to Paypal to differ from those
saved on the transaction, which causes the transaction to be rejected
upon return from Paypal because of an amount mismatch.

Since the transaction is created using the main partner of the order,
I believe it is preferrable to use it for the rendering as well. Some
may dislike this choice, as it means that if you use these fees to
manage your delivery fees, a customer with a shipping address to is not
the same as the company's country will pay domestic fees, while they
should pay international ones. However, this is mitigated by the fact
that:
- this did not work before this commit (hell of an argument)
- the delivery module is there to handle those cases with much higher
  configurability
- having a consistent computation is more important than managing this
  case

opw-2225023