### PR TITLE
[FIX] web: Model base class can dispatch at willStart

### DIFF
--- a/addons/web/static/src/js/model.js
+++ b/addons/web/static/src/js/model.js
@@ -137,7 +137,9 @@ odoo.define('web.model', function () {
         model.on('update', component, async modelRev => {
             if (mapping[componentId] < modelRev) {
                 mapping[componentId] = modelRev;
-                await component.render();
+                if (__owl__.isMounted) {
+                    await component.render();
+                }
             }
         });
 

--- a/addons/web/static/src/js/model.js
+++ b/addons/web/static/src/js/model.js
@@ -69,7 +69,7 @@ odoo.define('web.model', function () {
             let rev = this.rev;
             await Promise.resolve();
             if (rev === this.rev) {
-                await this._notifyComponents();
+                this._notifyComponents();
             }
             return result;
         }
@@ -137,9 +137,7 @@ odoo.define('web.model', function () {
         model.on('update', component, async modelRev => {
             if (mapping[componentId] < modelRev) {
                 mapping[componentId] = modelRev;
-                if (__owl__.isMounted) {
-                    await component.render();
-                }
+                await component.render();
             }
         });
 

--- a/addons/web/static/tests/component_extension_tests.js
+++ b/addons/web/static/tests/component_extension_tests.js
@@ -285,20 +285,20 @@ odoo.define('web.component_extension_tests', function (require) {
             Parent.env = makeTestEnvironment({}, () => Promise.resolve());
             Parent.template = xml`<div t-esc="text" />`;
 
-            const fixture = document.body.querySelector('#qunit-fixture');
-
+            const target = testUtils.prepareTarget();
             const model = new MyModel();
             Parent.env.mainModel = model;
             const parent = new Parent(null);
-            await parent.mount(fixture);
+            await parent.mount(target);
             assert.strictEqual(
-                fixture.innerHTML,
+                target.innerHTML,
                 '<div>tell me so</div>'
             );
 
             await model.dispatch('loadState', 'set my soul on fire');
+            await testUtils.nextTick();
             assert.strictEqual(
-                fixture.innerHTML,
+                target.innerHTML,
                 '<div>set my soul on fire</div>'
             );
             parent.destroy();


### PR DESCRIPTION
Have a component that uses a model with the useModel hook
During the mount, make that model dispatch a command
i.e. in the willStart of the component

Before this commit, there was a timeout because the model waited for
the end of the rendering to yield, and the willStart waited for that
to yield in turn. That was a deadlock

After this commit, we trigger a rendering on the component
only when we are already mounted

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
