### PR TITLE
[FIX] web: next activity kanban view regression

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -38,7 +38,7 @@ class Base(models.AbstractModel):
                 'length': 0,
                 'records': []
             }
-        if limit and (len(records) == limit or self.env.context.get('force_search_count')):
+        if limit and (len(records) >= limit and self.env.context.get('force_search_count')):
             length = self.search_count(domain)
         else:
             length = len(records) + offset


### PR DESCRIPTION
PURPOSE

When scheduling multiple next activities on one task (for example) and see the
tasks next activities via the systray activity menu. The column with the task
will display a "Load more... (x remaining)" prompt and clicking the prompt
makes the column task count fall to 0.

This is happening after recent changes (see: 13ec350)

SPECIFICIFICATIONS

This will allow the searching count only when the limit equals to record
length when having context 'force_search_count' true or false.

LINKS

Task- 2238562
PR https://github.com/odoo/odoo/pull/51251

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
