### PR TITLE
[IMP] core: refactor API of pre/post-commit/rollback hooks

### DIFF
--- a/addons/bus/models/bus.py
+++ b/addons/bus/models/bus.py
@@ -59,10 +59,10 @@ class ImBus(models.Model):
             # awakened and will fetch the notification in the bus table. If the
             # transaction is not commited yet, there will be nothing to fetch,
             # and the longpolling will return no notification.
+            @self._cr.postcommit
             def notify():
                 with odoo.sql_db.db_connect('postgres').cursor() as cr:
                     cr.execute("notify imbus, %s", (json_dump(list(channels)),))
-            self._cr.after('commit', notify)
 
     @api.model
     def sendone(self, channel, message):

--- a/addons/test_mail/tests/common.py
+++ b/addons/test_mail/tests/common.py
@@ -53,8 +53,7 @@ class TestMailCommon(common.SavepointCase, mail_common.MailCase):
 
     def flush_tracking(self):
         """ Force the creation of tracking values. """
-        self.env['base'].flush()
-        self.cr.precommit()
+        self.cr._precommit()
 
 
 class TestMailMultiCompanyCommon(TestMailCommon):

--- a/addons/website/__init__.py
+++ b/addons/website/__init__.py
@@ -7,11 +7,13 @@ from . import wizard
 
 import odoo
 from odoo import api, SUPERUSER_ID
-from functools import partial
 
 
 def uninstall_hook(cr, registry):
-    def rem_website_id_null(dbname):
+    dbname = cr.dbname
+
+    @cr.postcommit
+    def rem_website_id_null():
         db_registry = odoo.modules.registry.Registry.new(dbname)
         with api.Environment.manage(), db_registry.cursor() as cr:
             env = api.Environment(cr, SUPERUSER_ID, {})
@@ -19,7 +21,6 @@ def uninstall_hook(cr, registry):
                 ('name', '=', 'website_id'),
                 ('model', '=', 'res.config.settings'),
             ]).unlink()
-    cr.after('commit', partial(rem_website_id_null, cr.dbname))
 
 
 def post_init_hook(cr, registry):

--- a/odoo/addons/base/tests/test_misc.py
+++ b/odoo/addons/base/tests/test_misc.py
@@ -272,7 +272,8 @@ class TestFormatLangDate(TransactionCase):
         self.assertEqual(misc.format_time(lang.with_context(lang='zh_CN').env, time_part, time_format='medium', lang_code='fr_FR'), '16:30:22')
 
 
-class TestGroupCalls(BaseCase):
+class TestCallbacks(BaseCase):
+
     def test_callbacks(self):
         log = []
 
@@ -286,7 +287,7 @@ class TestGroupCalls(BaseCase):
         def baz():
             log.append("baz")
 
-        callbacks = misc.GroupCalls()
+        callbacks = misc.Callbacks()
         callbacks.add(foo)
         callbacks.add(bar, list)[0].append(1)
         callbacks.add(bar, list)[0].append(2)

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -351,8 +351,7 @@ class WebRequest(object):
             if self._cr is not None:
                 # flush here to avoid triggering a serialization error outside
                 # of this context, which would not retry the call
-                flush_env(self._cr)
-                self._cr.precommit()
+                self._cr._precommit()
             return result
 
         if self.db:

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -95,10 +95,10 @@ class BaseCursor:
     """ Base class for cursors that manages pre/post commit/rollback hooks. """
 
     def __init__(self):
-        self.precommit = tools.GroupCalls()
-        self.postcommit = tools.GroupCalls()
-        self.prerollback = tools.GroupCalls()
-        self.postrollback = tools.GroupCalls()
+        self.precommit = tools.Callbacks()
+        self.postcommit = tools.Callbacks()
+        self.prerollback = tools.Callbacks()
+        self.postrollback = tools.Callbacks()
 
     @contextmanager
     @check

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -373,13 +373,11 @@ class BaseCase(TreeCase, MetaCase('DummyCase', (object,), {})):
                 login = self.env.user.login
                 expected = counters.get(login, default)
                 if flush:
-                    self.env.user.flush()
-                    self.env.cr.precommit()
+                    self.env.cr._precommit()
                 count0 = self.cr.sql_log_count
                 yield
                 if flush:
-                    self.env.user.flush()
-                    self.env.cr.precommit()
+                    self.env.cr._precommit()
                 count = self.cr.sql_log_count - count0
                 if count != expected:
                     # add some info on caller to allow semi-automatic update of query count
@@ -397,12 +395,10 @@ class BaseCase(TreeCase, MetaCase('DummyCase', (object,), {})):
             # flush before and after during warmup, in order to reproduce the
             # same operations, otherwise the caches might not be ready!
             if flush:
-                self.env.user.flush()
-                self.env.cr.precommit()
+                self.env.cr._precommit()
             yield
             if flush:
-                self.env.user.flush()
-                self.env.cr.precommit()
+                self.env.cr._precommit()
 
     def assertRecordValues(self, records, expected_values):
         ''' Compare a recordset with a list of dictionaries representing the expected results.


### PR DESCRIPTION
The idea is that the method `cr._precommit()` takes care flushing all
pending updates and processing pre-commit hooks.