### PR TITLE
[IMP] website, *: login page customisation

### DIFF
--- a/addons/web/static/src/scss/login.scss
+++ b/addons/web/static/src/scss/login.scss
@@ -1,0 +1,29 @@
+.login_layout_opt {
+    height: calc(100vh - 308px);
+    background: url(https://source.unsplash.com/random);
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
+
+    &.login_layout_opt_1 {
+        flex: 0 0 33.33%;
+        max-width: 33.33%;
+        margin-left: 0;
+
+        @include media-breakpoint-down(md) {
+            flex: 0 0 100%;
+            max-width: 100%;
+        }
+    }
+
+    &.login_layout_opt_2 {
+        flex: 0 0 50%;
+        max-width: 50%;
+        margin-left: 0;
+
+        @include media-breakpoint-down(md) {
+            flex: 0 0 100%;
+            max-width: 100%;
+        }
+    }
+}

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -80,6 +80,7 @@
         <link rel="stylesheet" type="text/scss" href="/web/static/src/scss/name_and_signature.scss"/>
         <link rel="stylesheet" type="text/scss" href="/web/static/src/scss/web.zoomodoo.scss"/>
         <link rel="stylesheet" type="text/scss" href="/web/static/src/scss/color_picker.scss"/>
+        <link rel="stylesheet" type="text/scss" href="/web/static/src/scss/login.scss"/>
 
         <link rel="stylesheet" type="text/less" href="/web/static/src/scss/fontawesome_overridden.scss"/>
 
@@ -543,7 +544,7 @@
             <t t-set="body_classname" t-value="'bg-100'"/>
             <t t-set="no_header" t-value="True"/>
             <t t-set="no_footer" t-value="True"/>
-
+    
             <div class="container py-5">
                 <div t-attf-class="card border-0 mx-auto bg-100 {{login_card_classes}} o_database_list" style="max-width: 300px;">
                     <div class="card-body">

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4406,7 +4406,7 @@ registry.BackgroundPosition = SnippetOptionWidget.extend({
         this.trigger_up('block_preview_overlays');
 
         // Create empty clone of $target with same display size, make it draggable and give it a tooltip.
-        this.$bgDragger = this.$target.clone().empty();
+        this.$bgDragger = this.$target.clone().empty().removeClass('o_editable');
         // Some CSS child selector rules will not be applied since the clone has a different container from $target.
         // The background-attachment property should be the same in both $target & $bgDragger, this will keep the
         // preview more "wysiwyg" instead of getting different result when bg position saved (e.g. parallax snippet)

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -1332,7 +1332,7 @@
     </xpath>
 </template>
 
-<!-- Features template -->
+<!-- Web Login template -->
 <template id="login_layout" inherit_id="web.login_layout" name="Website Login Layout" priority="20">
     <xpath expr="t" position="replace">
         <t t-call="website.layout">
@@ -1346,6 +1346,14 @@
     </xpath>
 </template>
 
+<!-- Web Login side image switch -->
+<template id="login_layout_opt_switch" inherit_id="website.login_layout" active="False" customize_show="True" name="Side Image">
+    <xpath expr="//div[hasclass('login_layout_opt')]" position="replace">
+        <div class="login_layout_opt col-lg p-0" /> 
+    </xpath>
+</template>
+
+<!-- Web Login side image options -->
 <template id="login_layout_options" inherit_id="web_editor.snippet_options">
     <xpath expr="." position="inside">
         <div data-selector=".login_layout_opt">
@@ -1372,14 +1380,6 @@
             <we-input string="Height" data-select-style="auto" placeholder="auto" data-unit="px"/>
         </we-multi>
         </div>
-    </xpath>
-</template>
-
-<template id="login_layout_opt_switch" inherit_id="website.login_layout" active="False" customize_show="True" name="Side Image">
-    <xpath expr="//div[hasclass('login_layout_opt')]" position="replace">
-        <div class="login_layout_opt col-lg p-0">
-            <div class="login_layout_opt_1" />
-        </div>    
     </xpath>
 </template>
 

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -1338,7 +1338,7 @@
         <t t-call="website.layout">
             <div class="oe_website_login_container">
                 <div class="row h-100 m-0">
-                    <div class="login_layout"  />
+                    <div class="login_layout_opt"  />
                     <div class="col-lg align-self-center" t-raw="0" />
                 </div>
             </div>
@@ -1348,22 +1348,35 @@
 
 <template id="login_layout_options" inherit_id="web_editor.snippet_options">
     <xpath expr="." position="inside">
-        <div data-selector=".login_layout">
+        <div data-selector=".login_layout_opt">
             <we-select string="Image Size">
                 <we-button data-select-class="login_layout_opt_1">Small</we-button>
                 <we-button data-select-class="login_layout_opt_2">Big</we-button>
             </we-select>
         </div>
-        <div data-js="background" string="Background"
-            data-selector=".login_layout">
+        <div data-js="background" string="Background" data-selector=".login_layout_opt">
             <we-imagepicker string="Background" data-background="" data-allow-videos=":not(.parallax, .s_parallax_bg)"/>
+        </div>
+        <div data-js="BackgroundPosition" data-selector=".login_layout_opt">
+        <we-row>
+            <we-select data-no-preview="true">
+                <we-button data-background-type="cover">Cover</we-button>
+                <we-button data-background-type="repeat-pattern" data-name="background_repeat_opt">Repeat pattern</we-button>
+            </we-select>
+            <we-button class="fa fa-fw fa-crosshairs" title="Background Position"
+                       data-background-position-overlay="true" data-no-preview="true"/>
+        </we-row>
+        <we-multi data-css-property="background-size" data-dependencies="background_repeat_opt">
+            <we-input string="Width" data-select-style="auto" placeholder="auto" data-unit="px"/>
+            <we-input string="Height" data-select-style="auto" placeholder="auto" data-unit="px"/>
+        </we-multi>
         </div>
     </xpath>
 </template>
 
 <template id="login_layout_opt_switch" inherit_id="website.login_layout" active="False" customize_show="True" name="Side Image">
-    <xpath expr="//div[contains(@class, 'login_layout')]" position="replace">
-        <div class="login_layout col-lg p-0">
+    <xpath expr="//div[hasclass('login_layout_opt')]" position="replace">
+        <div class="login_layout_opt col-lg p-0">
             <div class="login_layout_opt_1" />
         </div>    
     </xpath>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -1350,6 +1350,7 @@
     <xpath expr="." position="inside">
         <div data-selector=".login_layout_opt">
             <we-select string="Image Size">
+                <we-button data-select-class="">Custom</we-button>
                 <we-button data-select-class="login_layout_opt_1">Small</we-button>
                 <we-button data-select-class="login_layout_opt_2">Big</we-button>
             </we-select>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -1336,8 +1336,36 @@
 <template id="login_layout" inherit_id="web.login_layout" name="Website Login Layout" priority="20">
     <xpath expr="t" position="replace">
         <t t-call="website.layout">
-            <div class="oe_website_login_container" t-raw="0"/>
+            <div class="oe_website_login_container">
+                <div class="row h-100 m-0">
+                    <div class="login_layout"  />
+                    <div class="col-lg align-self-center" t-raw="0" />
+                </div>
+            </div>
         </t>
+    </xpath>
+</template>
+
+<template id="login_layout_options" inherit_id="web_editor.snippet_options">
+    <xpath expr="." position="inside">
+        <div data-selector=".login_layout">
+            <we-select string="Image Size">
+                <we-button data-select-class="login_layout_opt_1">Small</we-button>
+                <we-button data-select-class="login_layout_opt_2">Big</we-button>
+            </we-select>
+        </div>
+        <div data-js="background" string="Background"
+            data-selector=".login_layout">
+            <we-imagepicker string="Background" data-background="" data-allow-videos=":not(.parallax, .s_parallax_bg)"/>
+        </div>
+    </xpath>
+</template>
+
+<template id="login_layout_opt_switch" inherit_id="website.login_layout" active="False" customize_show="True" name="Side Image">
+    <xpath expr="//div[contains(@class, 'login_layout')]" position="replace">
+        <div class="login_layout col-lg p-0">
+            <div class="login_layout_opt_1" />
+        </div>    
     </xpath>
 </template>
 


### PR DESCRIPTION
Now it's possible to enable a responsive side image, change its size and its
background position or even customise it, at the 'web/login' page. 

In the Customize header menu, there is a switch that enables this feature
and the user can select different options by using the Editor and selecting
this side image.

By default, this side image background is random, using the ones 
provided by Unsplash at 'https://source.unsplash.com/random', but the
user can choose any other desired option.

There are three Image Sizes:

1. Custom: 
allows the user to customise its width.

2. Small: 
it covers a 33.33% width of the viewport, with a fixed size but a fluid width in
smaller (< 720px) viewports. 

3. Big: 
it covers a 50% width of the viewport, with a fixed size but a fluid width in
smaller (< 720px) viewports.

It has also been added the 'background' and 'BackgroundPosition' snippet
options, which allows the user to change the background image and set
its background position. 

task-2118648

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
