### PR TITLE
[FIX] hr_holidays: fix calendar height

### DIFF
--- a/addons/hr_holidays/static/src/js/time_off_calendar.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar.js
@@ -36,6 +36,14 @@ odoo.define('hr_holidays.dashboard.view_custo', function(require) {
             'click .btn-allocation': '_onNewAllocation',
         }),
 
+        /**
+         * @override
+         */
+        start: function () {
+            this.$el.addClass('o_timeoff_calendar');
+            return this._super(...arguments);
+        },
+
         //--------------------------------------------------------------------------
         // Public
         //--------------------------------------------------------------------------

--- a/addons/hr_holidays/static/src/scss/time_off.scss
+++ b/addons/hr_holidays/static/src/scss/time_off.scss
@@ -1,10 +1,10 @@
-.o_content {
+.o_timeoff_calendar .o_content {
     .o_timeoff_container {
-        height: 10%;
+        height: 6rem;
     }
 
     .o_calendar_container {
-      height: 89.5%;
+      height: calc(100% - 6rem);
     }
 
     @include media-breakpoint-down(sm) {


### PR DESCRIPTION
Before this commit, calendar view's height was 89.5% of its container.
It was because of hr_holidays module which reduces the calendar's
height to add some elements on top of it.

This commit changes the css rule that reduces the calendar's
height to reduce it only when `.o_timeoff_container` is in the dom.

Task id: 2193921