### PR TITLE
[IMP] base: state field mandatory based on state in partner

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -164,6 +164,7 @@ class Lead(models.Model):
     country_id = fields.Many2one(
         'res.country', string='Country',
         compute='_compute_partner_id_values', readonly=False, store=True)
+    is_state_required = fields.Boolean(related='country_id.is_state_required')
     # Probability (Opportunity only)
     probability = fields.Float(
         'Probability', group_operator="avg", copy=False,

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -93,12 +93,13 @@
                                         'show_vat': True
                                     }" groups="base.group_no_one"/>
                                 <field name="partner_name"/>
+                                <field name="is_state_required" invisible="1"/>
                                 <label for="street" string="Address"/>
                                 <div class="o_address_format">
                                     <field name="street" placeholder="Street..." class="o_address_street"/>
                                     <field name="street2" placeholder="Street 2..." class="o_address_street"/>
                                     <field name="city" placeholder="City" class="o_address_city"/>
-                                    <field name="state_id" class="o_address_state" placeholder="State" options='{"no_open": True}'/>
+                                    <field name="state_id" class="o_address_state" attrs="{'required': [('is_state_required', '=', True)]}" placeholder="State" options='{"no_open": True}'/>
                                     <field name="zip" placeholder="ZIP" class="o_address_zip"/>
                                     <field name="country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'/>
                                 </div>

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -284,6 +284,14 @@ class CustomerPortal(Controller):
         error = dict()
         error_message = []
 
+        # Check if state required
+        if data.get('country_id'):
+            country = request.env['res.country'].browse(int(data.get('country_id')))
+            if country.is_state_required:
+                self.MANDATORY_BILLING_FIELDS.append('state_id')
+            elif 'state_id' in self.MANDATORY_BILLING_FIELDS:
+                self.MANDATORY_BILLING_FIELDS.remove('state_id')
+
         # Validation
         for field_name in self.MANDATORY_BILLING_FIELDS:
             if not data.get(field_name):

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -76,8 +76,9 @@ class Company(models.Model):
     city = fields.Char(compute='_compute_address', inverse='_inverse_city')
     state_id = fields.Many2one(
         'res.country.state', compute='_compute_address', inverse='_inverse_state',
-        string="Fed. State", domain="[('country_id', '=?', country_id)]"
+        string="State", domain="[('country_id', '=?', country_id)]"
     )
+    is_state_required = fields.Boolean(compute='_compute_state_required')
     bank_ids = fields.One2many('res.partner.bank', 'company_id', string='Bank Accounts', help='Bank accounts related to this company')
     country_id = fields.Many2one('res.country', compute='_compute_address', inverse='_inverse_country', string="Country")
     email = fields.Char(related='partner_id.email', store=True, readonly=False)
@@ -114,6 +115,11 @@ class Company(models.Model):
     def _get_company_address_update(self, partner):
         return dict((fname, partner[fname])
                     for fname in self._get_company_address_field_names())
+
+    @api.depends('country_id')
+    def _compute_state_required(self):
+        for company in self:
+            company.is_state_required = company.country_id.is_state_required
 
     # TODO @api.depends(): currently now way to formulate the dependency on the
     # partner's contact address

--- a/odoo/addons/base/models/res_country.py
+++ b/odoo/addons/base/models/res_country.py
@@ -60,6 +60,7 @@ class Country(models.Model):
     country_group_ids = fields.Many2many('res.country.group', 'res_country_res_country_group_rel',
                          'res_country_id', 'res_country_group_id', string='Country Groups')
     state_ids = fields.One2many('res.country.state', 'country_id', string='States')
+    is_state_required = fields.Boolean(string="State Mandatory", help="If checked, the state will be required in address forms.")
     name_position = fields.Selection([
             ('before', 'Before Address'),
             ('after', 'After Address'),

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -197,6 +197,7 @@ class Partner(models.Model):
     zip = fields.Char(change_default=True)
     city = fields.Char()
     state_id = fields.Many2one("res.country.state", string='State', ondelete='restrict', domain="[('country_id', '=?', country_id)]")
+    is_state_required = fields.Boolean(related='country_id.is_state_required')
     country_id = fields.Many2one('res.country', string='Country', ondelete='restrict')
     partner_latitude = fields.Float(string='Geo Latitude', digits=(16, 5))
     partner_longitude = fields.Float(string='Geo Longitude', digits=(16, 5))

--- a/odoo/addons/base/views/res_company_views.xml
+++ b/odoo/addons/base/views/res_company_views.xml
@@ -24,7 +24,8 @@
                                         <field name="street" placeholder="Street..." class="o_address_street"/>
                                         <field name="street2" placeholder="Street 2..." class="o_address_street"/>
                                         <field name="city" placeholder="City" class="o_address_city"/>
-                                        <field name="state_id" class="o_address_state" placeholder="State" options='{"no_open": True}'/>
+                                        <field name="is_state_required" invisible="1"/>
+                                        <field name="state_id" class="o_address_state" placeholder="State" attrs="{'required': [('is_state_required', '=', True)]}" options='{"no_open": True}'/>
                                         <field name="zip" placeholder="ZIP" class="o_address_zip"/>
                                         <field name="country_id" placeholder="Country" class="o_address_country" options='{"no_open": True}'/>
                                     </div>

--- a/odoo/addons/base/views/res_country_views.xml
+++ b/odoo/addons/base/views/res_country_views.xml
@@ -41,14 +41,18 @@
                                 <div colspan="2" name="div_address_format" class="text-muted">Change the way addresses are displayed in reports</div>
                                 <field name="name_position"/>
                             </group>
+                            <group string="States" colspan="4">
+                                <group>
+                                    <field name="is_state_required"/>
+                                </group>
+                                <field name="state_ids" nolabel="1" colspan="2">
+                                    <tree editable="bottom">
+                                        <field name="name"/>
+                                        <field name="code"/>
+                                    </tree>
+                                </field>
+                            </group>
                         </group>
-                        <label for="state_ids"/>
-                        <field name="state_ids">
-                            <tree editable="bottom">
-                                <field name="name"/>
-                                <field name="code"/>
-                            </tree>
-                        </field>
                     </sheet>
                 </form>
             </field>

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -117,7 +117,8 @@
                                 <field name="street" placeholder="Street..." class="o_address_street"/>
                                 <field name="street2" placeholder="Street 2..." class="o_address_street"/>
                                 <field name="city" placeholder="City" class="o_address_city"/>
-                                <field name="state_id" class="o_address_state" placeholder="State" options="{'no_open': True, 'no_quick_create': True}" context="{'default_country_id': country_id}"/>
+                                <field name="is_state_required" invisible="1"/>
+                                <field name="state_id" class="o_address_state" placeholder="State" attrs="{'required': [('is_state_required', '=', True)]}" options="{'no_open': True, 'no_quick_create': True}" context="{'default_country_id': country_id}"/>
                                 <field name="zip" placeholder="ZIP" class="o_address_zip"/>
                                 <field name="country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'/>
                             </div>
@@ -147,6 +148,7 @@
                         <field name="is_company" invisible="1"/>
                         <field name="commercial_partner_id" invisible="1"/>
                         <field name="active" invisible="1"/>
+                        <field name="is_state_required" invisible="1"/>
                         <field name="company_type" widget="radio"
                             class="oe_edit_only"
                             options="{'horizontal': true}"/>
@@ -185,7 +187,7 @@
                                 <field name="city" placeholder="City" class="o_address_city"
                                     attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}"/>
                                 <field name="state_id" class="o_address_state" placeholder="State" options="{'no_open': True, 'no_quick_create': True}"
-                                    attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}" context="{'country_id': country_id, 'default_country_id': country_id, 'zip': zip}"/>
+                                    attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)], 'required': [('is_state_required', '=', True)]}" context="{'country_id': country_id, 'default_country_id': country_id, 'zip': zip}"/>
                                 <field name="zip" placeholder="ZIP" class="o_address_zip"
                                     attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}"/>
                                 <field name="country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'
@@ -287,6 +289,7 @@
                                         dosen't support when a field is displayed several times in the same view.-->
                                         <field name="type" required="1" widget="radio" options="{'horizontal': true}"/>
                                         <field name="parent_id" invisible="1"/>
+                                        <field name="is_state_required" invisible="1"/>
                                         <hr/>
                                         <group col="12">
                                             <group colspan="5">
@@ -301,7 +304,7 @@
                                                         <field name="street" placeholder="Street..." class="o_address_street"/>
                                                         <field name="street2" placeholder="Street 2..." class="o_address_street"/>
                                                         <field name="city" placeholder="City" class="o_address_city"/>
-                                                        <field name="state_id" class="o_address_state" placeholder="State" options="{'no_open': True, 'no_quick_create': True}" context="{'country_id': country_id, 'default_country_id': country_id, 'zip': zip}"/>
+                                                        <field name="state_id" class="o_address_state" placeholder="State" options="{'no_open': True, 'no_quick_create': True}" context="{'country_id': country_id, 'default_country_id': country_id, 'zip': zip}" attrs="{'required': [('is_state_required', '=', True)]}"/>
                                                         <field name="zip" placeholder="ZIP" class="o_address_zip"/>
                                                         <field name="country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'/>
                                                     </div>
@@ -360,6 +363,7 @@
                         <field name="parent_id" invisible="1"/>
                         <label for="name" class="oe_editonly"/>
                         <field name="name" required="0"/>
+                        <field name="is_state_required" invisible="1"/>
                         <group>
                             <group>
                                 <label for="street" string="Address"/>
@@ -368,7 +372,7 @@
                                         <field name="street" placeholder="Street..." class="o_address_street"/>
                                         <field name="street2" placeholder="Street 2..." class="o_address_street"/>
                                         <field name="city" placeholder="City" class="o_address_city"/>
-                                        <field name="state_id" class="o_address_state" placeholder="State" options="{'no_open': True, 'no_quick_create': True}" context="{'country_id': country_id, 'default_country_id': country_id, 'zip': zip}"/>
+                                        <field name="state_id" class="o_address_state" placeholder="State" options="{'no_open': True, 'no_quick_create': True}" context="{'country_id': country_id, 'default_country_id': country_id, 'zip': zip}" attrs="{'required': [('is_state_required', '=', True)]}"/>
                                         <field name="zip" placeholder="ZIP" class="o_address_zip"/>
                                         <field name="country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'/>
                                     </div>


### PR DESCRIPTION
Before this commit state field was not mandatory in any condition.
but, for fiscal reasons, we need to know the state of united-state's
customers.so there is need to make it mandatory for usa-based customers.

we have added one boolean field in country form. if is true then state
field will be mandatory in partner form.

Task-ID: 2232229
