### PR TITLE
[IMP] website_form: known partners add as followers if in a CC

### DIFF
--- a/addons/website_form/controllers/main.py
+++ b/addons/website_form/controllers/main.py
@@ -197,6 +197,16 @@ class WebsiteForm(http.Controller):
             values.update({'reply_to': values.get('email_from')})
         record = request.env[model_name].with_user(SUPERUSER_ID).with_context(mail_create_nosubscribe=True).create(values)
 
+        # email_cc, email_from add as a follower if they are known res.partner
+        email_addresses = [values.get('email_from')]
+        if values.get('email_cc') and issubclass(request.registry[model_name], request.registry['mail.thread.cc']):
+            cc_mail_addresses = list(record._mail_cc_sanitized_raw_dict(values.get('email_cc')).values())
+            email_addresses.extend(cc_mail_addresses)
+
+        partner_ids = request.env['res.partner'].sudo().search([('email', 'in', email_addresses)])
+        if partner_ids:
+            record.message_subscribe(partner_ids=partner_ids.ids)
+
         if custom or meta:
             _custom_label = "%s\n___________\n\n" % _("Other Information:")  # Title for custom fields
             if model_name == 'mail.mail':


### PR DESCRIPTION
PURPOSE

People sending tickets through the website might add their vendors or consultant
in the CC field but the vendor or consultant is not added as a follower of the
task.

SPECIFICATIONS

It should be added automatically so they can easily follow what's happening to
their clients. Hence, this commit adds known partners as followers if added in
a CC.

LINKS

PR #48497
Task 1974030


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
