### PR TITLE
[IMP] stock: new forecasted report

### DIFF
--- a/addons/mrp/__manifest__.py
+++ b/addons/mrp/__manifest__.py
@@ -40,6 +40,7 @@
         'report/mrp_report_views_main.xml',
         'report/mrp_report_bom_structure.xml',
         'report/mrp_production_templates.xml',
+        'report/report_replenishment.xml',
         'report/report_stock_rule.xml',
         'report/mrp_zebra_production_templates.xml',
     ],

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -45,14 +45,15 @@ class StockMoveLine(models.Model):
             lines |= raw_moves_lines.filtered(lambda ml: ml.product_id == self.product_id and (ml.lot_id or ml.lot_name))
         return lines
 
-    def _reservation_is_updatable(self, quantity, reserved_quant):
-        self.ensure_one()
-        if self.produce_line_ids.lot_id:
-            ml_remaining_qty = self.qty_done - self.product_uom_qty
-            ml_remaining_qty = self.product_uom_id._compute_quantity(ml_remaining_qty, self.product_id.uom_id, rounding_method="HALF-UP")
-            if float_compare(ml_remaining_qty, quantity, precision_rounding=self.product_id.uom_id.rounding) < 0:
+    @api.model
+    def _reservation_is_updatable(self, move_line, quantity, reserved_quant):
+        if move_line.get('produce_line_ids'):
+            product = self.env['product.product'].browse(move_line['product_id'])
+            ml_remaining_qty = move_line['qty_done'] - move_line['product_uom_qty']
+            ml_remaining_qty = self.env['uom.uom'].browse(move_line['product_uom_id'])._compute_quantity(ml_remaining_qty, product.uom_id, rounding_method="HALF-UP")
+            if float_compare(ml_remaining_qty, quantity, precision_rounding=product.uom_id.rounding) < 0:
                 return False
-        return super(StockMoveLine, self)._reservation_is_updatable(quantity, reserved_quant)
+        return super()._reservation_is_updatable(move_line, quantity, reserved_quant)
 
     def write(self, vals):
         for move_line in self:
@@ -231,6 +232,10 @@ class StockMove(models.Model):
                 move.move_line_ids.write({'production_id': move.raw_material_production_id.id,
                                                'workorder_id': move.workorder_id.id,})
         return res
+    @api.model
+    def _action_assign_get_move_lines_fields_to_read(self):
+        res = super()._action_assign_get_move_lines_fields_to_read()
+        return res + ['produce_line_ids']
 
     def _action_confirm(self, merge=True, merge_into=False):
         moves = self.action_explode()

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -3,6 +3,7 @@
 
 from odoo import api, exceptions, fields, models, _
 from odoo.exceptions import UserError
+from odoo.osv import expression
 from odoo.tools import float_compare, float_round, float_is_zero
 
 
@@ -290,6 +291,46 @@ class StockMove(models.Model):
                 continue
             production._action_cancel()
         return res
+
+    def _get_consuming_document(self):
+        """ WIP """
+        res = super()._get_consuming_document()
+        return res or self.raw_material_production_id
+
+    @api.model
+    def _get_consuming_domain(self, location_ids):
+        consuming_domain = super()._get_consuming_domain(location_ids)
+        consuming_domain = expression.OR([
+            consuming_domain,
+            [('raw_material_production_id', '!=', False)]
+        ])
+        return consuming_domain
+
+    def _get_replenishment_document(self):
+        """ TODO WIP """
+        res = super()._get_replenishment_document()
+        return res or self.production_id
+
+    @api.model
+    def _get_replenishment_domain(self, location_ids):
+        replenishment_domain = super()._get_replenishment_domain(location_ids)
+        replenishment_domain = expression.OR([
+            replenishment_domain,
+            [('production_id', '!=', False)]
+        ])
+        return replenishment_domain
+
+    def _is_consuming(self, wh_location_ids):
+        """ TODO WIP """
+        res = super()._is_consuming(wh_location_ids)
+        # return res or (self.picking_code == 'mrp_operation' and self.raw_material_production_id)
+        return res or self.raw_material_production_id
+
+    def _is_replenishing(self, wh_location_ids):
+        """ TODO WIP """
+        res = super()._is_replenishing(wh_location_ids)
+        # return res or (self.picking_code == 'mrp_operation' and self.production_id)
+        return res or self.production_id
 
     def _prepare_move_split_vals(self, qty):
         defaults = super()._prepare_move_split_vals(qty)

--- a/addons/mrp/report/__init__.py
+++ b/addons/mrp/report/__init__.py
@@ -3,3 +3,4 @@
 
 from . import mrp_report_bom_structure
 from . import report_stock_rule
+from . import report_replenishment

--- a/addons/mrp/report/report_replenishment.py
+++ b/addons/mrp/report/report_replenishment.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class ReplenishmentReport(models.AbstractModel):
+    _inherit = 'report.stock.report_product_product_replenishment'
+
+    @api.model
+    def _get_report_data(self, product_template_ids=False, product_variant_ids=False):
+        res = super()._get_report_data(product_template_ids, product_variant_ids)
+        location_ids = False
+        # Get warehouse locations.
+        if self.env.context.get('wh_location_id'):
+            wh_location_id = self.env.context.get('wh_location_id')
+            location_ids = self.env['stock.location'].search_read(
+                [('id', 'child_of', wh_location_id)],
+                ['id'],
+            )
+            location_ids = [loc['id'] for loc in location_ids]
+        domain = [('state', '=', 'draft')]
+        domain += self._product_domain(product_template_ids, product_variant_ids)
+        mo_domain = domain
+        if location_ids:
+            mo_domain += [('location_dest_id', 'in', location_ids)]
+
+        qty_in, qty_out = 0, 0
+        # Pending incoming quantity.
+        grouped_mo = self.env['mrp.production'].read_group(mo_domain, ['product_qty'], 'product_id')
+        if grouped_mo:
+            qty_in = sum(mo['product_qty'] for mo in grouped_mo)
+        # Pending outgoing quantity.
+        move_domain = domain + [('raw_material_production_id', '!=', False)]
+        if location_ids:
+            move_domain += [('location_id', 'in', location_ids)]
+        grouped_moves = self.env['stock.move'].read_group(move_domain, ['product_qty'], 'product_id')
+        if grouped_moves:
+            qty_out = sum(move['product_qty'] for move in grouped_moves)
+
+        res['draft_production_qty'] = {
+            'in': qty_in,
+            'out': qty_out,
+        }
+        res['qty']['in'] += qty_in
+        res['qty']['out'] += qty_out
+        return res

--- a/addons/mrp/report/report_replenishment.xml
+++ b/addons/mrp/report/report_replenishment.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="mrp_report_product_product_replenishment" inherit_id="stock.report_product_product_replenishment">
+        <xpath expr="//tr[@name='draft_picking_in']" position="after">
+            <tr t-if="docs['draft_production_qty']['in']" name="draft_mo_in">
+                <td>Draft MO</td>
+                <td t-esc="docs['draft_production_qty']['in']" class="text-right"/>
+                <td t-esc="docs['uom']" groups="uom.group_uom"/>
+            </tr>
+        </xpath>
+        <xpath expr="//tr[@name='draft_picking_out']" position="after">
+            <tr t-if="docs['draft_production_qty']['out']" name="draft_mo_out">
+                <td>Draft MO</td>
+                <td t-esc="docs['draft_production_qty']['out']" class="text-right"/>
+                <td t-esc="docs['uom']" groups="uom.group_uom"/>
+            </tr>
+        </xpath>
+    </template>
+</odoo>

--- a/addons/mrp/tests/__init__.py
+++ b/addons/mrp/tests/__init__.py
@@ -5,6 +5,7 @@ from . import test_byproduct
 from . import test_cancel_mo
 from . import test_order
 from . import test_stock
+from . import test_stock_report
 from . import test_warehouse_multistep_manufacturing
 from . import test_procurement
 from . import test_unbuild

--- a/addons/mrp/tests/test_stock_report.py
+++ b/addons/mrp/tests/test_stock_report.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import Form
+from odoo.addons.stock.tests.test_report import TestReportsCommon
+
+
+class TestSaleStockReports(TestReportsCommon):
+    def test_report_forecast_1_production_backorder(self):
+        """ Creates a manufacturing order and produces half the quantity.
+        Then creates a backorder and checks the report.
+        """
+        # Configures the warehouse.
+        warehouse = self.env.ref('stock.warehouse0')
+        warehouse.manufacture_steps = 'pbm_sam'
+        # Configures a product.
+        product_apple_pie = self.env['product.product'].create({
+            'name': 'Apple Pie',
+            'type': 'product',
+        })
+        product_apple = self.env['product.product'].create({
+            'name': 'Apple',
+            'type': 'consu',
+        })
+        bom = self.env['mrp.bom'].create({
+            'product_id': product_apple_pie.id,
+            'product_tmpl_id': product_apple_pie.product_tmpl_id.id,
+            'product_uom_id': product_apple_pie.uom_id.id,
+            'product_qty': 1.0,
+            'type': 'normal',
+            'bom_line_ids': [
+                (0, 0, {'product_id': product_apple.id, 'product_qty': 5}),
+            ],
+        })
+        # Creates a MO and validates the pick components.
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.product_id = product_apple_pie
+        mo_form.bom_id = bom
+        mo_form.product_qty = 4
+        mo_1 = mo_form.save()
+        mo_1.action_confirm()
+        pick = mo_1.move_raw_ids.move_orig_ids.picking_id
+        pick_form = Form(pick)
+        with pick_form.move_line_ids_without_package.edit(0) as move_line:
+            move_line.qty_done = 20
+        pick = pick_form.save()
+        pick.button_validate()
+        # Produces 3 products then creates a backorder for the remaining product.
+        mo_form = Form(mo_1)
+        mo_form.qty_producing = 3
+        mo_1 = mo_form.save()
+        action = mo_1.button_mark_done()
+        backorder_form = Form(self.env['mrp.production.backorder'].with_context(**action['context']))
+        backorder = backorder_form.save()
+        backorder.action_backorder()
+
+        mo_2 = (mo_1.procurement_group_id.mrp_production_ids - mo_1)
+        # Checks the forecast report.
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=product_apple_pie.product_tmpl_id.ids)
+        self.assertEqual(len(lines), 2, "Must have two lines")
+        self.assertEqual(lines[0]['document_in'].id, mo_1.id)
+        self.assertEqual(lines[0]['quantity'], 3)
+        self.assertEqual(lines[0]['document_out'], False)
+        self.assertEqual(lines[1]['document_in'].id, mo_2.id)
+        self.assertEqual(lines[1]['quantity'], 1)
+        self.assertEqual(lines[1]['document_out'], False)
+
+        # Produces the last unit.
+        mo_form = Form(mo_2)
+        mo_form.qty_producing = 1
+        mo_2 = mo_form.save()
+        mo_2.button_mark_done()
+        # Checks the forecast report.
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=product_apple_pie.product_tmpl_id.ids)
+        self.assertEqual(len(lines), 1, "Must have one line")
+        self.assertEqual(lines[0]['document_in'].id, mo_1.id)
+        self.assertEqual(lines[0]['quantity'], 4)
+        self.assertEqual(lines[0]['document_out'], False)

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -18,7 +18,11 @@
                     <field name="bom_id" readonly="1" optional="hide"/>
                     <field name="origin" optional="show"/>
                     <field name="user_id" optional="hide" widget="many2one_avatar_user"/>
-                    <field name="reservation_state" optional="show"/>
+                    <field name="components_availability_state" invisible="1"/>
+                    <field name="components_availability" optional="show"
+                        decoration-bf="components_availability_state in ['waiting', 'late']"
+                        decoration-warning="components_availability_state == 'waiting'"
+                        decoration-danger="components_availability_state == 'late'"/>
                     <field name="product_qty" sum="Total Qty" string="Quantity" readonly="1" optional="show"/>
                     <field name="company_id" readonly="1" groups="base.group_multi_company" optional="show"/>
                     <field name="state" optional="show" widget='badge' decoration-success="state == 'done'" decoration-info="state not in ('done', 'cancel')"/>
@@ -250,7 +254,13 @@
                                     <field name="state" invisible="1" force_save="1"/>
                                     <field name="should_consume_qty" invisible="1"/>
                                     <field name="product_uom_qty" widget="mrp_should_consume" string="To Consume" attrs="{'readonly': ['&amp;', ('parent.state', '!=', 'draft'), '|', ('parent.state', 'not in', ('confirmed', 'planned', 'progress', 'to_close')), ('parent.is_locked', '=', True)]}" width="1"/>
-                                    <field name="reserved_availability" attrs="{'invisible': [('is_done', '=', True)], 'column_invisible': [('parent.state', 'in', ('draft', 'done'))]}" string="Reserved" decoration-danger="not is_done and reserved_availability &lt; product_uom_qty and product_uom_qty - reserved_availability &gt; 0.0001"/>
+                                    <field name="reserved_availability" invisible="1"/>
+                                    <field name="availability_state" invisible="1"/>
+                                    <field name="availability_indication"
+                                        decoration-bf="availability_state in ['late', 'partial', 'waiting']"
+                                        decoration-warning="availability_state in ['partial', 'waiting']"
+                                        decoration-danger="availability_state == 'late'"
+                                        attrs="{'column_invisible': [('parent.state', 'in', ('draft', 'done'))]}"/>
                                     <field name="is_quantity_done_editable" invisible="1"/>
                                     <field name="quantity_done" string="Consumed"
                                         decoration-success="not is_done and (quantity_done - should_consume_qty == 0)"

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -253,10 +253,11 @@
                                     <field name="location_dest_id" domain="[('id', 'child_of', parent.location_dest_id)]" invisible="1"/>
                                     <field name="state" invisible="1" force_save="1"/>
                                     <field name="should_consume_qty" invisible="1"/>
+                                    <field name="product_type" invisible="1"/>
                                     <field name="product_uom_qty" widget="mrp_should_consume" string="To Consume" attrs="{'readonly': ['&amp;', ('parent.state', '!=', 'draft'), '|', ('parent.state', 'not in', ('confirmed', 'planned', 'progress', 'to_close')), ('parent.is_locked', '=', True)]}" width="1"/>
                                     <field name="reserved_availability" invisible="1"/>
                                     <field name="availability_state" invisible="1"/>
-                                    <field name="availability_indication"
+                                    <field name="availability_indication" widget="forecast_button"
                                         decoration-bf="availability_state in ['late', 'partial', 'waiting']"
                                         decoration-warning="availability_state in ['partial', 'waiting']"
                                         decoration-danger="availability_state == 'late'"

--- a/addons/purchase_stock/__manifest__.py
+++ b/addons/purchase_stock/__manifest__.py
@@ -24,6 +24,7 @@
         'views/product_category_views.xml',
         'report/purchase_report_views.xml',
         'report/purchase_report_templates.xml',
+        'report/report_replenishment.xml',
         'report/report_stock_rule.xml',
     ],
     'demo': [

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -53,6 +53,9 @@ class StockMove(models.Model):
             return price_unit
         return super(StockMove, self)._get_price_unit()
 
+    def _get_replenishment_document(self):
+        return self.purchase_line_id.order_id or super()._get_replenishment_document()
+
     def _generate_valuation_lines_data(self, partner_id, qty, debit_value, credit_value, debit_account_id, credit_account_id, description):
         """ Overridden from stock_account to support amount_currency on valuation lines generated from po
         """

--- a/addons/purchase_stock/report/__init__.py
+++ b/addons/purchase_stock/report/__init__.py
@@ -2,5 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import purchase_report
+from . import report_replenishment
 from . import report_stock_rule
 from . import vendor_delay_report

--- a/addons/purchase_stock/report/report_replenishment.py
+++ b/addons/purchase_stock/report/report_replenishment.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class ReplenishmentReport(models.AbstractModel):
+    _inherit = 'report.stock.report_product_product_replenishment'
+
+    @api.model
+    def _get_report_data(self, product_template_ids=False, product_variant_ids=False):
+        res = super()._get_report_data(product_template_ids, product_variant_ids)
+        domain = [('state', 'in', ['draft', 'sent'])]
+        domain += self._product_purchase_domain(product_template_ids, product_variant_ids)
+        warehouse_id = self.env.context.get('warehouse', False)
+        if warehouse_id:
+            domain += [('order_id.picking_type_id.warehouse_id', '=', warehouse_id)]
+        qty_in = 0
+        po_lines = self.env['purchase.order.line'].read_group(domain, ['product_uom_qty'], 'product_id')
+        if po_lines:
+            qty_in = sum(line['product_uom_qty'] for line in po_lines)
+
+        res['draft_purchase_qty'] = qty_in
+        res['qty']['in'] += qty_in
+        return res
+
+    @api.model
+    def _product_purchase_domain(self, product_template_ids, product_variant_ids):
+        domain = []
+        if product_variant_ids:
+            domain += [('product_id', 'in', product_variant_ids)]
+        elif product_template_ids:
+            products = self.env['product.product'].search_read(
+                [('product_tmpl_id', 'in', product_template_ids)], ['id']
+            )
+            product_ids = [product['id'] for product in products]
+            domain += [('product_id', 'in', product_ids)]
+        return domain

--- a/addons/purchase_stock/report/report_replenishment.xml
+++ b/addons/purchase_stock/report/report_replenishment.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="purchase_report_product_product_replenishment" inherit_id="stock.report_product_product_replenishment">
+        <xpath expr="//tr[@name='draft_picking_in']" position="after">
+            <tr t-if="docs['draft_purchase_qty']" name="draft_po_in">
+                <td>Draft PO</td>
+                <td t-esc="docs['draft_purchase_qty']" class="text-right"/>
+                <td t-esc="docs['uom']" groups="uom.group_uom"/>
+            </tr>
+        </xpath>
+    </template>
+</odoo>

--- a/addons/purchase_stock/tests/__init__.py
+++ b/addons/purchase_stock/tests/__init__.py
@@ -11,6 +11,7 @@ from . import test_purchase_delete_order
 from . import test_purchase_lead_time
 from . import test_purchase_order
 from . import test_purchase_order_process
+from . import test_purchase_stock_report
 from . import test_stockvaluation
 from . import test_replenish_wizard
 from . import test_reordering_rule

--- a/addons/purchase_stock/tests/test_purchase_stock_report.py
+++ b/addons/purchase_stock/tests/test_purchase_stock_report.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import Form
+from odoo.addons.stock.tests.test_report import TestReportsCommon
+
+
+class TestPurchaseStockReports(TestReportsCommon):
+    def test_report_forecast_1_purchase_order_multi_receipt(self):
+        """ Create a PO for 5 product, receive them then increase the quantity to 10.
+        """
+        po_form = Form(self.env['purchase.order'])
+        po_form.partner_id = self.partner
+        with po_form.order_line.new() as line:
+            line.product_id = self.product
+            line.product_qty = 5
+        po = po_form.save()
+
+        # Checks the report.
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        draft_picking_qty_in = docs['draft_picking_qty']['in']
+        draft_purchase_qty = docs['draft_purchase_qty']
+        pending_qty_in = docs['qty']['in']
+        self.assertEqual(len(lines), 0, "Must have 0 line for now.")
+        self.assertEqual(draft_picking_qty_in, 0)
+        self.assertEqual(draft_purchase_qty, 5)
+        self.assertEqual(pending_qty_in, 5)
+
+        # Confirms the PO and checks the report again.
+        po.button_confirm()
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        draft_picking_qty_in = docs['draft_picking_qty']['in']
+        draft_purchase_qty = docs['draft_purchase_qty']
+        pending_qty_in = docs['qty']['in']
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines[0]['document_in'].id, po.id)
+        self.assertEqual(lines[0]['quantity'], 5)
+        self.assertEqual(lines[0]['document_out'], False)
+        self.assertEqual(draft_picking_qty_in, 0)
+        self.assertEqual(draft_purchase_qty, 0)
+        self.assertEqual(pending_qty_in, 0)
+
+        # Receives 5 products.
+        receipt = po.picking_ids
+        res_dict = receipt.button_validate()
+        wizard = Form(self.env[res_dict['res_model']].with_context(res_dict['context'])).save()
+        wizard.process()
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        draft_picking_qty_in = docs['draft_picking_qty']['in']
+        draft_purchase_qty = docs['draft_purchase_qty']
+        pending_qty_in = docs['qty']['in']
+        self.assertEqual(len(lines), 0)
+        self.assertEqual(draft_picking_qty_in, 0)
+        self.assertEqual(draft_purchase_qty, 0)
+        self.assertEqual(pending_qty_in, 0)
+
+        # Increase the PO quantity to 10, so must create a second receipt.
+        po_form = Form(po)
+        with po_form.order_line.edit(0) as line:
+            line.product_qty = 10
+        po = po_form.save()
+        # Checks the report.
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        draft_picking_qty_in = docs['draft_picking_qty']['in']
+        draft_purchase_qty = docs['draft_purchase_qty']
+        pending_qty_in = docs['qty']['in']
+        self.assertEqual(len(lines), 1, "Must have 1 line for now.")
+        self.assertEqual(lines[0]['document_in'].id, po.id)
+        self.assertEqual(lines[0]['quantity'], 5)
+        self.assertEqual(draft_picking_qty_in, 0)
+        self.assertEqual(draft_purchase_qty, 0)
+        self.assertEqual(pending_qty_in, 0)
+
+    def test_report_forecast_2_purchase_order_three_step_receipt(self):
+        """ Create a PO for 5 product, receive them then increase the quantity
+        to 10, but use three steps receipt.
+        """
+        grp_multi_loc = self.env.ref('stock.group_stock_multi_locations')
+        grp_multi_routes = self.env.ref('stock.group_adv_location')
+        self.env.user.write({'groups_id': [(4, grp_multi_loc.id)]})
+        self.env.user.write({'groups_id': [(4, grp_multi_routes.id)]})
+        # Configure warehouse.
+        warehouse = self.env.ref('stock.warehouse0')
+        warehouse.reception_steps = 'three_steps'
+
+        po_form = Form(self.env['purchase.order'])
+        po_form.partner_id = self.partner
+        with po_form.order_line.new() as line:
+            line.product_id = self.product
+            line.product_qty = 4
+        po = po_form.save()
+
+        # Checks the report -> Must be empty for now, just display some pending qty.
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        draft_picking_qty_in = docs['draft_picking_qty']['in']
+        draft_purchase_qty = docs['draft_purchase_qty']
+        pending_qty_in = docs['qty']['in']
+        self.assertEqual(len(lines), 0, "Must have 0 line for now.")
+        self.assertEqual(draft_picking_qty_in, 0)
+        self.assertEqual(draft_purchase_qty, 4)
+        self.assertEqual(pending_qty_in, 4)
+
+        # Confirms the PO and checks the report again.
+        po.button_confirm()
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        draft_picking_qty_in = docs['draft_picking_qty']['in']
+        draft_purchase_qty = docs['draft_purchase_qty']
+        pending_qty_in = docs['qty']['in']
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines[0]['document_in'].id, po.id)
+        self.assertEqual(lines[0]['quantity'], 4)
+        self.assertEqual(lines[0]['document_out'], False)
+        self.assertEqual(draft_picking_qty_in, 0)
+        self.assertEqual(draft_purchase_qty, 0)
+        self.assertEqual(pending_qty_in, 0)
+        # Get back the different transfers.
+        receipt = po.picking_ids
+        input_to_quality_check = receipt.move_lines.move_dest_ids.picking_id
+
+        # Receives 4 products.
+        res_dict = receipt.button_validate()
+        wizard = Form(self.env[res_dict['res_model']].with_context(res_dict['context'])).save()
+        wizard.process()
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        draft_picking_qty_in = docs['draft_picking_qty']['in']
+        draft_purchase_qty = docs['draft_purchase_qty']
+        pending_qty_in = docs['qty']['in']
+        self.assertEqual(
+            len(lines), 1,
+            "Must still have the PO line has the received qty. isn't in the stock location yet"
+        )
+        self.assertEqual(lines[0]['document_in'].id, input_to_quality_check.id)
+        self.assertEqual(lines[0]['quantity'], 4)
+        self.assertEqual(draft_picking_qty_in, 0)
+        self.assertEqual(draft_purchase_qty, 0)
+        self.assertEqual(pending_qty_in, 0)
+
+        # Increase the PO quantity to 10, so must create a second receipt.
+        po_form = Form(po)
+        with po_form.order_line.edit(0) as line:
+            line.product_qty = 10
+        po = po_form.save()
+        # Checks the report.
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        draft_picking_qty_in = docs['draft_picking_qty']['in']
+        draft_purchase_qty = docs['draft_purchase_qty']
+        pending_qty_in = docs['qty']['in']
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines[0]['document_in'].id, po.id)
+        self.assertEqual(lines[0]['quantity'], 10)
+        self.assertEqual(draft_picking_qty_in, 0)
+        self.assertEqual(draft_purchase_qty, 0)
+        self.assertEqual(pending_qty_in, 0)

--- a/addons/sale_mrp/tests/__init__.py
+++ b/addons/sale_mrp/tests/__init__.py
@@ -4,4 +4,5 @@
 from . import test_sale_mrp_flow
 from . import test_sale_mrp_lead_time
 from . import test_sale_mrp_procurement
+from . import test_sale_mrp_stock_report
 from . import test_multistep_manufacturing

--- a/addons/sale_mrp/tests/test_sale_mrp_stock_report.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_stock_report.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import Form
+from odoo.addons.stock.tests.test_report import TestReportsCommon
+
+
+class TestSaleMRPStockReports(TestReportsCommon):
+    def test_report_forecast_1_so_waiting_mo_multistep(self):
+        """ Creates a sale order who will trigger a production order.
+        With the pick-pack-ship config and 2 step manufacture, in the report,
+        the sale order must be linked to the production order.
+        """
+        grp_multi_loc = self.env.ref('stock.group_stock_multi_locations')
+        grp_multi_routes = self.env.ref('stock.group_adv_location')
+        self.env.user.write({'groups_id': [(4, grp_multi_loc.id)]})
+        self.env.user.write({'groups_id': [(4, grp_multi_routes.id)]})
+        # Warehouse config.
+        warehouse = self.env.ref('stock.warehouse0')
+        warehouse.delivery_steps = 'pick_pack_ship'
+        warehouse.manufacture_steps = 'pbm_sam'
+        route_manufacture = warehouse.manufacture_pull_id.route_id.id
+        route_mto = warehouse.mto_pull_id.route_id.id
+        # Configures a product.
+        product_apple_pie = self.env['product.product'].create({
+            'name': 'Apple Pie',
+            'type': 'product',
+            'route_ids': [(6, 0, [route_manufacture, route_mto])],
+        })
+        product_apple = self.env['product.product'].create({
+            'name': 'Apple',
+            'type': 'consu',
+        })
+        self.env['mrp.bom'].create({
+            'product_id': product_apple_pie.id,
+            'product_tmpl_id': product_apple_pie.product_tmpl_id.id,
+            'product_uom_id': product_apple_pie.uom_id.id,
+            'product_qty': 1.0,
+            'type': 'normal',
+            'bom_line_ids': [
+                (0, 0, {'product_id': product_apple.id, 'product_qty': 5}),
+            ],
+        })
+        # Creates and confirms the SO.
+        so_form = Form(self.env['sale.order'])
+        so_form.partner_id = self.partner
+        with so_form.order_line.new() as line:
+            line.product_id = product_apple_pie
+            line.product_uom_qty = 5
+        so = so_form.save()
+        so.action_confirm()
+        # Get back SO's pickings.
+        delivery = so.picking_ids.filtered(lambda picking: picking.picking_type_code == 'outgoing')
+        pack = delivery.move_lines.move_orig_ids.picking_id
+        pick = pack.move_lines.move_orig_ids.picking_id
+        sfp = pick.move_lines.move_orig_ids.picking_id
+        # Get back the MO and its picking.
+        mo = so.procurement_group_id.stock_move_ids.created_production_id.procurement_group_id.mrp_production_ids
+        from_stock_to_preprod = mo.picking_ids
+        # Check the report values.
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=product_apple_pie.product_tmpl_id.ids)
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(
+            lines[0]['document_in'].id, mo.id,
+            "Must refer to the MO even if it's waiting preprod move"
+        )
+        self.assertEqual(lines[0]['document_out'].id, so.id)
+        self.assertEqual(lines[0]['quantity'], 5)
+
+        # Proceeds the pre-prod. transfer and validates it.
+        picking_form = Form(from_stock_to_preprod)
+        with picking_form.move_line_ids_without_package.edit(0) as line:
+            line.qty_done = 25
+        from_stock_to_preprod = picking_form.save()
+        from_stock_to_preprod.button_validate()
+        # Check the report values (still must be the same).
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=product_apple_pie.product_tmpl_id.ids)
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines[0]['document_in'].id, mo.id)
+        self.assertEqual(lines[0]['document_out'].id, so.id)
+        self.assertEqual(lines[0]['quantity'], 5)
+
+        # Proceeds the MO and validates it.
+        mo_form = Form(mo)
+        mo_form.qty_producing = 5
+        mo = mo_form.save()
+        mo.button_mark_done()
+        # Check the report values.
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=product_apple_pie.product_tmpl_id.ids)
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(
+            lines[0]['document_in'].id, sfp.id,
+            "MO is done, must refer to the next transfer"
+        )
+        self.assertEqual(lines[0]['document_in'].id, sfp.id)
+        self.assertEqual(lines[0]['document_out'].id, so.id)
+        self.assertEqual(lines[0]['quantity'], 5)
+
+        # Proceeds the post-prod. transfer and validates it.
+        picking_form = Form(sfp)
+        with picking_form.move_line_ids_without_package.edit(0) as line:
+            line.qty_done = 5
+        sfp = picking_form.save()
+        sfp.button_validate()
+        # Check the report values.
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=product_apple_pie.product_tmpl_id.ids)
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(
+            lines[0]['document_in'].id, pick.id,
+            "MO and SFP are done, must refer to the pick transfer"
+        )
+        self.assertEqual(lines[0]['document_in'].id, pick.id)
+        self.assertEqual(lines[0]['document_out'].id, so.id)
+        self.assertEqual(lines[0]['quantity'], 5)
+
+        # Proceeds the pick transfer and validates it.
+        pick.move_line_ids_without_package[0].qty_done = 5
+        pick.button_validate()
+        # Check the report values.
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=product_apple_pie.product_tmpl_id.ids)
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(
+            lines[0]['document_in'].id, pack.id,
+            "The pick is done, must refer to the pack transfer"
+        )
+        self.assertEqual(lines[0]['document_in'].id, pack.id)
+        self.assertEqual(lines[0]['document_out'].id, so.id)
+        self.assertEqual(lines[0]['quantity'], 5)
+
+        # Proceeds the pack transfer and validates it.
+        pack.move_line_ids_without_package.qty_done = 5
+        pack.button_validate()
+        # Check the report values.
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=product_apple_pie.product_tmpl_id.ids)
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(
+            lines[0]['document_in'], False,
+            "The pack is done, and as the quantity is in the sotck now, must not refer to a transfer anymore"
+        )
+        self.assertEqual(lines[0]['replenishment_filled'], True)
+        self.assertEqual(lines[0]['document_in'], False)
+        self.assertEqual(lines[0]['document_out'].id, so.id)
+        self.assertEqual(lines[0]['quantity'], 5)

--- a/addons/sale_purchase_stock/tests/__init__.py
+++ b/addons/sale_purchase_stock/tests/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import models
-from . import tests
+from . import test_sale_purchase_stock_report

--- a/addons/sale_purchase_stock/tests/test_sale_purchase_stock_report.py
+++ b/addons/sale_purchase_stock/tests/test_sale_purchase_stock_report.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime, timedelta
+
+from odoo.tests.common import Form
+from odoo.addons.stock.tests.test_report import TestReportsCommon
+
+
+class TestSalePurchaseStockReports(TestReportsCommon):
+    def test_report_forecast_1_so_waiting_po(self):
+        """ Creates a sale order for a product buy MTO and checks the sale order
+        is correclty linked to the generated purchase order in the report.
+        """
+        # Product config.
+        warehouse = self.env.ref('stock.warehouse0')
+        route_mto = warehouse.mto_pull_id.route_id.id
+        route_buy = self.ref('purchase_stock.route_warehouse0_buy')
+        supplier_info1 = self.env['product.supplierinfo'].create({
+            'name': self.partner.id,
+            'price': 50,
+        })
+        self.product.seller_ids = supplier_info1.ids
+        self.product.route_ids = [(6, 0, [route_buy, route_mto])]
+
+        # Create a sale order.
+        so_form = Form(self.env['sale.order'])
+        so_form.partner_id = self.partner
+        with so_form.order_line.new() as so_line:
+            so_line.product_id = self.product
+            so_line.product_uom_qty = 5
+        so = so_form.save()
+        so.action_confirm()
+
+        # Get back the purchase order and confirms it.
+        po = self.env['purchase.order'].search([('product_id', '=', self.product.id)])
+        po.button_confirm()
+
+        # Checks the report values.
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines[0]['document_in'].id, po.id)
+        self.assertEqual(lines[0]['document_out'].id, so.id)
+
+    def test_report_forecast_2_multi_step_so_waiting_po(self):
+        """ With a multi-step receipt and multi-step delivery config, creates a
+        sale order for a product buy MTO and checks the sale order is correclty
+        linked to the generated purchase order in the report.
+        """
+        grp_multi_loc = self.env.ref('stock.group_stock_multi_locations')
+        grp_multi_routes = self.env.ref('stock.group_adv_location')
+        self.env.user.write({'groups_id': [(4, grp_multi_loc.id)]})
+        self.env.user.write({'groups_id': [(4, grp_multi_routes.id)]})
+        # Product config.
+        warehouse = self.env.ref('stock.warehouse0')
+        warehouse.reception_steps = 'three_steps'
+        warehouse.delivery_steps = 'pick_pack_ship'
+        route_mto = warehouse.mto_pull_id.route_id.id
+        route_buy = self.ref('purchase_stock.route_warehouse0_buy')
+        supplier_info1 = self.env['product.supplierinfo'].create({
+            'name': self.partner.id,
+            'price': 50,
+        })
+        self.product.seller_ids = supplier_info1.ids
+        self.product.route_ids = [(6, 0, [route_buy, route_mto])]
+
+        # Create a sale order.
+        so_form = Form(self.env['sale.order'])
+        so_form.partner_id = self.partner
+        with so_form.order_line.new() as so_line:
+            so_line.product_id = self.product
+            so_line.product_uom_qty = 5
+        so = so_form.save()
+        so.action_confirm()
+
+        # Get back the purchase order and confirms it.
+        po = self.env['purchase.order'].search([('product_id', '=', self.product.id)])
+        po.button_confirm()
+
+        # Checks the report values.
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines[0]['document_in'].id, po.id)
+        self.assertEqual(lines[0]['document_out'].id, so.id)
+
+        receipt = po.picking_ids
+        input_to_qc = receipt.move_lines.move_dest_ids.picking_id
+        qc_to_stock = input_to_qc.move_lines.move_dest_ids.picking_id
+        delivery = so.order_line.move_ids.picking_id
+        pack = delivery.move_lines.move_orig_ids.picking_id
+        pick = pack.move_lines.move_orig_ids.picking_id
+        # Change the pickings scheduled date.
+        today = datetime.today()
+        receipt.scheduled_date = today
+        input_to_qc.scheduled_date = today + timedelta(days=1)
+        qc_to_stock.scheduled_date = today + timedelta(days=2)
+        pick.scheduled_date = today + timedelta(days=3)
+        pack.scheduled_date = today + timedelta(days=4)
+        delivery.scheduled_date = today + timedelta(days=5)

--- a/addons/sale_stock/__manifest__.py
+++ b/addons/sale_stock/__manifest__.py
@@ -31,6 +31,7 @@ Preferences
         'views/report_invoice.xml',
         'views/res_users_views.xml',
         'report/sale_order_report_templates.xml',
+        'report/report_replenishment.xml',
         'report/stock_report_deliveryslip.xml',
         'data/sale_stock_data.xml',
         'wizard/stock_rules_report_views.xml',

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -263,7 +263,7 @@ class SaleOrderLine(models.Model):
     scheduled_date = fields.Datetime(compute='_compute_qty_at_date')
     free_qty_today = fields.Float(compute='_compute_qty_at_date')
     qty_available_today = fields.Float(compute='_compute_qty_at_date')
-    warehouse_id = fields.Many2one('stock.warehouse', compute='_compute_qty_at_date')
+    warehouse_id = fields.Many2one(related='order_id.warehouse_id')
     qty_to_deliver = fields.Float(compute='_compute_qty_to_deliver')
     is_mto = fields.Boolean(compute='_compute_is_mto')
     display_qty_widget = fields.Boolean(compute='_compute_qty_to_deliver')
@@ -278,7 +278,7 @@ class SaleOrderLine(models.Model):
             else:
                 line.display_qty_widget = False
 
-    @api.depends('product_id', 'customer_lead', 'product_uom_qty', 'product_uom', 'order_id.warehouse_id', 'order_id.commitment_date')
+    @api.depends('product_id', 'customer_lead', 'product_uom_qty', 'product_uom', 'order_id.commitment_date')
     def _compute_qty_at_date(self):
         """ Compute the quantity forecasted of product at delivery date. There are
         two cases:
@@ -292,7 +292,6 @@ class SaleOrderLine(models.Model):
         for line in self:
             if not line.display_qty_widget:
                 continue
-            line.warehouse_id = line.order_id.warehouse_id
             if line.order_id.commitment_date:
                 date = line.order_id.commitment_date
             else:
@@ -327,7 +326,6 @@ class SaleOrderLine(models.Model):
         remaining.scheduled_date = False
         remaining.free_qty_today = False
         remaining.qty_available_today = False
-        remaining.warehouse_id = False
 
     @api.depends('product_id', 'route_id', 'order_id.warehouse_id', 'product_id.route_ids')
     def _compute_is_mto(self):

--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -26,6 +26,9 @@ class StockMove(models.Model):
         keys_sorted.append(move.sale_line_id.id)
         return keys_sorted
 
+    def _get_consuming_document(self):
+        return self.sale_line_id.order_id or super()._get_consuming_document()
+
     def _get_related_invoices(self):
         """ Overridden from stock_account to return the customer invoices
         related to this stock move.

--- a/addons/sale_stock/report/__init__.py
+++ b/addons/sale_stock/report/__init__.py
@@ -2,4 +2,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import sale_report
+from . import report_replenishment
 from . import report_stock_rule

--- a/addons/sale_stock/report/report_replenishment.py
+++ b/addons/sale_stock/report/report_replenishment.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class ReplenishmentReport(models.AbstractModel):
+    _inherit = 'report.stock.report_product_product_replenishment'
+
+    @api.model
+    def _get_report_data(self, product_template_ids=False, product_variant_ids=False):
+        res = super()._get_report_data(product_template_ids, product_variant_ids)
+        domain = self._product_sale_domain(product_template_ids, product_variant_ids)
+        so_lines = self.env['sale.order.line'].search(domain)
+        qty_out = 0
+        if so_lines:
+            product_uom = so_lines[0].product_id.uom_id
+            quantities = so_lines.mapped(lambda line: line.product_uom._compute_quantity(line.product_uom_qty, product_uom))
+            qty_out = sum(quantities)
+        res['draft_sale_qty'] = qty_out
+        res['qty']['out'] += qty_out
+        return res
+
+    @api.model
+    def _product_sale_domain(self, product_template_ids, product_variant_ids):
+        domain = [('state', 'in', ['draft', 'sent'])]
+        if product_template_ids:
+            domain += [('product_template_id', 'in', product_template_ids)]
+        elif product_variant_ids:
+            domain += [('product_id', 'in', product_variant_ids)]
+        warehouse_id = self.env.context.get('warehouse', False)
+        if warehouse_id:
+            domain += [('warehouse_id', '=', warehouse_id)]
+        return domain

--- a/addons/sale_stock/report/report_replenishment.xml
+++ b/addons/sale_stock/report/report_replenishment.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="sale_report_product_product_replenishment" inherit_id="stock.report_product_product_replenishment">
+        <xpath expr="//tr[@name='draft_picking_out']" position="after">
+            <tr t-if="docs['draft_sale_qty']" name="draft_so_out">
+                <td>Draft SO</td>
+                <td t-esc="docs['draft_sale_qty']" class="text-right"/>
+                <td t-esc="docs['uom']" groups="uom.group_uom"/>
+            </tr>
+        </xpath>
+    </template>
+</odoo>

--- a/addons/sale_stock/tests/__init__.py
+++ b/addons/sale_stock/tests/__init__.py
@@ -7,3 +7,4 @@ from . import test_sale_stock
 from . import test_sale_stock_lead_time
 from . import test_sale_order_dates
 from . import test_sale_stock_multicompany
+from . import test_sale_stock_report

--- a/addons/sale_stock/tests/test_sale_stock_report.py
+++ b/addons/sale_stock/tests/test_sale_stock_report.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime, timedelta
+
+from odoo.tests.common import Form
+from odoo.addons.stock.tests.test_report import TestReportsCommon
+
+
+class TestSaleStockReports(TestReportsCommon):
+    def test_report_forecast_1_sale_order_replenishment(self):
+        """ Create and confirm two sale orders: one for the next week and one
+        for tomorrow. Then check in the report it's the most urgent who is
+        linked to the qty. on stock.
+        """
+        today = datetime.today()
+        # Put some quantity in stock.
+        quant_vals = {
+            'product_id': self.product.id,
+            'product_uom_id': self.product.uom_id.id,
+            'location_id': self.stock_location.id,
+            'quantity': 5,
+            'reserved_quantity': 0,
+        }
+        self.env['stock.quant'].create(quant_vals)
+        # Create a first SO for the next week.
+        so_form = Form(self.env['sale.order'])
+        so_form.partner_id = self.partner
+        # so_form.validity_date = today + timedelta(days=7)
+        with so_form.order_line.new() as so_line:
+            so_line.product_id = self.product
+            so_line.product_uom_qty = 5
+        so_1 = so_form.save()
+        so_1.action_confirm()
+        so_1.picking_ids.scheduled_date = today + timedelta(days=7)
+
+        # Create a second SO for tomorrow.
+        so_form = Form(self.env['sale.order'])
+        so_form.partner_id = self.partner
+        # so_form.validity_date = today + timedelta(days=1)
+        with so_form.order_line.new() as so_line:
+            so_line.product_id = self.product
+            so_line.product_uom_qty = 5
+        so_2 = so_form.save()
+        so_2.action_confirm()
+        so_2.picking_ids.scheduled_date = today + timedelta(days=1)
+
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        self.assertEqual(len(lines), 2)
+        line_1 = lines[0]
+        line_2 = lines[1]
+        self.assertEqual(line_1['quantity'], 5)
+        self.assertTrue(line_1['replenishment_filled'])
+        self.assertEqual(line_1['document_out'].id, so_2.id)
+        self.assertEqual(line_2['quantity'], 5)
+        self.assertEqual(line_2['replenishment_filled'], False)
+        self.assertEqual(line_2['document_out'].id, so_1.id)

--- a/addons/stock/__manifest__.py
+++ b/addons/stock/__manifest__.py
@@ -80,6 +80,7 @@
         'data/stock_sequence_data.xml',
     ],
     'qweb': [
+        'static/src/xml/forecast_button_widget.xml',
         'static/src/xml/inventory_report.xml',
         'static/src/xml/inventory_lines.xml',
         'static/src/xml/popover_widget.xml',

--- a/addons/stock/__manifest__.py
+++ b/addons/stock/__manifest__.py
@@ -26,6 +26,7 @@
         'data/stock_traceability_report_data.xml',
         'data/procurement_data.xml',
 
+        'report/report_replenishment.xml',
         'report/report_stock_quantity.xml',
         'report/stock_report_views.xml',
         'report/report_package_barcode.xml',
@@ -82,6 +83,7 @@
         'static/src/xml/inventory_report.xml',
         'static/src/xml/inventory_lines.xml',
         'static/src/xml/popover_widget.xml',
+        'static/src/xml/report_replenishment.xml',
         'static/src/xml/stock_orderpoint.xml',
         'static/src/xml/stock_traceability_report_backend.xml',
     ],

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -506,10 +506,8 @@ class Product(models.Model):
         return self.product_tmpl_id.with_context(default_product_id=self.id).action_update_quantity_on_hand()
 
     def action_product_forecast_report(self):
-        action = self.env.ref('stock.report_stock_quantity_action_product').read()[0]
-        action['domain'] = [
-            ('product_id', '=', self.id),
-        ]
+        self.ensure_one()
+        action = self.env.ref('stock.stock_replenishment_product_product_action').read()[0]
         return action
 
     @api.model
@@ -803,11 +801,8 @@ class ProductTemplate(models.Model):
         return action
 
     def action_product_tmpl_forecast_report(self):
-        action = self.env.ref('stock.report_stock_quantity_action_product').read()[0]
-        product_ids = self.with_context(active_test=False).product_variant_ids.filtered(lambda p: p.virtual_available != 0)
-        action['domain'] = [
-            ('product_id', 'in', product_ids.ids)
-        ]
+        self.ensure_one()
+        action = self.env.ref('stock.stock_replenishment_product_product_action').read()[0]
         return action
 
 class ProductCategory(models.Model):

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1157,11 +1157,11 @@ class StockMove(models.Model):
                 location_id=reserved_quant.location_id.id,
                 lot_id=reserved_quant.lot_id.id or False,
                 package_id=reserved_quant.package_id.id or False,
-                owner_id =reserved_quant.owner_id.id or False,
+                owner_id=reserved_quant.owner_id.id or False,
             )
         return vals
 
-    def _update_reserved_quantity(self, need, available_quantity, location_id, lot_id=None, package_id=None, owner_id=None, strict=True):
+    def _update_reserved_quantity(self, need, available_quantity, location_id, lot_id=None, package_id=None, owner_id=None, strict=True, move_lines_per_move=None):
         """ Create or update move lines.
         """
         self.ensure_one()
@@ -1206,20 +1206,33 @@ class StockMove(models.Model):
 
         # Find a candidate move line to update or create a new one.
         for reserved_quant, quantity in quants:
-            to_update = self.move_line_ids.filtered(lambda ml: ml._reservation_is_updatable(quantity, reserved_quant))
+            to_update = False
+            for move_line in move_lines_per_move[self.id]:
+                if self.env['stock.move.line']._reservation_is_updatable(move_line, quantity, reserved_quant):
+                    to_update = move_line
+                    break
             if to_update:
-                to_update[0].with_context(bypass_reservation_update=True).product_uom_qty += self.product_id.uom_id._compute_quantity(quantity, to_update[0].product_uom_id, rounding_method='HALF-UP')
+                to_update['product_uom_qty'] += self.product_id.uom_id._compute_quantity(quantity, self.env['uom.uom'].browse(to_update['product_uom_id']), rounding_method='HALF-UP')
+                to_update['to_write'] = 1
             else:
                 if self.product_id.tracking == 'serial':
                     for i in range(0, int(quantity)):
-                        self.env['stock.move.line'].create(self._prepare_move_line_vals(quantity=1, reserved_quant=reserved_quant))
+                        move_lines_per_move[self.id].append(dict(self._prepare_move_line_vals(quantity=1, reserved_quant=reserved_quant), to_create=1))
                 else:
-                    self.env['stock.move.line'].create(self._prepare_move_line_vals(quantity=quantity, reserved_quant=reserved_quant))
+                    move_lines_per_move[self.id].append(dict(self._prepare_move_line_vals(quantity=quantity, reserved_quant=reserved_quant), to_create=1))
         return taken_quantity
 
     def _should_bypass_reservation(self):
         self.ensure_one()
         return self.location_id.should_bypass_reservation() or self.product_id.type != 'product'
+
+    @api.model
+    def _action_assign_get_move_lines_fields_to_read(self):
+        return [
+            'picking_id', 'move_id', 'product_id', 'product_uom_id', 'product_uom_qty', 'qty_done',
+            'location_id', 'location_dest_id', 'lot_id', 'package_id', 'result_package_id',
+            'owner_id', 'state',
+        ]
 
     def _action_assign(self):
         """ Reserve stock moves by creating their stock move lines. A stock move is
@@ -1227,132 +1240,141 @@ class StockMove(models.Model):
         equal to its `product_qty`. If it is less, the stock move is considered
         partially available.
         """
-        assigned_moves = self.env['stock.move']
-        partially_available_moves = self.env['stock.move']
-        # Read the `reserved_availability` field of the moves out of the loop to prevent unwanted
-        # cache invalidation when actually reserving the move.
         reserved_availability = {move: move.reserved_availability for move in self}
         roundings = {move: move.product_id.uom_id.rounding for move in self}
-        move_line_vals_list = []
-        for move in self.filtered(lambda m: m.state in ['confirmed', 'waiting', 'partially_available']):
+        move_lines_per_move = defaultdict(list)
+        for move_line in self.env['stock.move.line']\
+                .search([('move_id', 'in', self.ids + self.move_orig_ids.ids + self.move_dest_ids.ids)])\
+                .read(self._action_assign_get_move_lines_fields_to_read(), load=False):
+            move_lines_per_move[move_line['move_id']].append(move_line)
+
+        to_assign = self.browse()
+        to_partially_available = self.browse()
+
+        for move in self:
+            if move.state not in ('confirmed', 'waiting', 'partially_available'):
+                continue
             rounding = roundings[move]
             missing_reserved_uom_quantity = move.product_uom_qty - reserved_availability[move]
             missing_reserved_quantity = move.product_uom._compute_quantity(missing_reserved_uom_quantity, move.product_id.uom_id, rounding_method='HALF-UP')
+
             if move._should_bypass_reservation():
-                # create the move line(s) but do not impact quants
                 if move.product_id.tracking == 'serial' and (move.picking_type_id.use_create_lots or move.picking_type_id.use_existing_lots):
                     for i in range(0, int(missing_reserved_quantity)):
-                        move_line_vals_list.append(move._prepare_move_line_vals(quantity=1))
+                        move_lines_per_move[move.id].append(dict(move._prepare_move_line_vals(quantity=1), to_create=True))
                 else:
-                    to_update = move.move_line_ids.filtered(lambda ml: ml.product_uom_id == move.product_uom and
-                                                            ml.location_id == move.location_id and
-                                                            ml.location_dest_id == move.location_dest_id and
-                                                            ml.picking_id == move.picking_id and
-                                                            not ml.lot_id and
-                                                            not ml.package_id and
-                                                            not ml.owner_id)
-                    if to_update:
-                        to_update[0].product_uom_qty += missing_reserved_uom_quantity
+                    for move_line in move_lines_per_move[move.id]:
+                        if move_line['product_uom_id'] == move.product_uom.id and\
+                                move_line['location_id'] == move.location_id.id and\
+                                move_line['location_dest_id'] == move.location_dest_id.id and\
+                                move_line['picking_id'] == move.picking_id.id and\
+                                not move_line.get('lot_id') and\
+                                not move_line.get('package_id') and\
+                                not move_line.get('owner_id'):
+                            move_line['product_uom_qty'] += missing_reserved_uom_quantity
+                            move_line['to_write'] = True
+                            break
                     else:
-                        move_line_vals_list.append(move._prepare_move_line_vals(quantity=missing_reserved_quantity))
-                assigned_moves |= move
+                        move_lines_per_move[move.id].append(dict(move._prepare_move_line_vals(quantity=missing_reserved_quantity), to_create=1))
+                to_assign |= move
             else:
                 if float_is_zero(move.product_uom_qty, precision_rounding=move.product_uom.rounding):
-                    assigned_moves |= move
-                elif not move.move_orig_ids:
+                    to_assign |= move
+                elif not move.move_orig_ids:  # MTS
                     if move.procure_method == 'make_to_order':
                         continue
-                    # If we don't need any quantity, consider the move assigned.
-                    need = missing_reserved_quantity
-                    if float_is_zero(need, precision_rounding=rounding):
-                        assigned_moves |= move
+                    if float_is_zero(missing_reserved_quantity, precision_rounding=rounding):
+                        to_assign |= move
                         continue
-                    # Reserve new quants and create move lines accordingly.
                     forced_package_id = move.package_level_id.package_id or None
                     available_quantity = self.env['stock.quant']._get_available_quantity(move.product_id, move.location_id, package_id=forced_package_id)
-                    if available_quantity <= 0:
+                    if float_compare(available_quantity, 0, precision_rounding=rounding) <= 0:
                         continue
-                    taken_quantity = move._update_reserved_quantity(need, available_quantity, move.location_id, package_id=forced_package_id, strict=False)
+                    taken_quantity = move._update_reserved_quantity(missing_reserved_quantity, available_quantity, move.location_id, package_id=forced_package_id, strict=False, move_lines_per_move=move_lines_per_move)
                     if float_is_zero(taken_quantity, precision_rounding=rounding):
                         continue
-                    if float_compare(need, taken_quantity, precision_rounding=rounding) == 0:
-                        assigned_moves |= move
+                    if float_compare(missing_reserved_quantity, taken_quantity, precision_rounding=rounding) == 0:
+                        to_assign |= move
                     else:
-                        partially_available_moves |= move
-                else:
-                    # Check what our parents brought and what our siblings took in order to
-                    # determine what we can distribute.
-                    # `qty_done` is in `ml.product_uom_id` and, as we will later increase
-                    # the reserved quantity on the quants, convert it here in
-                    # `product_id.uom_id` (the UOM of the quants is the UOM of the product).
-                    move_lines_in = move.move_orig_ids.filtered(lambda m: m.state == 'done').mapped('move_line_ids')
+                        to_partially_available |= move
+                else:  # MTO
+                    def _group_move_lines(move_lines, keys, field='qty_done'):
+                        grouped_move_lines = {}
+                        for k, g in groupby(sorted(move_lines, key=itemgetter(*keys)), key=itemgetter(*keys)):
+                            qty = 0
+                            for move_line in g:
+                                uom = self.env['uom.uom'].browse(move_line['product_uom_id'])
+                                qty += uom._compute_quantity(move_line[field], move.product_id.uom_id)
+                            grouped_move_lines[k] = qty
+                        return grouped_move_lines
+
                     keys_in_groupby = ['location_dest_id', 'lot_id', 'result_package_id', 'owner_id']
-
-                    def _keys_in_sorted(ml):
-                        return (ml.location_dest_id.id, ml.lot_id.id, ml.result_package_id.id, ml.owner_id.id)
-
-                    grouped_move_lines_in = {}
-                    for k, g in groupby(sorted(move_lines_in, key=_keys_in_sorted), key=itemgetter(*keys_in_groupby)):
-                        qty_done = 0
-                        for ml in g:
-                            qty_done += ml.product_uom_id._compute_quantity(ml.qty_done, ml.product_id.uom_id)
-                        grouped_move_lines_in[k] = qty_done
-                    move_lines_out_done = (move.move_orig_ids.mapped('move_dest_ids') - move)\
-                        .filtered(lambda m: m.state in ['done'])\
-                        .mapped('move_line_ids')
-                    # As we defer the write on the stock.move's state at the end of the loop, there
-                    # could be moves to consider in what our siblings already took.
-                    moves_out_siblings = move.move_orig_ids.mapped('move_dest_ids') - move
-                    moves_out_siblings_to_consider = moves_out_siblings & (assigned_moves + partially_available_moves)
-                    reserved_moves_out_siblings = moves_out_siblings.filtered(lambda m: m.state in ['partially_available', 'assigned'])
-                    move_lines_out_reserved = (reserved_moves_out_siblings | moves_out_siblings_to_consider).mapped('move_line_ids')
                     keys_out_groupby = ['location_id', 'lot_id', 'package_id', 'owner_id']
 
-                    def _keys_out_sorted(ml):
-                        return (ml.location_id.id, ml.lot_id.id, ml.package_id.id, ml.owner_id.id)
+                    move_lines_in = []
+                    for move_in in move.move_orig_ids.filtered(lambda m: m.state == 'done'):
+                        move_lines_in += move_lines_per_move[move_in.id]
+                    grouped_move_lines_in = _group_move_lines(move_lines_in, keys_in_groupby)
 
-                    grouped_move_lines_out = {}
-                    for k, g in groupby(sorted(move_lines_out_done, key=_keys_out_sorted), key=itemgetter(*keys_out_groupby)):
-                        qty_done = 0
-                        for ml in g:
-                            qty_done += ml.product_uom_id._compute_quantity(ml.qty_done, ml.product_id.uom_id)
-                        grouped_move_lines_out[k] = qty_done
-                    for k, g in groupby(sorted(move_lines_out_reserved, key=_keys_out_sorted), key=itemgetter(*keys_out_groupby)):
-                        grouped_move_lines_out[k] = sum(self.env['stock.move.line'].concat(*list(g)).mapped('product_qty'))
-                    available_move_lines = {key: grouped_move_lines_in[key] - grouped_move_lines_out.get(key, 0) for key in grouped_move_lines_in.keys()}
-                    # pop key if the quantity available amount to 0
+                    move_lines_out_done = []
+                    for move_out_done in (move.move_orig_ids.move_dest_ids - move).filtered(lambda m: m.state in ['done']):
+                        move_lines_out_done += move_lines_per_move[move_out_done.id]
+                    grouped_move_lines_out = _group_move_lines(move_lines_out_done, keys_out_groupby)
+
+                    move_lines_out_reserved = []
+                    moves_out_reserved = move.move_orig_ids.move_dest_ids.filtered(lambda m: m.state in ['partially_available', 'assigned'])
+                    moves_out_reserved |= move.move_orig_ids.move_dest_ids & (to_assign + to_partially_available)
+                    for move_out_reserved in moves_out_reserved:
+                        move_lines_out_reserved += move_lines_per_move[move_out_reserved.id]
+                    grouped_move_lines_out_reserved = _group_move_lines(move_lines_out_reserved, keys_out_groupby, field='product_uom_qty')
+
+                    available_move_lines = defaultdict(lambda: 0, grouped_move_lines_in)
+                    for out in (grouped_move_lines_out, grouped_move_lines_out_reserved):
+                        for key, value in out.items():
+                            available_move_lines[key] -= value
                     available_move_lines = dict((k, v) for k, v in available_move_lines.items() if v)
-
                     if not available_move_lines:
                         continue
-                    for move_line in move.move_line_ids.filtered(lambda m: m.product_qty):
-                        if available_move_lines.get((move_line.location_id, move_line.lot_id, move_line.result_package_id, move_line.owner_id)):
-                            available_move_lines[(move_line.location_id, move_line.lot_id, move_line.result_package_id, move_line.owner_id)] -= move_line.product_qty
+
                     for (location_id, lot_id, package_id, owner_id), quantity in available_move_lines.items():
-                        need = move.product_qty - sum(move.move_line_ids.mapped('product_qty'))
-                        # `quantity` is what is brought by chained done move lines. We double check
-                        # here this quantity is available on the quants themselves. If not, this
-                        # could be the result of an inventory adjustment that removed totally of
-                        # partially `quantity`. When this happens, we chose to reserve the maximum
-                        # still available. This situation could not happen on MTS move, because in
-                        # this case `quantity` is directly the quantity on the quants themselves.
+                        location_id = self.env['stock.location'].browse(location_id)
+                        lot_id = self.env['stock.production.lot'].browse(lot_id)
+                        package_id = self.env['stock.quant.package'].browse(package_id)
+                        owner_id = self.env['res.partner'].browse(owner_id)
+                        ml_product_qty = 0
+                        for move_line in move_lines_per_move[move.id]:
+                            ml_product_qty += self.env['uom.uom'].browse(move_line['product_uom_id'])._compute_quantity(move_line['product_uom_qty'], move.product_id.uom_id)
+                        need = move.product_qty - ml_product_qty
+                        # If `quantity` is not entirely available, reserve the maximum available.
                         available_quantity = self.env['stock.quant']._get_available_quantity(
                             move.product_id, location_id, lot_id=lot_id, package_id=package_id, owner_id=owner_id, strict=True)
                         if float_is_zero(available_quantity, precision_rounding=rounding):
                             continue
-                        taken_quantity = move._update_reserved_quantity(need, min(quantity, available_quantity), location_id, lot_id, package_id, owner_id)
+                        taken_quantity = move._update_reserved_quantity(need, min(quantity, available_quantity), location_id, lot_id, package_id, owner_id, move_lines_per_move=move_lines_per_move)
                         if float_is_zero(taken_quantity, precision_rounding=rounding):
                             continue
                         if float_is_zero(need - taken_quantity, precision_rounding=rounding):
-                            assigned_moves |= move
+                            to_assign |= move
                             break
-                        partially_available_moves |= move
+                        to_partially_available |= move
             if move.product_id.tracking == 'serial':
                 move.next_serial_count = move.product_uom_qty
 
-        self.env['stock.move.line'].create(move_line_vals_list)
-        partially_available_moves.write({'state': 'partially_available'})
-        assigned_moves.write({'state': 'assigned'})
+        to_create = []
+        for move, move_lines in move_lines_per_move.items():
+            for move_line in move_lines:
+                if move_line.get('to_create'):
+                    del move_line['to_create']
+                    if move_line.get('to_write'):
+                        del move_line['to_write']
+                    to_create.append(move_line)
+                if move_line.get('to_write'):
+                    del move_line['to_write']
+                    self.env['stock.move.line'].with_context(bypass_reservation_update=True).browse(move_line['id']).write(move_line)
+        self.env['stock.move.line'].create(to_create)
+
+        to_partially_available.write({'state': 'partially_available'})
+        to_assign.write({'state': 'assigned'})
         self.mapped('picking_id')._check_entire_pack()
 
     def _action_cancel(self):

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -665,6 +665,11 @@ class StockMove(models.Model):
         }
         return action
 
+    def action_open_replenishment_report(self):
+        self.ensure_one()
+        report = self.env.ref('stock.stock_replenishment_report_product_product_action')
+        return report.with_context(discard_logo_check=True).report_action(self.product_id)
+
     def _do_unreserve(self):
         moves_to_unreserve = self.env['stock.move']
         moves_not_to_recompute = self.env['stock.move']

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -511,13 +511,14 @@ class StockMoveLine(models.Model):
             'lot_id': lot.id
         })
 
-    def _reservation_is_updatable(self, quantity, reserved_quant):
-        self.ensure_one()
-        if (self.product_id.tracking != 'serial' and
-                self.location_id.id == reserved_quant.location_id.id and
-                self.lot_id.id == reserved_quant.lot_id.id and
-                self.package_id.id == reserved_quant.package_id.id and
-                self.owner_id.id == reserved_quant.owner_id.id):
+    @api.model
+    def _reservation_is_updatable(self, move_line, quantity, reserved_quant):
+        tracking = self.env['product.product'].browse(move_line['product_id']).tracking
+        if (tracking != 'serial' and
+                move_line['location_id'] == reserved_quant.location_id.id and
+                move_line['lot_id'] == reserved_quant.lot_id.id and
+                move_line['package_id'] == reserved_quant.package_id.id and
+                move_line['owner_id'] == reserved_quant.owner_id.id):
             return True
         return False
 

--- a/addons/stock/report/__init__.py
+++ b/addons/stock/report/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import report_replenishment
 from . import report_stock_quantity
 from . import report_stock_rule
 from . import stock_traceability

--- a/addons/stock/report/report_replenishment.py
+++ b/addons/stock/report/report_replenishment.py
@@ -1,0 +1,442 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from collections import defaultdict
+
+from odoo import api, models
+from odoo.tools import format_datetime
+
+
+class ReplenishmentReport(models.AbstractModel):
+    _name = 'report.stock.report_product_product_replenishment'
+    _description = "Stock Replenishment Report"
+
+    @api.model
+    def _move_domain(self, product_template_ids, product_variant_ids):
+        move_domain = self._product_domain(product_template_ids, product_variant_ids)
+        move_domain += [
+            ('product_uom_qty', '!=', 0),
+            ('state', 'not in', ['draft', 'cancel', 'done']),
+        ]
+        location_ids = False
+        # Add locations in domain if user is using multi-warehouse config.
+        if self.env.context.get('wh_location_id'):
+            wh_location_id = self.env.context.get('wh_location_id')
+            location_ids = self.env['stock.location'].search_read(
+                [('id', 'child_of', wh_location_id)],
+                ['id'],
+            )
+            location_ids = [loc['id'] for loc in location_ids]
+            move_domain += [
+                '|',
+                ('location_id', 'in', location_ids),
+                ('location_dest_id', 'in', location_ids),
+            ]
+        consuming_move_domain = move_domain + self.env['stock.move']._get_consuming_domain(location_ids)
+        replenishing_move_domain = move_domain + self.env['stock.move']._get_replenishment_domain(location_ids)
+        return consuming_move_domain, replenishing_move_domain
+
+    @api.model
+    def _product_domain(self, product_template_ids, product_variant_ids):
+        domain = []
+        if product_template_ids:
+            domain += [('product_tmpl_id', 'in', product_template_ids)]
+        elif product_variant_ids:
+            domain += [('product_id', 'in', product_variant_ids)]
+        return domain
+
+    @api.model
+    def _convert_date(self, lines):
+        """ Convert the datetime into formated string. """
+        timezone = self._context.get('tz')
+        for line in lines:
+            line['delivery_date'] = (line['delivery_date'] and format_datetime(self.env, line['delivery_date'], timezone, 'medium')) or ''
+            line['receipt_date'] = (line['receipt_date'] and format_datetime(self.env, line['receipt_date'], timezone, 'medium')) or ''
+        return lines
+
+    @api.model
+    def _get_report_values(self, docids, data=None):
+        docs = self._get_report_data(product_variant_ids=docids)
+        docargs = {
+            'data': data,
+            'doc_ids': docids,
+            'doc_model': 'product.product',
+            'docs': docs,
+        }
+        return docargs
+
+    @api.model
+    def _get_report_data(self, product_template_ids=False, product_variant_ids=False):
+        """ Return all the report data, which include report lines (documents,
+        quantity, expected date), quantity summary (On Hand Qty, Forecasted Qty
+        and Forcasted + Pending Qty) and the number of pending documents.
+
+        This method use the following context key:
+            - `warehouse`: will restrict the search move for this warehouse.
+              If missing, it will take the first company's warehouse.
+
+        :param product_template_ids: list of `product.product` ids.
+        :type product_template_ids: list
+        :param product_variant_ids: list of `product.template` ids.
+        :type product_variant_ids: list
+
+        :return: a dict with all the report data.
+        :rtype: dict
+        """
+        res = {
+            'product_templates': False,
+            'product_variants': False,
+        }
+        if self.user_has_groups('stock.group_stock_multi_warehouses') or len(self.env.companies) > 1:
+            # Add warehouse id in the context to reuse it to filter data to make
+            # the report warehouse specific.
+            warehouse_id = self.env.context.get('warehouse', False)
+            if warehouse_id:
+                warehouse = self.env['stock.warehouse'].browse(warehouse_id)
+            else:
+                warehouse = self.env['stock.warehouse'].search([
+                    ('company_id', '=', self.env.company.id)
+                ], limit=1)
+            self.env.context = dict(
+                self.env.context,
+                warehouse=warehouse.id,
+                wh_location_id=warehouse.view_location_id.id,
+            )
+            res['active_warehouse'] = warehouse.display_name
+        if product_template_ids:
+            product_templates = self.env['product.template'].browse(product_template_ids)
+            res['product_templates'] = product_templates
+            res['product_variants'] = product_templates.product_variant_ids
+        if product_variant_ids:
+            product_variants = self.env['product.product'].browse(product_variant_ids)
+            res['product_variants'] = product_variants
+
+        # Generates report lines.
+        consuming_lines, replenishing_lines = self._get_report_line_values(
+            product_template_ids=product_template_ids,
+            product_variant_ids=product_variant_ids,
+        )
+        replenishing_lines = self._merge_similar_replenishing_lines(replenishing_lines)
+        # Updates report lines, to link replenishment lines with consuming lines when it's possible.
+        # report_lines = consuming_lines + replenishing_lines
+        report_lines = self._link_report_lines(consuming_lines, replenishing_lines)
+        # Sorts lines to have:
+        # - lines without consuming document at the end;
+        # - nearest delivery date first;
+        # - lines with replenishment unfilled at the end.
+        report_lines.sort(key=lambda line: (
+            line['document_out'] is False,
+            line['replenishment_filled'] is False,
+            line['delivery_date'],
+            line['document_out'] and line['document_out'].id,
+            line['document_in'] is not False,
+            line['receipt_date'],
+            line['document_in'] and line['document_in'].id,
+        ))
+        self._convert_date(report_lines)
+
+        products = self.env['product.template']
+        if product_template_ids:
+            products = self.env['product.template'].browse(product_template_ids)
+            res['multiple_product'] = len(products.product_variant_ids) > 1
+        elif product_variant_ids:
+            products = self.env['product.product'].browse(product_variant_ids)
+            res['multiple_product'] = len(products) > 1
+        else:
+            res['multiple_product'] = True
+        # If the report will display lines for multiple products, sorts them by product.
+        if res['multiple_product']:
+            report_lines.sort(key=lambda line: line['product']['id'])
+        res['lines'] = report_lines
+        res['uom'] = products[:1].uom_id.display_name
+
+        # Computes quantities.
+        res['quantity_on_hand'] = sum(products.mapped('qty_available'))
+        res['virtual_available'] = sum(products.mapped('virtual_available'))
+
+        # Will keep the track of all the incoming/outgoing quantity from pending documents.
+        domain = [('state', '=', 'draft')]
+        if product_template_ids:
+            domain += [('product_tmpl_id', 'in', product_template_ids)]
+        elif product_variant_ids:
+            domain += [('product_id', 'in', product_variant_ids)]
+        qty_in, qty_out = 0, 0
+        location_ids = False
+        if self.env.context.get('wh_location_id'):
+            wh_location_id = self.env.context.get('wh_location_id')
+            location_ids = self.env['stock.location'].search_read(
+                [('id', 'child_of', wh_location_id)],
+                ['id'],
+            )
+            location_ids = [loc['id'] for loc in location_ids]
+        in_domain = [('picking_code', '=', 'incoming')] + domain
+        if location_ids:
+            in_domain += [('location_dest_id', 'in', location_ids)]
+        incoming_moves = self.env['stock.move'].read_group(in_domain, ['product_qty'], 'product_id')
+        if incoming_moves:
+            qty_in = sum(move['product_qty'] for move in incoming_moves)
+        out_domain = [('picking_code', '=', 'outgoing')] + domain
+        if location_ids:
+            out_domain += [('location_id', 'in', location_ids)]
+        outgoing_moves = self.env['stock.move'].read_group(out_domain, ['product_qty'], 'product_id')
+        if outgoing_moves:
+            qty_out = sum(move['product_qty'] for move in outgoing_moves)
+
+        res['qty'] = {
+            'in': qty_in,
+            'out': qty_out,
+        }
+        res['draft_picking_qty'] = {
+            'in': qty_in,
+            'out': qty_out,
+        }
+        return res
+
+    @api.model
+    def _get_report_line_values(self, product_template_ids, product_variant_ids):
+        """ Fetch the moves (`stock.move`) to generate the report lines.
+        Report lines are separate in two catgeory: consuming lines and replenishing lines
+
+        :param product_template_ids: list of `product.product` ids.
+        :type product_template_ids: list
+        :param product_variant_ids: list of `product.template` ids.
+        :type product_variant_ids: list
+
+        :return: two lists: the first one about consuming documents, and the second one about
+        replenishing documents.
+        :rtype: tuple
+        """
+        def take_incoming_moves(move):
+            return move.state not in ['cancel', 'done']
+
+        def take_done_moves(move):
+            return move.state == 'done'
+
+        consuming_lines = []
+        replenish_lines = []
+        # `reported_quantity` is a dict who will keep the quantity used by a consuming
+        # move from a replenishing move. Usefull when they aren't direclty linked.
+        reported_quantity = defaultdict(lambda: 0)
+        # Get consuming and replenishing moves and sorts them by expected date.
+        consuming_move_domain, replenishing_move_domain = self._move_domain(product_template_ids, product_variant_ids)
+        consuming_moves = self.env['stock.move'].search(consuming_move_domain)
+        consuming_moves = consuming_moves.sorted(lambda move: move.date_expected)
+        replenishing_moves = self.env['stock.move'].search(replenishing_move_domain)
+        replenishing_moves = replenishing_moves.sorted(lambda move: move.date_expected)
+
+        # Get the available quantity for each product (used for prevision on unreserved transfer).
+        virtual_available = {}
+        for product in (consuming_moves + replenishing_moves).product_id:
+            # virtual_available[product.id] = product.qty_available
+            product_moves = consuming_moves.filtered(lambda move: move.product_id.id == product.id)
+            qty_reserved = sum(product_moves.mapped('reserved_availability'))
+            virtual_available[product.id] = product.qty_available - qty_reserved
+
+        # Creates a report line for each move linked to a consuming document.
+        for move in consuming_moves:
+            if move in replenishing_moves:
+                continue
+            move_data_common = {
+                'document_in': False,
+                'document_out': move._get_consuming_document(),
+                'product': {
+                    'id': move.product_id.id,
+                    'display_name': move.product_id.display_name
+                },
+                'replenishment_filled': True,
+                'uom_id': move.product_id.uom_id,
+                'receipt_date': False,
+                'delivery_date': move.date_expected,
+                'is_late': False,
+            }
+
+            # Compute the quantity to report.
+            qty_to_process = move.product_qty
+            qty_reserved = move.reserved_availability
+            # Decreases the already received quantities from done moves.
+            qty_to_process -= move.quantity_done
+            # done_move_origins = move.move_orig_ids.filtered(take_done_moves)
+            # qty_to_process -= sum(done_move_origins.mapped('quantity_done'))
+
+            incoming_move_origins = move.move_orig_ids.filtered(take_incoming_moves)
+            # incoming_move_origins = move
+            # Get back the end of chain origin move to avoid intermediate moves.
+            while incoming_move_origins.move_orig_ids.filtered(take_incoming_moves).exists():
+            # while incoming_move_origins.move_orig_ids.exists():
+                incoming_move_origins = incoming_move_origins.move_orig_ids
+            # Creates also a report line for each linked replenishment document.
+            for move_origin in incoming_move_origins:
+                quantity = min(qty_to_process, move_origin.product_qty)
+                qty_to_process -= quantity
+                qty_reserved -= quantity
+                reported_quantity[move_origin.id] += quantity
+                move_data = dict(move_data_common)
+                move_data['quantity'] = quantity
+                move_data['receipt_date'] = move_origin.date_expected
+                move_data['is_late'] = move_origin.date_expected > move.date_expected
+                move_data['document_in'] = move_origin._get_replenishment_document()
+                consuming_lines.append(move_data)
+
+            product_id = move.product_id.id
+            # The move has still quantities who aren't fulfilled by a document.
+            while qty_to_process > 0:
+                move_data = dict(move_data_common)
+                if qty_reserved > 0:
+                    # Create a line for quantities reserved in stock.
+                    move_data['quantity'] = qty_reserved
+                    qty_to_process -= qty_reserved
+                    qty_reserved = 0
+                elif virtual_available[product_id] > 0:
+                    # Create a line for quantities not reserved in stock, but available.
+                    qty_from_stock = min(virtual_available[product_id], qty_to_process)
+                    move_data['quantity'] = qty_from_stock
+                    virtual_available[product_id] -= qty_from_stock
+                    qty_to_process -= qty_from_stock
+                else:
+                    # Create a line for remaining unreseved quantities.
+                    move_data['quantity'] = qty_to_process
+                    move_data['replenishment_filled'] = False
+                    qty_to_process = 0
+                consuming_lines.append(move_data)
+
+        # Creates a report line for each move linked to a replenishing document.
+        for move in replenishing_moves:
+            origin_filter = take_incoming_moves
+            quantity = move.product_qty
+            receipt_date = move.date_expected
+            if move.state == 'partially_available':
+                origin_filter = take_done_moves
+                move_orig_done = move.move_orig_ids.filtered(origin_filter)
+                quantity = sum(move_orig_done.mapped('product_qty'))
+            move_origin = move
+            while move_origin.move_orig_ids.exists():
+                # Avoid to take done or cancel origin moves in account.
+                new_move_origin = move_origin.move_orig_ids.filtered(origin_filter)
+                if new_move_origin.exists():
+                    move_origin = new_move_origin
+                else:
+                    break
+
+            quantity -= reported_quantity[move_origin.id]
+            if quantity <= 0:
+                continue
+            move_data = {
+                'document_in': move_origin._get_replenishment_document(),
+                'document_out': False,
+                'product': {
+                    'id': move.product_id.id,
+                    'display_name': move.product_id.display_name
+                },
+                'replenishment_filled': True,
+                'uom_id': move.product_id.uom_id,
+                'receipt_date': receipt_date,
+                'delivery_date': False,
+                'is_late': False,
+                'quantity': quantity,
+            }
+            replenish_lines.append(move_data)
+        return consuming_lines, replenish_lines
+
+    @api.model
+    def _link_report_lines(self, consuming_lines, replenishing_lines):
+        """ Try to link consuming lines without replenishment with replenishing
+        lines who have unreserved quantity.
+
+        :param consuming_lines: a list of report lines about documents using product qty.
+        :type consuming_lines: list
+        :param replenishing_lines: a list of report lines about documents who will restock.
+        :type replenishing_lines: list
+
+        :return: consuming lines and replenishing lines after they are eventually linked.
+        :rtype: list
+        """
+        consuming_lines.sort(key=lambda line: line['delivery_date'])
+        replenishing_lines.sort(key=lambda line: line['receipt_date'])
+        linked_replenishing_lines = []
+        for replenishing_line in replenishing_lines:
+            qty_to_process = replenishing_line['quantity']
+            for consuming_line in consuming_lines:
+                if consuming_line['replenishment_filled'] or replenishing_line['product']['id'] != consuming_line['product']['id']:
+                    continue
+                if consuming_line['quantity'] <= qty_to_process:
+                    # Enough quantity to fulfil the line.
+                    # Updates the line's quantity and marks it as fulfilled.
+                    consuming_line['document_in'] = replenishing_line['document_in']
+                    consuming_line['replenishment_filled'] = True
+                    consuming_line['receipt_date'] = replenishing_line['receipt_date']
+                    if consuming_line['receipt_date'] and consuming_line['delivery_date']:
+                        consuming_line['is_late'] = consuming_line['receipt_date'] > consuming_line['delivery_date']
+                    qty_to_process -= min(consuming_line['quantity'], qty_to_process)
+                    if qty_to_process <= 0:
+                        break
+                else:
+                    # No enough quantity to fulfil the line. So:
+                    # - Decreases the quantity on the line;
+                    # - Creates an another fulfilled line with lesser quantity.
+                    consuming_line['quantity'] -= qty_to_process
+                    separate_consuming_line = consuming_line.copy()
+                    separate_consuming_line.update(
+                        quantity=qty_to_process,
+                        replenishment_filled=True,
+                        document_in=replenishing_line['document_in'],
+                        receipt_date=replenishing_line['receipt_date'],
+                    )
+                    separate_consuming_line['is_late'] = separate_consuming_line['receipt_date'] > separate_consuming_line['delivery_date']
+                    linked_replenishing_lines.append(separate_consuming_line)
+                    qty_to_process = 0
+                    break
+            # If it still unassign quantity, create a report line for it.
+            if qty_to_process:
+                report_data = dict(replenishing_line)
+                report_data['quantity'] = qty_to_process
+                linked_replenishing_lines.append(report_data)
+
+        return consuming_lines + linked_replenishing_lines
+
+    @api.model
+    def _merge_similar_replenishing_lines(self, lines):
+        """ TODO SVS: I keep this method in case I could need it, but it's most
+        likely I'll just delete it soon."""
+        # Merge nothing if the report display intermediate moves.
+        merged_lines = []
+        while len(lines):
+            current_line = lines.pop(0)
+            for i in range(len(lines) - 1, -1, -1):
+                line = lines[i]
+                if current_line['product']['id'] == line['product']['id'] and\
+                   current_line['document_in'] and line['document_in'] and\
+                   current_line['document_in'].id == line['document_in'].id:
+                    current_line['quantity'] += line['quantity']
+                    # Take the most distant date.
+                    if line['receipt_date'] > current_line['receipt_date']:
+                        current_line['receipt_date'] = line['receipt_date']
+                    del lines[i]
+            merged_lines.append(current_line)
+        return merged_lines
+
+    @api.model
+    def get_filter_state(self):
+        res = {}
+        res['warehouses'] = self.env['stock.warehouse'].search_read(fields=['id', 'name', 'code'])
+        res['group_adv_location'] = self.env.user.has_group('stock.group_adv_location')
+        res['active_warehouse'] = self.env.context.get('warehouse', False)
+        if not res['active_warehouse']:
+            res['active_warehouse'] = self.env.context.get('allowed_company_ids')[0]
+        return res
+
+
+class ReplenishmentTemplateReport(models.AbstractModel):
+    _name = 'report.stock.report_product_template_replenishment'
+    _description = "Stock Replenishment Report"
+    _inherit = 'report.stock.report_product_product_replenishment'
+
+    @api.model
+    def _get_report_values(self, docids, data=None):
+        docs = self._get_report_data(product_template_ids=docids)
+        docargs = {
+            'data': data,
+            'doc_ids': docids,
+            'doc_model': 'product.product',
+            'docs': docs,
+        }
+        return docargs

--- a/addons/stock/report/report_replenishment.xml
+++ b/addons/stock/report/report_replenishment.xml
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+<!-- Reports -->
+    <record id="stock_replenishment_report_product_product_action" model="ir.actions.report">
+        <field name="name">Forecasted Report</field>
+        <field name="model">product.product</field>
+        <field name="report_type">qweb-html</field>
+        <field name="report_name">stock.report_product_product_replenishment</field>
+    </record>
+
+    <record id="stock_replenishment_report_product_template_action" model="ir.actions.report">
+        <field name="name">Forecasted Report</field>
+        <field name="model">product.template</field>
+        <field name="report_type">qweb-html</field>
+        <field name="report_name">stock.report_product_template_replenishment</field>
+    </record>
+
+    <record id="stock_replenishment_product_product_action" model="ir.actions.client">
+        <field name="name">Forecasted Report</field>
+        <field name="tag">replenish_report</field>
+    </record>
+
+<!-- Templates -->
+    <template id="assets_common_replenishment_report" name="Forecasted Inventory CSS" inherit_id="web.report_assets_common">
+        <xpath expr="." position="inside">
+            <link rel="stylesheet" type="text/scss" href="/web/static/src/scss/graph_view.scss"/>
+            <link rel="stylesheet" type="text/scss" href="/stock/static/src/scss/report_replenishment.scss"/>
+        </xpath>
+    </template>
+
+    <template id="report_replenishment_header">
+        <div class="d-flex justify-content-between">
+            <div class="o_product_name">
+                <h3>
+                    <t t-if="docs['product_templates']">
+                        <t t-foreach="docs['product_templates']" t-as="product_template">
+                            <a href="#" res-model="product.template" view-type="form" t-att-res-id="product_template.id">
+                                <t t-esc="product_template.display_name"/>
+                            </a>
+                        </t>
+                    </t>
+                    <t t-elif="docs['product_variants']">
+                        <t t-foreach="docs['product_variants']" t-as="product_variant">
+                            <a href="#" res-model="product.product" view-type="form" t-att-res-id="product_variant.id">
+                                <t t-esc="product_variant.display_name"/>
+                            </a>
+                        </t>
+                    </t>
+                </h3>
+                <h6 t-if="docs['product_templates'] and docs['product_variants'] and len(docs['product_templates']) != len(docs['product_variants'])">
+                    <t t-foreach="docs['product_variants']" t-as="product_variant">
+                        <a href="#" res-model="product.product" view-type="form" t-att-res-id="product_variant.id">
+                            <t t-esc="'[%s]' % product_variant.product_template_attribute_value_ids._get_combination_name()"/>
+                        </a>
+                    </t>
+                </h6>
+            </div>
+            <div class="row">
+                <div class="mx-3 text-center">
+                    <div class="h3">
+                        <t t-esc="docs['quantity_on_hand']"/>
+                        <t t-esc="docs['uom']" groups="uom.group_uom"/>
+                    </div>
+                    <div>On Hand</div>
+                </div>
+                <div t-attf-class="mx-3 text-center #{docs['virtual_available'] &lt; 0 and 'text-danger'}">
+                    <div class="h3">
+                        <t t-esc="docs['virtual_available']"/>
+                        <t t-esc="docs['uom']" groups="uom.group_uom"/>
+                    </div>
+                    <div>Forecasted</div>
+                </div>
+                <div name="pending_forecasted" t-attf-class="mx-3 text-center #{future_virtual_available &lt; 0 and 'text-danger'}">
+                    <div class="h3">
+                        <t t-esc="future_virtual_available"/>
+                        <t t-esc="docs['uom']" groups="uom.group_uom"/>
+                    </div>
+                    <div>Forecasted<br/>+ Pending</div>
+                </div>
+            </div>
+        </div>
+    </template>
+
+    <template id="report_product_product_replenishment">
+        <t t-call="web.html_container">
+            <div class="page pt-3 o_report_replenishment_page">
+                <t t-set="future_virtual_available" t-value="docs['virtual_available'] + docs['qty']['in'] - docs['qty']['out']"/>
+                <t t-call="stock.report_replenishment_header"/>
+                <div class="o_report_graph"/>
+                <table class="o_report_replenishment table table-bordered">
+                    <thead>
+                        <tr class="bg-light">
+                            <td>Replenishment</td>
+                            <td>Expected Receipt</td>
+                            <td t-if="docs['multiple_product']">Product</td>
+                            <td class="text-right">Quantity</td>
+                            <td groups="uom.group_uom">UoM</td>
+                            <td>Used by</td>
+                            <td>Expected Delivery</td>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <t t-foreach="docs['lines']" t-as="line"><tr>
+                            <td t-attf-class="#{line['is_late'] and 'o_grid_warning'}">
+                                <a t-if="line['document_in']"
+                                    t-attf-href="#" t-esc="line['document_in'].name"
+                                    class="font-weight-bold" view-type="form"
+                                    t-att-res-model="line['document_in']._name"
+                                    t-att-res-id="line['document_in'].id"/>
+                                <t t-elif="line['replenishment_filled']" t-esc="'Current Stock'"/>
+                                <span t-else="" class="text-muted" t-esc="'Not Available'"/>
+                            </td>
+                            <td t-esc="line['receipt_date']"
+                                t-attf-class="#{line['is_late'] and 'o_grid_warning'}"/>
+                            <td t-if="docs['multiple_product']" t-esc="line['product']['display_name']"/>
+                            <td t-esc="line['quantity']" class="text-right"/>
+                            <td t-esc="line['uom_id'].name" groups="uom.group_uom"/>
+                            <td t-attf-class="#{not line['replenishment_filled'] and 'o_grid_warning'}">
+                                <a t-if="line['document_out']"
+                                    t-attf-href="#" t-esc="line['document_out'].name"
+                                    class="font-weight-bold" view-type="form"
+                                    t-att-res-model="line['document_out']._name"
+                                    t-att-res-id="line['document_out'].id"/>
+                            </td>
+                            <td t-esc="line['delivery_date']"
+                                t-attf-class="#{not line['replenishment_filled'] and 'o_grid_warning'}"/>
+                        </tr></t>
+                    </tbody>
+                </table>
+                <table class="o_report_replenishment_summary table-sm table-bordered">
+                    <thead>
+                        <tr class="o_forecasted_row">
+                            <td>Forecasted Inventory</td>
+                            <td t-esc="docs['virtual_available']" class="text-right"/>
+                            <td t-esc="docs['uom']" groups="uom.group_uom"/>
+                        </tr>
+                        <tr t-if="docs['qty']['in']" class="bg-light">
+                            <td>Pending Incoming Documents</td>
+                            <td t-esc="docs['qty']['in']" class="text-right"/>
+                            <td t-esc="docs['uom']"  groups="uom.group_uom"/>
+                        </tr>
+                    </thead>
+                    <tbody t-if="docs['qty']['in']">
+                        <tr t-if="docs['draft_picking_qty']['in']" name="draft_picking_in">
+                            <td>Draft Transfer</td>
+                            <td t-esc="docs['draft_picking_qty']['in']" class="text-right"/>
+                            <td t-esc="docs['uom']" groups="uom.group_uom"/>
+                        </tr>
+                    </tbody>
+                    <thead t-if="docs['qty']['out']">
+                        <tr class="bg-light">
+                            <td>Pending Outgoing Documents</td>
+                            <td t-esc="docs['qty']['out']" class="text-right"/>
+                            <td t-esc="docs['uom']"  groups="uom.group_uom"/>
+                        </tr>
+                    </thead>
+                    <tbody t-if="docs['qty']['out']">
+                        <tr t-if="docs['draft_picking_qty']['out']" name="draft_picking_out">
+                            <td>Draft Transfer</td>
+                            <td t-esc="docs['draft_picking_qty']['out']" class="text-right"/>
+                            <td t-esc="docs['uom']" groups="uom.group_uom"/>
+                        </tr>
+                    </tbody>
+                    <thead>
+                        <tr class="o_forecasted_row">
+                            <td>Forecasted with Pending</td>
+                            <td t-esc="future_virtual_available" class="text-right"/>
+                            <td t-esc="docs['uom']" groups="uom.group_uom"/>
+                        </tr>
+                    </thead>
+                </table>
+            </div>
+        </t>
+    </template>
+
+    <template id="report_product_template_replenishment">
+        <t t-call="stock.report_product_product_replenishment"/>
+    </template>
+</odoo>

--- a/addons/stock/static/src/js/forecast_button_widget.js
+++ b/addons/stock/static/src/js/forecast_button_widget.js
@@ -1,0 +1,71 @@
+odoo.define('stock.forecast_button_widget', function (require) {
+"use strict";
+
+const AbstractField = require('web.AbstractField');
+const core = require('web.core');
+const registry = require('web.field_registry');
+
+const qweb = core.qweb;
+
+const forecastButtonWidget = AbstractField.extend({
+    template: 'forecastButton',
+    events: _.extend({}, AbstractField.prototype.events, {
+        'click .o_forecast_report_button': '_onOpenReport',
+    }),
+
+    init: function (parent, name, record, options) {
+        this._super(...arguments);
+        const parentState = parent.state.data[0].data.state;
+        // The button will be visible only for storable product (so, `product_type` need to be in
+        // the same view than this widget) and if the document's state is not draft or cancel.
+        this.displayButton = this.record.data.product_type === 'product' && !['draft', 'cancel'].includes(parentState);
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    _renderReadonly() {
+        this.$el.empty();
+        if (this.value) {
+            this.$el.html(qweb.render(this.template, {
+                value: this.value,
+                displayButton: this.displayButton,
+            }));
+        }
+    },
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Opens the Forecast Report for the `stock.move` product.
+     *
+     * @param {MouseEvent} ev
+     */
+    _onOpenReport: function (ev) {
+        ev.preventDefault();
+        ev.stopPropagation();
+        const productId = this.recordData.product_id.res_id;
+        const resModel = 'product.product';
+        this._rpc({
+            model: resModel,
+            method: 'action_product_forecast_report',
+            args: [productId],
+        }).then(action => {
+            action.context = {
+                active_model: resModel,
+                active_id: productId,
+            };
+            this.do_action(action);
+        });
+    }
+});
+
+registry.add('forecast_button', forecastButtonWidget);
+
+});

--- a/addons/stock/static/src/js/stock_replenish_report.js
+++ b/addons/stock/static/src/js/stock_replenish_report.js
@@ -1,0 +1,263 @@
+odoo.define('stock.ReplenishReport', function (require) {
+"use strict";
+
+const clientAction = require('report.client_action');
+const core = require('web.core');
+const dom = require('web.dom');
+const GraphView = require('web.GraphView');
+const session = require('web.session');
+
+const qweb = core.qweb;
+const _t = core._t;
+
+
+const ReplenishReport = clientAction.extend({
+    /**
+     * @override
+     */
+    init: function (parent, action, options) {
+        this._super.apply(this, arguments);
+        this.context = action.context;
+        this.productId = this.context.active_id;
+        this.resModel = this.context.active_model || 'product.template';
+        const isTemplate = this.resModel === 'product.template';
+        this.actionMethod = `action_product_${isTemplate ? 'tmpl_' : ''}forecast_report`;
+        const reportName = `report_product_${isTemplate ? 'template' : 'product'}_replenishment`;
+        this.report_url = `/report/html/stock.${reportName}/${this.productId}`;
+        if (this.context.warehouse) {
+            this.active_warehouse = {id: this.context.warehouse};
+        }
+        this.report_url += `?context=${JSON.stringify(this.context)}`;
+        this._title = action.name;
+    },
+
+    /**
+     * @override
+     */
+    start: function () {
+        return Promise.all([
+            this._super(...arguments),
+            session.is_bound,
+            this._renderWarehouseFilters(),
+        ]);
+    },
+
+    /**
+     * @override
+     */
+    on_attach_callback: function () {
+        this._super();
+        this._createGraphView();
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * Instanciates a chart graph and moves it into the report (which is in the iframe).
+     */
+    _createGraphView: async function () {
+        let viewController;
+        const appendGraph = () => {
+            promController.then(() => {
+                this.iframe.removeEventListener('load', appendGraph);
+                const $reportGraphDiv = $(this.iframe).contents().find('.o_report_graph');
+                dom.append(this.$el, viewController.$el, {
+                    in_DOM: true,
+                    callbacks: [{widget: viewController}],
+                });
+                const renderer = viewController.renderer;
+                // Remove the graph control panel.
+                $('.o_control_panel:last').remove();
+                const $graphPanel = $('.o_graph_controller');
+                $graphPanel.appendTo($reportGraphDiv);
+
+                if (!renderer.state.dataPoints.length) {
+                    // Changes the "No Data" helper message.
+                    const graphHelper = renderer.$('.o_view_nocontent');
+                    const newMessage = qweb.render('View.NoContentHelper', {
+                        description: _t("Try to add some incoming or outgoing transfers."),
+                    });
+                    graphHelper.replaceWith(newMessage);
+                } else {
+                    this.chart = renderer.chart;
+                    // Lame hack to fix the size of the graph.
+                    setTimeout(() => {
+                        this.chart.canvas.height = 300;
+                        this.chart.canvas.style.height = "300px";
+                        this.chart.resize();
+                    }, 1);
+                }
+            });
+        };
+        // Wait the iframe fo append the graph chart and move it into the iframe.
+        this.iframe.addEventListener('load', appendGraph);
+
+        const model = 'report.stock.quantity';
+        const promController = this._rpc({
+            model: model,
+            method: 'fields_view_get',
+            kwargs: {
+                view_type: 'graph',
+            }
+        }).then(viewInfo => {
+            const params = {
+                modelName: model,
+                domain: this._getReportDomain(),
+                hasActionMenus: false,
+            };
+            const graphView = new GraphView(viewInfo, params);
+            return graphView.getController(this);
+        }).then(res => {
+            viewController = res;
+            const fragment = document.createDocumentFragment();
+            return viewController.appendTo(fragment);
+        });
+    },
+
+    /**
+     * Return the action to open this report.
+     *
+     * @returns {Promise}
+     */
+    _getForecastedReportAction: function () {
+        return this._rpc({
+            model: this.resModel,
+            method: this.actionMethod,
+            args: [this.productId],
+            context: this.context,
+        });
+    },
+
+    /**
+     * Returns a domain to filter on the product variant or product template
+     * depending of the active model.
+     *
+     * @returns {Array}
+     */
+    _getReportDomain: function () {
+        const domain = [
+            ['state', '=', 'forecast'],
+            ['warehouse_id', '=', this.active_warehouse.id],
+        ];
+        if (this.resModel === 'product.template') {
+            domain.push(['product_tmpl_id', '=', this.productId]);
+        } else if (this.resModel === 'product.product') {
+            domain.push(['product_id', '=', this.productId]);
+        }
+        return domain;
+    },
+
+    /**
+     * TODO
+     *
+     * @param {Object} additionnalContext
+     */
+    _reloadReport: function (additionnalContext) {
+        return this._getForecastedReportAction().then((action) => {
+            action.context = Object.assign({
+                active_id: this.productId,
+                active_model: this.resModel,
+            }, this.context, additionnalContext);
+            return this.do_action(action, {replace_last_action: true});
+        });
+    },
+
+    /**
+     * Renders the 'Replenish' button and replaces the default 'Print' button by this new one.
+     */
+    _renderButtons: function () {
+        const $newButtons = $(qweb.render('replenish_report_buttons', {}));
+        this.$buttons.find('.o_report_print').replaceWith($newButtons);
+        this.$buttons.on('click', '.o_report_replenish_buy', this._onClickReplenish.bind(this));
+        this.controlPanelProps.cp_content = {
+            $buttons: this.$buttons,
+        };
+    },
+
+    /**
+     * TODO
+     * @returns {Promise}
+     */
+    _renderWarehouseFilters: function () {
+        return this._rpc({
+            model: 'report.stock.report_product_product_replenishment',
+            method: 'get_filter_state',
+        }).then((res) => {
+            const warehouses = res.warehouses;
+            const active_warehouse = (this.active_warehouse && this.active_warehouse.id) || res.active_warehouse;
+            if (active_warehouse) {
+                this.active_warehouse = _.findWhere(warehouses, {id: active_warehouse});
+            } else {
+                this.active_warehouse = warehouses[0];
+            }
+            const $filters = $(qweb.render('warehouseFilter', {
+                active_warehouse: this.active_warehouse,
+                warehouses: warehouses,
+                displayOptions: res.group_adv_location,
+                displayWarehouseFilter: (warehouses.length > 1),
+            }));
+            // Bind handlers.
+            $filters.on('click', '.warehouse_filter', this._onClickFilter.bind(this));
+            this.$('.o_search_options').append($filters);
+        });
+    },
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Opens the product replenish wizard. Could re-open the report if pending
+     * forecasted quantities need to be updated.
+     *
+     * @returns {Promise}
+     */
+    _onClickReplenish: function () {
+        const context = Object.assign({}, this.context);
+        if (this.resModel === 'product.product') {
+            context.default_product_id = this.productId;
+        } else if (this.resModel === 'product.template') {
+            context.default_product_tmpl_id = this.productId;
+        }
+        context.default_warehouse_id = this.active_warehouse.id;
+
+        const on_close = function (res) {
+            if (res && res.special) {
+                // Do nothing when the wizard is discarded.
+                return;
+            }
+            // Otherwise, opens again the report.
+            return this._reloadReport();
+        };
+
+        const action = {
+            res_model: 'product.replenish',
+            name: _t('Product Replenish'),
+            type: 'ir.actions.act_window',
+            views: [[false, 'form']],
+            target: 'new',
+            context: context,
+        };
+
+        return this.do_action(action, {
+            on_close: on_close.bind(this),
+        });
+    },
+
+    /**
+     * Re-opens the report with data for the specified warehouse.
+     *
+     * @returns {Promise}
+     */
+    _onClickFilter: function (ev) {
+        const data = ev.target.dataset;
+        const warehouse_id = Number(data.warehouseId);
+        return this._reloadReport({warehouse: warehouse_id});
+    }
+});
+
+core.action_registry.add('replenish_report', ReplenishReport);
+
+});

--- a/addons/stock/static/src/scss/report_replenishment.scss
+++ b/addons/stock/static/src/scss/report_replenishment.scss
@@ -1,0 +1,18 @@
+
+.o_report_replenishment_page {
+    .o_report_replenishment {
+        .o_grid_warning {
+            background-color: #f4cccc;
+        }
+    }
+
+    .o_report_replenishment_summary {
+        .o_forecasted_row {
+            background-color: #dee2e6;
+        }
+    }
+
+    .o_report_graph {
+        height: 300px;
+    }
+}

--- a/addons/stock/static/src/scss/stock_widget.scss
+++ b/addons/stock/static/src/scss/stock_widget.scss
@@ -1,0 +1,3 @@
+.o_forecast_button_cell {
+    text-align: right;
+}

--- a/addons/stock/static/src/xml/forecast_button_widget.xml
+++ b/addons/stock/static/src/xml/forecast_button_widget.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates id="template" xml:space="preserve">
+
+<t t-name="forecastButton">
+    <div>
+        <span t-esc="value"/>
+        <t t-if="displayButton">
+            <button class="o_forecast_report_button btn btn-link o_icon_button ml-2" title="Forecasted Report">
+                <i class="fa fa-fw fa-area-chart"/>
+            </button>
+        </t>
+    </div>
+</t>
+
+</templates>

--- a/addons/stock/static/src/xml/report_replenishment.xml
+++ b/addons/stock/static/src/xml/report_replenishment.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates id="template" xml:space="preserve">
+
+<button t-name="replenish_report_buttons"
+    class="btn btn-primary o_report_replenish_buy"
+    type="button" title="Replenish">
+    Replenish
+</button>
+
+<t t-name="warehouseFilter">
+    <div id="warehouse_filter" class="btn-group o_dropdown o_stock_report_warehouse_filter"
+        t-if="displayWarehouseFilter">
+        <button type="button" class="o_dropdown_toggler_btn btn btn-secondary dropdown-toggle"
+            data-toggle="dropdown">
+            <span class="fa fa-home"/> Warehouse: <t t-esc="active_warehouse['name']"/>
+        </button>
+        <div class="dropdown-menu o_filter_menu" role="menu">
+            <t t-foreach="warehouses" t-as="wh">
+                <a role="menuitem" class="dropdown-item warehouse_filter"
+                    data-filter="warehouses" t-att-data-warehouse-id="wh['id']"
+                    t-esc="wh['name']"/>
+            </t>
+        </div>
+    </div>
+</t>
+
+</templates>

--- a/addons/stock/tests/test_report.py
+++ b/addons/stock/tests/test_report.py
@@ -3,10 +3,42 @@
 
 from datetime import date, datetime, timedelta
 
-from odoo.tests.common import Form, TransactionCase
+from odoo.tests.common import Form, SavepointCase
 
 
-class TestReports(TransactionCase):
+class TestReportsCommon(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env['res.partner'].create({'name': 'Partner'})
+        cls.ModelDataObj = cls.env['ir.model.data']
+        cls.picking_type_in = cls.env['stock.picking.type'].browse(cls.ModelDataObj.xmlid_to_res_id('stock.picking_type_in'))
+        cls.picking_type_out = cls.env['stock.picking.type'].browse(cls.ModelDataObj.xmlid_to_res_id('stock.picking_type_out'))
+        cls.supplier_location = cls.env['stock.location'].browse(cls.ModelDataObj.xmlid_to_res_id('stock.stock_location_suppliers'))
+        cls.stock_location = cls.env['stock.location'].browse(cls.ModelDataObj.xmlid_to_res_id('stock.stock_location_stock'))
+
+        product_form = Form(cls.env['product.product'])
+        product_form.type = 'product'
+        product_form.name = 'Product'
+        cls.product = product_form.save()
+        cls.product_template = cls.product.product_tmpl_id
+
+    def get_report_forecast(self, product_template_ids=False, product_variant_ids=False, context=False):
+        if product_template_ids:
+            report = self.env['report.stock.report_product_template_replenishment']
+            product_ids = product_template_ids
+        elif product_variant_ids:
+            report = self.env['report.stock.report_product_product_replenishment']
+            product_ids = product_template_ids
+        if context:
+            report = report.with_context(context)
+        report_values = report._get_report_values(docids=product_ids)
+        docs = report_values['docs']
+        lines = docs['lines']
+        return report_values, docs, lines
+
+
+class TestReports(TestReportsCommon):
     def test_reports(self):
         product1 = self.env['product.product'].create({
             'name': 'Mellohi',
@@ -268,3 +300,692 @@ class TestReports(TransactionCase):
             [('product_id', '=', product.id), ('date', '=', date.today())],
             ['product_qty'], [], lazy=False)
         self.assertEqual(sum([r['product_qty'] for r in report_records]), 10.0)
+
+    def test_report_forecast_1(self):
+        """ Checks report data for product is empty. Then creates and process
+        some operations and checks the report data accords rigthly these operations.
+        """
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        draft_picking_qty = docs['draft_picking_qty']
+        self.assertEqual(len(lines), 0, "Must have 0 line.")
+        self.assertEqual(draft_picking_qty['in'], 0)
+        self.assertEqual(draft_picking_qty['out'], 0)
+
+        # Creates a receipt then checks draft picking quantities.
+        receipt_form = Form(self.env['stock.picking'].with_context(
+            force_detailed_view=True
+        ), view='stock.view_picking_form')
+        receipt_form.partner_id = self.partner
+        receipt_form.picking_type_id = self.picking_type_in
+        receipt = receipt_form.save()
+        with receipt_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = self.product
+            move_line.product_uom_qty = 2
+        receipt = receipt_form.save()
+
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        draft_picking_qty = docs['draft_picking_qty']
+        self.assertEqual(len(lines), 0, "Must have 0 line.")
+        self.assertEqual(draft_picking_qty['in'], 2)
+        self.assertEqual(draft_picking_qty['out'], 0)
+
+        # Creates a delivery then checks draft picking quantities.
+        delivery_form = Form(self.env['stock.picking'].with_context(
+            force_detailed_view=True
+        ), view='stock.view_picking_form')
+        delivery_form.partner_id = self.partner
+        delivery_form.picking_type_id = self.picking_type_out
+        delivery = delivery_form.save()
+        with delivery_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = self.product
+            move_line.product_uom_qty = 5
+        delivery = delivery_form.save()
+
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        draft_picking_qty = docs['draft_picking_qty']
+        self.assertEqual(len(lines), 0, "Must have 0 line.")
+        self.assertEqual(draft_picking_qty['in'], 2)
+        self.assertEqual(draft_picking_qty['out'], 5)
+
+        # Confirms the delivery: must have one report line and no more pending qty out now.
+        delivery.action_confirm()
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        draft_picking_qty = docs['draft_picking_qty']
+        self.assertEqual(len(lines), 1, "Must have 1 line.")
+        self.assertEqual(draft_picking_qty['in'], 2)
+        self.assertEqual(draft_picking_qty['out'], 0)
+        delivery_line = lines[0]
+        self.assertEqual(delivery_line['quantity'], 5)
+        self.assertEqual(delivery_line['replenishment_filled'], False)
+        self.assertEqual(delivery_line['document_out'].id, delivery.id)
+
+        # Confirms the receipt, must have two report lines now:
+        #   - line with 2 qty (from the receipt to the delivery)
+        #   - line with 3 qty (delivery, unavailable)
+        receipt.action_confirm()
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        draft_picking_qty = docs['draft_picking_qty']
+        self.assertEqual(len(lines), 2, "Must have 2 line.")
+        self.assertEqual(draft_picking_qty['in'], 0)
+        self.assertEqual(draft_picking_qty['out'], 0)
+        fulfilled_line = lines[0]
+        unavailable_line = lines[1]
+        self.assertEqual(fulfilled_line['replenishment_filled'], True)
+        self.assertEqual(fulfilled_line['quantity'], 2)
+        self.assertEqual(fulfilled_line['document_in'].id, receipt.id)
+        self.assertEqual(fulfilled_line['document_out'].id, delivery.id)
+        self.assertEqual(unavailable_line['replenishment_filled'], False)
+        self.assertEqual(unavailable_line['quantity'], 3)
+        self.assertEqual(unavailable_line['document_out'].id, delivery.id)
+
+        # Creates a new receipt for the remaining quantity, confirm it...
+        receipt_form = Form(self.env['stock.picking'].with_context(
+            force_detailed_view=True
+        ), view='stock.view_picking_form')
+        receipt_form.partner_id = self.partner
+        receipt_form.picking_type_id = self.picking_type_in
+        with receipt_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = self.product
+            move_line.product_uom_qty = 3
+        receipt2 = receipt_form.save()
+        receipt2.action_confirm()
+
+        # ... and valid the first one.
+        receipt_form = Form(receipt)
+        with receipt_form.move_ids_without_package.edit(0) as move_line:
+            move_line.quantity_done = 2
+        receipt = receipt_form.save()
+        receipt.button_validate()
+
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        draft_picking_qty = docs['draft_picking_qty']
+        self.assertEqual(len(lines), 2, "Still must have 2 line.")
+        self.assertEqual(draft_picking_qty['in'], 0)
+        self.assertEqual(draft_picking_qty['out'], 0)
+        line1 = lines[0]
+        line2 = lines[1]
+        # First line must be fulfilled thanks to the stock on hand.
+        self.assertEqual(line1['quantity'], 2)
+        self.assertEqual(line1['replenishment_filled'], True)
+        self.assertEqual(line1['document_in'], False)
+        self.assertEqual(line1['document_out'].id, delivery.id)
+        # Second line must be linked to the second receipt.
+        self.assertEqual(line2['quantity'], 3)
+        self.assertEqual(line2['replenishment_filled'], True)
+        self.assertEqual(line2['document_in'].id, receipt2.id)
+        self.assertEqual(line2['document_out'].id, delivery.id)
+
+    def test_report_forecast_2_replenishments_order(self):
+        """ Creates a receipt then creates a delivery using half of the receipt quantity.
+        Checks replenishment lines are correctly sorted (assigned first, unassigned at the end).
+        """
+        # Creates a receipt then checks draft picking quantities.
+        receipt_form = Form(self.env['stock.picking'].with_context(
+            force_detailed_view=True
+        ), view='stock.view_picking_form')
+        receipt_form.partner_id = self.partner
+        receipt_form.picking_type_id = self.picking_type_in
+        with receipt_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = self.product
+            move_line.product_uom_qty = 6
+        receipt = receipt_form.save()
+        receipt.action_confirm()
+
+        # Creates a delivery then checks draft picking quantities.
+        delivery_form = Form(self.env['stock.picking'].with_context(
+            force_detailed_view=True
+        ), view='stock.view_picking_form')
+        delivery_form.partner_id = self.partner
+        delivery_form.picking_type_id = self.picking_type_out
+        with delivery_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = self.product
+            move_line.product_uom_qty = 3
+        delivery = delivery_form.save()
+        delivery.action_confirm()
+
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        self.assertEqual(len(lines), 2, "Must have 2 line.")
+        line_1 = lines[0]
+        line_2 = lines[1]
+        self.assertEqual(line_1['document_in'].id, receipt.id)
+        self.assertEqual(line_1['document_out'].id, delivery.id)
+        self.assertEqual(line_2['document_in'].id, receipt.id)
+        self.assertEqual(line_2['document_out'], False)
+
+    def test_report_forecast_3_sort_by_date(self):
+        """ Creates some delivery with different dates and checks the report
+        lines are correctly sorted by date.
+        """
+        today = datetime.today()
+        one_hours = timedelta(hours=1)
+        one_day = timedelta(days=1)
+        one_month = timedelta(days=30)
+        # Creates a bunch of deliveries with different date.
+        delivery_form = Form(self.env['stock.picking'].with_context(
+            force_detailed_view=True
+        ), view='stock.view_picking_form')
+        delivery_form.partner_id = self.partner
+        delivery_form.picking_type_id = self.picking_type_out
+        delivery_form.scheduled_date = today
+        with delivery_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = self.product
+            move_line.product_uom_qty = 5
+        delivery_1 = delivery_form.save()
+        delivery_1.action_confirm()
+
+        delivery_form = Form(self.env['stock.picking'].with_context(
+            force_detailed_view=True
+        ), view='stock.view_picking_form')
+        delivery_form.partner_id = self.partner
+        delivery_form.picking_type_id = self.picking_type_out
+        delivery_form.scheduled_date = today + one_hours
+        with delivery_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = self.product
+            move_line.product_uom_qty = 5
+        delivery_2 = delivery_form.save()
+        delivery_2.action_confirm()
+
+        delivery_form = Form(self.env['stock.picking'].with_context(
+            force_detailed_view=True
+        ), view='stock.view_picking_form')
+        delivery_form.partner_id = self.partner
+        delivery_form.picking_type_id = self.picking_type_out
+        delivery_form.scheduled_date = today - one_hours
+        with delivery_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = self.product
+            move_line.product_uom_qty = 5
+        delivery_3 = delivery_form.save()
+        delivery_3.action_confirm()
+
+        delivery_form = Form(self.env['stock.picking'].with_context(
+            force_detailed_view=True
+        ), view='stock.view_picking_form')
+        delivery_form.partner_id = self.partner
+        delivery_form.picking_type_id = self.picking_type_out
+        delivery_form.scheduled_date = today + one_day
+        with delivery_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = self.product
+            move_line.product_uom_qty = 5
+        delivery_4 = delivery_form.save()
+        delivery_4.action_confirm()
+
+        delivery_form = Form(self.env['stock.picking'].with_context(
+            force_detailed_view=True
+        ), view='stock.view_picking_form')
+        delivery_form.partner_id = self.partner
+        delivery_form.picking_type_id = self.picking_type_out
+        delivery_form.scheduled_date = today - one_day
+        with delivery_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = self.product
+            move_line.product_uom_qty = 5
+        delivery_5 = delivery_form.save()
+        delivery_5.action_confirm()
+
+        delivery_form = Form(self.env['stock.picking'].with_context(
+            force_detailed_view=True
+        ), view='stock.view_picking_form')
+        delivery_form.partner_id = self.partner
+        delivery_form.picking_type_id = self.picking_type_out
+        delivery_form.scheduled_date = today + one_month
+        with delivery_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = self.product
+            move_line.product_uom_qty = 5
+        delivery_6 = delivery_form.save()
+        delivery_6.action_confirm()
+
+        delivery_form = Form(self.env['stock.picking'].with_context(
+            force_detailed_view=True
+        ), view='stock.view_picking_form')
+        delivery_form.partner_id = self.partner
+        delivery_form.picking_type_id = self.picking_type_out
+        delivery_form.scheduled_date = today - one_month
+        with delivery_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = self.product
+            move_line.product_uom_qty = 5
+        delivery_7 = delivery_form.save()
+        delivery_7.action_confirm()
+
+        # Order must be: 7, 5, 3, 1, 2, 4, 6
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        draft_picking_qty = docs['draft_picking_qty']
+        self.assertEqual(len(lines), 7, "The report must have 7 line.")
+        self.assertEqual(draft_picking_qty['in'], 0)
+        self.assertEqual(draft_picking_qty['out'], 0)
+        self.assertEqual(lines[0]['document_out'].id, delivery_7.id)
+        self.assertEqual(lines[1]['document_out'].id, delivery_5.id)
+        self.assertEqual(lines[2]['document_out'].id, delivery_3.id)
+        self.assertEqual(lines[3]['document_out'].id, delivery_1.id)
+        self.assertEqual(lines[4]['document_out'].id, delivery_2.id)
+        self.assertEqual(lines[5]['document_out'].id, delivery_4.id)
+        self.assertEqual(lines[6]['document_out'].id, delivery_6.id)
+
+    def test_report_forecast_4_intermediate_transfers(self):
+        """ Create a receipt in 3 steps and check the report lines.
+        """
+        grp_multi_loc = self.env.ref('stock.group_stock_multi_locations')
+        grp_multi_routes = self.env.ref('stock.group_adv_location')
+        self.env.user.write({'groups_id': [(4, grp_multi_loc.id)]})
+        self.env.user.write({'groups_id': [(4, grp_multi_routes.id)]})
+        # Warehouse config.
+        warehouse = self.env.ref('stock.warehouse0')
+        warehouse.reception_steps = 'three_steps'
+        # Product config.
+        self.product.write({'route_ids': [(4, self.env.ref('stock.route_warehouse0_mto').id)]})
+        # Create a RR
+        pg1 = self.env['procurement.group'].create({})
+        reordering_rule = self.env['stock.warehouse.orderpoint'].create({
+            'name': 'Product RR',
+            'location_id': warehouse.lot_stock_id.id,
+            'product_id': self.product.id,
+            'product_min_qty': 5,
+            'product_max_qty': 10,
+            'group_id': pg1.id,
+        })
+        reordering_rule.action_replenish()
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        pickings = self.env['stock.picking'].search([('product_id', '=', self.product.id)])
+        receipt = pickings.filtered(lambda p: p.picking_type_id.id == self.picking_type_in.id)
+
+        # By default, the Forecasted Report don't show intermediate moves.
+        self.assertEqual(len(lines), 1, "The report must have only 1 line.")
+        line = lines[0]
+        self.assertEqual(line['document_in'].id, receipt.id, "The report must show the receipt.")
+        self.assertEqual(line['document_out'], False)
+        self.assertEqual(line['quantity'], reordering_rule.product_max_qty)
+
+    def test_report_forecast_5_multi_warehouse(self):
+        """ Create some transfer for two different warehouses and check the
+        report display the good moves according to the selected warehouse.
+        """
+        # Warehouse config.
+        wh_2 = self.env['stock.warehouse'].create({
+            'name': 'Evil Twin Warehouse',
+            'code': 'ETWH',
+        })
+        picking_type_out_2 = self.env['stock.picking.type'].search([
+            ('code', '=', 'outgoing'),
+            ('warehouse_id', '=', wh_2.id),
+        ])
+
+        # Creates a delivery then checks draft picking quantities.
+        delivery_form = Form(self.env['stock.picking'].with_context(
+            force_detailed_view=True
+        ), view='stock.view_picking_form')
+        delivery_form.partner_id = self.partner
+        delivery_form.picking_type_id = self.picking_type_out
+        delivery = delivery_form.save()
+        with delivery_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = self.product
+            move_line.product_uom_qty = 5
+        delivery = delivery_form.save()
+
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        draft_picking_qty = docs['draft_picking_qty']
+        self.assertEqual(len(lines), 0, "Must have 0 line.")
+        self.assertEqual(draft_picking_qty['out'], 5)
+
+        report_values, docs, lines = self.get_report_forecast(
+            product_template_ids=self.product_template.ids,
+            context={'warehouse': wh_2.id},
+        )
+        draft_picking_qty = docs['draft_picking_qty']
+        self.assertEqual(len(lines), 0)
+        self.assertEqual(draft_picking_qty['out'], 0)
+
+        # Confirm the delivery -> The report must now have 1 line.
+        delivery.action_confirm()
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        draft_picking_qty = docs['draft_picking_qty']
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(draft_picking_qty['out'], 0)
+        self.assertEqual(lines[0]['document_out'].id, delivery.id)
+        self.assertEqual(lines[0]['quantity'], 5)
+
+        report_values, docs, lines = self.get_report_forecast(
+            product_template_ids=self.product_template.ids,
+            context={'warehouse': wh_2.id},
+        )
+        draft_picking_qty = docs['draft_picking_qty']
+        self.assertEqual(len(lines), 0)
+        self.assertEqual(draft_picking_qty['out'], 0)
+
+        # Creates a delivery for the second warehouse.
+        delivery_form = Form(self.env['stock.picking'].with_context(
+            force_detailed_view=True
+        ), view='stock.view_picking_form')
+        delivery_form.partner_id = self.partner
+        delivery_form.picking_type_id = picking_type_out_2
+        delivery_2 = delivery_form.save()
+        with delivery_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = self.product
+            move_line.product_uom_qty = 8
+        delivery_2 = delivery_form.save()
+
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        draft_picking_qty = docs['draft_picking_qty']
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(draft_picking_qty['out'], 0)
+        self.assertEqual(lines[0]['document_out'].id, delivery.id)
+        self.assertEqual(lines[0]['quantity'], 5)
+
+        report_values, docs, lines = self.get_report_forecast(
+            product_template_ids=self.product_template.ids,
+            context={'warehouse': wh_2.id},
+        )
+        draft_picking_qty = docs['draft_picking_qty']
+        self.assertEqual(len(lines), 0)
+        self.assertEqual(draft_picking_qty['out'], 8)
+        # Confirm the second delivery -> The report must now have 1 line.
+        delivery_2.action_confirm()
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        draft_picking_qty = docs['draft_picking_qty']
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(draft_picking_qty['out'], 0)
+        self.assertEqual(lines[0]['document_out'].id, delivery.id)
+        self.assertEqual(lines[0]['quantity'], 5)
+
+        report_values, docs, lines = self.get_report_forecast(
+            product_template_ids=self.product_template.ids,
+            context={'warehouse': wh_2.id},
+        )
+        draft_picking_qty = docs['draft_picking_qty']
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(draft_picking_qty['out'], 0)
+        self.assertEqual(lines[0]['document_out'].id, delivery_2.id)
+        self.assertEqual(lines[0]['quantity'], 8)
+
+    def test_report_forecast_6_multi_company(self):
+        """ Create transfers for two different companies and check report
+        display the right transfers.
+        """
+        # Configure second warehouse.
+        company_2 = self.env['res.company'].create({'name': 'Aperture Science'})
+        wh_2 = self.env['stock.warehouse'].search([('company_id', '=', company_2.id)])
+        wh_2_picking_type_in = wh_2.in_type_id
+
+        # Creates a receipt then checks draft picking quantities.
+        receipt_form = Form(self.env['stock.picking'].with_context(
+            force_detailed_view=True
+        ), view='stock.view_picking_form')
+        receipt_form.partner_id = self.partner
+        receipt_form.picking_type_id = self.picking_type_in
+        wh_1_receipt = receipt_form.save()
+        with receipt_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = self.product
+            move_line.product_uom_qty = 2
+        wh_1_receipt = receipt_form.save()
+
+        # Creates a receipt then checks draft picking quantities.
+        receipt_form = Form(self.env['stock.picking'].with_context(
+            force_detailed_view=True
+        ), view='stock.view_picking_form')
+        receipt_form.partner_id = self.partner
+        receipt_form.picking_type_id = wh_2_picking_type_in
+        wh_2_receipt = receipt_form.save()
+        with receipt_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = self.product
+            move_line.product_uom_qty = 5
+        wh_2_receipt = receipt_form.save()
+
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        draft_picking_qty = docs['draft_picking_qty']
+        self.assertEqual(len(lines), 0, "Must have 0 line.")
+        self.assertEqual(draft_picking_qty['in'], 2)
+        self.assertEqual(draft_picking_qty['out'], 0)
+
+        report_values, docs, lines = self.get_report_forecast(
+            product_template_ids=self.product_template.ids,
+            context={'warehouse': wh_2.id},
+        )
+        draft_picking_qty = docs['draft_picking_qty']
+        self.assertEqual(len(lines), 0, "Must have 0 line.")
+        self.assertEqual(draft_picking_qty['in'], 5)
+        self.assertEqual(draft_picking_qty['out'], 0)
+
+        # Confirm the receipts -> The report must now have one line for each company.
+        wh_1_receipt.action_confirm()
+        wh_2_receipt.action_confirm()
+
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        self.assertEqual(len(lines), 1, "Must have 1 line.")
+        self.assertEqual(lines[0]['document_in'].id, wh_1_receipt.id)
+        self.assertEqual(lines[0]['quantity'], 2)
+
+        report_values, docs, lines = self.get_report_forecast(
+            product_template_ids=self.product_template.ids,
+            context={'warehouse': wh_2.id},
+        )
+        self.assertEqual(len(lines), 1, "Must have 1 line.")
+        self.assertEqual(lines[0]['document_in'].id, wh_2_receipt.id)
+        self.assertEqual(lines[0]['quantity'], 5)
+
+    def test_report_forecast_7_multiple_variants(self):
+        """ Create receipts for different variant products and check the report
+        work well with them.Also, check the receipt/delivery lines are correctly
+        linked depending of their product variant.
+        """
+        # Create some variant's attributes.
+        product_attr_color = self.env['product.attribute'].create({'name': 'Color'})
+        color_gray = self.env['product.attribute.value'].create({
+            'name': 'Old Fashioned Gray',
+            'attribute_id': product_attr_color.id,
+        })
+        color_blue = self.env['product.attribute.value'].create({
+            'name': 'Electric Blue',
+            'attribute_id': product_attr_color.id,
+        })
+        product_attr_size = self.env['product.attribute'].create({'name': 'size'})
+        size_pocket = self.env['product.attribute.value'].create({
+            'name': 'Pocket',
+            'attribute_id': product_attr_size.id,
+        })
+        size_xl = self.env['product.attribute.value'].create({
+            'name': 'XL',
+            'attribute_id': product_attr_size.id,
+        })
+
+        # Create a new product and set some variants on the product.
+        product_template = self.env['product.template'].create({
+            'name': 'Game Joy',
+            'type': 'product',
+            'attribute_line_ids': [
+                (0, 0, {
+                    'attribute_id': product_attr_color.id,
+                    'value_ids': [(6, 0, [color_gray.id, color_blue.id])]
+                }),
+                (0, 0, {
+                    'attribute_id': product_attr_size.id,
+                    'value_ids': [(6, 0, [size_pocket.id, size_xl.id])]
+                }),
+            ],
+        })
+        gamejoy_pocket_gray = product_template.product_variant_ids[0]
+        gamejoy_xl_gray = product_template.product_variant_ids[1]
+        gamejoy_pocket_blue = product_template.product_variant_ids[2]
+        gamejoy_xl_blue = product_template.product_variant_ids[3]
+
+        # Create two receipts.
+        receipt_form = Form(self.env['stock.picking'].with_context(
+            force_detailed_view=True
+        ), view='stock.view_picking_form')
+        receipt_form.partner_id = self.partner
+        receipt_form.picking_type_id = self.picking_type_in
+        with receipt_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = gamejoy_pocket_gray
+            move_line.product_uom_qty = 8
+        with receipt_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = gamejoy_pocket_blue
+            move_line.product_uom_qty = 4
+        receipt_1 = receipt_form.save()
+        receipt_1.action_confirm()
+
+        receipt_form = Form(self.env['stock.picking'].with_context(
+            force_detailed_view=True
+        ), view='stock.view_picking_form')
+        receipt_form.partner_id = self.partner
+        receipt_form.picking_type_id = self.picking_type_in
+        with receipt_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = gamejoy_pocket_gray
+            move_line.product_uom_qty = 2
+        with receipt_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = gamejoy_xl_gray
+            move_line.product_uom_qty = 10
+        with receipt_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = gamejoy_xl_blue
+            move_line.product_uom_qty = 12
+        receipt_2 = receipt_form.save()
+        receipt_2.action_confirm()
+
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=product_template.ids)
+        self.assertEqual(len(lines), 5, "Must have 5 lines.")
+        self.assertEqual(docs['product_variants'].ids, product_template.product_variant_ids.ids)
+
+        # Create a delivery for one of these products and check the report line
+        # is correctly linked to the good receipt.
+
+        # Create some receipts.
+        delivery_form = Form(self.env['stock.picking'].with_context(
+            force_detailed_view=True
+        ), view='stock.view_picking_form')
+        delivery_form.partner_id = self.partner
+        delivery_form.picking_type_id = self.picking_type_out
+        with delivery_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = gamejoy_pocket_gray
+            move_line.product_uom_qty = 10
+        delivery = delivery_form.save()
+        delivery.action_confirm()
+
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=product_template.ids)
+        self.assertEqual(len(lines), 5, "Still must have 5 lines.")
+        self.assertEqual(docs['product_variants'].ids, product_template.product_variant_ids.ids)
+        # First and second lines should be about the "Game Joy Pocket (gray)"
+        # and must link the delivery with the two receipt lines.
+        line_1 = lines[0]
+        line_2 = lines[1]
+        self.assertEqual(line_1['product']['id'], gamejoy_pocket_gray.id)
+        self.assertEqual(line_1['quantity'], 8)
+        self.assertTrue(line_1['replenishment_filled'])
+        self.assertEqual(line_1['document_in'].id, receipt_1.id)
+        self.assertEqual(line_1['document_out'].id, delivery.id)
+        self.assertEqual(line_2['product']['id'], gamejoy_pocket_gray.id)
+        self.assertEqual(line_2['quantity'], 2)
+        self.assertTrue(line_2['replenishment_filled'])
+        self.assertEqual(line_2['document_in'].id, receipt_2.id)
+        self.assertEqual(line_2['document_out'].id, delivery.id)
+
+    def test_report_forecast_8_link_receipts_deliveries_in_multistep(self):
+        """ Creates 3 deliveries and 2 receipts at different dates and checks
+        they are correclty linked depending of their expected date.
+        """
+        grp_multi_loc = self.env.ref('stock.group_stock_multi_locations')
+        grp_multi_routes = self.env.ref('stock.group_adv_location')
+        self.env.user.write({'groups_id': [(4, grp_multi_loc.id)]})
+        self.env.user.write({'groups_id': [(4, grp_multi_routes.id)]})
+        # Warehouse config.
+        warehouse = self.env.ref('stock.warehouse0')
+        warehouse.reception_steps = 'three_steps'
+        # Dates.
+        today = datetime.today()
+        one_day = timedelta(days=1)
+        one_week = timedelta(days=7)
+        one_month = timedelta(days=30)
+
+        # Creates the first delivery for the next week.
+        delivery_form = Form(self.env['stock.picking'].with_context(
+            force_detailed_view=True
+        ), view='stock.view_picking_form')
+        delivery_form.partner_id = self.partner
+        delivery_form.picking_type_id = self.picking_type_out
+        delivery_form.scheduled_date = today + one_week
+        with delivery_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = self.product
+            move_line.product_uom_qty = 5
+        delivery_1 = delivery_form.save()
+        delivery_1.action_confirm()
+        # Creates the second delivery for tomorrow.
+        delivery_form = Form(self.env['stock.picking'].with_context(
+            force_detailed_view=True
+        ), view='stock.view_picking_form')
+        delivery_form.partner_id = self.partner
+        delivery_form.picking_type_id = self.picking_type_out
+        delivery_form.scheduled_date = today + one_day
+        with delivery_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = self.product
+            move_line.product_uom_qty = 5
+        delivery_2 = delivery_form.save()
+        delivery_2.action_confirm()
+        # Creates the third delivery for the next month.
+        delivery_form = Form(self.env['stock.picking'].with_context(
+            force_detailed_view=True
+        ), view='stock.view_picking_form')
+        delivery_form.partner_id = self.partner
+        delivery_form.picking_type_id = self.picking_type_out
+        delivery_form.scheduled_date = today + one_month
+        with delivery_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = self.product
+            move_line.product_uom_qty = 5
+        delivery_3 = delivery_form.save()
+        delivery_3.action_confirm()
+
+        # Creates the first receipt (20 units) for in 8 days.
+        receipt_form = Form(self.env['stock.picking'].with_context(
+            force_detailed_view=True
+        ), view='stock.view_picking_form')
+        receipt_form.partner_id = self.partner
+        receipt_form.picking_type_id = self.picking_type_in
+        receipt_form.scheduled_date = today + timedelta(days=8)
+        with receipt_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = self.product
+            move_line.product_uom_qty = 20
+        receipt_1 = receipt_form.save()
+        receipt_1.action_confirm()
+        # Creates the second receipt (5 units) for today.
+        receipt_form = Form(self.env['stock.picking'].with_context(
+            force_detailed_view=True
+        ), view='stock.view_picking_form')
+        receipt_form.partner_id = self.partner
+        receipt_form.picking_type_id = self.picking_type_in
+        receipt_form.scheduled_date = today
+        with receipt_form.move_ids_without_package.new() as move_line:
+            move_line.product_id = self.product
+            move_line.product_uom_qty = 5
+        receipt_2 = receipt_form.save()
+        receipt_2.action_confirm()
+
+        # Checks the report (without the immediate transfers).
+        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        self.assertEqual(
+            len(lines), 4,
+            "The report must have 4 lines: 1 by delivery and 1 for the extra qty. from the receipt"
+        )
+        line_1 = lines[0]
+        line_2 = lines[1]
+        line_3 = lines[2]
+        line_4 = lines[3]
+        # The first line must be about the most urgent delivery (`delivery_2`) and
+        # must be fullfilled by the first coming receipt (`receipt_2`).
+        self.assertEqual(line_1['quantity'], 5)
+        self.assertEqual(line_1['replenishment_filled'], True)
+        self.assertEqual(line_1['is_late'], False)  # the receipt is planned before the delivery.
+        self.assertEqual(line_1['document_in'].id, receipt_2.id)
+        self.assertEqual(line_1['document_out'].id, delivery_2.id)
+        # The second line must be about the next delivery (`delivery_1`) and
+        # must be fullfilled by the last coming receipt (`receipt_1`).
+        self.assertEqual(line_2['quantity'], 5)
+        self.assertEqual(line_2['replenishment_filled'], True)
+        self.assertEqual(line_2['is_late'], True)  # the receipt is planned after the delivery.
+        self.assertEqual(line_2['document_in'].id, receipt_1.id)
+        self.assertEqual(line_2['document_out'].id, delivery_1.id)
+        # The third line must be about the last delivery (`delivery_3`) and
+        # must be fullfilled by the last coming receipt (`receipt_1`).
+        self.assertEqual(line_3['quantity'], 5)
+        self.assertEqual(line_3['replenishment_filled'], True)
+        self.assertEqual(line_3['is_late'], False)  # the receipt is planned before the delivery.
+        self.assertEqual(line_3['document_in'].id, receipt_1.id)
+        self.assertEqual(line_3['document_out'].id, delivery_3.id)
+        # The last line must be about the extra quantities bring by the `receipt_1`.
+        self.assertEqual(line_4['quantity'], 10)
+        self.assertEqual(line_4['replenishment_filled'], True)
+        self.assertEqual(line_4['is_late'], False)  # No usage for this qty. are planned.
+        self.assertEqual(line_4['document_in'].id, receipt_1.id)
+        self.assertEqual(line_4['document_out'], False)

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -201,6 +201,11 @@
                     <field name="origin" optional="show"/>
                     <field name="group_id" invisible="1"/>
                     <field name="backorder_id" optional="hide"/>
+                    <field name="products_availability_state" invisible="1"/>
+                    <field name="products_availability" optional="show"
+                        decoration-bf="products_availability_state in ['waiting', 'late']"
+                        decoration-warning="products_availability_state == 'waiting'"
+                        decoration-danger="products_availability_state == 'late'"/>
                     <field name="priority" optional="hide"/>
                     <field name="picking_type_id" optional="hide"/>
                     <field name="company_id" groups="base.group_multi_company" optional="show"/>
@@ -305,6 +310,7 @@
                                 <field name="json_popover" widget="stock_rescheduling_popover" attrs="{'invisible': [('delay_alert_date', '=', False)]}"/>
                             </div>
                             <field name="date_done" string="Effective Date" attrs="{'invisible': [('state', '!=', 'done')]}"/>
+                            <field name="products_availability"/>
                             <field name="origin" placeholder="e.g. PO0032"/>
                             <field name="owner_id" groups="stock.group_tracking_owner"
                                    attrs="{'invisible': [('picking_type_code', '!=', 'incoming')]}"/>
@@ -363,8 +369,18 @@
                                     <field name="date_expected" optional="hide" attrs="{'readonly': [('show_operations', '=', True), ('is_locked', '=', True)]}"/>
                                     <field name="is_initial_demand_editable" invisible="1"/>
                                     <field name="is_quantity_done_editable" invisible="1"/>
+                                    <field name="reserved_availability" invisible="1"/>
+                                    <field name="availability_state" invisible="1"/>
                                     <field name="product_uom_qty" string="Demand" attrs="{'column_invisible': [('parent.immediate_transfer', '=', True)], 'readonly': ['|', ('is_initial_demand_editable', '=', False), '&amp;', '&amp;', ('show_operations', '=', True), ('is_locked', '=', True), ('is_initial_demand_editable', '=', False)]}"/>
-                                    <field name="reserved_availability" string="Reserved" attrs="{'column_invisible': (['|','|', ('parent.state','=', 'done'), ('parent.picking_type_code', '=', 'incoming'), ('parent.immediate_transfer', '=', True)])}"/>
+                                    <field name="availability_indication"
+                                        decoration-bf="availability_state in ['late', 'partial', 'waiting']"
+                                        decoration-warning="availability_state in ['partial', 'waiting']"
+                                        decoration-danger="availability_state == 'late'"
+                                        attrs="{'column_invisible': ([
+                                            '|','|',
+                                                ('parent.state','=', 'done'),
+                                                ('parent.picking_type_code', '=', 'incoming'),
+                                                ('parent.immediate_transfer', '=', True)])}"/>
                                     <field name="quantity_done" string="Done" attrs="{'readonly': [('is_quantity_done_editable', '=', False)]}"/>
                                     <field name="product_uom" attrs="{'readonly': [('state', '!=', 'draft'), ('additional', '=', False)]}" options="{'no_open': True, 'no_create': True}" string="Unit of Measure" groups="uom.group_uom"/>
                                     <button name="action_show_details" string="Register lots, packs, location" type="object" icon="fa-list" width="0.1"

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -372,7 +372,7 @@
                                     <field name="reserved_availability" invisible="1"/>
                                     <field name="availability_state" invisible="1"/>
                                     <field name="product_uom_qty" string="Demand" attrs="{'column_invisible': [('parent.immediate_transfer', '=', True)], 'readonly': ['|', ('is_initial_demand_editable', '=', False), '&amp;', '&amp;', ('show_operations', '=', True), ('is_locked', '=', True), ('is_initial_demand_editable', '=', False)]}"/>
-                                    <field name="availability_indication"
+                                    <field name="availability_indication" widget="forecast_button"
                                         decoration-bf="availability_state in ['late', 'partial', 'waiting']"
                                         decoration-warning="availability_state in ['partial', 'waiting']"
                                         decoration-danger="availability_state == 'late'"

--- a/addons/stock/views/stock_template.xml
+++ b/addons/stock/views/stock_template.xml
@@ -3,6 +3,7 @@
 
     <template id="stock_assets_backend" name="mrp_workorder assets" inherit_id="web.assets_backend">
         <xpath expr="." position="inside">
+            <script type="text/javascript" src="/stock/static/src/js/forecast_button_widget.js"></script>
             <script type="text/javascript" src="/stock/static/src/js/inventory_report_list_controller.js"></script>
             <script type="text/javascript" src="/stock/static/src/js/inventory_report_list_view.js"></script>
             <script type="text/javascript" src="/stock/static/src/js/inventory_singleton_list_controller.js"></script>
@@ -19,6 +20,7 @@
             <script type="text/javascript" src="/stock/static/src/js/basic_model.js"></script>
             <script type="text/javascript" src="/stock/static/src/js/stock_rescheduling_popover.js"></script>
             <link rel="stylesheet" type="text/scss" href="/stock/static/src/scss/stock_traceability_report.scss"/>
+            <link rel="stylesheet" type="text/scss" href="/stock/static/src/scss/stock_widget.scss"/>
         </xpath>
    </template>
 

--- a/addons/stock/views/stock_template.xml
+++ b/addons/stock/views/stock_template.xml
@@ -12,6 +12,7 @@
             <script type="text/javascript" src="/stock/static/src/js/stock_orderpoint_list_controller.js"></script>
             <script type="text/javascript" src="/stock/static/src/js/stock_orderpoint_list_model.js"></script>
             <script type="text/javascript" src="/stock/static/src/js/stock_orderpoint_list_view.js"></script>
+            <script type="text/javascript" src="/stock/static/src/js/stock_replenish_report.js"/>
             <script type="text/javascript" src="/stock/static/src/js/stock_traceability_report_backend.js"></script>
             <script type="text/javascript" src="/stock/static/src/js/stock_traceability_report_widgets.js"></script>
             <script type="text/javascript" src="/stock/static/src/js/popover_widget.js"></script>

--- a/addons/stock/wizard/product_replenish.py
+++ b/addons/stock/wizard/product_replenish.py
@@ -49,7 +49,7 @@ class ProductReplenish(models.TransientModel):
             res['product_uom_id'] = product_tmpl_id.uom_id.id
         if 'company_id' in fields:
             res['company_id'] = company.id
-        if 'warehouse_id' in fields:
+        if 'warehouse_id' in fields and 'warehouse_id' not in res:
             warehouse = self.env['stock.warehouse'].search([('company_id', '=', company.id)], limit=1)
             res['warehouse_id'] = warehouse.id
         if 'date_planned' in fields:

--- a/addons/stock_account/__init__.py
+++ b/addons/stock_account/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import models
+from . import report
 from . import wizard
 
 from odoo import api, SUPERUSER_ID, _, tools

--- a/addons/stock_account/__manifest__.py
+++ b/addons/stock_account/__manifest__.py
@@ -32,7 +32,8 @@ Dashboard / Reports for Warehouse Management includes:
         'views/product_views.xml',
         'views/stock_quant_views.xml',
         'views/stock_valuation_layer_views.xml',
-        'wizard/stock_valuation_layer_revaluation_views.xml'
+        'wizard/stock_valuation_layer_revaluation_views.xml',
+        'report/report_replenishment.xml',
     ],
     'test': [
     ],

--- a/addons/stock_account/report/__init__.py
+++ b/addons/stock_account/report/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import report_replenishment

--- a/addons/stock_account/report/report_replenishment.py
+++ b/addons/stock_account/report/report_replenishment.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+from odoo.tools.float_utils import float_repr
+
+
+class ReplenishmentReport(models.AbstractModel):
+    _inherit = 'report.stock.report_product_product_replenishment'
+
+    @api.model
+    def _get_report_data(self, product_template_ids=False, product_variant_ids=False):
+        """ Overrides to computes the valuations of the stock. """
+        res = super()._get_report_data(product_template_ids, product_variant_ids)
+        domain = self._product_domain(product_template_ids, product_variant_ids)
+        svl = self.env['stock.valuation.layer'].search(domain)
+        currency = svl.currency_id or self.env.company.currency_id
+        value = float_repr(sum(svl.mapped('value')), precision_digits=currency.decimal_places)
+        if currency.position == 'after':
+            value = '%s %s' % (value, currency.symbol)
+        else:
+            value = '%s %s' % (currency.symbol, value)
+        res['value'] = value
+        return res

--- a/addons/stock_account/report/report_replenishment.xml
+++ b/addons/stock_account/report/report_replenishment.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="stock_account_report_product_product_replenishment" inherit_id="stock.report_replenishment_header">
+        <xpath expr="//div[@name='pending_forecasted']" position="after">
+            <div t-attf-class="mx-3 text-center">
+                <div class="h3">
+                    <t t-esc="docs['value']"/>
+                </div>
+                <div>On Hand Value</div>
+            </div>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Those commits add:
* A product report with:
  - On Hand Quantity
  - Forecasted Quantity
  - Forecasted Quantity + pending (count draft document too)
  - A list with replenishing/consuming document (transfer, PO, SO, MO)

* A new widget to display the availability of a product in different forms (qty., date or warning) depending of the reservation (used in transfer and MO view).

* A button to quick access to the new report from the picking/MO move lines.

task-2058495