### PR TITLE
[IMP] core: replace uninstall context key by registry attribute

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -10,7 +10,6 @@ import pytz
 from odoo import api, exceptions, fields, models, _
 
 from odoo.tools.misc import clean_context
-from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 
 _logger = logging.getLogger(__name__)
 

--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -11,7 +11,6 @@ from odoo import _, api, fields, models, modules, tools
 from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
 from odoo.tools import ormcache, formataddr
-from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 
 MODERATION_FIELDS = ['moderation', 'moderator_ids', 'moderation_ids', 'moderation_notify', 'moderation_notify_msg', 'moderation_guidelines', 'moderation_guidelines_msg']
 _logger = logging.getLogger(__name__)
@@ -229,7 +228,7 @@ class Channel(models.Model):
             all_emp_group = self.env.ref('mail.channel_all_employees')
         except ValueError:
             all_emp_group = None
-        if all_emp_group and all_emp_group in self and not self._context.get(MODULE_UNINSTALL_FLAG):
+        if all_emp_group and all_emp_group in self and not self.pool.module_uninstall:
             raise UserError(_('You cannot delete those groups, as the Whole Company group is required by other modules.'))
         return super(Channel, self).unlink()
 

--- a/addons/stock/models/stock_inventory.py
+++ b/addons/stock/models/stock_inventory.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import _, api, fields, models
-from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
 from odoo.tools import float_compare, float_is_zero
@@ -79,8 +78,7 @@ class Inventory(models.Model):
 
     def unlink(self):
         for inventory in self:
-            if (inventory.state not in ('draft', 'cancel')
-               and not self.env.context.get(MODULE_UNINSTALL_FLAG, False)):
+            if (inventory.state not in ('draft', 'cancel') and not self.pool.module_uninstall):
                 raise UserError(_('You can only delete a draft inventory adjustment. If the inventory adjustment is not done, you can cancel it.'))
         return super(Inventory, self).unlink()
 

--- a/addons/test_mail/tests/test_message_track.py
+++ b/addons/test_mail/tests/test_message_track.py
@@ -337,5 +337,6 @@ class TestTrackingInternals(TestMailCommon):
         ir_model_field = self.env['ir.model.fields'].search([
             ('model', '=', 'mail.test.ticket'),
             ('name', '=', 'email_from')])
-        ir_model_field.with_context(_force_unlink=True).unlink()
+        with self.registry.uninstall_mode():
+            ir_model_field.unlink()
         self.assertEqual(len(record_sudo.message_ids.tracking_value_ids), 0)

--- a/addons/website_sale_comparison/tests/test_website_sale_comparison.py
+++ b/addons/website_sale_comparison/tests/test_website_sale_comparison.py
@@ -29,7 +29,7 @@ class TestWebsiteSaleComparison(odoo.tests.TransactionCase):
 
         # Create a generic inherited view, with a key not starting with
         # `website_sale_comparison` otherwise the unlink will work just based on
-        # the key, but we want to test also for `MODULE_UNINSTALL_FLAG`.
+        # the key, but we want to test also for `Registry.module_uninstall`
         product_add_to_compare = Website0.viewref('website_sale_comparison.product_add_to_compare')
         test_view_key = 'my_test.my_key'
         self.env['ir.ui.view'].with_context(website_id=None).create({

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -20,7 +20,6 @@ from odoo.tools.safe_eval import safe_eval
 
 _logger = logging.getLogger(__name__)
 
-MODULE_UNINSTALL_FLAG = '_force_unlink'
 RE_ORDER_FIELDS = re.compile(r'"?(\w+)"?\s*(?:asc|desc)?', flags=re.I)
 
 # base environment for doing a safe_eval
@@ -283,7 +282,7 @@ class IrModel(models.Model):
 
     def unlink(self):
         # Prevent manual deletion of module tables
-        if not self._context.get(MODULE_UNINSTALL_FLAG):
+        if not self.pool.module_uninstall:
             for model in self:
                 if model.state != 'manual':
                     raise UserError(_("Model '%s' contains module data and cannot be removed.") % model.name)
@@ -298,7 +297,7 @@ class IrModel(models.Model):
 
         # Reload registry for normal unlink only. For module uninstall, the
         # reload is done independently in odoo.modules.loading.
-        if not self._context.get(MODULE_UNINSTALL_FLAG):
+        if not self.pool.module_uninstall:
             # setup models; this automatically removes model from registry
             self.flush()
             self.pool.setup_models(self._cr)
@@ -751,7 +750,7 @@ class IrModelFields(models.Model):
                     if inverse.manual and inverse.type == 'one2many':
                         failed_dependencies.append((field, inverse))
 
-        if not self._context.get(MODULE_UNINSTALL_FLAG) and failed_dependencies:
+        if not self.pool.module_uninstall and failed_dependencies:
             msg = _("The field '%s' cannot be removed because the field '%s' depends on it.")
             raise UserError(msg % failed_dependencies[0])
         elif failed_dependencies:
@@ -777,7 +776,7 @@ class IrModelFields(models.Model):
             for view in views:
                 view._check_xml()
         except Exception:
-            if not self._context.get(MODULE_UNINSTALL_FLAG):
+            if not self.pool.module_uninstall:
                 raise UserError("\n".join([
                     _("Cannot rename/delete fields that are still present in views:"),
                     _("Fields: %s") % ", ".join(str(f) for f in fields),
@@ -797,7 +796,7 @@ class IrModelFields(models.Model):
             return True
 
         # Prevent manual deletion of module columns
-        if not self._context.get(MODULE_UNINSTALL_FLAG) and \
+        if not self.pool.module_uninstall and \
                 any(field.state != 'manual' for field in self):
             raise UserError(_("This column contains module data and cannot be removed!"))
 
@@ -833,7 +832,7 @@ class IrModelFields(models.Model):
 
         # The field we just deleted might be inherited, and the registry is
         # inconsistent in this case; therefore we reload the registry.
-        if not self._context.get(MODULE_UNINSTALL_FLAG):
+        if not self.pool.module_uninstall:
             # setup models; this re-initializes models in registry
             self.flush()
             self.pool.setup_models(self._cr)
@@ -1331,7 +1330,7 @@ class IrModelSelection(models.Model):
 
         # Reload registry for normal unlink only. For module uninstall, the
         # reload is done independently in odoo.modules.loading.
-        if not self._context.get(MODULE_UNINSTALL_FLAG):
+        if not self.pool.module_uninstall:
             # setup models; this re-initializes model in registry
             self.flush()
             self.pool.setup_models(self._cr)
@@ -2008,7 +2007,7 @@ class IrModelData(models.Model):
 
         # enable model/field deletion
         # we deactivate prefetching to not try to read a column that has been deleted
-        self = self.with_context(**{MODULE_UNINSTALL_FLAG: True, 'prefetch_fields': False})
+        self = self.with_context(**{'prefetch_fields': False})
 
         # determine records to unlink
         records_items = []              # [(model, id)]
@@ -2120,7 +2119,6 @@ class IrModelData(models.Model):
             return True
 
         bad_imd_ids = []
-        self = self.with_context({MODULE_UNINSTALL_FLAG: True})
         loaded_xmlids = self.pool.loaded_xmlids
 
         query = """ SELECT id, module || '.' || name, model, res_id FROM ir_model_data

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -25,7 +25,6 @@ import psycopg2
 
 import odoo
 from odoo import api, fields, models, modules, tools, _
-from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 from odoo.exceptions import AccessDenied, UserError
 from odoo.osv import expression
 from odoo.tools.parse_version import parse_version
@@ -480,7 +479,8 @@ class Module(models.Model):
         tables, columns, constraints, etc.
         """
         modules_to_remove = self.mapped('name')
-        self.env['ir.model.data']._module_data_uninstall(modules_to_remove)
+        with self.pool.uninstall_mode():
+            self.env['ir.model.data']._module_data_uninstall(modules_to_remove)
         # we deactivate prefetching to not try to read a column that has been deleted
         self.with_context(prefetch_fields=False).write({'state': 'uninstalled', 'latest_version': False})
         return True
@@ -495,8 +495,8 @@ class Module(models.Model):
         they rely on data that don't exist anymore if the module is removed.
         """
         domain = expression.OR([[('key', '=like', m.name + '.%')] for m in self])
-        orphans = self.env['ir.ui.view'].with_context(**{'active_test': False, MODULE_UNINSTALL_FLAG: True}).search(domain)
-        orphans.unlink()
+        with self.pool.uninstall_mode():
+            self.env['ir.ui.view'].with_context(**{'active_test': False}).search(domain).unlink()
 
     @api.returns('self')
     def downstream_dependencies(self, known_deps=None,

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -505,7 +505,7 @@ actual arch.
 
     def unlink(self):
         # if in uninstall mode and has children views, emulate an ondelete cascade
-        if self.env.context.get('_force_unlink', False) and self.inherit_children_ids:
+        if self.pool.module_uninstall and self.inherit_children_ids:
             self.inherit_children_ids.unlink()
         super(View, self).unlink()
 

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -18,7 +18,6 @@ from lxml.builder import E
 import passlib.context
 
 from odoo import api, fields, models, tools, SUPERUSER_ID, _
-from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 from odoo.exceptions import AccessDenied, AccessError, UserError, ValidationError
 from odoo.http import request
 from odoo.osv import expression
@@ -1101,7 +1100,7 @@ class GroupsView(models.Model):
         if not (view and view.exists() and view._name == 'ir.ui.view'):
             return
 
-        if self._context.get('install_filename') or self._context.get(MODULE_UNINSTALL_FLAG):
+        if self._context.get('install_filename') or self.pool.module_uninstall:
             # use a dummy view during install/upgrade/uninstall
             xml = E.field(name="groups_id", position="after")
 

--- a/odoo/addons/base/tests/test_ir_actions.py
+++ b/odoo/addons/base/tests/test_ir_actions.py
@@ -401,7 +401,8 @@ class TestCustomFields(common.TransactionCase):
             m2o_field.unlink()
 
         # uninstall mode: unlink dependant fields
-        m2o_field.with_context(_force_unlink=True).unlink()
+        with self.registry.uninstall_mode():
+            m2o_field.unlink()
         self.assertFalse(o2m_field.exists())
 
     def test_unlink_with_dependant(self):
@@ -424,7 +425,8 @@ class TestCustomFields(common.TransactionCase):
             field.unlink()
 
         # uninstall mode: unlink dependant fields
-        field.with_context(_force_unlink=True).unlink()
+        with self.registry.uninstall_mode():
+            field.unlink()
         self.assertFalse(dependant.exists())
 
     def test_create_binary(self):

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -479,7 +479,8 @@ def load_modules(db, force_demo=False, status=None, update_module=False):
                     _logger.runbot("Model %s is declared but cannot be loaded! (Perhaps a module was partially removed or renamed)", model)
 
             # Cleanup orphan records
-            env['ir.model.data']._process_end(processed_modules)
+            with registry.uninstall_mode():
+                env['ir.model.data']._process_end(processed_modules)
             env['base'].flush()
 
         for kind in ('init', 'demo', 'update'):
@@ -487,6 +488,7 @@ def load_modules(db, force_demo=False, status=None, update_module=False):
 
         # STEP 5: Uninstall modules to remove
         if update_module:
+            registry.module_uninstall = True
             # Remove records referenced from ir_model_data for modules to be
             # removed (and removed the references from ir_model_data).
             cr.execute("SELECT name, id FROM ir_module_module WHERE state=%s", ('to remove',))

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -143,8 +143,21 @@ class Registry(Mapping):
         self.registry_invalidated = False
         self.cache_invalidated = False
 
+        # Whether the registry is currently undergoing module uninstall operations
+        self.module_uninstall = False
+
         with closing(self.cursor()) as cr:
             self.has_unaccent = odoo.modules.db.has_unaccent(cr)
+
+    @contextmanager
+    def uninstall_mode(self):
+        previous_state = self.module_uninstall
+        try:
+            self.module_uninstall = True
+            yield
+        finally:
+            # in case the caller is already in a module_uninstall=True context
+            self.module_uninstall = previous_state
 
     @classmethod
     def delete(cls, db_name):


### PR DESCRIPTION
Before this commit, checking whether a module is being uninstalled or
not (e.g. in an unlink override) required importing
`MODULE_UNINSTALL_FLAG` and checking if it had been injected into the
current environment's context.

Not only is this tedious and verbose, but it's error-prone too as there
can be context propagation issues (leading to unexpected data loss) and
is fundamentally incorrect, as it's not a single environment that's in
"uninstall mode", but all the environments of the registry.

With this commit, checking whether the registry is in uninstall mode is
as simple as checking `Registry.module_uninstall` or
`self.pool.module_uninstall` from a BaseModel method.

This commit also introduces the `Registry.uninstall_mode` context
manager which allows any actions within its body to perform as if the
registry were performing a module uninstall.

Task-ID 2207696

TODO:
 - [ ] Add some basic tests for the context manager