### PR TITLE
[IMP] mail: open chatbox from chatter, activity user avatar

### DIFF
--- a/addons/mail/static/src/js/thread_widget.js
+++ b/addons/mail/static/src/js/thread_widget.js
@@ -30,7 +30,7 @@ var ThreadWidget = Widget.extend({
 
     events: {
         'click a': '_onClickRedirect',
-        'click img': '_onClickRedirect',
+        'click img.o_mail_redirect': '_onClickRedirect',
         'click strong': '_onClickRedirect',
         'click .o_thread_show_more': '_onClickShowMore',
         'click .o_attachment_download': '_onAttachmentDownload',

--- a/addons/mail/static/src/scss/chatter.scss
+++ b/addons/mail/static/src/scss/chatter.scss
@@ -22,6 +22,11 @@
         }
     }
 
+    .o_thread_message_sidebar img:hover {
+        filter: brightness(0.8);
+        cursor: pointer;
+    }
+
     &.o_chatter_composer_active .o_chatter_topbar {
         border-bottom-color: gray('300');
 

--- a/addons/mail/static/src/xml/activity.xml
+++ b/addons/mail/static/src/xml/activity.xml
@@ -17,7 +17,11 @@
                 <div class="o_thread_message" style="margin-bottom: 10px">
                     <div class="o_thread_message_sidebar">
                         <div class="o_avatar_stack">
-                            <img t-attf-src="/web/image#{activity.user_id[0] >= 0 ? ('/res.users/' + activity.user_id[0] + '/image_128') : ''}" class="o_thread_message_avatar rounded-circle mb8" t-att-title="activity.user_id[1]" t-att-alt="activity.user_id[1]"/>
+                            <img t-attf-src="/web/image#{activity.user_id[0] >= 0 ? ('/res.users/' + activity.user_id[0] + '/image_128') : ''}"
+                                class="o_thread_message_avatar rounded-circle mb8"
+                                t-att-title="activity.user_id[1]" t-att-alt="activity.user_id[1]"
+                                t-att-data-oe-id="activity.user_id[0] !== uid ? activity.user_id[0]: ''"
+                                data-oe-model="res.users"/>
                             <i t-att-class="'o_avatar_icon fa ' + activity.icon + ' bg-' + (activity.state == 'planned'? 'success' : (activity.state == 'today'? 'warning' : 'danger')) + '-full'"
                                t-att-title="activity.activity_type_id[1]"/>
                         </div>

--- a/addons/mail/static/src/xml/thread.xml
+++ b/addons/mail/static/src/xml/thread.xml
@@ -278,7 +278,7 @@
                             t-att-src="message.getAvatarSource()"
                             data-oe-model="res.partner"
                             t-att-data-oe-id="message.shouldRedirectToAuthor() ? message.getAuthorID() : ''"
-                            t-attf-class="o_thread_message_avatar rounded-circle #{message.shouldRedirectToAuthor() ? 'o_mail_redirect' : ''}"/>
+                            t-attf-class="o_thread_message_avatar rounded-circle #{message.shouldRedirectToAuthor() and !message.isLinkedToDocumentThread() ? 'o_mail_redirect' : ''}"/>
                         <t t-call="mail.UserStatus">
                             <t t-set="status" t-value="message.getAuthorImStatus()"/>
                             <t t-set="partnerID" t-value="message.getAuthorID()"/>


### PR DESCRIPTION
Purpose
=======

Task 2195254 introduced the wonderful avatar widget, which displays the user's avatar next to his name and allow to open a chatbox when clicking on it. The goal of this task is to do the same, but in the chatter and activity.

Specifications
===========

when clicking on an avatar from the chatter or activity, open the corresponding chatbox if the avatar belongs to:
- a user other than the logged user
- a partner who is linked to a user
- a user not archived/deleted

If the avatar belongs to the logged user,
- display a toast notification that states "Cannot chat with yourself / Click on the avatar of other users to chat with them."

If the avatar belongs to a partner who isn't linked to any user,
- display a toast notification that states: "No user to chat with / You can only chat with partners who have a dedicated user."

If avatar belongs to a user who is archived/deleted,
- display a toast notification that states: "No user to chat with / The user you are trying to chat with is either archived or deleted."

when hovering on the avatar, highlight the fact that it is a distinct UI item

Task ID: 2252894
PR #52650