### PR TITLE
[FIX] web_editor: fix uploaded image not available in media manager

### DIFF
--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -252,7 +252,7 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
             dataPointID: this.dataPointID,
             changes: _.object([this.fieldNameAttachment], [{
                 operation: 'ADD_M2M',
-                ids: attachments
+                ids: attachments.data,
             }])
         });
     },

--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -245,6 +245,10 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
      * @param {Object} attachments
      */
     _onAttachmentChange: function (attachments) {
+        // update res_id with the actual record id for the Attachment, when record going to save
+        // this will required for showing attachment under the media dialog
+        // because of the attachment already created with res_id = 0
+        this.getParent().wysiwygAttachmentsID = [attachments.data];
         if (!this.fieldNameAttachment) {
             return;
         }

--- a/addons/web_editor/static/src/js/backend/form_controller.js
+++ b/addons/web_editor/static/src/js/backend/form_controller.js
@@ -1,0 +1,32 @@
+odoo.define('web_editor.FormController', function (require) {
+"use strict";
+const FormController = require('web.FormController');
+
+FormController.include({
+
+    /**
+     * @override
+     */
+    saveRecord: function () {
+        return this._super(...arguments).then((changedFields) => {
+            // update res_id with the actual record id for the Attachment, when record going to save
+            // this will required for showing attachment under the media dialog
+            // because of the attachment already created with res_id = 0
+            const res_id = this.model.get(this.handle, {raw: true}).res_id;
+            const wysiwygAttachmentsID = this.renderer.wysiwygAttachmentsID || [];
+            if (wysiwygAttachmentsID.length && res_id){
+                return this._rpc({
+                    model: 'ir.attachment',
+                    method: 'write',
+                    args: [Array.from(wysiwygAttachmentsID, (attachment) => attachment.id), {
+                        res_id: res_id,
+                    }],
+                }).then((result) => {
+                    return changedFields;
+                });
+            }
+            return changedFields;
+        });
+    },
+});
+});

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
@@ -486,6 +486,11 @@ var FileWidget = SearchableMediaWidget.extend({
                 self.$media.css(style);
             }
 
+            if (self.options.onUpload) {
+                // We consider that when selecting an image it is as if we upload it in the html content.
+                self.options.onUpload(img);
+            }
+
             // Remove crop related attributes
             if (self.$media.attr('data-aspect-ratio')) {
                 var attrs = ['aspect-ratio', 'x', 'y', 'width', 'height', 'rotate', 'scale-x', 'scale-y'];

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
@@ -293,7 +293,7 @@ var FileWidget = SearchableMediaWidget.extend({
         // if the document is not yet created, do not see the documents of other users
         if (!this.options.res_id) {
             attachedDocumentDomain.unshift('&');
-            attachedDocumentDomain.push(['create_uid', '=', this.options.user_id]);
+            attachedDocumentDomain.push(['create_uid', '=', this.options.user_id || session.uid]);
         }
         if (this.options.data_res_model) {
             var relatedDomain = ['&',
@@ -301,7 +301,7 @@ var FileWidget = SearchableMediaWidget.extend({
                 ['res_id', '=', this.options.data_res_id|0]];
             if (!this.options.data_res_id) {
                 relatedDomain.unshift('&');
-                relatedDomain.push(['create_uid', '=', session.uid]);
+                relatedDomain.push(['create_uid', '=', this.options.user_id || session.uid]);
             }
             domain = domain.concat(['|'], attachedDocumentDomain, relatedDomain);
         } else {

--- a/addons/web_editor/views/editor.xml
+++ b/addons/web_editor/views/editor.xml
@@ -149,6 +149,7 @@
     <xpath expr="script[last()]" position="after">
         <script type="text/javascript" src="/web_editor/static/src/js/backend/field_html.js" />
         <script type="text/javascript" src="/web_editor/static/src/js/backend/convert_inline.js" />
+        <script type="text/javascript" src="/web_editor/static/src/js/backend/form_controller.js" />
     </xpath>
 </template>
 

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -450,8 +450,9 @@ class IrAttachment(models.Model):
                 # remove all corresponding attachment ids
                 ids.difference_update(itertools.chain(*targets.values()))
                 continue
-            # filter ids according to what access rules permit
-            target_ids = list(targets)
+            # filter ids according to what access rules permit and
+            # removed 0 value of id from the list because of the id does not exist in database
+            target_ids = list(filter(lambda target_id: target_id != 0, targets))
             allowed = self.env[res_model].with_context(active_test=False).search([('id', 'in', target_ids)])
             for res_id in set(target_ids).difference(allowed.ids):
                 ids.difference_update(targets[res_id])


### PR DESCRIPTION
when an image is uploaded from media manager on pads
and if the document is new (not yet created), Uploaded image is stored but was
not displayed in media manager.
Now uploaded image is displayed in media manager.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
