### PR TITLE
[ADD] Download user iCal with res.users.apikeys in URL.

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -58,6 +58,15 @@ def get_weekday_occurence(date):
     return occurence_in_month
 
 
+def ics_datetime(idate, allday=False):
+    if idate:
+        if allday:
+            return idate
+        else:
+            return idate.replace(tzinfo=pytz.timezone('UTC'))
+    return False
+
+
 class Meeting(models.Model):
     _name = 'calendar.event'
     _description = "Calendar Event"
@@ -1156,22 +1165,28 @@ class Meeting(models.Model):
         """
         result = {}
 
-        def ics_datetime(idate, allday=False):
-            if idate:
-                if allday:
-                    return idate
-                return idate.replace(tzinfo=pytz.timezone('UTC'))
-            return False
-
         if not vobject:
             return result
 
         for meeting in self:
-            cal = vobject.iCalendar()
-            event = cal.add('vevent')
+            result[meeting.id] = meeting.ics()
 
+        return result
+
+    def ics(self):
+        """ Returns serialized iCalendar file containing the events. """
+        if not vobject:
+            return None
+        cal = vobject.iCalendar()
+        self._vevents(cal)
+        return cal.serialize().encode('utf-8')
+
+    def _vevents(self, cal):
+        for meeting in self:
             if not meeting.start or not meeting.stop:
                 raise UserError(_("First you have to specify the date of the invitation."))
+
+            event = cal.add('vevent')
             event.add('created').value = ics_datetime(fields.Datetime.now())
             event.add('dtstart').value = ics_datetime(meeting.start, meeting.allday)
             event.add('dtend').value = ics_datetime(meeting.stop, meeting.allday)
@@ -1212,10 +1227,6 @@ class Meeting(models.Model):
                 organizer.value = u'MAILTO:' + meeting.partner_id.email
                 if meeting.partner_id.name:
                     organizer.params['CN'] = [meeting.partner_id.display_name.replace('\"', '\'')]
-
-            result[meeting.id] = cal.serialize().encode('utf-8')
-
-        return result
 
     def convert_online_event_desc_to_text(self, description):
         """

--- a/addons/calendar_ical/__init__.py
+++ b/addons/calendar_ical/__init__.py
@@ -1,0 +1,2 @@
+from . import controllers
+from . import models

--- a/addons/calendar_ical/__manifest__.py
+++ b/addons/calendar_ical/__manifest__.py
@@ -1,0 +1,33 @@
+{
+    'name': 'Calendar - iCal',
+    'version': '1.0',
+    'summary': 'Enable download of user calendars as iCal.',
+
+    'author': 'MetricWise, Inc.',
+    'license': 'LGPL-3',
+    'category': 'Tools',
+
+    'depends': [
+        'calendar',
+        'web',
+    ],
+
+    'external_dependencies': {
+        'python': [
+            'vobject',
+        ],
+    },
+
+    'assets': {
+        'web.assets_backend': [
+            'calendar_ical/static/src/js/*.js',
+        ],
+        'web.assets_qweb': [
+            'calendar_ical/static/src/xml/*.xml',
+        ],
+    },
+
+    'data': [
+        'views/res_users_views.xml',
+    ],
+}

--- a/addons/calendar_ical/controllers/__init__.py
+++ b/addons/calendar_ical/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import calendar_ics

--- a/addons/calendar_ical/controllers/calendar_ics.py
+++ b/addons/calendar_ical/controllers/calendar_ics.py
@@ -1,0 +1,26 @@
+from werkzeug.datastructures import MIMEAccept
+from werkzeug.exceptions import NotAcceptable
+from werkzeug.http import parse_accept_header
+
+from odoo.http import content_disposition, Controller, request, route
+
+
+class CalendarController(Controller):
+    @route('/calendar.ics', type='http', auth='calendar_ics', save_session=False)
+    def calendar_ics(self, key):
+        """
+        :param key: res.users.apikeys key
+        """
+        accept = parse_accept_header(request.httprequest.headers.get('Accept'), MIMEAccept)
+        if accept and not accept.best_match(['text/calendar']):
+            raise NotAcceptable()
+
+        domain = request.env['res.users'].browse(request.uid)._get_ics_domain()
+        events = request.env['calendar.event'].with_user(request.uid).search(domain)
+        data = events.ics()
+        headers = [
+            ('Content-Disposition', content_disposition('calendar.ics')),
+            ('Content-Length', len(data)),
+            ('Content-Type', 'text/calendar'),
+        ]
+        return request.make_response(data, headers)

--- a/addons/calendar_ical/models/__init__.py
+++ b/addons/calendar_ical/models/__init__.py
@@ -1,0 +1,2 @@
+from . import ir_http
+from . import res_users

--- a/addons/calendar_ical/models/ir_http.py
+++ b/addons/calendar_ical/models/ir_http.py
@@ -1,0 +1,20 @@
+from werkzeug.exceptions import BadRequest, Unauthorized
+
+from odoo import models
+from odoo.http import request
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = 'ir.http'
+
+    @classmethod
+    def _auth_method_calendar_ics(cls):
+        key = request.get_http_params().get('key')
+        if not key:
+            raise BadRequest()
+
+        uid = request.env['res.users.apikeys']._check_credentials(scope='calendar.ics', key=key)
+        if not uid:
+            raise Unauthorized()
+
+        request.update_env(user=uid)

--- a/addons/calendar_ical/models/res_users.py
+++ b/addons/calendar_ical/models/res_users.py
@@ -1,0 +1,36 @@
+from odoo import fields, models
+from odoo.addons.base.models.res_users import check_identity
+
+
+class User(models.Model):
+    _inherit = 'res.users'
+
+    @check_identity
+    def preference_calendar_subscribe(self):
+        base_url = self.get_base_url()
+        key = self.env['res.users.apikeys']._generate('calendar.ics', 'Calendar Subscription')
+        return {
+            'context': {
+                'calendar_url': f"{base_url}/calendar.ics?key={key}",
+            },
+            'tag': 'calendar_subscribe',
+            'target': 'new',
+            'type': 'ir.actions.client',
+        }
+
+    def _get_ics_domain(self, lower_bound=False, upper_bound=False):
+        get_param = self.env['ir.config_parameter'].sudo().get_param
+        if not lower_bound:
+            days = int(get_param('calendar.ics.lower_bound', default=30))
+            lower_bound = fields.Datetime.subtract(fields.Datetime.now(), days=days)
+        if not upper_bound:
+            days = int(get_param('calendar.ics.upper_bound', default=90))
+            upper_bound = fields.Datetime.add(fields.Datetime.now(), days=days)
+        # FIXME DRY google_calendar, microsoft_calendar
+        return [
+            ('partner_ids.user_ids', 'in', self.env.user.id),
+            ('stop', '>', lower_bound),
+            ('start', '<', upper_bound),
+            # Do not sync events that follow the recurrence, they are already synced at recurrence creation
+            '!', '&', '&', ('recurrency', '=', True), ('recurrence_id', '!=', False), ('follow_recurrence', '=', True)
+        ]

--- a/addons/calendar_ical/static/src/js/calendar_ical.js
+++ b/addons/calendar_ical/static/src/js/calendar_ical.js
@@ -1,0 +1,23 @@
+odoo.define("calendar_ical.CalendarSubscribe", function (require) {
+    "use strict";
+
+    const AbstractAction = require("web.AbstractAction");
+    const core = require("web.core");
+
+    const CalendarSubscribe = AbstractAction.extend({
+        template: "calendar_ical.CalendarSubscribe",
+
+        /**
+         * @override
+         */
+        init: function (parent, action) {
+            action.name = "Subscribe to Calendar"
+            this._super(...arguments);
+            this.calendar_url = action.context.calendar_url;
+        },
+    });
+
+    core.action_registry.add("calendar_subscribe", CalendarSubscribe);
+
+    return CalendarSubscribe;
+});

--- a/addons/calendar_ical/static/src/xml/calendar_ical_templates.xml
+++ b/addons/calendar_ical/static/src/xml/calendar_ical_templates.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <form t-name="calendar_ical.CalendarSubscribe" name="calendar_subscribe" method="POST" aria-atomic="true">
+        <div class="o_form_view">
+            Google
+            <ol>
+                <li>Click the "+" to the right of "Other calendars"</li>
+                <li>Select "From URL"</li>
+                <li>This URL grants access to your calendar. Do not write it down or share it.</li>
+                <li>Set URL of Calendar to <a t-att-href="widget.calendar_url" t-esc="widget.calendar_url"/></li>
+                <li><b>DO NOT</b> "Make the calendar publicly accessible"</li>
+                <li>Select "Add calendar"</li>
+            </ol>
+            Apple
+            <ol>
+                <li>Open the Calendar app on your iPhone</li>
+                <li>Select "Calendars"</li>
+                <li>Select "Add Calendar", then "Add Subscription Calendar"</li>
+                <li>Set Subscription URL to <a t-att-href="widget.calendar_url" t-esc="widget.calendar_url"/></li>
+                <li>Select "Subscribe"</li>
+            </ol>
+        </div>
+    </form>
+</templates>

--- a/addons/calendar_ical/tests/__init__.py
+++ b/addons/calendar_ical/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_calendar_ics

--- a/addons/calendar_ical/tests/test_calendar_ics.py
+++ b/addons/calendar_ical/tests/test_calendar_ics.py
@@ -1,0 +1,26 @@
+from odoo.tests import HttpCase
+
+
+class TestCalendarICS(HttpCase):
+    def setUp(self):
+        super().setUp()
+        user = self.env.ref('base.user_admin')
+        self.key = self.env['res.users.apikeys'].with_user(user)._generate('calendar.ics', 'Calendar')
+        self.url = f"{self.base_url()}/calendar.ics"
+
+    def test_success(self):
+        response = self.opener.get(self.url, params={'key': self.key})
+        self.assertEqual(response.status_code, 200)
+        self.assertRegex(response.text, r'^BEGIN:VCALENDAR')
+
+    def test_bad_request(self):
+        response = self.opener.get(self.url)
+        self.assertEqual(response.status_code, 400)
+
+    def test_unauthorized(self):
+        response = self.opener.get(self.url, params={'key': 'bogus'})
+        self.assertEqual(response.status_code, 401)
+
+    def test_unacceptable(self):
+        response = self.opener.get(self.url, params={'key': self.key}, headers={'Accept': 'image/jpeg'})
+        self.assertEqual(response.status_code, 406)

--- a/addons/calendar_ical/views/res_users_views.xml
+++ b/addons/calendar_ical/views/res_users_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="view_users_form_simple_modif" model="ir.ui.view">
+        <field name="name">res.users.preferences.form.inherit.calendar.ical</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_form_simple_modif"/>
+        <field name="arch" type="xml">
+            <data>
+                <button name="preference_change_password" position="after">
+                    <button name="preference_calendar_subscribe" type="object" string="Subscribe to Calendar" class="btn-secondary"/>
+                </button>
+            </data>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

There is no way for a user to synchronize their calendar directly from Odoo.

### Current behavior before PR:

Two-way CalDAV synchronization was retired in OpenERP 7?

### Desired behavior after PR is merged:

One-way read-only iCalendar synchronization from Odoo using a specially crafted URL containing a res.users.apikeys value. Calendar key setup has been added to account security tab in user preferences.

<img width="315" alt="Screenshot 2023-04-20 at 2 23 13 PM" src="https://user-images.githubusercontent.com/495315/233454443-01a9eb56-55f7-4ed4-b520-668c7cac76b9.png">
<img width="759" alt="Screenshot 2023-04-20 at 2 23 43 PM" src="https://user-images.githubusercontent.com/495315/233454554-f5f22777-e88c-443f-a5bd-9a9bf1ad9ce5.png">

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
