### PR TITLE
[FIX] web: kanban view quickcreate buttons

### DIFF
--- a/addons/web/static/src/xml/kanban.xml
+++ b/addons/web/static/src/xml/kanban.xml
@@ -72,7 +72,7 @@
     <div>
         <button class="btn btn-primary o_kanban_add">Add</button>
         <button class="btn btn-primary o_kanban_edit">Edit</button>
-        <button class="btn btn-secondary o_kanban_cancel ml8">Discard</button>
+        <button class="btn btn-secondary o_kanban_cancel fa fa-trash-o pull-right"></button>
     </div>
 </t>
 


### PR DESCRIPTION
the task quickcreate doesn't look good with(long) translations
so, we have removed the string 'discard' from the button.

we have added calss fa-trash to avoid the string on button. because
of this no any issue form translation.

TaskID: 2241742

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
