### PR TITLE
[IMP] web: show server action as list view button

### DIFF
--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -332,6 +332,7 @@
             <field name="binding_model_id" ref="account.model_account_move"/>
             <field name="binding_view_types">list</field>
             <field name="state">code</field>
+            <field name="display_in_controlpanel">True</field>
             <field name="code">
                 if records:
                     action = records.action_register_payment()
@@ -340,13 +341,14 @@
 
         <!-- Action confirm_payments for multi -->
         <record id="action_account_confirm_payments" model="ir.actions.server">
-            <field name="name">Post Payments</field>
+            <field name="name">Confirm</field>
             <field name="type">ir.actions.server</field>
             <field name="state">code</field>
             <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]"/>
             <field name="model_id" ref="account.model_account_payment"/>
             <field name="binding_model_id" ref="account.model_account_payment"/>
             <field name="binding_view_types">list</field>
+            <field name="display_in_controlpanel">True</field>
             <field name="code">
                 records.action_post()
             </field>

--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -332,7 +332,7 @@
             <field name="binding_model_id" ref="account.model_account_move"/>
             <field name="binding_view_types">list</field>
             <field name="state">code</field>
-            <field name="display_in_control_panel" eval="True"/>
+            <field name="display_as_button" eval="True"/>
             <field name="code">
                 if records:
                     action = records.action_register_payment()
@@ -348,7 +348,7 @@
             <field name="model_id" ref="account.model_account_payment"/>
             <field name="binding_model_id" ref="account.model_account_payment"/>
             <field name="binding_view_types">list</field>
-            <field name="display_in_control_panel" eval="True"/>
+            <field name="display_as_button" eval="True"/>
             <field name="code">
                 records.action_post()
             </field>

--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -332,7 +332,7 @@
             <field name="binding_model_id" ref="account.model_account_move"/>
             <field name="binding_view_types">list</field>
             <field name="state">code</field>
-            <field name="display_in_controlpanel">True</field>
+            <field name="display_in_control_panel" eval="True"/>
             <field name="code">
                 if records:
                     action = records.action_register_payment()
@@ -348,7 +348,7 @@
             <field name="model_id" ref="account.model_account_payment"/>
             <field name="binding_model_id" ref="account.model_account_payment"/>
             <field name="binding_view_types">list</field>
-            <field name="display_in_controlpanel">True</field>
+            <field name="display_in_control_panel" eval="True"/>
             <field name="code">
                 records.action_post()
             </field>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -576,13 +576,14 @@
             </field>
         </record>
 
-        <act_window name="Send email"
+        <act_window name="Email"
             res_model="mail.compose.message"
             binding_model="crm.lead"
             binding_views="list"
             view_mode="form"
             target="new"
             id="crm_lead_act_window_compose"
+            display_in_controlpanel="True"
             context="{
                 'default_composition_mode': 'comment',
                 'default_use_template': True,

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -583,7 +583,7 @@
             view_mode="form"
             target="new"
             id="crm_lead_act_window_compose"
-            display_in_control_panel="True"
+            display_as_button="True"
             context="{
                 'default_composition_mode': 'comment',
                 'default_use_template': True,

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -583,7 +583,7 @@
             view_mode="form"
             target="new"
             id="crm_lead_act_window_compose"
-            display_in_controlpanel="True"
+            display_in_control_panel="True"
             context="{
                 'default_composition_mode': 'comment',
                 'default_use_template': True,

--- a/addons/crm_sms/views/crm_lead_views.xml
+++ b/addons/crm_sms/views/crm_lead_views.xml
@@ -2,12 +2,13 @@
 <odoo>
     <!-- Add action entry in the Action Menu for Leads -->
     <act_window id="crm_lead_act_window_sms_composer_single"
-        name="Send SMS Text Message"
+        name="SMS"
         binding_model="crm.lead"
         res_model="sms.composer"
         binding_views="list"
         view_mode="form"
         target="new"
+        display_in_controlpanel="True"
         context="{
             'default_composition_mode': 'mass',
             'default_mass_keep_log': True,

--- a/addons/crm_sms/views/crm_lead_views.xml
+++ b/addons/crm_sms/views/crm_lead_views.xml
@@ -8,7 +8,7 @@
         binding_views="list"
         view_mode="form"
         target="new"
-        display_in_controlpanel="True"
+        display_in_control_panel="True"
         context="{
             'default_composition_mode': 'mass',
             'default_mass_keep_log': True,

--- a/addons/crm_sms/views/crm_lead_views.xml
+++ b/addons/crm_sms/views/crm_lead_views.xml
@@ -8,7 +8,7 @@
         binding_views="list"
         view_mode="form"
         target="new"
-        display_in_control_panel="True"
+        display_as_button="True"
         context="{
             'default_composition_mode': 'mass',
             'default_mass_keep_log': True,

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -828,6 +828,7 @@
             <field name="binding_model_id" ref="model_hr_expense"/>
             <field name="binding_view_types">list</field>
             <field name="state">code</field>
+            <field name="display_in_controlpanel">True</field>
             <field name="code">
 if records:
     action = records.action_submit_expenses()

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -828,7 +828,7 @@
             <field name="binding_model_id" ref="model_hr_expense"/>
             <field name="binding_view_types">list</field>
             <field name="state">code</field>
-            <field name="display_in_controlpanel">True</field>
+            <field name="display_in_control_panel" eval="True"/>
             <field name="code">
 if records:
     action = records.action_submit_expenses()

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -828,7 +828,7 @@
             <field name="binding_model_id" ref="model_hr_expense"/>
             <field name="binding_view_types">list</field>
             <field name="state">code</field>
-            <field name="display_in_control_panel" eval="True"/>
+            <field name="display_as_button" eval="True"/>
             <field name="code">
 if records:
     action = records.action_submit_expenses()

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -383,7 +383,7 @@
     </record>
 
     <record id="ir_actions_server_approve_allocations" model="ir.actions.server">
-        <field name="name">Approve</field>
+        <field name="name">Approve Allocations</field>
         <field name="model_id" ref="hr_holidays.model_hr_leave_allocation"/>
         <field name="binding_model_id" ref="hr_holidays.model_hr_leave_allocation"/>
         <field name="binding_view_types">list</field>

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -383,7 +383,7 @@
     </record>
 
     <record id="ir_actions_server_approve_allocations" model="ir.actions.server">
-        <field name="name">Approve Allocations</field>
+        <field name="name">Approve</field>
         <field name="model_id" ref="hr_holidays.model_hr_leave_allocation"/>
         <field name="binding_model_id" ref="hr_holidays.model_hr_leave_allocation"/>
         <field name="binding_view_types">list</field>

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -13,7 +13,7 @@
     </record>
 
     <record model="ir.actions.server" id="action_manager_approval">
-        <field name="name">Approve as Manager</field>
+        <field name="name">Manager Approval</field>
         <field name="model_id" ref="model_hr_leave"/>
         <field name="binding_model_id" ref="model_hr_leave" />
         <field name="state">code</field>
@@ -23,7 +23,7 @@
         </field>
     </record>
     <record model="ir.actions.server" id="action_hr_approval">
-        <field name="name">Approve as Officer</field>
+        <field name="name">HR Approval</field>
         <field name="model_id" ref="model_hr_leave"/>
         <field name="binding_model_id" ref="model_hr_leave" />
         <field name="state">code</field>

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -13,7 +13,7 @@
     </record>
 
     <record model="ir.actions.server" id="action_manager_approval">
-        <field name="name">Manager Approval</field>
+        <field name="name">Approve as Manager</field>
         <field name="model_id" ref="model_hr_leave"/>
         <field name="binding_model_id" ref="model_hr_leave" />
         <field name="state">code</field>
@@ -23,7 +23,7 @@
         </field>
     </record>
     <record model="ir.actions.server" id="action_hr_approval">
-        <field name="name">HR Approval</field>
+        <field name="name">Approve as Officer</field>
         <field name="model_id" ref="model_hr_leave"/>
         <field name="binding_model_id" ref="model_hr_leave" />
         <field name="state">code</field>

--- a/addons/lunch/data/lunch_data.xml
+++ b/addons/lunch/data/lunch_data.xml
@@ -42,7 +42,7 @@
         <field name="binding_model_id" ref="model_lunch_order"/>
         <field name="binding_view_types">list</field>
         <field name="state">code</field>
-        <field name="display_in_controlpanel">True</field>
+        <field name="display_in_control_panel" eval="True"/>
         <field name="code">records.action_confirm()</field>
     </record>
 

--- a/addons/lunch/data/lunch_data.xml
+++ b/addons/lunch/data/lunch_data.xml
@@ -37,11 +37,12 @@
 </data>
 <data>
     <record id="lunch_order_action_confirm" model="ir.actions.server">
-        <field name="name">Lunch: Receive meals</field>
+        <field name="name">Receive</field>
         <field name="model_id" ref="model_lunch_order"/>
         <field name="binding_model_id" ref="model_lunch_order"/>
         <field name="binding_view_types">list</field>
         <field name="state">code</field>
+        <field name="display_in_controlpanel">True</field>
         <field name="code">records.action_confirm()</field>
     </record>
 

--- a/addons/lunch/data/lunch_data.xml
+++ b/addons/lunch/data/lunch_data.xml
@@ -42,7 +42,7 @@
         <field name="binding_model_id" ref="model_lunch_order"/>
         <field name="binding_view_types">list</field>
         <field name="state">code</field>
-        <field name="display_in_control_panel" eval="True"/>
+        <field name="display_as_button" eval="True"/>
         <field name="code">records.action_confirm()</field>
     </record>
 

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -37,7 +37,7 @@
             <field name="groups_id" eval="[(4, ref('mrp.group_mrp_routings'))]"/>
             <field name="state">code</field>
             <field name="code">records.button_plan()</field>
-            <field name="display_in_controlpanel">True</field>
+            <field name="display_in_control_panel" eval="True"/>
         </record>
 
         <record id="action_production_order_mark_done" model="ir.actions.server">
@@ -502,7 +502,7 @@
             <field name="binding_model_id" ref="mrp.model_mrp_production"/>
             <field name="binding_view_types">list</field>
             <field name="state">code</field>
-            <field name="display_in_controlpanel">True</field>
+            <field name="display_in_control_panel" eval="True"/>
             <field name="code">
             if records:
                 records.do_unreserve()

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -37,6 +37,7 @@
             <field name="groups_id" eval="[(4, ref('mrp.group_mrp_routings'))]"/>
             <field name="state">code</field>
             <field name="code">records.button_plan()</field>
+            <field name="display_in_controlpanel">True</field>
         </record>
 
         <record id="action_production_order_mark_done" model="ir.actions.server">
@@ -501,6 +502,7 @@
             <field name="binding_model_id" ref="mrp.model_mrp_production"/>
             <field name="binding_view_types">list</field>
             <field name="state">code</field>
+            <field name="display_in_controlpanel">True</field>
             <field name="code">
             if records:
                 records.do_unreserve()

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -37,7 +37,7 @@
             <field name="groups_id" eval="[(4, ref('mrp.group_mrp_routings'))]"/>
             <field name="state">code</field>
             <field name="code">records.button_plan()</field>
-            <field name="display_in_control_panel" eval="True"/>
+            <field name="display_as_button" eval="True"/>
         </record>
 
         <record id="action_production_order_mark_done" model="ir.actions.server">
@@ -502,7 +502,7 @@
             <field name="binding_model_id" ref="mrp.model_mrp_production"/>
             <field name="binding_view_types">list</field>
             <field name="state">code</field>
-            <field name="display_in_control_panel" eval="True"/>
+            <field name="display_as_button" eval="True"/>
             <field name="code">
             if records:
                 records.do_unreserve()

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -30,7 +30,7 @@
         </record>
 
         <record id="production_order_server_action" model="ir.actions.server">
-            <field name="name">Mrp: Plan Production Orders</field>
+            <field name="name">Plan</field>
             <field name="model_id" ref="mrp.model_mrp_production"/>
             <field name="binding_model_id" ref="mrp.model_mrp_production"/>
             <field name="binding_view_types">list</field>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -731,7 +731,7 @@
         <field name="binding_model_id" ref="purchase.model_purchase_order"/>
         <field name='groups_id' eval="[(4, ref('account.group_account_invoice'))]"/>
         <field name="state">code</field>
-        <field name="display_in_control_panel" eval="True"/>
+        <field name="display_as_button" eval="True"/>
         <field name="code">
             if records:
                 action = records.action_create_invoice()

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -726,11 +726,12 @@
         </record>
 
     <record id="action_purchase_batch_bills" model="ir.actions.server">
-        <field name="name">Create Vendor Bills</field>
+        <field name="name">Create bills</field>
         <field name="model_id" ref="purchase.model_purchase_order"/>
         <field name="binding_model_id" ref="purchase.model_purchase_order"/>
         <field name='groups_id' eval="[(4, ref('account.group_account_invoice'))]"/>
         <field name="state">code</field>
+        <field name="display_in_controlpanel">True</field>
         <field name="code">
             if records:
                 action = records.action_create_invoice()

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -731,7 +731,7 @@
         <field name="binding_model_id" ref="purchase.model_purchase_order"/>
         <field name='groups_id' eval="[(4, ref('account.group_account_invoice'))]"/>
         <field name="state">code</field>
-        <field name="display_in_controlpanel">True</field>
+        <field name="display_in_control_panel" eval="True"/>
         <field name="code">
             if records:
                 action = records.action_create_invoice()

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -504,7 +504,7 @@
             <field name="binding_model_id" ref="stock.model_stock_picking"/>
             <field name="binding_view_types">list</field>
             <field name="state">code</field>
-            <field name="display_in_control_panel" eval="True"/>
+            <field name="display_as_button" eval="True"/>
             <field name="code">
             if records:
                 records.do_unreserve()

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -504,7 +504,7 @@
             <field name="binding_model_id" ref="stock.model_stock_picking"/>
             <field name="binding_view_types">list</field>
             <field name="state">code</field>
-            <field name="display_in_controlpanel">True</field>
+            <field name="display_in_control_panel" eval="True"/>
             <field name="code">
             if records:
                 records.do_unreserve()

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -504,6 +504,7 @@
             <field name="binding_model_id" ref="stock.model_stock_picking"/>
             <field name="binding_view_types">list</field>
             <field name="state">code</field>
+            <field name="display_in_controlpanel">True</field>
             <field name="code">
             if records:
                 records.do_unreserve()

--- a/addons/web/static/src/js/components/action_menus.js
+++ b/addons/web/static/src/js/components/action_menus.js
@@ -44,7 +44,7 @@ odoo.define('web.ActionMenus', function (require) {
             // Action based actions
             const relateActions = this.props.items.relate || [];
             const actionActions = (this.props.items.action || [])
-                .filter((action) => !action.display_in_controlpanel || this.env.view.type !== 'list');
+                .filter((action) => !action.display_in_control_panel || this.env.view.type !== 'list');
             const formattedActions = [...actionActions, ...relateActions].map(
                 action => ({ action, description: action.name, key: action.id })
             );
@@ -64,7 +64,7 @@ odoo.define('web.ActionMenus', function (require) {
          */
         get printItems() {
             const printActions = (this.props.items.print || [])
-                .filter((action) => !action.display_in_controlpanel || this.env.view.type !== 'list');
+                .filter((action) => !action.display_in_control_panel || this.env.view.type !== 'list');
             const printItems = printActions.map(
                 action => ({ action, description: action.name, key: action.id })
             );

--- a/addons/web/static/src/js/components/action_menus.js
+++ b/addons/web/static/src/js/components/action_menus.js
@@ -63,7 +63,8 @@ odoo.define('web.ActionMenus', function (require) {
          * @returns {Object[]}
          */
         get printItems() {
-            const printActions = this.props.items.print || [];
+            const printActions = (this.props.items.print || [])
+                .filter((action) => !action.display_in_controlpanel || this.env.view.type !== 'list');
             const printItems = printActions.map(
                 action => ({ action, description: action.name, key: action.id })
             );

--- a/addons/web/static/src/js/components/action_menus.js
+++ b/addons/web/static/src/js/components/action_menus.js
@@ -42,8 +42,9 @@ odoo.define('web.ActionMenus', function (require) {
                 action => Object.assign({ key: `action-${action.description}` }, action)
             );
             // Action based actions
-            const actionActions = this.props.items.action || [];
             const relateActions = this.props.items.relate || [];
+            const actionActions = (this.props.items.action || [])
+                .filter((action) => !action.display_in_controlpanel || this.env.view.type !== 'list');
             const formattedActions = [...actionActions, ...relateActions].map(
                 action => ({ action, description: action.name, key: action.id })
             );
@@ -67,6 +68,20 @@ odoo.define('web.ActionMenus', function (require) {
                 action => ({ action, description: action.name, key: action.id })
             );
             return printItems;
+        }
+
+        //--------------------------------------------------------------------------
+        // Public
+        //--------------------------------------------------------------------------
+
+        /**
+         * Perform the action for the button clicked
+         * it will be called from list view action buttons
+         *
+         * @param {Object} action
+         */
+        executeAction(action) {
+            return this._executeAction(action);
         }
 
         //---------------------------------------------------------------------

--- a/addons/web/static/src/js/components/action_menus.js
+++ b/addons/web/static/src/js/components/action_menus.js
@@ -44,7 +44,7 @@ odoo.define('web.ActionMenus', function (require) {
             // Action based actions
             const relateActions = this.props.items.relate || [];
             const actionActions = (this.props.items.action || [])
-                .filter((action) => !action.display_in_control_panel || this.env.view.type !== 'list');
+                .filter((action) => !action.display_as_button || this.env.view.type !== 'list');
             const formattedActions = [...actionActions, ...relateActions].map(
                 action => ({ action, description: action.name, key: action.id })
             );
@@ -64,7 +64,7 @@ odoo.define('web.ActionMenus', function (require) {
          */
         get printItems() {
             const printActions = (this.props.items.print || [])
-                .filter((action) => !action.display_in_control_panel || this.env.view.type !== 'list');
+                .filter((action) => !action.display_as_button || this.env.view.type !== 'list');
             const printItems = printActions.map(
                 action => ({ action, description: action.name, key: action.id })
             );

--- a/addons/web/static/src/js/control_panel/control_panel.js
+++ b/addons/web/static/src/js/control_panel/control_panel.js
@@ -121,6 +121,7 @@ odoo.define('web.ControlPanel', function (require) {
                 pager: useRef('pager'),
                 searchView: useRef('searchView'),
                 searchViewButtons: useRef('searchViewButtons'),
+                actionMenus: useRef('actionMenus'),
             };
 
             this.fields = this._formatFields(this.props.fields);

--- a/addons/web/static/src/js/views/list/list_controller.js
+++ b/addons/web/static/src/js/views/list/list_controller.js
@@ -64,7 +64,7 @@ var ListController = BasicController.extend({
         !config.device.isMobile &&
         (this.toolbarActions.action || this.toolbarActions.print) &&
         Object.keys(this.toolbarActions).forEach((actionType) => {
-            const actions = this.toolbarActions[actionType].filter((action) => action.display_in_control_panel);
+            const actions = this.toolbarActions[actionType].filter((action) => action.display_as_button);
             if (actions) {
                 this.actionButtons = this.actionButtons.concat(actions);
             }

--- a/addons/web/static/src/js/views/list/list_controller.js
+++ b/addons/web/static/src/js/views/list/list_controller.js
@@ -59,9 +59,17 @@ var ListController = BasicController.extend({
         this.fieldChangedPrevented = false;
         this.isPageSelected = false; // true iff all records of the page are selected
         this.isDomainSelected = false; // true iff the user selected all records matching the domain
-        this.actionButtons = !config.device.isMobile &&
-            this.toolbarActions.action &&
-            this.toolbarActions.action.filter((action) => action.display_in_controlpanel);
+        this.actionButtons = [];
+
+        !config.device.isMobile &&
+        (this.toolbarActions.action || this.toolbarActions.print) &&
+        Object.keys(this.toolbarActions).forEach((actionType) => {
+            const actions = this.toolbarActions[actionType].filter((action) => action.display_in_controlpanel);
+            if (actions) {
+                this.actionButtons = this.actionButtons.concat(actions);
+            }
+        });
+
         session.user_has_group('base.group_allow_export').then(has_group => {
             this.isExportEnable = has_group;
         });

--- a/addons/web/static/src/js/views/list/list_controller.js
+++ b/addons/web/static/src/js/views/list/list_controller.js
@@ -59,6 +59,9 @@ var ListController = BasicController.extend({
         this.fieldChangedPrevented = false;
         this.isPageSelected = false; // true iff all records of the page are selected
         this.isDomainSelected = false; // true iff the user selected all records matching the domain
+        this.actionButtons = !config.device.isMobile &&
+            this.toolbarActions.action &&
+            this.toolbarActions.action.filter((action) => action.display_in_controlpanel);
         session.user_has_group('base.group_allow_export').then(has_group => {
             this.isExportEnable = has_group;
         });
@@ -127,12 +130,6 @@ var ListController = BasicController.extend({
             });
             this.$buttons.on('mousedown', '.o_list_button_discard', this._onDiscardMousedown.bind(this));
             this.$buttons.on('click', '.o_list_button_discard', this._onDiscard.bind(this));
-        }
-        const actionButtons = !config.device.isMobile &&
-            this.toolbarActions.action &&
-            this.toolbarActions.action.filter((action) => action.display_in_controlpanel);
-        if (actionButtons) {
-            this.$actionButtons = this._generateActionButtons(actionButtons);
         }
         if ($node) {
             this.$buttons.appendTo($node);
@@ -613,7 +610,8 @@ var ListController = BasicController.extend({
         if (this.$('.o_list_action_button').length) {
             this.$('.o_list_action_button').remove();
         }
-        if (this.selectedRecords.length) {
+        if (this.selectedRecords.length && this.actionButtons) {
+            this.$actionButtons = this._generateActionButtons(this.actionButtons);
             this.$buttons.append(this.$actionButtons);
         }
     },

--- a/addons/web/static/src/js/views/list/list_controller.js
+++ b/addons/web/static/src/js/views/list/list_controller.js
@@ -64,7 +64,7 @@ var ListController = BasicController.extend({
         !config.device.isMobile &&
         (this.toolbarActions.action || this.toolbarActions.print) &&
         Object.keys(this.toolbarActions).forEach((actionType) => {
-            const actions = this.toolbarActions[actionType].filter((action) => action.display_in_controlpanel);
+            const actions = this.toolbarActions[actionType].filter((action) => action.display_in_control_panel);
             if (actions) {
                 this.actionButtons = this.actionButtons.concat(actions);
             }

--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -46,6 +46,7 @@
                 </div>
                 <ActionMenus t-if="props.actionMenus and props.actionMenus.items"
                     t-props="props.actionMenus"
+                    t-ref="actionMenus"
                 />
             </div>
             <div class="o_cp_bottom_right">

--- a/addons/web/static/tests/views/list_mobile_tests.js
+++ b/addons/web/static/tests/views/list_mobile_tests.js
@@ -26,7 +26,7 @@ QUnit.module('Views', {
 
     QUnit.module('ListViewMobile');
 
-    QUnit.test('server action with display_in_control_panel should not be shown as button in list view in mobile', async function (assert) {
+    QUnit.test('server action with display_as_button should not be shown as button in list view in mobile', async function (assert) {
         assert.expect(1);
 
         const list = await createView({
@@ -46,7 +46,7 @@ QUnit.module('Views', {
                     name: 'Server Action 2',
                     type: 'ir.actions.server',
                     usage: 'ir_actions_server',
-                    display_in_control_panel: true
+                    display_as_button: true
                 }],
             }
         });

--- a/addons/web/static/tests/views/list_mobile_tests.js
+++ b/addons/web/static/tests/views/list_mobile_tests.js
@@ -1,0 +1,60 @@
+odoo.define('web.list_tests', function (require) {
+"use strict";
+
+const ListView = require('web.ListView');
+const testUtils = require('web.test_utils');
+
+const createView = testUtils.createView;
+
+QUnit.module('Views', {
+    beforeEach: function () {
+        this.data = {
+            foo: {
+                fields: {
+                    foo: { string: "Foo", type: "char" },
+                },
+                records: [
+                    {
+                        id: 1,
+                        foo: "yop",
+                    },
+                ]
+            },
+        };
+    }
+}, function () {
+
+    QUnit.module('ListViewMobile');
+
+    QUnit.test('server action with display_in_controlpanel should not be shown as button in list view in mobile', async function (assert) {
+        assert.expect(1);
+
+        const list = await createView({
+            View: ListView,
+            model: 'foo',
+            data: this.data,
+            viewOptions: { hasActionMenus: true },
+            arch: '<tree><field name="foo"/></tree>',
+            toolbar: {
+                action: [{
+                    model_name: 'foo',
+                    name: 'Server Action 1',
+                    type: 'ir.actions.server',
+                    usage: 'ir_actions_server',
+                }, {
+                    model_name: 'foo',
+                    name: 'Server Action 2',
+                    type: 'ir.actions.server',
+                    usage: 'ir_actions_server',
+                    display_in_controlpanel: true
+                }],
+            }
+        });
+
+        assert.containsNone(list, '.o_list_action_button', 'List view contains one server action button');
+
+        list.destroy();
+    });
+});
+
+});

--- a/addons/web/static/tests/views/list_mobile_tests.js
+++ b/addons/web/static/tests/views/list_mobile_tests.js
@@ -26,7 +26,7 @@ QUnit.module('Views', {
 
     QUnit.module('ListViewMobile');
 
-    QUnit.test('server action with display_in_controlpanel should not be shown as button in list view in mobile', async function (assert) {
+    QUnit.test('server action with display_in_control_panel should not be shown as button in list view in mobile', async function (assert) {
         assert.expect(1);
 
         const list = await createView({
@@ -46,7 +46,7 @@ QUnit.module('Views', {
                     name: 'Server Action 2',
                     type: 'ir.actions.server',
                     usage: 'ir_actions_server',
-                    display_in_controlpanel: true
+                    display_in_control_panel: true
                 }],
             }
         });

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -254,7 +254,7 @@ QUnit.module('Views', {
         list.destroy();
     });
 
-    QUnit.test('server action with display_in_control_panel should be shown as button in list view', async function (assert) {
+    QUnit.test('server action with display_as_button should be shown as button in list view', async function (assert) {
         assert.expect(7);
 
         const list = await createView({
@@ -274,7 +274,7 @@ QUnit.module('Views', {
                     name: 'Button Action',
                     type: 'ir.actions.server',
                     usage: 'ir_actions_server',
-                    display_in_control_panel: true
+                    display_as_button: true
                 }],
             },
             mockRPC: function (route, args) {
@@ -1795,7 +1795,7 @@ QUnit.module('Views', {
                     name: 'Button Action',
                     type: 'ir.actions.server',
                     usage: 'ir_actions_server',
-                    display_in_control_panel: true
+                    display_as_button: true
                 }],
             },
         });

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -254,7 +254,7 @@ QUnit.module('Views', {
         list.destroy();
     });
 
-    QUnit.test('server action with display_in_controlpanel should be shown as button in list view', async function (assert) {
+    QUnit.test('server action with display_in_control_panel should be shown as button in list view', async function (assert) {
         assert.expect(7);
 
         const list = await createView({
@@ -274,7 +274,7 @@ QUnit.module('Views', {
                     name: 'Button Action',
                     type: 'ir.actions.server',
                     usage: 'ir_actions_server',
-                    display_in_controlpanel: true
+                    display_in_control_panel: true
                 }],
             },
             mockRPC: function (route, args) {
@@ -1795,7 +1795,7 @@ QUnit.module('Views', {
                     name: 'Button Action',
                     type: 'ir.actions.server',
                     usage: 'ir_actions_server',
-                    display_in_controlpanel: true
+                    display_in_control_panel: true
                 }],
             },
         });

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -799,6 +799,7 @@
         <script type="text/javascript" src="/web/static/lib/jquery.touchSwipe/jquery.touchSwipe.js"></script>
         <script type="text/javascript" src="/web/static/tests/fields/basic_fields_mobile_tests.js"></script>
         <script type="text/javascript" src="/web/static/tests/fields/relational_fields_mobile_tests.js"></script>
+        <script type="text/javascript" src="/web/static/tests/views/list_mobile_tests.js"></script>
     </template>
 
     <template id="web.benchmark_suite">

--- a/odoo/addons/base/data/ir_actions_data.xml
+++ b/odoo/addons/base/data/ir_actions_data.xml
@@ -2,11 +2,12 @@
 <odoo>
     <data>
         <record id="action_server_module_immediate_install" model="ir.actions.server">
-            <field name="name">Install Modules</field>
+            <field name="name">Install</field>
             <field name="type">ir.actions.server</field>
             <field name="model_id" ref="model_ir_module_module" />
             <field name="binding_model_id" ref="model_ir_module_module" />
             <field name="state">code</field>
+            <field name="display_in_controlpanel">True</field>
             <field name="code">records.button_immediate_install()</field>
         </record>
     </data>

--- a/odoo/addons/base/data/ir_actions_data.xml
+++ b/odoo/addons/base/data/ir_actions_data.xml
@@ -7,7 +7,7 @@
             <field name="model_id" ref="model_ir_module_module" />
             <field name="binding_model_id" ref="model_ir_module_module" />
             <field name="state">code</field>
-            <field name="display_in_control_panel" eval="True"/>
+            <field name="display_as_button" eval="True"/>
             <field name="code">records.button_immediate_install()</field>
         </record>
     </data>

--- a/odoo/addons/base/data/ir_actions_data.xml
+++ b/odoo/addons/base/data/ir_actions_data.xml
@@ -7,7 +7,7 @@
             <field name="model_id" ref="model_ir_module_module" />
             <field name="binding_model_id" ref="model_ir_module_module" />
             <field name="state">code</field>
-            <field name="display_in_controlpanel">True</field>
+            <field name="display_in_control_panel" eval="True"/>
             <field name="code">records.button_immediate_install()</field>
         </record>
     </data>

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -49,6 +49,7 @@ class IrActions(models.Model):
                                      ('report', 'Report')],
                                     required=True, default='action')
     binding_view_types = fields.Char(default='list,form')
+    display_in_controlpanel = fields.Boolean(string='Display in Controlpanel', default=False)
 
     def _compute_xml_id(self):
         res = self.get_external_id()
@@ -408,7 +409,6 @@ class IrActionsServer(models.Model):
     fields_lines = fields.One2many('ir.server.object.lines', 'server_id', string='Value Mapping', copy=True)
     groups_id = fields.Many2many('res.groups', 'ir_act_server_group_rel',
                                  'act_id', 'gid', string='Groups')
-    display_in_controlpanel = fields.Boolean(string='Display in Controlpanel', default=False)
 
     @api.constrains('code')
     def _check_python_code(self):

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -49,7 +49,7 @@ class IrActions(models.Model):
                                      ('report', 'Report')],
                                     required=True, default='action')
     binding_view_types = fields.Char(default='list,form')
-    display_in_control_panel = fields.Boolean(string='Display in Control Panel', default=False, help="Setting a True value makes this action to be displayed in the control panel as a Button and also removes it from the action dropdown.")
+    display_as_button = fields.Boolean(string='Display as Button', default=False, help="Setting a True value makes this action to be displayed in the control panel as a Button and also removes it from the action dropdown.")
 
     def _compute_xml_id(self):
         res = self.get_external_id()

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -408,6 +408,7 @@ class IrActionsServer(models.Model):
     fields_lines = fields.One2many('ir.server.object.lines', 'server_id', string='Value Mapping', copy=True)
     groups_id = fields.Many2many('res.groups', 'ir_act_server_group_rel',
                                  'act_id', 'gid', string='Groups')
+    display_in_controlpanel = fields.Boolean(string='Display in Controlpanel', default=False)
 
     @api.constrains('code')
     def _check_python_code(self):

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -49,7 +49,7 @@ class IrActions(models.Model):
                                      ('report', 'Report')],
                                     required=True, default='action')
     binding_view_types = fields.Char(default='list,form')
-    display_in_controlpanel = fields.Boolean(string='Display in Controlpanel', default=False)
+    display_in_control_panel = fields.Boolean(string='Display in Control Panel', default=False, help="Setting a True value makes this action to be displayed in the control panel as a Button and also removes it from the action dropdown.")
 
     def _compute_xml_id(self):
         res = self.get_external_id()

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -12,7 +12,8 @@
                     <group>
                         <field name="name"/>
                         <field name="type"/>
-                        <field name="display_in_control_panel"/>
+                        <field name="binding_model_id" invisible="1"/>
+                        <field name="display_as_button" attrs="{'invisible':[('binding_model_id','=',False)]}"/>
                     </group>
                 </sheet>
                 </form>
@@ -78,7 +79,7 @@
                                 <field name="model"/>
                                 <field name="report_name"/>
                                 <field name="print_report_name" />
-                                <field name="display_in_control_panel"/>
+                                <field name="display_as_button" attrs="{'invisible':[('binding_model_id','=',False)]}"/>
                             </group>
                         </group>
                         <notebook>
@@ -166,7 +167,8 @@
                             <field name="usage"/>
                             <field name="type" readonly="1"/>
                             <field name="target"/>
-                            <field name="display_in_control_panel"/>
+                            <field name="binding_model_id" invisible="1"/>
+                            <field name="display_as_button" attrs="{'invisible':[('binding_model_id','=',False)]}"/>
                         </group>
                     </group>
                     <notebook>
@@ -271,7 +273,7 @@
                             <group name="action_content">
                                 <field name="model_id" options="{'no_create': True}"/>
                                 <field name="model_name" invisible="1"/>
-                                <field name="display_in_control_panel"/>
+                                <field name="display_as_button" attrs="{'invisible':[('binding_model_id','=',False)]}"/>
                             </group>
                             <group>
                                 <field name="state"/>

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -268,7 +268,7 @@
                             <group name="action_content">
                                 <field name="model_id" options="{'no_create': True}"/>
                                 <field name="model_name" invisible="1"/>
-                                <field name="display_in_controlpanel"/>
+                                <field name="display_in_controlpanel" attrs="{'invisible': [('binding_model_id', '=', False)]}"/>
                             </group>
                             <group>
                                 <field name="state"/>

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -12,7 +12,7 @@
                     <group>
                         <field name="name"/>
                         <field name="type"/>
-                        <field name="display_in_controlpanel"/>
+                        <field name="display_in_control_panel"/>
                     </group>
                 </sheet>
                 </form>
@@ -78,7 +78,7 @@
                                 <field name="model"/>
                                 <field name="report_name"/>
                                 <field name="print_report_name" />
-                                <field name="display_in_controlpanel"/>
+                                <field name="display_in_control_panel"/>
                             </group>
                         </group>
                         <notebook>
@@ -166,7 +166,7 @@
                             <field name="usage"/>
                             <field name="type" readonly="1"/>
                             <field name="target"/>
-                            <field name="display_in_controlpanel"/>
+                            <field name="display_in_control_panel"/>
                         </group>
                     </group>
                     <notebook>
@@ -271,7 +271,7 @@
                             <group name="action_content">
                                 <field name="model_id" options="{'no_create': True}"/>
                                 <field name="model_name" invisible="1"/>
-                                <field name="display_in_controlpanel"/>
+                                <field name="display_in_control_panel"/>
                             </group>
                             <group>
                                 <field name="state"/>

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -78,6 +78,7 @@
                                 <field name="model"/>
                                 <field name="report_name"/>
                                 <field name="print_report_name" />
+                                <field name="display_in_controlpanel"/>
                             </group>
                         </group>
                         <notebook>
@@ -165,6 +166,7 @@
                             <field name="usage"/>
                             <field name="type" readonly="1"/>
                             <field name="target"/>
+                            <field name="display_in_controlpanel"/>
                         </group>
                     </group>
                     <notebook>
@@ -269,6 +271,7 @@
                             <group name="action_content">
                                 <field name="model_id" options="{'no_create': True}"/>
                                 <field name="model_name" invisible="1"/>
+                                <field name="display_in_controlpanel"/>
                             </group>
                             <group>
                                 <field name="state"/>

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -268,6 +268,7 @@
                             <group name="action_content">
                                 <field name="model_id" options="{'no_create': True}"/>
                                 <field name="model_name" invisible="1"/>
+                                <field name="display_in_controlpanel"/>
                             </group>
                             <group>
                                 <field name="state"/>

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -12,6 +12,7 @@
                     <group>
                         <field name="name"/>
                         <field name="type"/>
+                        <field name="display_in_controlpanel"/>
                     </group>
                 </sheet>
                 </form>
@@ -268,7 +269,6 @@
                             <group name="action_content">
                                 <field name="model_id" options="{'no_create': True}"/>
                                 <field name="model_name" invisible="1"/>
-                                <field name="display_in_controlpanel" attrs="{'invisible': [('binding_model_id', '=', False)]}"/>
                             </group>
                             <group>
                                 <field name="state"/>

--- a/odoo/import_xml.rng
+++ b/odoo/import_xml.rng
@@ -257,7 +257,7 @@
             <rng:optional> <rng:attribute name="groups"/> </rng:optional>
             <rng:optional> <rng:attribute name="limit"/> </rng:optional>
             <rng:optional> <rng:attribute name="usage"/> </rng:optional>
-            <rng:optional> <rng:attribute name="display_in_control_panel"/> </rng:optional>
+            <rng:optional> <rng:attribute name="display_as_button"/> </rng:optional>
             <rng:optional>
                 <rng:attribute name="binding_model"/>
                 <rng:optional>

--- a/odoo/import_xml.rng
+++ b/odoo/import_xml.rng
@@ -257,6 +257,7 @@
             <rng:optional> <rng:attribute name="groups"/> </rng:optional>
             <rng:optional> <rng:attribute name="limit"/> </rng:optional>
             <rng:optional> <rng:attribute name="usage"/> </rng:optional>
+            <rng:optional> <rng:attribute name="display_in_controlpanel"/> </rng:optional>
             <rng:optional>
                 <rng:attribute name="binding_model"/>
                 <rng:optional>

--- a/odoo/import_xml.rng
+++ b/odoo/import_xml.rng
@@ -257,7 +257,7 @@
             <rng:optional> <rng:attribute name="groups"/> </rng:optional>
             <rng:optional> <rng:attribute name="limit"/> </rng:optional>
             <rng:optional> <rng:attribute name="usage"/> </rng:optional>
-            <rng:optional> <rng:attribute name="display_in_controlpanel"/> </rng:optional>
+            <rng:optional> <rng:attribute name="display_in_control_panel"/> </rng:optional>
             <rng:optional>
                 <rng:attribute name="binding_model"/>
                 <rng:optional>

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -336,6 +336,7 @@ form: module.record_id""" % (xml_id,)
         view_mode = rec.get('view_mode') or 'tree,form'
         usage = rec.get('usage')
         limit = rec.get('limit')
+        display_in_controlpanel = rec.get('display_in_controlpanel')
         uid = self.env.user.id
 
         # Act_window's 'domain' and 'context' contain mostly literals
@@ -390,6 +391,7 @@ form: module.record_id""" % (xml_id,)
             'view_mode': view_mode,
             'usage': usage,
             'limit': limit,
+            'display_in_controlpanel': display_in_controlpanel
         }
 
         if rec.get('groups'):

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -336,7 +336,7 @@ form: module.record_id""" % (xml_id,)
         view_mode = rec.get('view_mode') or 'tree,form'
         usage = rec.get('usage')
         limit = rec.get('limit')
-        display_in_control_panel = rec.get('display_in_control_panel')
+        display_as_button = rec.get('display_as_button')
         uid = self.env.user.id
 
         # Act_window's 'domain' and 'context' contain mostly literals
@@ -391,7 +391,7 @@ form: module.record_id""" % (xml_id,)
             'view_mode': view_mode,
             'usage': usage,
             'limit': limit,
-            'display_in_control_panel': display_in_control_panel
+            'display_as_button': display_as_button
         }
 
         if rec.get('groups'):

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -336,7 +336,7 @@ form: module.record_id""" % (xml_id,)
         view_mode = rec.get('view_mode') or 'tree,form'
         usage = rec.get('usage')
         limit = rec.get('limit')
-        display_in_controlpanel = rec.get('display_in_controlpanel')
+        display_in_control_panel = rec.get('display_in_control_panel')
         uid = self.env.user.id
 
         # Act_window's 'domain' and 'context' contain mostly literals
@@ -391,7 +391,7 @@ form: module.record_id""" % (xml_id,)
             'view_mode': view_mode,
             'usage': usage,
             'limit': limit,
-            'display_in_controlpanel': display_in_controlpanel
+            'display_in_control_panel': display_in_control_panel
         }
 
         if rec.get('groups'):


### PR DESCRIPTION
PURPOSE

We want to enable the framework to define some of those server
actions in the controlpanel, same as buttons like
'create/edit/discard' buttons.

SPECIFICATION

- added a display_in_controlpanel Boolean field in
  ir.actions.server
- server action with this field having true value will be shown as 
  button in list view and that also displayed when user selects the 
  record from the list view and that action will not be shown in action menu

LINKS

PR https://github.com/odoo/odoo/pull/52425
Task 2246383

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
