### PR TITLE
[IMP] http_routing: remove pointless redirection

### DIFF
--- a/addons/http_routing/controllers/main.py
+++ b/addons/http_routing/controllers/main.py
@@ -8,7 +8,7 @@ from odoo.addons.web.controllers.main import WebClient, Home
 
 class Routing(Home):
 
-    @http.route('/website/translations/<string:unique>', type='http', auth="public", website=True)
+    @http.route('/website/translations/<string:unique>', type='http', auth="public", website=True, multilang=False)
     def get_website_translations(self, unique, lang, mods=None):
         IrHttp = request.env['ir.http'].sudo()
         modules = IrHttp.get_translation_frontend_modules()


### PR DESCRIPTION
There appears to be no reason to redirect routes like
  `/website/translations/<hash>`
to
  `/la_NG/website/translations/<hash>`
as this route only takes care of the language(s) passed as a parameter

We save one HTTP call here and potential failures while
redirecting (eg: #44110 opw-2259778 ).