### PR TITLE
[FIX] account: Fixed tax with 100% discount

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -433,7 +433,7 @@ class AccountTax(models.Model):
         # For the computation of move lines, we could have a negative base value.
         # In this case, compute all with positive values and negate them at the end.
         sign = 1
-        if base < 0:
+        if base <= 0:
             base = -base
             sign = -1
 


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a fixed tax T of 5€
- Create a customer invoice with one line L
- Set T on L and 100% discount on L

Bug:

A tax of -5€ was due by the customer (meaning the seller must return
5€ to the customer)

opw:2283875

closes #53882