### PR TITLE
[FIX] sale_stock: resist if write_date is null

### DIFF
--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -49,8 +49,8 @@ class AccountMove(models.Model):
         last_invoice = previous_invoices[-1] if len(previous_invoices) else None
 
         # Get the incoming and outgoing sml between self.invoice_date and the previous invoice (if any).
-        self_datetime = max(self.invoice_line_ids.mapped('write_date')) if self.invoice_line_ids else None
-        last_invoice_datetime = max(last_invoice.invoice_line_ids.mapped('write_date')) if last_invoice else None
+        self_datetime = max([w for w in self.invoice_line_ids.mapped('write_date') if w]) if self.invoice_line_ids else None
+        last_invoice_datetime = max([w for w in last_invoice.invoice_line_ids.mapped('write_date') if w]) if last_invoice else None
 
         def _filter_incoming_sml(ml):
             if ml.state == 'done' and ml.location_id.usage == 'customer' and ml.lot_id:


### PR DESCRIPTION
If account_move_line.write_date is False/None/Null there is an error like below.
TypeError: '>' not supported between instances of 'bool' and 'datetime.datetime'.
Now also support this case

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
