### PR TITLE
[FIX] im_livechat: remove accent of cookie

### DIFF
--- a/addons/im_livechat/static/src/js/im_livechat.js
+++ b/addons/im_livechat/static/src/js/im_livechat.js
@@ -247,7 +247,15 @@ var LivechatButton = Widget.extend({
                     self.call('bus_service', 'addChannel', self._livechat.getUUID());
                     self.call('bus_service', 'startPolling');
 
-                    utils.set_cookie('im_livechat_session', JSON.stringify(self._livechat.toData()), 60*60);
+                    // Safari doesn't accept cookies with non-ASCII characters, so we encode the
+                    // string.
+                    // Note that Python does this encoding automatically.
+                    // Taken from https://stackoverflow.com/a/31652607
+                    let im_livechat_session = JSON.stringify(self._livechat.toData());
+                    im_livechat_session = im_livechat_session.replace(/[\u007F-\uFFFF]/g, chr =>
+                        `\\u${`0000${chr.charCodeAt(0).toString(16)}`.substr(-4)}`
+                    );
+                    utils.set_cookie('im_livechat_session', im_livechat_session, 60*60);
                     utils.set_cookie('im_livechat_auto_popup', JSON.stringify(false), 60*60);
                     if (livechatData.operator_pid[0]) {
                         // livechatData.operator_pid contains a tuple (id, name)

--- a/addons/im_livechat/static/src/js/im_livechat.js
+++ b/addons/im_livechat/static/src/js/im_livechat.js
@@ -252,9 +252,9 @@ var LivechatButton = Widget.extend({
                     // Note that Python does this encoding automatically.
                     // Taken from https://stackoverflow.com/a/31652607
                     let im_livechat_session = JSON.stringify(self._livechat.toData());
-                    im_livechat_session = im_livechat_session.replace(/[\u007F-\uFFFF]/g, chr =>
-                        `\\u${`0000${chr.charCodeAt(0).toString(16)}`.substr(-4)}`
-                    );
+                    im_livechat_session = im_livechat_session.replace(/[\u007F-\uFFFF]/g, function(chr) {
+                        return "\\u" + ("0000" + chr.charCodeAt(0).toString(16)).substr(-4)
+                    })
                     utils.set_cookie('im_livechat_session', im_livechat_session, 60*60);
                     utils.set_cookie('im_livechat_auto_popup', JSON.stringify(false), 60*60);
                     if (livechatData.operator_pid[0]) {
@@ -400,7 +400,11 @@ var LivechatButton = Widget.extend({
      */
     _onSaveChatWindow: function (ev) {
         ev.stopPropagation();
-        utils.set_cookie('im_livechat_session', JSON.stringify(this._livechat.toData()), 60*60);
+        let im_livechat_session = JSON.stringify(this._livechat.toData());
+        im_livechat_session = im_livechat_session.replace(/[\u007F-\uFFFF]/g, function(chr) {
+            return "\\u" + ("0000" + chr.charCodeAt(0).toString(16)).substr(-4)
+        })
+        utils.set_cookie('im_livechat_session', im_livechat_session, 60*60);
     },
     /**
      * @private

--- a/addons/im_livechat/static/src/js/im_livechat.js
+++ b/addons/im_livechat/static/src/js/im_livechat.js
@@ -252,9 +252,9 @@ var LivechatButton = Widget.extend({
                     // Note that Python does this encoding automatically.
                     // Taken from https://stackoverflow.com/a/31652607
                     let im_livechat_session = JSON.stringify(self._livechat.toData());
-                    im_livechat_session = im_livechat_session.replace(/[\u007F-\uFFFF]/g, function(chr) {
-                        return "\\u" + ("0000" + chr.charCodeAt(0).toString(16)).substr(-4)
-                    })
+                    // im_livechat_session = im_livechat_session.replace(/[\u007F-\uFFFF]/g, function(chr) {
+                    //     return "\\u" + ("0000" + chr.charCodeAt(0).toString(16)).substr(-4)
+                    // })
                     utils.set_cookie('im_livechat_session', im_livechat_session, 60*60);
                     utils.set_cookie('im_livechat_auto_popup', JSON.stringify(false), 60*60);
                     if (livechatData.operator_pid[0]) {
@@ -401,9 +401,9 @@ var LivechatButton = Widget.extend({
     _onSaveChatWindow: function (ev) {
         ev.stopPropagation();
         let im_livechat_session = JSON.stringify(this._livechat.toData());
-        im_livechat_session = im_livechat_session.replace(/[\u007F-\uFFFF]/g, function(chr) {
-            return "\\u" + ("0000" + chr.charCodeAt(0).toString(16)).substr(-4)
-        })
+        // im_livechat_session = im_livechat_session.replace(/[\u007F-\uFFFF]/g, function(chr) {
+        //     return "\\u" + ("0000" + chr.charCodeAt(0).toString(16)).substr(-4)
+        // })
         utils.set_cookie('im_livechat_session', im_livechat_session, 60*60);
     },
     /**

--- a/addons/im_livechat/static/src/js/models/website_livechat.js
+++ b/addons/im_livechat/static/src/js/models/website_livechat.js
@@ -101,12 +101,20 @@ var WebsiteLivechat = AbstractThread.extend(ThreadTypingMixin, {
      * @returns {Object}
      */
     toData: function () {
+        let toAscii = function (str) {
+            return str.replace(/[\u007F-\uFFFF]/g, chr =>
+                `\\u${`0000${chr.charCodeAt(0).toString(16)}`.substr(-4)}`
+            );
+        };
+        let operatorPID = this.getOperatorPID();
+        operatorPID[1] = toAscii(operatorPID[1]);
+
         return {
             folded: this.isFolded(),
             id: this.getID(),
             message_unread_counter: this.getUnreadCounter(),
-            operator_pid: this.getOperatorPID(),
-            name: this.getName(),
+            operator_pid: operatorPID,
+            name: toAscii(this.getName()),
             uuid: this.getUUID(),
         };
     },


### PR DESCRIPTION
- Install `website_livechat`
- Publish the demo livechat
- Set an accent to the operator name, e.g. 'Bòb'
- Visit the website with Safari and start a chat session
- Close the window
- Refresh the page

Error in browser console that sometime appear as a traceback.

It happens because Safari refuses to send any cookie containing
non-ASCII characters [1]. Actually, Safari strips the value before the
first non-ASCII character, making the JSON string corrupted.

Having such special characters in cookies is uncommon, so we only clean
the necessary string. Moreover, it's better to avoid our tools modifying
all cookies set without being aware of it.

[1] https://stackoverflow.com/questions/1969232/what-are-allowed-characters-in-cookies/1969339#1969339

opw-2273293

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
