### PR TITLE
[FIX] odoo: date format is based on preferences when exported

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -55,7 +55,7 @@ from .tools import frozendict, lazy_classproperty, lazy_property, ormcache, \
                    Collector, LastOrderedSet, OrderedSet, pycompat, groupby
 from .tools.config import config
 from .tools.func import frame_codeinfo
-from .tools.misc import CountingStream, clean_context, DEFAULT_SERVER_DATETIME_FORMAT, DEFAULT_SERVER_DATE_FORMAT
+from .tools.misc import CountingStream, clean_context, format_date, DEFAULT_SERVER_DATETIME_FORMAT, DEFAULT_SERVER_DATE_FORMAT
 from .tools.safe_eval import safe_eval
 from .tools.translate import _
 from .tools import date_utils
@@ -766,6 +766,10 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                     # in order to reproduce the former behavior
                     if not isinstance(value, BaseModel):
                         current[i] = field.convert_to_export(value, record)
+
+                        # transform dates to their string representation - opw 2250447
+                        if field.type == 'date':
+                            current[i] = format_date(self.env, current[i])
                     else:
                         primary_done.append(name)
 


### PR DESCRIPTION
Steps to reproduce:
- install accounting
- install a language with a different default format (eg: fr_Be)
- go to accounting > accounting > journal entries > set your preferred language
to french
- select at least one entry > action > export > make sure the date field is selected
- click "export to file"

Previous behavior:
the date field is not formatted to the preferred format

Current behavior:
the date field is converted to its string representation during the export

opw-2250447