### PR TITLE
[FIX] mrp: change qty producing duplicate move line

### DIFF
--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -241,8 +241,26 @@ class TestMrpOrder(TestMrpCommon):
         mo.action_assign()
 
         mo_form = Form(mo)
+        mo_form.qty_producing = 1
+        mo = mo_form.save()
+        ml_p1 = mo.move_raw_ids.filtered(lambda m: m.product_id == p1).move_line_ids
+        ml_p2 = mo.move_raw_ids.filtered(lambda m: m.product_id == p2).move_line_ids
+        self.assertEqual(len(ml_p1), 1)
+        self.assertEqual(len(ml_p2), 1)
+        self.assertEqual(ml_p1.qty_done, 4.0)
+        self.assertEqual(ml_p2.qty_done, 1.0)
+
+        mo_form = Form(mo)
+        mo_form.qty_producing = 0
+        mo_form.qty_producing = 1
         mo_form.qty_producing = 2
         mo = mo_form.save()
+        ml_p1 = mo.move_raw_ids.filtered(lambda m: m.product_id == p1).move_line_ids
+        ml_p2 = mo.move_raw_ids.filtered(lambda m: m.product_id == p2).move_line_ids
+        self.assertEqual(len(ml_p1), 1)
+        self.assertEqual(len(ml_p2), 1)
+        self.assertEqual(ml_p1.qty_done, 8.0)
+        self.assertEqual(ml_p2.qty_done, 2.0)
 
         mo._post_inventory()
 


### PR DESCRIPTION
Usecase to reproduce:
- Produce 3 Desk Combination (no reservation)
- Set qty_producing to 1
- Set qty_producing to 2
- Set qty_producing to 3
First the show detail appear while it should not (no lot/sn, no multi
location, nothing)
When you click on show details you can see 3 move lines for each move
(a new move line is created each time the qty producing is modify)

It happens since _set_qty_producing set the qty done on existing move
line and _set_quantity_done_prepare_vals on fill move line with reserved
quantity greater than quantity done. It means that move line created
by the previous on change are set to 0 and new ones are created.

Fix it by removing the useless move line instead of setting them to 0.0
