### PR TITLE
[FIX] account: Fix bug in report Aged Receivable

### DIFF
--- a/addons/account/report/account_aged_partner_balance.py
+++ b/addons/account/report/account_aged_partner_balance.py
@@ -133,7 +133,7 @@ class ReportAgedPartnerBalance(models.AbstractModel):
             aml_ids = cr.fetchall()
             aml_ids = aml_ids and [x[0] for x in aml_ids] or []
             for line in self.env['account.move.line'].browse(aml_ids).with_context(prefetch_fields=False):
-                partner_id = line.partner_id.id or False
+                partner_id = line.partner_id.id or None
                 if partner_id not in partners_amount:
                     partners_amount[partner_id] = 0.0
                 line_amount = line.company_id.currency_id._convert(line.balance, user_currency, user_company, date_from)
@@ -172,7 +172,7 @@ class ReportAgedPartnerBalance(models.AbstractModel):
         aml_ids = cr.fetchall()
         aml_ids = aml_ids and [x[0] for x in aml_ids] or []
         for line in self.env['account.move.line'].browse(aml_ids):
-            partner_id = line.partner_id.id or False
+            partner_id = line.partner_id.id or None
             if partner_id not in undue_amounts:
                 undue_amounts[partner_id] = 0.0
             line_amount = line.company_id.currency_id._convert(line.balance, user_currency, user_company, date_from)
@@ -194,8 +194,6 @@ class ReportAgedPartnerBalance(models.AbstractModel):
                 })
 
         for partner in partners:
-            if partner['partner_id'] is None:
-                partner['partner_id'] = False
             at_least_one_amount = False
             values = {}
             undue_amt = 0.0


### PR DESCRIPTION
when account move line without a partner and not reconciled with an amount like 0.01

and change currency rounding factor changed to 0.1000(Decimal Place = 1) then it considers this as zero value as you can see here https://github.com/odoo/odoo/blob/13.0/addons/account/report/account_aged_partner_balance.py#L187

so when getting lines by key 'False' then an error occurred because 'False' key is not available because the value is zero as per rounding factor

In this commit, I remove that key confusion between 'False' and 'None'

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
