### PR TITLE
[FIX] website_sale: Incorrect Terms and Conditions applied in website

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -213,6 +213,8 @@ class Website(models.Model):
         company = self.company_id or pricelist.company_id
         if company:
             values['company_id'] = company.id
+            if self.env['ir.config_parameter'].sudo().get_param('sale.use_sale_note'):
+                values['note'] = company.sale_note or ''
 
         return values
 


### PR DESCRIPTION
Steps to reproduce the bug:

1. Install eShop and Sales
2. Change Mitchell Admin settings so that he can see the 3 companies
3. Go into Settings and set a distinct "Terms and Conditions" text for each companies
4. Go the Website > Configuration, set "My website" to "Company_1" and save
5. Go to the website shop and buy any items
6. Find its corresponding Sale order (should be on Company_1)

Bug:

"Terms and Conditions" used in the SO is the one of "YourCompany"

opw:2297114