### PR TITLE
[FIX] hr_attendance: All internal can modifiy hr.attendance

### DIFF
--- a/addons/hr_attendance/views/hr_employee_view.xml
+++ b/addons/hr_attendance/views/hr_employee_view.xml
@@ -41,7 +41,7 @@
                         icon="fa-clock-o"
                         type="action"
                         context="{'search_default_employee_id': active_id, 'search_default_check_in_filter': '1'}"
-                        groups="base.group_user"
+                        groups="hr_attendance.group_hr_attendance_user"
                         help="Worked hours last month">
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_value">
@@ -95,7 +95,7 @@
                         icon="fa-calendar"
                         type="action"
                         context="{'search_default_employee_id': employee_ids, 'search_default_check_in_filter': '1'}"
-                        groups="base.group_user"
+                        groups="hr_attendance.group_hr_attendance_user"
                         help="Worked hours last month">
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_value">


### PR DESCRIPTION
Steps to reproduce:

- Let's consider a user U with no access to hr.attendance
- Let's consider that U has made some check in and check out
- Log with U
- Go to your profile and on Last month

Bug:

U can modifiy manually his attendances.

opw:2279682