### PR TITLE
no content helper remove after record creation

### DIFF
--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -4207,6 +4207,18 @@ var BasicModel = AbstractModel.extend({
                             // Also keep data if we only reload groups' own data
                             delete updatedProps.data;
                         }
+                        // If only groups are updated, and no new records is in the group
+                        // we won't search_read it (optimization).
+                        // BUT we need to keep res_ids, in case a new record, not belonging to the group
+                        // is there (kanban quick create with domain)
+                        if (options && options.onlyGroups && newGroup.count === 0) {
+                            // LPE FIXME: The count will be reset to 0
+                            // if we keep it, we take the risk of breaking
+                            // loadMore stuff when a new record which doesn't belong
+                            // to the group is present in the group anyway (kanban quick create with domain)
+                            // Should we keep the count ????
+                            delete updatedProps.res_ids;
+                        }
                         // set the limit such that all previously loaded records
                         // (e.g. if we are coming back to the kanban view from a
                         // form view) are reloaded

--- a/addons/web/static/src/js/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/js/views/kanban/kanban_renderer.js
@@ -201,7 +201,10 @@ var KanbanRenderer = BasicRenderer.extend({
             }
             return $.when(def).then(function () {
                 newColumn.$el.insertAfter(column.$el);
-                self._toggleNoContentHelper();
+                // if openQuickCreate is true then do not show no content helper
+                if (!options || !options.openQuickCreate) {
+                    self._toggleNoContentHelper();
+                }
                 // When a record has been quick created, the new column directly
                 // renders the quick create widget (to allow quick creating several
                 // records in a row). However, as we render this column in a
@@ -516,7 +519,10 @@ var KanbanRenderer = BasicRenderer.extend({
         if (this.state.groupedBy.length) {
             _.invoke(this.widgets, 'cancelQuickCreate');
         }
-        this._toggleNoContentHelper();
+        // if quick create adds a record then do not show no content helper
+        if (!this.$('.o_kanban_record').length) {
+            this._toggleNoContentHelper();
+        }
     },
     /**
      * @private

--- a/addons/web/static/src/js/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/js/views/kanban/kanban_renderer.js
@@ -519,10 +519,7 @@ var KanbanRenderer = BasicRenderer.extend({
         if (this.state.groupedBy.length) {
             _.invoke(this.widgets, 'cancelQuickCreate');
         }
-        // if quick create adds a record then do not show no content helper
-        if (!this.$('.o_kanban_record').length) {
-            this._toggleNoContentHelper();
-        }
+        this._toggleNoContentHelper();
     },
     /**
      * @private

--- a/addons/web/static/tests/views/kanban_tests.js
+++ b/addons/web/static/tests/views/kanban_tests.js
@@ -3541,6 +3541,57 @@ QUnit.module('Views', {
         kanban.destroy();
     });
 
+    QUnit.test('nocontent helper after adding a record(kanban with progressbar)', function (assert) {
+        assert.expect(3);
+
+        var kanban = createView({
+            View: KanbanView,
+            model: 'partner',
+            data: this.data,
+            arch: '<kanban>' +
+                '<field name="int_field"/>' +
+                '<progressbar field="foo" colors=\'{"yop": "success", "gnap": "warning", "blip": "danger"}\' sum_field="int_field"/>' +
+                '<templates><t t-name="kanban-box">' +
+                '<div><field name="name"/></div>' +
+                '</t></templates>' +
+                '</kanban>',
+            groupBy: ['product_id'],
+            domain: [['name', '=', 'abcdef']],
+            mockRPC: function (route, args) {
+                if (args.method === 'read_group') {
+                    var result = [
+                        { __domain: [['product_id', '=', 3]], product_id_count: 0, product_id: [3, 'hello'] },
+                    ];
+                    return $.when(result);
+                }
+                return this._super.apply(this, arguments);
+            },
+            viewOptions: {
+                action: {
+                    help: "No content helper",
+                },
+            },
+        });
+
+        assert.strictEqual(kanban.$('.o_view_nocontent').length, 1,
+            "there should be a nocontent helper");
+
+        // add a record
+        kanban.$('.o_kanban_quick_add').click();
+        kanban.$('.o_kanban_quick_create .o_input').val('twilight sparkle').trigger('input');
+        kanban.$('button.o_kanban_add').click();
+
+        assert.strictEqual(kanban.$('.o_view_nocontent').length, 0,
+            "there should be no nocontent helper (there is now one record)");
+
+        // cancel quick create
+        kanban.$('button.o_kanban_cancel').click();
+        assert.strictEqual(kanban.$('.o_view_nocontent').length, 0,
+            "there should be no nocontent helper after cancelling quick create");
+
+        kanban.destroy();
+    });
+
     QUnit.test('remove nocontent helper when adding a record', function (assert) {
         assert.expect(2);
 


### PR DESCRIPTION
PURPOSE
The no content helper is shown after creating a record in a filtered view

SPEC
The no content help should not be displayed once record is created using quick create form.

TASK 2251734


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
