### PR TITLE
[FIX] web: in search view, use field modifiers to determine if filter is invisible

### DIFF
--- a/addons/web/static/src/js/views/control_panel/control_panel_view.js
+++ b/addons/web/static/src/js/views/control_panel/control_panel_view.js
@@ -177,7 +177,7 @@ var ControlPanelView = Factory.extend({
                                 attrs.name ||
                                 attrs.domain ||
                                 'Ω';
-        if (attrs.invisible) {
+        if (JSON.parse(attrs.modifiers || '{}').invisible) {
             filter.invisible = true;
         }
         if (filter.type === 'filter') {

--- a/addons/web/static/tests/views/control_panel_tests.js
+++ b/addons/web/static/tests/views/control_panel_tests.js
@@ -396,24 +396,28 @@ QUnit.module('Views', {
         actionManager.destroy();
     });
 
-    QUnit.test('fiels and filters with groups/invisible attribute are not always rendered but activable as search default', async function (assert) {
-        assert.expect(13);
+    QUnit.test('fields and filters with groups/invisible attribute are not always rendered but activable as search default', async function (assert) {
+        assert.expect(15);
         var controlPanel = await createControlPanel({
             model: 'partner',
             arch: "<search>" +
                         "<field name=\"display_name\" string=\"Foo B\" invisible=\"1\"/>" +
                         "<field name=\"foo\" string=\"Foo A\"/>" +
                         "<filter name=\"filterA\" string=\"FA\" domain=\"[]\"/>" +
-                        "<filter name=\"filterB\" string=\"FB\" invisible=\"1\" domain=\"[]\"/>" +
+                        "<filter name=\"filterB\" string=\"FB\" domain=\"[]\" invisible=\"1\"/>" +
+                        "<filter name=\"filterC\" string=\"FC\" invisible=\"not context.get('show_filterC')\"/>" +
                         "<filter name=\"groupByA\" string=\"GA\" context=\"{'group_by': 'date_field:day'}\"/>" +
                         "<filter name=\"groupByB\" string=\"GB\" context=\"{'group_by': 'date_field:day'}\" invisible=\"1\"/>" +
                     "</search>",
             data: this.data,
             searchMenuTypes: ['filter', 'groupBy'],
-            context: {
-                search_default_display_name: 'value',
-                search_default_filterB: true,
-                search_default_groupByB: true,
+            viewOptions: {
+                context: {
+                    show_filterC: true,
+                    search_default_display_name: 'value',
+                    search_default_filterB: true,
+                    search_default_groupByB: true,
+                },
             },
         });
 
@@ -424,6 +428,7 @@ QUnit.module('Views', {
         await testUtils.dom.click(controlPanel.$('.o_filters_menu_button'));
         assert.containsOnce(controlPanel, '.o_menu_item a:contains("FA")');
         assert.containsNone(controlPanel, '.o_menu_item a:contains("FB")');
+        assert.containsOnce(controlPanel, '.o_menu_item a:contains("FC")');
         // default filter should be activated even if invisible
         assert.containsOnce(controlPanel, '.o_searchview_facet .o_facet_values:contains(FB)');
 
@@ -450,6 +455,7 @@ QUnit.module('Views', {
         await testUtils.dom.click(controlPanel.$('.o_filters_menu_button'));
         assert.containsOnce(controlPanel, '.o_menu_item a:contains("FA")');
         assert.containsNone(controlPanel, '.o_menu_item a:contains("FB")');
+        assert.containsOnce(controlPanel, '.o_menu_item a:contains("FC")');
 
         await testUtils.dom.click(controlPanel.$('button span.fa-bars'));
         assert.containsOnce(controlPanel, '.o_menu_item a:contains("GA")');


### PR DESCRIPTION
For search view with filter having complex "invisible" attribute, like:

```xml
<search>
   ...
   <filter name="myfilter" string="My Filter" invisible="context.get('hide_myfilter')"/>
   ...
</search>
```

In such case, we must rely on the "modifiers" attribute set by the ir.ui.view
post-processing as the result can depends on the context

OPW-2243639

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
