### PR TITLE
[FIX] mail: activities without any summary display false in export

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -178,6 +178,13 @@ class MailActivity(models.Model):
     # access
     can_write = fields.Boolean(compute='_compute_can_write', help='Technical field to hide buttons if the current user has no access.')
 
+    def name_get(self):
+        res = []
+        for record in self:
+            name = record.summary or record.activity_type_id.display_name
+            res.append((record.id, name))
+        return res
+
     @api.onchange('previous_activity_type_id')
     def _compute_has_recommended_activities(self):
         for record in self:


### PR DESCRIPTION
PURPOSE:

Currently, activities having blank summary field exported in xls or csv display
False. Instead of that, need to display the activity type like Email, To Do,
Call, Meeting, etc. as its display in the list view.

SPEC:

We have override the name_get method and set the summary as a default value
and if summary not found then it will take the activity type name.

Task : 2254851