### PR TITLE
[FIX] base: check_xsd attachments search limit 1

### DIFF
--- a/odoo/tools/xml_utils.py
+++ b/odoo/tools/xml_utils.py
@@ -20,7 +20,8 @@ class odoo_resolver(etree.Resolver):
 
     def resolve(self, url, id, context):
         """Search url in ``ir.attachment`` and return the resolved content."""
-        attachment = self.env['ir.attachment'].search([('name', '=', url)])
+        attachment = self.env['ir.attachment'].search([('name', '=', url),
+                                                       ('create_uid', '=', self.env.ref('base.user_root').id)], limit=1)
         if attachment:
             return self.resolve_string(base64.b64decode(attachment.datas), context)
 
@@ -42,7 +43,8 @@ def _check_with_xsd(tree_or_str, stream, env=None):
     if env:
         parser.resolvers.add(odoo_resolver(env))
         if isinstance(stream, str) and stream.endswith('.xsd'):
-            attachment = env['ir.attachment'].search([('name', '=', stream)])
+            attachment = env['ir.attachment'].search([('name', '=', stream),
+                                                      ('create_uid', '=', env.ref('base.user_root').id)], limit=1)
             if not attachment:
                 raise FileNotFoundError()
             stream = BytesIO(base64.b64decode(attachment.datas))


### PR DESCRIPTION
We updated the check_xsd for the case when an xsd
refers to another xsd and as they are stored through
attachments we need a way to make them find each
other (commit 06a35f2e1 )

Here, we fix the case where we could have multiple
attachments with the same name.  Also, it is better
to restrict the attachments to those of the root user
as this is the default user for the crons that normally
download these files.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
