### PR TITLE
[FIX] l10n_ca, l10n_us: do not change paper format on upgrade

### DIFF
--- a/addons/l10n_ca/data/res_company_data.xml
+++ b/addons/l10n_ca/data/res_company_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo noupdate="1">
 <record model="res.company" id="base.main_company">
     <field name="paperformat_id" ref="base.paperformat_us"/>
 </record>

--- a/addons/l10n_us/data/res_company_data.xml
+++ b/addons/l10n_us/data/res_company_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo noupdate="1">
 <record model="res.company" id="base.main_company">
     <field name="paperformat_id" ref="base.paperformat_us"/>
 </record>


### PR DESCRIPTION
- Install US localization
- Change the paper format of the main company
- Upgrade `l10n_us`

The paper format is changed back to 'US Letter'.

Note that the current situation is not ideal since it forces the
paper format on the main company, whithout taking into account its actual
country.

opw-2272894

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
