### PR TITLE
Changing the value format to Integer

### DIFF
--- a/addons/web/static/src/js/views/graph/graph_renderer.js
+++ b/addons/web/static/src/js/views/graph/graph_renderer.js
@@ -261,7 +261,7 @@ return AbstractRenderer.extend({
      */
     _formatValue: function (value) {
         var measureField = this.fields[this.state.measure];
-        var formatter = fieldUtils.format.float;
+        var formatter = fieldUtils.format.integer;
         var formatedValue = formatter(value, measureField, FORMAT_OPTIONS);
         return formatedValue;
     },


### PR DESCRIPTION
In the graph view, the values in the yAxes and the tooltips are showing as floating point numbers.
As these are just the counts of records based on group_by, they will always be integers so, it will be neat if we format them as integers similar to pivot and tree views.

Description of the issue/feature this PR addresses:

Current behavior before PR:
The values in the yAxes and the tooltips are showing as floating point numbers. e.g.: 23.00
Desired behavior after PR is merged:
The values should be shown as integers. e.g.: 23




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
