### PR TITLE
production lot default order by name

### DIFF
--- a/addons/stock/models/stock_production_lot.py
+++ b/addons/stock/models/stock_production_lot.py
@@ -11,7 +11,8 @@ class ProductionLot(models.Model):
     _inherit = ['mail.thread','mail.activity.mixin']
     _description = 'Lot/Serial'
     _check_company_auto = True
-
+    _order = 'name'
+    
     name = fields.Char(
         'Lot/Serial Number', default=lambda self: self.env['ir.sequence'].next_by_code('stock.lot.serial'),
         required=True, help="Unique Lot/Serial Number")


### PR DESCRIPTION
Description of the issue/feature this PR addresses: 
production lot order by id

Current behavior before PR:
production lot order by id

Desired behavior after PR is merged:
production lot order by name



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
