### PR TITLE
[FIX] web: kanban: no content helper only displayed when non empty

### DIFF
--- a/addons/web/static/src/js/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/js/views/kanban/kanban_renderer.js
@@ -217,7 +217,9 @@ var KanbanRenderer = BasicRenderer.extend({
             }
             return Promise.resolve(def).then(function () {
                 newColumn.$el.insertAfter(column.$el);
-                self._toggleNoContentHelper();
+                if (column.$el.find('.o_kanban_no_records').length) {
+                    self._toggleNoContentHelper();
+                }
                 // When a record has been quick created, the new column directly
                 // renders the quick create widget (to allow quick creating several
                 // records in a row). However, as we render this column in a
@@ -599,7 +601,10 @@ var KanbanRenderer = BasicRenderer.extend({
      * @private
      */
     _onCancelQuickCreate: function () {
-        this._toggleNoContentHelper();
+        if (!this.$el.find('.o_kanban_no_records').length ||
+            !this.$el.find('.o_kanban_record').length) {
+            this._toggleNoContentHelper();
+        }
     },
     /**
      * Closes the opened quick create widgets in columns
@@ -610,7 +615,9 @@ var KanbanRenderer = BasicRenderer.extend({
         if (this.state.groupedBy.length) {
             _.invoke(this.widgets, 'cancelQuickCreate');
         }
-        this._toggleNoContentHelper();
+        if (!this.$el.find('.o_kanban_no_records').length) {
+            this._toggleNoContentHelper();
+        }
     },
     /**
      * @private


### PR DESCRIPTION
before this commit,
In a grouped kanban view, when the record is created,
the no content helper reappears, whereas it shouldn't.

this commit fixes the issue and now no content helper only
appears when there is no record in kanban view.

task - 2294300

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
