### PR TITLE
[13.0] [FIX] Purchase: display of analytic_tag_ids in purchase line form

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -241,7 +241,7 @@
                                             <group>
                                                 <field name="date_planned" widget="date" attrs="{'required': [('display_type', '=', False)]}"/>
                                                 <field name="account_analytic_id" colspan="2" domain="['|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]" groups="analytic.group_analytic_accounting"/>
-                                                <field name="analytic_tag_ids" groups="analytic.group_analytic_accounting" domain="['|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                                                <field name="analytic_tag_ids" groups="analytic.group_analytic_tags" domain="['|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]" widget="many2many_tags" options="{'color_field': 'color'}"/>
                                                 <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
                                             </group>
                                             <group colspan="12">


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Display of analytic tags on purchase order lines (form).

**Current behavior before PR:**
The tags are displayed even if the analytic tags option is disabled (analytic accounting is enough).

**Desired behavior after PR is merged:**
Use the same group as the tree view.




-----------------------
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
