### PR TITLE
[FIX] website: language install wizard redirects to website on cancel

### DIFF
--- a/addons/web/static/src/js/views/form/form_controller.js
+++ b/addons/web/static/src/js/views/form/form_controller.js
@@ -579,6 +579,10 @@ var FormController = BasicController.extend({
                 }).on("closed", null, resolve);
             });
         } else if (attrs.special === 'cancel') {
+            if (ev.data.record.context.params && ev.data.record.context.params.url_return) {
+                var url = ev.data.record.context.params.url_return.replace(/\[lang\]/g, ev.data.record.context.lang);
+                window.location.replace(url);
+            }
             def = this._callButtonAction(attrs, ev.data.record);
         } else if (!attrs.special || attrs.special === 'save') {
             // save the record but don't switch to readonly mode

--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -795,6 +795,11 @@ msgid ""
 msgstr ""
 
 #. module: website
+#: model_terms:ir.ui.view,arch_db:website.view_base_language_install
+msgid "<span>Cancel</span>"
+msgstr ""
+
+#. module: website
 #: model_terms:ir.ui.view,arch_db:website.s_call_to_action
 msgid ""
 "<span>Contact us</span>\n"

--- a/addons/website/wizard/base_language_install_views.xml
+++ b/addons/website/wizard/base_language_install_views.xml
@@ -9,6 +9,9 @@
             <group states="init" position="inside">
                 <field name="website_ids" widget="many2many_checkboxes" groups="website.group_multi_website"/>
             </group>
+            <xpath expr="//button[@special='cancel']" position="replace">
+                <button special="cancel" class="btn-secondary"><span>Cancel</span></button>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
Steps to reproduce:
- install website
- go to your website > click the "Add a language..." button
- click the cancel button on the wizard

Previous behavior:
the wizard left the user on a blank page, reloading the page just
reopens the wizard

Current behavior:
clicking the cancel button redirects the user to the website's root

opw-2301046