### PR TITLE
[FIX] odoo: force source value for empty translations

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4539,7 +4539,10 @@ Record ids: %(records)s
                     del vals['module']      # duplicated vals is not linked to any module
                     vals['res_id'] = target_id
                     if not callable(field.translate):
-                        vals['src'] = new_wo_lang[name]
+                        vals['src'] = new_val
+                        if not vals['value']:
+                            # avoid confusing empty translations and force new source
+                            vals['value'] = new_val
                     if vals['lang'] == old.env.lang and field.translate is True:
                         # update master record if the new_val was not changed by copy override
                         if new_val == old[name]:


### PR DESCRIPTION
Steps to reproduce:
- install sales
- load and activate a second language (fr_FR for example)
- set your interface to french and create a new product by setting
only the name (in french, do not set anything for english)
- duplicate the product
- change your language back to english

Previous behavior:
the product name defaulted to the underlying display_name
without notice which is confusing

Current behavior:
empty translation have a default value when duplicated to avoid confusion

opw-2266864