### PR TITLE
[IMP] calendar: Don't load all avatar when more than 20 filters.

### DIFF
--- a/addons/hr_holidays/tests/test_automatic_leave_dates.py
+++ b/addons/hr_holidays/tests/test_automatic_leave_dates.py
@@ -6,7 +6,6 @@ from odoo.tests.common import Form, tagged
 from odoo.addons.hr_holidays.tests.common import TestHrHolidaysBase
 
 
-@tagged('prout')
 class TestAutomaticLeaveDates(TestHrHolidaysBase):
     def setUp(self):
         super(TestAutomaticLeaveDates, self).setUp()

--- a/addons/resource/models/resource_mixin.py
+++ b/addons/resource/models/resource_mixin.py
@@ -102,8 +102,8 @@ class ResourceMixin(models.AbstractModel):
         day_total = calendar._get_day_total(from_datetime, to_datetime, resource)
 
         # compute actual hours per day
-        attendances = calendar._attendance_intervals(from_datetime, to_datetime, resource)
-        leaves = calendar._leave_intervals(from_datetime, to_datetime, resource, domain)
+        attendances = calendar._attendance_intervals(from_datetime, to_datetime, resource)[resource.id]
+        leaves = calendar._leave_intervals(from_datetime, to_datetime, resource, domain)[resource.id]
 
         return calendar._get_days_data(attendances & leaves, day_total)
 
@@ -153,8 +153,8 @@ class ResourceMixin(models.AbstractModel):
         if not to_datetime.tzinfo:
             to_datetime = to_datetime.replace(tzinfo=utc)
 
-        attendances = calendar._attendance_intervals(from_datetime, to_datetime, resource)
-        leaves = calendar._leave_intervals(from_datetime, to_datetime, resource, domain)
+        attendances = calendar._attendance_intervals(from_datetime, to_datetime, resource)[resource.id]
+        leaves = calendar._leave_intervals(from_datetime, to_datetime, resource, domain)[resource.id]
         result = []
         for start, stop, leave in (leaves & attendances):
             hours = (stop - start).total_seconds() / 3600

--- a/addons/resource/tests/test_resource.py
+++ b/addons/resource/tests/test_resource.py
@@ -296,7 +296,7 @@ class TestCalendar(TestResourceCommon):
             'hour_from': 0,
             'hour_to': 24
         })
-        res = self.calendar_jean.get_work_hours_count(
+        res = self.calendar_jean.with_context(caca=True).get_work_hours_count(
             datetime_tz(2018, 6, 19, 23, 0, 0, tzinfo=self.jean.tz),
             datetime_tz(2018, 6, 21, 1, 0, 0, tzinfo=self.jean.tz),
             compute_leaves=True)

--- a/addons/web/static/src/js/views/calendar/calendar_renderer.js
+++ b/addons/web/static/src/js/views/calendar/calendar_renderer.js
@@ -52,6 +52,7 @@ var SidebarFilter = Widget.extend(FieldManagerMixin, {
         this.fieldName = options.fieldName;
         this.write_model = options.write_model;
         this.write_field = options.write_field;
+        this.no_avatar = options.no_avatar;
         this.avatar_field = options.avatar_field;
         this.avatar_model = options.avatar_model;
         this.filters = options.filters;
@@ -631,6 +632,7 @@ return AbstractRenderer.extend({
             var self = this;
             options.getColor = this.getColor.bind(this);
             options.fields = this.state.fields;
+            options.no_avatar = options.filters.length > 20;
             var filter = new SidebarFilter(self, options);
             prom = filter.appendTo(this.$sidebar).then(function () {
                 // Show filter popover

--- a/addons/web/static/src/xml/web_calendar.xml
+++ b/addons/web/static/src/xml/web_calendar.xml
@@ -75,7 +75,7 @@
                                 <i class="fa fa-check position-relative"/>
                             </span>
                             <i t-if="filter.value == 'all'" class="o_cw_filter_avatar fa fa-users fa-fw  flex-shrink-0 mr-1" role="img" aria-label="Avatar" title="Avatar"/>
-                            <img t-elif="widget.avatar_field and filter.value" t-attf-src="/web/image/#{widget.avatar_model}/#{filter.value}/#{widget.avatar_field}" class="o_cw_filter_avatar flex-shrink-0 mr-1" alt="Avatar"/>
+                            <img t-elif="!widget.no_avatar and widget.avatar_field and filter.value" t-attf-src="/web/image/#{widget.avatar_model}/#{filter.value}/#{widget.avatar_field}" class="o_cw_filter_avatar flex-shrink-0 mr-1" alt="Avatar"/>
                             <span class="o_cw_filter_title text-truncate flex-grow" t-esc="filter.label" t-att-title="filter.label"/>
                         </label>
 


### PR DESCRIPTION
If there is too many filters (employees on planning slots for example),
this info doesn't bring a lot a advantages and the loading takes
~30 seconds instead of 3 for the following use case:

Globally, there are:
- 6 companies with the following name and employees count:
        'sa': 478,
        'inc': 178,
        'ltd': 68,
        'lux': 12,
        'dmcc': 52,
        'pvt_ltd': 124
- 110 roles, with the same name than for the OXP (catering - Redirecton,
  Aperodoo - Security, Demo Boot - F2, ...)
- Nearly 1500 slots, with the same repartition and start/end hours than for
  the OXP.

TaskID: 2235426

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
