### PR TITLE
Master pos fix indeterministic tests jcb

### DIFF
--- a/addons/point_of_sale/static/src/js/Popups/SelectionPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/SelectionPopup.js
@@ -1,4 +1,4 @@
-odoo.define('point_of_sale.SelectionPopup', function(require) {
+odoo.define('point_of_sale.SelectionPopup', function (require) {
     'use strict';
 
     const { useState } = owl.hooks;
@@ -26,16 +26,10 @@ odoo.define('point_of_sale.SelectionPopup', function(require) {
          */
         constructor() {
             super(...arguments);
-            this.list = useState([...this.props.list]);
+            this.state = useState({ selectedId: this.props.list.find((item) => item.isSelected) });
         }
         selectItem(itemId) {
-            for (let item of this.list) {
-                if (item.id === itemId) {
-                    item.isSelected = true;
-                } else {
-                    item.isSelected = false;
-                }
-            }
+            this.state.selectedId = itemId;
             this.confirm();
         }
         /**
@@ -44,7 +38,7 @@ odoo.define('point_of_sale.SelectionPopup', function(require) {
          * @override
          */
         getPayload() {
-            const selected = this.props.list.find(item => item.isSelected);
+            const selected = this.props.list.find((item) => this.state.selectedId === item.id);
             return selected && selected.item;
         }
     }

--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/NumpadWidget.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/NumpadWidget.js
@@ -1,23 +1,27 @@
-odoo.define('point_of_sale.NumpadWidget', function(require) {
+odoo.define('point_of_sale.NumpadWidget', function (require) {
     'use strict';
 
-    const { useState } = owl;
     const PosComponent = require('point_of_sale.PosComponent');
     const Registries = require('point_of_sale.Registries');
 
     /**
+     * @prop {'quantiy' | 'price' | 'discount'} activeMode
+     * @event set-numpad-mode - triggered when mode button is clicked
+     * @event numpad-click-input - triggered when numpad button is clicked
+     *
      * IMPROVEMENT: Whenever new-orderline-selected is triggered,
-     * numpad mode should be set to 'quantity'.
+     * numpad mode should be set to 'quantity'. Now that the mode state
+     * is lifted to the parent component, this improvement can be done in
+     * the parent component.
      */
     class NumpadWidget extends PosComponent {
-        constructor() {
-            super(...arguments);
-            this.state = useState({ mode: 'quantity' });
-        }
         mounted() {
+            // IMPROVEMENT: This listener shouldn't be here because in core point_of_sale
+            // there is no way of changing the cashier. Only when pos_hr is installed
+            // that this listener makes sense.
             this.env.pos.on('change:cashier', () => {
-                if (!this.hasPriceControlRights && this.state.mode === 'price') {
-                    this.state.mode = 'quantity';
+                if (!this.hasPriceControlRights && this.props.activeMode === 'price') {
+                    this.trigger('set-numpad-mode', { mode: 'quantity' });
                 }
             });
         }
@@ -32,7 +36,6 @@ odoo.define('point_of_sale.NumpadWidget', function(require) {
             if (!this.hasPriceControlRights && mode === 'price') {
                 return;
             }
-            this.state.mode = mode;
             this.trigger('set-numpad-mode', { mode });
         }
         sendInput(key) {

--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
@@ -6,6 +6,7 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
     const { useListener } = require('web.custom_hooks');
     const Registries = require('point_of_sale.Registries');
     const { onChangeOrder, useBarcodeReader } = require('point_of_sale.custom_hooks');
+    const { useState } = owl.hooks;
 
     class ProductScreen extends PosComponent {
         constructor() {
@@ -30,7 +31,7 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
                 triggerAtInput: 'update-selected-orderline',
                 useWithBarcode: true,
             });
-            this.numpadMode = 'quantity';
+            this.state = useState({ numpadMode: 'quantity' });
             this.mobile_pane = this.props.mobile_pane || 'right';
         }
         mounted() {
@@ -134,11 +135,11 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
         }
         async _setNumpadMode(event) {
             const { mode } = event.detail;
-            this.numpadMode = mode;
+            this.state.numpadMode = mode;
             NumberBuffer.reset();
         }
         async _updateSelectedOrderline(event) {
-            if(this.numpadMode === 'quantity' && this.env.pos.disallowLineQuantityChange()) {
+            if(this.state.numpadMode === 'quantity' && this.env.pos.disallowLineQuantityChange()) {
                 let order = this.env.pos.get_order();
                 let selectedLine = order.get_selected_orderline();
                 let lastId = order.orderlines.last().cid;
@@ -168,11 +169,11 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
         }
         _setValue(val) {
             if (this.currentOrder.get_selected_orderline()) {
-                if (this.numpadMode === 'quantity') {
+                if (this.state.numpadMode === 'quantity') {
                     this.currentOrder.get_selected_orderline().set_quantity(val);
-                } else if (this.numpadMode === 'discount') {
+                } else if (this.state.numpadMode === 'discount') {
                     this.currentOrder.get_selected_orderline().set_discount(val);
-                } else if (this.numpadMode === 'price') {
+                } else if (this.state.numpadMode === 'price') {
                     var selected_orderline = this.currentOrder.get_selected_orderline();
                     selected_orderline.price_manually_set = true;
                     selected_orderline.set_unit_price(val);

--- a/addons/point_of_sale/static/src/js/Screens/ScaleScreen/ScaleScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ScaleScreen/ScaleScreen.js
@@ -17,8 +17,11 @@ odoo.define('point_of_sale.ScaleScreen', function(require) {
             this.state = useState({ weight: 0 });
         }
         mounted() {
-            // start the scale reading
-            this._readScale();
+            // start a continuous scale reading
+            this.env.pos.proxy_queue.schedule(this._setWeight.bind(this), {
+                duration: 500,
+                repeat: true,
+            });
         }
         willUnmount() {
             // stop the scale reading
@@ -41,12 +44,6 @@ odoo.define('point_of_sale.ScaleScreen', function(require) {
             } else if (event.key === 'Enter') {
                 this.confirm();
             }
-        }
-        _readScale() {
-            this.env.pos.proxy_queue.schedule(this._setWeight.bind(this), {
-                duration: 500,
-                repeat: true,
-            });
         }
         async _setWeight() {
             const reading = await this.env.pos.proxy.scale_read();

--- a/addons/point_of_sale/static/src/xml/Popups/SelectionPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/SelectionPopup.xml
@@ -9,7 +9,7 @@
                         <t t-esc="props.title" />
                     </header>
                     <div class="selection scrollable-y touch-scrollable">
-                        <t t-foreach="props.list" t-as="item" t-key="item._id">
+                        <t t-foreach="props.list" t-as="item" t-key="item.id">
                             <div class="selection-item" t-att-class="{ selected: item.isSelected }"
                                  t-on-click="selectItem(item.id)">
                                 <t t-esc="item.label" />

--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/NumpadWidget.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/NumpadWidget.xml
@@ -6,20 +6,20 @@
             <button class="input-button number-char" t-on-click="sendInput('1')">1</button>
             <button class="input-button number-char" t-on-click="sendInput('2')">2</button>
             <button class="input-button number-char" t-on-click="sendInput('3')">3</button>
-            <button class="mode-button" t-att-class="{'selected-mode': state.mode === 'quantity'}"
+            <button class="mode-button" t-att-class="{'selected-mode': props.activeMode === 'quantity'}"
                     t-on-click="changeMode('quantity')">Qty</button>
             <br />
             <button class="input-button number-char" t-on-click="sendInput('4')">4</button>
             <button class="input-button number-char" t-on-click="sendInput('5')">5</button>
             <button class="input-button number-char" t-on-click="sendInput('6')">6</button>
-            <button class="mode-button" t-att-class="{'selected-mode': state.mode === 'discount'}"
+            <button class="mode-button" t-att-class="{'selected-mode': props.activeMode === 'discount'}"
                     t-on-click="changeMode('discount')">Disc</button>
             <br />
             <button class="input-button number-char" t-on-click="sendInput('7')">7</button>
             <button class="input-button number-char" t-on-click="sendInput('8')">8</button>
             <button class="input-button number-char" t-on-click="sendInput('9')">9</button>
             <button class="mode-button" t-att-class="{
-                    'selected-mode': state.mode === 'price',
+                    'selected-mode': props.activeMode === 'price',
                     'disabled-mode': !hasPriceControlRights
                 }" t-att-disabled="!hasPriceControlRights"
                     t-on-click="changeMode('price')">Price</button>

--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ProductScreen.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ProductScreen.xml
@@ -14,7 +14,7 @@
                         </div>
                         <div class="subpads">
                             <ActionpadWidget client="client"/>
-                            <NumpadWidget />
+                            <NumpadWidget activeMode="state.numpadMode" />
                         </div>
                     </div>
                     <t t-if="env.isMobile">

--- a/addons/point_of_sale/static/tests/tours/Chrome.tour.js
+++ b/addons/point_of_sale/static/tests/tours/Chrome.tour.js
@@ -12,19 +12,21 @@ odoo.define('point_of_sale.tour.Chrome', function (require) {
 
     // Order 1 is at Product Screen
     ProductScreen.do.clickHomeCategory();
-    ProductScreen.exec.order('Desk Pad', '1', '2');
+    ProductScreen.exec.order('Desk Pad', '1', '2', '2.0');
 
     // Order 2 is at Payment Screen
     Chrome.do.newOrder();
-    ProductScreen.exec.order('Monitor Stand', '3', '4');
+    ProductScreen.exec.order('Monitor Stand', '3', '4', '12.0');
     ProductScreen.do.clickPayButton();
     PaymentScreen.check.isShown();
 
     // Order 3 is at Receipt Screen
     Chrome.do.newOrder();
-    ProductScreen.exec.order('Whiteboard Pen', '5', '6');
+    ProductScreen.exec.order('Whiteboard Pen', '5', '6', '30.0');
     ProductScreen.do.clickPayButton();
     PaymentScreen.do.clickPaymentMethod('Bank');
+    PaymentScreen.check.remainingIs('0.0');
+    PaymentScreen.check.validateButtonIsHighlighted(true);
     PaymentScreen.do.clickValidate();
     ReceiptScreen.check.isShown();
 
@@ -47,6 +49,8 @@ odoo.define('point_of_sale.tour.Chrome', function (require) {
     ProductScreen.do.clickPayButton();
     PaymentScreen.do.clickPaymentMethod('Cash');
     PaymentScreen.do.pressNumpad('2 0');
+    PaymentScreen.check.remainingIs('0.0');
+    PaymentScreen.check.validateButtonIsHighlighted(true);
     PaymentScreen.do.clickValidate();
     ReceiptScreen.check.changeIs('18.0');
 

--- a/addons/point_of_sale/static/tests/tours/PaymentScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/PaymentScreen.tour.js
@@ -9,6 +9,7 @@ odoo.define('point_of_sale.tour.PaymentScreen', function (require) {
     startSteps();
 
     ProductScreen.exec.order('Letter Tray', '10');
+    ProductScreen.check.selectedOrderlineHas('Letter Tray', '10.0');
     ProductScreen.do.clickPayButton();
     PaymentScreen.check.emptyPaymentlines('52.8');
 
@@ -19,7 +20,9 @@ odoo.define('point_of_sale.tour.PaymentScreen', function (require) {
     PaymentScreen.check.changeIs('0.0');
     PaymentScreen.check.validateButtonIsHighlighted(false);
     // remove the selected paymentline with multiple backspace presses
-    PaymentScreen.do.pressNumpad('Backspace Backspace Backspace');
+    PaymentScreen.do.pressNumpad('Backspace Backspace');
+    PaymentScreen.check.selectedPaymentlineHas('Cash', '0.00');
+    PaymentScreen.do.pressNumpad('Backspace');
     PaymentScreen.check.emptyPaymentlines('52.8');
 
     // Pay with bank, the selected line should have full amount

--- a/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
@@ -27,6 +27,7 @@ odoo.define('point_of_sale.tour.ProductScreen', function (require) {
 
     // Check effects of clicking numpad buttons
     ProductScreen.do.clickOrderline('Letter Tray', '1');
+    ProductScreen.check.selectedOrderlineHas('Letter Tray', '1.0');
     ProductScreen.do.pressNumpad('Backspace');
     ProductScreen.check.selectedOrderlineHas('Letter Tray', '0.0', '0.0');
     ProductScreen.do.pressNumpad('Backspace');
@@ -46,10 +47,10 @@ odoo.define('point_of_sale.tour.ProductScreen', function (require) {
     ProductScreen.do.pressNumpad('Price');
     ProductScreen.do.pressNumpad('1');
     ProductScreen.check.selectedOrderlineHas('Desk Organizer', '123.5', '123.5');
-    ProductScreen.do.pressNumpad('1 . 0');
+    ProductScreen.do.pressNumpad('1 .');
     ProductScreen.check.selectedOrderlineHas('Desk Organizer', '123.5', '1,358.5');
     ProductScreen.do.pressNumpad('Disc');
-    ProductScreen.do.pressNumpad('5 . 0');
+    ProductScreen.do.pressNumpad('5 .');
     ProductScreen.check.selectedOrderlineHas('Desk Organizer', '123.5', '1,290.58');
     ProductScreen.do.pressNumpad('Qty');
     ProductScreen.do.pressNumpad('Backspace');
@@ -76,22 +77,29 @@ odoo.define('point_of_sale.tour.ProductScreen', function (require) {
     ProductScreen.do.clickOrderline('Whiteboard Pen', '1.0');
     ProductScreen.check.selectedOrderlineHas('Whiteboard Pen', '1.0');
     ProductScreen.do.pressNumpad('Backspace');
+    ProductScreen.check.selectedOrderlineHas('Whiteboard Pen', '0.0');
     ProductScreen.do.pressNumpad('Backspace');
+    ProductScreen.check.selectedOrderlineHas('Monitor Stand', '1.0');
     ProductScreen.do.clickOrderline('Wall Shelf Unit', '1.0');
     ProductScreen.check.selectedOrderlineHas('Wall Shelf Unit', '1.0');
     ProductScreen.do.pressNumpad('Backspace');
+    ProductScreen.check.selectedOrderlineHas('Wall Shelf Unit', '0.0');
     ProductScreen.do.pressNumpad('Backspace');
+    ProductScreen.check.selectedOrderlineHas('Monitor Stand', '1.0');
     ProductScreen.do.clickOrderline('Small Shelf', '1.0');
     ProductScreen.check.selectedOrderlineHas('Small Shelf', '1.0');
     ProductScreen.do.pressNumpad('Backspace');
+    ProductScreen.check.selectedOrderlineHas('Small Shelf', '0.0');
     ProductScreen.do.pressNumpad('Backspace');
+    ProductScreen.check.selectedOrderlineHas('Monitor Stand', '1.0');
     ProductScreen.do.clickOrderline('Magnetic Board', '1.0');
     ProductScreen.check.selectedOrderlineHas('Magnetic Board', '1.0');
     ProductScreen.do.pressNumpad('Backspace');
+    ProductScreen.check.selectedOrderlineHas('Magnetic Board', '0.0');
     ProductScreen.do.pressNumpad('Backspace');
-    // Monitor Stand should be automatically selected at this point
     ProductScreen.check.selectedOrderlineHas('Monitor Stand', '1.0');
     ProductScreen.do.pressNumpad('Backspace');
+    ProductScreen.check.selectedOrderlineHas('Monitor Stand', '0.0');
     ProductScreen.do.pressNumpad('Backspace');
     ProductScreen.check.orderIsEmpty();
 

--- a/addons/point_of_sale/static/tests/tours/ReceiptScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/ReceiptScreen.tour.js
@@ -11,8 +11,10 @@ odoo.define('point_of_sale.tour.ReceiptScreen', function (require) {
 
     // pay exact amount
     ProductScreen.exec.order('Letter Tray', '10');
+    ProductScreen.check.selectedOrderlineHas('Letter Tray', '10');
     ProductScreen.do.clickPayButton();
     PaymentScreen.do.clickPaymentMethod('Bank');
+    PaymentScreen.check.validateButtonIsHighlighted(true);
     PaymentScreen.do.clickValidate();
     ReceiptScreen.check.receiptIsThere();
     ReceiptScreen.check.changeIs('0.00');
@@ -20,15 +22,19 @@ odoo.define('point_of_sale.tour.ReceiptScreen', function (require) {
 
     // pay more than total price
     ProductScreen.do.clickHomeCategory();
-    ProductScreen.exec.order('Desk Pad', '6', '5.0');
-    ProductScreen.exec.order('Whiteboard Pen', '6', '6.1');
-    ProductScreen.exec.order('Monitor Stand', '6', '1.3');
+    ProductScreen.exec.order('Desk Pad', '6', '5', '30.0');
+    ProductScreen.exec.order('Whiteboard Pen', '6', '6', '36.0');
+    ProductScreen.exec.order('Monitor Stand', '6', '1', '6.0');
     ProductScreen.do.clickPayButton();
     PaymentScreen.do.clickPaymentMethod('Cash');
-    PaymentScreen.do.pressNumpad('8 0 0');
+    PaymentScreen.do.pressNumpad('7 0');
+    PaymentScreen.check.remainingIs('2.0');
+    PaymentScreen.do.pressNumpad('0');
+    PaymentScreen.check.remainingIs('0.00');
+    PaymentScreen.check.changeIs('628.0');
     PaymentScreen.do.clickValidate();
     ReceiptScreen.check.receiptIsThere();
-    ReceiptScreen.check.changeIs('725.6');
+    ReceiptScreen.check.changeIs('628.0');
     ReceiptScreen.do.clickNextOrder();
 
     Tour.register('ReceiptScreenTour', { test: true, url: '/pos/web' }, getSteps());

--- a/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
@@ -147,15 +147,41 @@ odoo.define('point_of_sale.tour.ProductScreenTourMethods', function (require) {
                 },
             ];
         }
+
+        modeIsActive(mode) {
+            return [
+                {
+                    content: `'${mode}' is active`,
+                    trigger: `.numpad button.selected-mode:contains('${mode}')`,
+                    run: function () {},
+                },
+            ];
+        }
     }
 
     class Execute {
-        order(productName, quantity, price) {
+        /**
+         * Create an orderline for the given `productName` and `quantity`.
+         * - If `unitPrice` is provided, price of the product of the created line
+         *   is changed to that value.
+         * - If `expectedTotal` is provided, the created orderline (which is the currently
+         *   selected orderline) is checked if it contains the correct quantity and total
+         *   price.
+         *
+         * @param {string} productName
+         * @param {string} quantity
+         * @param {string} unitPrice
+         * @param {string} expectedTotal
+         */
+        order(productName, quantity, unitPrice = undefined, expectedTotal = undefined) {
             const res = this._do.clickDisplayedProduct(productName);
-            if (price) {
+            if (unitPrice) {
                 res.push(...this._do.pressNumpad('Price'));
-                res.push(...this._do.pressNumpad(price.toString().split('').join(' ')));
+                res.push(...this._check.modeIsActive('Price'));
+                res.push(...this._do.pressNumpad(unitPrice.toString().split('').join(' ')));
+                res.push(...this._check.selectedOrderlineHas(productName, '1.0', unitPrice));
                 res.push(...this._do.pressNumpad('Qty'));
+                res.push(...this._check.modeIsActive('Qty'));
             }
             for (let char of quantity.toString()) {
                 if ('.0123456789'.includes(char)) {
@@ -163,6 +189,11 @@ odoo.define('point_of_sale.tour.ProductScreenTourMethods', function (require) {
                 } else if ('-'.includes(char)) {
                     res.push(...this._do.pressNumpad('+/-'));
                 }
+            }
+            if (expectedTotal) {
+                res.push(...this._check.selectedOrderlineHas(productName, quantity, expectedTotal));
+            } else {
+                res.push(...this._check.selectedOrderlineHas(productName, quantity));
             }
             return res;
         }

--- a/addons/point_of_sale/static/tests/tours/point_of_sale.js
+++ b/addons/point_of_sale/static/tests/tours/point_of_sale.js
@@ -152,20 +152,43 @@ odoo.define('point_of_sale.tour.pricelist', function (require) {
         content: "change qty to 2 kg",
         trigger: ".numpad button.input-button:visible:contains('2')",
     }, {
+        content: "qty of Wall Shelf line should be 2",
+        trigger: ".order-container .orderlines .orderline.selected .product-name:contains('Wall Shelf')",
+        extra_trigger: ".order-container .orderlines .orderline.selected .product-name:contains('Wall Shelf') ~ .info-list .info em:contains('2.0')",
+        run: function() {},
+    }, {
         content: "verify that unit price of shelf changed to $1",
         trigger: ".total > .value:contains('$ 2.00')",
+        run: function() {},
     }, {
         content: "order different shelf",
         trigger: ".product:contains('Small Shelf')",
     }, {
+        content: "Small Shelf line should be selected with quantity 1",
+        trigger: ".order-container .orderlines .orderline.selected .product-name:contains('Small Shelf')",
+        extra_trigger: ".order-container .orderlines .orderline.selected .product-name:contains('Small Shelf') ~ .info-list .info em:contains('1.0')",
+        run: function() {}
+    }, {
         content: "change to price mode",
         trigger: ".numpad button:contains('Price')",
+    }, {
+        content: "make sure price mode is activated",
+        trigger: ".numpad button.selected-mode:contains('Price')",
+        run: function() {},
     }, {
         content: "manually override the unit price of these shelf to $5",
         trigger: ".numpad button.input-button:visible:contains('5')",
     }, {
+        content: "Small Shelf line should be selected with unit price of 5",
+        trigger: ".order-container .orderlines .orderline.selected .product-name:contains('Small Shelf')",
+        extra_trigger: ".order-container .orderlines .orderline.selected .product-name:contains('Small Shelf') ~ .price:contains('5.0')",
+    }, {
         content: "change back to qty mode",
         trigger: ".numpad button:contains('Qty')",
+    }, {
+        content: "make sure qty mode is activated",
+        trigger: ".numpad button.selected-mode:contains('Qty')",
+        run: function() {},
     }, {
         content: "click pricelist button",
         trigger: ".control-button.o_pricelist_button",
@@ -173,8 +196,7 @@ odoo.define('point_of_sale.tour.pricelist', function (require) {
         content: "select public pricelist",
         trigger: ".selection-item:contains('Public Pricelist')",
     }, {
-        content: "verify that the boni shelf have been recomputed and the\
-shelf have not (their price was manually overridden)",
+        content: "verify that the boni shelf have been recomputed and the shelf have not (their price was manually overridden)",
         trigger: ".total > .value:contains('$ 8.96')",
     }, {
         content: "click pricelist button",
@@ -206,7 +228,7 @@ odoo.define('point_of_sale.tour.acceptance', function (require) {
         }, {
             content: 'the ' + product_name + ' have been added to the order',
             trigger: '.order .product-name:contains("' + product_name + '")',
-            run: function () {}, // it's a check
+            run: function () {},
         }];
     }
 
@@ -220,7 +242,7 @@ odoo.define('point_of_sale.tour.acceptance', function (require) {
         }, {
             content: 'the fiscal position ' + fp_name + ' has been set to the order',
             trigger: '.control-button.o_fiscal_position_button:contains("' + fp_name + '")',
-            run: function () {}, // it's a check
+            run: function () {},
         }];
     }
 
@@ -233,20 +255,49 @@ odoo.define('point_of_sale.tour.acceptance', function (require) {
                 trigger: keypad_selector + ' .input-button:contains("' + current_char + '"):visible'
             });
         }
-        steps.push({
-            content: 'do nothing check',
-            trigger: '.pos',
-            run: function () {},
-        })
         return steps;
     }
 
-    function generate_payment_screen_keypad_steps(amount_str) {
-        return generate_keypad_steps(amount_str, '.payment-numpad');
+    function press_payment_numpad(val) {
+        return [{
+            content: `press ${val} on payment screen numpad`,
+            trigger: `.payment-numpad .input-button:contains("${val}"):visible`,
+        }]
     }
 
-    function generate_product_screen_keypad_steps(amount_str) {
-        return generate_keypad_steps(amount_str, '.numpad');
+    function press_product_numpad(val) {
+        return [{
+            content: `press ${val} on product screen numpad`,
+            trigger: `.numpad .input-button:contains("${val}"):visible`,
+        }]
+    }
+
+    function selected_payment_has(name, val) {
+        return [{
+            content: `selected payment is ${name} and has ${val}`,
+            trigger: `.paymentlines .paymentline.selected .payment-name:contains("${name}")`,
+            extra_trigger: `.paymentlines .paymentline.selected .payment-name:contains("${name}") ~ .payment-amount:contains("${val}")`,
+            run: function () {},
+        }]
+    }
+
+    function selected_orderline_has({ product, price = null, quantity = null }) {
+        const result = [];
+        if (price !== null) {
+            result.push({
+                content: `Selected line has product '${product}' and price '${price}'`,
+                trigger: `.order-container .orderlines .orderline.selected .product-name:contains("${product}") ~ span.price:contains("${price}")`,
+                run: function () {},
+            });
+        }
+        if (quantity !== null) {
+            result.push({
+                content: `Selected line has product '${product}' and quantity '${quantity}'`,
+                trigger: `.order-container .orderlines .orderline.selected .product-name:contains('${product}') ~ .info-list .info em:contains('${quantity}')`,
+                run: function () {},
+            });
+        }
+        return result;
     }
 
     function verify_order_total(total_str) {
@@ -287,7 +338,7 @@ odoo.define('point_of_sale.tour.acceptance', function (require) {
         }, {
             content: "check if customer is set",
             trigger: 'span.js_customer_name:contains("TEST PARTNER")',
-            run: function () {}, // it's a check
+            run: function () {},
         }, {
             // sending email should be checked in different test
             content: "deactivate email",
@@ -306,7 +357,7 @@ odoo.define('point_of_sale.tour.acceptance', function (require) {
         }, {
             content: "verify that the order has been successfully sent to the backend",
             trigger: ".js_connected:visible",
-            run: function () {}, // it's a check
+            run: function () {},
         }, {
             content: "click Next Order",
             trigger: '.receipt-screen .button.next.highlight:visible',
@@ -320,11 +371,10 @@ odoo.define('point_of_sale.tour.acceptance', function (require) {
     var steps = [{
             content: 'waiting for loading to finish',
             trigger: 'body:not(:has(.loader))',
-            run: function () {}, // it's a check
+            run: function () {},
         }, { // Leave category displayed by default
             content: "click category switch",
             trigger: ".breadcrumb-home",
-            run: 'click',
         }];
 
     steps = steps.concat(add_product_to_order('Desk Organizer'));
@@ -342,15 +392,16 @@ odoo.define('point_of_sale.tour.acceptance', function (require) {
             remaining := 0.00
             change := 1.50
     */
-    steps = steps.concat(generate_payment_screen_keypad_steps("5.20"));
+    steps = steps.concat(press_payment_numpad('5'));
+    steps = steps.concat(selected_payment_has('Cash', '5.0'));
     steps = steps.concat([{
         content: "verify remaining",
-        trigger: '.payment-status-remaining .amount:contains("5.00")',
-        run: function () {}, // it's a check
+        trigger: '.payment-status-remaining .amount:contains("5.20")',
+        run: function () {},
     }, {
         content: "verify change",
         trigger: '.payment-status-change .amount:contains("0.00")',
-        run: function () {}, // it's a check
+        run: function () {},
     }]);
 
     /*  make additional payment line of 6.50
@@ -365,16 +416,17 @@ odoo.define('point_of_sale.tour.acceptance', function (require) {
         content: "pay with cash",
         trigger: '.paymentmethod:contains("Cash")',
     }]);
-    steps = steps.concat(generate_payment_screen_keypad_steps("6.50"));
-
+    steps = steps.concat(selected_payment_has('Cash', '5.2'));
+    steps = steps.concat(press_payment_numpad('6'))
+    steps = steps.concat(selected_payment_has('Cash', '6.0'));
     steps = steps.concat([{
         content: "verify remaining",
         trigger: '.payment-status-remaining .amount:contains("0.00")',
-        run: function () {}, // it's a check
+        run: function () {},
     }, {
         content: "verify change",
-        trigger: '.payment-status-change .amount:contains("1.50")',
-        run: function () {}, // it's a check
+        trigger: '.payment-status-change .amount:contains("0.80")',
+        run: function () {},
     }]);
 
     steps = steps.concat(activate_email_and_select_a_customer_then_deactivate_email());
@@ -382,14 +434,22 @@ odoo.define('point_of_sale.tour.acceptance', function (require) {
 
     // test opw-672118 orderline subtotal rounding
     steps = steps.concat(add_product_to_order('Desk Organizer'));
-    steps = steps.concat(generate_product_screen_keypad_steps('.999')); // sets orderline qty
-    steps = steps.concat(verify_order_total('5.09'));
+    steps = steps.concat(selected_orderline_has({product: 'Desk Organizer', quantity: '1.0'}));
+    steps = steps.concat(press_product_numpad('.'))
+    steps = steps.concat(selected_orderline_has({product: 'Desk Organizer', quantity: '0.0', price: '0.0'}));
+    steps = steps.concat(press_product_numpad('9'))
+    steps = steps.concat(selected_orderline_has({product: 'Desk Organizer', quantity: '0.9', price: '4.59'}));
+    steps = steps.concat(press_product_numpad('9'))
+    steps = steps.concat(selected_orderline_has({product: 'Desk Organizer', quantity: '0.99', price: '5.05'}));
+    steps = steps.concat(press_product_numpad('9'))
+    steps = steps.concat(selected_orderline_has({product: 'Desk Organizer', quantity: '0.999', price: '5.09'}));
     steps = steps.concat(goto_payment_screen_and_select_payment_method());
-    steps = steps.concat(generate_payment_screen_keypad_steps("10"));
+    steps = steps.concat(selected_payment_has('Cash', '5.09'));
     steps = steps.concat(finish_order());
 
     // Test fiscal position one2many map (align with backend)
     steps = steps.concat(add_product_to_order('Letter Tray'));
+    steps = steps.concat(selected_orderline_has({product: 'Letter Tray', quantity: '1.0'}));
     steps = steps.concat(verify_order_total('5.28'));
     steps = steps.concat(set_fiscal_position_on_order('FP-POS-2M'));
     steps = steps.concat(verify_order_total('5.52'));

--- a/addons/point_of_sale/static/tests/unit/test_ProductScreen.js
+++ b/addons/point_of_sale/static/tests/unit/test_ProductScreen.js
@@ -65,15 +65,17 @@ odoo.define('point_of_sale.tests.ProductScreen', function (require) {
     });
 
     QUnit.test('NumpadWidget', async function (assert) {
-        assert.expect(23);
+        assert.expect(25);
 
         class Parent extends PosComponent {
             constructor() {
                 super(...arguments);
                 useListener('set-numpad-mode', this.setNumpadMode);
                 useListener('numpad-click-input', this.numpadClickInput);
+                this.state = useState({ mode: 'quantity' });
             }
             setNumpadMode({ detail: { mode } }) {
+                this.state.mode = mode;
                 assert.step(mode);
             }
             numpadClickInput({ detail: { key } }) {
@@ -82,7 +84,7 @@ odoo.define('point_of_sale.tests.ProductScreen', function (require) {
         }
         Parent.env = makePosTestEnv();
         Parent.template = xml/* html */ `
-            <div><NumpadWidget></NumpadWidget></div>
+            <div><NumpadWidget activeMode="state.mode"></NumpadWidget></div>
         `;
 
         const pos = Parent.env.pos;
@@ -161,6 +163,10 @@ odoo.define('point_of_sale.tests.ProductScreen', function (require) {
 
         assert.ok(priceButton.classList.contains('disabled-mode'));
         assert.ok(qtyButton.classList.contains('selected-mode'));
+        // after the cashier is changed, since it is not a manager,
+        // the 'set-numpad-mode' is triggered, setting the mode to
+        // 'quantity'.
+        assert.verifySteps(['quantity']);
 
         // reset old config and cashier values to pos
         pos.config = old_config;

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -416,12 +416,12 @@ class TestUi(TestPointOfSaleHttpCommon):
         # this you end up with js, css but no qweb.
         self.env['ir.module.module'].search([('name', '=', 'point_of_sale')], limit=1).state = 'installed'
 
-        self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, 'pos_pricelist', login="admin", step_delay=50)
-        self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, 'pos_basic_order', login="admin", step_delay=50)
-        self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, 'ProductScreenTour', login="admin", step_delay=50)
-        self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, 'PaymentScreenTour', login="admin", step_delay=50)
-        self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, 'ReceiptScreenTour', login="admin", step_delay=50)
-        self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, 'ChromeTour', login="admin", step_delay=50)
+        self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, 'pos_pricelist', login="admin")
+        self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, 'pos_basic_order', login="admin")
+        self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, 'ProductScreenTour', login="admin")
+        self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, 'PaymentScreenTour', login="admin")
+        self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, 'ReceiptScreenTour', login="admin")
+        self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, 'ChromeTour', login="admin")
 
         for order in self.env['pos.order'].search([]):
             self.assertEqual(order.state, 'paid', "Validated order has payment of " + str(order.amount_paid) + " and total of " + str(order.amount_total))

--- a/addons/pos_hr/static/tests/tours/PosHrTour.js
+++ b/addons/pos_hr/static/tests/tours/PosHrTour.js
@@ -19,7 +19,9 @@ odoo.define('point_of_sale.tour.PosHr', function (require) {
     SelectionPopup.check.hasSelectionItem('Mitchell Admin');
     SelectionPopup.do.clickItem('Pos Employee1');
     NumberPopup.check.isShown();
-    NumberPopup.do.pressNumpad('2 5 8 1');
+    NumberPopup.do.pressNumpad('2 5');
+    NumberPopup.check.inputShownIs('••');
+    NumberPopup.do.pressNumpad('8 1');
     NumberPopup.check.inputShownIs('••••');
     NumberPopup.do.clickConfirm();
     ErrorPopup.check.isShown();
@@ -27,7 +29,9 @@ odoo.define('point_of_sale.tour.PosHr', function (require) {
     PosHr.do.clickLoginButton();
     SelectionPopup.do.clickItem('Pos Employee1');
     NumberPopup.check.isShown();
-    NumberPopup.do.pressNumpad('2 5 8 0');
+    NumberPopup.do.pressNumpad('2 5');
+    NumberPopup.check.inputShownIs('••');
+    NumberPopup.do.pressNumpad('8 0');
     NumberPopup.check.inputShownIs('••••');
     NumberPopup.do.clickConfirm();
     ProductScreen.check.isShown();
@@ -36,7 +40,13 @@ odoo.define('point_of_sale.tour.PosHr', function (require) {
     SelectionPopup.do.clickItem('Mitchell Admin');
     PosHr.check.cashierNameIs('Mitchell Admin');
     PosHr.do.clickLockButton();
-    PosHr.exec.login('Pos Employee2', '1234');
+    PosHr.do.clickLoginButton();
+    SelectionPopup.do.clickItem('Pos Employee2');
+    NumberPopup.do.pressNumpad('1 2');
+    NumberPopup.check.inputShownIs('••');
+    NumberPopup.do.pressNumpad('3 4');
+    NumberPopup.check.inputShownIs('••••');
+    NumberPopup.do.clickConfirm();
     ProductScreen.check.isShown();
 
     Tour.register('PosHrTour', { test: true, url: '/pos/web' }, getSteps());

--- a/addons/pos_hr/tests/test_frontend.py
+++ b/addons/pos_hr/tests/test_frontend.py
@@ -50,5 +50,4 @@ class TestUi(TestPosHrHttpCommon):
             "/pos/web?config_id=%d" % self.main_pos_config.id,
             "PosHrTour",
             login="admin",
-            step_delay=50,
         )

--- a/addons/pos_restaurant/static/src/js/Screens/FloorScreen/FloorScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/FloorScreen/FloorScreen.js
@@ -87,17 +87,18 @@ odoo.define('pos_restaurant.FloorScreen', function (require) {
             }
         }
         async _changeSeatsNum() {
-            if (!this.selectedTable) return;
+            const selectedTable = this.selectedTable
+            if (!selectedTable) return;
             const { confirmed, payload: inputNumber } = await this.showPopup('NumberPopup', {
-                startingValue: this.selectedTable.seats,
+                startingValue: selectedTable.seats,
                 cheap: true,
                 title: this.env._t('Number of Seats ?'),
             });
             if (!confirmed) return;
-            const newSeatsNum = parseInt(inputNumber, 10) || this.selectedTable.seats;
-            if (newSeatsNum !== this.selectedTable.seats) {
-                this.selectedTable.seats = newSeatsNum;
-                await this._save(this.selectedTable);
+            const newSeatsNum = parseInt(inputNumber, 10) || selectedTable.seats;
+            if (newSeatsNum !== selectedTable.seats) {
+                selectedTable.seats = newSeatsNum;
+                await this._save(selectedTable);
             }
         }
         async _changeShape() {
@@ -107,15 +108,16 @@ odoo.define('pos_restaurant.FloorScreen', function (require) {
             await this._save(this.selectedTable);
         }
         async _renameTable() {
-            if (!this.selectedTable) return;
+            const selectedTable = this.selectedTable;
+            if (!selectedTable) return;
             const { confirmed, payload: newName } = await this.showPopup('TextInputPopup', {
-                startingValue: this.selectedTable.name,
+                startingValue: selectedTable.name,
                 title: this.env._t('Table Name ?'),
             });
             if (!confirmed) return;
-            if (newName !== this.selectedTable.name) {
-                this.selectedTable.name = newName;
-                await this._save(this.selectedTable);
+            if (newName !== selectedTable.name) {
+                selectedTable.name = newName;
+                await this._save(selectedTable);
             }
         }
         async _setTableColor({ detail: color }) {

--- a/addons/pos_restaurant/static/tests/tours/ControlButtons.tour.js
+++ b/addons/pos_restaurant/static/tests/tours/ControlButtons.tour.js
@@ -16,16 +16,16 @@ odoo.define('pos_restaurant.tour.ControlButtons', function (require) {
 
     // Test TransferOrderButton
     FloorScreen.do.clickTable('T2');
-    ProductScreen.exec.order('Water', '5.0', '2.0');
+    ProductScreen.exec.order('Water', '5', '2', '10.0');
     ProductScreen.do.clickTransferButton();
     FloorScreen.do.clickTable('T4');
-    ProductScreen.do.clickOrderline('Water', '5.0', '2.0');
+    ProductScreen.do.clickOrderline('Water', '5', '2');
     Chrome.do.backToFloor();
     FloorScreen.do.clickTable('T2');
     ProductScreen.check.orderIsEmpty();
     Chrome.do.backToFloor();
     FloorScreen.do.clickTable('T4');
-    ProductScreen.do.clickOrderline('Water', '5.0', '2.0');
+    ProductScreen.do.clickOrderline('Water', '5', '2');
 
     // Test SplitBillButton
     ProductScreen.do.clickSplitBillButton();
@@ -36,9 +36,8 @@ odoo.define('pos_restaurant.tour.ControlButtons', function (require) {
     TextAreaPopup.check.isShown();
     TextAreaPopup.do.inputText('test note');
     TextAreaPopup.do.clickConfirm();
-    ProductScreen.check.orderlineHasNote('Water', '5.0', 'test note');
-    ProductScreen.exec.order('Water', '8', '1.1');
-    ProductScreen.check.selectedOrderlineHas('Water', '8', '8.80');
+    ProductScreen.check.orderlineHasNote('Water', '5', 'test note');
+    ProductScreen.exec.order('Water', '8', '1', '8.0');
 
     // Test PrintBillButton
     ProductScreen.do.clickPrintBillButton();

--- a/addons/pos_restaurant/static/tests/tours/FloorScreen.tour.js
+++ b/addons/pos_restaurant/static/tests/tours/FloorScreen.tour.js
@@ -35,6 +35,7 @@ odoo.define('pos_restaurant.tour.FloorScreen', function (require) {
     FloorScreen.do.clickFloor('Main Floor');
     FloorScreen.check.editModeIsActive(false);
     FloorScreen.do.clickEdit();
+    FloorScreen.check.editModeIsActive(true);
 
     // test add table
     FloorScreen.do.clickAddTable();
@@ -47,13 +48,18 @@ odoo.define('pos_restaurant.tour.FloorScreen', function (require) {
 
     // test duplicate table
     FloorScreen.do.clickDuplicate();
-    FloorScreen.do.clickRename();
-    TextInputPopup.do.inputText('T101');
+    // new table is already named T101
     FloorScreen.check.selectedTableIs('T101');
+    FloorScreen.do.clickRename();
+    TextInputPopup.check.isShown();
+    TextInputPopup.do.inputText('T1111');
+    TextInputPopup.do.clickConfirm();
+    FloorScreen.check.selectedTableIs('T1111');
 
     // switch floor, switch back and check if
     // the new tables are still there
     FloorScreen.do.clickFloor('Second Floor');
+    FloorScreen.check.editModeIsActive(false);
     FloorScreen.check.hasTable('T3');
     FloorScreen.check.hasTable('T1');
 
@@ -62,26 +68,31 @@ odoo.define('pos_restaurant.tour.FloorScreen', function (require) {
     FloorScreen.check.hasTable('T4');
     FloorScreen.check.hasTable('T5');
     FloorScreen.check.hasTable('T100');
-    FloorScreen.check.hasTable('T101');
+    FloorScreen.check.hasTable('T1111');
 
     // test delete table
     FloorScreen.do.clickEdit();
+    FloorScreen.check.editModeIsActive(true);
     FloorScreen.do.clickTable('T2');
+    FloorScreen.check.selectedTableIs('T2');
     FloorScreen.do.clickTrash();
     Chrome.do.confirmPopup();
 
     // change number of seats
     FloorScreen.do.clickTable('T4');
+    FloorScreen.check.selectedTableIs('T4');
     FloorScreen.do.clickSeats();
-    NumberPopup.do.pressNumpad('Backspace 1 0');
+    NumberPopup.do.pressNumpad('Backspace 9');
+    NumberPopup.check.inputShownIs('9');
     NumberPopup.do.clickConfirm();
-    FloorScreen.check.tableSeatIs('T4', '10');
+    FloorScreen.check.tableSeatIs('T4', '9');
 
     // change shape
     FloorScreen.do.changeShapeTo('round');
 
     // Opening product screen in main floor should go back to main floor
     FloorScreen.do.clickEdit();
+    FloorScreen.check.editModeIsActive(false);
     FloorScreen.check.hasTable('T4');
     FloorScreen.do.clickTable('T4');
     ProductScreen.check.isShown();

--- a/addons/pos_restaurant/static/tests/tours/SplitBillScreen.tour.js
+++ b/addons/pos_restaurant/static/tests/tours/SplitBillScreen.tour.js
@@ -14,9 +14,9 @@ odoo.define('pos_restaurant.tour.SplitBillScreen', function (require) {
     startSteps();
 
     FloorScreen.do.clickTable('T2');
-    ProductScreen.exec.order('Water', '5', '1.2');
-    ProductScreen.exec.order('Minute Maid', '3', '1.2');
-    ProductScreen.exec.order('Coca-Cola', '1', '1.2');
+    ProductScreen.exec.order('Water', '5', '2', '10.0');
+    ProductScreen.exec.order('Minute Maid', '3', '2', '6.0');
+    ProductScreen.exec.order('Coca-Cola', '1', '2', '2.0');
     ProductScreen.do.clickSplitBillButton();
 
     // Check if the screen contains all the orderlines
@@ -30,10 +30,10 @@ odoo.define('pos_restaurant.tour.SplitBillScreen', function (require) {
     SplitBillScreen.do.clickOrderline('Water');
     SplitBillScreen.do.clickOrderline('Water');
     SplitBillScreen.check.orderlineHas('Water', '5', '3');
-    SplitBillScreen.check.subtotalIs('3.60')
+    SplitBillScreen.check.subtotalIs('6.0')
     SplitBillScreen.do.clickOrderline('Coca-Cola');
     SplitBillScreen.check.orderlineHas('Coca-Cola', '1', '1');
-    SplitBillScreen.check.subtotalIs('4.80')
+    SplitBillScreen.check.subtotalIs('8.0')
 
     // click pay to split, go back to check the lines
     SplitBillScreen.do.clickPay();

--- a/addons/pos_restaurant/static/tests/tours/helpers/FloorScreenTourMethods.js
+++ b/addons/pos_restaurant/static/tests/tours/helpers/FloorScreenTourMethods.js
@@ -122,6 +122,7 @@ odoo.define('pos_restaurant.tour.FloorScreenTourMethods', function (require) {
                 {
                     content: `number of seats in table '${table}' is '${val}'`,
                     trigger: `.floor-map .tables .table .label:contains("${table}") ~ .table-seats:contains("${val}")`,
+                    run: () => {},
                 },
             ];
         }

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant.js
@@ -71,6 +71,10 @@ odoo.define('pos_reataurant.tour.synchronized_table_management', function (requi
     function open_table(table_id, order_count) {
         order_count = order_count || null;
         var steps = [{
+            content: 'wait for sync to finish',
+            trigger: '.oe_status .js_connected',
+            run: function() {},
+        },{
             content: 'open table ' + table_id,
             trigger: '.label:contains(' + table_id +')',
             run: 'click',
@@ -99,6 +103,10 @@ odoo.define('pos_reataurant.tour.synchronized_table_management', function (requi
 
     function finish_order() {
         var steps = [{
+            content: "validate button is highlighted",
+            trigger: '.payment-screen .button.next.highlight',
+            run: function() {},
+        },{
             content: "validate the order",
             trigger: '.payment-screen .button.next:visible',
         }];
@@ -134,7 +142,6 @@ odoo.define('pos_reataurant.tour.synchronized_table_management', function (requi
     steps = steps.concat(add_product_to_order('Minute Maid'));
     steps = steps.concat(verify_order_total('4.40'));
     steps = steps.concat(goto_payment_screen_and_select_payment_method());
-    steps = steps.concat(generate_payment_screen_keypad_steps('6.05'));
     steps = steps.concat(finish_order());
     steps = steps.concat(open_table('T5', 1));
     steps = steps.concat(verify_order_total('4.40'));
@@ -143,8 +150,14 @@ odoo.define('pos_reataurant.tour.synchronized_table_management', function (requi
         trigger: '.neworder-button',
         run: 'click',
     }]);
+    steps = steps.concat([{
+        content: 'order should be empty',
+        trigger: '.order .order-empty',
+        run: function() {},
+    }]);
     steps = steps.concat(add_product_to_order('Coca-Cola'));
     steps = steps.concat(add_product_to_order('Minute Maid'));
+    steps = steps.concat(verify_order_total('4.40'));
     steps = steps.concat([{
         content: 'back to floor',
         trigger: '.floor-button',
@@ -163,10 +176,6 @@ odoo.define('pos_reataurant.tour.synchronized_table_management', function (requi
         content: 'back to floor',
         trigger: '.floor-button',
         run: 'click',
-    }, {
-        content: 'back to floor',
-        trigger: '.oe_status .js_connected',
-        run: function() {},
     }]);
     steps = steps.concat(open_table('T5', 1));
 
@@ -196,9 +205,8 @@ odoo.define('pos_reataurant.tour.synchronized_table_management', function (requi
         run: function () {},
     })
     steps = steps.concat(generate_product_screen_keypad_steps('1'));
-
+    steps = steps.concat(verify_order_total('4.40'));
     steps = steps.concat(goto_payment_screen_and_select_payment_method());
-    steps = steps.concat(generate_payment_screen_keypad_steps('4.4'));
     steps = steps.concat(finish_order());
     steps = steps.concat(open_table('T2'));
 
@@ -224,6 +232,11 @@ odoo.define('pos_reataurant.tour.synchronized_table_management', function (requi
         content: 'click backspace to remove line',
         trigger: '.numpad-backspace',
         run: 'click',
+    }]);
+    steps = steps.concat([{
+        content: 'order should be empty',
+        trigger: '.order .order-empty',
+        run: function() {},
     }]);
     steps = steps.concat([{
         content: 'back to floor',

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -155,12 +155,12 @@ class TestFrontend(odoo.tests.HttpCase):
 
         self.pos_config.with_user(self.env.ref('base.user_admin')).open_session_cb(check_coa=False)
 
-        self.start_tour("/pos/web?config_id=%d" % self.pos_config.id, 'pos_restaurant_sync', login="admin", step_delay=50)
+        self.start_tour("/pos/web?config_id=%d" % self.pos_config.id, 'pos_restaurant_sync', login="admin")
 
         self.assertEqual(1, self.env['pos.order'].search_count([('amount_total', '=', 4.4), ('state', '=', 'draft')]))
         self.assertEqual(1, self.env['pos.order'].search_count([('amount_total', '=', 4.4), ('state', '=', 'paid')]))
 
-        self.start_tour("/pos/web?config_id=%d" % self.pos_config.id, 'pos_restaurant_sync_second_login', login="admin", step_delay=50)
+        self.start_tour("/pos/web?config_id=%d" % self.pos_config.id, 'pos_restaurant_sync_second_login', login="admin")
 
         self.assertEqual(0, self.env['pos.order'].search_count([('amount_total', '=', 4.4), ('state', '=', 'draft')]))
         self.assertEqual(1, self.env['pos.order'].search_count([('amount_total', '=', 2.2), ('state', '=', 'draft')]))
@@ -168,6 +168,6 @@ class TestFrontend(odoo.tests.HttpCase):
 
     def test_02_others(self):
         self.pos_config.with_user(self.env.ref('base.user_admin')).open_session_cb(check_coa=False)
-        self.start_tour("/pos/web?config_id=%d" % self.pos_config.id, 'SplitBillScreenTour', login="admin", step_delay=50)
-        self.start_tour("/pos/web?config_id=%d" % self.pos_config.id, 'ControlButtonsTour', login="admin", step_delay=50)
-        self.start_tour("/pos/web?config_id=%d" % self.pos_config.id, 'FloorScreenTour', login="admin", step_delay=50)
+        self.start_tour("/pos/web?config_id=%d" % self.pos_config.id, 'SplitBillScreenTour', login="admin")
+        self.start_tour("/pos/web?config_id=%d" % self.pos_config.id, 'ControlButtonsTour', login="admin")
+        self.start_tour("/pos/web?config_id=%d" % self.pos_config.id, 'FloorScreenTour', login="admin")


### PR DESCRIPTION
During the refactoring of point of sale to owl, new tours were written for testing. However, `step_delay` was set because of the suspicion that owl rendering needs it. It kinda works but because of conditions such as overloaded cpu (during testing), owl rendering might take more than 50ms to finish, thus, tour fails in indeterministic way. The issue isn't actually because of owl, but because of insufficient granularity in tour steps and that the mutation observer of the tour service is not observing `characterData`.

In 76700a4a1e1ca4aa675c9f48bae1e2bcbbdeb654, we allowed the tour to observe changes in `characterData`. With this change in the observer, we can now remove `step_delay` in pos tours but we still need to be more specific in the tour steps.

This development aims to reduce (if not eradicate) the indeterministic test fails caused by pos (and its extensions). We do this by building up on the ideas described in the 2 paragraphs above. We remove `step_delay` in every pos tour and we added extra tour steps to make sure the ui is properly rendered before proceeding to next steps.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
