### PR TITLE
[FIX] stock_account: allow access to stock.valuation.layer to Invento…

### DIFF
--- a/addons/stock_account/security/ir.model.access.csv
+++ b/addons/stock_account/security/ir.model.access.csv
@@ -3,3 +3,4 @@ access_account_account_stock_manager,account.account stock manager,account.model
 access_stock_picking_invoicing_payments,stock.picking,stock.model_stock_picking,account.group_account_invoice,1,1,1,0
 access_stock_move_invoicing_payments,stock.move,model_stock_move,account.group_account_invoice,1,1,1,0
 access_stock_valuation_layer,access_stock_valuation_layer,model_stock_valuation_layer,stock.group_stock_manager,1,1,1,0
+access_stock_valuation_layer_user,access_stock_valuation_layer,model_stock_valuation_layer,stock.group_stock_user,1,0,0,0


### PR DESCRIPTION
…ry User

When an Inventory user is trying to see valuation of a done transfer or
validate a return, he gets an access rights error on stock.valuation.layer
while he should be able to proceed the operation.

Description of the issue/feature this PR addresses:
opw-2256074

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
