### PR TITLE
[IMP] product: make packaging barcodes unique

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -710,6 +710,10 @@ class ProductPackaging(models.Model):
     product_uom_id = fields.Many2one('uom.uom', related='product_id.uom_id', readonly=True)
     company_id = fields.Many2one('res.company', 'Company', index=True)
 
+    _sql_constraints = [
+        ('barcode_uniq', 'unique(barcode)', "Barcodes should be unique across packages!"),
+    ]
+
 
 class SupplierInfo(models.Model):
     _name = "product.supplierinfo"


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Improve delivery package feature.

**Current behavior before PR:**

This PR addresses 2 delivery package shortcomings:
1. There is no check for unique `product.package` barcodes (which is used for both product packagings and delivery packages). This causes issues when doing barcode scanning of delivery packages and product packagings.

**Desired behavior after PR is merged:**

1. SQL constraint ensuring unique barcodes across `product.package`. Ideally we would have a check across all model's barcodes, but that would be a much larger refactoring task.

Part of task: 2039720
Related Enterprise PR: odoo/enterprise#9808

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
