### PR TITLE
Make mail links work through oauth

### DIFF
--- a/addons/mail/controllers/mail.py
+++ b/addons/mail/controllers/mail.py
@@ -18,7 +18,7 @@ class MailController(http.Controller):
 
     @classmethod
     def _redirect_to_messaging(cls):
-        url = '/web#%s' % url_encode({'action': 'mail.action_discuss'})
+        url = '/web?' + url_encode({'redirect': '/web#%s' % url_encode({'action': 'mail.action_discuss'})})
         return request.redirect(url)
 
     @classmethod

--- a/addons/portal/controllers/web.py
+++ b/addons/portal/controllers/web.py
@@ -22,6 +22,6 @@ class Home(WebHome):
 
     @http.route()
     def web_client(self, s_action=None, **kw):
-        if request.session.uid and not is_user_internal(request.session.uid):
+        if not kw.get('redirect') and request.session.uid and not is_user_internal(request.session.uid):
             return request.redirect_query('/my', query=request.params)
         return super().web_client(s_action, **kw)

--- a/addons/test_mail_full/__init__.py
+++ b/addons/test_mail_full/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
+from . import controllers
 from . import models
-from . import tests

--- a/addons/test_mail_full/controllers.py
+++ b/addons/test_mail_full/controllers.py
@@ -1,0 +1,8 @@
+from odoo import http
+from odoo.addons.portal.controllers.portal import CustomerPortal
+
+
+class Portal(CustomerPortal):
+    @http.route(['/my/thing', '/my/thing2'], type='http', auth="user", website=True)
+    def thing(self, **_):
+        return ""

--- a/addons/test_mail_full/models/__init__.py
+++ b/addons/test_mail_full/models/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
+from . import portal_or_not
 from . import test_mail_models_mail

--- a/addons/test_mail_full/models/portal_or_not.py
+++ b/addons/test_mail_full/models/portal_or_not.py
@@ -1,0 +1,17 @@
+from odoo import models
+
+
+class NotPortal(models.Model):
+    _name = _description = 'test_mail_full.not_portal'
+
+    def _compute_access_url(self):
+        super()._compute_access_url()
+        self.access_url = '/my/thing2'
+
+class Portal(models.Model):
+    _name = _description = 'test_mail_full.portal'
+    _inherit = 'portal.mixin'
+
+    def _compute_access_url(self):
+        super()._compute_access_url()
+        self.access_url = '/my/thing'

--- a/addons/test_mail_full/security/ir.model.access.csv
+++ b/addons/test_mail_full/security/ir.model.access.csv
@@ -4,3 +4,5 @@ access_mail_test_portal_user,mail.test.portal.user,model_mail_test_portal,base.g
 access_mail_test_rating_all,mail.test.rating.all,model_mail_test_rating,,0,0,0,0
 access_mail_test_rating_portal,mail.test.rating.portal,model_mail_test_rating,base.group_portal,1,0,0,0
 access_mail_test_rating_user,mail.test.rating.user,model_mail_test_rating,base.group_user,1,1,1,1
+test_portal_0,xxx,model_test_mail_full_portal,base.group_system,1,1,1,1
+test_portal_1,xxx,model_test_mail_full_not_portal,base.group_system,1,1,1,1

--- a/addons/test_mail_full/tests/test_portal.py
+++ b/addons/test_mail_full/tests/test_portal.py
@@ -1,16 +1,22 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
-from werkzeug.urls import url_parse, url_decode
-
 import json
+from collections import defaultdict
+from itertools import product
+
+from lxml import html
+from werkzeug import Response
+from werkzeug.test import Client
+from werkzeug.urls import url_encode, url_parse, url_decode
 
 from odoo import http
-from odoo.addons.test_mail_full.tests.common import TestMailFullCommon
-from odoo.addons.test_mail_sms.tests.common import TestSMSRecipients
 from odoo.tests import tagged, users
 from odoo.tests.common import HttpCase
+from odoo.tools import mute_logger
 
+from odoo.addons.base.tests.common import HttpCaseWithUserDemo
+from odoo.addons.test_mail_full.tests.common import TestMailFullCommon
+from odoo.addons.test_mail_sms.tests.common import TestSMSRecipients
 
 @tagged('portal')
 class TestPortal(HttpCase, TestMailFullCommon, TestSMSRecipients):
@@ -162,3 +168,144 @@ class TestPortalMixin(TestPortal):
 
         record_portal._portal_ensure_token()
         self.assertTrue(record_portal.access_token)
+
+OBJECT_URL = '/web#model={model}&id={id}&active_id={id}&cids=1'
+PORTAL_URL = '/my/thing{token}'
+NO_ACCESS = '/web#action=mail.action_discuss'
+PORTAL_ROOT = '/my' # portal user gets bounced from /web to /my
+@tagged('portal')
+class TestMailAccess(HttpCaseWithUserDemo):
+    def _cleanup(self, location):
+        # we want the absolute path but not the absolute URL, strip out bullshit
+        # scheme & domain, as well as fragment as Werkzeug's client doesn't
+        # support those (TBF they're a client-only concern)
+        return url_parse(location).replace(scheme='', netloc='', fragment='').to_url()
+
+    def do_login(self, client, body, user):
+        h = html.fromstring(body)
+        f = h.find('.//form[@class="oe_login_form"]')
+        fields = {
+            field.get('name'): field.get('value')
+            for field in f.xpath('.//input[@name] | .//button[@name]')
+            if field.get('value')
+        }
+        fields['login'] = fields['password'] = user
+        r = client.post(f.get('action'), data=fields, environ_base={
+            'REMOTE_HOST': 'localhost',
+            'REMOTE_ADDR': '127.0.0.1',
+        })
+        return r.headers['Location'], self._cleanup(r.headers['Location'])
+
+    def do_flow(self, model, user, *, login, token):
+        params = {}
+        Model = self.env[model]
+        if token and 'access_token' in Model._fields:
+            params = {'access_token': '12345'}
+
+        obj = Model.create(params)
+        c = Client(http.root, Response)
+        if login:
+            self.authenticate(user, user)
+            c.set_cookie('localhost', key='session_id', value=self.session.sid, httponly=True)
+        self.env.cr.flush()
+        self.env.cr.clear()
+        location = url = '/mail/view?' + url_encode({
+            'model': model,
+            'res_id': obj.id,
+            **params
+        })
+        while True:
+            r = c.get(url)
+            self.assertLess(r.status_code, 400, f'{url} = {r.status}')
+            if r.status_code // 100 == 2:
+                if url.startswith('/web/login'):
+                    location, url = self.do_login(c, r.data, user)
+                    continue
+                break
+
+            location = r.headers['Location']
+            redir = self._cleanup(location)
+            assert url != redir, "redirection loop"
+            url = redir
+        return obj, location, r
+
+    @mute_logger(
+        'odoo.http', # bunch of "Session expired" message
+        'odoo.addons.base.models.res_users', # on every login (~25)
+        'odoo.addons.base.models.ir_model', # on every ACL error (~15)
+    )
+    def test_mail_view_portal(self):
+        # Each case is a triplet of (model type, login, results) where the
+        # access context is a dict of (logged in, has token) mapping to a final
+        # URL.
+        #
+        # The model type indicates whether the model is portal-enabled
+        # (portal.mixin) or not.
+        #
+        # The login is used if the user gets bounced through `/web/login` during
+        # the flow execution in which case they will get logged in at that
+        # point, or if the `logged in` pre-set is selected, in which case they
+        # will get logged in before the process starts.
+        #
+        # For each case, the driver will perform the access flow through
+        # /mail/view in each of the 4 possible pre-set states then check if the
+        # URL it reaches at the end matches that specified for the preset state.
+        cases = [
+            ('not_portal', 'admin', defaultdict(lambda: OBJECT_URL)),
+            # admin always gets backend unless unlogged w/ a token
+            ('portal', 'admin', defaultdict(lambda: OBJECT_URL, {
+                (False, True): PORTAL_URL,
+            })),
+            ('not_portal', 'demo', defaultdict(lambda: NO_ACCESS)),
+             # demo gets portal if token
+            ('portal', 'demo', {
+                (True, True): PORTAL_URL, # no access + token => portal
+                (False, True): PORTAL_URL, # unlogged + token => portal
+                (True, False): NO_ACCESS,
+                (False, False): NO_ACCESS,
+            }),
+            ('not_portal', 'portal', defaultdict(lambda: PORTAL_ROOT)),
+            ('portal', 'portal', {
+                (True, True): PORTAL_URL,
+                (False, True): PORTAL_URL,
+                (True, False): PORTAL_ROOT,
+                (False, False): PORTAL_ROOT,
+            }),
+        ]
+        for mod, user, items in cases:
+            for (logged, token) in product([True, False], [True, False]):
+                result = items[logged, token]
+                label = f"object={mod} user={user}{', logged' if logged else ''}{', token' if token else ''}"
+                with self.subTest(label):
+                    obj, url, _ = self.do_flow(f'test_mail_full.{mod}', user, login=logged, token=token)
+                    url = url_parse(url).replace(scheme='', netloc='').to_url()
+                    tok = ''
+                    if token and 'access_token' in obj._fields:
+                        tok = f'?access_token={obj.access_token}'
+                    expected = result.format(model=obj._name, id=obj.id, token=tok)
+                    self.assertEqual(url, expected)
+
+    @mute_logger('odoo.addons.base.models.res_users', 'odoo.addons.base.models.ir_model')
+    def test_mail_view_portal_with_access(self):
+        """if portal user has access to the resource, then they get a portal
+        link with an access token
+        """
+        self.env['ir.model.access'].create({
+            'name': 'portal access',
+            'model_id': self.env.ref('test_mail_full.model_test_mail_full_portal').id,
+            'group_id': self.env.ref('base.group_portal').id,
+            'perm_read': True,
+        })
+        with self.subTest("object=portal user=portal[acl+] logged"):
+            obj, url, _ = self.do_flow('test_mail_full.portal', 'portal', login=True, token=False)
+            self.assertEqual(
+                self._cleanup(url),
+                PORTAL_URL.format(token=f'?access_token={obj.access_token}'),
+            )
+
+        with self.subTest("object=portal user=portal[acl+]"):
+            obj, url, _ = self.do_flow('test_mail_full.portal', 'portal', login=False, token=False)
+            self.assertEqual(
+                self._cleanup(url),
+                PORTAL_URL.format(token=f'?access_token={obj.access_token}'),
+            )

--- a/addons/web/controllers/home.py
+++ b/addons/web/controllers/home.py
@@ -3,6 +3,7 @@
 import json
 import logging
 
+from werkzeug.urls import URL, url_encode
 
 import odoo
 import odoo.modules.registry
@@ -39,10 +40,12 @@ class Home(http.Controller):
 
         # Ensure we have both a database and a user
         ensure_db()
+        redirect = kw.get('redirect')
         if not request.session.uid:
-            return request.redirect('/web/login', 303)
-        if kw.get('redirect'):
-            return request.redirect(kw.get('redirect'), 303)
+            redirect = URL('', '', '/web/login', url_encode({'redirect': redirect or None}), '')
+        if redirect:
+            return request.redirect(redirect, 303)
+
         if not security.check_session(request.session, request.env):
             raise http.SessionExpiredException("Session expired")
         if not is_user_internal(request.session.uid):


### PR DESCRIPTION
### note: not sure whether that's supposed to be fixed in master or in an older version, creating this in master for discussion anyway

Tasks 2234813, 2221168, 2230454 

The "final" URL of the oauth flow is generated by the server, which means it can't access the [fragment identifier](https://en.wikipedia.org/wiki/Fragment_identifier), which means while the fragment is kept from `/web#action=xxx` to `/web/login` it can't be merged into the "terminal" URL, and thus gets lost when we go through the authorization server. It works fine for regular login because that's a redirection and fragments get conserved through redirection, but the oauth flow starts through a *link*, which will not keep whatever fragment the current page has (plus we can't necessarily assume the oauth server is not a fragment-using weirdo anyway, I guess).

Anyway this implements a relatively simple fix specifically for chatter notification mails which provide a link to the corresponding object: this link goes through mail's `/mail/view` indirection which uses query string and derefs that to whatever action description is necessary. It's what used for e.g. the
"view task" link in notification emails.

The issue with it, is that it ends up deref'ing to a fragment-based URL, which has the issue notified above. Instead, bounce to /web with a `redirect` query string parameter of that fragment-based URL: [`auth_oauth` will use that parameter as its final URL instead of generating one from scratch](https://github.com/odoo/odoo/blob/de590816d8d06730d99499db9a068f8d0e2cd3f9/addons/auth_oauth/controllers/main.py#L73), and if the user is already logged in `/web` will just redirect to the "final" `/web` invocation, which is one more hop but shouldn't be a significant cost.

Then fix /web so it doesn't lose the `redirect` parameter when redirecting non-logged users to the login page: as noted above `/web` will use that parameter if the user is already logged, and `/web/login` will *also* use it on login (including auth_oauth), it would just go missing when bouncing from one to the other. Which doesn't seem like a security issue though maybe @mart-e will object.
