### PR TITLE
[FIX] account: Wrong base amount with included tax

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -285,6 +285,10 @@ class AccountMove(models.Model):
                     # N.B. currency_id/amount_currency are not set because if we have two lines with the same tax
                     # and different currencies, we have no idea which currency set on this line.
                     self.env['account.move.line'].new(line_vals)
+                    if tax.price_include and not tax.include_base_amount:
+                        line.debit = line.debit and line.debit - line_vals['debit']
+                        line.credit = line.credit and line.credit - line_vals['credit']
+
 
             # Keep record of the values used as taxes the last time this method has been run.
             line.tax_line_grouping_key = _build_grouping_key(line)


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a company C with french accounting
- Create a new journal entry JE with one line L with debit = 100 and credit = 0
  and account = 601100 Achats stockés - Matières premières ou groupe A)
- Set TVA déductible (achat) 20,0% TTC on JE (where this tax is included
  in price but not included in base maount)

Bug:

A new line is created on account 445660 TVA déductible sur autre bien et service with a debit = 16,67 and credit 0
But the debit stayed at 100 instead of 83,33 (as the tax is not included in the base)

opw:2244708