### PR TITLE
[FIX] base: fix the burmese translation iso committed

### DIFF
--- a/odoo/addons/base/data/res_lang_data.xml
+++ b/odoo/addons/base/data/res_lang_data.xml
@@ -3,4 +3,9 @@
     <data noupdate="1">
         <function name="install_lang" model="res.lang"/>
     </data>
+    <data>
+        <record id="base.lang_my" model="res.lang">
+            <field name="url_code">mya</field>
+        </record>
+    </data>
 </odoo>


### PR DESCRIPTION
The burmese ISO 639-1 code is "my" which conflicts with the page /my
We will now use the ISO 639-3 code "mya" to fix this.
https://iso639-3.sil.org/code/mya

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
