### PR TITLE
[FIX] web_enterprise: redirect to menu for instance on web client reload

### DIFF
--- a/addons/web/static/src/js/chrome/abstract_web_client.js
+++ b/addons/web/static/src/js/chrome/abstract_web_client.js
@@ -119,6 +119,7 @@ var AbstractWebClient = Widget.extend(KeyboardNavigationMixin, {
         this.on("change:title_part", this, this._title_changed);
         this._title_changed();
 
+        const originalState = $.bbq.getState();
         var state = $.bbq.getState();
         // If not set on the url, retrieve cids from the local storage
         // of from the default company on the user
@@ -138,7 +139,9 @@ var AbstractWebClient = Widget.extend(KeyboardNavigationMixin, {
         }
         // Update the user context with this configuration
         session.user_context.allowed_company_ids = stateCompanyIDS;
-        $.bbq.pushState(state);
+        if (!_.isEqual(originalState, state)) {
+            $.bbq.pushState(state);
+        }
         // Update favicon
         $("link[type='image/x-icon']").attr('href', '/web/image/res.company/' + String(stateCompanyIDS[0]) + '/favicon/')
 


### PR DESCRIPTION
**PURPOSE**
When you reload the web client (any view), it will redirect to the menu for
instance and then it will propagate to the view it self. with this, it is also
changing the url hash of the view for the first load and the second load of the
same view.

**SPEC**
We are checking before pushing the state that the current state is different from 
the previous state then only we push the state to bbq.
so, the view will load with the same url hash and no brief redirection to
the menu for instance.

Task : 2301277