### PR TITLE
[FIX] sale_timesheet: invalid view inherit

### DIFF
--- a/addons/sale_timesheet/views/sale_order_views.xml
+++ b/addons/sale_timesheet/views/sale_order_views.xml
@@ -3,7 +3,7 @@
         <record id="view_order_form_inherit_sale_timesheet" model="ir.ui.view">
             <field name="name">sale.order.form.sale.timesheet</field>
             <field name="model">sale.order</field>
-            <field name="inherit_id" ref="sale.view_order_form"/>
+            <field name="inherit_id" ref="sale_project.view_order_form_inherit_sale_project"/>
             <field name="arch" type="xml">
                 <data>
                     <xpath expr="//button[@name='action_view_project_ids']" position="attributes">


### PR DESCRIPTION
- The form view `sale.order.form.sale.timesheet` inherits
  the `sale.order` base form view instead of the
  `sale_project` view inherit for the `sale.order` form view.

  In certain cases, this would lead to a crash when rendering the
  `sale.order` form view as the `sale_timesheet` tries to modify
  the form view based on fields added by the `sale_project` module.

  You can reproduce this issue by changing the sequence of the
  `sale.order.form.sale.timesheet` view to be less than
  `sale.order.form.sale.project` sequence.

  This can happen naturally (mainly on migrated dbs).


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
