### PR TITLE
[FIX] mail: Activities newly created in chatter remain on next object

### DIFF
--- a/addons/mail/static/src/models/chatter/chatter.js
+++ b/addons/mail/static/src/models/chatter/chatter.js
@@ -68,7 +68,7 @@ function factory(dependencies) {
                 );
                 activities.push(activity);
             }
-            this.update({ activities: [['replace', activities]] });
+            this.update({ activities: [['replace', activities]], activityIds: [newActivityIds] });
         }
 
         showLogNote() {
@@ -169,8 +169,10 @@ function factory(dependencies) {
                     previous.thread.delete();
                 }
             }
-
-            if (previous.activityIds.join(',') !== this.activityIds.join(',')) {
+            if (
+                previous.activityIds.join(',') !== this.activityIds.join(',') &&
+                this.activities.map((activity) => activity.id).join(',') !== this.activityIds.join(',')
+            ) {
                 this.refreshActivities();
             }
             if (


### PR DESCRIPTION
Before this commit:
In a form view (with different objects accessible with the previous
and next buttons) with at least 2 objects without activity in sequence,
if you add an activity to the first one and then you press next, the
activity created for the first one will stay on the second one.

After this commit:
The activity view is properly refreshed



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
