### PR TITLE
[REF] test_main_flows: Remove the creation of a manual bank account

### DIFF
--- a/addons/account/__init__.py
+++ b/addons/account/__init__.py
@@ -34,12 +34,9 @@ def _auto_install_l10n(cr, registry):
             else:
                 module_list.append('l10n_generic_coa')
         if country_code == 'US':
-            module_list.append('account_plaid')
             module_list.append('l10n_us_check_printing')
         if country_code == 'CA':
             module_list.append('l10n_ca_check_printing')
-        if country_code in ['US', 'AU', 'NZ', 'CA', 'CO', 'EC', 'ES', 'FR', 'IN', 'MX', 'UK']:
-            module_list.append('account_yodlee')
         if country_code in SYSCOHADA_LIST + [
             'AT', 'BE', 'CA', 'CO', 'DE', 'EC', 'ES', 'ET', 'FR', 'GR', 'IT', 'LU', 'MX', 'NL', 'NO', 
             'PL', 'PT', 'RO', 'SI', 'TR', 'UK', 'VE', 'VN'


### PR DESCRIPTION
This part of the tour can't work with the new online synchronization because we can't be confident about what the proxy will display.
Remove account_plaid & account_yodlee from _auto_install_l10n.

This commit is a backport from #50267

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
