### PR TITLE
[FIX] account: cancel bank statement

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -422,7 +422,11 @@ class AccountBankStatement(models.Model):
             raise UserError(_("Only validated statements can be reset to new."))
 
         self.write({'state': 'open'})
+        names = self.line_ids.move_id.mapped('name')
         self.line_ids.move_id.button_draft()
+        self.line_ids.move_id.posted_before = False
+        for name, move in zip(names, self.line_ids.move_id):
+            move.name = name
         self.line_ids.button_undo_reconciliation()
 
     def button_journal_entries(self):


### PR DESCRIPTION
When we tried to cancel a bank statement, we had to reset the statement
to new, then delete the linked journal entries.
We couldn't do so because the entries have been posted before and kept
their sequence number.

In order to allow the deletion of a statement, we completely reset the
posted information of the linked journal items when we reset the
statement to draft.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
