### PR TITLE
[IMP] stock_move: Increase performance by using ORM defined functions

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -512,10 +512,9 @@ class StockMove(models.Model):
         return True
 
     def _push_apply(self):
+        # if the move is already chained, there is no need to check push rules
+        self = self.filtered(lambda r: not r.move_dest_ids)
         for move in self:
-            # if the move is already chained, there is no need to check push rules
-            if move.move_dest_ids:
-                continue
             # if the move is a returned move, we don't want to check push rules, as returning a returned move is the only decent way
             # to receive goods without triggering the push rules again (which would duplicate chained operations)
             domain = [('location_src_id', '=', move.location_dest_id.id), ('action', 'in', ('push', 'pull_push'))]

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -151,7 +151,7 @@ class StockRule(models.Model):
             new_move_vals = self._push_prepare_move_copy_values(move, new_date)
             new_move = move.sudo().copy(new_move_vals)
             move.write({'move_dest_ids': [(4, new_move.id)]})
-            new_move._action_confirm()
+            new_move.with_context(prefetch_fields=False)._action_confirm()
 
     def _push_prepare_move_copy_values(self, move_to_copy, new_date):
         company_id = self.company_id.id


### PR DESCRIPTION
Desired behavior after PR is merged:
Decrease waiting time after "Mark as TODO" on transfers (stock.picking) by fetching useful fields before looping on records

OPW-2233093
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
