### PR TITLE
[FIX] account: calculation of tax included of type division

### DIFF
--- a/addons/account/models/account.py
+++ b/addons/account/models/account.py
@@ -1460,7 +1460,7 @@ class AccountTax(models.Model):
             return base_amount / (1 - self.amount / 100) - base_amount if (1 - self.amount / 100) else 0.0
         # <=> new_base * (1 - tax_amount) = base
         if self.amount_type == 'division' and price_include:
-            return base_amount - (base_amount * (self.amount / 100))
+            return base_amount * (self.amount / 100)
 
     def json_friendly_compute_all(self, price_unit, currency_id=None, quantity=1.0, product_id=None, partner_id=None, is_refund=False):
         """ Called by the reconciliation to compute taxes on writeoff during bank reconciliation


### PR DESCRIPTION
The explanation in the help message for tax type
of type division (Percentage of Price Included)
did not correspond to reality.  It is probably not
a case much supported in reality, but by correcting
the formula, at least it stays consistent.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
