### PR TITLE
[FIX] l10n_nl: Wrong sign for Inkopen import binnen EU

### DIFF
--- a/addons/l10n_nl/data/account_tax_template.xml
+++ b/addons/l10n_nl/data/account_tax_template.xml
@@ -835,7 +835,7 @@
                     'plus_report_line_ids': [ref('tax_report_rub_4b')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_l_eu'),
                     'plus_report_line_ids': [ref('tax_report_rub_btw_4b')],
@@ -854,7 +854,7 @@
                     'minus_report_line_ids': [ref('tax_report_rub_4b')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_l_eu'),
                     'minus_report_line_ids': [ref('tax_report_rub_btw_4b')],
@@ -883,7 +883,7 @@
                     'plus_report_line_ids': [ref('tax_report_rub_4b')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_l_eu'),
                     'plus_report_line_ids': [ref('tax_report_rub_btw_4b')],
@@ -902,7 +902,7 @@
                     'minus_report_line_ids': [ref('tax_report_rub_4b')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_l_eu'),
                     'minus_report_line_ids': [ref('tax_report_rub_btw_4b')],
@@ -931,7 +931,7 @@
                     'plus_report_line_ids': [ref('tax_report_rub_4b')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_h_eu'),
                     'plus_report_line_ids': [ref('tax_report_rub_btw_4b')],
@@ -950,7 +950,7 @@
                     'minus_report_line_ids': [ref('tax_report_rub_4b')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_h_eu'),
                     'minus_report_line_ids': [ref('tax_report_rub_btw_4b')],
@@ -1109,7 +1109,7 @@
                     'plus_report_line_ids': [ref('tax_report_rub_4b')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_l_d_eu'),
                     'plus_report_line_ids': [ref('tax_report_rub_btw_4b')],
@@ -1128,7 +1128,7 @@
                     'minus_report_line_ids': [ref('tax_report_rub_4b')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_l_d_eu'),
                     'minus_report_line_ids': [ref('tax_report_rub_btw_4b')],
@@ -1157,7 +1157,7 @@
                     'plus_report_line_ids': [ref('tax_report_rub_4b')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_l_d_eu'),
                     'plus_report_line_ids': [ref('tax_report_rub_btw_4b')],
@@ -1176,7 +1176,7 @@
                     'minus_report_line_ids': [ref('tax_report_rub_4b')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_l_d_eu'),
                     'minus_report_line_ids': [ref('tax_report_rub_btw_4b')],
@@ -1205,7 +1205,7 @@
                     'plus_report_line_ids': [ref('tax_report_rub_4b')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_h_d_eu'),
                     'plus_report_line_ids': [ref('tax_report_rub_btw_4b')],
@@ -1224,7 +1224,7 @@
                     'minus_report_line_ids': [ref('tax_report_rub_4b')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_h_d_eu'),
                     'minus_report_line_ids': [ref('tax_report_rub_btw_4b')],
@@ -1288,7 +1288,7 @@
                     'plus_report_line_ids': [ref('tax_report_rub_4a')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_l_non_eu'),
                     'plus_report_line_ids': [ref('tax_report_rub_btw_4a')],
@@ -1307,7 +1307,7 @@
                     'minus_report_line_ids': [ref('tax_report_rub_4a')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_l_non_eu'),
                     'minus_report_line_ids': [ref('tax_report_rub_btw_4a')],
@@ -1336,7 +1336,7 @@
                     'plus_report_line_ids': [ref('tax_report_rub_4a')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_l_non_eu'),
                     'plus_report_line_ids': [ref('tax_report_rub_btw_4a')],
@@ -1355,7 +1355,7 @@
                     'minus_report_line_ids': [ref('tax_report_rub_4a')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_l_non_eu'),
                     'minus_report_line_ids': [ref('tax_report_rub_btw_4a')],
@@ -1384,7 +1384,7 @@
                     'plus_report_line_ids': [ref('tax_report_rub_4a')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_h_non_eu'),
                     'plus_report_line_ids': [ref('tax_report_rub_btw_4a')],
@@ -1403,7 +1403,7 @@
                     'minus_report_line_ids': [ref('tax_report_rub_4a')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_h_non_eu'),
                     'minus_report_line_ids': [ref('tax_report_rub_btw_4a')],
@@ -1432,7 +1432,7 @@
                     'plus_report_line_ids': [ref('tax_report_rub_4a')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_h_non_eu'),
                     'plus_report_line_ids': [ref('tax_report_rub_btw_4a')],
@@ -1451,7 +1451,7 @@
                     'minus_report_line_ids': [ref('tax_report_rub_4a')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_h_non_eu'),
                     'minus_report_line_ids': [ref('tax_report_rub_btw_4a')],
@@ -1546,7 +1546,7 @@
                     'plus_report_line_ids': [ref('tax_report_rub_4a')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_l_d_non_eu'),
                     'plus_report_line_ids': [ref('tax_report_rub_btw_4a')],
@@ -1565,7 +1565,7 @@
                     'minus_report_line_ids': [ref('tax_report_rub_4a')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_l_d_non_eu'),
                     'minus_report_line_ids': [ref('tax_report_rub_btw_4a')],
@@ -1594,7 +1594,7 @@
                     'plus_report_line_ids': [ref('tax_report_rub_4a')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_l_d_non_eu'),
                     'plus_report_line_ids': [ref('tax_report_rub_btw_4a')],
@@ -1613,7 +1613,7 @@
                     'minus_report_line_ids': [ref('tax_report_rub_4a')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_l_d_non_eu'),
                     'minus_report_line_ids': [ref('tax_report_rub_btw_4a')],
@@ -1642,7 +1642,7 @@
                     'plus_report_line_ids': [ref('tax_report_rub_4a')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_h_d_non_eu'),
                     'plus_report_line_ids': [ref('tax_report_rub_btw_4a')],
@@ -1661,7 +1661,7 @@
                     'minus_report_line_ids': [ref('tax_report_rub_4a')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_h_d_non_eu'),
                     'minus_report_line_ids': [ref('tax_report_rub_btw_4a')],
@@ -1690,7 +1690,7 @@
                     'plus_report_line_ids': [ref('tax_report_rub_4a')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_h_d_non_eu'),
                     'plus_report_line_ids': [ref('tax_report_rub_btw_4a')],
@@ -1709,7 +1709,7 @@
                     'minus_report_line_ids': [ref('tax_report_rub_4a')],
                 }),
                 (0,0, {
-                    'factor_percent': -100,
+                    'factor_percent': 100,
                     'repartition_type': 'tax',
                     'account_id': ref('vat_payable_h_d_non_eu'),
                     'minus_report_line_ids': [ref('tax_report_rub_btw_4a')],


### PR DESCRIPTION
The purchase tax report for purchases outside and inside Europe
were wrongly reported in the tax report.

opw:2243383