### PR TITLE
[FIX] account: active ids on cutoff

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4664,7 +4664,11 @@ class AccountMoveLine(models.Model):
 
     def action_automatic_entry(self):
         [action] = self.env.ref('account.account_automatic_entry_wizard_action').read()
-        action['context'] = self.env.context
+        action['context'] = {
+            **self.env.context,
+            'active_model': 'account.move.line',
+            'active_ids': self.ids,
+        }
         return action
 
     @api.model


### PR DESCRIPTION
In some cases, the active ids were not correctly set (id of the
account.move)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
