### PR TITLE
[FIX] round to prevent rounding issue, that prevent to write value

### DIFF
--- a/addons/hr_holidays/models/hr.py
+++ b/addons/hr_holidays/models/hr.py
@@ -103,7 +103,7 @@ class Employee(models.Model):
     def _compute_remaining_leaves(self):
         remaining = self._get_remaining_leaves()
         for employee in self:
-            employee.remaining_leaves = remaining.get(employee.id, 0.0)
+            employee.remaining_leaves = round(remaining.get(employee.id, 0.0),2)
 
     @api.multi
     def _inverse_remaining_leaves(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Sometimes depend on datas , value can be like 3.45555555555555555, and why because the field
have a inverse function, it try to write down the value because float field is displayed like 3.45




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
