### PR TITLE
[FIX] sale: UOM not displayed on e-quote

### DIFF
--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -463,7 +463,7 @@
                                     <td class="text-right">
                                         <div id="quote_qty">
                                             <span t-field="line.product_uom_qty"/>
-                                            <span t-field="line.product_uom" groups="uom.group_uom"/>
+                                            <span t-field="line.product_uom"/>
                                         </div>
                                     </td>
                                     <td t-attf-class="text-right {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">


### PR DESCRIPTION
Steps to reproduce:

- Create an e-quote using a specific uom on a line and share it

Bug:

The uom was not displayed if the user was not signed

opw:2224344