### PR TITLE
assert tour query count pka

### DIFF
--- a/addons/account/tests/test_account_onboarding.py
+++ b/addons/account/tests/test_account_onboarding.py
@@ -21,4 +21,6 @@ class TestAccountDocumentLayout(HttpCase):
             self.env.ref('account.account_invoices_without_payment').write({
                 'report_type': 'qweb-html',
             })
-            self.start_tour("/web", 'account_render_report', login='admin', timeout=200)
+            # runbot needs +1071 compared to local
+            with self.assertQueryCount(__system__=3647):
+                self.start_tour("/web", 'account_render_report', login='admin', timeout=200)

--- a/addons/account/tests/test_account_onboarding.py
+++ b/addons/account/tests/test_account_onboarding.py
@@ -22,5 +22,5 @@ class TestAccountDocumentLayout(HttpCase):
                 'report_type': 'qweb-html',
             })
             # runbot needs +1071 compared to local
-            with self.assertQueryCount(__system__=3647):
+            with self.assertQueryCount(__system__=3659):
                 self.start_tour("/web", 'account_render_report', login='admin', timeout=200)

--- a/addons/account/tests/test_account_onboarding.py
+++ b/addons/account/tests/test_account_onboarding.py
@@ -22,5 +22,5 @@ class TestAccountDocumentLayout(HttpCase):
                 'report_type': 'qweb-html',
             })
             # runbot needs +1071 compared to local
-            with self.assertQueryCount(__system__=3659):
+            with self.assertQueryCount(__system__=3660):
                 self.start_tour("/web", 'account_render_report', login='admin', timeout=200)

--- a/addons/crm/tests/test_crm_ui.py
+++ b/addons/crm/tests/test_crm_ui.py
@@ -7,5 +7,5 @@ import odoo.tests
 class TestUi(odoo.tests.HttpCase):
 
     def test_01_crm_tour(self):
-        with self.assertQueryCount(__system__=4879):
+        with self.assertQueryCount(__system__=4893):
             self.start_tour("/web", 'crm_tour', login="admin")

--- a/addons/crm/tests/test_crm_ui.py
+++ b/addons/crm/tests/test_crm_ui.py
@@ -7,4 +7,5 @@ import odoo.tests
 class TestUi(odoo.tests.HttpCase):
 
     def test_01_crm_tour(self):
-        self.start_tour("/web", 'crm_tour', login="admin")
+        with self.assertQueryCount(__system__=4879):
+            self.start_tour("/web", 'crm_tour', login="admin")

--- a/addons/event_sale/tests/test_event_sale_ui.py
+++ b/addons/event_sale/tests/test_event_sale_ui.py
@@ -26,4 +26,6 @@ class TestUi(HttpCase):
             'event_id': event.id,
             'product_id': self.env.ref('event_sale.product_product_event').id,
         }])
-        self.start_tour("/web", 'event_configurator_tour', login="admin")
+        # runbot needs +1198 compared to local
+        with self.assertQueryCount(__system__=3448):
+            self.start_tour("/web", 'event_configurator_tour', login="admin")

--- a/addons/event_sale/tests/test_event_sale_ui.py
+++ b/addons/event_sale/tests/test_event_sale_ui.py
@@ -27,5 +27,5 @@ class TestUi(HttpCase):
             'product_id': self.env.ref('event_sale.product_product_event').id,
         }])
         # runbot needs +1198 compared to local
-        with self.assertQueryCount(__system__=3448):
+        with self.assertQueryCount(__system__=3463):
             self.start_tour("/web", 'event_configurator_tour', login="admin")

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -415,12 +415,18 @@ class TestUi(TestPointOfSaleHttpCommon):
         # this you end up with js, css but no qweb.
         self.env['ir.module.module'].search([('name', '=', 'point_of_sale')], limit=1).state = 'installed'
 
-        self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, 'pos_pricelist', login="admin", step_delay=50)
-        self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, 'pos_basic_order', login="admin", step_delay=50)
-        self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, 'ProductScreenTour', login="admin", step_delay=50)
-        self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, 'PaymentScreenTour', login="admin", step_delay=50)
-        self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, 'ReceiptScreenTour', login="admin", step_delay=50)
-        self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, 'ChromeTour', login="admin", step_delay=50)
+        with self.assertQueryCount(__system__=3031):
+            self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, 'pos_pricelist', login="admin", step_delay=50)
+        with self.assertQueryCount(__system__=1247):
+            self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, 'pos_basic_order', login="admin", step_delay=50)
+        with self.assertQueryCount(__system__=1126):
+            self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, 'ProductScreenTour', login="admin", step_delay=50)
+        with self.assertQueryCount(__system__=1238):
+            self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, 'PaymentScreenTour', login="admin", step_delay=50)
+        with self.assertQueryCount(__system__=1310):
+            self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, 'ReceiptScreenTour', login="admin", step_delay=50)
+        with self.assertQueryCount(__system__=1303):
+            self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, 'ChromeTour', login="admin", step_delay=50)
 
         for order in self.env['pos.order'].search([]):
             self.assertEqual(order.state, 'paid', "Validated order has payment of " + str(order.amount_paid) + " and total of " + str(order.amount_total))

--- a/addons/point_of_sale/tests/test_point_of_sale_ui.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_ui.py
@@ -8,9 +8,10 @@ from odoo import tools
 @tagged('post_install', '-at_install')
 class TestUi(HttpCase):
 
-	# Avoid "A Chart of Accounts is not yet installed in your current company."
-	# Everything is set up correctly even without installed CoA
+    # Avoid "A Chart of Accounts is not yet installed in your current company."
+    # Everything is set up correctly even without installed CoA
     @tools.mute_logger('odoo.http')
     def test_01_point_of_sale_tour(self):
 
-        self.start_tour("/web", 'point_of_sale_tour', login="admin")
+        with self.assertQueryCount(__system__=2385):
+            self.start_tour("/web", 'point_of_sale_tour', login="admin")

--- a/addons/point_of_sale/tests/test_point_of_sale_ui.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_ui.py
@@ -13,5 +13,5 @@ class TestUi(HttpCase):
     @tools.mute_logger('odoo.http')
     def test_01_point_of_sale_tour(self):
 
-        with self.assertQueryCount(__system__=2385):
+        with self.assertQueryCount(__system__=2400):
             self.start_tour("/web", 'point_of_sale_tour', login="admin")

--- a/addons/portal/tests/test_load_process.py
+++ b/addons/portal/tests/test_load_process.py
@@ -8,4 +8,5 @@ from odoo.tests import tagged
 @tagged('post_install', '-at_install')
 class TestUi(HttpCaseWithUserPortal):
     def test_01_portal_load_tour(self):
-        self.start_tour("/", 'portal_load_homepage', login="portal")
+        with self.assertQueryCount(__system__=794):
+            self.start_tour("/", 'portal_load_homepage', login="portal")

--- a/addons/pos_hr/tests/test_frontend.py
+++ b/addons/pos_hr/tests/test_frontend.py
@@ -45,10 +45,10 @@ class TestUi(TestPosHrHttpCommon):
     def test_01_pos_hr_tour(self):
         # open a session, the /pos/web controller will redirect to it
         self.main_pos_config.open_session_cb(check_coa=False)
-
-        self.start_tour(
-            "/pos/web?config_id=%d" % self.main_pos_config.id,
-            "PosHrTour",
-            login="admin",
-            step_delay=50,
-        )
+        with self.assertQueryCount(__system__=2649):
+            self.start_tour(
+                "/pos/web?config_id=%d" % self.main_pos_config.id,
+                "PosHrTour",
+                login="admin",
+                step_delay=50,
+            )

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -174,5 +174,5 @@ class TestFrontend(odoo.tests.HttpCase):
             self.start_tour("/pos/web?config_id=%d" % self.pos_config.id, 'SplitBillScreenTour', login="admin", step_delay=50)
         with self.assertQueryCount(admin=2210):
             self.start_tour("/pos/web?config_id=%d" % self.pos_config.id, 'ControlButtonsTour', login="admin", step_delay=50)
-        with self.assertQueryCount(admin=2053):
+        with self.assertQueryCount(admin=2060):
             self.start_tour("/pos/web?config_id=%d" % self.pos_config.id, 'FloorScreenTour', login="admin", step_delay=50)

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -155,12 +155,14 @@ class TestFrontend(odoo.tests.HttpCase):
 
         self.pos_config.with_user(self.env.ref('base.user_admin')).open_session_cb(check_coa=False)
 
-        self.start_tour("/pos/web?config_id=%d" % self.pos_config.id, 'pos_restaurant_sync', login="admin", step_delay=50)
+        with self.assertQueryCount(admin=3700):
+            self.start_tour("/pos/web?config_id=%d" % self.pos_config.id, 'pos_restaurant_sync', login="admin", step_delay=50)
 
         self.assertEqual(1, self.env['pos.order'].search_count([('amount_total', '=', 4.4), ('state', '=', 'draft')]))
         self.assertEqual(1, self.env['pos.order'].search_count([('amount_total', '=', 4.4), ('state', '=', 'paid')]))
 
-        self.start_tour("/pos/web?config_id=%d" % self.pos_config.id, 'pos_restaurant_sync_second_login', login="admin", step_delay=50)
+        with self.assertQueryCount(admin=2386):
+            self.start_tour("/pos/web?config_id=%d" % self.pos_config.id, 'pos_restaurant_sync_second_login', login="admin", step_delay=50)
 
         self.assertEqual(0, self.env['pos.order'].search_count([('amount_total', '=', 4.4), ('state', '=', 'draft')]))
         self.assertEqual(1, self.env['pos.order'].search_count([('amount_total', '=', 2.2), ('state', '=', 'draft')]))
@@ -168,6 +170,9 @@ class TestFrontend(odoo.tests.HttpCase):
 
     def test_02_others(self):
         self.pos_config.with_user(self.env.ref('base.user_admin')).open_session_cb(check_coa=False)
-        self.start_tour("/pos/web?config_id=%d" % self.pos_config.id, 'SplitBillScreenTour', login="admin", step_delay=50)
-        self.start_tour("/pos/web?config_id=%d" % self.pos_config.id, 'ControlButtonsTour', login="admin", step_delay=50)
-        self.start_tour("/pos/web?config_id=%d" % self.pos_config.id, 'FloorScreenTour', login="admin", step_delay=50)
+        with self.assertQueryCount(admin=3368):
+            self.start_tour("/pos/web?config_id=%d" % self.pos_config.id, 'SplitBillScreenTour', login="admin", step_delay=50)
+        with self.assertQueryCount(admin=2210):
+            self.start_tour("/pos/web?config_id=%d" % self.pos_config.id, 'ControlButtonsTour', login="admin", step_delay=50)
+        with self.assertQueryCount(admin=2053):
+            self.start_tour("/pos/web?config_id=%d" % self.pos_config.id, 'FloorScreenTour', login="admin", step_delay=50)

--- a/addons/project/tests/test_project_ui.py
+++ b/addons/project/tests/test_project_ui.py
@@ -7,4 +7,5 @@ import odoo.tests
 class TestUi(odoo.tests.HttpCase):
 
     def test_01_project_tour(self):
-        self.start_tour("/web", 'project_tour', login="admin")
+        with self.assertQueryCount(__system__=3659):
+            self.start_tour("/web", 'project_tour', login="admin")

--- a/addons/project/tests/test_project_ui.py
+++ b/addons/project/tests/test_project_ui.py
@@ -7,5 +7,5 @@ import odoo.tests
 class TestUi(odoo.tests.HttpCase):
 
     def test_01_project_tour(self):
-        with self.assertQueryCount(__system__=3659):
+        with self.assertQueryCount(__system__=3669):
             self.start_tour("/web", 'project_tour', login="admin")

--- a/addons/purchase_product_matrix/tests/test_purchase_matrix.py
+++ b/addons/purchase_product_matrix/tests/test_purchase_matrix.py
@@ -9,7 +9,7 @@ from odoo.addons.product_matrix.tests.common import TestMatrixCommon
 class TestPurchaseMatrixUi(TestMatrixCommon):
 
     def test_purchase_matrix_ui(self):
-        with self.assertQueryCount(__system__=4499):
+        with self.assertQueryCount(__system__=4514):
             self.start_tour("/web", 'purchase_matrix_tour', login="admin")
 
         # Ensures some dynamic create variants have been created by the matrix

--- a/addons/purchase_product_matrix/tests/test_purchase_matrix.py
+++ b/addons/purchase_product_matrix/tests/test_purchase_matrix.py
@@ -9,7 +9,8 @@ from odoo.addons.product_matrix.tests.common import TestMatrixCommon
 class TestPurchaseMatrixUi(TestMatrixCommon):
 
     def test_purchase_matrix_ui(self):
-        self.start_tour("/web", 'purchase_matrix_tour', login="admin")
+        with self.assertQueryCount(__system__=4499):
+            self.start_tour("/web", 'purchase_matrix_tour', login="admin")
 
         # Ensures some dynamic create variants have been created by the matrix
         # Ensures a PO has been created with exactly x lines ...

--- a/addons/sale/tests/test_sale_signature.py
+++ b/addons/sale/tests/test_sale_signature.py
@@ -27,5 +27,6 @@ class TestSaleSignature(HttpCaseWithUserPortal):
         email_act = sales_order.action_quotation_send()
         email_ctx = email_act.get('context', {})
         sales_order.with_context(**email_ctx).message_post_with_template(email_ctx.get('default_template_id'))
-
-        self.start_tour("/", 'sale_signature', login="portal")
+        # runbot needs +340 compared to local
+        with self.assertQueryCount(__system__=1424):
+            self.start_tour("/", 'sale_signature', login="portal")

--- a/addons/sale_management/tests/test_sale_ui.py
+++ b/addons/sale_management/tests/test_sale_ui.py
@@ -6,5 +6,5 @@ import odoo.tests
 class TestUi(odoo.tests.HttpCase):
 
     def test_01_sale_tour(self):
-        with self.assertQueryCount(__system__=4169):
+        with self.assertQueryCount(__system__=4178):
             self.start_tour("/web", 'sale_tour', login="admin", step_delay=100)

--- a/addons/sale_management/tests/test_sale_ui.py
+++ b/addons/sale_management/tests/test_sale_ui.py
@@ -6,5 +6,5 @@ import odoo.tests
 class TestUi(odoo.tests.HttpCase):
 
     def test_01_sale_tour(self):
-        with self.assertQueryCount(__system__=4178):
+        with self.assertQueryCount(__system__=4184):
             self.start_tour("/web", 'sale_tour', login="admin", step_delay=100)

--- a/addons/sale_management/tests/test_sale_ui.py
+++ b/addons/sale_management/tests/test_sale_ui.py
@@ -6,4 +6,5 @@ import odoo.tests
 class TestUi(odoo.tests.HttpCase):
 
     def test_01_sale_tour(self):
-        self.start_tour("/web", 'sale_tour', login="admin", step_delay=100)
+        with self.assertQueryCount(__system__=4169):
+            self.start_tour("/web", 'sale_tour', login="admin", step_delay=100)

--- a/addons/sale_product_configurator/tests/test_sale_product_configurator_ui.py
+++ b/addons/sale_product_configurator/tests/test_sale_product_configurator_ui.py
@@ -106,7 +106,8 @@ class TestUi(odoo.tests.HttpCase):
         # To be able to test the product configurator, admin user must have access to "variants" feature, so we give him the right group for that
         self.env.ref('base.user_admin').write({'groups_id': [(4, self.env.ref('product.group_product_variant').id)]})
 
-        self.start_tour("/web", 'sale_product_configurator_tour', login="admin")
+        with self.assertQueryCount(__system__=4006):
+            self.start_tour("/web", 'sale_product_configurator_tour', login="admin")
 
     def test_02_product_configurator_advanced(self):
         # group_product_variant: use the product configurator
@@ -167,13 +168,15 @@ class TestUi(odoo.tests.HttpCase):
             'value_ids': [(6, 0, product_attribute.value_ids.ids)],
         } for product_attribute in product_attributes])
 
-        self.start_tour("/web", 'sale_product_configurator_advanced_tour', login="admin")
+        with self.assertQueryCount(__system__=4129):
+            self.start_tour("/web", 'sale_product_configurator_advanced_tour', login="admin")
 
     def test_03_product_configurator_edition(self):
         # To be able to test the product configurator, admin user must have access to "variants" feature, so we give him the right group for that
         self.env.ref('base.user_admin').write({'groups_id': [(4, self.env.ref('product.group_product_variant').id)]})
 
-        self.start_tour("/web", 'sale_product_configurator_edition_tour', login="admin")
+        with self.assertQueryCount(__system__=4192):
+            self.start_tour("/web", 'sale_product_configurator_edition_tour', login="admin")
 
     def test_04_product_configurator_single_custom_value(self):
         # group_product_variant: use the product configurator
@@ -208,7 +211,8 @@ class TestUi(odoo.tests.HttpCase):
             'value_ids': [(6, 0, [product_attribute_values[0].id])]
         }])
 
-        self.start_tour("/web", 'sale_product_configurator_single_custom_attribute_tour', login="admin")
+        with self.assertQueryCount(__system__=3622):
+            self.start_tour("/web", 'sale_product_configurator_single_custom_attribute_tour', login="admin")
 
     def test_05_product_configurator_pricelist(self):
         """The goal of this test is to make sure pricelist rules are correctly
@@ -248,7 +252,8 @@ class TestUi(odoo.tests.HttpCase):
                 'compute_price': 'formula',
             })
 
-        self.start_tour("/web", 'sale_product_configurator_pricelist_tour', login="admin")
+        with self.assertQueryCount(__system__=4441):
+            self.start_tour("/web", 'sale_product_configurator_pricelist_tour', login="admin")
 
     def test_06_product_configurator_optional_products(self):
         """The goal of this test is to check that the product configurator
@@ -268,4 +273,5 @@ class TestUi(odoo.tests.HttpCase):
         custo_desk.update({
             'optional_product_ids': [(6, 0, [office_chair.product_tmpl_id.id, self.product_product_11_product_template.id])]
         })
-        self.start_tour("/web", 'sale_product_configurator_optional_products_tour', login="admin")
+        with self.assertQueryCount(__system__=4685):
+            self.start_tour("/web", 'sale_product_configurator_optional_products_tour', login="admin")

--- a/addons/sale_product_configurator/tests/test_sale_product_configurator_ui.py
+++ b/addons/sale_product_configurator/tests/test_sale_product_configurator_ui.py
@@ -106,7 +106,7 @@ class TestUi(odoo.tests.HttpCase):
         # To be able to test the product configurator, admin user must have access to "variants" feature, so we give him the right group for that
         self.env.ref('base.user_admin').write({'groups_id': [(4, self.env.ref('product.group_product_variant').id)]})
 
-        with self.assertQueryCount(__system__=4006):
+        with self.assertQueryCount(__system__=4022):
             self.start_tour("/web", 'sale_product_configurator_tour', login="admin")
 
     def test_02_product_configurator_advanced(self):
@@ -168,14 +168,14 @@ class TestUi(odoo.tests.HttpCase):
             'value_ids': [(6, 0, product_attribute.value_ids.ids)],
         } for product_attribute in product_attributes])
 
-        with self.assertQueryCount(__system__=4129):
+        with self.assertQueryCount(__system__=4130):
             self.start_tour("/web", 'sale_product_configurator_advanced_tour', login="admin")
 
     def test_03_product_configurator_edition(self):
         # To be able to test the product configurator, admin user must have access to "variants" feature, so we give him the right group for that
         self.env.ref('base.user_admin').write({'groups_id': [(4, self.env.ref('product.group_product_variant').id)]})
 
-        with self.assertQueryCount(__system__=4192):
+        with self.assertQueryCount(__system__=4207):
             self.start_tour("/web", 'sale_product_configurator_edition_tour', login="admin")
 
     def test_04_product_configurator_single_custom_value(self):
@@ -211,7 +211,7 @@ class TestUi(odoo.tests.HttpCase):
             'value_ids': [(6, 0, [product_attribute_values[0].id])]
         }])
 
-        with self.assertQueryCount(__system__=3622):
+        with self.assertQueryCount(__system__=3652):
             self.start_tour("/web", 'sale_product_configurator_single_custom_attribute_tour', login="admin")
 
     def test_05_product_configurator_pricelist(self):
@@ -252,7 +252,7 @@ class TestUi(odoo.tests.HttpCase):
                 'compute_price': 'formula',
             })
 
-        with self.assertQueryCount(__system__=4441):
+        with self.assertQueryCount(__system__=4470):
             self.start_tour("/web", 'sale_product_configurator_pricelist_tour', login="admin")
 
     def test_06_product_configurator_optional_products(self):

--- a/addons/sale_product_configurator/tests/test_sale_product_configurator_ui.py
+++ b/addons/sale_product_configurator/tests/test_sale_product_configurator_ui.py
@@ -168,14 +168,14 @@ class TestUi(odoo.tests.HttpCase):
             'value_ids': [(6, 0, product_attribute.value_ids.ids)],
         } for product_attribute in product_attributes])
 
-        with self.assertQueryCount(__system__=4130):
+        with self.assertQueryCount(__system__=4159):
             self.start_tour("/web", 'sale_product_configurator_advanced_tour', login="admin")
 
     def test_03_product_configurator_edition(self):
         # To be able to test the product configurator, admin user must have access to "variants" feature, so we give him the right group for that
         self.env.ref('base.user_admin').write({'groups_id': [(4, self.env.ref('product.group_product_variant').id)]})
 
-        with self.assertQueryCount(__system__=4207):
+        with self.assertQueryCount(__system__=4221):
             self.start_tour("/web", 'sale_product_configurator_edition_tour', login="admin")
 
     def test_04_product_configurator_single_custom_value(self):
@@ -273,5 +273,5 @@ class TestUi(odoo.tests.HttpCase):
         custo_desk.update({
             'optional_product_ids': [(6, 0, [office_chair.product_tmpl_id.id, self.product_product_11_product_template.id])]
         })
-        with self.assertQueryCount(__system__=4685):
+        with self.assertQueryCount(__system__=4700):
             self.start_tour("/web", 'sale_product_configurator_optional_products_tour', login="admin")

--- a/addons/sale_product_matrix/tests/test_sale_matrix.py
+++ b/addons/sale_product_matrix/tests/test_sale_matrix.py
@@ -16,7 +16,8 @@ class TestSaleMatrixUi(common.TestMatrixCommon):
         # Set the template as configurable by matrix.
         self.matrix_template.product_add_mode = "matrix"
 
-        self.start_tour("/web", 'sale_matrix_tour', login="admin")
+        with self.assertQueryCount(__system__=5454):
+            self.start_tour("/web", 'sale_matrix_tour', login="admin")
 
         # Ensures some dynamic create variants have been created by the matrix
         # Ensures a SO has been created with exactly x lines ...

--- a/addons/sale_product_matrix/tests/test_sale_matrix.py
+++ b/addons/sale_product_matrix/tests/test_sale_matrix.py
@@ -16,7 +16,7 @@ class TestSaleMatrixUi(common.TestMatrixCommon):
         # Set the template as configurable by matrix.
         self.matrix_template.product_add_mode = "matrix"
 
-        with self.assertQueryCount(__system__=5454):
+        with self.assertQueryCount(__system__=5470):
             self.start_tour("/web", 'sale_matrix_tour', login="admin")
 
         # Ensures some dynamic create variants have been created by the matrix

--- a/addons/survey/tests/test_survey_ui_certification.py
+++ b/addons/survey/tests/test_survey_ui_certification.py
@@ -275,8 +275,10 @@ class TestUiCertification(HttpCaseWithUserDemo):
 
     def test_04_certification_success_tour(self):
         access_token = self.survey_certification.access_token
-        self.start_tour("/survey/start/%s" % access_token, 'test_certification_success', login="demo")
+        with self.assertQueryCount(__system__=1489):
+            self.start_tour("/survey/start/%s" % access_token, 'test_certification_success', login="demo")
 
     def test_05_certification_failure_tour(self):
         access_token = self.survey_certification.access_token
-        self.start_tour("/survey/start/%s" % access_token, 'test_certification_failure', login="demo")
+        with self.assertQueryCount(__system__=2102):
+            self.start_tour("/survey/start/%s" % access_token, 'test_certification_failure', login="demo")

--- a/addons/survey/tests/test_survey_ui_feedback.py
+++ b/addons/survey/tests/test_survey_ui_feedback.py
@@ -154,16 +154,20 @@ class TestUiFeedback(HttpCaseWithUserDemo):
 
     def test_01_admin_survey_tour(self):
         access_token = self.survey_feedback.access_token
-        self.start_tour("/survey/start/%s" % access_token, 'test_survey', login="admin")
+        with self.assertQueryCount(__system__=1124):
+            self.start_tour("/survey/start/%s" % access_token, 'test_survey', login="admin")
 
     def test_02_demo_survey_tour(self):
         access_token = self.survey_feedback.access_token
-        self.start_tour("/survey/start/%s" % access_token, 'test_survey', login="demo")
+        with self.assertQueryCount(__system__=1090):
+            self.start_tour("/survey/start/%s" % access_token, 'test_survey', login="demo")
 
     def test_03_public_survey_tour(self):
         access_token = self.survey_feedback.access_token
-        self.start_tour("/survey/start/%s" % access_token, 'test_survey')
+        with self.assertQueryCount(__system__=878):
+            self.start_tour("/survey/start/%s" % access_token, 'test_survey')
 
     def test_06_survey_prefill(self):
         access_token = self.survey_feedback.access_token
-        self.start_tour("/survey/start/%s" % access_token, 'test_survey_prefill')
+        with self.assertQueryCount(__system__=2301):
+            self.start_tour("/survey/start/%s" % access_token, 'test_survey_prefill')

--- a/addons/survey/tests/test_survey_ui_session.py
+++ b/addons/survey/tests/test_survey_ui_session.py
@@ -142,7 +142,7 @@ class TestUiSession(HttpCase):
         # PART 1 : CREATE SESSION
         # =======================
 
-        with self.assertQueryCount(__system__=3214):
+        with self.assertQueryCount(__system__=3229):
             self.start_tour('/web', 'test_survey_session_create_tour', login='admin')
 
         # tricky part: we only take into account answers created after the session_start_time
@@ -206,7 +206,7 @@ class TestUiSession(HttpCase):
         attendee_3.save_lines(timed_scored_choice_question,
             [timed_scored_choice_answer_2.id])
 
-        with self.assertQueryCount(__system__=1909):
+        with self.assertQueryCount(__system__=1924):
             self.start_tour('/web', 'test_survey_session_manage_tour', login='admin')
 
         self.assertFalse(bool(survey_session.session_state))

--- a/addons/survey/tests/test_survey_ui_session.py
+++ b/addons/survey/tests/test_survey_ui_session.py
@@ -142,7 +142,8 @@ class TestUiSession(HttpCase):
         # PART 1 : CREATE SESSION
         # =======================
 
-        self.start_tour('/web', 'test_survey_session_create_tour', login='admin')
+        with self.assertQueryCount(__system__=3214):
+            self.start_tour('/web', 'test_survey_session_create_tour', login='admin')
 
         # tricky part: we only take into account answers created after the session_start_time
         # the create_date of the answers we just saved is set to the beginning of the test.
@@ -165,7 +166,8 @@ class TestUiSession(HttpCase):
         # PART 2 : OPEN SESSION AND CHECK ATTENDEES
         # =========================================
 
-        self.start_tour('/web', 'test_survey_session_start_tour', login='admin')
+        with self.assertQueryCount(__system__=1806):
+            self.start_tour('/web', 'test_survey_session_start_tour', login='admin')
 
         self.assertEqual('in_progress', survey_session.session_state)
         self.assertTrue(bool(survey_session.session_start_time))
@@ -204,7 +206,8 @@ class TestUiSession(HttpCase):
         attendee_3.save_lines(timed_scored_choice_question,
             [timed_scored_choice_answer_2.id])
 
-        self.start_tour('/web', 'test_survey_session_manage_tour', login='admin')
+        with self.assertQueryCount(__system__=1909):
+            self.start_tour('/web', 'test_survey_session_manage_tour', login='admin')
 
         self.assertFalse(bool(survey_session.session_state))
         self.assertTrue(all(answer.state == 'done' for answer in all_attendees))

--- a/addons/test_mail/tests/test_ui.py
+++ b/addons/test_mail/tests/test_ui.py
@@ -7,4 +7,5 @@ import odoo.tests
 class TestUi(odoo.tests.HttpCase):
 
     def test_01_mail_tour(self):
-        self.start_tour("/web", 'mail_tour', login="admin")
+        with self.assertQueryCount(__system__=546):
+            self.start_tour("/web", 'mail_tour', login="admin")

--- a/addons/test_website/tests/test_error.py
+++ b/addons/test_website/tests/test_error.py
@@ -7,4 +7,5 @@ class TestWebsiteError(odoo.tests.HttpCase):
 
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
     def test_01_run_test(self):
-        self.start_tour("/test_error_view", 'test_error_website')
+        with self.assertQueryCount(__system__=1089, demo=0):
+            self.start_tour("/test_error_view", 'test_error_website')

--- a/addons/test_website/tests/test_reset_views.py
+++ b/addons/test_website/tests/test_reset_views.py
@@ -90,9 +90,11 @@ class TestWebsiteResetViews(odoo.tests.HttpCase):
 
     @mute_logger('odoo.addons.http_routing.models.ir_http')
     def test_07_reset_page_view_complete_flow(self):
-        self.start_tour("/", 'test_reset_page_view_complete_flow_part1', login="admin")
+        with self.assertQueryCount(__system__=2565):
+            self.start_tour("/", 'test_reset_page_view_complete_flow_part1', login="admin")
         self.fix_it('/test_page_view')
-        self.start_tour("/", 'test_reset_page_view_complete_flow_part2', login="admin")
+        with self.assertQueryCount(__system__=2652):
+            self.start_tour("/", 'test_reset_page_view_complete_flow_part2', login="admin")
         self.fix_it('/test_page_view')
 
     @mute_logger('odoo.addons.http_routing.models.ir_http')

--- a/addons/test_website/tests/test_session.py
+++ b/addons/test_website/tests/test_session.py
@@ -6,4 +6,5 @@ from odoo.tools import mute_logger
 class TestWebsiteSession(odoo.tests.HttpCase):
 
     def test_01_run_test(self):
-        self.start_tour('/', 'test_json_auth')
+        with self.assertQueryCount(__system__=2185):
+            self.start_tour('/', 'test_json_auth')

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -87,7 +87,8 @@ class TestUiHtmlEditor(odoo.tests.HttpCase):
             </t>
         '''
         generic_page.arch = oe_structure_layout
-        self.start_tour("/", 'html_editor_multiple_templates', login='admin')
+        with self.assertQueryCount(__system__=3198):
+            self.start_tour("/", 'html_editor_multiple_templates', login='admin')
         self.assertEqual(View.search_count([('key', '=', 'test.generic_view')]), 2, "homepage view should have been COW'd")
         self.assertTrue(generic_page.arch == oe_structure_layout, "Generic homepage view should be untouched")
         self.assertEqual(len(generic_page.inherit_children_ids.filtered(lambda v: 'oe_structure' in v.name)), 0, "oe_structure view should have been deleted when aboutus was COW")
@@ -96,7 +97,8 @@ class TestUiHtmlEditor(odoo.tests.HttpCase):
         self.assertEqual(len(specific_page.inherit_children_ids.filtered(lambda v: 'oe_structure' in v.name)), 1, "oe_structure view should have been created on the specific tree")
 
     def test_html_editor_scss(self):
-        self.start_tour("/", 'test_html_editor_scss', login='admin')
+        with self.assertQueryCount(__system__=3447):
+            self.start_tour("/", 'test_html_editor_scss', login='admin')
 
 @odoo.tests.tagged('-at_install', 'post_install')
 class TestUiTranslate(odoo.tests.HttpCase):
@@ -104,14 +106,16 @@ class TestUiTranslate(odoo.tests.HttpCase):
         fr_BE = self.env.ref('base.lang_fr_BE')
         fr_BE.active = True
         self.env.ref('website.default_website').language_ids |= fr_BE
-        self.start_tour("/", 'rte_translator', login='admin', timeout=120)
+        with self.assertQueryCount(__system__=7113):
+            self.start_tour("/", 'rte_translator', login='admin', timeout=120)
 
 
 @odoo.tests.common.tagged('post_install', '-at_install')
 class TestUi(odoo.tests.HttpCase):
 
     def test_01_admin_tour_banner(self):
-        self.start_tour("/", 'banner', login='admin', step_delay=100)
+        with self.assertQueryCount(__system__=4157):
+            self.start_tour("/", 'banner', login='admin', step_delay=100)
 
     def test_02_restricted_editor(self):
         self.restricted_editor = self.env['res.users'].create({
@@ -123,10 +127,12 @@ class TestUi(odoo.tests.HttpCase):
                     self.ref('website.group_website_publisher')
                 ])]
         })
-        self.start_tour("/", 'restricted_editor', login='restricted')
+        with self.assertQueryCount(__system__=2114):
+            self.start_tour("/", 'restricted_editor', login='restricted')
 
     def test_03_backend_dashboard(self):
-        self.start_tour("/", 'backend_dashboard', login='admin')
+        with self.assertQueryCount(__system__=3089):
+            self.start_tour("/", 'backend_dashboard', login='admin')
 
     def test_04_website_navbar_menu(self):
         website = self.env['website'].search([], limit=1)
@@ -137,7 +143,8 @@ class TestUi(odoo.tests.HttpCase):
             'sequence': 0,
             'website_id': website.id,
         })
-        self.start_tour("/", 'website_navbar_menu')
+        with self.assertQueryCount(__system__=1010):
+            self.start_tour("/", 'website_navbar_menu')
 
     def test_05_specific_website_editor(self):
         website_default = self.env['website'].search([], limit=1)
@@ -154,8 +161,10 @@ class TestUi(odoo.tests.HttpCase):
                 </xpath>
             """,
         })
-        self.start_tour("/?fw=%s" % website_default.id, "generic_website_editor", login='admin')
-        self.start_tour("/?fw=%s" % new_website.id, "specific_website_editor", login='admin')
+        with self.assertQueryCount(__system__=1779):
+            self.start_tour("/?fw=%s" % website_default.id, "generic_website_editor", login='admin')
+        with self.assertQueryCount(__system__=1673):
+            self.start_tour("/?fw=%s" % new_website.id, "specific_website_editor", login='admin')
 
     def test_06_public_user_editor(self):
         website_default = self.env['website'].search([], limit=1)
@@ -166,7 +175,9 @@ class TestUi(odoo.tests.HttpCase):
                 </t>
             </t>
         """
-        self.start_tour("/", "public_user_editor", login=None)
+        with self.assertQueryCount(__system__=674):
+            self.start_tour("/", "public_user_editor", login=None)
 
     def test_07_snippet_version(self):
-        self.start_tour("/", 'snippet_version', login='admin')
+        with self.assertQueryCount(__system__=3055):
+            self.start_tour("/", 'snippet_version', login='admin')

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -163,7 +163,7 @@ class TestUi(odoo.tests.HttpCase):
         })
         with self.assertQueryCount(__system__=1779):
             self.start_tour("/?fw=%s" % website_default.id, "generic_website_editor", login='admin')
-        with self.assertQueryCount(__system__=1673):
+        with self.assertQueryCount(__system__=1675):
             self.start_tour("/?fw=%s" % new_website.id, "specific_website_editor", login='admin')
 
     def test_06_public_user_editor(self):

--- a/addons/website/tests/test_website_reset_password.py
+++ b/addons/website/tests/test_website_reset_password.py
@@ -56,7 +56,8 @@ class TestWebsiteResetPassword(HttpCase):
             user.action_reset_password()
             user.invalidate_cache()
 
-            self.start_tour(user.signup_url, 'website_reset_password', login=None)
+            with self.assertQueryCount(__system__=2276):
+                self.start_tour(user.signup_url, 'website_reset_password', login=None)
 
     def test_02_multi_user_login(self):
         # In case Specific User Account is activated on a website, the same login can be used for

--- a/addons/website_blog/tests/test_ui.py
+++ b/addons/website_blog/tests/test_ui.py
@@ -9,4 +9,5 @@ from odoo import tools
 class TestUi(odoo.tests.HttpCase):
     def test_admin(self):
         self.env['blog.blog'].create({'name': 'Travel'})
-        self.start_tour("/", 'blog', login='admin')
+        with self.assertQueryCount(__system__=2108):
+            self.start_tour("/", 'blog', login='admin')

--- a/addons/website_crm/tests/test_website_crm.py
+++ b/addons/website_crm/tests/test_website_crm.py
@@ -8,7 +8,8 @@ import odoo.tests
 class TestWebsiteCrm(odoo.tests.HttpCase):
 
     def test_tour(self):
-        self.start_tour("/", 'website_crm_tour')
+        with self.assertQueryCount(__system__=1678):
+            self.start_tour("/", 'website_crm_tour')
 
         # check result
         record = self.env['crm.lead'].search([('description', '=', '### TOUR DATA ###')])

--- a/addons/website_event/tests/test_ui.py
+++ b/addons/website_event/tests/test_ui.py
@@ -8,4 +8,5 @@ from odoo import tools
 @odoo.tests.tagged('post_install', '-at_install')
 class TestUi(odoo.tests.HttpCase):
     def test_admin(self):
-        self.start_tour("/", 'event', login='admin', step_delay=100)
+        with self.assertQueryCount(__system__=3367):
+            self.start_tour("/", 'event', login='admin', step_delay=100)

--- a/addons/website_event_questions/tests/test_event_ui.py
+++ b/addons/website_event_questions/tests/test_event_ui.py
@@ -48,7 +48,8 @@ class TestUi(tests.HttpCase):
             })]
         })
 
-        self.start_tour("/", 'test_tickets_questions', login="portal")
+        with self.assertQueryCount(__system__=1910):
+            self.start_tour("/", 'test_tickets_questions', login="portal")
 
         registrations = self.env['event.registration'].search([
             ('email', 'in', ['attendee-a@gmail.com', 'attendee-b@gmail.com'])

--- a/addons/website_event_sale/tests/test_frontend_buy_tickets.py
+++ b/addons/website_event_sale/tests/test_frontend_buy_tickets.py
@@ -60,7 +60,7 @@ class TestUi(HttpCaseWithUserDemo):
         # we have to force company currency as USDs only for this test
         self.cr.execute("UPDATE res_company SET currency_id = %s WHERE id = %s", [self.env.ref('base.USD').id, self.env.ref('base.main_company').id])
 
-        with self.assertQueryCount(__system__=3266):
+        with self.assertQueryCount(__system__=3267):
             self.start_tour("/", 'event_buy_tickets', login="admin")
 
     def test_demo(self):

--- a/addons/website_event_sale/tests/test_frontend_buy_tickets.py
+++ b/addons/website_event_sale/tests/test_frontend_buy_tickets.py
@@ -60,9 +60,11 @@ class TestUi(HttpCaseWithUserDemo):
         # we have to force company currency as USDs only for this test
         self.cr.execute("UPDATE res_company SET currency_id = %s WHERE id = %s", [self.env.ref('base.USD').id, self.env.ref('base.main_company').id])
 
-        self.start_tour("/", 'event_buy_tickets', login="admin")
+        with self.assertQueryCount(__system__=3266):
+            self.start_tour("/", 'event_buy_tickets', login="admin")
 
     def test_demo(self):
-        self.start_tour("/", 'event_buy_tickets', login="demo")
+        with self.assertQueryCount(__system__=3173):
+            self.start_tour("/", 'event_buy_tickets', login="demo")
 
     # TO DO - add public test with new address when convert to web.tour format.

--- a/addons/website_form/tests/test_website_form_editor.py
+++ b/addons/website_form/tests/test_website_form_editor.py
@@ -7,6 +7,9 @@ import odoo.tests
 @odoo.tests.tagged('post_install','-at_install')
 class TestWebsiteFormEditor(odoo.tests.HttpCase):
     def test_tour(self):
-        self.start_tour("/", 'website_form_editor_tour', login="admin")
-        self.start_tour("/", 'website_form_editor_tour_submit')
-        self.start_tour("/", 'website_form_editor_tour_results', login="admin")
+        with self.assertQueryCount(__system__=2209):
+            self.start_tour("/", 'website_form_editor_tour', login="admin")
+        with self.assertQueryCount(__system__=448):
+            self.start_tour("/", 'website_form_editor_tour_submit')
+        with self.assertQueryCount(__system__=1538):
+            self.start_tour("/", 'website_form_editor_tour_results', login="admin")

--- a/addons/website_forum/tests/test_forum_process.py
+++ b/addons/website_forum/tests/test_forum_process.py
@@ -8,10 +8,12 @@ from odoo.tests import tagged
 class TestUi(HttpCaseWithUserDemo):
 
     def test_01_admin_forum_tour(self):
-        self.start_tour("/", 'question', login="admin", step_delay=100)
+        with self.assertQueryCount(__system__=1507):
+            self.start_tour("/", 'question', login="admin", step_delay=100)
 
     def test_02_demo_question(self):
         forum = self.env.ref('website_forum.forum_help')
         demo = self.user_demo
         demo.karma = forum.karma_post + 1
-        self.start_tour("/", 'forum_question', login="demo")
+        with self.assertQueryCount(__system__=1472):
+            self.start_tour("/", 'forum_question', login="demo")

--- a/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
+++ b/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
@@ -12,7 +12,8 @@ class TestWebsiteHrRecruitmentForm(odoo.tests.HttpCase):
             'is_published': True,
         })
 
-        self.start_tour("/", 'website_hr_recruitment_tour')
+        with self.assertQueryCount(__system__=1357):
+            self.start_tour("/", 'website_hr_recruitment_tour')
 
         # check result
         record = self.env['hr.applicant'].search([('description', '=', '### HR RECRUITMENT TEST DATA ###')])

--- a/addons/website_links/tests/test_ui.py
+++ b/addons/website_links/tests/test_ui.py
@@ -13,4 +13,5 @@ class TestUi(odoo.tests.HttpCase):
             'source_id': 2,
             'url': self.env["ir.config_parameter"].sudo().get_param("web.base.url") + '/contactus',
         })
-        self.start_tour("/", 'website_links_tour', login="admin")
+        with self.assertQueryCount(__system__=1458):
+            self.start_tour("/", 'website_links_tour', login="admin")

--- a/addons/website_livechat/tests/test_ui.py
+++ b/addons/website_livechat/tests/test_ui.py
@@ -16,30 +16,36 @@ class TestLivechatUI(tests.HttpCase, TestLivechatCommon):
         self.target_visitor = self.visitor_tour
 
     def test_complete_rating_flow_ui(self):
-        self.start_tour("/", 'website_livechat_complete_flow_tour')
+        with self.assertQueryCount(__system__=1020):
+            self.start_tour("/", 'website_livechat_complete_flow_tour')
         self._check_end_of_rating_tours()
 
     def test_happy_rating_flow_ui(self):
-        self.start_tour("/", 'website_livechat_happy_rating_tour')
+        with self.assertQueryCount(__system__=3270):
+            self.start_tour("/", 'website_livechat_happy_rating_tour')
         self._check_end_of_rating_tours()
 
     def test_ok_rating_flow_ui(self):
-        self.start_tour("/", 'website_livechat_ok_rating_tour')
+        with self.assertQueryCount(__system__=2870):
+            self.start_tour("/", 'website_livechat_ok_rating_tour')
         self._check_end_of_rating_tours()
 
     def test_bad_rating_flow_ui(self):
-        self.start_tour("/", 'website_livechat_sad_rating_tour')
+        with self.assertQueryCount(__system__=3360):
+            self.start_tour("/", 'website_livechat_sad_rating_tour')
         self._check_end_of_rating_tours()
 
     def test_no_rating_flow_ui(self):
-        self.start_tour("/", 'website_livechat_no_rating_tour')
+        with self.assertQueryCount(__system__=782):
+            self.start_tour("/", 'website_livechat_no_rating_tour')
         channel = self.env['mail.channel'].search([('livechat_visitor_id', '=', self.visitor_tour.id)])
         self.assertEqual(len(channel), 1, "There can only be one channel created for 'Visitor Tour'.")
         self.assertEqual(channel.livechat_active, False, 'Livechat must be inactive after closing the chat window.')
 
     def test_no_rating_no_close_flow_ui(self):
-        self.start_tour("/", 'website_livechat_no_rating_no_close_tour')
-        channel = self.env['mail.channel'].search([('livechat_visitor_id', '=', self.visitor_tour.id)])
+        with self.assertQueryCount(__system__=1547):
+            self.start_tour("/", 'website_livechat_no_rating_no_close_tour')
+            channel = self.env['mail.channel'].search([('livechat_visitor_id', '=', self.visitor_tour.id)])
         self.assertEqual(len(channel), 1, "There can only be one channel created for 'Visitor Tour'.")
         self.assertEqual(channel.livechat_active, True, 'Livechat must be active while the chat window is not closed.')
 
@@ -49,7 +55,8 @@ class TestLivechatUI(tests.HttpCase, TestLivechatCommon):
         chat_request = self.env['mail.channel'].search([('livechat_visitor_id', '=', self.visitor_tour.id), ('livechat_active', '=', True)])
 
         # Visitor ask a new livechat session before the operator start to send message in chat request session
-        self.start_tour("/", 'website_livechat_no_rating_no_close_tour')
+        with self.assertQueryCount(__system__=1818):
+            self.start_tour("/", 'website_livechat_no_rating_no_close_tour')
 
         # Visitor's session must be active (gets the priority)
         channel = self.env['mail.channel'].search([('livechat_visitor_id', '=', self.visitor_tour.id), ('livechat_active', '=', True)])
@@ -70,7 +77,8 @@ class TestLivechatUI(tests.HttpCase, TestLivechatCommon):
         self.assertEqual(len(chat_request.message_ids), 1, "Number of messages incorrect.")
 
         # Visitor comes to the website and receives the chat request
-        self.start_tour("/", 'website_livechat_chat_request_part_1_no_close_tour')
+        with self.assertQueryCount(__system__=1923):
+            self.start_tour("/", 'website_livechat_chat_request_part_1_no_close_tour')
 
         # Check that the current session is the chat request
         channel = self.env['mail.channel'].search([('livechat_visitor_id', '=', self.visitor_tour.id), ('livechat_active', '=', True)])
@@ -78,7 +86,8 @@ class TestLivechatUI(tests.HttpCase, TestLivechatCommon):
         self.assertEqual(channel, chat_request, "The active livechat session must be the chat request one.")
 
         # Visitor reload the page and continues the chat with the operator normally
-        self.start_tour("/", 'website_livechat_chat_request_part_2_end_session_tour')
+        with self.assertQueryCount(__system__=2021):
+            self.start_tour("/", 'website_livechat_chat_request_part_2_end_session_tour')
         self._check_end_of_rating_tours()
 
     def _check_end_of_rating_tours(self):

--- a/addons/website_sale/tests/test_customize.py
+++ b/addons/website_sale/tests/test_customize.py
@@ -56,7 +56,8 @@ class TestUi(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
     def test_01_admin_shop_customize_tour(self):
         # Enable Variant Group
         self.env.ref('product.group_product_variant').write({'users': [(4, self.env.ref('base.user_admin').id)]})
-        self.start_tour("/", 'shop_customize', login="admin")
+        with self.assertQueryCount(__system__=7232):
+            self.start_tour("/", 'shop_customize', login="admin")
 
     def test_02_admin_shop_custom_attribute_value_tour(self):
         # Make sure pricelist rule exist
@@ -159,7 +160,8 @@ class TestUi(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
 
             pricelist.discount_policy = 'without_discount'
 
-        self.start_tour("/", 'shop_custom_attribute_value', login="admin")
+        with self.assertQueryCount(__system__=3643):
+            self.start_tour("/", 'shop_custom_attribute_value', login="admin")
 
     def test_03_public_tour_shop_dynamic_variants(self):
         """ The goal of this test is to make sure product variants with dynamic
@@ -208,7 +210,8 @@ class TestUi(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
                 # 0 to not bother with the pricelist of the public user
                 ptav.price_extra = 0
 
-        self.start_tour("/", 'tour_shop_dynamic_variants')
+        with self.assertQueryCount(__system__=2310):
+            self.start_tour("/", 'tour_shop_dynamic_variants')
 
     def test_04_portal_tour_deleted_archived_variants(self):
         """The goal of this test is to make sure deleted and archived variants
@@ -264,7 +267,8 @@ class TestUi(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
         # delete second combination (which is now first variant since cache has been cleared)
         product_template.product_variant_ids[0].unlink()
 
-        self.start_tour("/", 'tour_shop_deleted_archived_variants', login="portal")
+        with self.assertQueryCount(__system__=1745):
+            self.start_tour("/", 'tour_shop_deleted_archived_variants', login="portal")
 
     def test_05_demo_tour_no_variant_attribute(self):
         """The goal of this test is to make sure attributes no_variant are
@@ -301,7 +305,8 @@ class TestUi(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
         # set a price on the value
         ptal.product_template_value_ids.price_extra = 10
 
-        self.start_tour("/", 'tour_shop_no_variant_attribute', login="demo")
+        with self.assertQueryCount(__system__=1863):
+            self.start_tour("/", 'tour_shop_no_variant_attribute', login="demo")
 
     def test_06_admin_list_view_b2c(self):
         self.env.ref('product.group_product_variant').write({'users': [(4, self.env.ref('base.user_admin').id)]})
@@ -312,4 +317,5 @@ class TestUi(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
         config._onchange_sale_tax()
         config.execute()
 
-        self.start_tour("/", 'shop_list_view_b2c', login="admin")
+        with self.assertQueryCount(__system__=3054):
+            self.start_tour("/", 'shop_list_view_b2c', login="admin")

--- a/addons/website_sale/tests/test_sale_process.py
+++ b/addons/website_sale/tests/test_sale_process.py
@@ -66,7 +66,7 @@ class TestUi(HttpCaseWithUserDemo):
         })
 
     def test_01_admin_shop_tour(self):
-        with self.assertQueryCount(__system__=5346):
+        with self.assertQueryCount(__system__=5356):
             self.start_tour("/", 'shop', login="admin")
 
     def test_02_admin_checkout(self):

--- a/addons/website_sale/tests/test_sale_process.py
+++ b/addons/website_sale/tests/test_sale_process.py
@@ -66,13 +66,16 @@ class TestUi(HttpCaseWithUserDemo):
         })
 
     def test_01_admin_shop_tour(self):
-        self.start_tour("/", 'shop', login="admin")
+        with self.assertQueryCount(__system__=5346):
+            self.start_tour("/", 'shop', login="admin")
 
     def test_02_admin_checkout(self):
-        self.start_tour("/", 'shop_buy_product', login="admin")
+        with self.assertQueryCount(__system__=4665):
+            self.start_tour("/", 'shop_buy_product', login="admin")
 
     def test_03_demo_checkout(self):
-        self.start_tour("/", 'shop_buy_product', login="demo")
+        with self.assertQueryCount(__system__=4552):
+            self.start_tour("/", 'shop_buy_product', login="demo")
 
     def test_04_admin_website_sale_tour(self):
         tax_group = self.env['account.tax.group'].create({'name': 'Tax 15%'})
@@ -99,7 +102,8 @@ class TestUi(HttpCaseWithUserDemo):
             'group_show_line_subtotals_tax_included': False,
         }).execute()
 
-        self.start_tour("/", 'website_sale_tour')
+        with self.assertQueryCount(__system__=14236):
+            self.start_tour("/", 'website_sale_tour')
 
 
 @odoo.tests.tagged('post_install', '-at_install')

--- a/addons/website_sale/tests/test_website_sale_cart_recovery.py
+++ b/addons/website_sale/tests/test_website_sale_cart_recovery.py
@@ -16,7 +16,8 @@ class TestWebsiteSaleCartRecovery(HttpCaseWithUserPortal):
             'website_published': True,
         })
 
-        self.start_tour("/", 'shop_cart_recovery', login="portal")
+        with self.assertQueryCount(__system__=5050):
+            self.start_tour("/", 'shop_cart_recovery', login="portal")
 
 
 @tagged('post_install', '-at_install')

--- a/addons/website_sale/tests/test_website_sale_cart_recovery.py
+++ b/addons/website_sale/tests/test_website_sale_cart_recovery.py
@@ -16,7 +16,7 @@ class TestWebsiteSaleCartRecovery(HttpCaseWithUserPortal):
             'website_published': True,
         })
 
-        with self.assertQueryCount(__system__=5050):
+        with self.assertQueryCount(__system__=5062):
             self.start_tour("/", 'shop_cart_recovery', login="portal")
 
 

--- a/addons/website_sale/tests/test_website_sale_image.py
+++ b/addons/website_sale/tests/test_website_sale_image.py
@@ -202,7 +202,8 @@ class TestWebsiteSaleImage(odoo.tests.HttpCase):
 
         # self.env.cr.commit()  # uncomment to save the product to test in browser
 
-        self.start_tour("/", 'shop_zoom', login="admin")
+        with self.assertQueryCount(__system__=1628):
+            self.start_tour("/", 'shop_zoom', login="admin")
 
         # CASE: unlink move image to fallback if fallback image empty
         template.image_1920 = False

--- a/addons/website_sale/tests/test_website_sale_mail.py
+++ b/addons/website_sale/tests/test_website_sale_mail.py
@@ -28,4 +28,5 @@ class TestWebsiteSaleMail(HttpCase):
         MailMail = odoo.addons.mail.models.mail_mail.MailMail
 
         with patch.object(MailMail, 'unlink', lambda self: None):
-            self.start_tour("/", 'shop_mail', login="admin")
+            with self.assertQueryCount(__system__=5853):
+                self.start_tour("/", 'shop_mail', login="admin")

--- a/addons/website_sale/tests/test_website_sale_mail.py
+++ b/addons/website_sale/tests/test_website_sale_mail.py
@@ -28,5 +28,5 @@ class TestWebsiteSaleMail(HttpCase):
         MailMail = odoo.addons.mail.models.mail_mail.MailMail
 
         with patch.object(MailMail, 'unlink', lambda self: None):
-            with self.assertQueryCount(__system__=5853):
+            with self.assertQueryCount(__system__=5876):
                 self.start_tour("/", 'shop_mail', login="admin")

--- a/addons/website_sale_comparison/tests/test_website_sale_comparison.py
+++ b/addons/website_sale_comparison/tests/test_website_sale_comparison.py
@@ -113,7 +113,8 @@ class TestUi(odoo.tests.HttpCase):
         # YTI FIXME: Adapt to work without demo data
         if tools.config["without_demo"]:
             return
-        self.start_tour("/", 'product_comparison', login='admin')
+        with self.assertQueryCount(__system__=6351):
+            self.start_tour("/", 'product_comparison', login='admin')
 
     def test_02_attribute_multiple_lines(self):
         # Case product page with "Product attributes table" disabled (website_sale standard case)

--- a/addons/website_sale_coupon/tests/test_shop_sale_coupon.py
+++ b/addons/website_sale_coupon/tests/test_shop_sale_coupon.py
@@ -84,7 +84,8 @@ class TestUi(TestSaleProductAttributeValueCommon, HttpCase):
         })
 
         self.env.ref("website_sale.search_count_box").write({"active": True})
-        self.start_tour("/", 'shop_sale_coupon', login="admin")
+        with self.assertQueryCount(__system__=6459):
+            self.start_tour("/", 'shop_sale_coupon', login="admin")
 
 
 @tagged('post_install', '-at_install')

--- a/addons/website_sale_delivery/tests/test_ui.py
+++ b/addons/website_sale_delivery/tests/test_ui.py
@@ -69,4 +69,5 @@ class TestUi(odoo.tests.HttpCase):
         # Acquirers are sorted by state, showing `test` acquirers first (don't ask why).
         self.env.ref("payment.payment_acquirer_transfer").write({"state": "test"})
 
-        self.start_tour("/", 'check_free_delivery', login="admin")
+        with self.assertQueryCount(__system__=3357):
+            self.start_tour("/", 'check_free_delivery', login="admin")

--- a/addons/website_sale_wishlist/tests/test_wishlist_process.py
+++ b/addons/website_sale_wishlist/tests/test_wishlist_process.py
@@ -60,4 +60,5 @@ class TestUi(odoo.tests.HttpCase):
 
         self.env.ref('base.user_admin').name = 'Mitchell Admin'
 
-        self.start_tour("/", 'shop_wishlist')
+        with self.assertQueryCount(__system__=8402):
+            self.start_tour("/", 'shop_wishlist')

--- a/odoo/addons/test_main_flows/tests/test_flow.py
+++ b/odoo/addons/test_main_flows/tests/test_flow.py
@@ -65,7 +65,8 @@ class BaseTestUi(odoo.tests.HttpCase):
             'refund_sequence': True,
         })
 
-        self.start_tour("/web", 'main_flow_tour', login="admin", timeout=180)
+        with self.assertQueryCount(__system__=23293):
+            self.start_tour("/web", 'main_flow_tour', login="admin", timeout=180)
 
 @odoo.tests.tagged('post_install', '-at_install')
 class TestUi(BaseTestUi):

--- a/odoo/addons/test_main_flows/tests/test_flow.py
+++ b/odoo/addons/test_main_flows/tests/test_flow.py
@@ -65,7 +65,7 @@ class BaseTestUi(odoo.tests.HttpCase):
             'refund_sequence': True,
         })
 
-        with self.assertQueryCount(__system__=23293):
+        with self.assertQueryCount(__system__=23363):
             self.start_tour("/web", 'main_flow_tour', login="admin", timeout=180)
 
 @odoo.tests.tagged('post_install', '-at_install')

--- a/odoo/addons/test_new_api/tests/test_ui.py
+++ b/odoo/addons/test_new_api/tests/test_ui.py
@@ -38,6 +38,6 @@ class TestUiTranslation(odoo.tests.HttpCase):
         # is rollbacked at insert and a new cursor is opened, can not test that
         # the message is translated (_load_module_terms is also) rollbacked.
         # Test individually the external id and loading of translation.
-        with self.assertQueryCount(__system__=3140):
+        with self.assertQueryCount(__system__=3155):
             self.start_tour("/web#action=test_new_api.action_categories",
                 'sql_constaint', login="admin")

--- a/odoo/addons/test_new_api/tests/test_ui.py
+++ b/odoo/addons/test_new_api/tests/test_ui.py
@@ -17,7 +17,7 @@ class TestUi(HttpCaseWithUserDemo):
         # the default, but doesn't account for the fact that it could
         # "fall off" into the "o_extra_menu_items" section if the window is
         # too small or there are too many items preceding it in the tests menu
-        with self.assertQueryCount(__system__=5058):
+        with self.assertQueryCount(__system__=5073):
             self.start_tour("/web#action=test_new_api.action_discussions",
                 'widget_x2many', step_delay=100, login="admin", timeout=120)
 

--- a/odoo/addons/test_new_api/tests/test_ui.py
+++ b/odoo/addons/test_new_api/tests/test_ui.py
@@ -17,8 +17,9 @@ class TestUi(HttpCaseWithUserDemo):
         # the default, but doesn't account for the fact that it could
         # "fall off" into the "o_extra_menu_items" section if the window is
         # too small or there are too many items preceding it in the tests menu
-        self.start_tour("/web#action=test_new_api.action_discussions",
-            'widget_x2many', step_delay=100, login="admin", timeout=120)
+        with self.assertQueryCount(__system__=5058):
+            self.start_tour("/web#action=test_new_api.action_discussions",
+                'widget_x2many', step_delay=100, login="admin", timeout=120)
 
 
 @odoo.tests.tagged('-at_install', 'post_install')
@@ -37,5 +38,6 @@ class TestUiTranslation(odoo.tests.HttpCase):
         # is rollbacked at insert and a new cursor is opened, can not test that
         # the message is translated (_load_module_terms is also) rollbacked.
         # Test individually the external id and loading of translation.
-        self.start_tour("/web#action=test_new_api.action_categories",
-            'sql_constaint', login="admin")
+        with self.assertQueryCount(__system__=3140):
+            self.start_tour("/web#action=test_new_api.action_categories",
+                'sql_constaint', login="admin")


### PR DESCRIPTION
PURPOSE
The number of queries keeps growing version after version. A change often requires additional queries and it is fine. However, in some cases, the developper simply doesn't realize its feature adds a lot of queries that may be unnecessary most of the time.

The idea here is to add an assert (assertQueryCount) in python tests executing tours, to check the number of queries done by the tour. That way, everyone will be forced to acknowledge they added queries when they do.

SPEC
Add assertQueryCount on all tour in python tests

Task 2199227



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
