### PR TITLE
[FIX] sign: sign_widgets_tour does not fail in test

### DIFF
--- a/addons/web/static/lib/jSignature/jSignatureCustom.js
+++ b/addons/web/static/lib/jSignature/jSignatureCustom.js
@@ -1286,9 +1286,12 @@ var GlobalJSignatureObjectInitializer = function(window){
     };
 
     function _clearDrawingArea( data, dontClear ) {
-        this.find('canvas.'+apinamespace)
+        var canvas = this.find('canvas.'+apinamespace)
             .add(this.filter('canvas.'+apinamespace))
-            .data(apinamespace+'.this').resetCanvas( data, dontClear );
+            .data(apinamespace+'.this');
+        if(canvas) {
+            canvas.resetCanvas( data, dontClear );
+        }
         return this;
     }
 


### PR DESCRIPTION
Steps to reproduce:
- install sign
- activate debug mode
- start the tour (x2)

Previous behavior:
the tour 'sign_widgets_tour' fails when runned multiple times
it shows a traceback with the following message:
"Uncaught TypeError: Cannot read property 'resetCanvas' of undefined"

Current behavior:
tour does not fail

opw-2251078