### PR TITLE
[FIX] web: flicker issue on tab in the form view

### DIFF
--- a/addons/web/static/src/js/views/form/form_renderer.js
+++ b/addons/web/static/src/js/views/form/form_renderer.js
@@ -254,9 +254,6 @@ var FormRenderer = BasicRenderer.extend({
                         nav => !nav.classList.contains('o_invisible_modifier')
                     );
                 }
-                if (activeIndex <= 0) {
-                    continue; // No visible tab OR first tab = active tab (no change to make).
-                }
                 for (let i = 0; i < validTabsAmount; i++) {
                     navs[i].querySelector('.nav-link').classList.toggle('active', activeIndex === i);
                     pages[i].classList.toggle('active', activeIndex === i);
@@ -942,7 +939,12 @@ var FormRenderer = BasicRenderer.extend({
                 },
             });
         });
-        this._activateFirstVisibleTab(renderedTabs);
+        // if state from getLocalState is non empty then setLocalState will do the job
+        // setLocalState will set last active tab.
+        const state = this.getLocalState();
+        if (!Object.entries(state).length) {
+            this._activateFirstVisibleTab(renderedTabs);
+        }
         var $notebookHeaders = $('<div class="o_notebook_headers">').append($headers);
         var $notebook = $('<div class="o_notebook">').append($notebookHeaders, $pages);
         $notebook[0].dataset.name = node.attrs.name || '_default_';


### PR DESCRIPTION
before this commit,
activating the tab other than the first one and then on saving time or editing time
a small flicker occurs. first, it displays the first tab and then the actual tab
where the user left it.

this commit fixes the flickering issue by passing the correct condition.

task - 2321220