### PR TITLE
[IMP] web: support custom rec_name in calendar view

### DIFF
--- a/addons/web/static/src/js/views/calendar/calendar_model.js
+++ b/addons/web/static/src/js/views/calendar/calendar_model.js
@@ -35,7 +35,8 @@ return AbstractModel.extend({
      */
     calendarEventToRecord: function (event) {
         // Normalize event_end without changing fullcalendars event.
-        var data = {'name': event.title};
+        var data = {};
+        data[this.mapping.rec_name || 'name'] = event.title;
         var start = event.start.clone();
         var end = event.end && event.end.clone();
 

--- a/addons/web/static/src/js/views/calendar/calendar_view.js
+++ b/addons/web/static/src/js/views/calendar/calendar_view.js
@@ -17,7 +17,8 @@ var fieldsToGather = [
     "date_delay",
     "date_stop",
     "all_day",
-    "recurrence_update"
+    "recurrence_update",
+    "rec_name",
 ];
 
 const scalesInfo = {

--- a/addons/web/static/tests/views/calendar_tests.js
+++ b/addons/web/static/tests/views/calendar_tests.js
@@ -476,6 +476,74 @@ QUnit.module('Views', {
         calendar.destroy();
     });
 
+    QUnit.test('quickcreate with custom rec_name', async function (assert) {
+        assert.expect(3);
+
+        var event = $.Event();
+        this.data.custom_event = {
+            fields: {
+                id: {string: "ID", type: "integer"},
+                x_name: {string: "name", type: "char"},
+                x_start_date: {string: "start date", type: "date"},
+            },
+            records: [
+                {id: 1, x_name: 'some event', x_start_date: "2016-12-06"}
+            ],
+            check_access_rights: function () {
+                return Promise.resolve(true);
+            }
+        };
+        var calendar = await createCalendarView({
+            View: CalendarView,
+            model: 'custom_event',
+            data: this.data,
+            arch:
+            '<calendar class="o_calendar_test" '+
+                'string="Custom Events" ' +
+                'date_start="x_start_date" '+
+                'rec_name="x_name" '+
+                'mode="month"/>',
+            archs: archs,
+            viewOptions: {
+                initialDate: initialDate,
+            },
+            mockRPC: function (route, args) {
+                if (args.method === "create") {
+                    assert.deepEqual(args.args[0], {
+                        "x_name": "custom event in quick create",
+                        "x_start_date": "2016-12-13 00:00:00",
+                    },
+                    "the custom rec_name field should be used instead of name");
+                    this.data.custom_event.records.push({
+                        id: 1,
+                        x_name: args.args[0].x_name,
+                        x_start_date: args.args[0].x_start_date,
+                        display_name: args.args[0].x_name,
+                    })
+                    return Promise.resolve(1);
+                }
+                return this._super(route, args);
+            },
+        });
+
+        // create a new event
+        var $cell = calendar.$('.fc-day-grid .fc-row:eq(2) .fc-day:eq(2)');
+        testUtils.dom.triggerMouseEvent($cell, "mousedown");
+        testUtils.dom.triggerMouseEvent($cell, "mouseup");
+        await testUtils.nextTick();
+
+        assert.strictEqual($('.modal-sm .modal-title').text(), 'Create: Custom Events',
+            "should open the quick create dialog");
+
+        await testUtils.fields.editInput($('.modal-body input:first'), 'custom event in quick create');
+        await testUtils.dom.click($('.modal-footer button.btn:contains(Create)'));
+        await testUtils.nextTick();
+
+        assert.containsOnce(calendar, '.fc-event:contains(custom event in quick create)',
+        "should display the new custom event record");
+        calendar.destroy();
+    });
+
     QUnit.test('quickcreate switching to actual create for required fields', async function (assert) {
         assert.expect(4);
 

--- a/doc/reference/views.rst
+++ b/doc/reference/views.rst
@@ -403,8 +403,12 @@ calendar view are:
     in a new form view (with a do_action)
 ``quick_add``
     enables quick-event creation on click: only asks the user for a ``name``
-    and tries to create a new event with just that and the clicked event
-    time. Falls back to a full form dialog if the quick creation fails
+    (the field to which this values is saved can be controlled through
+    ``rec_name``) and tries to create a new event with just that and the clicked
+    event time. Falls back to a full form dialog if the quick creation fails
+``rec_name``
+    name of the record's field holding the textual representation of the record,
+    this is used when creating records through the 'quick create' mechanism
 ``all_day``
     name of a boolean field on the record indicating whether the corresponding
     event is flagged as day-long (and duration is irrelevant)

--- a/odoo/addons/base/rng/calendar_view.rng
+++ b/odoo/addons/base/rng/calendar_view.rng
@@ -15,6 +15,7 @@
             <rng:optional><rng:attribute name="all_day" /></rng:optional>
             <rng:optional><rng:attribute name="form_view_id" /></rng:optional>
             <rng:optional><rng:attribute name="event_limit" /></rng:optional>
+            <rng:optional><rng:attribute name="rec_name" /></rng:optional>
             <rng:optional><rng:attribute name="quick_add" /></rng:optional>
             <rng:optional><rng:attribute name="color" /></rng:optional>
             <rng:optional><rng:attribute name="event_open_popup" /></rng:optional>


### PR DESCRIPTION
Until now, the quick creation dialog of the calendar view assumed that
the underlying model used a 'name' field for its rec_name, with a
graceful degradation if it was not the case.

This prevented quick creation of models created through customizations
(for example).

This commit adds a `rec_name` attribute on the view declaration that
allows to specify the field to use during quick creation.

Task-2185423