### PR TITLE
[FIX] payment: Better error message for Stripe session

### DIFF
--- a/addons/payment_stripe/i18n/payment_stripe.pot
+++ b/addons/payment_stripe/i18n/payment_stripe.pot
@@ -168,6 +168,30 @@ msgid "Stripe gave us the following info about the problem: '%s'"
 msgstr ""
 
 #. module: payment_stripe
+#: code:addons/payment_stripe/models/payment.py
+#, python-format
+msgid "Error while creating Stripe session: %s."
+msgstr ""
+
+#. module: payment_stripe
+#: code:addons/payment_stripe/models/payment.py
+#, python-format
+msgid "Please double check that the user email is formatted correctly : '%s'"
+msgstr ""
+
+#. module: payment_stripe
+#: code:addons/payment_stripe/models/payment.py
+#, python-format
+msgid "Stripe error code: '%s'"
+msgstr ""
+
+#. module: payment_stripe
+#: code:addons/payment_stripe/models/payment.py
+#, python-format
+msgid "See documentation at: %s"
+msgstr ""
+
+#. module: payment_stripe
 #: code:addons/payment_stripe/models/payment.py:184
 #, python-format
 msgid "Stripe: %s orders found for reference %s"

--- a/addons/payment_stripe_sca/models/payment.py
+++ b/addons/payment_stripe_sca/models/payment.py
@@ -52,6 +52,8 @@ class PaymentAcquirerStripeSCA(models.Model):
             "AUTHORIZATION": "Bearer %s" % self.sudo().stripe_secret_key,
             "Stripe-Version": "2019-05-16",  # SetupIntent need a specific version
         }
+        if data and data.get("customer_email"):
+            data["customer_email"] = data["customer_email"].strip()
         resp = requests.request(method, url, data=data, headers=headers)
         # Stripe can send 4XX errors for payment failure (not badly-formed requests)
         # check if error `code` is present in 4XX response and raise only if not


### PR DESCRIPTION
Before this commit:
When opening a Stripe session, if an error happened, a basic error message was displayed with no relevant information in it.
You can reproduce it by adding some space character in the partner email for instances.

With this commit:
Some details on the errors reason is given into the payment form and more detailed into the sale order/invoice chatter.


OPW-2225881
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
