### PR TITLE
[13.0][IMP] base: ir.sequence get_number_next_actual error if gap implementation and NewId sequence

### DIFF
--- a/odoo/addons/base/models/ir_sequence.py
+++ b/odoo/addons/base/models/ir_sequence.py
@@ -89,7 +89,7 @@ class IrSequence(models.Model):
         '''Return number from ir_sequence row when no_gap implementation,
         and number from postgres sequence when standard implementation.'''
         for seq in self:
-            if seq.implementation != 'standard':
+            if seq.implementation != 'standard' or not isinstance(seq.id, int):
                 seq.number_next_actual = seq.number_next
             else:
                 seq_id = "%03d" % seq.id


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When I try to get some sequences created yet, I get a problem with the NewId like this ('ir.sequence(<NewId origin=86>,).number_next_actual', None)

Current behavior before PR:
When I do this change, the error does not appear, and the sequences work normally

Desired behavior after PR is merged:
When the people try to get some sequences they don't get the same error



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
@Tecnativa