### PR TITLE
[IMP] gamification: using join and avoid unnecessary table

### DIFF
--- a/addons/gamification/models/challenge.py
+++ b/addons/gamification/models/challenge.py
@@ -243,19 +243,14 @@ class Challenge(models.Model):
         # exclude goals for users that did not connect since the last update
         yesterday = fields.Date.to_string(date.today() - timedelta(days=1))
         self.env.cr.execute("""SELECT gg.id
-                        FROM gamification_goal as gg,
-                             gamification_challenge as gc,
-                             res_users as ru,
-                             res_users_log as log
-                       WHERE gg.challenge_id = gc.id
-                         AND gg.user_id = ru.id
-                         AND ru.id = log.create_uid
-                         AND gg.write_date < log.create_date
-                         AND gg.closed IS NOT TRUE
+                        FROM gamification_goal as gg
+                        JOIN gamification_challenge as gc ON gg.challenge_id = gc.id
+                       WHERE gg.closed IS NOT TRUE
                          AND gc.id IN %s
                          AND (gg.state = 'inprogress'
                               OR (gg.state = 'reached'
                                   AND (gg.end_date >= %s OR gg.end_date IS NULL)))
+                         AND EXISTS (SELECT 1 FROM res_users_log as log WHERE gg.user_id = log.create_uid AND gg.write_date < log.create_date)
                       GROUP BY gg.id
         """, [tuple(self.ids), yesterday])
 
@@ -358,7 +353,7 @@ class Challenge(models.Model):
                 participant_user_ids = set(challenge.user_ids.ids)
                 user_squating_challenge_ids = user_with_goal_ids - participant_user_ids
                 if user_squating_challenge_ids:
-                    # users that used to match the challenge 
+                    # users that used to match the challenge
                     Goals.search([
                         ('challenge_id', '=', challenge.id),
                         ('user_id', 'in', list(user_squating_challenge_ids))
@@ -446,7 +441,7 @@ class Challenge(models.Model):
             'action': <{True,False}>,
             'display_mode': <{progress,boolean}>,
             'target': <challenge line target>,
-            'state': <gamification.goal state {draft,inprogress,reached,failed,canceled}>,                                
+            'state': <gamification.goal state {draft,inprogress,reached,failed,canceled}>,
             'completeness': <percentage>,
             'current': <current value>,
         }

--- a/addons/gamification/models/res_users.py
+++ b/addons/gamification/models/res_users.py
@@ -299,3 +299,11 @@ WHERE sub.user_id IN %%s""" % {
         """
         self.ensure_one()
         return []
+
+
+class ResUsersLog(models.Model):
+    _inherit = 'res.users.log'
+
+    def init(self):
+        self._cr.execute("CREATE INDEX IF NOT EXISTS res_users_log_create_uid_date_idx ON res_users_log(create_uid,create_date)")
+        super().init()


### PR DESCRIPTION
join the required tables, using an exists clause and skip the useless 
res_users table, combined with `create index on 
res_users_log(create_uid,create_date)` results in a query executed 10 
times faster

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
