### PR TITLE
[FIX] pos_loyalty: Check loyalty product availability before opening

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -5116,6 +5116,7 @@ msgid ""
 "You must configure an intermediary account for the payment methods: %s."
 msgstr ""
 
+
 #. module: point_of_sale
 #: model_terms:ir.actions.act_window,help:point_of_sale.product_product_action
 msgid ""

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -355,6 +355,12 @@ class PosConfig(models.Model):
                 _("You must configure an intermediary account for the payment methods: %s.") % method_names
             )
 
+    @api.constrains('module_pos_loyalty')
+    def _check_loyalties_product_availability(self):
+        if self.module_pos_loyalty:
+            for l in self.loyalty_id:
+                l._check_loyalties_product_availability()
+
     @api.constrains('company_id', 'available_pricelist_ids')
     def _check_companies(self):
         if any(self.available_pricelist_ids.mapped(lambda pl: pl.company_id.id not in (False, self.company_id.id))):
@@ -555,6 +561,8 @@ class PosConfig(models.Model):
             self._check_company_payment()
             self._check_currencies()
             self._check_payment_method_receivable_accounts()
+            self._check_loyalties_product_availability()
+
             self.env['pos.session'].create({
                 'user_id': self.env.uid,
                 'config_id': self.id


### PR DESCRIPTION
Before this commit:
Traceback in PoS session if a loyalty product is archived.

After this commit:
Prevent PoS opening by announcing wrongly configured products

OPW-2276745

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr