### PR TITLE
[REF] test_main_flows: Remove the creation of a manual bank account

### DIFF
--- a/addons/account/__init__.py
+++ b/addons/account/__init__.py
@@ -35,12 +35,8 @@ def _auto_install_l10n(cr, registry):
                 module_list.append('l10n_' + country_code.lower())
             else:
                 module_list.append('l10n_generic_coa')
-        if country_code == 'US':
-            module_list.append('account_plaid')
         if country_code in ['US', 'CA']:
             module_list.append('account_check_printing')
-        if country_code in ['US', 'AU', 'NZ', 'CA', 'CO', 'EC', 'ES', 'FR', 'IN', 'MX', 'GB']:
-            module_list.append('account_yodlee')
         if country_code in SYSCOHADA_LIST + [
             'AT', 'BE', 'CA', 'CO', 'DE', 'EC', 'ES', 'ET', 'FR', 'GR', 'IT', 'LU', 'MX', 'NL', 'NO',
             'PL', 'PT', 'RO', 'SI', 'TR', 'GB', 'VE', 'VN'

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -692,26 +692,6 @@ tour.register('main_flow_tour', {
     position: 'bottom',
 }, {
     edition: "enterprise",
-    trigger: 'button[data-name=action_configure_bank_journal]',
-    content: _t('Configure Bank Journal'),
-    position: 'bottom',
-}, {
-    edition: "enterprise",
-    trigger: '.js_configure_manually',
-    content: _t('Enter manual data for bank account'),
-    position: 'bottom',
-}, {
-    edition: "enterprise",
-    trigger: ".o_field_widget[name=acc_number]",
-    content: _t("Enter an account number"),
-    position: "right",
-    run: "text 867656544",
-}, {
-    trigger: ".modal-footer .btn-primary",
-    content: _t('Save'),
-    position: 'bottom',
-}, {
-    edition: "enterprise",
     trigger: 'div[name=bank_statement_create_button] > a[data-name=create_bank_statement], div[name=bank_statement_create_button] > a[data-name=create_bank_statement]',
     content: _t('Create a new bank statement'),
     position: 'bottom',


### PR DESCRIPTION
This part of the tour can't work with the new online synchronization because we can't be confident about what the proxy will display.
Remove account_plaid & account_yodlee from _auto_install_l10n.

This commit is a backport from #50267

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
