### PR TITLE
[FIX] crm: Wrong form view from planner

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -449,7 +449,6 @@
         <record id="crm_case_form_view_oppor" model="ir.ui.view">
             <field name="name">crm.lead.form.opportunity</field>
             <field name="model">crm.lead</field>
-            <field name="priority">15</field>
             <field name="arch" type="xml">
                 <form string="Opportunities" class="o_opportunity_form">
                     <header>
@@ -627,6 +626,7 @@
         <record id="crm_case_tree_view_oppor" model="ir.ui.view">
             <field name="name">crm.lead.tree.opportunity</field>
             <field name="model">crm.lead</field>
+            <field name="priority">15</field>
             <field name="arch" type="xml">
                 <tree string="Opportunities" decoration-bf="message_needaction==True" decoration-muted="probability == 100" decoration-danger="activity_date_deadline and (activity_date_deadline &lt; current_date)">
                     <field name="date_deadline" invisible="1"/>


### PR DESCRIPTION
Steps to reproduce the bug:

Go to Lead/Opportunity in the planner
Open an existing record and create a new record from the form view
Bug:

The form view crm.lead.form.opportunity was used instead of crm.lead.form.lead
As the default type is a lead, the default view must be crm.lead.form.lead

PS: When clicking on Lead/Opportunity in the planner, leads and opportunities
are displayed with the same form view crm.lead.form.opportunity (which is the default view
of an opportunity due to its priority)

opw:2292545