### PR TITLE
[FIX] mail: prevent the creation of unreachable next activity

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -307,8 +307,7 @@ class MailActivity(models.Model):
                     target_user = activity.user_id
                     target_record = self.env[activity.res_model].browse(activity.res_id)
                     if hasattr(target_record, 'company_id') and (
-                        target_record.company_id != target_user.company_id and (
-                            len(target_user.sudo().company_ids) > 1)):
+                        target_record.company_id in target_user.sudo().company_ids):
                         return  # in that case we skip the check, assuming it would fail because of the company
                     model.browse(activity.res_id).check_access_rule('read')
                 except exceptions.AccessError:


### PR DESCRIPTION
User A has access to company 1, 2
User B has access to companies 1, 2, 3

Create an activity type linked to employee model, set User A in default user.

With User B, create an employee in company 3.
Schedule an activity with type created above, it will set it by default to user A.
Save -> no "UserError", the activity is created while the concerned user cannot see the record.

Description of the issue/feature this PR addresses:
opw-2262765

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
