### PR TITLE
[IMP] Raise an error when there is a user-defined default value in JS…

### DIFF
--- a/odoo/addons/base/models/ir_default.py
+++ b/odoo/addons/base/models/ir_default.py
@@ -148,7 +148,10 @@ class IrDefault(models.Model):
         for row in cr.fetchall():
             # keep the highest priority default for each field
             if row[0] not in result:
-                result[row[0]] = json.loads(row[1])
+                if len(row[1]) > 0 and (row[1][0] != "\"" or row[1][-1] != "\""):
+                    raise ValidationError(_("There is a misconfigured user-defined default value for : " + row[0] + ". Please, make sure the value is surrounded by double quote like this exemple : \"value\". "))
+                else:
+                    result[row[0]] = json.loads(row[1])
         return result
 
     @api.model


### PR DESCRIPTION
…ON that is not surrounded by " "

Avoid a JSON traceback error and show which user-defined default value isn't surrounded by double quotes. 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
