### PR TITLE
[IMP] payment_stripe: split authorization and capture

### DIFF
--- a/addons/account_payment/views/account_portal_templates.xml
+++ b/addons/account_payment/views/account_portal_templates.xml
@@ -25,7 +25,7 @@
                 <t t-if="invoice.state == 'posted' and last_tx.state == 'pending' and last_tx.acquirer_id.provider not in ('transfer', 'manual')">
                   <span class="badge badge-pill badge-warning"><span class="d-none d-md-inline"> Pending</span></span>
                 </t>
-                <t t-if="invoice.state == 'posted' and invoice.payment_state == 'paid' or last_tx.state == 'done'">
+                <t t-if="invoice.state == 'posted' and invoice.payment_state == 'paid'">
                     <span class="badge badge-pill badge-success"><i class="fa fa-fw fa-check"></i><span class="d-none d-md-inline"> Paid</span></span>
                 </t>
                 <t t-if="invoice.state == 'cancel'">
@@ -70,14 +70,18 @@
         <xpath expr="//t[@t-call='portal.portal_record_sidebar']//div[hasclass('o_download_pdf')]" position="before">
             <t t-set="tx_ids" t-value="invoice.transaction_ids.filtered(lambda tx: tx.state in ('pending', 'authorized', 'done'))"/>
             <t t-set="pending_manual_txs" t-value="tx_ids.filtered(lambda tx: tx.state == 'pending' and tx.acquirer_id.provider in ('transfer', 'manual'))"/>
+            <t t-set="last_tx" t-value="invoice.get_portal_last_transaction()"/>
             <div>
                 <a href="#" t-if="invoice.state == 'posted' and invoice.payment_state in ('not_paid', 'partial') and invoice.amount_total and invoice.move_type == 'out_invoice' and (pending_manual_txs or not tx_ids)"
 
                     class="btn btn-primary btn-block mb-2" data-toggle="modal" data-target="#pay_with">
                     <i class="fa fa-fw fa-arrow-circle-right"/> Pay Now
                 </a>
-                <div t-if="tx_ids and not pending_manual_txs and invoice.payment_state != 'paid'" class="alert alert-info py-1 mb-2" >
+                <div t-if="tx_ids and not pending_manual_txs and invoice.payment_state != 'paid' and last_tx.state not in ('authorized', 'done')" class="alert alert-info py-1 mb-2" >
                     <i class="fa fa-fw fa-check-circle"/> Pending
+                </div>
+                <div t-if="tx_ids and not pending_manual_txs and invoice.payment_state != 'paid' and last_tx.state == 'authorized'" class="alert alert-info py-1 mb-2" >
+                    <i class="fa fa-fw fa-check-circle"/> Authorized
                 </div>
                 <div t-if="invoice.payment_state == 'paid'" class="alert alert-success py-1 mb-2" >
                     <i class="fa fa-fw fa-check-circle"/> Paid

--- a/addons/payment/models/payment_acquirer.py
+++ b/addons/payment/models/payment_acquirer.py
@@ -713,8 +713,12 @@ class PaymentTransaction(models.Model):
         elif self.state == 'authorized':
             message = _('The transaction %s with %s for %s has been authorized. Waiting for capture...')
         elif self.state == 'done':
-            message = _('The transaction %s with %s for %s has been confirmed. The related payment is posted: %s')
-            message_vals.append(self.payment_id._get_payment_chatter_link())
+            message = _('The transaction %s with %s for %s has been confirmed.')
+            if self.payment_id:
+                message += _(" The related payment is posted: %s")
+                message_vals.append(self.payment_id._get_payment_chatter_link())
+            else:
+                message += _(" Waiting for reconciliation...")
         elif self.state == 'cancel' and self.state_message:
             message = _('The transaction %s with %s for %s has been cancelled with the following message: %s')
             message_vals.append(self.state_message)
@@ -809,6 +813,7 @@ class PaymentTransaction(models.Model):
             'date': fields.Datetime.now(),
             'state_message': '',
         })
+        tx_to_process._log_payment_transaction_received()
 
     def _reconcile_after_transaction_done(self):
         # Validate invoices automatically upon the transaction is posted.

--- a/addons/payment_stripe/controllers/main.py
+++ b/addons/payment_stripe/controllers/main.py
@@ -6,6 +6,7 @@ import werkzeug
 
 from odoo import http
 from odoo.http import request
+from ..models.stripe_request import StripeApi
 
 _logger = logging.getLogger(__name__)
 
@@ -48,7 +49,7 @@ class StripeController(http.Controller):
     @http.route('/payment/stripe/s2s/create_setup_intent', type='json', auth='public', csrf=False)
     def stripe_s2s_create_setup_intent(self, acquirer_id, **kwargs):
         acquirer = request.env['payment.acquirer'].browse(int(acquirer_id))
-        res = acquirer.with_context(stripe_manual_payment=True)._create_setup_intent(kwargs)
+        res = StripeApi(acquirer.sudo().with_context(stripe_manual_payment=True)).create_setup_intent()
         return res.get('client_secret')
 
     @http.route('/payment/stripe/s2s/process_payment_intent', type='json', auth='public', csrf=False)

--- a/addons/payment_stripe/models/stripe_request.py
+++ b/addons/payment_stripe/models/stripe_request.py
@@ -1,0 +1,224 @@
+"""
+This module mimics a subset of the API client of Stripe.
+We can't use the official Stripe API client since it is not available in the debian stable repos.
+"""
+import requests
+import logging
+import pprint
+from requests.exceptions import HTTPError
+
+from odoo.addons.payment.models.payment_acquirer import ValidationError
+from odoo.tools.float_utils import float_round
+from odoo import _
+
+_logger = logging.getLogger(__name__)
+
+BASE_URL = 'https://api.stripe.com/v1'
+VERSION = '2019-05-16'  # SetupIntent need a specific version
+
+# The following currencies are integer only, see https://stripe.com/docs/currencies#zero-decimal
+INT_CURRENCIES = [
+    'BIF', 'XAF', 'XPF', 'CLP', 'KMF', 'DJF', 'GNF', 'JPY', 'MGA', 'PYG', 'RWF', 'KRW',
+    'VUV', 'VND', 'XOF'
+]
+
+
+class StripeApi:
+    """
+    Implementation of a subset of https://stripe.com/docs/api
+    """
+
+    def __init__(self, acquirer):
+        self.publishable_key = acquirer.stripe_publishable_key
+        self.secret_key = acquirer.stripe_secret_key
+
+    def create_payment_intent(self, tx, **params):
+        """
+        Create a new payment intent from a PaymentTransactionStripe
+        See https://stripe.com/docs/api/payment_intents/create
+
+        To create payment_intent without capturing the amount, set parameter capture_method to 'manual'
+
+        :param tx: create a payment intent from it
+        :type tx: PaymentTransactionStripe
+        :return: the created Stripe payment_intent
+        """
+        url = f'{BASE_URL}/payment_intents'
+
+        if not tx.payment_token_id.stripe_payment_method:
+            # old token before using sca, need to fetch data from the api
+            tx.payment_token_id._stripe_sca_migrate_customer()
+
+        pi_params = {
+            'amount': int(tx.amount if tx.currency_id.name in INT_CURRENCIES else float_round(tx.amount * 100, 2)),
+            'currency': tx.currency_id.name.lower(),
+            'off_session': True,
+            'confirm': True,
+            'payment_method': tx.payment_token_id.stripe_payment_method,
+            'customer': tx.payment_token_id.acquirer_ref,
+            "description": tx.reference,
+        }
+
+        pi_params.update(params)
+        if not tx.env.context.get('off_session'):
+            pi_params.update(setup_future_usage='off_session', off_session=False)
+
+        return self._request(url, **pi_params)
+
+    def get_payment_intent(self, tx):
+        """
+        :param tx: transaction related to requested payment_intent
+        :type tx: PaymentTransactionStripe
+        :return: the requested Stripe payment_intent
+        """
+        payment_intent = tx.acquirer_reference or tx.stripe_payment_intent
+        url = f'{BASE_URL}/payment_intents/{payment_intent}'
+
+        return self._request(url, method='GET')
+
+    def capture_payment_intent(self, tx):
+        """
+        Capture a previously authorized payment intent (full amount)
+        See https://stripe.com/docs/api/payment_intents/capture
+
+        :param tx: transaction we want to capture the payment_intent of
+        :type tx: PaymentTransactionStripe
+        :return: modified Stripe payment_intent
+        """
+        url = f'{BASE_URL}/payment_intents/{tx.acquirer_reference}/capture'
+
+        return self._request(url)
+
+    def cancel_payment_intent(self, tx):
+        """
+        Cancel a previously authorized payment intent (remaining amount)
+        See https://stripe.com/docs/api/payment_intents/cancel
+
+        :param tx: transaction we want to cancel the payment_intent of
+        :type tx: PaymentTransactionStripe
+        :return: modified Stripe payment_intent
+        """
+        url = f'{BASE_URL}/payment_intents/{tx.acquirer_reference}/cancel'
+
+        return self._request(url)
+
+    def get_payment_method(self, payment_method):
+        """
+        See https://stripe.com/docs/api/payment_methods/retrieve
+        """
+        url = f'{BASE_URL}/payment_methods/{payment_method}'
+        return self._request(url, method='GET', data=False)
+
+    def list_payment_methods(self, customer, payment_method_type='card'):
+        """
+        See https://stripe.com/docs/api/payment_methods/list
+
+        :param customer: the Stripe ID of the customer whose payment_method's will be retrieved
+        :param payment_method_type: A required filter on the list
+        """
+        url = f'{BASE_URL}/payment_methods'
+
+        return self._request(url, method='GET', customer=customer, type=payment_method_type)
+
+    def attach_payment_method(self, payment_method, customer):
+        """
+        Attach a payment method to a customer for future payments
+        See https://stripe.com/docs/api/payment_methods/attach
+        """
+        url = f'{BASE_URL}/payment_methods/{payment_method}/attach'
+
+        return self._request(url, customer=customer)
+
+    def create_refund(self, tx):
+        """
+        Create a new refund for an existing charge
+
+        :param tx: the transaction to refund (full amount)
+        :type tx: PaymentTransactionStripe
+        :return: the created refund
+        """
+        url = f'{BASE_URL}/refunds'
+
+        pi = self.get_payment_intent(tx)
+        charge_id = pi['charges']['data'][0]['id']
+
+        refund_params = {
+            'charge': charge_id,
+            'metadata[reference]': tx.reference,
+        }
+
+        return self._request(url, **refund_params)
+
+    def create_checkout_session(self, **kwargs):
+        """
+        See https://stripe.com/docs/api/checkout/sessions/create
+        """
+        url = f'{BASE_URL}/checkout/sessions'
+
+        return self._request(url, **kwargs)
+
+    def create_setup_intent(self):
+        """
+        See https://stripe.com/docs/api/setup_intents/create
+        """
+        url = f'{BASE_URL}/setup_intents'
+        params = {
+            'usage': 'off_session',
+        }
+
+        return self._request(url, **params)
+
+    def create_customer(self, **params):
+        """
+        See https://stripe.com/docs/api/customers/create
+        """
+        url = f'{BASE_URL}/customers'
+
+        return self._request(url, **params)
+
+    def get_customer(self, customer):
+        """
+        See https://stripe.com/docs/api/customers/retrieve
+        """
+        url = f'{BASE_URL}/customers/{customer}'
+
+        return self._request(url, method='GET')
+
+    def _request(self, url, method='POST', stripe_manual_payment=False, **params):
+        """
+        General purpose Stripe client
+
+        :param url: to attack
+        :param method: HTTP verb
+        :param stripe_manual_payment: determine if the errors must face a user (True means they will)
+        :param params: any params to send to Stripe
+        :return: Stripe response
+        """
+        headers = {
+            'AUTHORIZATION': 'Bearer %s' % self.secret_key,
+            'Stripe-Version': VERSION,
+        }
+        _logger.info(f'Sending values to Stripe URL {url}:\n{pprint.pformat(params)}')
+        resp = requests.request(method, url, data=params, headers=headers)
+        json = resp.json()
+        _logger.info(f'Values received:\n{pprint.pformat(json)}')
+
+        # Stripe can send 4XX errors for payment failure (not badly-formed requests)
+        # check if error `code` is present in 4XX response and raise only if not
+        # cfr https://stripe.com/docs/error-codes
+        # these can be made customer-facing, as they usually indicate a problem with the payment
+        # (e.g. insufficient funds, expired card, etc.)
+        # if the context key `stripe_manual_payment` is set then these errors will be raised as ValidationError,
+        # otherwise, they will be silenced, and the will be returned no matter the status.
+        # This key should typically be set for payments in the present and unset for automated payments
+        # (e.g. through crons)
+        if not resp.ok and stripe_manual_payment \
+                and (400 <= resp.status_code < 500 and json.get('error', {}).get('code')):
+            try:
+                resp.raise_for_status()
+            except HTTPError:
+                _logger.error(resp.text)
+                stripe_error = json.get('error', {}).get('message', '')
+                error_msg = " " + (_("Stripe gave us the following info about the problem:") + " '%s'" % stripe_error)
+                raise ValidationError(error_msg)
+        return json

--- a/addons/payment_stripe/tests/__init__.py
+++ b/addons/payment_stripe/tests/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-from . import test_stripe
+from . import test_stripe, test_stripe_request

--- a/addons/payment_stripe/tests/test_stripe_request.py
+++ b/addons/payment_stripe/tests/test_stripe_request.py
@@ -1,0 +1,100 @@
+from .test_stripe import StripeCommon
+
+from ..models.stripe_request import StripeApi
+
+import odoo
+from odoo.tools import mute_logger
+
+
+@odoo.tests.tagged('post_install', '-at_install', '-standard', 'external')
+class StripeRequestTest(StripeCommon):
+    def setUp(self):
+        StripeCommon.setUp(self)
+        self.api = StripeApi(self.stripe)
+
+    def run(self, result=None):
+        with mute_logger('odoo.addons.payment_stripe.models.stripe_request'):
+            StripeCommon.run(self, result)
+
+    def test_create_payment_intent(self):
+        tx = self.env['payment.transaction'].create({
+            'amount': 4700.0,
+            'acquirer_id': self.stripe.id,
+            'currency_id': self.currency_euro.id,
+            'reference': 'tx_test_create_payment_intent',
+            'partner_name': 'Norbert Buyer',
+            'partner_country_id': self.country_france.id,
+            'payment_token_id': self.token.id,
+        })
+
+        actual = self.api.create_payment_intent(tx.with_context(off_session=True))
+
+        self.assertEqual(actual['object'], 'payment_intent')
+        self.assertEqual(actual['amount'], 470000)
+        self.assertEqual(actual['amount_capturable'], 0)
+        self.assertEqual(actual['amount_received'], 470000)
+        self.assertEqual(actual['capture_method'], 'automatic')
+
+    def test_authorize_payment_intent(self):
+        tx = self.env['payment.transaction'].create({
+            'amount': 4700.0,
+            'acquirer_id': self.stripe.id,
+            'currency_id': self.currency_euro.id,
+            'reference': 'tx_test_create_payment_intent',
+            'partner_name': 'Norbert Buyer',
+            'partner_country_id': self.country_france.id,
+            'payment_token_id': self.token.id,
+        })
+
+        actual = self.api.create_payment_intent(tx.with_context(off_session=True), capture_method='manual')
+
+        self.assertEqual(actual['object'], 'payment_intent')
+        self.assertEqual(actual['amount'], 470000)
+        self.assertEqual(actual['amount_capturable'], 470000)
+        self.assertEqual(actual['amount_received'], 0)
+        self.assertEqual(actual['capture_method'], 'manual')
+
+    def test_capture_payment_intent(self):
+        tx = self.env['payment.transaction'].create({
+            'amount': 4700.0,
+            'acquirer_id': self.stripe.id,
+            'currency_id': self.currency_euro.id,
+            'reference': 'tx_test_create_payment_intent',
+            'partner_name': 'Norbert Buyer',
+            'partner_country_id': self.country_france.id,
+            'payment_token_id': self.token.id,
+        })
+        self.stripe.capture_manually = True
+        tx.stripe_s2s_do_transaction()
+
+        actual = self.api.capture_payment_intent(tx)
+
+        self.assertEqual(actual['object'], 'payment_intent')
+        self.assertEqual(actual['amount'], 470000)
+        self.assertEqual(actual['amount_capturable'], 0)
+        self.assertEqual(actual['amount_received'], 470000)
+        self.assertEqual(actual['capture_method'], 'manual')
+
+    def test_create_refund(self):
+        tx = self.env['payment.transaction'].create({
+            'amount': 4700.0,
+            'acquirer_id': self.stripe.id,
+            'currency_id': self.currency_euro.id,
+            'reference': 'tx_test_create_payment_intent',
+            'partner_name': 'Norbert Buyer',
+            'partner_country_id': self.country_france.id,
+            'payment_token_id': self.token.id,
+        })
+        tx.stripe_s2s_do_transaction()
+
+        actual = self.api.create_refund(tx)
+
+        self.assertEqual(actual['object'], 'refund')
+        self.assertEqual(actual['amount'], 470000)
+        self.assertEqual(actual['metadata']['reference'], tx.reference)
+        self.assertEqual(actual['status'], 'succeeded')
+
+    def test_create_setup_intent(self):
+        actual = self.api.create_setup_intent()
+
+        self.assertEqual(actual['object'], 'setup_intent')


### PR DESCRIPTION
Rather than doing a full payment upon payment intent creation,
Stripe offers to authorize the payment first,
and then capture the (full/partial) amount later,
when order is sent, by example.

Odoo only does full and manual capture at the moment as
1 - Odoo doesn't support partial payment
2 - Order could be sent in multiple delivery (would be a shame capture full amount when you didn't send everything)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
