### PR TITLE
[FIX] crm: fix bugs related to the lead merge/conversion

### DIFF
--- a/addons/crm/wizard/crm_lead_to_opportunity_mass.py
+++ b/addons/crm/wizard/crm_lead_to_opportunity_mass.py
@@ -85,7 +85,7 @@ class Lead2OpportunityMassConvert(models.TransientModel):
 
     def action_mass_convert(self):
         self.ensure_one()
-        if self.name == 'convert' and self.deduplicate:
+        if self.name == 'convert' and self.deduplicate or self.name == 'merge':
             merged_lead_ids = set()
             remaining_lead_ids = set()
             for lead in self.lead_tomerge_ids:
@@ -102,7 +102,11 @@ class Lead2OpportunityMassConvert(models.TransientModel):
             active_ids = set(self._context.get('active_ids', {}))
             active_ids = (active_ids - merged_lead_ids) | remaining_lead_ids
 
+            if self.name == 'merge':
+                return self.env['crm.lead'].browse(list(active_ids)[0]).redirect_lead_opportunity_view()
+
             self = self.with_context(active_ids=list(active_ids))  # only update active_ids when there are set
+
         return self.action_apply()
 
     def _convert_handle_partner(self, lead, action, partner_id):

--- a/addons/crm/wizard/crm_lead_to_opportunity_mass.py
+++ b/addons/crm/wizard/crm_lead_to_opportunity_mass.py
@@ -89,7 +89,7 @@ class Lead2OpportunityMassConvert(models.TransientModel):
             merged_lead_ids = set()
             remaining_lead_ids = set()
             for lead in self.lead_tomerge_ids:
-                if lead not in merged_lead_ids:
+                if lead.id not in merged_lead_ids:
                     duplicated_leads = self.env['crm.lead']._get_lead_duplicates(
                         partner=lead.partner_id,
                         email=lead.partner_id.email or lead.email_from,


### PR DESCRIPTION
Bug 1
=====
Create one lead, "lead_1" and copy this lead to "lead_1_bis".
Create one lead, "lead_2" and copy this lead to "lead_2_bis".

Select the lead 1 and the lead 2, click on the action "merge opportunities".
Choose "merge with existing opportunities" and apply.

The lead 1 will be merged with the lead 2, instead of merging
"lead_1" with "lead_1_bis" and "lead_2" with "lead_2_bis".

Bug 2
=====
1. Create a new lead
2. Duplicate the lead
3. In the list view, select the first lead and the duplicated one
4. Select the action "Convert to opportunities"
5. Choose "convert" and check "Apply deduplication"
6. Convert the leads
=> Error message

Task-2228921