### PR TITLE
[FIX] website_helpdesk: don't forcecreate website menu

### DIFF
--- a/addons/website/data/website_data.xml
+++ b/addons/website/data/website_data.xml
@@ -14,7 +14,7 @@
             <field name="website_id" ref="default_website"/>
         </record>
 
-        <record id="menu_homepage" model="website.menu">
+        <record id="menu_homepage" model="website.menu" forcecreate="False">
             <field name="name">Home</field>
             <field name="url">/</field>
             <field name="parent_id" ref="website.main_menu"/>
@@ -22,7 +22,7 @@
             <field name="website_id" ref="default_website"/>
         </record>
 
-        <record id="menu_contactus" model="website.menu">
+        <record id="menu_contactus" model="website.menu" forcecreate="False">
             <field name="name">Contact us</field>
             <field name="url">/contactus</field>
             <field name="parent_id" ref="website.main_menu"/>

--- a/addons/website_blog/data/website_blog_data.xml
+++ b/addons/website_blog/data/website_blog_data.xml
@@ -5,7 +5,7 @@
             <field name="name">Our Blog</field>
             <field name="subtitle">Get in touch with us</field>
         </record>
-        <record id="menu_news" model="website.menu">
+        <record id="menu_news" model="website.menu" forcecreate="False">
             <field name="name">Blog</field>
             <field name="url" eval="'/blog/'+str(ref('website_blog.blog_blog_1'))"/>
             <field name="parent_id" ref="website.main_menu"/>

--- a/addons/website_event/data/event_data.xml
+++ b/addons/website_event/data/event_data.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="1">
 
-        <record id="menu_events" model="website.menu">
+        <record id="menu_events" model="website.menu" forcecreate="False">
             <field name="name">Events</field>
             <field name="url">/event</field>
             <field name="parent_id" ref="website.main_menu"/>

--- a/addons/website_forum/data/forum_data.xml
+++ b/addons/website_forum/data/forum_data.xml
@@ -5,7 +5,7 @@
             <field name="name">Help</field>
         </record>
 
-        <record id="menu_questions" model="website.menu">
+        <record id="menu_questions" model="website.menu" forcecreate="False">
             <field name="name">Forum</field>
             <field name="url" eval="'/forum/'+str(ref('website_forum.forum_help'))"/>
             <field name="parent_id" ref="website.main_menu"/>

--- a/addons/website_forum_doc/data/doc_data.xml
+++ b/addons/website_forum_doc/data/doc_data.xml
@@ -10,7 +10,7 @@
     </data>
 
     <data noupdate="1">
-        <record id="menu_questions" model="website.menu">
+        <record id="menu_questions" model="website.menu" forcecreate="False">
             <field name="name">Documentation</field>
             <field name="url" eval="'/forum/how-to'"/>
             <field name="parent_id" ref="website.main_menu"/>

--- a/addons/website_hr_recruitment/data/config_data.xml
+++ b/addons/website_hr_recruitment/data/config_data.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data noupdate="1">
-        <record id="menu_jobs" model="website.menu">
+        <record id="menu_jobs" model="website.menu" forcecreate="False">
             <field name="name">Jobs</field>
             <field name="url">/jobs</field>
             <field name="parent_id" ref="website.main_menu"/>

--- a/addons/website_sale/data/data.xml
+++ b/addons/website_sale/data/data.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="1">
 
-        <record id="menu_shop" model="website.menu">
+        <record id="menu_shop" model="website.menu" forcecreate="False">
             <field name="name">Shop</field>
             <field name="url">/shop</field>
             <field name="parent_id" ref="website.main_menu"/>

--- a/addons/website_slides/data/website_slides_data.xml
+++ b/addons/website_slides/data/website_slides_data.xml
@@ -7,7 +7,7 @@
             <field name="value">AIzaSyDOWlmDW-7DbLmOR9ZsT5AOEXf4n6TFwQA</field>
         </record>
 
-        <record id="website_menu_slides" model="website.menu">
+        <record id="website_menu_slides" model="website.menu" forcecreate="False">
             <field name="name">Presentations</field>
             <field name="url">/slides</field>
             <field name="parent_id" ref="website.main_menu"/>


### PR DESCRIPTION
Because I we want it, we want for all menus:
https://github.com/odoo/odoo/pull/42262

but btw do we really want this change in stable ? 
If you delete by error your menu, don't you like to have it back on update ?