### PR TITLE
[FIX] mrp: Manufacture prodcut without a kit

### DIFF
--- a/addons/mrp/i18n/mrp.pot
+++ b/addons/mrp/i18n/mrp.pot
@@ -3865,6 +3865,14 @@ msgid ""
 msgstr ""
 
 #. module: mrp
+#: code:addons/mrp/models/product.py:0
+#, python-format
+msgid ""
+"There is no Bill of Material of type manufacture or kit found for this "
+"product. Please define a Bill of Material for this product."
+msgstr ""
+
+#. module: mrp
 #: model_terms:ir.actions.act_window,help:mrp.action_mrp_unbuild_move_line
 msgid "There's no product move yet"
 msgstr ""

--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -2,7 +2,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import timedelta
-from odoo import api, fields, models
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
 from odoo.tools.float_utils import float_round, float_is_zero
 
 
@@ -48,6 +49,13 @@ class ProductTemplate(models.Model):
             'time_ranges': {'field': 'date_planned_start', 'range': 'last_365_days'}
         }
         return action
+
+    @api.onchange('route_ids')
+    def _onchange_routes(self):
+        route_manufacture = self.env.ref('mrp.route_warehouse0_manufacture')
+        if route_manufacture.id in self.route_ids.ids:
+            if not self.env['mrp.bom']._bom_find(product_tmpl=self, bom_type='phantom'):
+                raise UserError(_('There is no Bill of Material of type manufacture or kit found for this product. Please define a Bill of Material for this product.'))
 
 
 class ProductProduct(models.Model):

--- a/addons/sale_mrp/tests/test_sale_mrp_procurement.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_procurement.py
@@ -35,7 +35,6 @@ class TestSaleMrpProcurement(TransactionCase):
         product.uom_id = uom_unit
         product.uom_po_id = uom_unit
         product.route_ids.clear()
-        product.route_ids.add(warehouse0.manufacture_pull_id.route_id)
         product.route_ids.add(warehouse0.mto_pull_id.route_id)
         product_template_slidermobile0 = product.save()
 
@@ -53,6 +52,7 @@ class TestSaleMrpProcurement(TransactionCase):
                 line.product_id = product_product_bettery
                 line.product_qty = 4
 
+        product_template_slidermobile0.route_ids += self.env.ref('mrp.route_warehouse0_manufacture')
         # I create a sale order for product Slider mobile
         so_form = Form(self.env['sale.order'])
         so_form.partner_id = self.env.ref('base.res_partner_4')


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a consumable product template PT with routes MTO and Manufacture
- Notice that PT has no phantom BOM
- Create a SO for PT and validate it

Bug:

A userError was raised saying that TP must have at least one phantom BOM

opw:2314731