### PR TITLE
[FIX] web: list views don't show empty groups

### DIFF
--- a/addons/web/static/src/js/views/list/list_renderer.js
+++ b/addons/web/static/src/js/views/list/list_renderer.js
@@ -490,6 +490,9 @@ var ListRenderer = BasicRenderer.extend({
             if (!$tbody) {
                 $tbody = $('<tbody>');
             }
+            if(!group.count) {
+                return;
+            }
             $tbody.append(self._renderGroupRow(group, groupLevel));
             if (group.data.length) {
                 result.push($tbody);


### PR DESCRIPTION
Steps to reproduce:
- install timesheets
- go to timesheets > all timesheets > group by employee/project/task
- open a second level group

Previous behavior:
some groups have no content and are shown with the (0) suffix

Current behavior:
empty groups are not shown in the view

opw-2221126