### PR TITLE
[FIX] website: background color glitch for transparent header 

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -838,6 +838,11 @@ header {
             }
         }
     }
+    header.o_header_affixed {
+        > .navbar {
+            background-color: transparent !important;
+        }
+    }
 }
 
 // Footer Templates


### PR DESCRIPTION
Previously, when we apply custom color on the transparent header, it's
color is changed to default when we scroll down to the page.

In this commit, we have applied a transparent color strictly when the page is
scrolled down to fix the above issue.

task-2151408