### PR TITLE
[ADD] Health checks for load balancers.

### DIFF
--- a/addons/bus/controllers/main.py
+++ b/addons/bus/controllers/main.py
@@ -1,4 +1,6 @@
-# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import json
 
 from odoo import exceptions, _
 from odoo.http import Controller, request, route
@@ -42,3 +44,12 @@ class BusController(Controller):
     @route('/longpolling/im_status', type="json", auth="user")
     def im_status(self, partner_ids):
         return request.env['res.partner'].with_context(active_test=False).search([('id', 'in', partner_ids)]).read(['im_status'])
+
+    @route('/longpolling/health', type='http', auth='none', save_session=False)
+    def health(self):
+        data = json.dumps({
+            'status': 'pass',
+        })
+        headers = [('Content-Type', 'application/json'),
+                   ('Cache-Control', 'no-store')]
+        return request.make_response(data, headers)

--- a/addons/bus/tests/__init__.py
+++ b/addons/bus/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_assetsbundle
+from . import test_health

--- a/addons/bus/tests/test_health.py
+++ b/addons/bus/tests/test_health.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import HttpCase
+
+
+class TestBusController(HttpCase):
+    def test_health(self):
+        response = self.url_open('/longpolling/health')
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload['status'], 'pass')
+        self.assertNotIn('session_id', response.cookies)

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -903,6 +903,16 @@ class Home(http.Controller):
 
         return request.redirect(self._login_redirect(uid))
 
+    @http.route('/web/health', type='http', auth='none', save_session=False)
+    def health(self):
+        data = json.dumps({
+            'status': 'pass',
+        })
+        headers = [('Content-Type', 'application/json'),
+                   ('Cache-Control', 'no-store')]
+        return request.make_response(data, headers)
+
+
 class WebClient(http.Controller):
 
     @http.route('/web/webclient/locale/<string:lang>', type='http', auth="none")

--- a/addons/web/tests/__init__.py
+++ b/addons/web/tests/__init__.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_health
 from . import test_image
 from . import test_js
 from . import test_menu

--- a/addons/web/tests/test_health.py
+++ b/addons/web/tests/test_health.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import HttpCase
+
+
+class TestWebController(HttpCase):
+    def test_health(self):
+        response = self.url_open('/web/health')
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload['status'], 'pass')
+        self.assertNotIn('session_id', response.cookies)

--- a/doc/cla/individual/amh-mw.md
+++ b/doc/cla/individual/amh-mw.md
@@ -1,0 +1,11 @@
+United States, February 26, 2020
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Adam Heinz amh@metricwise.net https://github.com/amh-mw


### PR DESCRIPTION
### Current behavior before PR:

There is no obvious route to use for a load balancer health check.

### Desired behavior after PR is merged:

Two routes are created; one for the web port and a second for the longpolling port.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
