### PR TITLE
[FIX] website_event_track: Missing depends in compute fields

### DIFF
--- a/addons/website_event_track/models/event_event.py
+++ b/addons/website_event_track/models/event_event.py
@@ -68,7 +68,7 @@ class Event(models.Model):
             elif event.website_track_proposal and not event.website_track:
                 event.website_track = True
 
-    @api.depends('event_type_id', 'website_track')
+    @api.depends('event_type_id', 'event_type_id.website_track_proposal', 'website_track')
     def _compute_website_track_proposal(self):
         for event in self:
             if event.event_type_id and event.event_type_id != event._origin.event_type_id:


### PR DESCRIPTION
When the field `website_track_proposal` is changed on the
`event_type_id`, it wasn't properly propagated to the linked events
resulting in some inconsistensies.

