### PR TITLE
[FIX] fields.py: do not copy `oldname` attribute from related field

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -531,7 +531,7 @@ class Field(MetaField('DummyField', (object,), {})):
                 setattr(self, attr, getattr(field, prop))
 
         for attr, value in field._attrs.items():
-            if attr not in self._attrs:
+            if attr not in self._attrs and attr != 'oldname':
                 setattr(self, attr, value)
 
         # special case for states: copy it only for inherited fields


### PR DESCRIPTION
Indeed, if by, bad, chance the target model has the same field name as
the one set by `oldname` attribute the column will get wrongly renamed.