### PR TITLE
[FIX] web: fix fieldsinfo for invisible x2m field

### DIFF
--- a/addons/web/static/src/js/views/basic/basic_view.js
+++ b/addons/web/static/src/js/views/basic/basic_view.js
@@ -148,7 +148,7 @@ var BasicView = AbstractView.extend({
                             var x2mFieldInfo = record.fieldsInfo[this.viewType][name];
                             var viewType = x2mFieldInfo.viewType || x2mFieldInfo.mode;
                             var knownFields = Object.keys(record.data[name].fieldsInfo[record.data[name].viewType] || {});
-                            var newFields = Object.keys(record.data[name].fieldsInfo[viewType]);
+                            var newFields = Object.keys(record.data[name].fieldsInfo[viewType] || {});
                             if (_.difference(newFields, knownFields).length) {
                                 fieldNames.push(name);
                             }


### PR DESCRIPTION
PURPOSE

once any x2m field is invisible and included in attrs of any
field it is raising a error for empty fieldsinfo

SPECIFICATIONS

if any x2m field is present in the view and also if it is invisible,
then it's fieldsinfo will be the empty dict. it will be available
only in the case of field is visible.

like,
```
<field name="a_ids" invisible="1"/>
<field name="b_ids">
    <tree>
        <field name="a_ids" domain="[('id', 'in', parent.a_ids)]"
     </tree>
</field>

```
here while, evaluating domain, it will check for the fieldsinfo and as the
a_ids is invisible it fails to show fieldsinfo

LINKS

PR https://github.com/odoo/odoo/pull/49409
Task 2230090

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
