### PR TITLE
[FIX] web: priority widget star alignment issue with label

### DIFF
--- a/addons/web/static/src/less/fields.less
+++ b/addons/web/static/src/less/fields.less
@@ -132,7 +132,7 @@
     &.o_priority {
         display: inline-block;
         padding: 0;
-        margin: 0;
+        margin: 2px 0 0 0;
         vertical-align: baseline;
         > .o_priority_star {
             display: inline-block;


### PR DESCRIPTION
**PURPOSE**
Star is not vertically aligned with the label of the priority widget it is 2px
higher than the label itself. As tags in the crm is perfectly vertically aligned
with labels for reference.

**SPEC**
With this commit, we have given 2px of margin from top to make it vertically
align.

Task : 2277348