### PR TITLE
[FIX] account: Product taxes not updated

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2869,7 +2869,7 @@ class AccountMoveLine(models.Model):
                 tax_ids = self.account_id.tax_ids
             else:
                 tax_ids = self.env['account.tax']
-            if not tax_ids and not self.exclude_from_invoice_tab:
+            if not tax_ids and not self.exclude_from_invoice_tab and not self.product_id:
                 tax_ids = self.move_id.company_id.account_sale_tax_id
         elif self.move_id.is_purchase_document(include_receipts=True):
             # In invoice.
@@ -2879,7 +2879,7 @@ class AccountMoveLine(models.Model):
                 tax_ids = self.account_id.tax_ids
             else:
                 tax_ids = self.env['account.tax']
-            if not tax_ids and not self.exclude_from_invoice_tab:
+            if not tax_ids and not self.exclude_from_invoice_tab and not self.product_id:
                 tax_ids = self.move_id.company_id.account_purchase_tax_id
         else:
             # Miscellaneous operation.


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a product P without sales taxe
- Set in Accounting > Settings a default sale tax T
- Create a SO and add a new line L with P

Bug:

The tax set on L was T instead of no tax.

opw:2221104