### PR TITLE
[FIX] hr_holidays: fix add to dashboard for time off analysis

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report.py
+++ b/addons/hr_holidays/report/hr_leave_report.py
@@ -110,6 +110,7 @@ class LeaveReport(models.Model):
 
         return {
             'name': _('Time Off Analysis'),
+            'id': self.env.ref('hr_holidays.action_hr_available_holidays_report').id,
             'type': 'ir.actions.act_window',
             'res_model': 'hr.leave.report',
             'view_mode': 'tree,form,pivot',


### PR DESCRIPTION
Steps to reproduce:
- install dashboard and hr_holidays
- go to time off > reporting > by type > select the view pivot
- select 'by employee' for the left side and 'leave type' for the top side
- click 'add to favorites' > add to dashboard > ok

Previous behavior:
because the action_id is not defined,
the interface shows an error message; "could not add filter to dashboard"

Current behavior:
the view is added to the dashboard

opw-2277342