### PR TITLE
[IMP] mail: improve placeholders of chatter

### DIFF
--- a/addons/mail/static/src/js/chatter.js
+++ b/addons/mail/static/src/js/chatter.js
@@ -348,6 +348,7 @@ var Chatter = Widget.extend({
             defaultBody: oldComposer && oldComposer.$input && oldComposer.$input.val(),
             defaultMentionSelections: oldComposer && oldComposer.getMentionListenerSelections(),
             attachmentIds: (oldComposer && oldComposer.get('attachment_ids')) || [],
+            placeholder: options && options.isLog ? _t('Log an internal note...') : _t('Send a message to followers...'),
         });
         this._composer.on('input_focused', this, function () {
             this._composer.mentionSetPrefetchedPartners(this._mentionSuggestions || []);

--- a/addons/mail/static/src/xml/composer.xml
+++ b/addons/mail/static/src/xml/composer.xml
@@ -15,7 +15,7 @@
                     <h4>Drag Files Here <span class="fa fa-download"/></h4>
                 </div>
                 <div class="o_composer_input">
-                    <textarea class="o_input o_composer_text_field" tabindex="2" placeholder="Write something..."/>
+                    <textarea class="o_input o_composer_text_field" tabindex="2" t-att-placeholder="widget.options.placeholder || _t('Write Something...')"/>
                     <div class="o_chatter_composer_tools">
                         <button tabindex="4" class="btn btn-secondary fa fa-smile-o o_composer_button_emoji" type="button" data-toggle="popover" title="Emojis" aria-label="Emojis"/>
                         <button tabindex="5" class="btn btn-secondary fa fa-paperclip o_composer_button_add_attachment" type="button" aria-label="Add attachment" title="Add attachment"/>


### PR DESCRIPTION
PURPOSE

In the chatter, the placeholder for messages and notes is the same
which is not sufficiently clear for user to understand.

SPECIFICATION

Improving the placeholder for messages and notes so that user
can easily understand the difference between messages and notes.

LINKS
Task-2250887
PR https://github.com/odoo/odoo/pull/50841

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
