### PR TITLE
[IMP] mail: open activities creation popup fullscreen in mobile

### DIFF
--- a/addons/mail/static/src/js/activity.js
+++ b/addons/mail/static/src/js/activity.js
@@ -230,7 +230,7 @@ var BasicActivity = AbstractField.extend({
             },
             res_id: id || false,
         };
-        return this.do_action(action, { on_close: callback });
+        return this.do_action(action, { on_close: callback, fullscreen: config.device.isMobile });
     },
     /**
      * @private

--- a/addons/mail/static/src/js/views/activity/activity_controller.js
+++ b/addons/mail/static/src/js/views/activity/activity_controller.js
@@ -3,6 +3,7 @@ odoo.define('mail.ActivityController', function (require) {
 
 var BasicController = require('web.BasicController');
 var core = require('web.core');
+const config = require('web.config');
 var field_registry = require('web.field_registry');
 var ViewDialogs = require('web.view_dialogs');
 
@@ -75,6 +76,7 @@ var ActivityController = BasicController.extend({
             res_id: false,
         }, {
             on_close: this.reload.bind(this),
+            fullscreen: config.device.isMobile,
         });
     },
     /**

--- a/addons/mail/static/tests/activity_mobile_tests.js
+++ b/addons/mail/static/tests/activity_mobile_tests.js
@@ -1,0 +1,133 @@
+odoo.define('mail.activity_view_mobile_tests', function (require) {
+'use strict';
+
+const testUtils = require('web.test_utils');
+const createActionManager = testUtils.createActionManager;
+
+QUnit.module('mail mobile', {}, function () {
+QUnit.module('activity view mobile', {
+    beforeEach: function () {
+        this.data = {
+            task: {
+                fields: {
+                    id: {string: 'ID', type: 'integer'},
+                    foo: {string: "Foo", type: "char"},
+                    activity_ids: {
+                        string: 'Activities',
+                        type: 'one2many',
+                        relation: 'mail.activity',
+                        relation_field: 'res_id',
+                    },
+                },
+                records: [
+                    {id: 13, foo: 'Meeting Room Furnitures', activity_ids: [1]},
+                ],
+            },
+            partner: {
+                fields: {
+                    display_name: { string: "Displayed name", type: "char" },
+                },
+                records: [{
+                    id: 2,
+                    display_name: "first partner",
+                }]
+            },
+            'mail.activity': {
+                fields: {
+                    res_id: { string: 'Related document id', type: 'integer' },
+                    activity_type_id: { string: "Activity type", type: "many2one", relation: "mail.activity.type" },
+                    display_name: { string: "Display name", type: "char" },
+                    date_deadline: { string: "Due Date", type: "date" },
+                    can_write: { string: "Can write", type: "boolean" },
+                    state: {
+                        string: 'State',
+                        type: 'selection',
+                        selection: [['overdue', 'Overdue'], ['today', 'Today'], ['planned', 'Planned']],
+                    },
+                    mail_template_ids: { string: "Mail templates", type: "many2many", relation: "mail.template" },
+                    user_id: { string: "Assigned to", type: "many2one", relation: 'partner' },
+                },
+                records:[
+                    {
+                        id: 1,
+                        res_id: 13,
+                        display_name: "An activity",
+                        date_deadline: moment().add(3, "days").format("YYYY-MM-DD"), // now
+                        can_write: true,
+                        state: "planned",
+                        activity_type_id: 1,
+                        mail_template_ids: [9],
+                        user_id:2,
+                    },
+                ],
+            },
+            'mail.template': {
+                fields: {
+                    name: { string: "Name", type: "char" },
+                },
+                records: [
+                    { id: 9, name: "Template1" },
+                ],
+            },
+            'mail.activity.type': {
+                fields: {
+                    mail_template_ids: { string: "Mail templates", type: "many2many", relation: "mail.template" },
+                    name: { string: "Name", type: "char" },
+                },
+                records: [
+                    { id: 1, name: "Email", mail_template_ids: [9]},
+                    { id: 2, name: "Call" },
+                ],
+            },
+        };
+    }
+});
+
+QUnit.test('Activity view: in mobile, open fullscreen activity creation dialog', async function (assert) {
+    assert.expect(2);
+
+    const actionManager = await createActionManager({
+        actions: [{
+            id: 1,
+            name: 'Task Action',
+            res_model: 'task',
+            type: 'ir.actions.act_window',
+            views: [[false, 'activity']],
+        }],
+        archs: {
+            'task,false,activity': `
+                <activity string="Task">
+                    <templates>
+                        <div t-name="activity-box">
+                            <field name="foo"/>
+                        </div>
+                    </templates>
+                </activity>`,
+            'task,false,search': '<search></search>',
+            'mail.activity,false,form': `
+                <form>
+                    <field name="display_name"/>
+                    <footer>
+                        <button string="Discard" class="btn-secondary" special="cancel"/>
+                    </footer>
+                </form>`
+        },
+        data: this.data,
+        intercepts: {
+            do_action(ev) {
+                assert.ok(ev.data.options.fullscreen, "'fullscreen' options should be there with true value set");
+                actionManager.doAction(ev.data.action, ev.data.options);
+            }
+        },
+    });
+    await actionManager.doAction(1);
+
+    await testUtils.dom.click(actionManager.$('.o_activity_view .o_data_row .o_activity_empty_cell:first'));
+    assert.containsOnce($, '.modal.o_technical_modal.o_modal_full.show',
+        "A fullscreen activity modal should be opened");
+
+    actionManager.destroy();
+});
+
+});
+});

--- a/addons/mail/static/tests/chatter_mobile_tests.js
+++ b/addons/mail/static/tests/chatter_mobile_tests.js
@@ -1,0 +1,208 @@
+odoo.define('mail.chatter_mobile_tests', function (require) {
+"use strict";
+
+const mailTestUtils = require('mail.testUtils');
+
+const FormView = require('web.FormView');
+const testUtils = require('web.test_utils');
+const createView = testUtils.createView;
+
+QUnit.module('mail mobile', {}, function () {
+
+QUnit.module('Chatter', {
+    beforeEach: function () {
+
+        this.services = mailTestUtils.getMailServices();
+        this.data = {
+            'res.partner': {
+                fields: {
+                    im_status: {
+                        string: "im_status",
+                        type: "char",
+                    }
+                },
+                records: [{
+                    id: 1,
+                    im_status: 'online',
+                }]
+            },
+            partner: {
+                fields: {
+                    display_name: { string: "Displayed name", type: "char" },
+                    foo: {string: "Foo", type: "char", default: "My little Foo Value"},
+                    message_follower_ids: {
+                        string: "Followers",
+                        type: "one2many",
+                        relation: 'mail.followers',
+                        relation_field: "res_id",
+                    },
+                    message_ids: {
+                        string: "messages",
+                        type: "one2many",
+                        relation: 'mail.message',
+                        relation_field: "res_id",
+                    },
+                    activity_ids: {
+                        string: 'Activities',
+                        type: 'one2many',
+                        relation: 'mail.activity',
+                        relation_field: 'res_id',
+                    },
+                    activity_exception_decoration: {
+                        string: 'Decoration',
+                        type: 'selection',
+                        selection: [['warning', 'Alert'], ['danger', 'Error']],
+                    },
+                    activity_exception_icon: {
+                        string: 'icon',
+                        type: 'char',
+                    },
+                    activity_state: {
+                        string: 'State',
+                        type: 'selection',
+                        selection: [['overdue', 'Overdue'], ['today', 'Today'], ['planned', 'Planned']],
+                    },
+                    message_attachment_count: {
+                        string: 'Attachment count',
+                        type: 'integer',
+                    },
+                },
+                records: [{
+                    id: 2,
+                    message_attachment_count: 3,
+                    display_name: "first partner",
+                    foo: "HELLO",
+                    message_follower_ids: [],
+                    message_ids: [],
+                    activity_ids: [],
+                }]
+            },
+            'mail.activity': {
+                fields: {
+                    activity_type_id: { string: "Activity type", type: "many2one", relation: "mail.activity.type" },
+                    create_uid: { string: "Created By", type: "many2one", relation: 'partner' },
+                    can_write: { string: "Can write", type: "boolean" },
+                    display_name: { string: "Display name", type: "char" },
+                    date_deadline: { string: "Due Date", type: "date" },
+                    user_id: { string: "Assigned to", type: "many2one", relation: 'partner' },
+                    state: {
+                        string: 'State',
+                        type: 'selection',
+                        selection: [['overdue', 'Overdue'], ['today', 'Today'], ['planned', 'Planned']],
+                    },
+                    activity_category: {
+                        string: 'Category',
+                        type: 'selection',
+                        selection: [['default', 'Other'], ['upload_file', 'Upload File']],
+                    },
+                    note : { string: "Note", type: "char" },
+                },
+            },
+            'mail.activity.type': {
+                fields: {
+                    name: { string: "Name", type: "char" },
+                    category: {
+                        string: 'Category',
+                        type: 'selection',
+                        selection: [['default', 'Other'], ['upload_file', 'Upload File']],
+                    },
+                    decoration_type: { string: "Decoration Type", type: "selection", selection: [['warning', 'Alert'], ['danger', 'Error']]},
+                    icon: {string: 'icon', type:"char"},
+                },
+                records: [
+                    { id: 1, name: "Type 1" },
+                ],
+            },
+            'mail.message': {
+                fields: {
+                    attachment_ids: {
+                        string: "Attachments",
+                        type: 'many2many',
+                        relation: 'ir.attachment',
+                        default: [],
+                    },
+                    author_id: {
+                        string: "Author",
+                        relation: 'res.partner',
+                    },
+                    body: {
+                        string: "Contents",
+                        type: 'html',
+                    },
+                    date: {
+                        string: "Date",
+                        type: 'datetime',
+                    },
+                    is_note: {
+                        string: "Note",
+                        type: 'boolean',
+                    },
+                    is_discussion: {
+                        string: "Discussion",
+                        type: 'boolean',
+                    },
+                    is_notification: {
+                        string: "Notification",
+                        type: 'boolean',
+                    },
+                    is_starred: {
+                        string: "Starred",
+                        type: 'boolean',
+                    },
+                    model: {
+                        string: "Related Document Model",
+                        type: 'char',
+                    },
+                    res_id: {
+                        string: "Related Document ID",
+                        type: 'integer',
+                    }
+                },
+                records: [],
+            },
+            'ir.attachment': {
+                fields:{
+                    name:{type:'char', string:"attachment name", required:true},
+                    res_model:{type:'char', string:"res model"},
+                    res_id:{type:'integer', string:"res id"},
+                    url:{type:'char', string:'url'},
+                    type:{ type:'selection', selection:[['url',"URL"],['binary',"BINARY"]]},
+                    mimetype:{type:'char', string:"mimetype"},
+                },
+                records:[],
+            },
+        };
+    },
+});
+
+QUnit.test('form activity widget: open activity creation dialog in fullscreen for mobile', async function (assert) {
+    assert.expect(1);
+
+    var form = await createView({
+        View: FormView,
+        model: 'partner',
+        data: this.data,
+        arch: '<form string="Partners">' +
+                '<sheet>' +
+                    '<field name="foo"/>' +
+                '</sheet>' +
+                '<div class="oe_chatter">' +
+                    '<field name="activity_ids" widget="mail_activity"/>' +
+                '</div>' +
+            '</form>',
+        res_id: 2,
+        intercepts: {
+            do_action: function (ev) {
+                assert.ok(ev.data.options.fullscreen, "'fullscreen' options should be there with true value set");
+                ev.data.options.on_close();
+            },
+        },
+    });
+    // schedule an activity (this triggers a do_action)
+    await testUtils.dom.click(form.$('.o_chatter_button_schedule_activity'));
+
+    form.destroy();
+});
+
+});
+});

--- a/addons/mail/views/mail_templates.xml
+++ b/addons/mail/views/mail_templates.xml
@@ -140,6 +140,14 @@
             </xpath>
         </template>
 
+    <template id="qunit_mobile_suite" name="mail_mobile_tests" inherit_id="web.qunit_mobile_suite">
+         <xpath expr="//t[@t-set='head']" position="inside">
+            <script type="text/javascript" src="/mail/static/tests/chatter_mobile_tests.js"></script>
+            <!-- activity view -->
+            <script type="text/javascript" src="/mail/static/tests/activity_mobile_tests.js"></script>
+         </xpath>
+     </template>
+
         <template id="message_origin_link">
             <p>This <t t-esc="self.env['ir.model']._get(self._name).name.lower()"/> has been <span t-if="edit">modified</span><span t-if="not edit">created</span> from:
                 <t t-foreach="origin" t-as="o">


### PR DESCRIPTION
PURPOSE

Improve the User Experience and consistency between all popups in the mobile application.

SPECIFICATIONS

The activity creation popup is almost full screen: we should adapt it and use full screen

LINKS:
Task-Id : 2210401
Closes https://github.com/odoo/odoo/pull/49235