### PR TITLE
[IMP] crm: improve the "lead to opportunity" view and the reveal form view

### DIFF
--- a/addons/crm/wizard/crm_lead_to_opportunity_mass_views.xml
+++ b/addons/crm/wizard/crm_lead_to_opportunity_mass_views.xml
@@ -9,7 +9,7 @@
                 <separator string="Conversion Options"/>
                 <group>
                     <field name="name" class="oe_inline" widget="radio"/>
-                    <field name="deduplicate" class="oe_inline"/>
+                    <field name="deduplicate" class="oe_inline" attrs="{'invisible': [('name', '=', 'merge')]}"/>
                 </group>
                 <group string="Assign these opportunities to">
                     <field name="team_id" kanban_view_ref="%(sales_team.crm_team_view_kanban)s"/>

--- a/addons/crm_iap_lead_website/views/crm_reveal_views.xml
+++ b/addons/crm_iap_lead_website/views/crm_reveal_views.xml
@@ -131,9 +131,6 @@
         <field name="model">crm.reveal.view</field>
         <field name="arch" type="xml">
             <form>
-                <header>
-                    <field name="reveal_state" widget="statusbar"/>
-                </header>
                 <sheet>
                     <group>
                         <field name="reveal_ip"/>


### PR DESCRIPTION
Purpose
=======
Improve the "mass lead to opportunity" view. The field `deduplicate` is used only when the name is "convert", so we can hide it to clarify the view.

Improve the CRM reveal form view. The field `state` is defined 2 times in the same view with different widget. This is impossible and only the last field (no-widget) information will be kept (so the widget `statusbar` is never used).

Task-2228921