### PR TITLE
[FIX] survey: allow access to survey at deadline date

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -4,7 +4,7 @@
 import json
 import logging
 import werkzeug
-from datetime import datetime
+from datetime import datetime, timedelta
 from math import ceil
 
 from odoo import fields, http, SUPERUSER_ID
@@ -44,7 +44,9 @@ class Survey(http.Controller):
         deadline = user_input.deadline
         if deadline:
             dt_deadline = fields.Datetime.from_string(deadline)
-            dt_now = datetime.now()
+            if user_input.appraisal_id:
+                dt_deadline = dt_deadline + timedelta(days=1, seconds=-1)
+            dt_now = fields.Datetime.context_timestamp(user_input,datetime.now()).replace(tzinfo=None)
             if dt_now > dt_deadline:  # survey is not open anymore
                 return request.render("survey.notopen")
         return None


### PR DESCRIPTION
We should compare date and not datetime in order to allow the survey to be
visible on the deadline date.

Description of the issue/feature this PR addresses:
opw-2229582

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
