### PR TITLE
[FIX] catch Access denied errors when acessing storage properties

### DIFF
--- a/addons/web/static/src/js/core/local_storage.js
+++ b/addons/web/static/src/js/core/local_storage.js
@@ -7,8 +7,8 @@ var mixins = require('web.mixins');
 // use a fake localStorage in RAM if the native localStorage is unavailable
 // (e.g. private browsing in Safari)
 var storage;
-var localStorage = window.localStorage;
 try {
+    var localStorage = window.localStorage;
     var uid = new Date();
     localStorage.setItem(uid, uid);
     localStorage.removeItem(uid);

--- a/addons/web/static/src/js/core/session_storage.js
+++ b/addons/web/static/src/js/core/session_storage.js
@@ -7,8 +7,8 @@ var mixins = require('web.mixins');
 // use a fake sessionStorage in RAM if the native sessionStorage is unavailable
 // (e.g. private browsing in Safari)
 var storage;
-var sessionStorage = window.sessionStorage;
 try {
+    var sessionStorage = window.sessionStorage;
     var uid = new Date();
     sessionStorage.setItem(uid, uid);
     sessionStorage.removeItem(uid);

--- a/addons/website/static/src/js/visitor_timezone.js
+++ b/addons/website/static/src/js/visitor_timezone.js
@@ -7,6 +7,7 @@ odoo.define('website.visitor_timezone', function (require) {
 'use strict';
 
 var ajax = require('web.ajax');
+var localStorage = require('web.local_storage');
 var utils = require('web.utils');
 var publicWidget = require('web.public.widget');
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses: When loading some Odoo form (in my case generated by `website_form`) in an iframe from a different domain in Chrome, accessing `window.localStorage` and `window.sessionStorage` raises an exception immediately. So I propose to move those calls into the exception handler too.

Current behavior before PR: Javascript execution is halted when the exceptions are raised. This makes the form nonfunctional.

Desired behavior after PR is merged: Javascript execution works as expected, but then with the RamStorage.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
