### PR TITLE
[FIX] coupon: fix warning about security during installation

### DIFF
--- a/addons/coupon/__manifest__.py
+++ b/addons/coupon/__manifest__.py
@@ -10,6 +10,7 @@
     'data': [
         'wizard/coupon_generate_views.xml',
         'security/coupon_security.xml',
+        'security/ir.model.access.csv',
         'views/coupon_views.xml',
         'views/coupon_program_views.xml',
         'report/coupon_report.xml',

--- a/addons/coupon/security/ir.model.access.csv
+++ b/addons/coupon/security/ir.model.access.csv
@@ -1,0 +1,6 @@
+id,name,model_id/id,group_id/id,perm_read,perm_write,perm_create,perm_unlink
+access_coupon_program_system,Coupon Program System,coupon.model_coupon_program,base.group_system,1,1,1,0
+access_coupon_rule_system,Coupon Rule System,coupon.model_coupon_rule,base.group_system,1,1,1,0
+access_coupon_reward_system,Coupon Reward System,coupon.model_coupon_reward,base.group_system,1,1,1,0
+access_coupon_system,Coupon System,coupon.model_coupon_coupon,base.group_system,1,1,1,0
+access_coupon_generate_wizard_system,Coupon Generation System,coupon.model_coupon_generate_wizard,base.group_system,1,1,1,0


### PR DESCRIPTION
No access rights were declared in the new coupon module, this results
to warning messages after installation when it is installed and not
installing any module that inherits it. This commit adds minimum
access rights to the coupon module models to prevent the warning
messages.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
