### PR TITLE
[FIX] account_analytic_default: Copy analytic_account_id and analytic_tag_ids when copying a journal entry

### DIFF
--- a/addons/account_analytic_default/models/account_analytic_default.py
+++ b/addons/account_analytic_default/models/account_analytic_default.py
@@ -69,8 +69,8 @@ class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'
 
     # Overload of fields defined in account
-    analytic_account_id = fields.Many2one(compute="_compute_analytic_account", store=True, readonly=False)
-    analytic_tag_ids = fields.Many2many(compute="_compute_analytic_account", store=True, readonly=False)
+    analytic_account_id = fields.Many2one(compute="_compute_analytic_account", store=True, readonly=False, copy=True)
+    analytic_tag_ids = fields.Many2many(compute="_compute_analytic_account", store=True, readonly=False, copy=True)
 
     @api.depends('product_id', 'account_id', 'partner_id', 'date_maturity')
     def _compute_analytic_account(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

1. Install account_analytic_default
2. Create a journal entry and manually add analytic account and tags
3. Duplicate the journal entry

Current behavior before PR:

Analytic account and tags are reset to default when copying a journal entry.

Desired behavior after PR is merged:

Analytic account and tags should be copied from the original journal entry as other line specific info.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
