### PR TITLE
[FIX] mail: Access rights error when opening the guidelines of a channel mail

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -452,9 +452,11 @@ class Channel(models.Model):
                 'body_html': view.render({'channel': self, 'partner': partner}, engine='ir.qweb', minimal_qcontext=True),
                 'subject': _("Guidelines of channel %s") % self.name,
                 'email_from': partner.company_id.catchall or partner.company_id.email,
+                'author_id': self.create_uid.partner_id.id,
+                'partner_ids': [(4, partner.id)],
                 'recipient_ids': [(4, partner.id)]
             }
-            mail = self.env['mail.mail'].create(create_values)
+            mail = self.env['mail.mail'].sudo().create(create_values)
             mail.send()
         return True
 

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -70,6 +70,12 @@ class MailMail(models.Model):
         return new_mail
 
     @api.multi
+    def read(self, fields=None, load='_classic_read'):
+        if self.user_has_groups('base.group_system') and self.sudo().filtered(lambda m: not (m.res_id and m.model)):
+            self = self.sudo()
+        return super(MailMail, self).read(fields=fields, load=load)
+
+    @api.multi
     def write(self, vals):
         res = super(MailMail, self).write(vals)
         if vals.get('attachment_ids'):

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -209,7 +209,7 @@ class TestAdvMailPerformance(TransactionCase):
         self.user_test.write({'notification_type': 'email'})
         record = self.env['mail.test.track'].create({'name': 'Test'})
 
-        with self.assertQueryCount(__system__=59, emp=77):  # com runbot: 59 - 77 // test_mail only: 56 - 70
+        with self.assertQueryCount(__system__=60, emp=77):  # com runbot: 59 - 77 // test_mail only: 56 - 70
             record.write({
                 'user_id': self.user_test.id,
             })
@@ -386,7 +386,7 @@ class TestHeavyMailPerformance(TransactionCase):
         })
         mail_ids = mail.ids
 
-        with self.assertQueryCount(__system__=14, emp=21):  # test_mail only: 14 - 21
+        with self.assertQueryCount(__system__=15, emp=21):  # test_mail only: 14 - 21
             self.env['mail.mail'].browse(mail_ids).send()
 
         self.assertEqual(mail.body_html, '<p>Test</p>')
@@ -509,7 +509,7 @@ class TestHeavyMailPerformance(TransactionCase):
         customer_id = self.customer.id
         user_id = self.user_portal.id
 
-        with self.assertQueryCount(__system__=162, emp=199):  # com runbot: 161 - 198 // test_mail only: 161 - 191
+        with self.assertQueryCount(__system__=166, emp=201):  # com runbot: 161 - 198 // test_mail only: 161 - 191
             rec = self.env['mail.test.full'].create({
                 'name': 'Test',
                 'umbrella_id': umbrella_id,
@@ -538,7 +538,7 @@ class TestHeavyMailPerformance(TransactionCase):
         })
         self.assertEqual(rec.message_partner_ids, self.user_portal.partner_id | self.env.user.partner_id)
 
-        with self.assertQueryCount(__system__=99, emp=120):  # com runbot: 98 - 120 // test_mail only: 98 - 116
+        with self.assertQueryCount(__system__=102, emp=122):  # com runbot: 98 - 120 // test_mail only: 98 - 116
             rec.write({
                 'name': 'Test2',
                 'umbrella_id': self.umbrella.id,
@@ -576,7 +576,7 @@ class TestHeavyMailPerformance(TransactionCase):
         })
         self.assertEqual(rec.message_partner_ids, self.user_portal.partner_id | self.env.user.partner_id)
 
-        with self.assertQueryCount(__system__=105, emp=126):  # test_mail only: 105 - 126
+        with self.assertQueryCount(__system__=108, emp=128):  # test_mail only: 105 - 126
             rec.write({
                 'name': 'Test2',
                 'umbrella_id': umbrella_id,
@@ -610,7 +610,7 @@ class TestHeavyMailPerformance(TransactionCase):
         })
         self.assertEqual(rec.message_partner_ids, self.partners | self.env.user.partner_id | self.user_portal.partner_id)
 
-        with self.assertQueryCount(__system__=55, emp=75):  # test_mail only: 55 - 75
+        with self.assertQueryCount(__system__=55, emp=76):  # test_mail only: 55 - 75
             rec.write({
                 'name': 'Test2',
                 'customer_id': customer_id,

--- a/addons/test_mass_mailing/tests/test_performance.py
+++ b/addons/test_mass_mailing/tests/test_performance.py
@@ -49,7 +49,7 @@ class TestMassMailPerformance(TestMassMailPerformanceBase):
             'mailing_domain': [('id', 'in', self.mm_recs.ids)],
         })
 
-        with self.assertQueryCount(__system__=2480, marketing=3136):
+        with self.assertQueryCount(__system__=2529, marketing=3234):
             mailing.send_mail()
 
         self.assertEqual(mailing.sent, 50)
@@ -86,7 +86,7 @@ class TestMassMailBlPerformance(TestMassMailPerformanceBase):
             'mailing_domain': [('id', 'in', self.mm_recs.ids)],
         })
 
-        with self.assertQueryCount(__system__=2867, marketing=3619):
+        with self.assertQueryCount(__system__=2940, marketing=3741):
             mailing.send_mail()
 
         self.assertEqual(mailing.sent, 50)


### PR DESCRIPTION
**Current behavior before PR:**

An Access rights error raised when trying to open the 'Guidelines of channel XX'
mail. This is happening because here for this mail, author_id is an environment
user partner (i.e Demo User) and recipient_ids is also 'Demo User' who doesn't
have the rights to read mail.message as there is no recipient in it. And also
users are going to send mail to themselves which should not be the case.

**Desired behavior after PR is merged:**

An access rights error will not be raised as now the channel creator will send
the mail regarding 'Guidelines of channel' to respective recipients and for that
set author_id as a channel creator partner instead of environment users
partner and add partner_ids while sending the mail.

**LINKS**

PR https://github.com/odoo/odoo/pull/54934
Task-2282599


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
