### PR TITLE
[IMP] crm: Lead/opportunity converter/merge improvements

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1557,6 +1557,7 @@ class Lead(models.Model):
             used mainly for first classification;
           * stage sequence: the higher the better as it indicates we are moving
             towards won stage;
+          * probability: the higher the better as it is more likely to be won;
           * ID: the higher the better when all other parameters are equal. We
             consider newer leads to be more reliable;
         """
@@ -1564,6 +1565,7 @@ class Lead(models.Model):
             return opportunity.type == 'opportunity' or opportunity.active,  \
                 opportunity.type == 'opportunity', \
                 opportunity.stage_id.sequence, \
+                opportunity.probability, \
                 -opportunity._origin.id
 
         return self.sorted(key=opps_key, reverse=reverse)

--- a/addons/crm/tests/common.py
+++ b/addons/crm/tests/common.py
@@ -119,6 +119,7 @@ class TestCrmCommon(TestSalesCommon, MailCase):
             'contact_name': 'Amy Wong',
             'email_from': 'amy.wong@test.example.com',
             'country_id': cls.env.ref('base.us').id,
+            'probability': 20,
         })
         # update lead_1: stage_id is not computed anymore by default for leads
         cls.lead_1.write({
@@ -333,6 +334,7 @@ class TestCrmCommon(TestSalesCommon, MailCase):
             'type': 'lead',
             'team_id': lead.team_id.id,
             'email_from': lead.email_from,
+            'probability': lead.probability,
         })
         lead_email_normalized = self.env['crm.lead'].create({
             'name': 'Duplicate: email_normalize comparison',
@@ -340,12 +342,14 @@ class TestCrmCommon(TestSalesCommon, MailCase):
             'team_id': lead.team_id.id,
             'stage_id': lead.stage_id.id,
             'email_from': 'CUSTOMER WITH NAME <%s>' % lead.email_normalized.upper(),
+            'probability': lead.probability,
         })
         lead_partner = self.env['crm.lead'].create({
             'name': 'Duplicate: customer ID',
             'type': 'lead',
             'team_id': lead.team_id.id,
             'partner_id': customer.id,
+            'probability': lead.probability,
         })
         if create_opp:
             opp_lost = self.env['crm.lead'].create({
@@ -354,6 +358,7 @@ class TestCrmCommon(TestSalesCommon, MailCase):
                 'team_id': lead.team_id.id,
                 'stage_id': lead.stage_id.id,
                 'email_from': lead.email_from,
+                'probability': lead.probability,
             })
             opp_lost.action_set_lost()
         else:
@@ -605,7 +610,7 @@ class TestLeadConvertMassCommon(TestLeadConvertCommon):
         cls.lead_w_partner_company = cls.env['crm.lead'].create({
             'name': 'New1',
             'type': 'lead',
-            'probability': 15,
+            'probability': 50,
             'user_id': cls.user_sales_manager.id,
             'stage_id': cls.stage_team1_1.id,
             'partner_id': cls.contact_company_1.id,
@@ -615,7 +620,7 @@ class TestLeadConvertMassCommon(TestLeadConvertCommon):
         cls.lead_w_contact = cls.env['crm.lead'].create({
             'name': 'LeadContact',
             'type': 'lead',
-            'probability': 15,
+            'probability': 25,
             'contact_name': 'TestContact',
             'user_id': cls.user_sales_salesman.id,
             'stage_id': cls.stage_gen_1.id,

--- a/addons/crm/tests/test_crm_lead_convert.py
+++ b/addons/crm/tests/test_crm_lead_convert.py
@@ -366,6 +366,7 @@ class TestLeadConvert(crm_common.TestLeadConvertCommon):
                 'type': 'lead', 'user_id': False, 'team_id': self.lead_1.team_id.id,
                 'contact_name': 'Duplicate %02d of %s' % (x+1, self.lead_1.contact_name),
                 'email_from': self.lead_1.email_from,
+                'probability': 10,
             })
 
         convert = self.env['crm.lead2opportunity.partner'].with_context({

--- a/addons/crm/tests/test_crm_lead_merge.py
+++ b/addons/crm/tests/test_crm_lead_merge.py
@@ -52,7 +52,7 @@ class TestLeadMerge(TestLeadMergeCommon):
 
         Original order:
 
-        lead_w_contact ----------lead---seq=30---proba=15
+        lead_w_contact ----------lead---seq=3----proba=15
         lead_w_email ------------lead---seq=3----proba=15
         lead_1 ------------------lead---seq=1----proba=?
         lead_w_partner ----------lead---seq=False---proba=10
@@ -89,7 +89,7 @@ class TestLeadMerge(TestLeadMergeCommon):
     def test_lead_merge_internals(self):
         """ Test internals of merge wizard. In this test leads are ordered as
 
-        lead_w_contact --lead---seq=30
+        lead_w_contact --lead---seq=3
         lead_w_email ----lead---seq=3
         lead_1 ----------lead---seq=1
         lead_w_partner --lead---seq=False
@@ -113,7 +113,7 @@ class TestLeadMerge(TestLeadMergeCommon):
         ordered_merge_description = '<br><br>'.join(l.description for l in ordered_merge)
 
         # merged opportunity: in this test, all input are leads. Confidence is based on stage
-        # sequence -> lead_w_contact has a stage sequence of 30
+        # sequence -> lead_w_contact has a stage sequence of 3 and ID is greater than lead_w_email
         result = merge.action_merge()
         merge_opportunity = self.env['crm.lead'].browse(result['res_id'])
         self.assertFalse((ordered_merge - merge_opportunity).exists())
@@ -132,7 +132,7 @@ class TestLeadMerge(TestLeadMergeCommon):
 
         lead_1 -------------------opp----seq=1
         lead_w_partner_company ---opp----seq=1 (ID greater)
-        lead_w_contact -----------lead---seq=30
+        lead_w_contact -----------lead---seq=3
         lead_w_email -------------lead---seq=3
         lead_w_partner -----------lead---seq=False
         """
@@ -175,6 +175,8 @@ class TestLeadMerge(TestLeadMergeCommon):
     @mute_logger('odoo.models.unlink')
     def test_lead_merge_probability_auto(self):
         """ Check master lead keeps its automated probability when merged. """
+        self.lead_1.write({'probability': self.lead_1.automated_probability})
+        self.assertTrue(self.lead_1.is_automated_probability)
         leads = self.env['crm.lead'].browse((self.lead_1 + self.lead_w_partner + self.lead_w_partner_company).ids)
         merged_lead = self._run_merge_wizard(leads)
         self.assertEqual(merged_lead, self.lead_1)
@@ -186,6 +188,7 @@ class TestLeadMerge(TestLeadMergeCommon):
         """ Check master lead keeps its automated probability when merged
         even if its probability is 0. """
         self.lead_1.write({'probability': 0, 'automated_probability': 0})
+        self.assertTrue(self.lead_1.is_automated_probability)
         leads = self.env['crm.lead'].browse((self.lead_1 + self.lead_w_partner + self.lead_w_partner_company).ids)
         merged_lead = self._run_merge_wizard(leads)
         self.assertEqual(merged_lead, self.lead_1)
@@ -196,6 +199,7 @@ class TestLeadMerge(TestLeadMergeCommon):
     def test_lead_merge_probability_manual(self):
         """ Check master lead keeps its manual probability when merged. """
         self.lead_1.write({'probability': 40})
+        self.assertFalse(self.lead_1.is_automated_probability)
         leads = self.env['crm.lead'].browse((self.lead_1 + self.lead_w_partner + self.lead_w_partner_company).ids)
         merged_lead = self._run_merge_wizard(leads)
         self.assertEqual(merged_lead, self.lead_1)
@@ -221,7 +225,7 @@ class TestLeadMerge(TestLeadMergeCommon):
 
         lead_1 -------------------opp----seq=1
         lead_w_partner_company ---opp----seq=1 (ID greater)
-        lead_w_contact -----------lead---seq=30
+        lead_w_contact -----------lead---seq=3
         lead_w_email -------------lead---seq=3
         lead_w_partner -----------lead---seq=False
         """
@@ -240,7 +244,7 @@ class TestLeadMerge(TestLeadMergeCommon):
         this test leads are ordered as
 
         lead_w_partner_company ---opp----seq=1 (ID greater)
-        lead_w_contact -----------lead---seq=30
+        lead_w_contact -----------lead---seq=3
         lead_w_email -------------lead---seq=3----------------attachments
         lead_1 -------------------lead---seq=1----------------activity+meeting
         lead_w_partner -----------lead---seq=False


### PR DESCRIPTION
Purpose

Improve the Confidence level sorting for lead/opportunities

Specifications

1) Confidence level (from feedback 2176733)

Current :
When merging opportunities. They are sorted by "confidence level", which is basically
  * opp > lead
  * stage sequence higher is better
  * older ID is better*
  
To Be
=> Include the probability as the third criterion taken into account. The higher the probability, the better.

LINKS
PR: #51893
Task-id: 2198562
