### PR TITLE
[FIX] website_slides: unlink category with archived slides properly

### DIFF
--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -462,7 +462,7 @@ class Slide(models.Model):
     def unlink(self):
         if self.question_ids and self.channel_id.channel_partner_ids:
             raise UserError(_("People already took this quiz. To keep course progression it should not be deleted."))
-        for category in self.filtered(lambda slide: slide.is_category):
+        for category in self.with_context(active_test=False).filtered(lambda slide: slide.is_category):
             category.channel_id._move_category_slides(category, False)
         super(Slide, self).unlink()
 

--- a/addons/website_slides/tests/test_slide_utils.py
+++ b/addons/website_slides/tests/test_slide_utils.py
@@ -102,6 +102,14 @@ class TestSequencing(slides_common.SlidesCase):
         self.assertEqual([s.id for s in self.channel.slide_ids], [self.slide.id, new_category.id, self.slide_3.id, self.category.id, self.slide_2.id])
 
 
+class TestDeleteCategory(slides_common.SlidesCase):
+
+    @users('user_manager')
+    def test_delete_category_with_archived_slides(self):
+        self.slide_2.active = False
+        self.category.with_user(self.user_manager).unlink()
+
+
 class TestFromURL(slides_common.SlidesCase):
     def test_youtube_urls(self):
         urls = {


### PR DESCRIPTION
Before this commit, trying to delete a category having archived slides
was resulting into traceback.

This commit fixes the issue and makes it possible to delete the
category that might contain archived slides.

TaskID - 2093671
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
