### PR TITLE
[FIX] account: concurency in sequence.mixin

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -288,6 +288,13 @@ class AccountMove(models.Model):
     inalterable_hash = fields.Char(string="Inalterability Hash", readonly=True, copy=False)
     string_to_hash = fields.Char(compute='_compute_string_to_hash', readonly=True)
 
+    _sql_constraints = [
+        ('unique_name',
+         """EXCLUDE (name WITH =, journal_id WITH =, move_type WITH =)
+              WHERE (state = 'posted' AND name != '/')""",
+         'Posted Journal Entries\' numbers must be unique by journal.'),
+    ]
+
     @api.model
     def _field_will_change(self, record, vals, field_name):
         if field_name not in vals:
@@ -1524,30 +1531,6 @@ class AccountMove(models.Model):
     def _validate_move_modification(self):
         if 'posted' in self.mapped('line_ids.payment_id.state'):
             raise ValidationError(_("You cannot modify a journal entry linked to a posted payment."))
-
-    @api.constrains('name', 'journal_id', 'state')
-    def _check_unique_sequence_number(self):
-        moves = self.filtered(lambda move: move.state == 'posted')
-        if not moves:
-            return
-
-        self.flush()
-
-        # /!\ Computed stored fields are not yet inside the database.
-        self._cr.execute('''
-            SELECT move2.id, move2.name
-            FROM account_move move
-            INNER JOIN account_move move2 ON
-                move2.name = move.name
-                AND move2.journal_id = move.journal_id
-                AND move2.move_type = move.move_type
-                AND move2.id != move.id
-            WHERE move.id IN %s AND move2.state = 'posted'
-        ''', [tuple(moves.ids)])
-        res = self._cr.fetchall()
-        if res:
-            raise ValidationError(_('Posted journal entry must have an unique sequence number per company.\n'
-                                    'Problematic numbers: %s\n') % ', '.join(r[1] for r in res))
 
     @api.constrains('ref', 'move_type', 'partner_id', 'journal_id', 'invoice_date')
     def _check_duplicate_supplier_reference(self):

--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -133,11 +133,14 @@ class SequenceMixin(models.AbstractModel):
             param['id'] = self.id or self.id.origin
 
         query = """
-            SELECT {field} FROM {table}
-            {where_string}
-            AND sequence_prefix = (SELECT sequence_prefix FROM account_move {where_string} ORDER BY id DESC LIMIT 1)
-            ORDER BY sequence_number DESC
-            LIMIT 1 FOR UPDATE
+            UPDATE {table} SET write_date = write_date WHERE id = (
+                SELECT id FROM {table}
+                {where_string}
+                AND sequence_prefix = (SELECT sequence_prefix FROM {table} {where_string} ORDER BY id DESC LIMIT 1)
+                ORDER BY sequence_number DESC
+                LIMIT 1
+            )
+            RETURNING {field};
         """.format(
             table=self._table,
             where_string=where_string,

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -2,12 +2,14 @@
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import tagged, new_test_user
 from odoo.tests.common import Form
-from odoo import fields
+from odoo import fields, api, SUPERUSER_ID
 from odoo.exceptions import ValidationError, UserError
+from odoo.tools import mute_logger
 
 from dateutil.relativedelta import relativedelta
 from functools import reduce
 import json
+import psycopg2
 
 
 @tagged('post_install', '-at_install')
@@ -529,6 +531,53 @@ class TestAccountMove(AccountTestInvoicingCommon):
         self.assertEqual(copies[3].state, 'posted')
         self.assertEqual(copies[5].name, 'XMISC/2019/10005')
         self.assertEqual(copies[5].state, 'draft')
+
+    def test_sequence_concurency(self):
+        with self.env.registry.cursor() as cr0,\
+                self.env.registry.cursor() as cr1,\
+                self.env.registry.cursor() as cr2:
+            env0 = api.Environment(cr0, SUPERUSER_ID, {})
+            env1 = api.Environment(cr1, SUPERUSER_ID, {})
+            env2 = api.Environment(cr2, SUPERUSER_ID, {})
+
+            journal = env0['account.journal'].create({
+                'name': 'concurency_test',
+                'code': 'CT',
+                'type': 'general',
+            })
+            account = env0['account.account'].create({
+                'code': 'CT',
+                'name': 'CT',
+                'user_type_id': env0.ref('account.data_account_type_fixed_assets').id,
+            })
+            moves = env0['account.move'].create([{
+                'journal_id': journal.id,
+                'date': fields.Date.from_string('2016-01-01'),
+                'line_ids': [(0, 0, {'name': 'name', 'account_id': account.id})]
+            }] * 3)
+            moves.name = '/'
+            moves[0].post()
+            self.assertEqual(moves.mapped('name'), ['CT/2016/01/0001', '/', '/'])
+            env0.cr.commit()
+
+            # start the transactions here on cr2 to simulate concurency with cr1
+            env2.cr.execute('SELECT 1')
+
+            move = env1['account.move'].browse(moves[1].id)
+            move.post()
+            env1.cr.commit()
+
+            move = env2['account.move'].browse(moves[2].id)
+            with self.assertRaises(psycopg2.OperationalError), env2.cr.savepoint(), mute_logger('odoo.sql_db'):
+                move.post()
+
+            self.assertEqual(moves.mapped('name'), ['CT/2016/01/0001', 'CT/2016/01/0002', '/'])
+            moves.button_draft()
+            moves.posted_before = False
+            moves.unlink()
+            journal.unlink()
+            account.unlink()
+            env0.cr.commit()
 
     def test_add_followers_on_post(self):
         # Add some existing partners, some from another company

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -3,7 +3,7 @@ from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import tagged, new_test_user
 from odoo.tests.common import Form
 from odoo import fields, api, SUPERUSER_ID
-from odoo.exceptions import ValidationError, UserError
+from odoo.exceptions import UserError
 from odoo.tools import mute_logger
 
 from dateutil.relativedelta import relativedelta
@@ -493,7 +493,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
         self.assertEqual(copies[5].name, 'XMISC/2019/00004')
 
         # Can't have twice the same name
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(psycopg2.IntegrityError), mute_logger('odoo.sql_db'), self.env.cr.savepoint():
             copies[0].name = 'XMISC/2019/00001'
 
         # Lets remove the order by date

--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -219,6 +219,16 @@ class AccountMove(models.Model):
                     [('l10n_ar_letter', '=', self.l10n_latam_document_type_id.l10n_ar_letter)]).ids)
         return where_string, param
 
+    def _get_key_compute_name(self):
+        journal_key, date_key = super()._get_key_compute_name()
+        if self.company_id.country_id == self.env.ref('base.ar') and self.l10n_latam_use_documents and self.is_sale_document():
+            if not self.journal_id.l10n_ar_share_sequences:
+                journal_key = self.l10n_latam_document_type_id
+            else:
+                journal_key = self.l10n_latam_document_type_id.l10n_ar_letter
+            date_key = False
+        return journal_key, date_key
+
     def _get_name_invoice_report(self, report_xml_id):
         self.ensure_one()
         if self.l10n_latam_use_documents and self.company_id.country_id.code == 'AR':

--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -198,14 +198,18 @@ class AccountMove(models.Model):
     def _get_starting_sequence(self):
         """ If use documents then will create a new starting sequence using the document type code prefix and the
         journal document number with a 8 padding number """
-        if self.journal_id.l10n_latam_use_documents and self.env.company.country_id == self.env.ref('base.ar'):
+        if (
+            self.journal_id.l10n_latam_use_documents
+            and self.env.company.country_id == self.env.ref('base.ar')
+            and self.is_sale_document()
+        ):
             if self.l10n_latam_document_type_id:
                 return self._get_formatted_sequence()
         return super()._get_starting_sequence()
 
     def _get_last_sequence_domain(self, relaxed=False):
         where_string, param = super(AccountMove, self)._get_last_sequence_domain(relaxed)
-        if self.company_id.country_id == self.env.ref('base.ar') and self.l10n_latam_use_documents:
+        if self.company_id.country_id == self.env.ref('base.ar') and self.l10n_latam_use_documents and self.is_sale_document():
             if not self.journal_id.l10n_ar_share_sequences:
                 where_string += " AND l10n_latam_document_type_id = %(l10n_latam_document_type_id)s"
                 param['l10n_latam_document_type_id'] = self.l10n_latam_document_type_id.id or 0

--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -108,7 +108,7 @@ class AccountMove(models.Model):
 
     def _get_last_sequence_domain(self, relaxed=False):
         where_string, param = super(AccountMove, self)._get_last_sequence_domain(relaxed)
-        if self.company_id.country_id == self.env.ref('base.cl') and self.l10n_latam_use_documents:
+        if self.company_id.country_id == self.env.ref('base.cl') and self.l10n_latam_use_documents and self.is_sale_document():
             journals = self.journal_id.l10n_cl_sequence_ids.filtered(lambda s: s.l10n_latam_document_type_id == self.l10n_latam_document_type_id).l10n_cl_journal_ids.ids
             if len(journals) > 1:
                 where_string.replace("journal_id = %(journal_ids)s", "journal_id in %(journal_ids)s")

--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -117,6 +117,13 @@ class AccountMove(models.Model):
             param['l10n_latam_document_type_id'] = self.l10n_latam_document_type_id.id or 0
         return where_string, param
 
+    def _get_key_compute_name(self):
+        journal_key, date_key = super()._get_key_compute_name()
+        if self.company_id.country_id == self.env.ref('base.cl') and self.l10n_latam_use_documents and self.is_sale_document():
+            journal_key = self.l10n_latam_document_type_id
+            date_key = False
+        return journal_key, date_key
+
     def _get_name_invoice_report(self, report_xml_id):
         self.ensure_one()
         if self.l10n_latam_use_documents and self.company_id.country_id.code == 'CL':

--- a/addons/l10n_latam_invoice_document/models/account_move.py
+++ b/addons/l10n_latam_invoice_document/models/account_move.py
@@ -26,18 +26,13 @@ class AccountMove(models.Model):
     def _compute_name(self):
         """ Change the way that the use_document moves name is computed:
 
-        * If move use document but does not have document type selected then name = '/' to do not show the name.
-        * If move use document and are numbered manually do not compute name at all (will be set manually)
         * If move use document and is in draft state and has not been posted before we restart name to '/' (this is
            when we change the document type) """
-        without_doc_type = self.filtered(lambda x: x.journal_id.l10n_latam_use_documents and not x.l10n_latam_document_type_id)
-        manual_documents = self.filtered(lambda x: x.journal_id.l10n_latam_use_documents and x.l10n_latam_manual_document_number)
-        (without_doc_type + manual_documents.filtered(lambda x: not x.name or x.name and x.state == 'draft' and not x.posted_before)).name = '/'
         # if we change document or journal and we are in draft and not posted, we clean number so that is recomputed in super
         self.filtered(
             lambda x: x.journal_id.l10n_latam_use_documents and x.l10n_latam_document_type_id
             and not x.l10n_latam_manual_document_number and x.state == 'draft' and not x.posted_before).name = '/'
-        super(AccountMove, self - without_doc_type - manual_documents)._compute_name()
+        super()._compute_name()
 
     @api.depends('l10n_latam_document_type_id', 'journal_id')
     def _compute_l10n_latam_manual_document_number(self):
@@ -51,28 +46,22 @@ class AccountMove(models.Model):
     def _is_manual_document_number(self, journal):
         return True if journal.type == 'purchase' else False
 
-    @api.depends('name')
+    @api.depends('ref')
     def _compute_l10n_latam_document_number(self):
-        recs_with_name = self.filtered(lambda x: x.name != '/')
-        for rec in recs_with_name:
-            name = rec.name
-            doc_code_prefix = rec.l10n_latam_document_type_id.doc_code_prefix
-            if doc_code_prefix and name:
-                name = name.split(" ", 1)[-1]
-            rec.l10n_latam_document_number = name
-        remaining = self - recs_with_name
-        remaining.l10n_latam_document_number = False
+        for rec in self:
+            ref = rec.ref
+            if ref and rec.l10n_latam_document_type_id.doc_code_prefix:
+                ref = ref.split(" ", 1)[-1]
+            rec.l10n_latam_document_number = ref
 
     @api.onchange('l10n_latam_document_type_id', 'l10n_latam_document_number')
     def _inverse_l10n_latam_document_number(self):
         for rec in self.filtered(lambda x: x.l10n_latam_document_type_id and (x.l10n_latam_manual_document_number or not x.highest_name)):
-            if not rec.l10n_latam_document_number:
-                rec.name = '/'
-            else:
+            if rec.l10n_latam_document_number:
                 l10n_latam_document_number = rec.l10n_latam_document_type_id._format_document_number(rec.l10n_latam_document_number)
                 if rec.l10n_latam_document_number != l10n_latam_document_number:
                     rec.l10n_latam_document_number = l10n_latam_document_number
-                rec.name = "%s %s" % (rec.l10n_latam_document_type_id.doc_code_prefix, l10n_latam_document_number)
+                rec.ref = "%s %s" % (rec.l10n_latam_document_type_id.doc_code_prefix, l10n_latam_document_number)
 
     @api.depends('journal_id', 'l10n_latam_document_type_id')
     def _compute_highest_name(self):
@@ -87,7 +76,7 @@ class AccountMove(models.Model):
         return super(AccountMove, self)._deduce_sequence_number_reset(name)
 
     def _get_starting_sequence(self):
-        if self.journal_id.l10n_latam_use_documents:
+        if self.journal_id.l10n_latam_use_documents and self.is_sale_document():
             if self.l10n_latam_document_type_id:
                 return "%s 00000000" % (self.l10n_latam_document_type_id.doc_code_prefix)
             # There was no pattern found, propose one
@@ -124,12 +113,34 @@ class AccountMove(models.Model):
                 raise UserError(_('We do not accept the usage of document types on receipts yet. '))
         return super().post()
 
-    @api.constrains('name', 'journal_id', 'state')
-    def _check_unique_sequence_number(self):
-        """ This uniqueness verification is only valid for customer invoices, and vendor bills that does not use
-        documents. A new constraint method _check_unique_vendor_number has been created just for validate for this purpose """
-        vendor = self.filtered(lambda x: x.is_purchase_document() and x.l10n_latam_use_documents)
-        return super(AccountMove, self - vendor)._check_unique_sequence_number()
+    @api.constrains('ref', 'move_type', 'partner_id', 'journal_id', 'invoice_date')
+    def _check_duplicate_supplier_reference(self):
+        # The constraint doesn't depend on the date like it is the case in general
+        latam_bills = self.filtered(lambda x: x.is_purchase_document() and x.l10n_latam_use_documents)
+        if latam_bills:
+            self.env["account.move"].flush([
+                "ref", "move_type", "company_id", "partner_id", "commercial_partner_id",
+            ])
+            self.env["res.partner"].flush(["commercial_partner_id"])
+
+            self._cr.execute('''
+                SELECT move2.id
+                FROM account_move move
+                JOIN res_partner partner ON partner.id = move.partner_id
+                INNER JOIN account_move move2 ON
+                    move2.ref = move.ref
+                    AND move2.company_id = move.company_id
+                    AND move2.commercial_partner_id = partner.commercial_partner_id
+                    AND move2.move_type = move.move_type
+                    AND move2.id != move.id
+                WHERE move.id IN %s
+            ''', [tuple(latam_bills.ids)])
+            duplicated_moves = self.browse([r[0] for r in self._cr.fetchall()])
+            if duplicated_moves:
+                raise ValidationError(_('Duplicated vendor reference detected. You probably encoded twice the same vendor bill/credit note:\n%s') % "\n".join(
+                    duplicated_moves.mapped(lambda m: "%(partner)s - %(ref)s" % {'ref': m.ref, 'partner': m.partner_id.display_name})
+                ))
+        return super(AccountMove, self - latam_bills)._check_duplicate_supplier_reference()
 
     @api.constrains('state', 'l10n_latam_document_type_id')
     def _check_l10n_latam_documents(self):
@@ -141,13 +152,13 @@ class AccountMove(models.Model):
         without_doc_type = validated_invoices.filtered(lambda x: not x.l10n_latam_document_type_id)
         if without_doc_type:
             raise ValidationError(_(
-                'The journal require a document type but not document type has been selected on invoices %s.' % (
-                    without_doc_type.ids)))
+                'The journal require a document type but not document type has been selected on invoices %s.') % (
+                    without_doc_type.ids))
         without_number = validated_invoices.filtered(
             lambda x: not x.l10n_latam_document_number and x.l10n_latam_manual_document_number)
         if without_number:
-            raise ValidationError(_('Please set the document number on the following invoices %s.' % (
-                without_number.ids)))
+            raise ValidationError(_('Please set the document number on the following invoices %s.') % (
+                without_number.ids))
 
     @api.constrains('move_type', 'l10n_latam_document_type_id')
     def _check_invoice_type_document_type(self):
@@ -219,23 +230,3 @@ class AccountMove(models.Model):
                 group.id,
             ) for group, amounts in res]
         super(AccountMove, self - move_with_doc_type)._compute_invoice_taxes_by_group()
-
-    @api.constrains('name', 'partner_id', 'company_id', 'posted_before')
-    def _check_unique_vendor_number(self):
-        """ The constraint _check_unique_sequence_number is valid for customer bills but not valid for us on vendor
-        bills because the uniqueness must be per partner """
-        for rec in self.filtered(
-                lambda x: x.name and x.name != '/' and x.is_purchase_document() and x.l10n_latam_use_documents):
-            domain = [
-                ('move_type', '=', rec.move_type),
-                # by validating name we validate l10n_latam_document_type_id
-                ('name', '=', rec.name),
-                ('company_id', '=', rec.company_id.id),
-                ('id', '!=', rec.id),
-                ('commercial_partner_id', '=', rec.commercial_partner_id.id),
-                # allow to have to equal if they are cancelled
-                ('state', '!=', 'cancel'),
-            ]
-            if rec.search(domain):
-                raise ValidationError(_('Vendor bill number must be unique per vendor and company.'))
-

--- a/addons/l10n_latam_invoice_document/views/account_move_view.xml
+++ b/addons/l10n_latam_invoice_document/views/account_move_view.xml
@@ -50,7 +50,7 @@
 
             <!-- on latam_documents we use document_number to set name -->
             <field name="name" position="attributes">
-                <attribute name="attrs">{'readonly': ['|', ('state', '!=', 'draft'), ('l10n_latam_use_documents', '=', True)]}</attribute>
+                <attribute name="attrs">{'readonly': ['|', ('state', '!=', 'draft'), ('l10n_latam_use_documents', '=', True)], 'invisible': [('l10n_latam_use_documents', '=', True), ('move_type', 'in', ('in_invoice', 'in_refund'))]}</attribute>
             </field>
 
         </field>

--- a/addons/sale_timesheet/report/project_profitability_report_analysis.py
+++ b/addons/sale_timesheet/report/project_profitability_report_analysis.py
@@ -34,6 +34,14 @@ class ProfitabilityAnalysis(models.Model):
     other_revenues = fields.Float("Other Revenues", digits=(16, 2), readonly=True, group_operator="sum",
                                   help="All revenues that are not from timesheets and that are linked to the analytic account of the project.")
 
+    _depends = {
+        'sale.order': ['date_order', 'currency_rate'],
+        'sale.order.line': ['untaxed_amount_to_invoice', 'invoice_status', 'qty_delivered_method', 'product_id', 'price_reduce', 'task_id', 'project_id'],
+        'product.product': ['product_tmpl_id'],
+        'product.template': ['expense_policy'],
+        'project.project': ['partner_id', 'analytic_account_id', 'user_id', 'company_id', 'allow_timesheets', 'sale_line_id'],
+    }
+
     def init(self):
         tools.drop_view_if_exists(self._cr, self._table)
         query = """


### PR DESCRIPTION
## [FIX] account: concurency in sequence.mixin

The `SELECT FOR UPDATE` clause stopped concurrent executions but did 
not prevent from writing on other rows.
By doing a real `UPDATE`, we now have the desired behaviour with a 
`SerializationFailure` error.

________

## [FIX] account: unicity constraint on account.move sequence

The constraint was previously implemented as a `@api.constrains` executing
a SQL query. This had for effect that if two different transactions were
trying to add one row with the same value for the sequence at the same
time, this would not be detected.
To correct this, we use a more robust constraint at database level using
a partial unique index.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
