### PR TITLE
[FIX] account: Fix price_unit with fisc. pos. to price-included tax

### DIFF
--- a/addons/purchase/tests/__init__.py
+++ b/addons/purchase/tests/__init__.py
@@ -4,3 +4,5 @@
 from . import test_purchase
 from . import test_purchase_order_report
 from . import test_access_rights
+from . import test_purchase_order_fiscal_position
+from . import test_purchase_order_product_sellers

--- a/addons/purchase/tests/test_purchase_order_fiscal_position.py
+++ b/addons/purchase/tests/test_purchase_order_fiscal_position.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+from odoo.addons.account.tests.invoice_test_common import InvoiceTestCommon
+from odoo.tests.common import Form
+from odoo.tests import tagged
+from odoo import fields
+
+
+@tagged('post_install', '-at_install')
+class TestPurchaseOrderFiscalPosition(InvoiceTestCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.tax_10_price_include = cls.env['account.tax'].create({
+            'name': '10% incl',
+            'type_tax_use': 'sale',
+            'amount_type': 'percent',
+            'amount': 10,
+            'price_include': True,
+            'include_base_amount': True,
+        })
+        cls.tax_20_price_include = cls.env['account.tax'].create({
+            'name': '20% incl',
+            'type_tax_use': 'sale',
+            'amount_type': 'percent',
+            'amount': 20,
+            'price_include': True,
+            'include_base_amount': True,
+        })
+        cls.tax_15_price_exclude = cls.env['account.tax'].create({
+            'name': '15% excl',
+            'type_tax_use': 'sale',
+            'amount_type': 'percent',
+            'amount': 15,
+        })
+
+        cls.fiscal_position_exclude_to_include = cls.env['account.fiscal.position'].create({
+            'name': 'fiscal_position_exclude_to_include',
+            'tax_ids': [
+                (0, None, {
+                    'tax_src_id': cls.tax_15_price_exclude.id,
+                    'tax_dest_id': cls.tax_10_price_include.id,
+                }),
+            ],
+        })
+
+        cls.fiscal_position_include_to_exclude = cls.env['account.fiscal.position'].create({
+            'name': 'fiscal_position_include_to_exclude',
+            'tax_ids': [
+                (0, None, {
+                    'tax_src_id': cls.tax_10_price_include.id,
+                    'tax_dest_id': cls.tax_15_price_exclude.id,
+                }),
+            ],
+        })
+
+        cls.fiscal_position_include_to_include = cls.env['account.fiscal.position'].create({
+            'name': 'fiscal_position_include_to_include',
+            'tax_ids': [
+                (0, None, {
+                    'tax_src_id': cls.tax_10_price_include.id,
+                    'tax_dest_id': cls.tax_20_price_include.id,
+                }),
+            ],
+        })
+
+        cls.product_tax_10_price_include = cls.env['product.product'].create({
+            'name': 'product',
+            'uom_id': cls.env.ref('uom.product_uom_unit').id,
+            'standard_price': 110.0,
+            'taxes_id': [(6, 0, cls.tax_10_price_include.ids)],
+        })
+
+        cls.product_tax_15_price_exclude = cls.env['product.product'].create({
+            'name': 'product',
+            'uom_id': cls.env.ref('uom.product_uom_unit').id,
+            'standard_price': 200.0,
+            'taxes_id': [(6, 0, cls.tax_15_price_exclude.ids)],
+        })
+
+    def test_fiscal_position_price_included_to_price_excluded_tax(self):
+        ''' Test the purchase order when dealing with a fiscal position mapping a price-included tax set by default on a
+        product. Indeed, mapping a price-included-tax to a price-excluded-tax must remove the tax amount from the
+        price_unit set on the product.
+        '''
+
+        self.partner_a.property_account_position_id = self.fiscal_position_include_to_exclude
+
+        po_form = Form(self.env['purchase.order'])
+        po_form.partner_id = self.partner_a
+        po_form.date_order = fields.Date.from_string('2019-01-01')
+        po_form.currency_id = self.currency_data['currency']
+        with po_form.order_line.new() as line_form:
+            line_form.product_id = self.product_tax_10_price_include
+            line_form.product_qty = 1.0
+        purchase_order = po_form.save()
+
+        # The original price_unit is 110.0. The price-included tax should be subtracted as 110.0 / 1.1 = 100.0.
+        # Then, the currency should be applied (x2 in 2019) making the price_unit becoming 100.0 x 2 = 200.0.
+
+        self.assertRecordValues(purchase_order.order_line, [{
+            'product_id': self.product_tax_10_price_include.id,
+            'product_qty': 1.0,
+            'price_unit': 200.0,
+            'taxes_id': self.tax_15_price_exclude.ids,
+            'price_subtotal': 200.0,
+        }])
+
+    def test_fiscal_position_price_included_to_price_included_tax(self):
+        ''' Test the purchase order when dealing with a fiscal position mapping a price-included tax set by default on a
+        product. Indeed, mapping a price-included-tax to a price-included-tax must remove the tax amount from the
+        price_unit set on the product and then add the tax amount from the new price-included tax.
+        '''
+
+        self.partner_a.property_account_position_id = self.fiscal_position_include_to_include
+
+        po_form = Form(self.env['purchase.order'])
+        po_form.partner_id = self.partner_a
+        po_form.date_order = fields.Date.from_string('2019-01-01')
+        po_form.currency_id = self.currency_data['currency']
+        with po_form.order_line.new() as line_form:
+            line_form.product_id = self.product_tax_10_price_include
+            line_form.product_qty = 1.0
+        purchase_order = po_form.save()
+
+        # The original price_unit is 110.0. The price-included tax should be subtracted as 110.0 / 1.1 = 100.0.
+        # Due to the fiscal position, the price_unit is set to 120.0 due to the 20% price-included tax.
+        # Then, the currency should be applied (x2 in 2019) making the price_unit becoming 100.0 x 2 = 200.0.
+
+        self.assertRecordValues(purchase_order.order_line, [{
+            'product_id': self.product_tax_10_price_include.id,
+            'product_qty': 1.0,
+            'price_unit': 240.0,
+            'taxes_id': self.tax_20_price_include.ids,
+            'price_subtotal': 200.0,
+        }])

--- a/addons/purchase/tests/test_purchase_order_product_sellers.py
+++ b/addons/purchase/tests/test_purchase_order_product_sellers.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+from odoo.addons.account.tests.invoice_test_common import InvoiceTestCommon
+from odoo.tests.common import Form
+from odoo.tests import tagged
+from odoo import fields
+
+
+@tagged('post_install', '-at_install')
+class TestPurchaseOrderProductSellers(InvoiceTestCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.product = cls.env['product.product'].create({
+            'name': 'product',
+            'uom_id': cls.env.ref('uom.product_uom_unit').id,
+            'standard_price': 100.0,
+            'taxes_id': [(6, 0, cls.tax_sale_a.ids)],
+        })
+
+    def assertPoLineValues(self, seller_vals_list, expected_po_line_vals):
+        ''' Helper to check the po line values with a specific setup of sellers set on the product.
+
+        :param seller_vals_list:        The values to create the sellers (product.supplierinfo).
+        :param expected_po_line_vals:   The expected values of the po line.
+        '''
+
+        self.product.write({
+            'seller_ids': [(0, 0, seller_vals) for seller_vals in seller_vals_list],
+        })
+
+        with self.mocked_today('2019-01-01'):
+            po_form = Form(self.env['purchase.order'])
+            po_form.partner_id = self.partner_a
+            po_form.date_order = fields.Date.from_string('2018-01-01')
+            with po_form.order_line.new() as line_form:
+                line_form.product_id = self.product
+            purchase_order = po_form.save()
+
+        self.assertRecordValues(purchase_order.order_line, [expected_po_line_vals])
+
+    def test_no_matching_seller(self):
+        self.assertPoLineValues([
+            {
+                'name': self.partner_b.id,
+                'min_qty': 12.0,
+            }
+        ], {
+            'product_qty': 0.0,
+            'price_unit': 100.0,
+            'product_uom': self.env.ref('uom.product_uom_unit').id,
+            'date_planned': fields.Datetime.from_string('2019-01-01 00:00:00'),
+        })
+
+    def test_seller_min_quantity_no_product(self):
+        self.assertPoLineValues([
+            {
+                'name': self.partner_a.id,
+                'product_id': False,
+                'min_qty': 12.0,
+                'price': 100.0,
+            },
+            {
+                'name': self.partner_a.id,
+                'product_id': False,
+                'min_qty': 8.0,
+                'price': 200.0,
+            }
+        ], {
+            'product_qty': 8.0,
+            'price_unit': 200.0,
+            'product_uom': self.env.ref('uom.product_uom_unit').id,
+            'date_planned': fields.Datetime.from_string('2018-01-02 00:00:00'),
+        })


### PR DESCRIPTION
Suppose a tax 10% incl and 20% incl.
Suppose a fiscal position mapping 10% -> 20%.
Suppose a product having 110 as sale price.

The price_unit should be 120 on the invoice when setting the product with the fiscal position.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
