### PR TITLE
[FIX] stock: Fix traceback when disabling Planning/Timesheets

### DIFF
--- a/addons/stock/models/res_config_settings.py
+++ b/addons/stock/models/res_config_settings.py
@@ -86,7 +86,6 @@ class ResConfigSettings(models.TransientModel):
         warehouses.mapped('int_type_id').write({'active': active})
 
     def execute(self):
-        res = super(ResConfigSettings, self).execute()
         self.ensure_one()
         if self.group_stock_multi_locations or self.group_stock_production_lot or self.group_stock_tracking_lot:
             picking_types = self.env['stock.picking.type'].with_context(active_test=False).search([
@@ -94,4 +93,4 @@ class ResConfigSettings(models.TransientModel):
                 ('show_operations', '=', False)
             ])
             picking_types.sudo().write({'show_operations': True})
-        return res
+        return super(ResConfigSettings, self).execute()


### PR DESCRIPTION
Steps to reproduce:
- go to Project > Configuration > Settings
- unselect planning + timesheets and save

Observed behavior:
the following traceback is generated
TypeError: Composed elements must be Composable, got 'project_worksheet_template_res_company_rel' instead

LINKS
PR: #54762
Task-id: 2297047
