### PR TITLE
[FIX] tests

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -1013,7 +1013,10 @@ class AccountTestInvoicingCommon(SavepointCase):
 
     @classmethod
     def init_invoice(cls, move_type, partner=None, invoice_date=None):
-        move_form = Form(cls.env['account.move'].with_context(default_move_type=move_type))
+        move_form = Form(cls.env['account.move'].with_context(
+            default_move_type=move_type,
+            default_date=invoice_date or fields.Date.from_string('2019-01-01'),
+        ))
         move_form.invoice_date = invoice_date or fields.Date.from_string('2019-01-01')
         move_form.partner_id = partner or cls.partner_a
         with move_form.invoice_line_ids.new() as line_form:


### PR DESCRIPTION
So that the name is generated correctly when the date is in a different period. This caused saft tests to fail.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
