### PR TITLE
[FIX] base:  fix admin access rights

### DIFF
--- a/odoo/addons/base/security/base_security.xml
+++ b/odoo/addons/base/security/base_security.xml
@@ -2,6 +2,7 @@
 <odoo>
         <record id="group_private_addresses" model="res.groups">
             <field name="name">Access to Private Addresses</field>
+            <field name="category_id" ref="base.module_category_hidden"/>
         </record>
 
     <data noupdate="1">


### PR DESCRIPTION
Currently, the access to private addresses group show in the non debug mode and
debug mode

So in this commit, the access to private addresses group only show in the debug
mode.

LINKS
PR: #56456
Task-Id: 2318509

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
