### PR TITLE
[FIX] base: Impossible to display ir.sequence form view

### DIFF
--- a/odoo/addons/base/i18n/es.po
+++ b/odoo/addons/base/i18n/es.po
@@ -7935,7 +7935,7 @@ msgid ""
 "                                <span colspan=\"2\">Week of the Year: %(woy)s</span>\n"
 "                                <span colspan=\"2\">Day of the Week (0:Monday): %(weekday)s</span>"
 msgstr ""
-"Día del Año: %(doy)s</span>\n"
+"<span colspan=\"2\">Día del Año: %(doy)s</span>\n"
 "                                <span colspan=\"2\">Semana del Año: %(woy)s</span>\n"
 "                                <span colspan=\"2\">Día de la Semana (0:Lunes: %(weekday)s</span>"
 


### PR DESCRIPTION
Steps to reproduce the bug:

- Load spanish lang
- Go to Settings > Technical > Sequences > Customer Invoices : Check Number Sequence
- Set in your preference spanish as lang

Bug:

A traceback was raised.

opw:2237126