### PR TITLE
[IMP] website_event_track_online: text displayed

### DIFF
--- a/addons/website_event_track_online/static/src/xml/website_event_pwa.xml
+++ b/addons/website_event_track_online/static/src/xml/website_event_pwa.xml
@@ -2,7 +2,7 @@
 
     <t t-name="pwa_install_banner">
         <div class="alert alert-default o_pwa_install_banner">
-            <strong>Install Application</strong>
+            <strong>Events Application</strong>
             <button class="btn btn-primary o_btn_install">Install</button>
         </div>
     </t>


### PR DESCRIPTION
On mobile device, the event PWA display an install bar to ask the user
to install the event app.

This commit allows change the displayed text to avoid the duplicate
"ìnstall" word.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
