### PR TITLE
[IMP] core: avoid errors when upgrading new test modules

### DIFF
--- a/odoo/modules/graph.py
+++ b/odoo/modules/graph.py
@@ -65,7 +65,8 @@ class Graph(dict):
             if info and info['installable']:
                 packages.append((module, info)) # TODO directly a dict, like in get_modules_with_version
             elif module != 'studio_customization':
-                _logger.warning('module %s: not installable, skipped', module)
+                level = logging.RUNBOT if module.startswith('test_') else logging.WARNING
+                _logger.log(level, 'module %s: not installable, skipped', module)
 
         dependencies = dict([(p, info['depends']) for p, info in packages])
         current, later = set([p for p, info in packages]), set()

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -440,11 +440,11 @@ def load_modules(db, force_demo=False, status=None, update_module=False):
                     ['to install'], force, status, report,
                     loaded_modules, update_module, models_to_check)
 
-        # check that new module dependencies have been properly installed after a migration/upgrade
         cr.execute("SELECT name from ir_module_module WHERE state IN ('to install', 'to upgrade')")
         module_list = [name for (name,) in cr.fetchall()]
+        level = logging.ERROR if any(not mod.startswith('test_') for mod in module_list) else logging.RUNBOT
         if module_list:
-            _logger.error("Some modules have inconsistent states, some dependencies may be missing: %s", sorted(module_list))
+            _logger.log(level, "Some modules have inconsistent states, some dependencies may be missing: %s", sorted(module_list))
 
         # check that all installed modules have been loaded by the registry after a migration/upgrade
         cr.execute("SELECT name from ir_module_module WHERE state = 'installed' and name != 'studio_customization'")


### PR DESCRIPTION
When a test module is added in stable, it will be forwarported in next versions.
This commit avoid a migration to fail if a test_module does not exists in sources 
in next versions, by changing log level to 25 (RUNBOT).

With this solution, the module will stay in a `to_upgarde` state, and this should
be temporary, waiting fot the module to be added in next version. As a side effect,
if a test_module is removed, the migration test won't fail. Anyway, the logs will 
allow to spot that and fix it later if needed.