### PR TITLE
Add internal category field to expense products form

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -323,6 +323,7 @@
                             <group string="General Information">
                                 <field name="active" invisible="1"/>
                                 <field name="type"/>
+                                <field name="categ_id"/>
                                 <field name="list_price"/>
                                 <field name="standard_price"/>
                                 <field name="uom_id" groups="uom.group_uom" options="{'no_create': True}"/>


### PR DESCRIPTION
When the expense product created from expense products form the internal category will be ALL and the user doesn't see that in the form so it's better to add the category field into the expense product form.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
