### PR TITLE
studio tour tip issue

### DIFF
--- a/addons/web_tour/static/src/js/tour_manager.js
+++ b/addons/web_tour/static/src/js/tour_manager.js
@@ -199,8 +199,10 @@ return core.Class.extend(mixins.EventDispatcherMixin, ServicesMixin, {
                 var tip = this.active_tooltips[tourName];
                 var activated = this._check_for_tooltip(tip, tourName);
                 if (activated) {
-                    break;
+                    continue;
                 }
+                // deactivate all other tips except activated one
+                this._deactivate_tip(tip);
             }
         }
     },


### PR DESCRIPTION
PURPOSE
Studio tour tip should be deactivated when application switch.

SPEC
Make sure that the 'open studio to customize backgroud' tour step only appears while in the app switcher.

TASK 2196860

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
