### PR TITLE
[FIX] sales_team: Portal users suggested as Salesperson

### DIFF
--- a/addons/sales_team/models/res_partner.py
+++ b/addons/sales_team/models/res_partner.py
@@ -10,3 +10,9 @@ class ResPartner(models.Model):
     team_id = fields.Many2one(
         'crm.team', 'Sales Team',
         help='If set, this Sales Team will be used for sales and assignations related to this partner')
+    salesman_user_ids = fields.One2many(comodel_name='res.users', compute='_compute_salesman_user_ids')
+
+
+    def _compute_salesman_user_ids(self):
+        for record in self:
+            record.salesman_user_ids = self.env.ref('sales_team.group_sale_salesman').users

--- a/addons/sales_team/views/crm_team_views.xml
+++ b/addons/sales_team/views/crm_team_views.xml
@@ -177,5 +177,21 @@
             <field name="view_mode">tree,form</field>
             <field name="domain">['|', ('res_model_id', '=', False), ('res_model_id.model', '=', 'res.partner')]</field>
         </record>
+
+        <record id="view_partner_form_inherit_sales_team" model="ir.ui.view">
+            <field name="name">res.partner.sales.team.inherit</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base.view_partner_form"/>
+            <field name="arch" type="xml">
+                <data>
+                    <xpath expr="//group[@name='sale']" position="inside">
+                        <field name='salesman_user_ids' invisible="1"/>
+                    </xpath>
+                    <xpath expr="//group[@name='sale']/field[@name='user_id']" position="attributes">
+                        <attribute name="domain">[('id', 'in', salesman_user_ids)]</attribute>
+                    </xpath>
+                </data>
+            </field>
+        </record>
     </data>
 </odoo>


### PR DESCRIPTION
Steps to reproduce the bug:

- Create a portal user U
- Go to Contact app and create a new contact
- In the page Sales & Purchases, select a salesperson

Bug:

It was possible to select U even if U was not in the group group_sale_salesman

Same behavior as field user_id on model 'sale.order'

opw:2246954