### PR TITLE
[FIX] im_livechat: Traceback on Safari and Chrome mobile

### DIFF
--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -122,7 +122,7 @@ class ImLivechatChannel(models.Model):
             'anonymous_name': False if user_id else anonymous_name,
             'country_id': country_id,
             'channel_type': 'livechat',
-            'name': ', '.join([visitor_user.display_name if visitor_user else anonymous_name, operator.livechat_username if operator.livechat_username else operator.name]),
+            'name': ', '.join([visitor_user.display_name.replace(',', ' ') if visitor_user else anonymous_name, operator.livechat_username.replace(',', ' ') if operator.livechat_username else operator.name.replace(',', ' ')]),
             'public': 'private',
             'email_send': False,
         }


### PR DESCRIPTION
Steps to reproduce the bug:

- Install website_livechat
- Go to login page on mobile with Safari
- Click on "Have a Question?"
- Close the chat by clicking on the arrow

Bug:

A traceback was raised

Ref:https://stackoverflow.com/questions/19359326/json-parse-fails-in-safari-when-a-string-value-contains-a-comma

opw:2243871