### PR TITLE
[FIX] filter the invoice line ids in case there is no write_date on o…

### DIFF
--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -51,7 +51,7 @@ class AccountMove(models.Model):
         last_invoice = previous_invoices[-1] if len(previous_invoices) else None
 
         # Get the incoming and outgoing sml between self.invoice_date and the previous invoice (if any).
-        self_datetime = max(self.invoice_line_ids.mapped('write_date')) if self.invoice_line_ids else None
+        self_datetime = max(self.invoice_line_ids.filtered(lambda l: l.write_date).mapped('write_date')) if self.invoice_line_ids else None
         last_invoice_datetime = max(last_invoice.invoice_line_ids.mapped('write_date')) if last_invoice else None
 
         def _filter_incoming_sml(ml):


### PR DESCRIPTION
Issue : 
error when printing an invoice in pdf 

Reproduction : 
With the module sale_stock, print an invoice with on of its line that doesn't have a write_date

Link to the support ticket : 
https://www.odoo.com/web#id=2301363&action=333&active_id=49&model=project.task&view_type=form&cids=1&menu_id=4720

Current behavior before PR:
A traceback appears 

Desired behavior after PR is merged:
The invoice lines that doesn't have a write_date are ignored

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
