### PR TITLE
[FIX] sale_crm: don't write crm.team in batch on module uninstall

### DIFF
--- a/addons/sale_crm/__init__.py
+++ b/addons/sale_crm/__init__.py
@@ -10,4 +10,5 @@ from odoo import api, SUPERUSER_ID
 def uninstall_hook(cr, registry):
     env = api.Environment(cr, SUPERUSER_ID, {})
     teams = env['crm.team'].search([('use_opportunities', '=', False)])
-    teams.write({'use_opportunities': True})
+    for team in teams:
+        team.use_opportunities = True


### PR DESCRIPTION
It is possible that the search query for crm.team inside the sale_crm
uninstall hook will return more than one crm.team, when writing to it it
will go through _synchronize_alias() which only works on N=1 recordsets
because of self.ensure_one()

Thus, on a db with crm.team > 1, uninstalling sale_crm will crash.

This commit avoids that simply by iterating over the teams and writing
to them one by one