### PR TITLE
[IMP] Allow superuser to set log_access fields.

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3736,8 +3736,8 @@ class BaseModel(metaclass=MetaModel):
 
         bad_names = {'id', 'parent_path'}
         if self._log_access:
-            # the superuser can set log_access fields while loading registry
-            if not(self.env.uid == SUPERUSER_ID and not self.pool.ready):
+            # the superuser can set log_access fields
+            if not(self.env.uid == SUPERUSER_ID):
                 bad_names.update(LOG_ACCESS_COLUMNS)
 
         # set magic fields
@@ -4095,8 +4095,8 @@ class BaseModel(metaclass=MetaModel):
         """
         bad_names = ['id', 'parent_path']
         if self._log_access:
-            # the superuser can set log_access fields while loading registry
-            if not(self.env.uid == SUPERUSER_ID and not self.pool.ready):
+            # the superuser can set log_access fields
+            if not(self.env.uid == SUPERUSER_ID):
                 bad_names.extend(LOG_ACCESS_COLUMNS)
 
         # also discard precomputed readonly fields (to force their computation)


### PR DESCRIPTION
### Current behavior before PR:

After https://github.com/odoo/odoo/pull/26788, the superuser is able to set log_access fields, but only during module installation. This is not sufficient for users migrating data from other systems of record, whose create and write times are correct and have value, and whose data sets are too large for inclusion in a module.

### Desired behavior after PR is merged:

A user can update log_access fields during record creation instead of afterwards:
```python
record = self.env[model].sudo().create(vals)

# Update timestamps to match source system
cols = set(vals) & set(models.LOG_ACCESS_COLUMNS):
if cols:
    # Please pardon lack of defensive coding in this example, I always have all four of these fields.
    sql = f"update {record._table} set create_date = %(create_date)s, create_uid = %(create_uid)s, write_date = %(write_date)s, write_uid = %(write_uid)s where id = {record.id}"
    self.env.cr.execute(sql, vals)
```

Given the prevalence of `.sudo().create/write` in the codebase, I do think it would be perfectly reasonable to guard this behavior with a `log_access` context variable, or to limit it to record creation. Opinions?

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
