### PR TITLE
[FIX] website_form: default data-values no become permanent


### DIFF
--- a/addons/website_form/static/src/js/website_form.js
+++ b/addons/website_form/static/src/js/website_form.js
@@ -64,6 +64,7 @@ odoo.define('website_form.animation', function (require) {
                         var $field = self.$target.find('input[name="' + field + '"], textarea[name="' + field + '"]');
                         if (!$field.val()) {
                             $field.val(values[field]);
+                            $field.data('website_form_original_default_value', $field.val());
                         }
                     }
                 });

--- a/addons/website_form/static/src/js/website_form_editor.js
+++ b/addons/website_form/static/src/js/website_form_editor.js
@@ -434,6 +434,14 @@ odoo.define('website_form_editor', function (require) {
                     }
                 }
             });
+
+            // Clear default values coming from data-for/data-values attributes
+            this.$target.find('input[name],textarea[name]').each(function () {
+                var original = $(this).data('website_form_original_default_value');
+                if (original !== undefined && $(this).val() === original) {
+                    $(this).val('').removeAttr('value');
+                }
+            });
         }
     });
 


### PR DESCRIPTION
When there is data-for and data-value on an element before web website
form, the values are used to set as default for the fields.

For example in website_hr_recruitment, on a form for job application for
a given job, we set the default value job_id for that job.

But in 126d180bc1 modfication, we set the value at when the form is
shown, so if we edit the form and save that value will become permanent
(so for example if you edit the application for job "Trainee", you will
get all new jobs applications set to "Trainee").

So in this commit, we set the default value only when the form is being
sent.

opw-2247107
