### PR TITLE
[web] stop datepicker shifting on scroll

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -583,6 +583,10 @@ var LinkButton = AbstractField.extend({
 var FieldDateRange = InputField.extend({
     className: 'o_field_date_range',
     tagName: 'span',
+    events: {
+        'show.daterangepicker': '_onDateTimePickerShow',
+        'hide.daterangepicker': '_onDateTimePickerHide',
+    },
     jsLibs: [
         '/web/static/lib/daterangepicker/daterangepicker.js',
         '/web/static/src/js/libs/daterangepicker.js',
@@ -617,6 +621,9 @@ var FieldDateRange = InputField.extend({
      * @override
      */
     destroy: function () {
+        if (this._onScroll) {
+            window.removeEventListener('scroll', this._onScroll, true);
+        }
         if (this.$pickerContainer) {
             this.$pickerContainer.remove();
         }
@@ -697,6 +704,37 @@ var FieldDateRange = InputField.extend({
         this.$pickerContainer.on('focusin.bs.modal', 'select', function (ev) {
             ev.stopPropagation();
         });
+    },
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Reacts to the daterangepicker being hidden
+     * Used to unbind the scroll event from the daterangepicker
+     *
+     * @private
+     */
+    _onDateTimePickerHide() {
+        if (this._onScroll) {
+            window.removeEventListener('scroll', this._onScroll, true);
+        }
+    },
+    /**
+     * Reacts to the daterangepicker being shown
+     * Used to bind scroll event to close daterange picker
+     *
+     * @private
+     */
+    _onDateTimePickerShow() {
+        // hide daterangepicker on window scroll
+        this._onScroll = (ev) => {
+            if (this.$pickerContainer) {
+                this.$el.data('daterangepicker').hide();
+            }
+        };
+        window.addEventListener('scroll', this._onScroll, true);
     },
 });
 

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -3051,6 +3051,43 @@ QUnit.module('basic_fields', {
         form.destroy();
     });
 
+    QUnit.test('Daterange field hide on scroll', async function (assert) {
+        assert.expect(3);
+
+        this.data.partner.fields.date_end = {string: 'Date End', type: 'date'};
+        this.data.partner.records[0].date_end = '2017-02-08';
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: `<form>
+                    <field name="date" widget="daterange" options="{'related_end_date': 'date_end'}"/>
+                </form>`,
+            res_id: 1,
+            viewOptions: {
+                mode: 'edit',
+            }
+        });
+
+        // click to daterange picker input to open daterange picker.
+        await testUtils.dom.click(form.el.querySelector('.o_field_date_range'));
+        // get daterangepicker using querySelector.
+        const dateRangePicker = document.body.querySelector('.daterangepicker');
+        // check daterangepicker is not null.
+        assert.ok(dateRangePicker, "there should be 1 daterangepicker.");
+        // check date range picker should be opened.
+        assert.strictEqual(dateRangePicker.style.display, 'block',
+            "date range picker should be opened");
+        // dispatch wheel event for close daterange picker.
+        form.el.dispatchEvent(new Event('scroll'));
+        // check date range picker should be closed.
+        assert.strictEqual(dateRangePicker.style.display, 'none',
+            "date range picker should be closed");
+
+        form.destroy();
+    });
+
     QUnit.module('FieldDate');
 
     QUnit.test('date field: toggle datepicker [REQUIRE FOCUS]', async function (assert) {


### PR DESCRIPTION
when use open daterangepicker and scroll daterangepicker is shifting down this is wrong behaviour
the right behaviour is when user scroll the page and if daterangepicker is open then is then close
the daterangepicker like datepicker.

Task-2266941