### PR TITLE
Convert Newsletter Popup in Popup

### DIFF
--- a/addons/website/views/snippets/s_popup.xml
+++ b/addons/website/views/snippets/s_popup.xml
@@ -1,22 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-<template id="s_popup_content" name="Popup Content">
-    <section class="s_banner oe_img_bg pt96 pb96"
-        data-snippet="s_banner"
-        style="background-image: url('/web/image/website.s_popup_default_image');">
-        <div class="container">
-            <div class="row s_nb_column_fixed">
-                <div class="col-lg-10 offset-lg-1 text-center o_cc o_cc1 jumbotron pt48 pb48">
-                    <h2><font style="font-size: 62px;">Win $20</font></h2>
-                    <p class="lead">Check out now and get $20 off your first order.</p>
-                    <a href="#" class="btn btn-primary">New customer</a>
-                </div>
-            </div>
-        </div>
-    </section>
-</template>
-
 <template id="s_popup" name="Popup">
     <div class="s_popup o_snippet_invisible" data-vcss="001">
         <div class="modal fade s_popup_middle"

--- a/addons/website/views/snippets/s_popup.xml
+++ b/addons/website/views/snippets/s_popup.xml
@@ -1,6 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
+<template id="s_popup_content" name="Popup Content">
+    <section class="s_banner oe_img_bg pt96 pb96"
+        data-snippet="s_banner"
+        style="background-image: url('/web/image/website.s_popup_default_image');">
+        <div class="container">
+            <div class="row s_nb_column_fixed">
+                <div class="col-lg-10 offset-lg-1 text-center o_cc o_cc1 jumbotron pt48 pb48">
+                    <h2><font style="font-size: 62px;">Win $20</font></h2>
+                    <p class="lead">Check out now and get $20 off your first order.</p>
+                    <a href="#" class="btn btn-primary">New customer</a>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
 <template id="s_popup" name="Popup">
     <div class="s_popup o_snippet_invisible" data-vcss="001">
         <div class="modal fade s_popup_middle"
@@ -15,7 +31,7 @@
             <div class="modal-dialog d-flex">
                 <div class="modal-content oe_structure">
                     <div class="s_popup_close js_close_popup o_we_no_overlay o_not_editable" aria-label="Close">×</div>
-                    <section class="s_banner oe_img_bg o_bg_img_center pt96 pb96"
+                    <section id="s_popup_content" class="s_banner oe_img_bg o_bg_img_center pt96 pb96"
                              data-snippet="s_banner"
                              style="background-image: url('/web/image/website.s_popup_default_image');">
                         <div class="container">

--- a/addons/website_mass_mailing/static/src/js/website_mass_mailing.editor.js
+++ b/addons/website_mass_mailing/static/src/js/website_mass_mailing.editor.js
@@ -159,8 +159,7 @@ options.registry.newsletter_popup = options.registry.mailing_list_subscribe.exte
      * @override
      */
     onTargetShow: function () {
-        // Open the modal
-        this.$target.data('quick-open', true);
+        this.$target.modal('show');
         return this._refreshPublicWidgets();
     },
     /**
@@ -194,6 +193,7 @@ options.registry.newsletter_popup = options.registry.mailing_list_subscribe.exte
      */
     destroy: function () {
         this.$target.off('.newsletter_popup_option');
+        this.$target.find('.o_newsletter_content').empty();
         this._super.apply(this, arguments);
     },
 

--- a/addons/website_mass_mailing/static/src/js/website_mass_mailing.editor.js
+++ b/addons/website_mass_mailing/static/src/js/website_mass_mailing.editor.js
@@ -14,7 +14,7 @@ var _t = core._t;
 
 
 options.registry.mailing_list_subscribe = options.Class.extend({
-    
+
     //--------------------------------------------------------------------------
     // Options
     //--------------------------------------------------------------------------
@@ -32,7 +32,7 @@ options.registry.mailing_list_subscribe = options.Class.extend({
      */
     onBuilt(){
         this._super();
-        const mailingListID = this._getMailingListID();
+        const mailingListID = parseInt(this.$target.attr('data-list-id')) || this.defaultMailingID;
         if (mailingListID) {
             this.$target.attr("data-list-id", mailingListID);
         } else {
@@ -58,13 +58,14 @@ options.registry.mailing_list_subscribe = options.Class.extend({
      * @override
      */
     async _renderCustomXML(uiFragment) {
-        this.mailingLists = await this._renderMailingListButtons();
+        const mailingLists = await this._renderMailingListButtons();
         const selectEl = uiFragment.querySelector('we-select[data-name="mailing_list"]');
-        for (const mailingList of this.mailingLists) {
+        for (const mailingList of mailingLists) {
             const button = document.createElement('we-button');
             button.dataset.selectMailingList = mailingList[0];
             button.textContent = mailingList[1];
             selectEl.appendChild(button);
+            this.defaultMailingID = mailingList[0];
         }
     },
     /**
@@ -74,7 +75,7 @@ options.registry.mailing_list_subscribe = options.Class.extend({
     _computeWidgetState(methodName, params) {
         switch (methodName) {
             case 'selectMailingList':
-                return this._getMailingListID();
+                return parseInt(this.$target.attr('data-list-id')) || this.defaultMailingID;
         }
         return this._super(...arguments);
     },
@@ -90,18 +91,6 @@ options.registry.mailing_list_subscribe = options.Class.extend({
             args: ['', [['is_public', '=', true]]],
             context: this.options.recordInfo.context,
         });
-    },
-    /**
-     * active mailing list id or set default one for use
-     *
-     * @private
-     */
-    _getMailingListID() {
-        let listID = parseInt(this.$target.attr('data-list-id'));
-        if (!listID && this.mailingLists.length) {
-            listID = this.mailingLists[0][0];
-        }
-        return listID;
     },
 });
 

--- a/addons/website_mass_mailing/views/snippets_templates.xml
+++ b/addons/website_mass_mailing/views/snippets_templates.xml
@@ -79,8 +79,11 @@
         <t t-set="selector" t-value="'.js_subscribe'"/>
         <div data-js="mailing_list_subscribe"
             t-att-data-selector="selector"
-            t-attf-data-exclude=".o_newsletter_modal #{selector}">
-            <we-button data-select_mailing_list="" data-no-preview="true">Change Newsletter</we-button>
+            t-attf-data-exclude=".o_newsletter_content #{selector}">
+            <we-row>
+                <we-title>Change Newsletter</we-title>
+                <we-select data-name="mailing_list" data-no-preview="true"></we-select>
+            </we-row>
         </div>
         <div data-js="recaptchaSubscribe"
             t-att-data-selector="selector">
@@ -88,9 +91,11 @@
             <we-checkbox t-if="recaptcha_public_key" string="Show reCaptcha Policy" data-toggle-recaptcha-legal="" data-no-preview="true"/>
         </div>
         <div t-att-data-selector="selector" data-drop-near="p, h1, h2, h3, blockquote, .card"/>
-        <div data-js="newsletter_popup"
-            data-selector=".o_newsletter_popup">
-            <we-button data-select_mailing_list="" data-no-preview="true">Change Newsletter</we-button>
+        <div data-js="newsletter_popup" data-selector=".o_newsletter_popup">
+            <we-row>
+                <we-title>Change Newsletter</we-title>
+                <we-select data-name="mailing_list" data-no-preview="true"></we-select>
+            </we-row>
         </div>
     </xpath>
 </template>

--- a/addons/website_mass_mailing/views/snippets_templates.xml
+++ b/addons/website_mass_mailing/views/snippets_templates.xml
@@ -59,7 +59,7 @@
     <xpath expr="//div[hasclass('modal-content')]" position="attributes">
         <attribute name="class" remove="oe_structure" separator=" "/>
     </xpath>
-    <xpath expr="//t[@t-call='website.s_popup_content']" position="replace">
+    <xpath expr="//section[@id='s_popup_content']" position="replace">
         <div class="o_newsletter_content"></div>
     </xpath>
 </template>

--- a/addons/website_mass_mailing/views/snippets_templates.xml
+++ b/addons/website_mass_mailing/views/snippets_templates.xml
@@ -50,19 +50,31 @@
     </section>
 </template>
 
-<template id="s_newsletter_subscribe_popup" name="Newsletter Popup">
-    <div class="o_newsletter_popup o_snippet_invisible" data-list-id="0"/>
+<template id="s_newsletter_subscribe_popup" name="Newsletter Popup" inherit_id="website.s_popup" primary="True">
+    <xpath expr="//div[hasclass('s_popup')]" position="attributes">
+        <attribute name="data-list-id">0</attribute>
+        <attribute name="class" separator=" " add="o_newsletter_popup"/>
+    </xpath>
+    <!-- remove oe_structure class from modal-content -->
+    <xpath expr="//div[hasclass('modal-content')]" position="attributes">
+        <attribute name="class" remove="oe_structure" separator=" "/>
+    </xpath>
+    <xpath expr="//t[@t-call='website.s_popup_content']" position="replace">
+        <div class="o_newsletter_content"></div>
+    </xpath>
 </template>
 
 <template id="s_newsletter_subscribe_popup_content" name="Newsletter Popup Content">
     <section class="s_text_block oe_img_bg o_bg_img_center pt88 pb64" data-snippet="s_text_block"
              style="background-image: url('/web/image/website.s_cover_default_image'); background-position: 0 100%;">
         <div class="container s_allow_columns">
-            <h1 style="text-align: center;">Always <b>First</b>.</h1>
-            <p style="text-align: center;">Be the first to find out all the latest news,<br/> products, and trends.</p>
+            <span class="o_cc o_cc1">
+                <h1 style="text-align: center;">Always <b>First</b>.</h1>
+                <p style="text-align: center;">Be the first to find out all the latest news,<br/> products, and trends.</p>
+            </span>
         </div>
     </section>
-    <section class="s_text_block" data-snippet="s_text_block">
+    <section class="s_text_block o_cc o_cc1" data-snippet="s_text_block">
         <div class="container">
             <div class="row s_nb_column_fixed">
                 <div class="col-lg-8 offset-lg-2 pt32 pb32">


### PR DESCRIPTION
Previously we had only a few options available for newsletter popup in the web editor and had to use a popup in order to change the newsletter.

In the first commit, we have changed popup to a select so that we can change newsletter from options panel itself.

In the second commit, we made all options from the popup to be available for the newsletter popup.
Here the newsletter popup used the exact same structure as the s_popup we only fill the popup content using the public widget.

task-2246975