### PR TITLE
[FIX] account: avoid setting due_date to null on partner change

### DIFF
--- a/addons/account/models/account_invoice.py
+++ b/addons/account/models/account_invoice.py
@@ -869,7 +869,6 @@ class AccountInvoice(models.Model):
         self.account_id = account_id
         if payment_term_id:
             self.payment_term_id = payment_term_id
-        self.date_due = False
         self.fiscal_position_id = fiscal_position
 
         if type in ('in_invoice', 'out_refund'):


### PR DESCRIPTION
Steps to reproduce bug:
            Send an invoice to OCR.
            Wait for OCR result
            Edit the invoice and select a due_date using box selector
            Select a VAT number with box selector
            => Due date is set to False
Reason: _onchange_partner_id is called on VAT change.

Youtube link: https://www.youtube.com/watch?v=r5CYBUfDo3E&feature=youtu.be

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
