### PR TITLE
[IMP] website_event_track: Improve the speaker display

### DIFF
--- a/addons/website_event_track/views/event_track_templates.xml
+++ b/addons/website_event_track/views/event_track_templates.xml
@@ -219,18 +219,13 @@
                     <div class="col-lg-8">
                         <div t-field="track.description"/>
                         <h3>About The Speaker</h3>
-                        <div t-field="track.partner_biography"/>
-                        <div t-if="track.partner_id" class="row mt32">
+                        <div class="row mt32">
                             <div class="col-md-2">
                                 <span t-if="track.image" t-field="track.image" t-options="{'widget': 'image', 'class': 'rounded-circle'}"/>
-                                <span t-else="" t-field="track.partner_id.sudo().image_128" t-options='{"widget": "image", "class": "rounded-circle"}'/>
                             </div>
                             <div class="col-md-10">
-                                <h4 t-field="track.partner_id.name" class="mb4"/>
-                                <div class="mb16" t-if="track.partner_id.website">
-                                    <i class="fa fa-home mr-2"/><a t-att-href="track.partner_id.website"><span t-field="track.partner_id.website"/></a>
-                                </div>
-                                <div t-field="track.partner_id.website_description"/>
+                                <h4 t-field="track.partner_name" class="mb16"/>
+                                <div t-field="track.partner_biography"/>
                             </div>
                         </div>
                     </div>

--- a/addons/website_event_track/views/event_track_views.xml
+++ b/addons/website_event_track/views/event_track_views.xml
@@ -150,7 +150,9 @@
                         <notebook>
                             <page string="Speakers" name="speakers">
                                 <group>
-                                    <field name="partner_id" domain="['|', ('company_id', '=', company_id), ('company_id', '=', False)]"/>
+                                    <field name="partner_id"
+                                        domain="['|', ('company_id', '=', company_id), ('company_id', '=', False)]"
+                                        context="{'default_phone': partner_phone, 'default_email': partner_email}"/>
                                     <field name="partner_name"/>
                                     <field name="partner_email"/>
                                     <field name="partner_phone" class="o_force_ltr"/>


### PR DESCRIPTION
Purpose

Improve the way tracks are handled without a partner.
Mainly an internal request for the OXP.

Specifications 

1) Auto-completion
When a new partner is selected:
    Set the image set on the partner on the track, except if there is already one 
    If there is no text (I know it's tricky since it is an html field), set what is in the partner_id.website_description as a partner_biography

2) Image
Never display the picture set on the partner. (thanks to 1, it will be stored on the track instead).

3) Track web page
It should not be necessary to set a partner on a track to get a complete page (remove the website url)

LINKS
PR: #52251
Task-Id: 2267689