### PR TITLE
[FIX] account: name of invoices sent by mail

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2182,11 +2182,13 @@ class AccountMove(models.Model):
 
         # Create the invoice.
         values = {
+            'name': '/',  # we have to give the name otherwise it will be set to the mail's subject
             'invoice_source_email': from_mail_addresses[0],
             'partner_id': partners and partners[0].id or False,
         }
         move_ctx = self.with_context(default_move_type=custom_values['move_type'], default_journal_id=custom_values['journal_id'])
         move = super(AccountMove, move_ctx).message_new(msg_dict, custom_values=values)
+        move._compute_name()  # because the name is given, we need to recompute in case it is the first invoice of the journal
 
         # Assign followers.
         all_followers_ids = set(partner.id for partner in followers + senders + partners if is_internal_partner(partner))

--- a/addons/account/tests/test_account_incoming_supplier_invoice.py
+++ b/addons/account/tests/test_account_incoming_supplier_invoice.py
@@ -61,6 +61,7 @@ class TestAccountIncomingSupplierInvoice(AccountTestCommon):
 
         following_partners = invoice.message_follower_ids.mapped('partner_id')
         self.assertEqual(following_partners, self.env.ref('base.partner_root'))
+        self.assertRegex(invoice.name, 'TST/\d{4}/\d{2}/0001')
 
     def test_supplier_invoice_forwarded_by_internal_user_without_supplier(self):
         """ In this test, the bill was forwarded by an employee,


### PR DESCRIPTION
The name set by the mail gateway was the title of the mail. The name
should be set with the journal sequence when posting instead.
This behavior was broken by 5d24244f417cb8f221f8d418663f4544adcd5613




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
