### PR TITLE
[IMP] web: add markdown support for lists

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3,7 +3,7 @@
 from odoo import api, fields, models, _
 from odoo.exceptions import RedirectWarning, UserError, ValidationError, AccessError
 from odoo.tools import float_is_zero, float_repr, float_compare, date_utils, email_split, email_escape_char, email_re
-from odoo.tools.misc import formatLang, format_date, get_lang
+from odoo.tools.misc import formatLang, format_date, get_lang, escape_markdown
 
 from datetime import date, timedelta
 from itertools import groupby
@@ -1795,11 +1795,11 @@ class AccountMove(models.Model):
         result = []
         for move in self:
             if self._context.get('name_groupby'):
-                name = '**%s**, %s' % (format_date(self.env, move.date), move._get_move_display_name())
+                name = '**%s**, %s' % (format_date(self.env, move.date), escape_markdown(move._get_move_display_name()))
                 if move.ref:
-                    name += '     (%s)' % move.ref
+                    name += '     (%s)' % escape_markdown(move.ref)
                 if move.partner_id.name:
-                    name += ' - %s' % move.partner_id.name
+                    name += ' - %s' % escape_markdown(move.partner_id.name)
             else:
                 name = move._get_move_display_name(show_ref=True)
             result.append((move.id, name))

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -172,7 +172,7 @@
                 <tree string="Journal Items" create="false" expand="context.get('expand', False)" multi_edit="1">
                     <field name="date" optional="show" readonly="1"/>
                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" optional="show"/>
-                    <field name="move_id" optional="show"/>
+                    <field name="move_id" optional="show" widget="many2one_markdown" options="{'no_open': True}"/>
                     <field name="account_id" optional="show" options="{'no_open': True, 'no_create': True}"
                            domain="[('company_id', '=', company_id)]"
                            groups="account.group_account_readonly"/>
@@ -197,7 +197,7 @@
                     <field name="tax_tag_ids" widget="many2many_tags" width="0.5" optional="hide" string="Tax Grids"
                            options="{'no_open': True, 'no_create': True}"
                            domain="[('applicability', '=', 'taxes')]"/>
-                    <groupby name="move_id">
+                    <groupby name="move_id" group_markdown="1" no_count="1">
                         <field name="state" invisible="1"/>
                         <button name="edit" type="edit" icon="fa-edit" title="Edit"/>
                         <button name="action_post" states="draft" icon="fa-check" title="Post" type="object" groups="account.group_account_invoice"/>

--- a/addons/web/static/src/js/core/utils.js
+++ b/addons/web/static/src/js/core/utils.js
@@ -977,6 +977,24 @@ var utils = {
             ['name', '=like', '%.assets\_%.js'],
         ];
     },
+
+    /*
+     *  Split the node into multiple elements according to its marked down text
+     *  Supported markdowns are
+     *   - ** to set to bold
+     *   - __ to set to italic
+     */
+    split_node_markdown: function(node) {
+        node.css('white-space', 'pre').css('font-weight', 'normal');
+        let html = node.html();
+        // format according to markdown
+        html = html.replace(/(\*\*)(.*?)\1/g, '<b>$2</b>');
+        html = html.replace(/(__)(.*?)\1/g, '<i>$2</i>');
+        // unescape the string
+        html = html.replace(/\\\*/g, '*');
+        html = html.replace(/\\\_/g, '_');
+        node.html(html);
+    },
 };
 
 return utils;

--- a/addons/web/static/src/js/fields/field_registry.js
+++ b/addons/web/static/src/js/fields/field_registry.js
@@ -82,6 +82,7 @@ registry
     .add('selection_badge', relational_fields.FieldSelectionBadge)
     .add('many2one', relational_fields.FieldMany2One)
     .add('many2one_barcode', relational_fields.Many2oneBarcode)
+    .add('many2one_markdown', relational_fields.Many2oneMarkdown)
     .add('list.many2one', relational_fields.ListFieldMany2One)
     .add('kanban.many2one', relational_fields.KanbanFieldMany2One)
     .add('many2one_avatar', relational_fields.Many2OneAvatar)

--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -33,6 +33,7 @@ const { escape } = owl.utils;
 var _t = core._t;
 var _lt = core._lt;
 var qweb = core.qweb;
+var utils = require('web.utils');
 
 //------------------------------------------------------------------------------
 // Many2one widgets
@@ -960,6 +961,13 @@ var ListFieldMany2One = FieldMany2One.extend({
         } else {
             this.mustSetValue = true;
         }
+    },
+});
+
+var Many2oneMarkdown = FieldMany2One.extend({
+    _renderReadonly: function () {
+        this._super.apply(this, arguments);
+        utils.split_node_markdown(this.$el);
     },
 });
 
@@ -3371,6 +3379,7 @@ var FieldReference = FieldMany2One.extend({
 return {
     FieldMany2One: FieldMany2One,
     Many2oneBarcode: Many2oneBarcode,
+    Many2oneMarkdown: Many2oneMarkdown,
     KanbanFieldMany2One: KanbanFieldMany2One,
     ListFieldMany2One: ListFieldMany2One,
     Many2OneAvatar: Many2OneAvatar,

--- a/addons/web/static/src/js/views/list/list_renderer.js
+++ b/addons/web/static/src/js/views/list/list_renderer.js
@@ -697,13 +697,17 @@ var ListRenderer = BasicRenderer.extend({
 
         var name = group.value === undefined ? _t('Undefined') : group.value;
         var groupBy = this.state.groupedBy[groupLevel];
+        let groupAttrs = this.groupbys[groupBy] ? this.groupbys[groupBy].arch.attrs : {};
         if (group.fields[groupBy.split(':')[0]].type !== 'boolean') {
             name = name || _t('Undefined');
         }
         var $th = $('<th>')
             .addClass('o_group_name')
             .attr('tabindex', -1)
-            .text(name + ' (' + group.count + ')');
+            .text(name + (!groupAttrs.no_count ? (' (' + group.count + ')') : ''));
+        if (groupAttrs.group_markdown) {
+            utils.split_node_markdown($th);
+        }
         var $arrow = $('<span>')
             .css('padding-left', (groupLevel * 20) + 'px')
             .css('padding-right', '5px')

--- a/addons/web/static/src/js/views/list/list_view.js
+++ b/addons/web/static/src/js/views/list/list_view.js
@@ -93,6 +93,7 @@ var ListView = BasicView.extend({
     _extractGroup: function (node) {
         var innerView = this.fields[node.attrs.name].views.groupby;
         this.groupbys[node.attrs.name] = this._processFieldsView(innerView, 'groupby');
+        _.extend(this.groupbys[node.attrs.name].arch.attrs, node.attrs);
     },
     /**
      * @override

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -4484,6 +4484,33 @@ QUnit.module('Views', {
         list.destroy();
     });
 
+    QUnit.test('groupby with name markdown', async function (assert) {
+        assert.expect(3);
+
+        _.each(this.data.res_currency.records, record => {
+            record.display_name = '__<b>' + record.display_name + '</b>__';
+        })
+
+        const list = await createView({
+            View: ListView,
+            model : 'foo',
+            data: this.data,
+            arch: `<tree expand="1">
+                       <field name="currency_id" widget="many2one_markdown"/>
+                       <groupby name="currency_id" group_markdown="1" no_count="1">
+                           <field name="position" invisible="1"/>
+                       </groupby>
+                   </tree>`,
+            groupBy: ['currency_id'],
+        })
+        assert.containsOnce(list, '.o_group_name:first i', 'should have parsed markdown');
+        assert.containsNone(list, '.o_group_name:first b', 'should not have parsed xml');
+
+        assert.containsOnce(list, '.o_many2one_markdown_cell:first', 'should have parsed markdown');
+
+        list.destroy();
+    })
+
     QUnit.test('list view, editable, without data', async function (assert) {
         assert.expect(12);
 

--- a/odoo/addons/base/rng/tree_view.rng
+++ b/odoo/addons/base/rng/tree_view.rng
@@ -11,6 +11,8 @@
         <rng:element name="groupby">
             <rng:attribute name="name"/>
             <rng:optional><rng:attribute name="expand"/></rng:optional>
+            <rng:optional><rng:attribute name="group_markdown"/></rng:optional>
+            <rng:optional><rng:attribute name="no_count"/></rng:optional>
             <rng:zeroOrMore>
                 <rng:ref name="field"/>
             </rng:zeroOrMore>

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -1596,3 +1596,10 @@ def hmac(env, scope, message, hash_function=hashlib.sha256):
         message.encode(),
         hash_function,
     ).hexdigest()
+
+
+def escape_markdown(string):
+    """Escape strings to be displayed with a markdown widget."""
+    string = string.replace('*', r'\*')
+    string = string.replace('_', r'\_')
+    return string


### PR DESCRIPTION
Task [2300190](https://www.odoo.com/web#id=2300190&action=333&active_id=967&model=project.task&view_type=form&cids=1&menu_id=4720)

Add the ability to have enriched text coming from many2one fields and in list groups.
For now, the only possible markdown is
* `**` for bold
* `__` for italic



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
