### PR TITLE
[FIX] base/web: make report.layout name translatable

### DIFF
--- a/addons/web/i18n/web.pot
+++ b/addons/web/i18n/web.pot
@@ -669,6 +669,11 @@ msgid "Avatar"
 msgstr ""
 
 #. module: web
+#: model:report.layout,name:web.report_layout_background
+msgid "Background"
+msgstr ""
+
+#. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/fields/relational_fields.js:0
 #, python-format
@@ -722,6 +727,11 @@ msgstr ""
 #: code:addons/web/static/src/xml/colorpicker_dialog.xml:0
 #, python-format
 msgid "Blue"
+msgstr ""
+
+#. module: web
+#: model:report.layout,name:web.report_layout_boxed
+msgid "Boxed"
 msgstr ""
 
 #. module: web
@@ -868,6 +878,11 @@ msgstr ""
 #: code:addons/web/static/src/js/widgets/colorpicker_dialog.js:0
 #, python-format
 msgid "Choose"
+msgstr ""
+
+#. module: web
+#: model:report.layout,name:web.report_layout_clean
+msgid "Clean"
 msgstr ""
 
 #. module: web
@@ -3454,6 +3469,11 @@ msgstr ""
 #: code:addons/web/static/src/xml/base.xml:0
 #, python-format
 msgid "Stacked"
+msgstr ""
+
+#. module: web
+#: model:report.layout,name:web.report_layout_standard
+msgid "Standard"
 msgstr ""
 
 #. module: web

--- a/odoo/addons/base/models/report_layout.py
+++ b/odoo/addons/base/models/report_layout.py
@@ -12,4 +12,4 @@ class ReportLayout(models.Model):
     image = fields.Char(string="Preview image src")
     pdf = fields.Char(string="Preview pdf src")
 
-    name = fields.Char()
+    name = fields.Char(translate=True)


### PR DESCRIPTION
The report.layout name (Standard, Background, Boxed, Clean) was not translated.
We make it translatable and add translations.

opw 2271172

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
