### PR TITLE
[FIX] base : force css word-wrap in the ir_attachment index_content field

### DIFF
--- a/odoo/addons/base/views/ir_attachment_views.xml
+++ b/odoo/addons/base/views/ir_attachment_views.xml
@@ -36,7 +36,7 @@
                             <field name="description" nolabel="1"/>
                         </group>
                         <group groups="base.group_no_one" string="Indexed Content" colspan="4">
-                            <field name="index_content" nolabel="1"/>
+                            <field class="text-break" name="index_content" nolabel="1"/>
                         </group>
                     </group>
                   </sheet>


### PR DESCRIPTION
Long indexed content without space can break the layout. So we forced the word wrap to avoid visual bug.

task id : 2238654
