### PR TITLE
[FIX] core: validate custom related fields

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -683,6 +683,14 @@ class Field(MetaField('DummyField', (object,), {})):
 
     def resolve_depends(self, model):
         """ Return the dependencies of `self` as a collection of field tuples. """
+        # ensure related path is resolvable
+        if self.related:
+            target = model
+            for name in self.related:
+                field = target._fields[name]
+                set(field.resolve_depends(target))
+                target = target[name]
+
         for dotnames in self.depends:
             field_seq = []
             field_model = model


### PR DESCRIPTION
Ensure that each component of the `related` attribute has it depends
resolved.

It can happen when a related field points to an invalid custom field.

Minimal reproducible case:
 - create database
 - define new custom fields

```sql
begin work;
INSERT INTO ir_model_fields(field_description, model, model_id, name, state, ttype, related, compute, depends)
VALUES (
    'A manual computed field with invalid dependencies',
    'res.partner', (SELECT id FROM ir_model WHERE model = 'res.partner'),
    'x_namecap', 'manual', 'char',
    NULL, 'for r in self: r["x_namecap"] = r.name.upper()', 'name, oops'
), (
    'A related on this manual field',
    'res.partner', (SELECT id FROM ir_model WHERE model = 'res.partner'),
    'x_parent_namecap', 'manual', 'char',
    'parent_id.x_namecap', NULL, NULL
);
commit work;
```

 - When you run odoo, a traceback occurs