### PR TITLE
Master web add sorting in graph pka

### DIFF
--- a/addons/web/static/src/js/views/graph/graph_controller.js
+++ b/addons/web/static/src/js/views/graph/graph_controller.js
@@ -184,6 +184,10 @@ var GraphController = AbstractController.extend({
             .data('stacked', state.stacked)
             .toggleClass('active', state.stacked)
             .toggleClass('o_hidden', state.mode !== 'bar');
+        this.$buttons
+            .find('.o_graph_button[data-mode="' + state.orderby_mode + '"]')
+            .toggleClass('active', state.orderby)
+            .toggleClass('o_hidden', state.mode == 'pie');
     },
 
     //--------------------------------------------------------------------------
@@ -258,6 +262,8 @@ var GraphController = AbstractController.extend({
                 this.update({ mode: $target.data('mode') });
             } else if ($target.data('mode') === 'stack') {
                 this.update({ stacked: !$target.data('stacked') });
+            } else if (_.contains(['ascending','descending'], $target.data('mode'))) {
+                this.update({ orderby: this.model.chart.orderby == $target.data('mode') ? false : $target.data('mode'), orderby_mode: $target.data('mode')});
             }
         }
     },

--- a/addons/web/static/src/js/views/graph/graph_controller.js
+++ b/addons/web/static/src/js/views/graph/graph_controller.js
@@ -185,9 +185,9 @@ var GraphController = AbstractController.extend({
             .toggleClass('active', state.stacked)
             .toggleClass('o_hidden', state.mode !== 'bar');
         this.$buttons
-            .find('.o_graph_button[data-mode="' + state.orderby_mode + '"]')
+            .find('.o_graph_button[data-order="' + state.orderby + '"]')
             .toggleClass('active', state.orderby)
-            .toggleClass('o_hidden', state.mode == 'pie');
+            .toggleClass('o_hidden', state.mode === 'pie');
     },
 
     //--------------------------------------------------------------------------
@@ -262,8 +262,9 @@ var GraphController = AbstractController.extend({
                 this.update({ mode: $target.data('mode') });
             } else if ($target.data('mode') === 'stack') {
                 this.update({ stacked: !$target.data('stacked') });
-            } else if (_.contains(['ascending','descending'], $target.data('mode'))) {
-                this.update({ orderby: this.model.chart.orderby == $target.data('mode') ? false : $target.data('mode'), orderby_mode: $target.data('mode')});
+            } else if (['ascending', 'descending'].includes($target.data('order'))) {
+                const order = $target.data('order');
+                this.update({ orderby: this.model.chart.orderby === order ? false : order });
             }
         }
     },

--- a/addons/web/static/src/js/views/graph/graph_controller.js
+++ b/addons/web/static/src/js/views/graph/graph_controller.js
@@ -186,7 +186,7 @@ var GraphController = AbstractController.extend({
             .toggleClass('o_hidden', state.mode !== 'bar');
         this.$buttons
             .find('.o_graph_button[data-order="' + state.orderby + '"]')
-            .toggleClass('active', state.orderby)
+            .toggleClass('active', !!state.orderby)
             .toggleClass('o_hidden', state.mode === 'pie');
     },
 

--- a/addons/web/static/src/js/views/graph/graph_model.js
+++ b/addons/web/static/src/js/views/graph/graph_model.js
@@ -117,7 +117,6 @@ return AbstractModel.extend({
         }
         if ('orderby' in params) {
             this.chart.orderby = params.orderby;
-            this.chart.orderby_mode = params.orderby_mode;
         }
 
         this._computeDerivedParams();
@@ -195,12 +194,12 @@ return AbstractModel.extend({
         var context = _.extend({fill_temporal: true}, this.chart.context);
 
         var proms = [];
-        var orderBy = [];
+        let orderBy = [];
 
         if (this.chart.orderby) {
-            orderBy = _.map(groupBy, function(group) {
+            orderBy = groupBy.map(function (group) {
                 return {name: group, asc: self.chart.orderby === 'ascending' ? true : false};
-            })
+            });
         }
 
         this.chart.domains.forEach(function (domain, originIndex) {

--- a/addons/web/static/src/js/views/graph/graph_model.js
+++ b/addons/web/static/src/js/views/graph/graph_model.js
@@ -115,6 +115,10 @@ return AbstractModel.extend({
         if ('timeRanges' in params) {
             this.chart.timeRanges = params.timeRanges;
         }
+        if ('orderby' in params) {
+            this.chart.orderby = params.orderby;
+            this.chart.orderby_mode = params.orderby_mode;
+        }
 
         this._computeDerivedParams();
 
@@ -191,6 +195,14 @@ return AbstractModel.extend({
         var context = _.extend({fill_temporal: true}, this.chart.context);
 
         var proms = [];
+        var orderBy = [];
+
+        if (this.chart.orderby) {
+            orderBy = _.map(groupBy, function(group) {
+                return {name: group, asc: self.chart.orderby === 'ascending' ? true : false};
+            })
+        }
+
         this.chart.domains.forEach(function (domain, originIndex) {
             proms.push(self._rpc({
                 model: self.modelName,
@@ -199,6 +211,7 @@ return AbstractModel.extend({
                 domain: domain,
                 fields: fields,
                 groupBy: groupBy,
+                orderBy: orderBy,
                 lazy: false,
             }).then(self._processData.bind(self, originIndex)));
         });

--- a/addons/web/static/src/scss/graph_view.scss
+++ b/addons/web/static/src/scss/graph_view.scss
@@ -1,10 +1,4 @@
 .o_graph_controller {
-    .btn-divider {
-        display: inline-block;
-        border-left: 1px solid #ccc;
-        margin-right: 0.5rem;
-        height: 2rem;
-    }
     .o_graph_renderer {
         height: 100%;
         .o_graph_canvas_container {
@@ -83,5 +77,10 @@
             color: black;
             font-weight: bolder;
         }
+    }
+    .btn-divider {
+        border-left: 1px solid #ccc;
+        margin: 0 0.5rem;
+        height: 2rem;
     }
 }

--- a/addons/web/static/src/scss/graph_view.scss
+++ b/addons/web/static/src/scss/graph_view.scss
@@ -1,4 +1,10 @@
 .o_graph_controller {
+    .btn-divider {
+        display: inline-block;
+        border-left: 1px solid #ccc;
+        margin-right: 0.5rem;
+        height: 2rem;
+    }
     .o_graph_renderer {
         height: 100%;
         .o_graph_canvas_container {

--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -1039,15 +1039,13 @@
         <button class="btn btn-secondary fa fa-area-chart o_graph_button" title="Line Chart" aria-label="Line Chart" data-mode="line"/>
         <button class="btn btn-secondary fa fa-pie-chart o_graph_button" title="Pie Chart" aria-label="Pie Chart" data-mode="pie"/>
     </div>
-    <div class="btn-group btn-divider"/>
     <div class="btn-group" role="toolbar" aria-label="Change graph">
         <button class="btn btn-secondary fa fa-database o_graph_button" title="Stacked" aria-label="Stacked" data-mode="stack"/>
     </div>
-    <div class="btn-group" role="toolbar" aria-label="Change graph">
-        <button class="btn btn-secondary fa fa-sort-amount-desc o_graph_button" title="Descending" aria-label="Descending" data-mode="descending"/>
-    </div>
-    <div class="btn-group" role="toolbar" aria-label="Change graph">
-        <button class="btn btn-secondary fa fa-sort-amount-asc o_graph_button" title="Ascending" aria-label="Ascending" data-mode="ascending"/>
+    <div class="btn-group btn-divider"/>
+    <div class="btn-group" role="toolbar" aria-label="Sort graph">
+        <button class="btn btn-secondary fa fa-sort-amount-desc o_graph_button" title="Descending" aria-label="Descending" data-order="descending"/>
+        <button class="btn btn-secondary fa fa-sort-amount-asc o_graph_button" title="Ascending" aria-label="Ascending" data-order="ascending"/>
     </div>
 </t>
 

--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -1039,8 +1039,15 @@
         <button class="btn btn-secondary fa fa-area-chart o_graph_button" title="Line Chart" aria-label="Line Chart" data-mode="line"/>
         <button class="btn btn-secondary fa fa-pie-chart o_graph_button" title="Pie Chart" aria-label="Pie Chart" data-mode="pie"/>
     </div>
+    <div class="btn-group btn-divider"/>
     <div class="btn-group" role="toolbar" aria-label="Change graph">
         <button class="btn btn-secondary fa fa-database o_graph_button" title="Stacked" aria-label="Stacked" data-mode="stack"/>
+    </div>
+    <div class="btn-group" role="toolbar" aria-label="Change graph">
+        <button class="btn btn-secondary fa fa-sort-amount-desc o_graph_button" title="Descending" aria-label="Descending" data-mode="descending"/>
+    </div>
+    <div class="btn-group" role="toolbar" aria-label="Change graph">
+        <button class="btn btn-secondary fa fa-sort-amount-asc o_graph_button" title="Ascending" aria-label="Ascending" data-mode="ascending"/>
     </div>
 </t>
 

--- a/addons/web/static/tests/views/graph_tests.js
+++ b/addons/web/static/tests/views/graph_tests.js
@@ -1119,14 +1119,15 @@ QUnit.module('Views', {
         graph.destroy();
     });
 
-    QUnit.test('sort graph rendering', async function (assert) {
+    QUnit.only('graph view sort axis', async function (assert) {
         assert.expect(6);
 
-        var rpcCount = 0;
-        var graph = await createView({
+        let rpcCount = 0;
+        const graph = await createView({
             View: GraphView,
             model: "foo",
             data: this.data,
+            debug: true,
             arch: '<graph string="Partners">' +
                         '<field name="product_id"/>' +
                 '</graph>',
@@ -1146,9 +1147,9 @@ QUnit.module('Views', {
         });
 
         assert.checkLabels(graph, [['xphone'], ['xpad']], 'Initially Lable should be in acceding with ID');
-        await testUtils.dom.click(graph.$buttons.find('button[data-mode="descending"]'));
+        await testUtils.dom.click(graph.$buttons.find('button[data-order="descending"]'));
         assert.checkLabels(graph, [['xpad'], ['xphone']], 'After click on descending Lable should be in descending with ID');
-        await testUtils.dom.click(graph.$buttons.find('button[data-mode="ascending"]'));
+        await testUtils.dom.click(graph.$buttons.find('button[data-order="ascending"]'));
         assert.checkLabels(graph, [['xphone'], ['xpad']], 'After click on ascending Lable should be in ascending with ID');
 
         graph.destroy();


### PR DESCRIPTION
PURPOSE

Currently, reporting views such as the bar and line charts have their x-axis
sorted either alphabetically  or according to a sequence. When reporting, the
user would be interested in sorting the x-axis values.

SPECIFICATIONS

added 'ascending' and 'descending'  options in graph view for bar and line chart
options are separated from the graph switcher by thin vertical line for clarity.

LINKS

PR https://github.com/odoo/odoo/pull/49216
Task 2070103

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
