### PR TITLE
[FIX] base: fix portal attachment upload

### DIFF
--- a/addons/portal/controllers/mail.py
+++ b/addons/portal/controllers/mail.py
@@ -140,6 +140,7 @@ class PortalChatter(http.Controller):
                 'message': message,
                 'send_after_commit': False,
                 'attachment_ids': attachment_ids,
+                'attachment_tokens': attachment_tokens,
             }
             post_values.update((fname, kw.get(fname)) for fname in self._portal_post_filter_params())
             message = _message_post_helper(**post_values)

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -693,6 +693,7 @@ class Task(models.Model):
             vals.update(self.update_date_end(vals['stage_id']))
             vals['date_last_stage_update'] = fields.Datetime.now()
         task = super(Task, self.with_context(context)).create(vals)
+        task._portal_ensure_token()
         return task
 
     def write(self, vals):

--- a/addons/website_slides/controllers/mail.py
+++ b/addons/website_slides/controllers/mail.py
@@ -57,7 +57,7 @@ class SlidesPortalChatter(PortalChatter):
         message = request.env['mail.message'].search(domain, limit=1)
         if not message:
             raise NotFound()
-        message.write({
+        message.sudo().write({
             'body': message_body,
             'attachment_ids': [(4, aid) for aid in attachment_ids],
         })

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -439,7 +439,7 @@ class WebsiteSlides(WebsiteProfile):
                 last_message_values = last_message.read(['body', 'rating_value', 'attachment_ids'])[0]
                 last_message_attachment_ids = last_message_values.pop('attachment_ids', [])
                 if last_message_attachment_ids:
-                    last_message_attachment_ids = json.dumps(request.env['ir.attachment'].browse(last_message_attachment_ids).read(
+                    last_message_attachment_ids = json.dumps(request.env['ir.attachment'].browse(last_message_attachment_ids).sudo().read(
                         ['id', 'name', 'mimetype', 'file_size', 'access_token']
                     ))
             else:


### PR DESCRIPTION
Bugs
====
Since #38358, only internal user can read attachments. But, during the mail message creation, we check if the user can read the attachment of the mail message. If he can't, an error is raised.

Because of the change, portal can not upload attachments in some application
- website sale (in the comments under the online product)
- website slide (in the reviews of the courses)
- website blog (in the comments under the blog post)
- website crm partner assign (in the comment under the leads/opps in the portal)
- project (on the task created in a stage without mail template)

Task-2214795