### PR TITLE
[IMP] web: static templates support path-like fully qualified name

### DIFF
--- a/addons/web/tests/test_serving_base.py
+++ b/addons/web/tests/test_serving_base.py
@@ -716,6 +716,13 @@ class TestStaticInheritance(TestStaticInheritanceCommon):
 
         self.assertXMLEqual(contents, expected)
 
+
+@tagged('static_templates')
+class TestStaticTemplatesNaming(TestStaticInheritanceCommon):
+
+    # the t-name (and t-inherit) directive supports dotted fully qualified names
+    # separated by dot (.)
+    # This is essentially legacy behavior
     def test_inherit_from_dotted_tname_1(self):
         self.modules = [
             ('module_1_file_1', None, 'module_1'),
@@ -896,6 +903,200 @@ class TestStaticInheritance(TestStaticInheritanceCommon):
         expected = b"""
             <templates>
                 <form t-name="module_1.template_1_1.dot" random-attr="gloria">
+                    <div>At first I was afraid</div>
+                 </form>
+                 <div overriden-attr="overriden" t-name="template_2_1">
+                    And I grew strong
+                    <p>And I learned how to get along</p>
+                 </div>
+            </templates>
+        """
+
+        self.assertXMLEqual(contents, expected)
+
+    # the t-name (and t-inherit) directive also supports path-like fully qualified names
+    # separated by forward slashes (/)
+    # This is the direction we want to take in the future
+    def test_inherit_from_slashed_tname_1(self):
+        self.modules = [
+            ('module_1_file_1', None, 'module_1'),
+        ]
+        self.template_files = {
+            'module_1_file_1': b"""
+                <templates id="template" xml:space="preserve">
+                    <form t-name="module_1/template_1_1.dot" random-attr="gloria">
+                        <div>At first I was afraid</div>
+                    </form>
+                    <t t-name="template_1_2" t-inherit="template_1_1.dot" t-inherit-mode="primary">
+                        <xpath expr="." position="replace">
+                            <div overriden-attr="overriden">
+                                And I grew strong
+                                <p>And I learned how to get along</p>
+                            </div>
+                        </xpath>
+                    </t>
+                </templates>
+                """,
+        }
+
+        contents = HomeStaticTemplateHelpers.get_qweb_templates(addons=self._get_module_names(), debug=True)
+        expected = b"""
+            <templates>
+                <form t-name="module_1/template_1_1.dot" random-attr="gloria">
+                    <div>At first I was afraid</div>
+                 </form>
+                 <div overriden-attr="overriden" t-name="template_1_2">
+                    And I grew strong
+                    <p>And I learned how to get along</p>
+                 </div>
+            </templates>
+        """
+
+        self.assertXMLEqual(contents, expected)
+
+    def test_inherit_from_slashed_tname_2(self):
+        self.modules = [
+            ('module_1_file_1', None, 'module_1'),
+        ]
+        self.template_files = {
+            'module_1_file_1': b"""
+                <templates id="template" xml:space="preserve">
+                    <form t-name="template_1_1/dot" random-attr="gloria">
+                        <div>At first I was afraid</div>
+                    </form>
+                    <t t-name="template_1_2" t-inherit="template_1_1/dot" t-inherit-mode="primary">
+                        <xpath expr="." position="replace">
+                            <div overriden-attr="overriden">
+                                And I grew strong
+                                <p>And I learned how to get along</p>
+                            </div>
+                        </xpath>
+                    </t>
+                </templates>
+                """,
+        }
+
+        contents = HomeStaticTemplateHelpers.get_qweb_templates(addons=self._get_module_names(), debug=True)
+        expected = b"""
+            <templates>
+                <form t-name="template_1_1/dot" random-attr="gloria">
+                    <div>At first I was afraid</div>
+                 </form>
+                 <div overriden-attr="overriden" t-name="template_1_2">
+                    And I grew strong
+                    <p>And I learned how to get along</p>
+                 </div>
+            </templates>
+        """
+
+        self.assertXMLEqual(contents, expected)
+
+    def test_inherit_from_slashed_tname_2bis(self):
+        self.modules = [
+            ('module_1_file_1', None, 'module_1'),
+        ]
+        self.template_files = {
+            'module_1_file_1': b"""
+                <templates id="template" xml:space="preserve">
+                    <form t-name="template_1_1/dot" random-attr="gloria">
+                        <div>At first I was afraid</div>
+                    </form>
+                    <t t-name="template_1_2" t-inherit="module_1/template_1_1/dot" t-inherit-mode="primary">
+                        <xpath expr="." position="replace">
+                            <div overriden-attr="overriden">
+                                And I grew strong
+                                <p>And I learned how to get along</p>
+                            </div>
+                        </xpath>
+                    </t>
+                </templates>
+                """,
+        }
+
+        contents = HomeStaticTemplateHelpers.get_qweb_templates(addons=self._get_module_names(), debug=True)
+        expected = b"""
+            <templates>
+                <form t-name="template_1_1/dot" random-attr="gloria">
+                    <div>At first I was afraid</div>
+                 </form>
+                 <div overriden-attr="overriden" t-name="template_1_2">
+                    And I grew strong
+                    <p>And I learned how to get along</p>
+                 </div>
+            </templates>
+        """
+
+        self.assertXMLEqual(contents, expected)
+
+    def test_inherit_from_slashed_tname_2ter(self):
+        self.modules = [
+            ('module_1_file_1', None, 'module_1'),
+        ]
+        self.template_files = {
+            'module_1_file_1': b"""
+                <templates id="template" xml:space="preserve">
+                    <form t-name="module_1" random-attr="gloria">
+                        <div>At first I was afraid</div>
+                    </form>
+                    <t t-name="template_1_2" t-inherit="module_1" t-inherit-mode="primary">
+                        <xpath expr="." position="replace">
+                            <div overriden-attr="overriden">
+                                And I grew strong
+                                <p>And I learned how to get along</p>
+                            </div>
+                        </xpath>
+                    </t>
+                </templates>
+                """,
+        }
+
+        contents = HomeStaticTemplateHelpers.get_qweb_templates(addons=self._get_module_names(), debug=True)
+        expected = b"""
+            <templates>
+                <form t-name="module_1" random-attr="gloria">
+                    <div>At first I was afraid</div>
+                 </form>
+                 <div overriden-attr="overriden" t-name="template_1_2">
+                    And I grew strong
+                    <p>And I learned how to get along</p>
+                 </div>
+            </templates>
+        """
+
+        self.assertXMLEqual(contents, expected)
+
+    def test_inherit_from_slashed_tname_3(self):
+        self.modules = [
+            ('module_1_file_1', None, 'module_1'),
+            ('module_2_file_1', None, 'module_2'),
+        ]
+        self.template_files = {
+            'module_1_file_1': b"""
+                <templates id="template" xml:space="preserve">
+                    <form t-name="module_1/template_1_1/dot" random-attr="gloria">
+                        <div>At first I was afraid</div>
+                    </form>
+                </templates>
+                """,
+
+            'module_2_file_1': b"""
+                <templates id="template" xml:space="preserve">
+                    <t t-name="template_2_1" t-inherit="module_1/template_1_1/dot" t-inherit-mode="primary">
+                        <xpath expr="." position="replace">
+                            <div overriden-attr="overriden">
+                                And I grew strong
+                                <p>And I learned how to get along</p>
+                            </div>
+                        </xpath>
+                    </t>
+                </templates>
+            """
+        }
+
+        contents = HomeStaticTemplateHelpers.get_qweb_templates(addons=self._get_module_names(), debug=True)
+        expected = b"""
+            <templates>
+                <form t-name="module_1/template_1_1/dot" random-attr="gloria">
                     <div>At first I was afraid</div>
                  </form>
                  <div overriden-attr="overriden" t-name="template_2_1">


### PR DESCRIPTION
Before this commit, a static template's name could (should) contain
the module name at its beginning, separated from the proper name by a dot
This is always the case after this commit for backward compatibility

After this commit, the module name and the template name can be separated by a slash
The overall behavior is the same as the dot separator

Note :This is the direction we want to take in the future essentially to match
what the JS native module management incites to do
A component will be fully described as its file path
which then will be declined into its JS and xml parts
The module description will be the path of the JS file and the template of a component
will be the path of its xml

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
