### PR TITLE
[IMP] base: Allow filtering l10n fields depending the multi-company s…

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1290,7 +1290,7 @@ actual arch.
                 for group in expr.replace('!', '').split(','):
                     # further improvement: add all groups to name_manager in
                     # order to batch check them at the end
-                    if not self.env['ir.model.data'].xmlid_to_res_id(group.strip(), raise_if_not_found=False):
+                    if not re.match('base\.l10n_[a-z]{2}$', group) and not self.env['ir.model.data'].xmlid_to_res_id(group.strip(), raise_if_not_found=False):
                         msg = _("The group %r defined in view does not exist!") % group
                         self.handle_view_error(msg, raise_exception=False)
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1296,6 +1296,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         """
         from odoo.http import request
         user = self.env.user
+        company_country_codes = self.env.companies.country_id.mapped('code')
 
         has_groups = []
         not_has_groups = []
@@ -1307,7 +1308,9 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                 has_groups.append(group_ext_id)
 
         for group_ext_id in not_has_groups:
-            if group_ext_id == 'base.group_no_one':
+            if re.match('base\.l10n_[a-z]{2}$', group_ext_id) and group_ext_id[-2:].upper() in company_country_codes:
+                return False
+            elif group_ext_id == 'base.group_no_one':
                 # check: the group_no_one is effective in debug mode only
                 if user.has_group(group_ext_id) and request and request.session.debug:
                     return False
@@ -1316,7 +1319,9 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                     return False
 
         for group_ext_id in has_groups:
-            if group_ext_id == 'base.group_no_one':
+            if re.match('base\.l10n_[a-z]{2}$', group_ext_id) and group_ext_id[-2:].upper() in company_country_codes:
+                return True
+            elif group_ext_id == 'base.group_no_one':
                 # check: the group_no_one is effective in debug mode only
                 if user.has_group(group_ext_id) and request and request.session.debug:
                     return True


### PR DESCRIPTION
…etup

Localisation modules bring a lot a specific fields in many views. Otherwise,
when working in a multi-companies environment, we don't expect to see such
fields depending the selected companies in the multi-companies switcher.

For example, suppose the module l10n_mx_edi is installed adding custom fields on
the product.template form view. If no Mexican company is selected, I could hide
these additional fields by additing groups="base.l10n_mx" in the view.

/!\ This solution doesn't work for menu items.

--task: 2247368

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
