### PR TITLE
poc in 13 not for 13

### DIFF
--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -604,7 +604,6 @@ def run_unit_tests(module_name, position='at_install'):
     for m in mods:
         tests = unwrap_suite(unittest.TestLoader().loadTestsFromModule(m))
         suite = unittest.TestSuite(t for t in tests if position_tag.check(t) and config_tags.check(t))
-
         if suite.countTestCases():
             t0 = time.time()
             t0_sql = odoo.sql_db.sql_counter


### PR DESCRIPTION
Got bored to wait for module update when writing at_install test. 

This is my poc of the test_enable expected behaviour. This change is maybe a little to extreme for 13.0. 

No need to use -u or -i to run at_install tests. Test can be filtered by modules with --test-tags /module.

- --test-tags /module -> only /module is tested
- --test-enable -u module  -> all installed modules are tested

An alternative solution would be to only execute tests in this context if no -u or -i is given

- --test-tags /module -> only /module is tested
- --test-enable -u module  ->  only /module is tested
- --test-enable -> all modules are tested