### PR TITLE
[FIX] crm_iap_lead_website: fix the CRM reveal form view

### DIFF
--- a/addons/crm_iap_lead_website/views/crm_reveal_views.xml
+++ b/addons/crm_iap_lead_website/views/crm_reveal_views.xml
@@ -132,13 +132,12 @@
         <field name="arch" type="xml">
             <form>
                 <header>
-                    <field name="reveal_state" widget="statusbar"/>
+                    <field name="reveal_state" widget="statusbar" options="{'clickable': '1'}"/>
                 </header>
                 <sheet>
                     <group>
                         <field name="reveal_ip"/>
                         <field name="reveal_rule_id"/>
-                        <field name="reveal_state"/>
                         <field name="create_date"/>
                     </group>
                 </sheet>


### PR DESCRIPTION
Purpose
=======
The field `state` is defined 2 times in the same view with different
widget. This is impossible and only the last field (no-widget)
information will be kept (so the widget `statusbar` is never used).

Task-2228921