### PR TITLE
[IMP] mass_mailing : improve auto generated mailing name and utm source name

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -260,8 +260,8 @@ class MassMailing(models.Model):
 
     @api.model
     def create(self, values):
-        if values.get('subject') and not values.get('name'):
-            values['name'] = "%s %s" % (values['subject'], datetime.strftime(fields.datetime.now(), tools.DEFAULT_SERVER_DATETIME_FORMAT))
+        values['name'] = self._get_mailing_name(values.get('name'), values.get('subject'))
+
         if values.get('body_html'):
             values['body_html'] = self._convert_inline_images_to_urls(values['body_html'])
         return super(MassMailing, self).create(values)
@@ -277,6 +277,9 @@ class MassMailing(models.Model):
         default = dict(default or {},
                        name=_('%s (copy)', self.name),
                        contact_list_ids=self.contact_list_ids.ids)
+        # we don't keep the name during duplication
+        # because we want the system to regenerate the name based on the subject
+        default["name"] = None
         return super(MassMailing, self).copy(default=default)
 
     def _group_expand_states(self, states, domain, order):
@@ -753,6 +756,36 @@ class MassMailing(models.Model):
     # ------------------------------------------------------
     # TOOLS
     # ------------------------------------------------------
+
+    def _get_mailing_name(self, base_name, subject):
+        """Generate a name for the mailing.
+
+        :param base_name: base name to use
+        :param subject: subject of the mailing
+        """
+        base_name = base_name or ''
+        if subject and not base_name:
+            base_name = _(
+                "%s (Mailing created on %s)",
+                subject,
+                fields.Date.to_string(fields.Datetime.now().date()),
+            )
+
+        # remove trailing " [XX]" to avoid having "Name (Created on ...) [X] [Y]"
+        base_name = re.sub(r'\s\[([0-9]+)\]$', '', base_name)
+
+        last_mailing_name = self.env['utm.source'].search_read(
+            domain=[('name', '=like', base_name + "%")],
+            fields=['name'],
+            limit=1,
+            order='name DESC',
+        )
+
+        if last_mailing_name:
+            match = re.findall(r"\[([0-9]+)\]$", last_mailing_name[0]['name'])
+            count = int(match[0]) + 1 if match else 2
+            return "%s [%i]" % (base_name, count)
+        return base_name
 
     def _get_default_mailing_domain(self):
         default_mailing_domain = self.default_get(['mailing_domain']).get('mailing_domain')

--- a/addons/mass_mailing/tests/test_mailing_internals.py
+++ b/addons/mass_mailing/tests/test_mailing_internals.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import date
 from ast import literal_eval
 
 from odoo.addons.mass_mailing.tests.common import MassMailCommon
@@ -108,6 +109,65 @@ class TestMassMailValues(MassMailCommon):
             'mailing_model_id': self.env['ir.model']._get('res.partner').id,
         })
         self.assertEqual(literal_eval(mailing.mailing_domain), [('email', 'ilike', 'test.example.com')])
+
+    @users('user_marketing')
+    def test_mailing_generated_source_name(self):
+        today_str = date.today().strftime('%Y-%m-%d')
+        mailing1, mailing2, mailing3 = self.env['mailing.mailing'].create(
+            [{
+                'subject': 'Test source',
+                'mailing_type': 'mail',
+                'body_html': '<p>Hello ${object.name}</p>',
+                'mailing_model_id': self.env['ir.model']._get('res.partner').id,
+            }, {
+                'subject': 'Test source',
+                'mailing_type': 'mail',
+                'body_html': '<p>Hello ${object.name}</p>',
+                'mailing_model_id': self.env['ir.model']._get('res.partner').id,
+            }, {
+                'subject': 'Test source',
+                'mailing_type': 'mail',
+                'body_html': '<p>Hello ${object.name}</p>',
+                'mailing_model_id': self.env['ir.model']._get('res.partner').id,
+            }])
+
+        self.assertEqual(mailing1.name, 'Test source (Mailing created on %s)' % today_str)
+        self.assertEqual(mailing2.name, 'Test source (Mailing created on %s) [2]' % today_str)
+        self.assertEqual(mailing3.name, 'Test source (Mailing created on %s) [3]' % today_str)
+
+        # removing an old mailing should not change the count
+        mailing2.sudo().source_id.unlink()
+        mailing4 = self.env['mailing.mailing'].create({
+            'subject': 'Test source',
+            'mailing_type': 'mail',
+            'body_html': '<p>Hello ${object.name}</p>',
+            'mailing_model_id': self.env['ir.model']._get('res.partner').id,
+        })
+        self.assertEqual(mailing4.name, 'Test source (Mailing created on %s) [4]' % today_str)
+
+        # test if remove `[count]` from the given name
+        mailing5 = self.env['mailing.mailing'].create({
+            'name': 'Test source (Mailing created on %s) [4]' % today_str,
+            'subject': 'Test source',
+            'mailing_type': 'mail',
+            'body_html': '<p>Hello ${object.name}</p>',
+            'mailing_model_id': self.env['ir.model']._get('res.partner').id,
+        })
+        self.assertEqual(mailing5.name, 'Test source (Mailing created on %s) [5]' % today_str)
+
+        # removing the last mailing make its number available
+        mailing5.sudo().source_id.unlink()
+        mailing5 = self.env['mailing.mailing'].create({
+            'subject': 'Test source',
+            'mailing_type': 'mail',
+            'body_html': '<p>Hello ${object.name}</p>',
+            'mailing_model_id': self.env['ir.model']._get('res.partner').id,
+        })
+        self.assertEqual(mailing5.name, 'Test source (Mailing created on %s) [5]' % today_str)
+
+        # the copy should regenerate the name
+        mailing6 = mailing5.copy()
+        self.assertEqual(mailing6.name, 'Test source (Mailing created on %s) [6]' % today_str)
 
     @users('user_marketing')
     def test_mailing_computed_fields_form(self):

--- a/addons/mass_mailing_sms/data/mailing_demo.xml
+++ b/addons/mass_mailing_sms/data/mailing_demo.xml
@@ -3,6 +3,7 @@
     <record id="mailing_sms_0" model="mailing.mailing">
         <field name="name">XMas Promo</field>
         <field name="subject">XMas Promo</field>
+        <field name="name">XMas Promo</field>
         <field name="mailing_type">sms</field>
         <field name="state">done</field>
         <field name="user_id" ref="base.user_admin"/>
@@ -112,6 +113,7 @@
     <record id="mailing_sms_1" model="mailing.mailing">
         <field name="name">Extra Promo</field>
         <field name="subject">Extra Promo</field>
+        <field name="name">Extra Promo</field>
         <field name="mailing_type">sms</field>
         <field name="state">done</field>
         <field name="user_id" ref="base.user_admin"/>


### PR DESCRIPTION
 * Simpler and more user friendly generated source name
 * Avoid duplicate source name in the DB
 * Add name in mailing.mailing demo data to avoid creating unnecessary i18n lines

task id : 2245823