### PR TITLE
[IMP] web_editor: set opacity by default on the color filter

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -1234,8 +1234,9 @@ const ColorpickerUserValueWidget = SelectUserValueWidget.extend({
      * @returns {Promise}
      */
     _renderColorPalette: function () {
+        const preselectedColor = this.options.dataAttributes.preselectedColor || '';
         const options = {
-            selectedColor: this._value,
+            selectedColor: this._value || preselectedColor,
         };
         if (this.options.dataAttributes.excluded) {
             options.excluded = this.options.dataAttributes.excluded.replace(/ /g, '').split(',');

--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -43,7 +43,10 @@
         </we-title>
     </div>
     <!-- &emsp; -->
-    <we-colorpicker t-att-string="indent and (' ⌙ %s' % filter_label) or filter_label" data-set-filter="" data-excluded="common, theme"/>
+    <we-colorpicker t-att-string="indent and (' ⌙ %s' % filter_label) or filter_label"
+                    data-set-filter=""
+                    data-preselected-color="rgba(255,0,0,0.5)"
+                    data-excluded="common, theme"/>
     <we-select t-att-string="indent and (' ⌙ %s' % width_label) or width_label" data-name="width_select_opt"/>
     <we-range t-att-string="indent and (' ⌙ %s' % quality_label) or quality_label" data-set-quality=""/>
     <div class="o_we_image_weight d-none"><i class="fa fa-long-arrow-right"/><span/></div>


### PR DESCRIPTION
Set the color filter an opacity by default to not have the image
completely hidden by the color during the preview/choice of a colour
with the color filter option.

task-2312967

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
