### PR TITLE
[IMP] base, *: allow html fields not to sanitize forms

### DIFF
--- a/addons/sale_quotation_builder/models/sale_order.py
+++ b/addons/sale_quotation_builder/models/sale_order.py
@@ -8,7 +8,7 @@ from odoo.tools.translate import html_translate
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
-    website_description = fields.Html('Website Description', sanitize_attributes=False, translate=html_translate)
+    website_description = fields.Html('Website Description', sanitize_attributes=False, translate=html_translate, sanitize_form=False)
 
     @api.onchange('partner_id')
     def onchange_update_description_lang(self):
@@ -40,7 +40,7 @@ class SaleOrder(models.Model):
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
-    website_description = fields.Html('Website Description', sanitize=False, translate=html_translate)
+    website_description = fields.Html('Website Description', sanitize=False, translate=html_translate, sanitize_form=False)
 
     @api.model
     def create(self, values):

--- a/addons/sale_quotation_builder/models/sale_order_template.py
+++ b/addons/sale_quotation_builder/models/sale_order_template.py
@@ -8,7 +8,7 @@ from odoo.tools.translate import html_translate
 class SaleOrderTemplate(models.Model):
     _inherit = "sale.order.template"
 
-    website_description = fields.Html('Website Description', translate=html_translate, sanitize_attributes=False)
+    website_description = fields.Html('Website Description', translate=html_translate, sanitize_attributes=False, sanitize_form=False)
 
     def open_template(self):
         self.ensure_one()
@@ -22,7 +22,7 @@ class SaleOrderTemplate(models.Model):
 class SaleOrderTemplateLine(models.Model):
     _inherit = "sale.order.template.line"
 
-    website_description = fields.Html('Website Description', related='product_id.product_tmpl_id.quotation_only_description', translate=html_translate, readonly=False)
+    website_description = fields.Html('Website Description', related='product_id.product_tmpl_id.quotation_only_description', translate=html_translate, readonly=False, sanitize_form=False)
 
     @api.onchange('product_id')
     def _onchange_product_id(self):

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -80,7 +80,7 @@ class Track(models.Model):
              " * Grey is the default situation\n"
              " * Red indicates something is preventing the progress of this track\n"
              " * Green indicates the track is ready to be pulled to the next stage")
-    description = fields.Html(translate=html_translate, sanitize_attributes=False)
+    description = fields.Html(translate=html_translate, sanitize_attributes=False, sanitize_form=False)
     date = fields.Datetime('Track Date')
     date_end = fields.Datetime('Track End Date', compute='_compute_end_date', store=True)
     duration = fields.Float('Duration', default=1.5, help="Track duration in hours.")

--- a/addons/website_hr_recruitment/models/hr_recruitment.py
+++ b/addons/website_hr_recruitment/models/hr_recruitment.py
@@ -44,7 +44,7 @@ class Job(models.Model):
         default_description = self.env["ir.model.data"].xmlid_to_object("website_hr_recruitment.default_website_description")
         return (default_description.render() if default_description else "")
 
-    website_description = fields.Html('Website description', translate=html_translate, sanitize_attributes=False, default=_get_default_website_description, prefetch=False)
+    website_description = fields.Html('Website description', translate=html_translate, sanitize_attributes=False, default=_get_default_website_description, prefetch=False, sanitize_form=False)
 
     def _compute_website_url(self):
         super(Job, self)._compute_website_url()

--- a/addons/website_livechat/models/im_livechat.py
+++ b/addons/website_livechat/models/im_livechat.py
@@ -16,4 +16,4 @@ class ImLivechatChannel(models.Model):
         for channel in self:
             channel.website_url = "/livechat/channel/%s" % (slug(channel),)
 
-    website_description = fields.Html("Website description", default=False, help="Description of the channel displayed on the website page", sanitize_attributes=False, translate=html_translate)
+    website_description = fields.Html("Website description", default=False, help="Description of the channel displayed on the website page", sanitize_attributes=False, translate=html_translate, sanitize_form=False)

--- a/addons/website_sale/models/product.py
+++ b/addons/website_sale/models/product.py
@@ -150,7 +150,7 @@ class ProductPublicCategory(models.Model):
     parents_and_self = fields.Many2many('product.public.category', compute='_compute_parents_and_self')
     sequence = fields.Integer(help="Gives the sequence order when displaying a list of product categories.", index=True)
     website_description = fields.Html('Category Description', sanitize_attributes=False, translate=html_translate)
-    product_tmpl_ids = fields.Many2many('product.template', relation='product_public_category_product_template_rel')
+    product_tmpl_ids = fields.Many2many('product.template', relation='product_public_category_product_template_rel', sanitize_form=False)
 
     @api.constrains('parent_id')
     def check_parent_id(self):
@@ -181,7 +181,7 @@ class ProductTemplate(models.Model):
     _mail_post_access = 'read'
     _check_company_auto = True
 
-    website_description = fields.Html('Description for the website', sanitize_attributes=False, translate=html_translate)
+    website_description = fields.Html('Description for the website', sanitize_attributes=False, translate=html_translate, sanitize_form=False)
     alternative_product_ids = fields.Many2many(
         'product.template', 'product_alternative_rel', 'src_id', 'dest_id', check_company=True,
         string='Alternative Products', help='Suggest alternatives to your customer (upsell strategy). '

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -87,7 +87,7 @@ class Channel(models.Model):
     name = fields.Char('Name', translate=True, required=True)
     active = fields.Boolean(default=True)
     description = fields.Text('Short Description', translate=True)
-    description_html = fields.Html('Description', translate=tools.html_translate, sanitize_attributes=False)
+    description_html = fields.Html('Description', translate=tools.html_translate, sanitize_attributes=False, sanitize_form=False)
     channel_type = fields.Selection([
         ('documentation', 'Documentation'), ('training', 'Training')],
         string="Course type", default="documentation", required=True)

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -158,7 +158,7 @@ class Slide(models.Model):
     document_id = fields.Char('Document ID', help="Youtube or Google Document ID")
     link_ids = fields.One2many('slide.slide.link', 'slide_id', string="External URL for this slide")
     mime_type = fields.Char('Mime-type')
-    html_content = fields.Html("HTML Content", help="Custom HTML content for slides of type 'Web Page'.", translate=True)
+    html_content = fields.Html("HTML Content", help="Custom HTML content for slides of type 'Web Page'.", translate=True, sanitize_form=False)
     # website
     website_id = fields.Many2one(related='channel_id.website_id', readonly=True)
     date_published = fields.Datetime('Publish Date', readonly=True, tracking=True)

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1592,6 +1592,7 @@ class Html(_String):
         'sanitize_tags': True,          # whether to sanitize tags (only a white list of attributes is accepted)
         'sanitize_attributes': True,    # whether to sanitize attributes (only a white list of attributes is accepted)
         'sanitize_style': False,        # whether to sanitize style attributes
+        'sanitize_form': True,          # whether to sanitize forms
         'strip_style': False,           # whether to strip style attributes (removed and therefore not sanitized)
         'strip_classes': False,         # whether to strip classes attributes
     }
@@ -1627,6 +1628,7 @@ class Html(_String):
                 sanitize_tags=self.sanitize_tags,
                 sanitize_attributes=self.sanitize_attributes,
                 sanitize_style=self.sanitize_style,
+                sanitize_form=self.sanitize_form,
                 strip_style=self.strip_style,
                 strip_classes=self.strip_classes)
         return value
@@ -1640,6 +1642,7 @@ class Html(_String):
                 sanitize_tags=self.sanitize_tags,
                 sanitize_attributes=self.sanitize_attributes,
                 sanitize_style=self.sanitize_style,
+                sanitize_form=self.sanitize_form,
                 strip_style=self.strip_style,
                 strip_classes=self.strip_classes)
         return value

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -176,7 +176,7 @@ class _Cleaner(clean.Cleaner):
                 del el.attrib['style']
 
 
-def html_sanitize(src, silent=True, sanitize_tags=True, sanitize_attributes=False, sanitize_style=False, strip_style=False, strip_classes=False):
+def html_sanitize(src, silent=True, sanitize_tags=True, sanitize_attributes=False, sanitize_style=False, sanitize_form=True, strip_style=False, strip_classes=False):
     if not src:
         return src
     src = ustr(src, errors='replace')
@@ -194,7 +194,7 @@ def html_sanitize(src, silent=True, sanitize_tags=True, sanitize_attributes=Fals
         'page_structure': True,
         'style': strip_style,              # True = remove style tags/attrs
         'sanitize_style': sanitize_style,  # True = sanitize styling
-        'forms': True,                     # True = remove form tags
+        'forms': sanitize_form,            # True = remove form tags
         'remove_unknown_tags': False,
         'comments': False,
         'processing_instructions': False


### PR DESCRIPTION
Cherry pick of 388c222c6c4bb7e2fe
OPW-2277923


--------------

* = event, website_event_track, website_sale, website_hr_recruitment,
website_livechat, website_sale, website_slides

The option to sanitize or not the forms was not available, this will
allow better flexibility on whether forms should be sanitized or not on
an HTML field.
Also we use this new param to allow forms to be added on some already
existing html fields where forms where sanitized out.

task-2209554

closes odoo/odoo#47318

Signed-off-by: Jérémy Kersten (jke) <jke@openerp.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
