### PR TITLE
[IMP] purchase: allow to search record using reference

### DIFF
--- a/addons/purchase/report/purchase_bill.py
+++ b/addons/purchase/report/purchase_bill.py
@@ -53,8 +53,8 @@ class PurchaseBillUnion(models.Model):
             result.append((doc.id, name))
         return result
     
-        @api.model
-        def _name_search(self, name='', args=None, operator='ilike', limit=100, name_get_uid=None):
+    @api.model
+    def _name_search(self, name='', args=None, operator='ilike', limit=100, name_get_uid=None):
         if args is None:
             args = []
         domain = args + ['|', ('reference', operator, name), ('name', operator, name)]

--- a/addons/purchase/report/purchase_bill.py
+++ b/addons/purchase/report/purchase_bill.py
@@ -52,3 +52,12 @@ class PurchaseBillUnion(models.Model):
             name += ': ' + formatLang(self.env, amount, monetary=True, currency_obj=doc.currency_id)
             result.append((doc.id, name))
         return result
+    
+        @api.model
+        def _name_search(self, name='', args=None, operator='ilike', limit=100, name_get_uid=None):
+        if args is None:
+            args = []
+        domain = args + ['|', ('reference', operator, name), ('name', operator, name)]
+        purchase_bill_union_ids = self._search(domain, limit=limit, access_rights_uid=name_get_uid)
+        return models.lazy_name_get(self.browse(purchase_bill_union_ids).with_user(name_get_uid))
+


### PR DESCRIPTION
Before this commit It was not possible to search for Purchase Order Or Bill using Reference. (We are already displaying Reference in name_get)

Now we allow to search using Reference field. (To make it aligned with result of name_get)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
