### PR TITLE
[IMP] mail: Add technical channel for admins with system status messages

### DIFF
--- a/addons/crm_iap_lead_enrich/models/iap_enrich_api.py
+++ b/addons/crm_iap_lead_enrich/models/iap_enrich_api.py
@@ -12,7 +12,16 @@ class IapEnrichAPI(models.AbstractModel):
 
     @api.model
     def _contact_iap(self, local_endpoint, params):
-        account = self.env['iap.account'].get('reveal')
+        # Get IAP account model
+        iap_account_model = self.env['iap.account']
+        # Get current credits :
+        # in 'get_credits' method : the targeted account getter is called with a 'force_create=False' (see iap.py > 'get_credits()')
+        account_credits = iap_account_model.get_credits('reveal')
+        # Test if credits min value reached
+        if account_credits <= 5:
+            # Send notification to admin : low credits on lead enrichment
+            self._notify_admins(*self._get_admin_notification('iap__low_credits')(account_credits))
+        account = iap_account_model.get('reveal')
         dbuuid = self.env['ir.config_parameter'].sudo().get_param('database.uuid')
         params['account_token'] = account.account_token
         params['dbuuid'] = dbuuid

--- a/addons/mail/data/ir_cron_data.xml
+++ b/addons/mail/data/ir_cron_data.xml
@@ -55,5 +55,15 @@
             <field name="state">code</field>
         </record>
 
+        <record id="ir_cron_mail_notify_administrators" model="ir.cron">
+            <field name="name">Mail: Notify admins about technical issues</field>
+            <field name="model_id" ref="model_mail_notification"/>
+            <field name="state">code</field>
+            <field name="code">model._cron_notify_admins()</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="numbercall">-1</field>
+            <field name="doall" eval="False"/>
+        </record>
     </data>
 </odoo>

--- a/addons/mail/data/mail_channel_data.xml
+++ b/addons/mail/data/mail_channel_data.xml
@@ -8,6 +8,14 @@
             <field name="description">General announcements for all employees.</field>
         </record>
 
+        <!-- Admins channel record > authorized group : 'base.group_system' -->
+        <record model="mail.channel" id="channel_admins">
+            <field name="name">Administrators</field>
+            <field name="group_ids" eval="[(4, ref('base.group_system'))]"/>
+            <field name="group_public_id" ref="base.group_system"/>
+            <field name="description">Notifications about system silent failures to make admins aware of them.</field>
+        </record>
+
         <!-- notify all employees of module installation -->
         <record model="mail.message" id="module_install_notification">
             <field name="model">mail.channel</field>

--- a/addons/mail/data/mail_data.xml
+++ b/addons/mail/data/mail_data.xml
@@ -402,5 +402,26 @@
 <p></p>
 </div>
         </template>
+        <!-- Admin technical notifications template -->
+        <template id="mail_channel_notify_admins">
+            <div>
+                <p><b><t t-esc='subject'/></b></p>
+                <pre><t t-esc='message'/></pre><br/>
+                <!-- 
+                    Optional documentation section (added on template with the same model 
+                    to minimise parameters on "_notify_admins()" method) 
+                -->
+                <t t-if="helper_related_doc">
+                    <a class="btn btn-primary" t-att-href="helper_related_doc">
+                        check related documentation
+                    </a>
+                </t>
+                <t t-if="helper_related_view_url and helper_related_view_text">
+                    <a class="btn btn-secondary {{ helper_related_doc ? 'ml-4' : '' }}" t-att-href="helper_related_view_url">
+                       <t t-esc='helper_related_view_text'/>
+                    </a>
+                </t>
+            </div>
+        </template>
     </data>
 </odoo>

--- a/addons/mail/models/__init__.py
+++ b/addons/mail/models/__init__.py
@@ -32,3 +32,4 @@ from . import ir_http
 from . import ir_model
 from . import ir_model_fields
 from . import ir_ui_view
+from . import ir_cron

--- a/addons/mail/models/ir_cron.py
+++ b/addons/mail/models/ir_cron.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from datetime import datetime
+from odoo import api, fields, models
+
+
+class ir_cron(models.Model):
+    _inherit = 'ir.cron'
+
+    @api.model
+    def _handle_callback_exception(self, cron_name, server_action_id, job_id, job_exception):
+        """
+            Method that overrides the original one from base to post a notification on admins channel.
+        """
+        super(ir_cron, self)._handle_callback_exception(cron_name, server_action_id, job_id, job_exception)
+        # Get datetime when error occured != self.search([('id', '=', job_id)], limit=1).nextcall
+        cron_error_datetime = fields.Datetime.now()
+        job = self.browse(job_id)
+        # Send notification to admin : errors related to cron job callback
+        self._notify_admins(
+            *self._get_admin_notification('base__cron')(
+                job._format_record_link('go to scheduled action'),
+                job_exception,
+                cron_error_datetime,
+                self._cr.dbname
+            )
+        )

--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -228,6 +228,8 @@ class Channel(models.Model):
 
     def unlink(self):
         # Delete mail.channel
+        if any(channel_xmlid == 'mail.channel_admins' for channel_xmlid in self.get_external_id().values()):
+            raise UserError(_('The "Administrators" channel is used to post notifications about system failures, it cannot be deleted.'))
         try:
             all_emp_group = self.env.ref('mail.channel_all_employees')
         except ValueError:

--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
-from odoo import models, api
+import logging
+from odoo import models, api, _
 from lxml.builder import E
+from datetime import datetime, timedelta
+_logger = logging.getLogger(__name__)
 
 
 class BaseModel(models.AbstractModel):
@@ -31,3 +34,164 @@ class BaseModel(models.AbstractModel):
         return {
             'X-Odoo-Objects': "%s-%s" % (self._name, self.id),
         }
+
+    @api.model
+    def _notify_admins(self, subject, body, helper={}, **kwargs):
+        """
+            Posts notifications about system failures on Admins channel (recreates the channel if it no longer exists).
+        """
+        ir_model_data = self.env['ir.model.data']
+        model_mail_channel = self.env['mail.channel']
+        odoobot_id = ir_model_data.xmlid_to_res_id("base.partner_root")
+        admins_channel = ir_model_data.xmlid_to_object('mail.channel_admins')
+        # Create a new channel if it no longer exists
+        if not admins_channel:
+            admins_channel = model_mail_channel.sudo().with_context(mail_create_nosubscribe=True).create({
+                'group_ids': [(4, self.env.ref('base.group_system').id)],
+                'group_public_id': self.env.ref('base.group_system').id,
+                'public': 'groups',
+                'channel_type': 'channel',
+                'email_send': False,
+                'name': 'Administrators',
+                'description': _('Channel to post notifications about system silent failures to make admins aware of them.')
+            })
+        # Get the message to post (body) from template
+        helper_related_doc = helper.get("related_doc", False)
+        helper_related_view_url = helper.get("related_view_url", False)
+        helper_related_view_text = helper.get("related_view_text", False)
+        message = self._format_notification(subject, body, helper_related_doc, helper_related_view_url, helper_related_view_text)
+        # Check Repeat delay (default : 7 days -> can be updated in method parameters)
+        channel_last_message = self.env['mail.message'].search([
+            ("channel_ids", "in", [admins_channel.id]),
+            ("subject", "=", subject)], limit=1)
+        message_after_repeat_delay = False
+        if channel_last_message:
+            repeat_delay = kwargs.get('repeat_delay', None) or timedelta(days=7)
+            repeat_last_datetime = datetime.now() - repeat_delay
+            message_after_repeat_delay = channel_last_message.date < repeat_last_datetime
+        if not channel_last_message or message_after_repeat_delay:
+            admins_channel.sudo().message_post(subject=subject, body=message, author_id=odoobot_id, message_type="comment", subtype_xmlid="mail.mt_comment")
+
+    @api.model
+    def _format_record_link(self, name):
+        """
+            Get record local url (used to get links to targeted records in notifications : mail servers with failures...).
+        """
+        return {
+            "url": "/mail/view?model=%s&res_id=%s" % (self._name, self.id),
+            "text": name,
+        }
+
+    @api.model
+    def _format_notification(self, subject, message, helper_related_doc, helper_related_view_url, helper_related_view_text):
+        """
+            Returns the notification message to post on admins channel using a template.
+            If template not found > returns the original message.
+        """
+        render_context = {
+            "subject": subject,
+            "message": message,
+            "helper_related_doc": helper_related_doc,
+            "helper_related_view_url": helper_related_view_url,
+            "helper_related_view_text": helper_related_view_text,
+        }
+        template = self.env.ref('mail.mail_channel_notify_admins', raise_if_not_found=False)
+        if not template:
+            _logger.warning('Template "mail.mail_channel_notify_admins" was not found. Cannot send Admins notifications.')
+            return message
+        notification_body = template._render(render_context, engine='ir.qweb', minimal_qcontext=True)
+        # Local > global links
+        notification_body = self.env['mail.render.mixin']._replace_local_links(notification_body)
+        return notification_body
+
+    @api.model
+    def _get_admin_notification(self, failure_type, module_messages=None):
+        """
+            To simplify failure notification process, this method will work as wrapper and will
+            return parameters (messages + doc links) to use in '_notify_admins' depending on a 'failure_type' value,
+            which makes code easier to extend if other failure messages added.
+            * 'failure_type' strings follow the structure : [MODULE_NAME__TARGET_FAILURE]
+
+            Failure messages can be added/overrided in other modules using 'module_messages' param.
+        """
+        messages = {
+            "mail__smtp_connection": lambda failed_emails_counter, mail_sms_notifications_window_action: (
+                _('Odoo has been unable to send email(s)'),
+                _(
+                    "%(failed_emails_counter)d email(s) could not be sent due to technical issues.\n"
+                    "To solve SMTP connection related issues make sure that SMTP configuration is correct and click on 'Test Connection'.\n"
+                    "If your configuration is incorrect, an error message should help you diagnose the issue.\n"
+                    "Ex : If you get a '[AUTHENTICATIONFAILED] Invalid credentials (Failure)' warning when you test connection on a Gmail address, "
+                    "activate the Less secure app access option.\n"
+                    "In addition to that, enable the IMAP setting on your Gmail account.\n"
+                    "You can check your mail notifications for more details about failed emails "
+                    "(an error message should help you diagnose the issue.)"
+                ) % {
+                    'failed_emails_counter': failed_emails_counter,
+                },
+                {
+                   "related_doc": 'https://www.odoo.com/documentation/user/online/discuss/email_servers.html',
+                   "related_view_url": "/web#action=%(mail_sms_notifications_window_action)s&amp;view_type=list" % {
+                       'mail_sms_notifications_window_action': mail_sms_notifications_window_action
+                   },
+                   "related_view_text": "go to mail notifications"
+                }
+            ),
+
+            "mail__invalid_recipient": lambda failed_ignored_emails_counter, mail_sms_notifications_window_action: (
+                _('failed emails due to invalid email address'),
+                _(
+                    "%(failed_ignored_emails_counter)d email(s) failed / ignored to avoid blocking delivery to other recipients.\n"
+                    "Please make sure that recipient's email address really exists and if it's actually valid.\n"
+                    "You can check your mail notifications for more details about failed emails "
+                    "(an error message should help you diagnose the issue.)"
+                ) % {
+                    'failed_ignored_emails_counter': failed_ignored_emails_counter,
+                },
+                {
+                   "related_view_url": "/web#action=%(mail_sms_notifications_window_action)s&amp;view_type=list" % {
+                       'mail_sms_notifications_window_action': mail_sms_notifications_window_action
+                   },
+                   "related_view_text": "go to mail notifications"
+                }
+            ),
+
+            "iap__low_credits": lambda account_credits: (
+                _('Your credits balance is too low'),
+                _(
+                    "Your current balance reached %(account_credits)1.2f, It’s time to recharge your credits!\n"
+                    "To avoid service interruption (SMS, snailmail, lead enrichment...),"
+                    "please go to your 'IAP Portal' [Settings app > Odoo IAP > View my Services].\n"
+                    "From there, you can view your current balance, recharge your credits, "
+                    "review your consumption and set another reminder (by email) to when credits are low."
+                ) % {
+                    'account_credits': account_credits
+                },
+                {
+                   "related_doc": 'https://www.odoo.com/documentation/user/online/general/in_app_purchase/in_app_purchase.html'
+                }
+            ),
+
+            "base__cron": lambda record_link, cron_exception, cron_error_datetime, cron_database: (
+                _('Scheduled action failure'),
+                _(
+                    "An error occurred while running a cron job in Odoo.\n\n"
+                    "Failure details :\n"
+                    "- Execption: %(cron_exception)s\n"
+                    "- Occurred on: %(cron_error_datetime)s\n"
+                    "- Database: %(cron_database)s"
+                ) % {
+                    'cron_exception': cron_exception,
+                    'cron_error_datetime': cron_error_datetime,
+                    'cron_database': cron_database
+                },
+                {
+                    "related_view_url": record_link.get('url', False),
+                    "related_view_text": record_link.get('text', False),
+                }
+            )
+        }
+        # This way we can add messages in other models or even override genesis ones
+        if module_messages:
+            messages.update(module_messages)
+        return messages[failure_type]

--- a/addons/mass_mailing/models/__init__.py
+++ b/addons/mass_mailing/models/__init__.py
@@ -13,3 +13,4 @@ from . import res_config_settings
 from . import res_users
 from . import utm
 from . import res_company
+from . import mail_notification

--- a/addons/mass_mailing/models/mail_notification.py
+++ b/addons/mass_mailing/models/mail_notification.py
@@ -1,0 +1,42 @@
+from odoo import fields, models, api, tools, _
+from datetime import timedelta
+from dateutil.relativedelta import relativedelta
+
+
+class MailNotification(models.Model):
+    _inherit = 'mail.notification'
+
+    @api.model
+    def _cron_notify_admins(self):
+        super()._cron_notify_admins()
+        cron = self.env.ref('mail.ir_cron_mail_notify_administrators')
+        previous_date = fields.Datetime.now() - relativedelta(**{cron.interval_type: cron.interval_number})
+        ignored_mailing_counter = self.env['mailing.trace'].sudo().search_count([
+            ('create_date', '>=', previous_date.strftime(tools.DEFAULT_SERVER_DATETIME_FORMAT)),
+            ('state', '=', 'ignored')])
+        mass_mailing_message = {
+            "mass_mailing__ignored": lambda failed_ignored_mailing_counter, mailing_traces_window_action: (
+                _('Email marketing : ignored emails'),
+                _(
+                    "%(failed_ignored_mailing_counter)d email(s) have been ignored and will not be sent.\n"
+                    "Please make sure that recipient's email address really exists and if it's actually valid.\n"
+                    "You can check your mailing traces for more details."
+                ) % {
+                    'failed_ignored_mailing_counter': failed_ignored_mailing_counter,
+                },
+                {
+                    "related_view_url": "/web#action=%(mailing_traces_window_action)s&amp;view_type=list" % {
+                        'mailing_traces_window_action': mailing_traces_window_action
+                    },
+                    "related_view_text": "go to mailing traces"
+                }
+            )
+        }
+        if ignored_mailing_counter:
+            self._notify_admins(
+                *self._get_admin_notification('mass_mailing__ignored', mass_mailing_message)(
+                    ignored_mailing_counter,
+                    self.env.ref('mass_mailing.mailing_trace_action').id
+                ),
+                repeat_delay=timedelta(days=1)
+            )

--- a/addons/partner_autocomplete/models/res_partner.py
+++ b/addons/partner_autocomplete/models/res_partner.py
@@ -95,6 +95,13 @@ class ResPartner(models.Model):
             'country_code': self.env.company.country_id.code,
             'zip': self.env.company.zip,
         })
+        # This method is used for search & enrich (search will only return the list of suggested partners)
+        if action == 'enrich':
+            account_credits = self.env['iap.account'].get_credits('partner_autocomplete')
+            if account_credits <= 5:
+                # Send notification to admin : low credits on partner autocomplete
+                # (threshold fixed to 5 - should be updated for each service!)
+                self._notify_admins(*self._get_admin_notification('iap__low_credits')(account_credits))
         try:
             return jsonrpc(url=url, params=params, timeout=timeout), False
         except (ConnectionError, HTTPError, exceptions.AccessError, exceptions.UserError) as exception:

--- a/addons/sms/models/mail_notification.py
+++ b/addons/sms/models/mail_notification.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import fields, models, api, tools, _
+from datetime import timedelta
+from dateutil.relativedelta import relativedelta
 
 
 class MailNotification(models.Model):
@@ -19,3 +21,44 @@ class MailNotification(models.Model):
         ('sms_server', 'Server Error'),
         ('sms_acc', 'Unregistered Account')
     ])
+
+    @api.model
+    def _cron_notify_admins(self):
+        super()._cron_notify_admins()
+        cron = self.env.ref('mail.ir_cron_mail_notify_administrators')
+        previous_date = fields.Datetime.now() - relativedelta(**{cron.interval_type: cron.interval_number})
+        # Count failed SMS
+        failed_sms_counter = self.env['sms.sms'].sudo().search_count([
+            ('create_date', '>=', previous_date.strftime(tools.DEFAULT_SERVER_DATETIME_FORMAT)),
+            ('state', '=', 'error')])
+        # Send notifications about failed SMS (_notify_admins methods in daily cron job should set a repeat_delay of 1 day)
+        if failed_sms_counter:
+            sms_messages = {
+                "sms__failure": lambda failed_sms_counter, mail_sms_notifications_window_action: (
+                    _('Odoo has been unable to send SMS'),
+                    _(
+                        "%(failed_sms_counter)d SMS(s) could not be sent due to technical issues.\n"
+                        "Please check whether recipient's phone number exists and if your have enaugh IAP credits.\n"
+                        "To recharge your IAP credits please go to your 'IAP Portal' [Settings app > Odoo IAP > View my Services].\n"
+                        "From there, you can view your current balance, recharge your credits, review your consumption and "
+                        "set another reminder (by email) to when credits are low.\n"
+                        "You can check SMS notifications for more details about failed SMS messages (an error message should help you diagnose the issue.)"
+                    ) % {
+                        'failed_sms_counter': failed_sms_counter,
+                    },
+                    {
+                        "related_doc": 'https://www.odoo.com/documentation/user/online/general/in_app_purchase/in_app_purchase.html',
+                        "related_view_url": "/web#action=%(mail_sms_notifications_window_action)s&amp;view_type=list" % {
+                            'mail_sms_notifications_window_action': mail_sms_notifications_window_action
+                        },
+                        "related_view_text": "go to sms notifications"
+                    }
+                )
+            }
+            self._notify_admins(
+                *self._get_admin_notification('sms__failure', sms_messages)(
+                    failed_sms_counter,
+                    self.env.ref('mail.mail_notification_action').id
+                ),
+                repeat_delay=timedelta(days=1)
+            )


### PR DESCRIPTION
This PR attempts to add a technical channel for system silent failures to make admins aware of them.

This feature will be added in 2 parts:

- Create a generic notification system allowing devs to easily send messages to admins.
- Identify process and flows that could use this system for a smoother experience for users. When a problem is detected, a message should be sent on through this system.

Task ID 2049528
ENT PR : https://github.com/odoo/enterprise/pull/11291