### PR TITLE
[IMP] base: problem uninstalling studio

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1926,7 +1926,7 @@ class IrModelData(models.Model):
         # column no longer exists. We can therefore completely ignore them. That
         # is why selections are removed after fields: most selections are
         # deleted on cascade by their corresponding field.
-        delete(self.env['ir.model.fields'].browse(field_ids))
+        delete(self.env['ir.model.fields'].browse(field_ids).exists())
         delete(self.env['ir.model.fields.selection'].browse(selection_ids).exists())
         relations = self.env['ir.model.relation'].search([('module', 'in', modules.ids)])
         relations._module_data_uninstall()


### PR DESCRIPTION
PURPOSE

Adding a custom field on a model, and then uninstall the app that contained that
model, later on try to uninstall studio app will trigger an error.

SPECIFICATION

Those records should be passed which exists in the database. Hence, this commit
removes the problem of not installing studio app.

LINKS

PR https://github.com/odoo/odoo/pull/48709
Task 2208172

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
