### PR TITLE
[FIX] remove width of o_progressbar_value

### DIFF
--- a/addons/web/static/src/scss/progress_bar.scss
+++ b/addons/web/static/src/scss/progress_bar.scss
@@ -29,7 +29,6 @@
     }
 
     .o_progressbar_value {
-        width: 100px;
         white-space: nowrap;
         padding-left: 10px;
     }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Remove  width in .o_progressbar_value in css

Current behavior before PR:
When progress bar widget used in a tree view,and there are a lot of fields show together,the progress number in the progress bar widget is not shown.
![image](https://user-images.githubusercontent.com/5561864/82215095-671f7a80-9949-11ea-8b90-185674f4a109.png)


Desired behavior after PR is merged:
after remove  width in .o_progressbar_value css, the number is show.
![image](https://user-images.githubusercontent.com/5561864/82215573-368c1080-994a-11ea-95a2-579545d3f24f.png)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
