### PR TITLE
[FIX] mass_mailing: fix the mail preview on external mail client

### DIFF
--- a/addons/mass_mailing/tests/test_mass_mailing_shortener.py
+++ b/addons/mass_mailing/tests/test_mass_mailing_shortener.py
@@ -12,7 +12,7 @@ except ImportError:
 
 class TestMassMailingShortener(common.TransactionCase):
     def getHrefFor(self, html, id):
-        return html.xpath("*[@id='%s']" % id)[0].attrib.get('href')
+        return html.xpath("//*[@id='%s']" % id)[0].attrib.get('href')
 
     def shorturl_to_link(self, short_url):
         return self.env['link.tracker.code'].search([('code', '=', short_url.split('/r/')[-1])]).link_id
@@ -80,7 +80,7 @@ Email: <a id="url4" href="mailto:test@odoo.com">test@odoo.com</h1>
         self.assertEqual(mailing_list_A.contact_nbr, len(sent_messages),
                          'Some message has not been sent')
 
-        xbody = etree.fromstring(sent_messages[0].body)
+        xbody = etree.fromstring("<div>%s</div>" % sent_messages[0].body)
         after_url0 = self.getHrefFor(xbody, 'url0')
         after_url1 = self.getHrefFor(xbody, 'url1')
         after_url2 = self.getHrefFor(xbody, 'url2')
@@ -103,7 +103,7 @@ Email: <a id="url4" href="mailto:test@odoo.com">test@odoo.com</h1>
         self.assertEqual(short2.url, "https://www.odoo.com", 'URL mismatch')
         self.assertEqual(short3.url, "https://www.odoo.eu", 'URL mismatch')
 
-        _xbody = etree.fromstring(sent_messages[1].body)
+        _xbody = etree.fromstring("<div>%s</div>" % sent_messages[1].body)
         _after_url0 = self.getHrefFor(_xbody, 'url0')
         _after_url1 = self.getHrefFor(_xbody, 'url1')
         _after_url2 = self.getHrefFor(_xbody, 'url2')

--- a/addons/mass_mailing/wizard/test_mailing.py
+++ b/addons/mass_mailing/wizard/test_mailing.py
@@ -21,7 +21,8 @@ class TestMassMailing(models.TransientModel):
         mass_mail_layout = self.env.ref('mass_mailing.mass_mailing_mail_layout')
         for test_mail in test_emails:
             # Convert links in absolute URLs before the application of the shortener
-            body = self.env['mail.thread']._replace_local_links(mailing.body_html)
+            body = mailing._prepare_mail_body(mailing.body_html)
+            body = self.env['mail.thread']._replace_local_links(body)
             body = tools.html_sanitize(body, sanitize_attributes=True, sanitize_style=True)
             mail_values = {
                 'email_from': mailing.email_from,


### PR DESCRIPTION
Purpose
=======
When we send an email, the mail client (gmail, outlook...) compute
a mail preview based on the content.

Actually, this preview contains a lot of garbage, and it should contain
only relevant text.

Technical
=========
To build this preview, all mail clients read the content of the email.
The only way to be able to customize the preview is to add an invisible
HTML element at the beginning of the email with the wanted preview text.

We add at the end of the preview `&zwnj;` (zero-width non-joiner) to
fill the end of the preview in order to not have the beginning of the
mail at the end of the preview. It doesn't work with simple space as
the mail clients trim each HTML element content.

Task-2172125