### PR TITLE
[IMP] http: allow to handle HTTP and JSON requests on the same endpoint

### DIFF
--- a/addons/im_livechat/models/mail_channel.py
+++ b/addons/im_livechat/models/mail_channel.py
@@ -31,7 +31,6 @@ class MailChannel(models.Model):
     _name = 'mail.channel'
     _inherit = ['mail.channel', 'rating.mixin']
 
-    anonymous_name = fields.Char('Anonymous Name')
     channel_type = fields.Selection(selection_add=[('livechat', 'Livechat Conversation')])
     livechat_active = fields.Boolean('Is livechat ongoing?', help='Livechat session is active until visitor leave the conversation.')
     livechat_channel_id = fields.Many2one('im_livechat.channel', 'Channel')

--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -122,6 +122,7 @@ class Channel(models.Model):
     moderation_notify_msg = fields.Text(string="Notification message")
     moderation_guidelines = fields.Boolean(string="Send guidelines to new subscribers", help="Newcomers on this moderated channel will automatically receive the guidelines.")
     moderation_guidelines_msg = fields.Text(string="Guidelines")
+    anonymous_name = fields.Char('Anonymous Name')
 
     @api.depends('channel_partner_ids')
     def _compute_is_subscribed(self):
@@ -562,6 +563,7 @@ class Channel(models.Model):
                 'is_moderator': self.env.uid in channel.moderator_ids.ids,
                 'group_based_subscription': bool(channel.group_ids),
                 'create_uid': channel.create_uid.id,
+                'anonymous_name': channel.anonymous_name,
             }
             if extra_info:
                 info['info'] = extra_info

--- a/addons/mail/static/src/components/discuss_sidebar/discuss_sidebar.js
+++ b/addons/mail/static/src/components/discuss_sidebar/discuss_sidebar.js
@@ -7,6 +7,8 @@ const components = {
 };
 const useStore = require('mail/static/src/component_hooks/use_store/use_store.js');
 
+const patchMixin = require('web.patchMixin');
+
 const { Component } = owl;
 const { useRef } = owl.hooks;
 
@@ -302,6 +304,6 @@ Object.assign(DiscussSidebar, {
     template: 'mail.DiscussSidebar',
 });
 
-return DiscussSidebar;
+return patchMixin(DiscussSidebar);
 
 });

--- a/addons/mail/static/src/components/message/message.js
+++ b/addons/mail/static/src/components/message/message.js
@@ -128,26 +128,6 @@ class Message extends Component {
     //--------------------------------------------------------------------------
 
     /**
-     * @returns {string}
-     */
-    get avatar() {
-        if (
-            this.message.author &&
-            this.message.author === this.env.messaging.partnerRoot
-        ) {
-            return '/mail/static/src/img/odoobot.png';
-        } else if (this.message.author) {
-            // TODO FIXME for public user this might not be accessible. task-2223236
-            // we should probably use the correspondig attachment id + access token
-            // or create a dedicated route to get message image, checking the access right of the message
-            return `/web/image/res.partner/${this.message.author.id}/image_128`;
-        } else if (this.message.message_type === 'email') {
-            return '/mail/static/src/img/email_icon.png';
-        }
-        return '/mail/static/src/img/smiley/avatar.jpg';
-    }
-
-    /**
      * Get the date time of the message at current user locale time.
      *
      * @returns {string}

--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -18,7 +18,7 @@
                 <div class="o_Message_sidebar" t-att-class="{ 'o-message-squashed': props.isSquashed }">
                     <t t-if="!props.isSquashed">
                         <div class="o_Message_authorAvatarContainer o_Message_sidebarItem">
-                            <img class="o_Message_authorAvatar rounded-circle" t-att-class="{ o_Message_authorRedirect: hasAuthorOpenChat, o_redirect: hasAuthorOpenChat }" t-att-src="avatar" t-on-click="_onClickAuthorAvatar" t-att-title="hasAuthorOpenChat ? OPEN_CHAT : ''" alt="Avatar"/>
+                            <img class="o_Message_authorAvatar rounded-circle" t-att-class="{ o_Message_authorRedirect: hasAuthorOpenChat, o_redirect: hasAuthorOpenChat }" t-att-src="message.avatar" t-on-click="_onClickAuthorAvatar" t-att-title="hasAuthorOpenChat ? OPEN_CHAT : ''" alt="Avatar"/>
                             <t t-if="message.author and message.author.im_status">
                                 <PartnerImStatusIcon
                                     class="o_Message_partnerImStatusIcon"
@@ -70,7 +70,7 @@
                             </t>
                             <t t-else="">
                                 <div class="o_Message_authorName">
-                                    Anonymous
+                                    <t t-esc="message.anonymousName"/>
                                 </div>
                             </t>
                             <div class="o_Message_date o_Message_headerDate" t-att-class="{ 'o-message-selected': props.isSelected }" t-att-title="datetime">

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -183,6 +183,9 @@ function factory(dependencies) {
             if ('name' in data) {
                 data2.name = data.name;
             }
+            if ('anonymous_name' in data) {
+                data2.anonymous_name = data.anonymous_name;
+            }
             if ('public' in data) {
                 data2.public = data.public;
             }
@@ -1202,6 +1205,7 @@ function factory(dependencies) {
                 'originThreadAttachments',
             ],
         }),
+        anonymous_name: attr(),
         areAttachmentsLoaded: attr({
             default: false,
         }),

--- a/addons/test_website/controllers/main.py
+++ b/addons/test_website/controllers/main.py
@@ -120,6 +120,17 @@ class WebsiteTest(Home):
     def get_post_method_no_multilang(self, **kw):
         return request.make_response('get_post_nomultilang')
 
+    @http.route(['/test_route_json_http'], type='*', auth="public", methods=['GET', 'POST'], csrf=False)
+    def test_route_json_http(self, **kw):
+        if hasattr(request, 'jsonrequest'):
+            return request.jsonrequest
+        return str(kw)
+
+    @http.route(['/test_route_json_and_http_type_return_dict'], type='*', auth="public", methods=['GET'], csrf=False)
+    def test_route_json_and_http_type_return_dict(self):
+        """Return a dict for HTTP call (Content-type != json) and "JSON call"."""
+        return {'a': 7, 'b': 8}
+
     # Test Perfs
 
     @http.route(['/empty_controller_test'], type='http', auth='public', website=True, multilang=False, sitemap=False)

--- a/addons/test_website/tests/test_controller_args.py
+++ b/addons/test_website/tests/test_controller_args.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 import odoo.tests
 
 
@@ -29,3 +30,32 @@ class TestWebsiteControllerArgs(odoo.tests.HttpCase):
         req = self.url_open('/ignore_args/kw?a=valueA&b=valueB')
         self.assertEqual(req.status_code, 200)
         self.assertEqual(req.json(), {'a': 'valueA', 'kw': {'b': 'valueB'}})
+
+    def test_route_type_all(self):
+        """
+        The route type "*" must be able to receive both JSON and simple HTTP requests.
+        """
+        response = self.url_open('/test_route_json_http?param=value')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.text, "{'param': 'value'}")
+
+        response = self.url_open(
+            '/test_route_json_http',
+            data=b"param=value",
+            headers={'Content-type': 'application/x-www-form-urlencoded'}
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.text, "{'param': 'value'}")
+
+        response = self.url_open(
+            '/test_route_json_http',
+            data=b'{"a": "value", "b": {"c": 2}}',
+            headers={'Content-type': 'application/json'}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['result'], {"a": "value", "b": {"c": 2}})
+
+        response = self.url_open('/test_route_json_and_http_type_return_dict')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'a': 7, 'b': 8})

--- a/addons/website/tools.py
+++ b/addons/website/tools.py
@@ -115,6 +115,7 @@ class MockRequest(object):
                 'sale_order_id': kw.get('sale_order_id'),
             },
             'website': kw.get('website'),
+            '_request_type': kw.get('request_type', 'http'),
         })
 
     def __enter__(self):

--- a/addons/website_sale/tests/test_website_sale_visitor.py
+++ b/addons/website_sale/tests/test_website_sale_visitor.py
@@ -22,7 +22,7 @@ class WebsiteSaleVisitorTests(TransactionCase):
             'website_published': True,
         })
 
-        with MockRequest(self.env, website=self.website):
+        with MockRequest(self.env, website=self.website, request_type='json'):
             self.cookies = self.WebsiteSaleController.products_recently_viewed_update(product.id)
 
         new_visitors = self.env['website.visitor'].search([('id', 'not in', existing_visitors.ids)])
@@ -30,7 +30,7 @@ class WebsiteSaleVisitorTests(TransactionCase):
         self.assertEqual(len(new_visitors), 1, "A visitor should be created after visiting a tracked product")
         self.assertEqual(len(new_tracks), 1, "A track should be created after visiting a tracked product")
 
-        with MockRequest(self.env, website=self.website, cookies=self.cookies):
+        with MockRequest(self.env, website=self.website, cookies=self.cookies, request_type='json'):
             self.WebsiteSaleController.products_recently_viewed_update(product.id)
 
         new_visitors = self.env['website.visitor'].search([('id', 'not in', existing_visitors.ids)])
@@ -44,7 +44,7 @@ class WebsiteSaleVisitorTests(TransactionCase):
             'list_price': 320.0,
         })
 
-        with MockRequest(self.env, website=self.website, cookies=self.cookies):
+        with MockRequest(self.env, website=self.website, cookies=self.cookies, request_type='json'):
             self.WebsiteSaleController.products_recently_viewed_update(product.id)
 
         new_visitors = self.env['website.visitor'].search([('id', 'not in', existing_visitors.ids)])

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -318,7 +318,7 @@ class WebRequest(object):
 
     def _call_function(self, *args, **kwargs):
         request = self
-        if self.endpoint.routing['type'] != self._request_type:
+        if self.endpoint.routing['type'] != self._request_type and self.endpoint.routing['type'] != '*':
             msg = "%s, %s: Function declared as capable of handling request of type '%s' but called with a request of type '%s'"
             params = (self.endpoint.original, self.httprequest.path, self.endpoint.routing['type'], self._request_type)
             _logger.info(msg, *params)
@@ -501,7 +501,7 @@ def route(route=None, **kw):
 
     """
     routing = kw.copy()
-    assert 'type' not in routing or routing['type'] in ("http", "json")
+    assert 'type' not in routing or routing['type'] in ("http", "json", "*")
     def decorator(f):
         if route:
             if isinstance(route, list):
@@ -525,7 +525,16 @@ def route(route=None, **kw):
                     _logger.info("<function %s.%s> called ignoring args %s" % (f.__module__, f.__name__, ', '.join(ignored)))
 
             response = f(*args, **kw)
-            if isinstance(response, Response) or f.routing_type == 'json':
+
+            if (
+                request.endpoint
+                and request.endpoint.routing.get('type') == "*"
+                and isinstance(response, (dict, list))
+                and request._request_type == 'http'
+            ):
+                return Response(json.dumps(response))
+
+            if isinstance(response, Response) or request._request_type == 'json':
                 return response
 
             if isinstance(response, (bytes, str)):

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -293,7 +293,7 @@ def html_keep_url(text):
     return final
 
 
-def html2plaintext(html, body_id=None, encoding='utf-8'):
+def html2plaintext(html, body_id=None, encoding='utf-8', link_summary=True):
     """ From an HTML text, convert the HTML to plain text.
     If @param body_id is provided then this is the tag where the
     body (not necessarily <body>) starts.
@@ -317,14 +317,15 @@ def html2plaintext(html, body_id=None, encoding='utf-8'):
         tree = source[0]
 
     url_index = []
-    i = 0
-    for link in tree.findall('.//a'):
-        url = link.get('href')
-        if url:
-            i += 1
-            link.tag = 'span'
-            link.text = '%s [%s]' % (link.text, i)
-            url_index.append(url)
+    if link_summary:
+        i = 0
+        for link in tree.findall('.//a'):
+            url = link.get('href')
+            if url:
+                i += 1
+                link.tag = 'span'
+                link.text = '%s [%s]' % (link.text, i)
+                url_index.append(url)
 
     html = ustr(etree.tostring(tree, encoding=encoding))
     # \r char is converted into &#13;, must remove it


### PR DESCRIPTION
Purpose
=======
Be able to send/receive Facebook messages in Discuss.

Specifications
==============
Routing type
----------------
Actually, there are only 2 routing types, `http` and `json`.
But, in some case, we might need to manage standard HTTP
requests and JSON requests, on the same endpoint.

That's the case with the Facebook webhook. They first make a
simple HTTP request to check if the endpoint is a valid webhook
endpoint and then, the events are sent in a JSON request.

That's why we need a new routing type.

Customize the header of the thread window
---------------------------
We want to be able to customize the thread window, so we can have a blue header for the Facebook channel.

`anonymous_name` field
------------------------
In livechat, we have an "anonymous name" on the mail channel.
This field is useful because we do not have one partner per visitor.

In social, we also need this field (as we do not have a partner per
Facebook user) so we move it to mail.

Task-2124457