### PR TITLE
[IMP] website_event_track: the sponsors area make interactive as like snippet

### DIFF
--- a/addons/website_event_track/controllers/main.py
+++ b/addons/website_event_track/controllers/main.py
@@ -126,6 +126,14 @@ class WebsiteEventTrackController(http.Controller):
         }
         return request.render("website_event_track.tracks", values)
 
+    @http.route('/event/<model("event.event"):event>/our_sponsors', type='json', auth='public', website=True)
+    def our_sponsors(self, event, **kwargs):
+        """returns list of sponsors for event"""
+        if event.can_access_from_current_website():
+            return request.env['event.sponsor'].search_read(
+                [('event_id','=', event.id)],
+                ['id', 'url', 'partner_name', 'sponsor_type_id'])
+
     @http.route(['''/event/<model("event.event"):event>/track_proposal'''], type='http', auth="public", website=True, sitemap=False)
     def event_track_proposal(self, event, **post):
         if not event.can_access_from_current_website():

--- a/addons/website_event_track/static/src/js/website_event_track_sponsors.js
+++ b/addons/website_event_track/static/src/js/website_event_track_sponsors.js
@@ -1,0 +1,25 @@
+odoo.define('website_event_track.our_sponsors', function (require) {
+
+const { qweb } = require('web.core');
+const publicWidget = require('web.public.widget');
+
+publicWidget.registry.eventSponsors = publicWidget.Widget.extend({
+    selector: '.o_our_sponsors',
+    xmlDependencies: ['/website_event_track/static/src/xml/our_sponsors.xml'],
+
+    /**
+     * @override
+     */
+    async start() {
+        await this._super.apply(this, arguments);
+        const data = await this._rpc({
+            route: '/event/' + this.$target.data('eventId') + '/our_sponsors',
+        });
+        this.$target.find('#sponsor_details').html(
+            $(qweb.render('website_event_track.ourSponsors', {
+                sponsor_ids: data
+            }))
+        );
+    },
+});
+});

--- a/addons/website_event_track/static/src/xml/our_sponsors.xml
+++ b/addons/website_event_track/static/src/xml/our_sponsors.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="website_event_track.ourSponsors">
+        <div class="row o_not_editable">
+            <div t-attf-class="col-sm-6 col-lg-#{(sponsor_ids.length > 6)  and 2 or (12 / sponsor_ids.length)} text-center mb16"
+                 t-foreach="sponsor_ids" t-as="sponsor" contenteditable="false">
+                <t t-if="sponsor.url">
+                    <a t-att-href="sponsor.url" t-att-data-sponsor="sponsor.id" class="bg-white o_wevent_sponsor">
+                        <img class="img img-fluid shadow"
+                             t-att-data-sponsor-id="sponsor.id"
+                             t-attf-src="/web/image/event.sponsor/#{sponsor.id}/image_128"
+                             t-att-alt="sponsor.partner_name"/>
+                        <span t-esc="sponsor.sponsor_type_id[1]"
+                              t-attf-class="o_ribbon o_ribbon_right ribbon_#{sponsor.sponsor_type_id[1]}"/>
+                    </a>
+                </t>
+                <t t-else="">
+                    <span class="bg-white o_wevent_sponsor">
+                        <img class="img img-fluid shadow"
+                             t-att-data-sponsor-id="sponsor.id"
+                             t-attf-src="/web/image/event.sponsor/#{sponsor.id}/image_128"
+                             t-att-alt="sponsor.partner_name"/>
+                        <span t-esc="sponsor.sponsor_type_id[1]"
+                              t-attf-class="o_ribbon o_ribbon_right ribbon_#{sponsor.sponsor_type_id[1]}"/>
+                    </span>
+                </t>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/website_event_track/views/event_track_templates.xml
+++ b/addons/website_event_track/views/event_track_templates.xml
@@ -6,34 +6,18 @@
         <link rel="stylesheet" href="/website_event_track/static/src/css/website_event_track.css"/>
         <script type="text/javascript" src="/website_event_track/static/src/js/website_event_track.js"></script>
         <script type="text/javascript" src="/website_event_track/static/src/js/website_event_track_set_customize_options.js"></script>
+        <script type="text/javascript" src="/website_event_track/static/src/js/website_event_track_sponsors.js"></script>
     </xpath>
 </template>
 
 <template name="Sponsors" id="event_sponsor" customize_show="True" inherit_id="website_event.layout">
     <xpath expr="//div[@id='wrap']" position="inside">
-        <div class="container mt32 mb16 d-print-none" t-if="event.sponsor_ids">
-            <section>
+        <section t-if="event.sponsor_ids" class="o_our_sponsors pt16 pb16" t-att-data-event-id="event.id">
+            <div class="container mt32 mb16 d-print-none">
                 <h2 class="text-center mb32">Our Sponsors</h2>
-            </section>
-            <div class="row">
-                <div t-attf-class="col-sm-6 col-lg-#{(len(event.sponsor_ids) > 6) and 2 or (12 // len(event.sponsor_ids))} text-center mb16 oe_sponsor" t-foreach="event.sponsor_ids" t-as="sponsor">
-                    <t t-if="sponsor.url">
-                        <a t-att-href="sponsor.url" class="bg-white o_wevent_sponsor">
-                            <span t-field="sponsor.image_128"
-                                t-options='{"widget": "image", "class": "shadow"}'/>
-                            <span t-field="sponsor.sponsor_type_id" t-attf-class="o_ribbon o_ribbon_right ribbon_#{sponsor.sponsor_type_id.name}"/>
-                        </a>
-                    </t>
-                    <t t-if="not sponsor.url">
-                        <span class="bg-white o_wevent_sponsor">
-                            <span t-field="sponsor.image_128"
-                                t-options='{"widget": "image", "class": "shadow"}'/>
-                            <span t-field="sponsor.sponsor_type_id" t-attf-class="o_ribbon o_ribbon_right ribbon_#{sponsor.sponsor_type_id.name}"/>
-                        </span>
-                    </t>
-                </div>
+                <div id="sponsor_details" class="o_our_sponsor_details o_not_editable"></div>
             </div>
-        </div>
+        </section>
     </xpath>
 </template>
 


### PR DESCRIPTION
the purpose of this task is, the area of "Our Sponsors" isn't a snippet.
Not good. Make it good as of like a snippet. so the user can change the block easily to make it more customize as per requirement using web edit mode

task-2210772


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
