### PR TITLE
[IMP] web: remove nocontent helper on graph views

### DIFF
--- a/addons/web/static/src/js/views/graph/graph_renderer.js
+++ b/addons/web/static/src/js/views/graph/graph_renderer.js
@@ -763,7 +763,9 @@ return AbstractRenderer.extend({
         var dataPoints = this._filterDataPoints();
         dataPoints = this._sortDataPoints(dataPoints);
         if (!dataPoints.length && this.state.mode !== 'pie') {
-            this.$el.append(qweb.render('View.NoContentHelper'));
+            while (this.el.firstChild) {
+                this.el.removeChild(this.el.firstChild);
+            }
         } else if (this.isInDOM) {
             // only render the graph if the widget is already in the DOM (this
             // happens typically after an update), otherwise, it will be
@@ -893,22 +895,10 @@ return AbstractRenderer.extend({
             someNegative = someNegative || (datapt.value < 0);
             allZero = allZero && (datapt.value === 0);
         });
-        if (someNegative && !allNegative) {
-            this.$el.empty();
-            this.$el.append(qweb.render('View.NoContentHelper', {
-                title: _t("Invalid data"),
-                description: _t("Pie chart cannot mix positive and negative numbers. " +
-                    "Try to change your domain to only display positive results"),
-            }));
-            return;
-        }
-        if (allZero && !this.isEmbedded && this.state.origins.length === 1) {
-            this.$el.empty();
-            this.$el.append(qweb.render('View.NoContentHelper', {
-                title: _t("Invalid data"),
-                description: _t("Pie chart cannot display all zero numbers.. " +
-                    "Try to change your domain to display positive results"),
-            }));
+        if ((someNegative && !allNegative) || (allZero && !this.isEmbedded && this.state.origins.length === 1)) {
+            while (this.el.firstChild) {
+                this.el.removeChild(this.el.firstChild);
+            }
             return;
         }
 

--- a/addons/web/static/src/js/views/graph/graph_renderer.js
+++ b/addons/web/static/src/js/views/graph/graph_renderer.js
@@ -762,11 +762,7 @@ return AbstractRenderer.extend({
         }
         var dataPoints = this._filterDataPoints();
         dataPoints = this._sortDataPoints(dataPoints);
-        if (!dataPoints.length && this.state.mode !== 'pie') {
-            while (this.el.firstChild) {
-                this.el.removeChild(this.el.firstChild);
-            }
-        } else if (this.isInDOM) {
+        if (dataPoints.length && this.isInDOM) {
             // only render the graph if the widget is already in the DOM (this
             // happens typically after an update), otherwise, it will be
             // rendered when the widget will be attached to the DOM (see
@@ -895,10 +891,9 @@ return AbstractRenderer.extend({
             someNegative = someNegative || (datapt.value < 0);
             allZero = allZero && (datapt.value === 0);
         });
+
         if ((someNegative && !allNegative) || (allZero && !this.isEmbedded && this.state.origins.length === 1)) {
-            while (this.el.firstChild) {
-                this.el.removeChild(this.el.firstChild);
-            }
+            this.$el.empty();
             return;
         }
 

--- a/addons/web/static/tests/views/graph_tests.js
+++ b/addons/web/static/tests/views/graph_tests.js
@@ -337,7 +337,28 @@ QUnit.module('Views', {
         graph.destroy();
     });
 
-    QUnit.test('no content helper (bar chart)', async function (assert) {
+    QUnit.test('no no content helper (line chart)', async function (assert) {
+        assert.expect(2);
+        this.data.foo.records = [];
+
+        var graph = await createView({
+            View: GraphView,
+            model: "foo",
+            data: this.data,
+            arch: '<graph type="line">' +
+                        '<field name="product_id"/>' +
+                '</graph>',
+        });
+
+        assert.containsNone(graph, 'div.o_graph_canvas_container canvas',
+                    "should not contain a div with a canvas element");
+        assert.containsNone(graph, 'div.o_view_nocontent',
+            "should not display the no content helper");
+
+        graph.destroy();
+    });
+
+    QUnit.test('no no content helper (bar chart)', async function (assert) {
         assert.expect(2);
         this.data.foo.records = [];
 
@@ -352,13 +373,13 @@ QUnit.module('Views', {
 
         assert.containsNone(graph, 'div.o_graph_canvas_container canvas',
                     "should not contain a div with a canvas element");
-        assert.containsOnce(graph, 'div.o_view_nocontent',
-            "should display the no content helper");
+        assert.containsNone(graph, 'div.o_view_nocontent',
+            "should not display the no content helper");
 
         graph.destroy();
     });
 
-    QUnit.test('no content helper (pie chart)', async function (assert) {
+    QUnit.test('no no content helper (pie chart)', async function (assert) {
         assert.expect(2);
         this.data.foo.records =  [];
 
@@ -373,8 +394,8 @@ QUnit.module('Views', {
 
         assert.containsNone(graph, 'div.o_graph_canvas_container canvas',
             "should not contain a div with a canvas element");
-        assert.containsOnce(graph, 'div.o_view_nocontent',
-            "should display the no content helper");
+        assert.containsNone(graph, 'div.o_view_nocontent',
+            "should not display the no content helper");
 
         graph.destroy();
     });
@@ -412,7 +433,7 @@ QUnit.module('Views', {
         graph.destroy();
     });
 
-    QUnit.test('no content helper after update', async function (assert) {
+    QUnit.test('no no content helper after update', async function (assert) {
         assert.expect(4);
 
         var graph = await createView({
@@ -432,8 +453,8 @@ QUnit.module('Views', {
         await testUtils.graph.reload(graph, {domain: [['product_id', '=', 4]]});
         assert.containsNone(graph, 'div.o_graph_canvas_container canvas',
                     "should not contain a div with a canvas element");
-        assert.containsOnce(graph, 'div.o_view_nocontent',
-            "should display the no content helper");
+        assert.containsNone(graph, 'div.o_view_nocontent',
+            "should not display the no content helper");
         graph.destroy();
     });
 

--- a/addons/web/static/tests/views/graph_tests.js
+++ b/addons/web/static/tests/views/graph_tests.js
@@ -337,69 +337,6 @@ QUnit.module('Views', {
         graph.destroy();
     });
 
-    QUnit.test('no no content helper (line chart)', async function (assert) {
-        assert.expect(2);
-        this.data.foo.records = [];
-
-        var graph = await createView({
-            View: GraphView,
-            model: "foo",
-            data: this.data,
-            arch: '<graph type="line">' +
-                        '<field name="product_id"/>' +
-                '</graph>',
-        });
-
-        assert.containsNone(graph, 'div.o_graph_canvas_container canvas',
-                    "should not contain a div with a canvas element");
-        assert.containsNone(graph, 'div.o_view_nocontent',
-            "should not display the no content helper");
-
-        graph.destroy();
-    });
-
-    QUnit.test('no no content helper (bar chart)', async function (assert) {
-        assert.expect(2);
-        this.data.foo.records = [];
-
-        var graph = await createView({
-            View: GraphView,
-            model: "foo",
-            data: this.data,
-            arch: '<graph string="Gloups">' +
-                        '<field name="product_id"/>' +
-                '</graph>',
-        });
-
-        assert.containsNone(graph, 'div.o_graph_canvas_container canvas',
-                    "should not contain a div with a canvas element");
-        assert.containsNone(graph, 'div.o_view_nocontent',
-            "should not display the no content helper");
-
-        graph.destroy();
-    });
-
-    QUnit.test('no no content helper (pie chart)', async function (assert) {
-        assert.expect(2);
-        this.data.foo.records =  [];
-
-        var graph = await createView({
-            View: GraphView,
-            model: "foo",
-            data: this.data,
-            arch: '<graph type="pie">' +
-                        '<field name="product_id"/>' +
-                '</graph>',
-        });
-
-        assert.containsNone(graph, 'div.o_graph_canvas_container canvas',
-            "should not contain a div with a canvas element");
-        assert.containsNone(graph, 'div.o_view_nocontent',
-            "should not display the no content helper");
-
-        graph.destroy();
-    });
-
     QUnit.test('render pie chart in comparison mode', async function (assert) {
         assert.expect(2);
 
@@ -430,31 +367,6 @@ QUnit.module('Views', {
         assert.checkLegend(graph, 'No data');
 
         unpatchDate();
-        graph.destroy();
-    });
-
-    QUnit.test('no no content helper after update', async function (assert) {
-        assert.expect(4);
-
-        var graph = await createView({
-            View: GraphView,
-            model: "foo",
-            data: this.data,
-            arch: '<graph string="Gloups">' +
-                        '<field name="product_id"/>' +
-                '</graph>',
-        });
-
-        assert.containsOnce(graph, 'div.o_graph_canvas_container canvas',
-                    "should contain a div with a canvas element");
-        assert.containsNone(graph, 'div.o_view_nocontent',
-            "should not display the no content helper");
-
-        await testUtils.graph.reload(graph, {domain: [['product_id', '=', 4]]});
-        assert.containsNone(graph, 'div.o_graph_canvas_container canvas',
-                    "should not contain a div with a canvas element");
-        assert.containsNone(graph, 'div.o_view_nocontent',
-            "should not display the no content helper");
         graph.destroy();
     });
 
@@ -1411,10 +1323,10 @@ QUnit.module('Views', {
                 for await (var combination of graphGenerator(combinations)) {
                     // we can check particular combinations here
                     if (combination.toString() in self.combinationsToCheck) {
-                        if (self.combinationsToCheck[combination].errorMessage) {
+                        if (self.combinationsToCheck[combination].noContent) {
                             assert.strictEqual(
-                                graph.$('.o_nocontent_help p').eq(1).text().trim(),
-                                self.combinationsToCheck[combination].errorMessage
+                                graph.$('.o_graph_renderer').text().trim(),
+                                ""
                             );
                         } else {
                             assert.checkLabels(graph, self.combinationsToCheck[combination].labels);
@@ -1817,8 +1729,7 @@ QUnit.module('Views', {
             await this.testCombinations(combinations, assert);
 
             this.combinationsToCheck['previous_period,this_year,quarter'] = {
-                errorMessage: 'Pie chart cannot mix positive and negative numbers. ' +
-                                'Try to change your domain to only display positive results'
+                noContent: true
             };
             await this.setMode('pie');
             await this.testCombinations(combinations, assert);


### PR DESCRIPTION
PURPOSE

On the graph view, for clarity/consistency, instead of displaying the
no content helper we should simply let the graph display nothing.

SPECIFICATION

Instead of the no content helper, let the view display nothing

task - 2299904