### PR TITLE
[FIX] website: duplicate page popup bug is fixed.

### DIFF
--- a/addons/website/static/src/js/menu/content.js
+++ b/addons/website/static/src/js/menu/content.js
@@ -1092,7 +1092,11 @@ function _clonePage(pageId) {
                     window.location.href = path;
                 }).guardedCatch(reject);
             },
-            cancel_callback: reject,
+            cancel_callback: () => {
+                reject();
+                //display inactive modal
+                self.$modal.removeClass('d-none');
+            }
         }).on('closed', null, reject);
     });
 }


### PR DESCRIPTION
Previously, when we click on duplicate page button then click cancel,
In the background, the blue overlay is still there, which makes the website
non-clickable.

In this commit- we have displayed the previous modal, once the cancel button
is clicked to fix the above issue.

task-2272141