### PR TITLE
[IMP] hr_leave: Request leave in the employee's timezone

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -12,6 +12,7 @@ from datetime import datetime, time
 from pytz import timezone, UTC
 
 from odoo import api, fields, models
+from odoo.addons.base.models.res_partner import _tz_get
 from odoo.addons.resource.models.resource import float_to_time, HOURS_PER_DAY
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.tools import float_compare
@@ -125,6 +126,8 @@ class HolidaysRequest(models.Model):
     employee_id = fields.Many2one(
         'hr.employee', string='Employee', index=True, readonly=True,
         states={'draft': [('readonly', False)], 'confirm': [('readonly', False)]}, default=_default_employee, track_visibility='onchange')
+    tz_mismatch = fields.Boolean(compute='_compute_tz_mismatch')
+    tz = fields.Selection(_tz_get, compute='_compute_tz')
     manager_id = fields.Many2one('hr.employee', string='Manager', readonly=True)
     department_id = fields.Many2one(
         'hr.department', string='Department', readonly=True,
@@ -311,10 +314,8 @@ class HolidaysRequest(models.Model):
         else:
             hour_from = float_to_time(attendance_from.hour_from)
             hour_to = float_to_time(attendance_to.hour_to)
-
-        tz = self.env.user.tz if self.env.user.tz and not self.request_unit_custom else 'UTC'  # custom -> already in UTC
-        self.date_from = timezone(tz).localize(datetime.combine(self.request_date_from, hour_from)).astimezone(UTC).replace(tzinfo=None)
-        self.date_to = timezone(tz).localize(datetime.combine(self.request_date_to, hour_to)).astimezone(UTC).replace(tzinfo=None)
+        self.date_from = timezone(self.tz).localize(datetime.combine(self.request_date_from, hour_from)).astimezone(UTC).replace(tzinfo=None)
+        self.date_to = timezone(self.tz).localize(datetime.combine(self.request_date_to, hour_to)).astimezone(UTC).replace(tzinfo=None)
         self._onchange_leave_dates()
 
     @api.onchange('request_unit_half')
@@ -379,6 +380,27 @@ class HolidaysRequest(models.Model):
             self.number_of_days = self._get_number_of_days(self.date_from, self.date_to, self.employee_id.id)
         else:
             self.number_of_days = 0
+
+    @api.depends('tz')
+    # @api.depends_context('uid')
+    def _compute_tz_mismatch(self):
+        for leave in self:
+            leave.tz_mismatch = leave.tz != self.env.user.tz
+
+    @api.depends('request_unit_custom', 'employee_id', 'holiday_type', 'department_id.company_id.resource_calendar_id.tz', 'mode_company_id.resource_calendar_id.tz')
+    def _compute_tz(self):
+        for leave in self:
+            tz = None
+            if leave.request_unit_custom:
+                tz = 'UTC'  # custom -> already in UTC
+            elif leave.holiday_type == 'employee':
+                tz = leave.employee_id.tz
+            elif leave.holiday_type == 'department':
+                tz = leave.department_id.company_id.resource_calendar_id.tz
+            elif leave.holiday_type == 'company':
+                tz = leave.mode_company_id.resource_calendar_id.tz
+            tz = tz or self.env.user.company_id.resource_calendar_id.tz or self.env.user.tz or 'UTC'
+            leave.tz = tz
 
     @api.multi
     @api.depends('number_of_days')
@@ -828,16 +850,21 @@ class HolidaysRequest(models.Model):
     def activity_update(self):
         to_clean, to_do = self.env['hr.leave'], self.env['hr.leave']
         for holiday in self:
+            start = UTC.localize(holiday.date_from).astimezone(timezone(holiday.employee_id.tz or 'UTC'))
+            end = UTC.localize(holiday.date_to).astimezone(timezone(holiday.employee_id.tz or 'UTC'))
+            note = _('New %s Request created by %s from %s to %s') % (holiday.holiday_status_id.name, holiday.create_uid.name, start, end)
             if holiday.state == 'draft':
                 to_clean |= holiday
             elif holiday.state == 'confirm':
                 holiday.activity_schedule(
                     'hr_holidays.mail_act_leave_approval',
+                    note=note,
                     user_id=holiday.sudo()._get_responsible_for_approval().id or self.env.user.id)
             elif holiday.state == 'validate1':
                 holiday.activity_feedback(['hr_holidays.mail_act_leave_approval'])
                 holiday.activity_schedule(
                     'hr_holidays.mail_act_leave_second_approval',
+                    note=note,
                     user_id=holiday.sudo()._get_responsible_for_approval().id or self.env.user.id)
             elif holiday.state == 'validate':
                 to_do |= holiday

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from datetime import datetime
+from datetime import date, datetime
 from dateutil.relativedelta import relativedelta
 
 from odoo import fields
@@ -175,3 +175,62 @@ class TestLeaveRequests(TestHrHolidaysBase):
         allocation_form = Form(self.env['hr.leave.allocation'].sudo(self.user_employee))
         allocation_form.holiday_status_id = self.holidays_type_1
         allocation = allocation_form.save()
+
+    @mute_logger('odoo.models.unlink', 'odoo.addons.mail.models.mail_mail')
+    def test_timezone_employee_leave_request(self):
+        """ Create a leave request for an employee in another timezone """
+        self.employee_emp.tz = 'NZ'  # GMT+12
+        leave = self.env['hr.leave'].new({
+            'employee_id': self.employee_emp.id,
+            'holiday_type': "employee",
+            'holiday_status_id': self.holidays_type_1.id,
+            'request_unit_hours': True,
+            'request_date_from': date(2019, 5, 6),
+            'request_date_to': date(2019, 5, 6),
+            'request_hour_from': '8',  # 8:00 AM in the employee's timezone
+            'request_hour_to': '17',  # 5:00 PM in the employee's timezone
+        })
+        leave._onchange_request_parameters()
+        self.assertEqual(leave.date_from, datetime(2019, 5, 5, 20, 0, 0), "It should have been localized before saving in UTC")
+        self.assertEqual(leave.date_to, datetime(2019, 5, 6, 5, 0, 0), "It should have been localized before saving in UTC")
+
+    @mute_logger('odoo.models.unlink', 'odoo.addons.mail.models.mail_mail')
+    def test_timezone_company_leave_request(self):
+        """ Create a leave request for a company in another timezone """
+        company = self.env['res.company'].create({'name': "Hergé"})
+        company.resource_calendar_id.tz = 'NZ'  # GMT+12
+        leave = self.env['hr.leave'].new({
+            'employee_id': self.employee_emp.id,
+            'holiday_status_id': self.holidays_type_1.id,
+            'request_unit_hours': True,
+            'holiday_type': 'company',
+            'mode_company_id': company.id,
+            'request_date_from': date(2019, 5, 6),
+            'request_date_to': date(2019, 5, 6),
+            'request_hour_from': '8',  # 8:00 AM in the company's timezone
+            'request_hour_to': '17',  # 5:00 PM in the company's timezone
+        })
+        leave._onchange_request_parameters()
+        self.assertEqual(leave.date_from, datetime(2019, 5, 5, 20, 0, 0), "It should have been localized before saving in UTC")
+        self.assertEqual(leave.date_to, datetime(2019, 5, 6, 5, 0, 0), "It should have been localized before saving in UTC")
+
+    @mute_logger('odoo.models.unlink', 'odoo.addons.mail.models.mail_mail')
+    def test_timezone_department_leave_request(self):
+        """ Create a leave request for a department in another timezone """
+        company = self.env['res.company'].create({'name': "Hergé"})
+        company.resource_calendar_id.tz = 'NZ'  # GMT+12
+        department = self.env['hr.department'].create({'name': "Museum", 'company_id': company.id})
+        leave = self.env['hr.leave'].new({
+            'employee_id': self.employee_emp.id,
+            'holiday_status_id': self.holidays_type_1.id,
+            'request_unit_hours': True,
+            'holiday_type': 'department',
+            'department_id': department.id,
+            'request_date_from': date(2019, 5, 6),
+            'request_date_to': date(2019, 5, 6),
+            'request_hour_from': '8',  # 8:00 AM in the department's timezone
+            'request_hour_to': '17',  # 5:00 PM in the department's timezone
+        })
+        leave._onchange_request_parameters()
+        self.assertEqual(leave.date_from, datetime(2019, 5, 5, 20, 0, 0), "It should have been localized before saving in UTC")
+        self.assertEqual(leave.date_to, datetime(2019, 5, 6, 5, 0, 0), "It should have been localized before saving in UTC")

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -149,6 +149,20 @@
                 <field name="state" widget="statusbar" statusbar_visible="confirm,validate"/>
             </header>
             <sheet>
+                <div class="alert alert-info" role="alert" attrs="{'invisible': ['|', ('tz_mismatch', '=', False), ('holiday_type', '=', 'category')]}">
+                    <span attrs="{'invisible': [('holiday_type', '!=', 'employee')]}">
+                        The employee has a different timezone than yours! Here dates and times are displayed in the employee's timezone
+                    </span>
+                    <span attrs="{'invisible': [('holiday_type', '!=', 'department')]}">
+                        The department's company has a different timezone than yours! Here dates and times are displayed in the company's timezone
+                    </span>
+                    <span attrs="{'invisible': [('holiday_type', '!=', 'company')]}">
+                        The company has a different timezone than yours! Here dates and times are displayed in the company's timezone
+                    </span>
+                    (<field name="tz"/>).
+                </div>
+                <field name="tz_mismatch" invisible="1"/>
+                <field name="holiday_type" invisible="1"/>
                 <field name="leave_type_request_unit" invisible="1"/>
                 <group>
                     <group>


### PR DESCRIPTION
backporting changes from commit 4f59004a0f407e93cfed2126198208738ed47f9a

Purpose
=======
If a manager creates a leave for an employee in another timezone,
the employee's timezone should be used, not the user's timezone.
Currently, if a manager with timezone UTC creates a leave (one day)
for an employee in New Zealand timezone, the leave is during the
night from the employee's perspective.

Specification
=============
1) Use the employee's timezone for saving leave dates.
2) Display a warning if the user and the employee have different timezones.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
