### PR TITLE
[IMP] mass_mailing: allow to customize the text preview

### DIFF
--- a/addons/link_tracker/tests/common.py
+++ b/addons/link_tracker/tests/common.py
@@ -22,8 +22,9 @@ class MockLinkTracker(common.BaseCase):
         self.addCleanup(link_tracker_title_patch.stop)
 
     def _get_href_from_anchor_id(self, body, anchor_id):
+        body = "<div>%s</div>" % body  # XML always need a root element
         html = etree.fromstring(body)
-        return html.xpath("*[@id='%s']" % anchor_id)[0].attrib.get('href')
+        return html.xpath("//*[@id='%s']" % anchor_id)[0].attrib.get('href')
 
     def _get_tracker_from_short_url(self, short_url):
         code = self.env['link.tracker.code'].sudo().search([

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -520,7 +520,7 @@ class MassMailing(models.Model):
             composer_values = {
                 'author_id': author_id,
                 'attachment_ids': [(4, attachment.id) for attachment in mailing.attachment_ids],
-                'body': mailing.body_html,
+                'body': self._prepare_mail_body(),
                 'subject': mailing.subject,
                 'model': mailing.mailing_model_real,
                 'email_from': mailing.email_from,
@@ -650,3 +650,29 @@ class MassMailing(models.Model):
             return lxml.html.tostring(root)
 
         return body_html
+
+    def _prepare_mail_body(self, body=None):
+        """Prepare the email body before sending.
+
+        Add the text preview at the beginning of the mail. The preview text is displayed
+        bellow the mail subject of most mail client (gmail, outlook...).
+
+        We add the character `&zwnj;` (zero-width non-joiner) to fill the end of the
+        preview in order to not have the beginning of the mail at the end of the preview
+        (don't work with simple space as the content is trimmed).
+
+        https://litmus.com/blog/the-ultimate-guide-to-preview-text-support
+        """
+        self.ensure_one()
+
+        body = body or self.body_html
+        preview = re.findall(r'\>([^<>]+)\<', body)
+        preview = ' '.join([p.strip() for p in preview if p.strip()])[:500]
+
+        html_preview = f"""
+            <div style="display:none;font-size:1px;height:0px;width:0px;opacity:0;">
+              {tools.html_escape(preview)} {'&zwnj;&nbsp;' * 500}
+            </div>
+        """ if preview else ''
+
+        return html_preview + body

--- a/addons/mass_mailing/wizard/mailing_mailing_test.py
+++ b/addons/mass_mailing/wizard/mailing_mailing_test.py
@@ -24,7 +24,8 @@ class TestMassMailing(models.TransientModel):
         mass_mail_layout = self.env.ref('mass_mailing.mass_mailing_mail_layout')
         for test_mail in test_emails:
             # Convert links in absolute URLs before the application of the shortener
-            body = self.env['mail.render.mixin']._replace_local_links(mailing.body_html)
+            body = mailing._prepare_mail_body(mailing.body_html)
+            body = self.env['mail.render.mixin']._replace_local_links(body)
             body = tools.html_sanitize(body, sanitize_attributes=True, sanitize_style=True)
             mail_values = {
                 'email_from': mailing.email_from,


### PR DESCRIPTION
Purpose
=======
Be able to customize the preview text displayed in the mailbox of most
mail clients (gmail, outlook...) as this sentence highly influences
whether or not the recipient decides to open the email or not.

Technical
=========
To build this preview, all mail clients read the content of the email.
The only way to be able to customize the preview is to add an invisible
HTML element at the beginning of the email with the wanted preview text.

We add at the end of the preview `&zwnj;` (zero-width non-joiner) to
fill the end of the preview in order to not have the beginning of the
mail at the end of the preview. It doesn't work with simple space as
the mail clients trim each HTML element content.

Task-2172125