### PR TITLE
[IMP] *: assign default/unique computed values in batch

### DIFF
--- a/addons/delivery/models/stock_picking.py
+++ b/addons/delivery/models/stock_picking.py
@@ -29,15 +29,11 @@ class StockQuantPackage(models.Model):
                     weight += quant.quantity * quant.product_id.weight
             package.weight = weight
 
-    def _get_default_weight_uom(self):
-        return self.env['product.template']._get_weight_uom_name_from_ir_config_parameter()
-
     def _compute_weight_uom_name(self):
-        for package in self:
-            package.weight_uom_name = self.env['product.template']._get_weight_uom_name_from_ir_config_parameter()
+        self.weight_uom_name = self.env['product.template']._get_weight_uom_name_from_ir_config_parameter()
 
     weight = fields.Float(compute='_compute_weight', help="Total weight of all the products contained in the package.")
-    weight_uom_name = fields.Char(string='Weight unit of measure label', compute='_compute_weight_uom_name', readonly=True, default=_get_default_weight_uom)
+    weight_uom_name = fields.Char(string='Weight unit of measure label', compute='_compute_weight_uom_name')
     shipping_weight = fields.Float(string='Shipping Weight', help="Total weight of the package.")
 
 
@@ -69,12 +65,8 @@ class StockPicking(models.Model):
             # if shipping weight is not assigned => default to calculated product weight
             picking.shipping_weight = picking.weight_bulk + sum([pack.shipping_weight or pack.weight for pack in picking.package_ids])
 
-    def _get_default_weight_uom(self):
-        return self.env['product.template']._get_weight_uom_name_from_ir_config_parameter()
-
     def _compute_weight_uom_name(self):
-        for package in self:
-            package.weight_uom_name = self.env['product.template']._get_weight_uom_name_from_ir_config_parameter()
+        self.weight_uom_name = self.env['product.template']._get_weight_uom_name_from_ir_config_parameter()
 
     carrier_price = fields.Float(string="Shipping Cost")
     delivery_type = fields.Selection(related='carrier_id.delivery_type', readonly=True)
@@ -82,7 +74,7 @@ class StockPicking(models.Model):
     weight = fields.Float(compute='_cal_weight', digits='Stock Weight', store=True, help="Total weight of the products in the picking.", compute_sudo=True)
     carrier_tracking_ref = fields.Char(string='Tracking Reference', copy=False)
     carrier_tracking_url = fields.Char(string='Tracking URL', compute='_compute_carrier_tracking_url')
-    weight_uom_name = fields.Char(string='Weight unit of measure label', compute='_compute_weight_uom_name', readonly=True, default=_get_default_weight_uom)
+    weight_uom_name = fields.Char(string='Weight unit of measure label', compute='_compute_weight_uom_name')
     package_ids = fields.Many2many('stock.quant.package', compute='_compute_packages', string='Packages')
     weight_bulk = fields.Float('Bulk Weight', compute='_compute_bulk_weight', help="Total weight of products which are not in a package.")
     shipping_weight = fields.Float("Weight for Shipping", compute='_compute_shipping_weight',

--- a/addons/hr/models/hr_employee_base.py
+++ b/addons/hr/models/hr_employee_base.py
@@ -45,7 +45,7 @@ class HrEmployeeBase(models.AbstractModel):
     hr_presence_state = fields.Selection([
         ('present', 'Present'),
         ('absent', 'Absent'),
-        ('to_define', 'To Define')], compute='_compute_presence_state', default='to_define')
+        ('to_define', 'To Define')], compute='_compute_presence_state')
     last_activity = fields.Date(compute="_compute_last_activity")
     last_activity_time = fields.Char(compute="_compute_last_activity")
     hr_icon_display = fields.Selection([

--- a/addons/hr_expense/models/product_template.py
+++ b/addons/hr_expense/models/product_template.py
@@ -7,7 +7,8 @@ from odoo import api, fields, models
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
-    can_be_expensed = fields.Boolean(string="Can be Expensed", compute='_compute_can_be_expensed',
+    can_be_expensed = fields.Boolean(
+        string="Can be Expensed", compute='_compute_can_be_expensed',
         store=True, readonly=False, help="Specify whether the product can be selected in an expense.")
 
     @api.model_create_multi
@@ -21,4 +22,7 @@ class ProductTemplate(models.Model):
 
     @api.depends('type')
     def _compute_can_be_expensed(self):
-        self.filtered(lambda p: p.type not in ['consu', 'service']).update({'can_be_expensed': False})
+        expensable_products = self.filtered(lambda p: p.type in ['consu', 'service'])
+        # VFE FIXME for those products, set as can be expensed = p.can_be_expensed ?
+        expensable_products.can_be_expensed = True
+        (self - expensable_products).can_be_expensed = False

--- a/addons/note/data/note_demo.xml
+++ b/addons/note/data/note_demo.xml
@@ -84,7 +84,7 @@
       <p>* Odoo for Retail and Industrial Management</p>]]>
       </field>
       <field name="color">7</field>
-      <field name="stage_ids" eval="[(6,0,[ref('note_stage_03')])]"/>
+      <field name="stage_id" ref="note_stage_03"/>
       <field name="user_id" ref="base.user_admin"/>
     </record>
 

--- a/addons/note/models/note.py
+++ b/addons/note/models/note.py
@@ -37,21 +37,25 @@ class Note(models.Model):
     _description = "Note"
     _order = 'sequence'
 
-    def _get_default_stage_id(self):
+    def _default_stage_id(self):
         return self.env['note.stage'].search([('user_id', '=', self.env.uid)], limit=1)
 
-    name = fields.Text(compute='_compute_name', string='Note Summary', store=True)
-    user_id = fields.Many2one('res.users', string='Owner', default=lambda self: self.env.uid)
     memo = fields.Html('Note Content')
     sequence = fields.Integer('Sequence')
-    stage_id = fields.Many2one('note.stage', compute='_compute_stage_id',
-        inverse='_inverse_stage_id', string='Stage', default=_get_default_stage_id)
-    stage_ids = fields.Many2many('note.stage', 'note_stage_rel', 'note_id', 'stage_id',
-        string='Stages of Users',  default=_get_default_stage_id)
     open = fields.Boolean(string='Active', default=True)
     date_done = fields.Date('Date done')
     color = fields.Integer(string='Color Index')
+
+    name = fields.Text(compute='_compute_name', string='Note Summary', store=True)
+
+    user_id = fields.Many2one('res.users', string='Owner', default=lambda self: self.env.uid)
+    stage_ids = fields.Many2many('note.stage', string="User note stages", compute="_compute_stage_ids")
+
+    stage_id = fields.Many2one(
+        'note.stage', string='Stage',
+        default=_default_stage_id, domain="[('id', 'in', stage_ids)]")
     tag_ids = fields.Many2many('note.tag', 'note_tags_rel', 'note_id', 'tag_id', string='Tags')
+
     # modifying property of ``mail.thread`` field
     message_partner_ids = fields.Many2many(compute_sudo=True)
 
@@ -62,67 +66,14 @@ class Note(models.Model):
             text = html2plaintext(note.memo) if note.memo else ''
             note.name = text.strip().replace('*', '').split("\n")[0]
 
-    def _compute_stage_id(self):
-        first_user_stage = self.env['note.stage'].search([('user_id', '=', self.env.uid)], limit=1)
+    @api.depends('user_id')
+    def _compute_stage_ids(self):
         for note in self:
-            for stage in note.stage_ids.filtered(lambda stage: stage.user_id == self.env.user):
-                note.stage_id = stage
-            # note without user's stage
-            if not note.stage_id:
-                note.stage_id = first_user_stage
-
-    def _inverse_stage_id(self):
-        for note in self.filtered('stage_id'):
-            note.stage_ids = note.stage_id + note.stage_ids.filtered(lambda stage: stage.user_id != self.env.user)
+            note.stage_ids = note.user_id.note_stage_ids
 
     @api.model
     def name_create(self, name):
         return self.create({'memo': name}).name_get()[0]
-
-    @api.model
-    def read_group(self, domain, fields, groupby, offset=0, limit=None, orderby=False, lazy=True):
-        if groupby and groupby[0] == "stage_id" and (len(groupby) == 1 or lazy):
-            stages = self.env['note.stage'].search([('user_id', '=', self.env.uid)])
-            if stages:  # if the user has some stages
-                result = [{  # notes by stage for stages user
-                    '__context': {'group_by': groupby[1:]},
-                    '__domain': domain + [('stage_ids.id', '=', stage.id)],
-                    'stage_id': (stage.id, stage.name),
-                    'stage_id_count': self.search_count(domain + [('stage_ids', '=', stage.id)]),
-                    '__fold': stage.fold,
-                } for stage in stages]
-
-                # note without user's stage
-                nb_notes_ws = self.search_count(domain + [('stage_ids', 'not in', stages.ids)])
-                if nb_notes_ws:
-                    # add note to the first column if it's the first stage
-                    dom_not_in = ('stage_ids', 'not in', stages.ids)
-                    if result and result[0]['stage_id'][0] == stages[0].id:
-                        dom_in = result[0]['__domain'].pop()
-                        result[0]['__domain'] = domain + ['|', dom_in, dom_not_in]
-                        result[0]['stage_id_count'] += nb_notes_ws
-                    else:
-                        # add the first stage column
-                        result = [{
-                            '__context': {'group_by': groupby[1:]},
-                            '__domain': domain + [dom_not_in],
-                            'stage_id': (stages[0].id, stages[0].name),
-                            'stage_id_count': nb_notes_ws,
-                            '__fold': stages[0].name,
-                        }] + result
-            else:  # if stage_ids is empty, get note without user's stage
-                nb_notes_ws = self.search_count(domain)
-                if nb_notes_ws:
-                    result = [{  # notes for unknown stage
-                        '__context': {'group_by': groupby[1:]},
-                        '__domain': domain,
-                        'stage_id': False,
-                        'stage_id_count': nb_notes_ws
-                    }]
-                else:
-                    result = []
-            return result
-        return super(Note, self).read_group(domain, fields, groupby, offset=offset, limit=limit, orderby=orderby, lazy=lazy)
 
     def action_close(self):
         return self.write({'open': False, 'date_done': fields.date.today()})

--- a/addons/note/models/res_users.py
+++ b/addons/note/models/res_users.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from odoo import api, models, modules, _
+from odoo import api, fields, models, modules, _
 
 _logger = logging.getLogger(__name__)
 
@@ -11,6 +11,8 @@ _logger = logging.getLogger(__name__)
 class Users(models.Model):
     _name = 'res.users'
     _inherit = ['res.users']
+
+    note_stage_ids = fields.One2many('note.stage', 'user_id')
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/note/views/note_views.xml
+++ b/addons/note/views/note_views.xml
@@ -155,6 +155,7 @@
                 <header>
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" placeholder="Tags"/>
                     <field name="stage_id" domain="[('user_id','=',uid)]" widget="statusbar" options="{'clickable': '1'}"/>
+                    <field name="stage_ids" invisible="1"/>
                 </header>
                 <sheet>
                   <field name="memo" type="html" class="oe_memo" default_focus="1" options="{'resizable': false}"/>

--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -44,10 +44,7 @@ class ProductTemplate(models.Model):
 
     @api.depends('name')
     def _compute_visible_expense_policy(self):
-        visibility = self.user_has_groups('analytic.group_analytic_accounting')
-        for product_template in self:
-            product_template.visible_expense_policy = visibility
-
+        self.visible_expense_policy = self.user_has_groups('analytic.group_analytic_accounting')
 
     @api.onchange('sale_ok')
     def _change_sale_ok(self):

--- a/addons/sale/models/res_config_settings.py
+++ b/addons/sale/models/res_config_settings.py
@@ -30,11 +30,6 @@ class ResConfigSettings(models.TransientModel):
         config_parameter='sale.default_deposit_product_id',
         help='Default product used for payment advances')
 
-    auth_signup_uninvited = fields.Selection([
-        ('b2b', 'On invitation'),
-        ('b2c', 'Free sign up'),
-    ], string='Customer Account', default='b2b', config_parameter='auth_signup.invitation_scope')
-
     module_delivery = fields.Boolean("Delivery Methods")
     module_delivery_dhl = fields.Boolean("DHL USA Connector")
     module_delivery_fedex = fields.Boolean("FedEx Connector")

--- a/addons/sale_expense/models/product_template.py
+++ b/addons/sale_expense/models/product_template.py
@@ -9,12 +9,8 @@ class ProductTemplate(models.Model):
 
     @api.depends('can_be_expensed')
     def _compute_visible_expense_policy(self):
+        super(ProductTemplate, self)._compute_visible_expense_policy()
         expense_products = self.filtered(lambda p: p.can_be_expensed)
-        for product_template in self - expense_products:
-            product_template.visible_expense_policy = False
-
-        super(ProductTemplate, expense_products)._compute_visible_expense_policy()
-        visibility = self.user_has_groups('hr_expense.group_hr_expense_user')
-        for product_template in expense_products:
-            if not product_template.visible_expense_policy:
-                product_template.visible_expense_policy = visibility
+        if self.user_has_groups('hr_expense.group_hr_expense_user'):
+            # If not, the value assigned by the super call is the correct one.
+            expense_products.visible_expense_policy = True

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -656,8 +656,7 @@ class ProductTemplate(models.Model):
     location_id = fields.Many2one('stock.location', 'Location', store=False)
     warehouse_id = fields.Many2one('stock.warehouse', 'Warehouse', store=False)
     has_available_route_ids = fields.Boolean(
-        'Routes can be selected on this product', compute='_compute_has_available_route_ids',
-        default=lambda self: self.env['stock.location.route'].search_count([('product_selectable', '=', True)]))
+        'Routes can be selected on this product', compute='_compute_has_available_route_ids')
     route_ids = fields.Many2many(
         'stock.location.route', 'stock_route_product', 'product_id', 'route_id', 'Routes',
         domain=[('product_selectable', '=', True)],
@@ -684,7 +683,7 @@ class ProductTemplate(models.Model):
 
     @api.depends('type')
     def _compute_has_available_route_ids(self):
-        self.has_available_route_ids = self.env['stock.location.route'].search_count([('product_selectable', '=', True)])
+        self.has_available_route_ids = bool(self.env['stock.location.route'].search([('product_selectable', '=', True)], limit=1))
 
     @api.depends(
         'product_variant_ids.qty_available',

--- a/addons/website/models/res_config_settings.py
+++ b/addons/website/models/res_config_settings.py
@@ -37,7 +37,7 @@ class ResConfigSettings(models.TransientModel):
     cdn_activated = fields.Boolean(related='website_id.cdn_activated', readonly=False)
     cdn_url = fields.Char(related='website_id.cdn_url', readonly=False)
     cdn_filters = fields.Text(related='website_id.cdn_filters', readonly=False)
-    auth_signup_uninvited = fields.Selection(compute="_compute_auth_signup", inverse="_set_auth_signup")
+    auth_signup_uninvited = fields.Selection(related="website_id.auth_signup_uninvited", readonly=False)
 
     social_twitter = fields.Char(related='website_id.social_twitter', readonly=False)
     social_facebook = fields.Char(related='website_id.social_facebook', readonly=False)
@@ -67,15 +67,6 @@ class ResConfigSettings(models.TransientModel):
 
     google_maps_api_key = fields.Char(related='website_id.google_maps_api_key', readonly=False)
     group_multi_website = fields.Boolean("Multi-website", implied_group="website.group_multi_website")
-
-    @api.depends('website_id.auth_signup_uninvited')
-    def _compute_auth_signup(self):
-        for config in self:
-            config.auth_signup_uninvited = config.website_id.auth_signup_uninvited
-
-    def _set_auth_signup(self):
-        for config in self:
-            config.website_id.auth_signup_uninvited = config.auth_signup_uninvited
 
     @api.depends('website_id')
     def has_google_analytics(self):

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -378,6 +378,11 @@ class Field(MetaField('DummyField', (object,), {})):
             if not (attrs['store'] and not attrs.get('readonly', True)):
                 attrs['copy'] = attrs.get('copy', False)
             attrs['readonly'] = attrs.get('readonly', not attrs.get('inverse'))
+            if not store and attrs.get('default'):
+                default = attrs.get('default')
+                compute = attrs.get('compute')
+                if compute not in ['_compute_repeat']:
+                    _logger.warning("Non stored computed field %s (%s) shouldn't have a default value (%s)", name, compute, default)
         if attrs.get('related'):
             # by default, related fields are not stored, computed in superuser
             # mode, not copied and readonly


### PR DESCRIPTION
* Avoid triggering function calls n times when doing it once is enough.
* Remove useless defaults for not stored computed fields (triggered at create for nothing)

--> Better performance in case of multi-records computation (even if some of those fields are not shown in multi-records view atm).

Waiting for https://github.com/odoo/odoo/pull/52767 to remove the "useless" defaults on non stored computed fields

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
