### PR TITLE
[IMP] crm : Multi-editing on tree views (PHASE II)

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -322,10 +322,10 @@
             <field name="model">crm.lead</field>
             <field name="priority">10</field>
             <field name="arch" type="xml">
-                <tree string="Leads" sample="1">
+                <tree string="Leads" sample="1" multi_edit="1">
                     <field name="date_deadline" invisible="1"/>
                     <field name="create_date" optional="hide"/>
-                    <field name="name" string="Lead"/>
+                    <field name="name" string="Lead" readonly="1"/>
                     <field name="contact_name" optional="hide"/>
                     <field name="partner_name" optional="hide"/>
                     <field name="email_from" optional="show"/>
@@ -335,7 +335,7 @@
                     <field name="state_id" optional="hide"/>
                     <field name="country_id" optional="show"/>
                     <field name="partner_id" invisible="1"/>
-                    <field name="user_id" optional="show"  widget="many2one_avatar_user"/>
+                    <field name="user_id" optional="show"  widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
                     <field name="team_id" optional="show"/>
                     <field name="active" invisible="1"/>
                     <field name="probability" invisible="1"/>
@@ -647,10 +647,10 @@
             <field name="model">crm.lead</field>
             <field name="priority">1</field>
             <field name="arch" type="xml">
-                <tree string="Opportunities" sample="1">
+                <tree string="Opportunities" sample="1" multi_edit="1">
                     <field name="date_deadline" invisible="1"/>
                     <field name="create_date" optional="hide"/>
-                    <field name="name" string="Opportunity"/>
+                    <field name="name" string="Opportunity" readonly="1"/>
                     <field name="partner_id" optional="hide"/>
                     <field name="contact_name" optional="show"/>
                     <field name="email_from"/>
@@ -659,7 +659,7 @@
                     <field name="city" optional="hide"/>
                     <field name="state_id" optional="hide"/>
                     <field name="country_id" optional="hide"/>
-                    <field name="user_id" widget="many2one_avatar_user" optional="show"/>
+                    <field name="user_id" widget="many2one_avatar_user" optional="show" domain="[('share', '=', False)]"/>
                     <field name="team_id" optional="show"/>
                     <field name="priority" optional="hide"/>
                     <field name="activity_ids" widget="list_activity"/>

--- a/addons/crm/views/crm_stage_views.xml
+++ b/addons/crm/views/crm_stage_views.xml
@@ -14,13 +14,14 @@
         </field>
     </record>
 
+    <!-- STAGES TREE VIEW + MUTI_EDIT -->
     <record id="crm_stage_tree" model="ir.ui.view">
         <field name="name">crm.stage.tree</field>
         <field name="model">crm.stage</field>
         <field name="arch" type="xml">
-            <tree string="Stages">
+            <tree string="Stages" multi_edit="1">
                 <field name="sequence" widget="handle"/>
-                <field name="name"/>
+                <field name="name" readonly="1"/>
                 <field name="is_won"/>
                 <field name="team_id"/>
             </tree>

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -62,18 +62,19 @@
         </field>
     </record>
 
+    <!-- ACTIVITY TREE VIEW + MUTI_EDIT -->
     <record id="mail_activity_type_view_tree" model="ir.ui.view">
         <field name="name">mail.activity.type.view.tree</field>
         <field name="model">mail.activity.type</field>
         <field name="arch" type="xml">
-            <tree string="Activities" sample="1">
+            <tree string="Activities" sample="1" multi_edit="1">
                 <field name="sequence" widget="handle"/>
-                <field name="name"/>
+                <field name="name" readonly="1"/>
                 <field name="summary"/>
                 <field name="delay_label" string="Planned in" class="text-right"/>
                 <field name="delay_from" string="Type"/>
-                <field name="res_model_id" groups="base.group_no_one"/>
-                <field name="icon" groups="base.group_no_one"/>
+                <field name="res_model_id" groups="base.group_no_one" readonly="1"/>
+                <field name="icon" groups="base.group_no_one" readonly="1"/>
             </tree>
         </field>
     </record>

--- a/addons/sales_team/views/crm_team_views.xml
+++ b/addons/sales_team/views/crm_team_views.xml
@@ -72,16 +72,17 @@
         </field>
     </record>
 
+    <!-- SALES TEAMS TREE VIEW + MUTI_EDIT -->
     <record id="crm_team_view_tree" model="ir.ui.view">
         <field name="name">crm.team.tree</field>
         <field name="model">crm.team</field>
         <field name="field_parent">child_ids</field>
         <field name="arch" type="xml">
-            <tree string="Sales Team" sample="1">
+            <tree string="Sales Team" sample="1" multi_edit="1">
                 <field name="sequence" widget="handle"/>
-                <field name="name"/>
+                <field name="name" readonly="1"/>
                 <field name="active" invisible="1"/>
-                <field name="user_id"/>
+                <field name="user_id" domain="[('share', '=', False)]"/>
                 <field name="company_id" groups="base.group_multi_company"/>
             </tree>
         </field>

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -37,24 +37,35 @@
             <field name="help">Manage the contact titles you want to have available in your system and the way you want to print them in letters and other documents. Some example: Mr., Mrs. </field>
         </record>
 
+        <!-- PARTNER TREE VIEW + MUTI_EDIT :
+                VISIBLE FIELDS WITH ONCHANGE ON BASE/PARTNER VIEW WON'T BE EDITABLE ON "MULTI_EDIT" MODE:
+                - parent_id
+                - country_id
+                - state_id
+                - email
+                - company_type
+                - company_id
+                
+                THIS WILL ADD "MULTI_EDIT" OPTION ON ALL MODULES USING THIS TREE VIEW / RELATED ACTION...
+        -->
         <!-- Partner -->
         <record id="view_partner_tree" model="ir.ui.view">
             <field name="name">res.partner.tree</field>
             <field name="model">res.partner</field>
             <field eval="8" name="priority"/>
             <field name="arch" type="xml">
-                <tree string="Contacts" sample="1">
+                <tree string="Contacts" sample="1" multi_edit="1">
                     <field name="display_name" string="Name"/>
                     <field name="function" invisible="1"/>
                     <field name="phone" class="o_force_ltr" optional="show"/>
                     <field name="email" optional="show"/>
-                    <field name="user_id" optional="show" widget="many2one_avatar_user"/>
+                    <field name="user_id" optional="show" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
                     <field name="city" optional="show"/>
-                    <field name="state_id" optional="hide"/>
-                    <field name="country_id" optional="show"/>
-                    <field name="vat" optional="hide"/>
+                    <field name="state_id" optional="hide" readonly="1"/>
+                    <field name="country_id" optional="show" readonly="1"/>
+                    <field name="vat" optional="hide" readonly="1"/>
                     <field name="category_id" optional="hide" widget="many2many_tags" options="{'color_field': 'color'}"/>
-                    <field name="company_id" groups="base.group_multi_company"/>
+                    <field name="company_id" groups="base.group_multi_company" readonly="1"/>
                     <field name="is_company" invisible="1"/>
                     <field name="parent_id" invisible="1"/>
                     <field name="active" invisible="1"/>


### PR DESCRIPTION
- The fields below, if present in the list view, should be editable.
- Readonly attribute added on : [other fields + onchange-based fields] (if displayed).
- "Multi edit" mode added to all modules using these views (non onchange-based fields will be editable on base res.partner view & all views inheriting from it or using its action in other modules).

1) Contact (res.partner)
View : base.view_partner_tree
phone
email
company_id
city
state_id
country_id
category_id
date_review_next
grade_id
user_id (set if from invisible to optional default hidden)

2) Opportunities (crm.lead)
View : crm.crm_case_tree_view_oppor
partner_id
email_from
phone
city
state_id
country_id
stage_id
probability
partner_assigned_id
user_id
team_id
planned_revenue
company_id
campaign_id
medium_id
source_id
tag_ids
priority

3) Opportunities (crm.lead)
View : crm.crm_case_tree_view_leads
contact_name
partner_name
email_from
phone
city
state_id
country_id
partner_assigned_id
user_id
team_id
company_id
probability
campaign_id
medium_id
source_id
tag_ids
priority

4) Sales Teams (crm.team)
View : crm.team.tree
user_id
company_id

5) Activity Types (mail.activity.type)
View : mail.mail_activity_type_view_tree
 summary
delay_count
delay_unit
delay_from

6) Stages (crm.stage)
View :  crm.crm_stage_tree
is_won
team_id

Task #2200674
