### PR TITLE
 [IMP] tests: convert HttpCase to a SavepointCase

### DIFF
--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -11,14 +11,15 @@ import odoo.tests
 
 class TestPointOfSaleHttpCommon(odoo.tests.HttpCase):
 
-    def setUp(self):
-        super().setUp()
-        env = self.env(user=self.env.ref('base.user_admin'))
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        env = cls.env(user=cls.env.ref('base.user_admin'))
 
         journal_obj = env['account.journal']
         account_obj = env['account.account']
         main_company = env.ref('base.main_company')
-        self.main_pos_config = env.ref('point_of_sale.pos_config_main')
+        cls.main_pos_config = env.ref('point_of_sale.pos_config_main')
 
         env['res.partner'].create({
             'name': 'Deco Addict',
@@ -28,9 +29,9 @@ class TestPointOfSaleHttpCommon(odoo.tests.HttpCase):
                                                  'name': 'Account Receivable - Test',
                                                  'user_type_id': env.ref('account.data_account_type_receivable').id,
                                                  'reconcile': True})
-        self.env.company.account_default_pos_receivable_account_id = account_receivable
+        cls.env.company.account_default_pos_receivable_account_id = account_receivable
 
-        self.env['ir.property']._set_default('property_account_receivable_id', 'res.partner', account_receivable, main_company)
+        cls.env['ir.property']._set_default('property_account_receivable_id', 'res.partner', account_receivable, main_company)
 
         cash_journal = journal_obj.create({
             'name': 'Cash Test',
@@ -41,9 +42,9 @@ class TestPointOfSaleHttpCommon(odoo.tests.HttpCase):
         })
 
         # Archive all existing product to avoid noise during the tours
-        all_pos_product = self.env['product.product'].search([('available_in_pos', '=', True)])
-        discount = self.env.ref('point_of_sale.product_product_consumable')
-        tip = self.env.ref('point_of_sale.product_product_tip')
+        all_pos_product = cls.env['product.product'].search([('available_in_pos', '=', True)])
+        discount = cls.env.ref('point_of_sale.product_product_consumable')
+        tip = cls.env.ref('point_of_sale.product_product_tip')
         (all_pos_product - discount - tip)._write({'active': False})
 
         # In DESKS categ: Desk Pad
@@ -341,13 +342,13 @@ class TestPointOfSaleHttpCommon(odoo.tests.HttpCase):
         excluded_pricelist = env['product.pricelist'].create({
             'name': 'Not loaded'
         })
-        res_partner_18 = self.env['res.partner'].create({
+        res_partner_18 = cls.env['res.partner'].create({
             'name': 'Lumber Inc',
             'is_company': True,
         })
         res_partner_18.property_product_pricelist = excluded_pricelist
 
-        partner = self.env['res.partner'].create({
+        partner = cls.env['res.partner'].create({
             'name': 'TEST PARTNER',
             'email': 'test@partner.com',
         })
@@ -371,7 +372,7 @@ class TestPointOfSaleHttpCommon(odoo.tests.HttpCase):
 
         letter_tray.taxes_id = [(6, 0, [src_tax.id])]
 
-        self.main_pos_config.write({
+        cls.main_pos_config.write({
             'tax_regime_selection': True,
             'fiscal_position_ids': [(0, 0, {
                                             'name': "FP-POS-2M",

--- a/addons/point_of_sale/tests/test_js.py
+++ b/addons/point_of_sale/tests/test_js.py
@@ -7,10 +7,11 @@ import odoo.tests
 
 @odoo.tests.tagged("post_install", "-at_install")
 class WebSuite(odoo.tests.HttpCase):
-    def setUp(self):
-        super().setUp()
-        env = self.env(user=self.env.ref('base.user_admin'))
-        self.main_pos_config = env.ref('point_of_sale.pos_config_main')
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        env = cls.env(user=cls.env.ref('base.user_admin'))
+        cls.main_pos_config = env.ref('point_of_sale.pos_config_main')
 
     def test_pos_js(self):
         # open a session, the /pos/web controller will redirect to it

--- a/addons/pos_hr/tests/test_frontend.py
+++ b/addons/pos_hr/tests/test_frontend.py
@@ -11,19 +11,20 @@ from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCom
 
 
 class TestPosHrHttpCommon(TestPointOfSaleHttpCommon):
-    def setUp(self):
-        super().setUp()
-        self.main_pos_config.write({"module_pos_hr": True})
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.main_pos_config.write({"module_pos_hr": True})
 
         # Admin employee
-        self.env.ref("hr.employee_admin").write(
+        cls.env.ref("hr.employee_admin").write(
             {"name": "Mitchell Admin", "pin": False}
         )
 
         # User employee
-        emp1 = self.env.ref("hr.employee_han")
+        emp1 = cls.env.ref("hr.employee_han")
         emp1_user = new_test_user(
-            self.env,
+            cls.env,
             login="emp1_user",
             groups="base.group_user",
             name="Pos Employee1",
@@ -32,10 +33,10 @@ class TestPosHrHttpCommon(TestPointOfSaleHttpCommon):
         emp1.write({"name": "Pos Employee1", "pin": "2580", "user_id": emp1_user.id})
 
         # Non-user employee
-        emp2 = self.env.ref("hr.employee_jve")
+        emp2 = cls.env.ref("hr.employee_jve")
         emp2.write({"name": "Pos Employee2", "pin": "1234"})
 
-        with Form(self.main_pos_config) as config:
+        with Form(cls.main_pos_config) as config:
             config.employee_ids.add(emp1)
             config.employee_ids.add(emp2)
 

--- a/addons/product_matrix/tests/common.py
+++ b/addons/product_matrix/tests/common.py
@@ -6,12 +6,13 @@ from odoo.tests import tagged, common
 @tagged('post_install', '-at_install')
 class TestMatrixCommon(common.HttpCase):
 
-    def setUp(self):
-        super(TestMatrixCommon, self).setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
         # Prepare relevant test data
         # This is not included in demo data to avoid useless noise
-        product_attributes = self.env['product.attribute'].create([{
+        product_attributes = cls.env['product.attribute'].create([{
             'name': 'PA1',
             'create_variant': 'always',
             'sequence': 1
@@ -29,16 +30,16 @@ class TestMatrixCommon(common.HttpCase):
             'sequence': 4
         }])
 
-        self.env['product.attribute.value'].create([{
+        cls.env['product.attribute.value'].create([{
             'name': 'PAV' + str(product_attribute.sequence) + str(i),
             'attribute_id': product_attribute.id
         } for i in range(1, 3) for product_attribute in product_attributes])
 
-        self.matrix_template = self.env['product.template'].create({
+        cls.matrix_template = cls.env['product.template'].create({
             'name': "Matrix",
             'type': "consu",
-            'uom_id': self.ref("uom.product_uom_unit"),
-            'uom_po_id': self.ref("uom.product_uom_unit"),
+            'uom_id': cls.ref("uom.product_uom_unit"),
+            'uom_po_id': cls.ref("uom.product_uom_unit"),
             'attribute_line_ids': [(0, 0, {
                 'attribute_id': attribute.id,
                 'value_ids': [(6, 0, attribute.value_ids.ids)]

--- a/addons/product_matrix/tests/common.py
+++ b/addons/product_matrix/tests/common.py
@@ -38,8 +38,8 @@ class TestMatrixCommon(common.HttpCase):
         cls.matrix_template = cls.env['product.template'].create({
             'name': "Matrix",
             'type': "consu",
-            'uom_id': cls.ref("uom.product_uom_unit"),
-            'uom_po_id': cls.ref("uom.product_uom_unit"),
+            'uom_id': cls.env.ref("uom.product_uom_unit").id,
+            'uom_po_id': cls.env.ref("uom.product_uom_unit").id,
             'attribute_line_ids': [(0, 0, {
                 'attribute_id': attribute.id,
                 'value_ids': [(6, 0, attribute.value_ids.ids)]

--- a/addons/sale_product_configurator/tests/test_sale_product_configurator_ui.py
+++ b/addons/sale_product_configurator/tests/test_sale_product_configurator_ui.py
@@ -10,96 +10,97 @@ from odoo.modules.module import get_module_resource
 @odoo.tests.tagged('post_install', '-at_install')
 class TestUi(odoo.tests.HttpCase):
 
-    def setUp(self):
-        super(TestUi, self).setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
         # Setup attributes and attributes values
-        self.product_attribute_1 = self.env['product.attribute'].create({
+        cls.product_attribute_1 = cls.env['product.attribute'].create({
             'name': 'Legs',
             'sequence': 10,
         })
-        product_attribute_value_1 = self.env['product.attribute.value'].create({
+        product_attribute_value_1 = cls.env['product.attribute.value'].create({
             'name': 'Steel',
-            'attribute_id': self.product_attribute_1.id,
+            'attribute_id': cls.product_attribute_1.id,
             'sequence': 1,
         })
-        product_attribute_value_2 = self.env['product.attribute.value'].create({
+        product_attribute_value_2 = cls.env['product.attribute.value'].create({
             'name': 'Aluminium',
-            'attribute_id': self.product_attribute_1.id,
+            'attribute_id': cls.product_attribute_1.id,
             'sequence': 2,
         })
-        product_attribute_2 = self.env['product.attribute'].create({
+        product_attribute_2 = cls.env['product.attribute'].create({
             'name': 'Color',
             'sequence': 20,
         })
-        product_attribute_value_3 = self.env['product.attribute.value'].create({
+        product_attribute_value_3 = cls.env['product.attribute.value'].create({
             'name': 'White',
             'attribute_id': product_attribute_2.id,
             'sequence': 1,
         })
-        product_attribute_value_4 = self.env['product.attribute.value'].create({
+        product_attribute_value_4 = cls.env['product.attribute.value'].create({
             'name': 'Black',
             'attribute_id': product_attribute_2.id,
             'sequence': 2,
         })
 
         # Create product template
-        self.product_product_4_product_template = self.env['product.template'].create({
+        cls.product_product_4_product_template = cls.env['product.template'].create({
             'name': 'Customizable Desk (TEST)',
             'standard_price': 500.0,
             'list_price': 750.0,
         })
 
         # Generate variants
-        self.env['product.template.attribute.line'].create([{
-            'product_tmpl_id': self.product_product_4_product_template.id,
-            'attribute_id': self.product_attribute_1.id,
+        cls.env['product.template.attribute.line'].create([{
+            'product_tmpl_id': cls.product_product_4_product_template.id,
+            'attribute_id': cls.product_attribute_1.id,
             'value_ids': [(4, product_attribute_value_1.id), (4, product_attribute_value_2.id)],
         }, {
-            'product_tmpl_id': self.product_product_4_product_template.id,
+            'product_tmpl_id': cls.product_product_4_product_template.id,
             'attribute_id': product_attribute_2.id,
             'value_ids': [(4, product_attribute_value_3.id), (4, product_attribute_value_4.id)],
 
         }])
 
         # Apply a price_extra for the attribute Aluminium
-        self.product_product_4_product_template.attribute_line_ids[0].product_template_value_ids[1].price_extra = 50.40
+        cls.product_product_4_product_template.attribute_line_ids[0].product_template_value_ids[1].price_extra = 50.40
 
 
         # Add a Custom attribute
-        product_attribute_value_7 = self.env['product.attribute.value'].create({
+        product_attribute_value_7 = cls.env['product.attribute.value'].create({
             'name': 'Custom',
-            'attribute_id': self.product_attribute_1.id,
+            'attribute_id': cls.product_attribute_1.id,
             'sequence': 3,
             'is_custom': True
         })
-        self.product_product_4_product_template.attribute_line_ids[0].write({'value_ids': [(4, product_attribute_value_7.id)]})
+        cls.product_product_4_product_template.attribute_line_ids[0].write({'value_ids': [(4, product_attribute_value_7.id)]})
 
         # Disable the aluminium + black product
-        self.product_product_4_product_template.product_variant_ids[3].active = False
+        cls.product_product_4_product_template.product_variant_ids[3].active = False
 
         # Setup a first optional product
         img_path = get_module_resource('product', 'static', 'img', 'product_product_11-image.png')
         img_content = base64.b64encode(open(img_path, "rb").read())
-        self.product_product_11_product_template = self.env['product.template'].create({
+        cls.product_product_11_product_template = cls.env['product.template'].create({
             'name': 'Conference Chair (TEST)',
             'image_1920': img_content,
             'list_price': 16.50,
         })
 
-        self.env['product.template.attribute.line'].create({
-            'product_tmpl_id': self.product_product_11_product_template.id,
-            'attribute_id': self.product_attribute_1.id,
+        cls.env['product.template.attribute.line'].create({
+            'product_tmpl_id': cls.product_product_11_product_template.id,
+            'attribute_id': cls.product_attribute_1.id,
             'value_ids': [(4, product_attribute_value_1.id), (4, product_attribute_value_2.id)],
         })
-        self.product_product_4_product_template.optional_product_ids = [(4, self.product_product_11_product_template.id)]
+        cls.product_product_4_product_template.optional_product_ids = [(4, cls.product_product_11_product_template.id)]
 
         # Setup a second optional product
-        self.product_product_1_product_template = self.env['product.template'].create({
+        cls.product_product_1_product_template = cls.env['product.template'].create({
             'name': 'Chair floor protection',
             'list_price': 12.0,
         })
-        self.product_product_11_product_template.optional_product_ids = [(4, self.product_product_1_product_template.id)]
+        cls.product_product_11_product_template.optional_product_ids = [(4, cls.product_product_1_product_template.id)]
 
 
     def test_01_product_configurator(self):

--- a/addons/snailmail_account/tests/test_pingen_send.py
+++ b/addons/snailmail_account/tests/test_pingen_send.py
@@ -12,20 +12,21 @@ _logger = logging.getLogger(__name__)
 @tagged('post_install', '-at_install', '-standard', 'external')
 class TestPingenSend(HttpCase):
 
-    def setUp(self):
-        super(TestPingenSend, self).setUp()
-        self.pingen_url = "https://stage-api.pingen.com/document/upload/token/30fc3947dbea4792eb12548b41ec8117/"
-        self.sample_invoice = self.create_invoice()
-        self.sample_invoice.partner_id.vat = "BE000000000"
-        self.letter = self.env['snailmail.letter'].create({
-            'partner_id': self.sample_invoice.partner_id.id,
+    @classmethod
+    def setUpClass(cls):
+        super(TestPingenSend, cls).setUpClass()
+        cls.pingen_url = "https://stage-api.pingen.com/document/upload/token/30fc3947dbea4792eb12548b41ec8117/"
+        cls.sample_invoice = cls.create_invoice()
+        cls.sample_invoice.partner_id.vat = "BE000000000"
+        cls.letter = cls.env['snailmail.letter'].create({
+            'partner_id': cls.sample_invoice.partner_id.id,
             'model': 'account.move',
-            'res_id': self.sample_invoice.id,
-            'user_id': self.env.user.id,
-            'company_id': self.sample_invoice.company_id.id,
-            'report_template': self.env.ref('account.account_invoices').id
+            'res_id': cls.sample_invoice.id,
+            'user_id': cls.env.user.id,
+            'company_id': cls.sample_invoice.company_id.id,
+            'report_template': cls.env.ref('account.account_invoices').id
         })
-        self.data = {
+        cls.data = {
             'data': json.dumps({
                 'speed': 1,
                 'color': 1,

--- a/addons/survey/tests/test_survey_ui_certification.py
+++ b/addons/survey/tests/test_survey_ui_certification.py
@@ -8,10 +8,11 @@ from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 @odoo.tests.common.tagged('post_install', '-at_install')
 class TestUiCertification(HttpCaseWithUserDemo):
 
-    def setUp(self):
-        super(TestUiCertification, self).setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
-        self.survey_certification = self.env['survey.survey'].create({
+        cls.survey_certification = cls.env['survey.survey'].create({
             'title': 'MyCompany Vendor Certification',
             'access_token': '4ead4bc8-b8f2-4760-a682-1fde8daaaaac',
             'state': 'open',
@@ -20,7 +21,7 @@ class TestUiCertification(HttpCaseWithUserDemo):
             'users_login_required': True,
             'scoring_type': 'scoring_with_answers',
             'certification': True,
-            'certification_mail_template_id': self.env.ref('survey.mail_template_certification').id,
+            'certification_mail_template_id': cls.env.ref('survey.mail_template_certification').id,
             'is_time_limited': 'limited',
             'time_limit': 10.0,
             'is_attempts_limited': True,

--- a/addons/survey/tests/test_survey_ui_feedback.py
+++ b/addons/survey/tests/test_survey_ui_feedback.py
@@ -8,9 +8,10 @@ from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 @odoo.tests.common.tagged('post_install', '-at_install')
 class TestUiFeedback(HttpCaseWithUserDemo):
 
-    def setUp(self):
-        super(TestUiFeedback, self).setUp()
-        self.survey_feedback = self.env['survey.survey'].create({
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.survey_feedback = cls.env['survey.survey'].create({
             'title': 'User Feedback Form',
             'access_token': 'b137640d-14d4-4748-9ef6-344caaaaaae',
             'state': 'open',

--- a/addons/test_website/tests/test_reset_views.py
+++ b/addons/test_website/tests/test_reset_views.py
@@ -25,11 +25,12 @@ class TestWebsiteResetViews(odoo.tests.HttpCase):
         find = re.search(r'<input.*type="hidden".*name="view_id".*value="([0-9]+)?"', response.text)
         return find and find.group(1)
 
-    def setUp(self):
-        super(TestWebsiteResetViews, self).setUp()
-        self.Website = self.env['website']
-        self.View = self.env['ir.ui.view']
-        self.test_view = self.Website.viewref('test_website.test_view')
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.Website = cls.env['website']
+        cls.View = cls.env['ir.ui.view']
+        cls.test_view = cls.Website.viewref('test_website.test_view')
 
     @mute_logger('odoo.addons.http_routing.models.ir_http')
     def test_01_reset_specific_page_view(self):

--- a/addons/test_xlsx_export/tests/test_export.py
+++ b/addons/test_xlsx_export/tests/test_export.py
@@ -18,22 +18,23 @@ class XlsxCreatorCase(common.HttpCase):
         super().__init__(*args, **kwargs)
         self.model = None
 
-    def setUp(self):
-        super().setUp()
-        self.model = self.env[self.model_name]
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.model = cls.env[cls.model_name]
 
-        u = mail_new_test_user(self.env, login='fof', password='123456789', groups='base.group_user,base.group_allow_export')
-        self.authenticate('fof', '123456789')
+        u = mail_new_test_user(cls.env, login='fof', password='123456789', groups='base.group_user,base.group_allow_export')
+        cls.authenticate('fof', '123456789')
 
-        self.worksheet = {}  # mock worksheet
+        cls.worksheet = {}  # mock worksheet
 
-        self.default_params = {
+        cls.default_params = {
             'domain': [],
-            'fields': [{'name': field.name, 'label': field.string} for field in self.model._fields.values()],
+            'fields': [{'name': field.name, 'label': field.string} for field in cls.model._fields.values()],
             'groupby': [],
             'ids': False,
             'import_compat': False,
-            'model': self.model._name,
+            'model': cls.model._name,
         }
 
     def _mock_write(self, row, column, value, style=None):

--- a/addons/test_xlsx_export/tests/test_export.py
+++ b/addons/test_xlsx_export/tests/test_export.py
@@ -18,23 +18,22 @@ class XlsxCreatorCase(common.HttpCase):
         super().__init__(*args, **kwargs)
         self.model = None
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.model = cls.env[cls.model_name]
+    def setUp(self):
+        super().setUp()
+        self.model = self.env[self.model_name]
 
-        u = mail_new_test_user(cls.env, login='fof', password='123456789', groups='base.group_user,base.group_allow_export')
-        cls.authenticate('fof', '123456789')
+        u = mail_new_test_user(self.env, login='fof', password='123456789', groups='base.group_user,base.group_allow_export')
+        self.authenticate('fof', '123456789')
 
-        cls.worksheet = {}  # mock worksheet
+        self.worksheet = {}  # mock worksheet
 
-        cls.default_params = {
+        self.default_params = {
             'domain': [],
-            'fields': [{'name': field.name, 'label': field.string} for field in cls.model._fields.values()],
+            'fields': [{'name': field.name, 'label': field.string} for field in self.model._fields.values()],
             'groupby': [],
             'ids': False,
             'import_compat': False,
-            'model': cls.model._name,
+            'model': self.model._name,
         }
 
     def _mock_write(self, row, column, value, style=None):

--- a/addons/website/tests/test_base_url.py
+++ b/addons/website/tests/test_base_url.py
@@ -7,17 +7,19 @@ import odoo.tests
 
 
 class TestUrlCommon(odoo.tests.HttpCase):
-    def setUp(self):
-        super(TestUrlCommon, self).setUp()
-        self.domain = 'http://' + odoo.tests.HOST
-        self.website = self.env['website'].create({
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.domain = 'http://' + odoo.tests.HOST
+        cls.website = cls.env['website'].create({
             'name': 'test base url',
-            'domain': self.domain,
+            'domain': cls.domain,
         })
 
-        lang_fr = self.env['res.lang']._activate_lang('fr_FR')
-        self.website.language_ids = self.env.ref('base.lang_en') + lang_fr
-        self.website.default_lang_id = self.env.ref('base.lang_en')
+        lang_fr = cls.env['res.lang']._activate_lang('fr_FR')
+        cls.website.language_ids = cls.env.ref('base.lang_en') + lang_fr
+        cls.website.default_lang_id = cls.env.ref('base.lang_en')
 
     def _assertCanonical(self, url, canonical_url):
         res = self.url_open(url)

--- a/addons/website/tests/test_crawl.py
+++ b/addons/website/tests/test_crawl.py
@@ -24,17 +24,18 @@ class Crawler(HttpCaseWithUserDemo):
     starting the crawl
     """
 
-    def setUp(self):
-        super(Crawler, self).setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
-        if hasattr(self.env['res.partner'], 'grade_id'):
+        if hasattr(cls.env['res.partner'], 'grade_id'):
             # Create at least one published parter, so that /partners doesn't
             # return a 404
-            grade = self.env['res.partner.grade'].create({
+            grade = cls.env['res.partner.grade'].create({
                 'name': 'A test grade',
                 'website_published': True,
             })
-            self.env['res.partner'].create({
+            cls.env['res.partner'].create({
                 'name': 'A Company for /partners',
                 'is_company': True,
                 'grade_id': grade.id,

--- a/addons/website/tests/test_lang_url.py
+++ b/addons/website/tests/test_lang_url.py
@@ -8,15 +8,16 @@ from odoo.tests import HttpCase, tagged
 
 @tagged('-at_install', 'post_install')
 class TestLangUrl(HttpCase):
-    def setUp(self):
-        super(TestLangUrl, self).setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
         # Simulate multi lang without loading translations
-        self.website = self.env.ref('website.default_website')
-        self.lang_fr = self.env['res.lang']._activate_lang('fr_FR')
-        self.lang_fr.write({'url_code': 'fr'})
-        self.website.language_ids = self.env.ref('base.lang_en') + self.lang_fr
-        self.website.default_lang_id = self.env.ref('base.lang_en')
+        cls.website = cls.env.ref('website.default_website')
+        cls.lang_fr = cls.env['res.lang']._activate_lang('fr_FR')
+        cls.lang_fr.write({'url_code': 'fr'})
+        cls.website.language_ids = cls.env.ref('base.lang_en') + cls.lang_fr
+        cls.website.default_lang_id = cls.env.ref('base.lang_en')
 
     def test_01_url_lang(self):
         with MockRequest(self.env, website=self.website):

--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -198,10 +198,11 @@ class TestPage(common.TransactionCase):
 
 @tagged('-at_install', 'post_install')
 class WithContext(HttpCase):
-    def setUp(self):
-        super().setUp()
-        Page = self.env['website.page']
-        View = self.env['ir.ui.view']
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        Page = cls.env['website.page']
+        View = cls.env['ir.ui.view']
         base_view = View.create({
             'name': 'Base',
             'type': 'qweb',
@@ -212,7 +213,7 @@ class WithContext(HttpCase):
                     </t>''',
             'key': 'test.base_view',
         })
-        self.page = Page.create({
+        cls.page = Page.create({
             'view_id': base_view.id,
             'url': '/page_1',
             'is_published': True,

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -45,9 +45,10 @@ class TestStandardPerformance(UtilPerf):
 
 class TestWebsitePerformance(UtilPerf):
 
-    def setUp(self):
-        super().setUp()
-        self.page, self.menu = self._create_page_with_menu('/sql_page')
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.page, cls.menu = cls._create_page_with_menu('/sql_page')
 
     def _create_page_with_menu(self, url):
         name = url[1:]

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -50,10 +50,12 @@ class TestWebsitePerformance(UtilPerf):
         super().setUpClass()
         cls.page, cls.menu = cls._create_page_with_menu('/sql_page')
 
-    def _create_page_with_menu(self, url):
+    
+    @classmethod
+    def _create_page_with_menu(cls, url):
         name = url[1:]
-        website = self.env['website'].browse(1)
-        page = self.env['website.page'].create({
+        website = cls.env['website'].browse(1)
+        page = cls.env['website.page'].create({
             'url': url,
             'name': name,
             'type': 'qweb',
@@ -67,7 +69,7 @@ class TestWebsitePerformance(UtilPerf):
             'website_id': website.id,
             'track': False,
         })
-        menu = self.env['website.menu'].create({
+        menu = cls.env['website.menu'].create({
             'name': name,
             'url': url,
             'page_id': page.id,

--- a/addons/website/tests/test_views.py
+++ b/addons/website/tests/test_views.py
@@ -943,21 +943,22 @@ class TestCowViewSaving(common.TransactionCase):
 
 @tagged('-at_install', 'post_install')
 class Crawler(HttpCase):
-    def setUp(self):
-        super(Crawler, self).setUp()
-        View = self.env['ir.ui.view']
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        View = cls.env['ir.ui.view']
 
-        self.base_view = View.create({
+        cls.base_view = View.create({
             'name': 'Base',
             'type': 'qweb',
             'arch': '<div>base content</div>',
             'key': 'website.base_view',
         }).with_context(load_all_views=True)
 
-        self.inherit_view = View.create({
+        cls.inherit_view = View.create({
             'name': 'Extension',
             'mode': 'extension',
-            'inherit_id': self.base_view.id,
+            'inherit_id': cls.base_view.id,
             'arch': '<div position="inside">, extended content</div>',
             'key': 'website.extension_view',
         })

--- a/addons/website/tests/test_website_visitor.py
+++ b/addons/website/tests/test_website_visitor.py
@@ -4,12 +4,13 @@ from datetime import datetime, timedelta
 
 @tests.tagged('-at_install', 'post_install')
 class WebsiteVisitorTests(tests.HttpCase):
-    def setUp(self):
-        super(WebsiteVisitorTests, self).setUp()
-        Page = self.env['website.page']
-        View = self.env['ir.ui.view']
-        self.Visitor = self.env['website.visitor']
-        self.Track = self.env['website.track']
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        Page = cls.env['website.page']
+        View = cls.env['ir.ui.view']
+        cls.Visitor = cls.env['website.visitor']
+        cls.Track = cls.env['website.track']
         untracked_view = View.create({
             'name': 'Base',
             'type': 'qweb',
@@ -32,7 +33,7 @@ class WebsiteVisitorTests(tests.HttpCase):
             'key': 'test.base_view',
             'track': True,
         })
-        [self.untracked_view, self.tracked_view] = Page.create([
+        [cls.untracked_view, cls.tracked_view] = Page.create([
             {
                 'view_id': untracked_view.id,
                 'url': '/untracked_view',

--- a/addons/website_event_sale/tests/test_frontend_buy_tickets.py
+++ b/addons/website_event_sale/tests/test_frontend_buy_tickets.py
@@ -12,45 +12,46 @@ from odoo.fields import Datetime
 @odoo.tests.common.tagged('post_install', '-at_install')
 class TestUi(HttpCaseWithUserDemo):
 
-    def setUp(self):
-        super().setUp()
-        self.event_2 = self.env['event.event'].create({
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.event_2 = cls.env['event.event'].create({
             'name': 'Conference for Architects TEST',
-            'user_id': self.env.ref('base.user_admin').id,
+            'user_id': cls.env.ref('base.user_admin').id,
             'date_begin': (Datetime.today() + timedelta(days=5)).strftime('%Y-%m-%d 07:00:00'),
             'date_end': (Datetime.today() + timedelta(days=5)).strftime('%Y-%m-%d 16:30:00'),
         })
 
-        self.env['event.event.ticket'].create([{
+        cls.env['event.event.ticket'].create([{
             'name': 'Standard',
-            'event_id': self.event_2.id,
-            'product_id': self.env.ref('event_sale.product_product_event').id,
+            'event_id': cls.event_2.id,
+            'product_id': cls.env.ref('event_sale.product_product_event').id,
             'start_sale_date': (Datetime.today() - timedelta(days=5)).strftime('%Y-%m-%d 07:00:00'),
             'end_sale_date': (Datetime.today() + timedelta(90)).strftime('%Y-%m-%d'),
             'price': 1000.0,
         }, {
             'name': 'VIP',
-            'event_id': self.event_2.id,
-            'product_id': self.env.ref('event_sale.product_product_event').id,
+            'event_id': cls.event_2.id,
+            'product_id': cls.env.ref('event_sale.product_product_event').id,
             'end_sale_date': (Datetime.today() + timedelta(90)).strftime('%Y-%m-%d'),
             'price': 1500.0,
         }])
 
         # flush event to ensure having tickets available in the tests
-        self.event_2.flush()
+        cls.event_2.flush()
 
-        (self.env.ref('base.partner_admin') + self.partner_demo).write({
+        (cls.env.ref('base.partner_admin') + cls.partner_demo).write({
             'street': '215 Vine St',
             'city': 'Scranton',
             'zip': '18503',
-            'country_id': self.env.ref('base.us').id,
-            'state_id': self.env.ref('base.state_us_39').id,
+            'country_id': cls.env.ref('base.us').id,
+            'state_id': cls.env.ref('base.state_us_39').id,
             'phone': '+1 555-555-5555',
             'email': 'admin@yourcompany.example.com',
         })
 
-        cash_journal = self.env['account.journal'].create({'name': 'Cash - Test', 'type': 'cash', 'code': 'CASH - Test'})
-        self.env.ref('payment.payment_acquirer_transfer').journal_id = cash_journal
+        cash_journal = cls.env['account.journal'].create({'name': 'Cash - Test', 'type': 'cash', 'code': 'CASH - Test'})
+        cls.env.ref('payment.payment_acquirer_transfer').journal_id = cash_journal
 
     def test_admin(self):
         # Seen that:

--- a/addons/website_livechat/tests/common.py
+++ b/addons/website_livechat/tests/common.py
@@ -4,12 +4,13 @@
 from odoo import fields, tests
 
 
-class TestLivechatCommon(tests.TransactionCase):
-    def setUp(self):
-        super(TestLivechatCommon, self).setUp()
-        self.base_datetime = fields.Datetime.from_string("2019-11-11 21:30:00")
+class TestLivechatCommon(tests.SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.base_datetime = fields.Datetime.from_string("2019-11-11 21:30:00")
 
-        self.operator = self.env['res.users'].create({
+        cls.operator = cls.env['res.users'].create({
             'name': 'Operator Michel',
             'login': 'operator',
             'email': 'operator@example.com',
@@ -17,36 +18,37 @@ class TestLivechatCommon(tests.TransactionCase):
             'livechat_username': 'El Deboulonnator',
         })
 
-        self.livechat_channel = self.env['im_livechat.channel'].create({
+        cls.livechat_channel = cls.env['im_livechat.channel'].create({
             'name': 'The basic channel',
-            'user_ids': [(6, 0, [self.operator.id])]
+            'user_ids': [(6, 0, [cls.operator.id])]
         })
 
-        self.max_sessions_per_operator = 5
+        cls.max_sessions_per_operator = 5
         visitor_vals = {
-            'lang_id': self.env.ref('base.lang_en').id,
-            'country_id': self.env.ref('base.be').id,
-            'website_id': self.env.ref('website.default_website').id,
+            'lang_id': cls.env.ref('base.lang_en').id,
+            'country_id': cls.env.ref('base.be').id,
+            'website_id': cls.env.ref('website.default_website').id,
         }
-        self.visitors = self.env['website.visitor'].create([{
-            'lang_id': self.env.ref('base.lang_en').id,
-            'country_id': self.env.ref('base.de').id,
-            'website_id': self.env.ref('website.default_website').id,
-            'partner_id': self.env.ref('base.user_demo').partner_id.id,
-        }] + [visitor_vals]*self.max_sessions_per_operator)
-        self.visitor_demo, self.visitor = self.visitors[0], self.visitors[1]
+        cls.visitors = cls.env['website.visitor'].create([{
+            'lang_id': cls.env.ref('base.lang_en').id,
+            'country_id': cls.env.ref('base.de').id,
+            'website_id': cls.env.ref('website.default_website').id,
+            'partner_id': cls.env.ref('base.user_demo').partner_id.id,
+        }] + [visitor_vals]*cls.max_sessions_per_operator)
+        cls.visitor_demo, cls.visitor = cls.visitors[0], cls.visitors[1]
 
-        base_url = self.env['ir.config_parameter'].sudo().get_param('web.base.url')
+        base_url = cls.env['ir.config_parameter'].sudo().get_param('web.base.url')
 
-        self.open_chat_url = base_url + "/im_livechat/get_session"
-        self.open_chat_params = {'params': {
-            'channel_id': self.livechat_channel.id,
+        cls.open_chat_url = base_url + "/im_livechat/get_session"
+        cls.open_chat_params = {'params': {
+            'channel_id': cls.livechat_channel.id,
             'anonymous_name': "Wrong Name"
         }}
 
-        self.send_feedback_url = base_url + "/im_livechat/feedback"
-        self.leave_session_url = base_url + "/im_livechat/visitor_leave_session"
+        cls.send_feedback_url = base_url + "/im_livechat/feedback"
+        cls.leave_session_url = base_url + "/im_livechat/visitor_leave_session"
 
+    def setUp(self):
         # override the get_available_users to return only Michel as available
         operators = self.operator
         def get_available_users(self):

--- a/addons/website_livechat/tests/test_ui.py
+++ b/addons/website_livechat/tests/test_ui.py
@@ -7,13 +7,14 @@ from odoo.addons.website_livechat.tests.common import TestLivechatCommon
 
 @tests.tagged('post_install', '-at_install')
 class TestLivechatUI(tests.HttpCase, TestLivechatCommon):
-    def setUp(self):
-        super(TestLivechatUI, self).setUp()
-        self.visitor_tour = self.env['website.visitor'].create({
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.visitor_tour = cls.env['website.visitor'].create({
             'name': 'Visitor Tour',
-            'website_id': self.env.ref('website.default_website').id,
+            'website_id': cls.env.ref('website.default_website').id,
         })
-        self.target_visitor = self.visitor_tour
+        cls.target_visitor = cls.visitor_tour
 
     def test_complete_rating_flow_ui(self):
         self.start_tour("/", 'website_livechat_complete_flow_tour')

--- a/addons/website_mail_channel/tests/test_unsubscribe.py
+++ b/addons/website_mail_channel/tests/test_unsubscribe.py
@@ -6,17 +6,18 @@ from odoo.tools.misc import mute_logger, ustr
 
 @tagged('-at_install', 'post_install')
 class TestConfirmUnsubscribe(common.HttpCase):
-    def setUp(self):
-        super(TestConfirmUnsubscribe, self).setUp()
-        self.partner = self.env['res.partner'].create({
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env['res.partner'].create({
             'name': 'Bob',
             'email': 'bob@bob.bob'
         })
-        self.mailing_list = self.env['mail.channel'].create({
+        cls.mailing_list = cls.env['mail.channel'].create({
             'name': 'Test Mailing List',
             'public': 'public',
         })
-        self.token = self.mailing_list._generate_action_token(self.partner.id, action='unsubscribe')
+        cls.token = cls.mailing_list._generate_action_token(cls.partner.id, action='unsubscribe')
 
     def test_not_subscribed(self):
         """Test warning works"""

--- a/addons/website_sale/tests/test_customize.py
+++ b/addons/website_sale/tests/test_customize.py
@@ -9,42 +9,43 @@ from odoo.tests import tagged
 @tagged('post_install', '-at_install')
 class TestUi(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
 
-    def setUp(self):
-        super(TestUi, self).setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
         # create a template
-        product_template = self.env['product.template'].create({
+        product_template = cls.env['product.template'].create({
             'name': 'Test Product',
             'is_published': True,
             'list_price': 750,
         })
 
-        tax = self.env['account.tax'].create({'name': "Test tax", 'amount': 10})
+        tax = cls.env['account.tax'].create({'name': "Test tax", 'amount': 10})
         product_template.taxes_id = tax
 
-        product_attribute = self.env['product.attribute'].create({
+        product_attribute = cls.env['product.attribute'].create({
             'name': 'Legs',
             'sequence': 10,
         })
-        product_attribute_value_1 = self.env['product.attribute.value'].create({
+        product_attribute_value_1 = cls.env['product.attribute.value'].create({
             'name': 'Steel - Test',
             'attribute_id': product_attribute.id,
             'sequence': 1,
         })
-        product_attribute_value_2 = self.env['product.attribute.value'].create({
+        product_attribute_value_2 = cls.env['product.attribute.value'].create({
             'name': 'Aluminium',
             'attribute_id': product_attribute.id,
             'sequence': 2,
         })
 
         # set attribute and attribute values on the template
-        self.env['product.template.attribute.line'].create([{
+        cls.env['product.template.attribute.line'].create([{
             'attribute_id': product_attribute.id,
             'product_tmpl_id': product_template.id,
             'value_ids': [(6, 0, [product_attribute_value_1.id, product_attribute_value_2.id])]
         }])
 
         # set a different price on the variants to differentiate them
-        product_template_attribute_values = self.env['product.template.attribute.value'] \
+        product_template_attribute_values = cls.env['product.template.attribute.value'] \
             .search([('product_tmpl_id', '=', product_template.id)])
 
         for ptav in product_template_attribute_values:

--- a/addons/website_sale/tests/test_sale_process.py
+++ b/addons/website_sale/tests/test_sale_process.py
@@ -12,55 +12,56 @@ from odoo.addons.website.tools import MockRequest
 @odoo.tests.tagged('post_install', '-at_install')
 class TestUi(HttpCaseWithUserDemo):
 
-    def setUp(self):
-        super(TestUi, self).setUp()
-        product_product_7 = self.env['product.product'].create({
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        product_product_7 = cls.env['product.product'].create({
             'name': 'Storage Box',
             'standard_price': 70.0,
             'list_price': 79.0,
             'website_published': True,
         })
-        self.product_attribute_1 = self.env['product.attribute'].create({
+        cls.product_attribute_1 = cls.env['product.attribute'].create({
             'name': 'Legs',
             'sequence': 10,
         })
-        product_attribute_value_1 = self.env['product.attribute.value'].create({
+        product_attribute_value_1 = cls.env['product.attribute.value'].create({
             'name': 'Steel',
-            'attribute_id': self.product_attribute_1.id,
+            'attribute_id': cls.product_attribute_1.id,
             'sequence': 1,
         })
-        product_attribute_value_2 = self.env['product.attribute.value'].create({
+        product_attribute_value_2 = cls.env['product.attribute.value'].create({
             'name': 'Aluminium',
-            'attribute_id': self.product_attribute_1.id,
+            'attribute_id': cls.product_attribute_1.id,
             'sequence': 2,
         })
-        self.product_product_11_product_template = self.env['product.template'].create({
+        cls.product_product_11_product_template = cls.env['product.template'].create({
             'name': 'Conference Chair (CONFIG)',
             'list_price': 16.50,
             'accessory_product_ids': [(4, product_product_7.id)],
         })
-        self.env['product.template.attribute.line'].create({
-            'product_tmpl_id': self.product_product_11_product_template.id,
-            'attribute_id': self.product_attribute_1.id,
+        cls.env['product.template.attribute.line'].create({
+            'product_tmpl_id': cls.product_product_11_product_template.id,
+            'attribute_id': cls.product_attribute_1.id,
             'value_ids': [(4, product_attribute_value_1.id), (4, product_attribute_value_2.id)],
         })
 
-        self.product_product_1_product_template = self.env['product.template'].create({
+        cls.product_product_1_product_template = cls.env['product.template'].create({
             'name': 'Chair floor protection',
             'list_price': 12.0,
         })
-        self.product_product_11_product_template.optional_product_ids = [(6, 0, [self.product_product_1_product_template.id])]
+        cls.product_product_11_product_template.optional_product_ids = [(6, 0, [cls.product_product_1_product_template.id])]
 
-        cash_journal = self.env['account.journal'].create({'name': 'Cash - Test', 'type': 'cash', 'code': 'CASH - Test'})
-        self.env.ref('payment.payment_acquirer_transfer').journal_id = cash_journal
+        cash_journal = cls.env['account.journal'].create({'name': 'Cash - Test', 'type': 'cash', 'code': 'CASH - Test'})
+        cls.env.ref('payment.payment_acquirer_transfer').journal_id = cash_journal
 
         # Avoid Shipping/Billing address page
-        (self.env.ref('base.partner_admin') + self.partner_demo).write({
+        (cls.env.ref('base.partner_admin') + cls.partner_demo).write({
             'street': '215 Vine St',
             'city': 'Scranton',
             'zip': '18503',
-            'country_id': self.env.ref('base.us').id,
-            'state_id': self.env.ref('base.state_us_39').id,
+            'country_id': cls.env.ref('base.us').id,
+            'state_id': cls.env.ref('base.state_us_39').id,
             'phone': '+1 555-555-5555',
             'email': 'admin@yourcompany.example.com',
         })

--- a/addons/website_sale/tests/test_sitemap.py
+++ b/addons/website_sale/tests/test_sitemap.py
@@ -6,18 +6,19 @@ from odoo.tests import HttpCase, tagged
 @tagged('post_install', '-at_install')
 class TestSitemap(HttpCase):
 
-    def setUp(self):
-        super(TestSitemap, self).setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
-        self.cats = self.env['product.public.category'].create([{
+        cls.cats = cls.env['product.public.category'].create([{
             'name': 'Level 0',
         }, {
             'name': 'Level 1',
         }, {
             'name': 'Level 2',
         }])
-        self.cats[2].parent_id = self.cats[1].id
-        self.cats[1].parent_id = self.cats[0].id
+        cls.cats[2].parent_id = cls.cats[1].id
+        cls.cats[1].parent_id = cls.cats[0].id
 
     def test_01_shop_route_sitemap(self):
         resp = self.url_open('/sitemap.xml')

--- a/addons/website_sale_comparison/tests/test_website_sale_comparison.py
+++ b/addons/website_sale_comparison/tests/test_website_sale_comparison.py
@@ -69,45 +69,46 @@ class TestWebsiteSaleComparison(odoo.tests.TransactionCase):
 @odoo.tests.tagged('post_install', '-at_install')
 class TestUi(odoo.tests.HttpCase):
 
-    def setUp(self):
-        super(TestUi, self).setUp()
-        self.template_margaux = self.env['product.template'].create({
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.template_margaux = cls.env['product.template'].create({
             'name': "Château Margaux",
             'website_published': True,
             'list_price': 0,
         })
-        self.attribute_varieties = self.env['product.attribute'].create({
+        cls.attribute_varieties = cls.env['product.attribute'].create({
             'name': 'Grape Varieties',
             'sequence': 2,
         })
-        self.attribute_vintage = self.env['product.attribute'].create({
+        cls.attribute_vintage = cls.env['product.attribute'].create({
             'name': 'Vintage',
             'sequence': 1,
         })
-        self.values_varieties = self.env['product.attribute.value'].create({
+        cls.values_varieties = cls.env['product.attribute.value'].create({
             'name': n,
-            'attribute_id': self.attribute_varieties.id,
+            'attribute_id': cls.attribute_varieties.id,
             'sequence': i,
         } for i, n in enumerate(['Cabernet Sauvignon', 'Merlot', 'Cabernet Franc', 'Petit Verdot']))
-        self.values_vintage = self.env['product.attribute.value'].create({
+        cls.values_vintage = cls.env['product.attribute.value'].create({
             'name': n,
-            'attribute_id': self.attribute_vintage.id,
+            'attribute_id': cls.attribute_vintage.id,
             'sequence': i,
         } for i, n in enumerate(['2018', '2017', '2016', '2015']))
-        self.attribute_line_varieties = self.env['product.template.attribute.line'].create([{
-            'product_tmpl_id': self.template_margaux.id,
-            'attribute_id': self.attribute_varieties.id,
+        cls.attribute_line_varieties = cls.env['product.template.attribute.line'].create([{
+            'product_tmpl_id': cls.template_margaux.id,
+            'attribute_id': cls.attribute_varieties.id,
             'value_ids': [(6, 0, v.ids)],
-        } for v in self.values_varieties])
-        self.attribute_line_vintage = self.env['product.template.attribute.line'].create({
-            'product_tmpl_id': self.template_margaux.id,
-            'attribute_id': self.attribute_vintage.id,
-            'value_ids': [(6, 0, self.values_vintage.ids)],
+        } for v in cls.values_varieties])
+        cls.attribute_line_vintage = cls.env['product.template.attribute.line'].create({
+            'product_tmpl_id': cls.template_margaux.id,
+            'attribute_id': cls.attribute_vintage.id,
+            'value_ids': [(6, 0, cls.values_vintage.ids)],
         })
-        self.variants_margaux = self.template_margaux._get_possible_variants_sorted()
+        cls.variants_margaux = cls.template_margaux._get_possible_variants_sorted()
 
-        for variant, price in zip(self.variants_margaux, [487.32, 394.05, 532.44, 1047.84]):
-            variant.product_template_attribute_value_ids.filtered(lambda ptav: ptav.attribute_id == self.attribute_vintage).price_extra = price
+        for variant, price in zip(cls.variants_margaux, [487.32, 394.05, 532.44, 1047.84]):
+            variant.product_template_attribute_value_ids.filtered(lambda ptav: ptav.attribute_id == cls.attribute_vintage).price_extra = price
 
     def test_01_admin_tour_product_comparison(self):
         # YTI FIXME: Adapt to work without demo data

--- a/addons/website_slides/tests/test_ui_wslides.py
+++ b/addons/website_slides/tests/test_ui_wslides.py
@@ -11,17 +11,18 @@ from odoo.addons.base.tests.common import HttpCaseWithUserDemo, HttpCaseWithUser
 
 class TestUICommon(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
     
-    def setUp(self):
-        super(TestUICommon, self).setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
         # Load pdf and img contents
         pdf_path = get_module_resource('website_slides', 'static', 'src', 'img', 'presentation.pdf')
         pdf_content = base64.b64encode(open(pdf_path, "rb").read())
         img_path = get_module_resource('website_slides', 'static', 'src', 'img', 'slide_demo_gardening_1.jpg')
         img_content = base64.b64encode(open(img_path, "rb").read())
 
-        self.env['slide.channel'].create({
+        cls.env['slide.channel'].create({
             'name': 'Basics of Gardening - Test',
-            'user_id': self.env.ref('base.user_admin').id,
+            'user_id': cls.env.ref('base.user_admin').id,
             'enroll': 'public',
             'channel_type': 'training',
             'allow_comment': True,

--- a/odoo/addons/base/tests/common.py
+++ b/odoo/addons/base/tests/common.py
@@ -30,23 +30,24 @@ class TransactionCaseWithUserDemo(TransactionCase):
 
 class HttpCaseWithUserDemo(HttpCase):
 
-    def setUp(self):
-        super(HttpCaseWithUserDemo, self).setUp()
-        self.env.ref('base.partner_admin').write({'name': 'Mitchell Admin'})
-        self.user_demo = self.env['res.users'].search([('login', '=', 'demo')])
-        self.partner_demo = self.user_demo.partner_id
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.ref('base.partner_admin').write({'name': 'Mitchell Admin'})
+        cls.user_demo = cls.env['res.users'].search([('login', '=', 'demo')])
+        cls.partner_demo = cls.user_demo.partner_id
 
-        if not self.user_demo:
-            self.env['ir.config_parameter'].sudo().set_param('auth_password_policy.minlength', 4)
-            self.partner_demo = self.env['res.partner'].create({
+        if not cls.user_demo:
+            cls.env['ir.config_parameter'].sudo().set_param('auth_password_policy.minlength', 4)
+            cls.partner_demo = cls.env['res.partner'].create({
                 'name': 'Marc Demo',
                 'email': 'mark.brown23@example.com',
             })
-            self.user_demo = self.env['res.users'].create({
+            cls.user_demo = cls.env['res.users'].create({
                 'login': 'demo',
                 'password': 'demo',
-                'partner_id': self.partner_demo.id,
-                'groups_id': [(6, 0, [self.env.ref('base.group_user').id, self.env.ref('base.group_partner_manager').id])],
+                'partner_id': cls.partner_demo.id,
+                'groups_id': [(6, 0, [cls.env.ref('base.group_user').id, cls.env.ref('base.group_partner_manager').id])],
             })
 
 
@@ -177,20 +178,21 @@ class SavepointCaseWithUserDemo(SavepointCase):
 
 class HttpCaseWithUserPortal(HttpCase):
 
-    def setUp(self):
-        super(HttpCaseWithUserPortal, self).setUp()
-        self.user_portal = self.env['res.users'].search([('login', '=', 'portal')])
-        self.partner_portal = self.user_portal.partner_id
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user_portal = cls.env['res.users'].search([('login', '=', 'portal')])
+        cls.partner_portal = cls.user_portal.partner_id
 
-        if not self.user_portal:
-            self.env['ir.config_parameter'].sudo().set_param('auth_password_policy.minlength', 4)
-            self.partner_portal = self.env['res.partner'].create({
+        if not cls.user_portal:
+            cls.env['ir.config_parameter'].sudo().set_param('auth_password_policy.minlength', 4)
+            cls.partner_portal = cls.env['res.partner'].create({
                 'name': 'Joel Willis',
                 'email': 'joel.willis63@example.com',
             })
-            self.user_portal = self.env['res.users'].with_context(no_reset_password=True).create({
+            cls.user_portal = cls.env['res.users'].with_context(no_reset_password=True).create({
                 'login': 'portal',
                 'password': 'portal',
-                'partner_id': self.partner_portal.id,
-                'groups_id': [(6, 0, [self.env.ref('base.group_portal').id])],
+                'partner_id': cls.partner_portal.id,
+                'groups_id': [(6, 0, [cls.env.ref('base.group_portal').id])],
             })

--- a/odoo/addons/base/tests/test_xmlrpc.py
+++ b/odoo/addons/base/tests/test_xmlrpc.py
@@ -8,9 +8,10 @@ from odoo.tests import common
 @common.tagged('post_install', '-at_install')
 class TestXMLRPC(common.HttpCase):
 
-    def setUp(self):
-        super(TestXMLRPC, self).setUp()
-        self.admin_uid = self.env.ref('base.user_admin').id
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.admin_uid = cls.env.ref('base.user_admin').id
 
     def test_01_xmlrpc_login(self):
         """ Try to login on the common service. """

--- a/odoo/addons/test_access_rights/tests/test_check_access.py
+++ b/odoo/addons/test_access_rights/tests/test_check_access.py
@@ -5,21 +5,22 @@ import odoo.tests
 
 @odoo.tests.tagged('-at_install', 'post_install')
 class TestAccess(odoo.tests.HttpCase):
-    def setUp(self):
-        super(TestAccess, self).setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
-        self.portal_user = self.env['res.users'].create({
+        cls.portal_user = cls.env['res.users'].create({
             'login': 'P',
             'name': 'P',
-            'groups_id': [(6, 0, [self.env.ref('base.group_portal').id])],
+            'groups_id': [(6, 0, [cls.env.ref('base.group_portal').id])],
         })
         # a partner that can't be read by the portal user, would typically be a user's
-        self.internal_user_partner = self.env['res.partner'].create({'name': 'I'})
+        cls.internal_user_partner = cls.env['res.partner'].create({'name': 'I'})
 
-        self.document = self.env['test_access_right.ticket'].create({
+        cls.document = cls.env['test_access_right.ticket'].create({
             'name': 'Need help here',
-            'message_partner_ids': [(6, 0, [self.portal_user.partner_id.id,
-                                            self.internal_user_partner.id])],
+            'message_partner_ids': [(6, 0, [cls.portal_user.partner_id.id,
+                                            cls.internal_user_partner.id])],
         })
 
     def test_check_access(self):

--- a/odoo/addons/test_rpc/tests/test_error.py
+++ b/odoo/addons/test_rpc/tests/test_error.py
@@ -11,7 +11,7 @@ class TestError(common.HttpCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        uid = cls.ref("base.user_admin")
+        uid = cls.env.ref("base.user_admin").id
         cls.rpc = partial(cls.xmlrpc_object.execute, common.get_db_name(), uid, "admin")
 
         # Reset the admin's lang to avoid breaking tests due to admin not in English

--- a/odoo/addons/test_rpc/tests/test_error.py
+++ b/odoo/addons/test_rpc/tests/test_error.py
@@ -8,13 +8,14 @@ from odoo.tools.misc import mute_logger
 
 @tagged('-at_install', 'post_install')
 class TestError(common.HttpCase):
-    def setUp(self):
-        super(TestError, self).setUp()
-        uid = self.ref("base.user_admin")
-        self.rpc = partial(self.xmlrpc_object.execute, common.get_db_name(), uid, "admin")
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        uid = cls.ref("base.user_admin")
+        cls.rpc = partial(cls.xmlrpc_object.execute, common.get_db_name(), uid, "admin")
 
         # Reset the admin's lang to avoid breaking tests due to admin not in English
-        self.rpc("res.users", "write", [uid], {"lang": False})
+        cls.rpc("res.users", "write", [uid], {"lang": False})
 
     def test_01_create(self):
         """ Create: mandatory field not provided """

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -314,6 +314,16 @@ class BaseCase(TreeCase, MetaCase('DummyCase', (object,), {})):
     def cursor(self):
         return self.registry.cursor()
 
+    def patch(self, obj, key, val):
+        """ Do the patch ``setattr(obj, key, val)``, and prepare cleanup. """
+        old = getattr(obj, key)
+        setattr(obj, key, val)
+        self.addCleanup(setattr, obj, key, old)
+
+    def patch_order(self, model, order):
+        """ Patch the order of the given model (name), and prepare cleanup. """
+        self.patch(type(self.env[model]), '_order', order)
+
     @property
     def uid(self):
         """ Get the current uid. """
@@ -595,16 +605,6 @@ class TransactionCase(BaseCase):
         self.addCleanup(self.env.reset)
 
         self.patch(type(self.env['res.partner']), '_get_gravatar_image', lambda *a: False)
-
-    def patch(self, obj, key, val):
-        """ Do the patch ``setattr(obj, key, val)``, and prepare cleanup. """
-        old = getattr(obj, key)
-        setattr(obj, key, val)
-        self.addCleanup(setattr, obj, key, old)
-
-    def patch_order(self, model, order):
-        """ Patch the order of the given model (name), and prepare cleanup. """
-        self.patch(type(self.env[model]), '_order', order)
 
 
 class SingleTransactionCase(BaseCase):


### PR DESCRIPTION
The HttpCase can sometimes require a heavy setup (e.g. accounting tours,
barcode tests); since SavepointCase provides an more efficient way to do
so, it makes sense to use it as the baseclass of the HttpCase: you have
the opportunity to make your setup for the whole class *and* for single
tests, while using TransactionCase forces you to do the setup for each
test, which can be time consuming.

In short: provide a way to have a single test setup whilst keeping the
possibility to do it one test at a time should you wish it.