### PR TITLE
[FIX] hr_attendance: Check In / Check Out by default

### DIFF
--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -176,9 +176,9 @@
 
     <menuitem id="menu_hr_attendance_root" name="Attendances" sequence="90" groups="hr_attendance.group_hr_attendance,hr_attendance.group_hr_attendance_kiosk" web_icon="hr_attendance,static/description/icon.png"/>
 
-    <menuitem id="menu_hr_attendance_kiosk_no_user_mode" name="Kiosk Mode" parent="menu_hr_attendance_root" sequence="1" groups="hr_attendance.group_hr_attendance_kiosk" action="hr_attendance_action_kiosk_mode"/>
+    <menuitem id="menu_hr_attendance_my_attendances" name="Check In / Check Out" parent="menu_hr_attendance_root" sequence="1" groups="hr_attendance.group_hr_attendance" action="hr_attendance_action_my_attendances"/>
 
-    <menuitem id="menu_hr_attendance_my_attendances" name="Check In / Check Out" parent="menu_hr_attendance_root" sequence="10" groups="hr_attendance.group_hr_attendance" action="hr_attendance_action_my_attendances"/>
+    <menuitem id="menu_hr_attendance_kiosk_no_user_mode" name="Kiosk Mode" parent="menu_hr_attendance_root" sequence="10" groups="hr_attendance.group_hr_attendance_kiosk" action="hr_attendance_action_kiosk_mode"/>
 
     <menuitem id="menu_hr_attendance_manage_attendances" name="Manager" parent="menu_hr_attendance_root" sequence="20" groups="hr_attendance.group_hr_attendance_user"/>
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Set the check in / check out menu first instead of kiosk.

Current behavior before PR:

Kiosk is first and default.

Desired behavior after PR is merged:

Check in / Check out is first and default

TASK ID  2266096

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
