### PR TITLE
[FIX] website_hr_recruitment: Jobs menu should be shown if job is pub…

### DIFF
--- a/addons/website_hr_recruitment/data/config_data.xml
+++ b/addons/website_hr_recruitment/data/config_data.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data noupdate="1">
+        <record id="menu_job" model="website.menu">
+            <field name="name">Jobs</field>
+            <field name="url">/jobs</field>
+            <field name="parent_id" ref="website.main_menu"/>
+            <field name="sequence" type="int">50</field>
+        </record>
         <record id="action_open_website" model="ir.actions.act_url">
             <field name="name">Website Recruitment Form</field>
             <field name="target">self</field>


### PR DESCRIPTION
…lished

Currently, when we try to show the jobs menu on the website,
it does not show even if the job is published.

So in this commit, we show jobs menu on the website if the job
is published.

LINKS
PR: #55613
Task-Id: 2282005

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
