### PR TITLE
[FIX] mail: fix can't add follower

### DIFF
--- a/addons/mail/models/mail_followers.py
+++ b/addons/mail/models/mail_followers.py
@@ -322,7 +322,7 @@ GROUP BY fol.id%s""" % (
                 elif existing_policy in ('replace', 'update'):
                     fol_id, sids = next(((key, val[3]) for key, val in data_fols.items() if val[0] == res_id and val[1] == partner_id), (False, []))
                     new_sids = set(partner_subtypes[partner_id]) - set(sids)
-                    old_sids = set(sids) - set(partner_subtypes[partner_id])
+                    old_sids = set(sids  if sids[0] is not None else []) - set(partner_subtypes[partner_id])
                     if fol_id and new_sids:
                         update[fol_id] = {'subtype_ids': [(4, sid) for sid in new_sids]}
                     if fol_id and old_sids and existing_policy == 'replace':


### PR DESCRIPTION
Backport of 2f7f32107917316

Issue

	- Install Contacts
	- Technical / Email / Subtypes / Discussions
	- Uncheck Default
	- Go on any contact
	- Add an user as follower
	- Edit the follower, check any box
	- Save
	- Re-edit for checking

	Not saved

Cause

	In mail_followers.py _add_followers method

	We do:
	```py
	new_sids = set(channel_subtypes[channel_id]) - set(sids)
       	old_sids = set(sids) - set(channel_subtypes[channel_id])
	```

	If no box are checked, sids value will be [None] instead
	of [] (_get_subscription_data) so, new_sids and old_sids
	will have a value but old_sids should not, it override
	the change we made

	We have [None] value because in _get_subscription_data
	we use array_agg which returns a list or None if there
	are no input rows

Solution

	Compute old_sids if sids is not [None]

OPW-2271472

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
