### PR TITLE
[FIX] website_crm_partner_assign: fix the random weighted choice algorithm

### DIFF
--- a/addons/website_crm_partner_assign/models/crm_lead.py
+++ b/addons/website_crm_partner_assign/models/crm_lead.py
@@ -169,8 +169,7 @@ class CrmLead(models.Model):
                     total_weight += partner.partner_weight
                     toassign.append((partner.id, total_weight))
 
-                random.shuffle(toassign)  # avoid always giving the leads to the first ones in db natural order!
-                nearest_weight = random.randint(0, total_weight)
+                nearest_weight = random.randint(1, total_weight)
                 for partner_id, weight in toassign:
                     if nearest_weight <= weight:
                         res_partner_ids[lead.id] = partner_id


### PR DESCRIPTION
Bug
===
If 2 partners have the same weight, the first partner will
have 2 times more chance to be chosen.

Technical
=========
We do not need to shuffle `toassign` as `nearest_weight` is
already random. The cumulative weights in `toassign` need to
be sorted otherwise the algorithm will fail.

Adjust also the random range to have the exact same probability
for 2 partners with the same weight.

Task-2228921