### PR TITLE
Revert "[IMP] base: server_attachment add max-age when unique is prov…

### DIFF
--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -162,10 +162,7 @@ class IrHttp(models.AbstractModel):
             response.last_modified = wdate
 
             response.set_etag(checksum)
-            response.make_conditional(
-                request.httprequest,
-                max_age=http.STATIC_CACHE_LONG if request.params.get('unique') else 0
-            )
+            response.make_conditional(request.httprequest)
 
             if response.status_code == 304:
                 return response


### PR DESCRIPTION
…ided"

make_conditional does not have a `max_age` parameter[1]
This reverts commit f7d7c53cd51c402672a49f98ddebab2cce7cb6ad.

[1] https://werkzeug.palletsprojects.com/en/1.0.x/wrappers/?highlight=make_conditional#werkzeug.wrappers.ETagResponseMixin.make_conditional





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
