### PR TITLE
[FIX] website_editor: resizing on body leave

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -491,6 +491,7 @@ registry.marginAndResize = SnippetOption.extend({
             var body_mouseup = function () {
                 $body.unbind('mousemove', body_mousemove);
                 $body.unbind('mouseup', body_mouseup);
+                $body.unbind('mouseleave', body_mouseup);
                 $body.removeClass(cursor);
                 setTimeout(function () {
                     if (begin !== current) {
@@ -511,6 +512,7 @@ registry.marginAndResize = SnippetOption.extend({
             };
             $body.mousemove(body_mousemove);
             $body.mouseup(body_mouseup);
+            $body.mouseleave(body_mouseup);
         });
         $auto_size.on('click', function () {
             self.$target.css('height', '');


### PR DESCRIPTION
To resize a snippet, you click on one of the arrow icon and drag to the
desired size. Unfortunately, if you 'mouseup' outside of the body,
you'll still be in 'resize' mode and be able to change size by moving
your pointer around until you click somewhere on the page. In order to
avoid that, 'resize' mode is automatically leave when the pointer leave
the body.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
