### PR TITLE
[FIX] iap: fix IAP account creation

### DIFF
--- a/addons/iap/models/iap.py
+++ b/addons/iap/models/iap.py
@@ -186,8 +186,10 @@ class IapAccount(models.Model):
                     account = IapAccount.create({'service_name': service_name})
                 # fetch 'account_token' into cache with this cursor,
                 # as self's cursor cannot see this account
-                account.account_token
-            return self.browse(account.id)
+                account_token = account.account_token
+            account = self.browse(account.id)
+            self.env.cache.set(account, IapAccount._fields['account_token'], account_token)
+            return account
         accounts_with_company = accounts.filtered(lambda acc: acc.company_ids)
         if accounts_with_company:
             return accounts_with_company[0]

--- a/addons/iap/tests/__init__.py
+++ b/addons/iap/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_iap

--- a/addons/iap/tests/test_iap.py
+++ b/addons/iap/tests/test_iap.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import TransactionCase
+
+
+class TestIAP(TransactionCase):
+    def test_get_account(self):
+        account = self.env["iap.account"].get("random_service_name")
+        self.assertTrue(account.account_token, "Must be able to read the field")


### PR DESCRIPTION
Bug
===
Install CRM, then go to the lead kanban view and try to generate leads.
An error will be raised.

Technical
=========
In the "iap.account" model, in the `get` method, we can create the IAP
account if it doesn't exist yet. Since 5307f47d975c3b3ebd87c7f7e2248802a1aa5be7
the operation is done in a different SQL cursor than the current one.

The reason is that we need to commit the change, and committing the current
SQL cursor can cause issue and break some flows (mainly if it's not done
at the very beginning/end of the flow).

In the current code, we cache the `account_token` to be able to read it
with the current SQL cursor (otherwise, the current cursor has no access
to the field because change has not yet being committing for it).

But, the cache is invalidated when the "IAP account SQL cursor" is closed.

```python
with self.pool.cursor() as cr:
    ...
    IapAccount = self.with_env(self.env(cr=cr))
    account = IapAccount.search(domain, order='id desc', limit=1)
    if not account:
        if not force_create:
            return account
        account = IapAccount.create({'service_name': service_name})
    # fetch 'account_token' into cache with this cursor,
    # as self's cursor cannot see this account
    account.account_token
    # <---- Cache is invalidated here
...
```

So we can not access the the field value after the invalidation.

Solution
========
The solution is the store the `account_token` value before closing the
"IAP account SQL cursor" and then, after closing it, we add it in the cache.

Task-2277733