### PR TITLE
[FIX] sale_management: Unit price in optional product of a quotation template

### DIFF
--- a/addons/sale_management/models/sale_order_template.py
+++ b/addons/sale_management/models/sale_order_template.py
@@ -140,7 +140,7 @@ class SaleOrderTemplateOption(models.Model):
         if not self.product_id:
             return
         product = self.product_id
-        self.price_unit = product.list_price
+        self.price_unit = product.lst_price
         name = product.name
         if self.product_id.description_sale:
             name += '\n' + self.product_id.description_sale
@@ -157,4 +157,4 @@ class SaleOrderTemplateOption(models.Model):
             self.price_unit = 0.0
             return
         if self.uom_id.id != self.product_id.uom_id.id:
-            self.price_unit = self.product_id.uom_id._compute_price(self.price_unit, self.uom_id)
+            self.price_unit = self.product_id.uom_id._compute_price(self.product_id.lst_price, self.uom_id)


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a product template PT with two variants V1 and V2
- The sales price on PT is 10€ and the extra price on V1 is -2€
- Create a quotation template QT
- Add an optional line L with V1

Bug:

The unit price of V1 was 10€ instead of 8€.
This behavior is the same as adding a quotation line.

opw:2239380