### PR TITLE
[FIX] mass_mailing: fix duplicate snippet_options

### DIFF
--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -72,8 +72,8 @@
         </div>
     </xpath>
 
-    <xpath expr="//div[@id='snippet_options']" position="inside">
-        <t t-call="mass_mailing.snippet_options"/>
+    <xpath expr="//div[@id='snippet_options']/t" position="attributes">
+        <attribute name="t-call">mass_mailing.snippet_options</attribute>
     </xpath>
 </template>
 


### PR DESCRIPTION
The web_editor snippet_options were duplicated in mass mailing

Introduced by: https://github.com/odoo/odoo/commit/9749b93250fe0834f664fa6f0da27db6f51cd745

task-2189669
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
