### PR TITLE
[IMP] point_of_sale,pos_restaurant: keep orders to tip locally

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ReceiptScreen/ReceiptScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ReceiptScreen/ReceiptScreen.js
@@ -102,7 +102,7 @@ odoo.define('point_of_sale.ReceiptScreen', function (require) {
                 const client = order.get_client();
                 const orderName = order.get_name();
                 const orderClient = { email: this.orderUiState.inputEmail, name: client ? client.name : this.orderUiState.inputEmail };
-                const order_server_id = this.env.pos.validated_orders_name_server_id_map[orderName];
+                const order_server_id = this.env.pos.db.server_ids.getItem(orderName);
                 await this.rpc({
                     model: 'pos.order',
                     method: 'action_receipt_to_customer',

--- a/addons/point_of_sale/static/src/js/SimpleCollectionDB.js
+++ b/addons/point_of_sale/static/src/js/SimpleCollectionDB.js
@@ -1,0 +1,48 @@
+odoo.define('point_of_sale.SimpleCollectionDB', function (require) {
+    'use strict';
+
+    class SimpleCollectionDB {
+        constructor(prefixGetter, name) {
+            this.name = name;
+            this.prefixGetter = prefixGetter;
+            this.keyForKeys = `${this.prefixGetter()}-${this.name}-item-keys`;
+        }
+        _getRealKey(key) {
+            return `${this.prefixGetter()}-${this.name}-${key}`;
+        }
+        getKeys() {
+            return JSON.parse(localStorage.getItem(this.keyForKeys)) || [];
+        }
+        getItems() {
+            return this.getKeys().map((key) => this.getItem(key)) || [];
+        }
+        getItem(key) {
+            const realKey = this._getRealKey(key);
+            return JSON.parse(localStorage.getItem(realKey));
+        }
+        setItem(key, item) {
+            const realKey = this._getRealKey(key);
+            const keySet = new Set(this.getKeys());
+            keySet.add(key);
+            localStorage.setItem(this.keyForKeys, JSON.stringify([...keySet]));
+            localStorage.setItem(realKey, JSON.stringify(item));
+        }
+        removeItem(key) {
+            const realKey = this._getRealKey(key);
+            const keySet = new Set(this.getKeys());
+            keySet.delete(key);
+            localStorage.setItem(this.keyForKeys, JSON.stringify([...keySet]));
+            localStorage.removeItem(realKey);
+        }
+        clearItems() {
+            const keys = this.getKeys();
+            for (const key of keys) {
+                const realKey = this._getRealKey(key);
+                localStorage.removeItem(realKey);
+            }
+            localStorage.removeItem(this.keyForKeys);
+        }
+    }
+
+    return SimpleCollectionDB;
+});

--- a/addons/point_of_sale/static/src/js/db.js
+++ b/addons/point_of_sale/static/src/js/db.js
@@ -3,6 +3,8 @@ odoo.define('point_of_sale.DB', function (require) {
 
 var core = require('web.core');
 var utils = require('web.utils');
+const SimpleCollectionDB = require('point_of_sale.SimpleCollectionDB');
+
 /* The PosDB holds reference to data that is either
  * - static: does not change between pos reloads
  * - persistent : must stay between reloads ( orders )
@@ -545,7 +547,38 @@ var PosDB = core.Class.extend({
     },
     get_cashier: function() {
         return this.load('cashier');
-    }
+    },
+    getName: function() {
+        return this.name;
+    },
+    /**
+     * With the introduction of `SimpleCollectionDB`, we now have the
+     * following API. This free us from rewriting getters/setters/removers
+     * for different types of data we stored in `PosDB`.
+     *
+     * ```
+     * // Sample Usage:
+     * const db = PosDB();
+     * db.registerNameSpace('falseOrders');
+     * db.registerNameSpace('falseProducts');
+     * // db now has 'falseOrders' and 'falseProducts' fields which
+     * // can be used to store data like so:
+     * db.falseOrders.setItem('fOrder1', { product_id: 1, price: 1 });
+     * db.falseOrders.setItem('fOrder2', { product_id: 2, price: 2 });
+     * db.falseProducts.setItem('fProduct1', { name: 'x', id: 1 });
+     * db.falseProducts.setItem('fProduct2', { name: 'y', id: 2 });
+     * // And of course, we have the getters.
+     * console.log(db.falseOrders.getItem('fOrder1'));
+     * // logs { product_id: 1, price: 1 }
+     * console.log(db.falseProducts.getItems());
+     * // logs [{ name: 'x', id: 1 }, { name: 'y', id: 2 }];
+     * // You can also use `getKeys()`, `removeItem()`, `clearItems()`,
+     * // see `SimpleCollectionDB`.
+     * ```
+     */
+    registerNameSpace: function(name) {
+        this[name] = new SimpleCollectionDB(this.getName.bind(this), name);
+    },
 });
 
 return PosDB;

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1395,6 +1395,34 @@ exports.PosModel = Backbone.Model.extend({
     getCurrencySymbol() {
         return this.currency ? this.currency.symbol : '$';
     },
+    /**
+     * Round amount based on pos currency.
+     */
+    roundAmount(amount) {
+        return round_di(amount, this.currency.decimals || 2);
+    },
+    /**
+     * Round amount based on pos currency but return as string.
+     */
+    roundAmountStr(amount) {
+        return this.roundAmount(amount).toFixed(this.currency.decimals || 2);
+    },
+    /**
+     * Compares two amounts with precision based on currency.
+     * Inspired by float_compare.
+     */
+    amountCompare(amount1, amount2) {
+        const decimals = this.currency.decimals || 2;
+        const rounding = this.currency.rounding || 0.01;
+        const diff = round_di(amount1 - amount2, decimals);
+        if (Math.abs(diff) < rounding) {
+            return 0;
+        } else if (diff < 0) {
+            return -1;
+        } else {
+            return 1;
+        }
+    }
 });
 
 /**

--- a/addons/point_of_sale/static/tests/unit/test_SimpleCollectionDB.js
+++ b/addons/point_of_sale/static/tests/unit/test_SimpleCollectionDB.js
@@ -1,0 +1,58 @@
+odoo.define('point_of_sale.tests.SimpleCollectionDB', function (require) {
+    'use strict';
+
+    const SimpleCollectionDB = require('point_of_sale.SimpleCollectionDB');
+
+    QUnit.test('basics', function (assert) {
+        assert.expect(11);
+        const testDB = new SimpleCollectionDB(() => 'simple-collection-test', 'testDB');
+
+        testDB.setItem('a', { x: 1 });
+        testDB.setItem('b', { y: 2 });
+
+        assert.deepEqual(testDB.getKeys(), ['a', 'b']);
+        assert.deepEqual(testDB.getItem('a'), { x: 1 });
+        assert.deepEqual(testDB.getItem('b'), { y: 2 });
+
+        testDB.setItem('a', { newX: 2 });
+        assert.deepEqual(testDB.getItem('a'), { newX: 2 });
+
+        testDB.removeItem('a');
+        assert.deepEqual(testDB.getItem('a'), null);
+        assert.deepEqual(testDB.getKeys(), ['b']);
+        assert.deepEqual(testDB.getItems(), [{ y: 2 }]);
+
+        testDB.removeItem('b');
+        assert.deepEqual(testDB.getKeys(), []);
+        assert.deepEqual(testDB.getItem('b'), null);
+
+        testDB.setItem('b', 1);
+        assert.deepEqual(testDB.getItem('b'), 1);
+
+        testDB.clearItems();
+        assert.deepEqual(testDB.getItem('b'), null);
+    });
+
+    QUnit.test('no leaks between different dbs', function (assert) {
+        assert.expect(6);
+        const db1 = new SimpleCollectionDB(() => 'simple-test', 'db1');
+        const db2 = new SimpleCollectionDB(() => 'simple-test', 'db2');
+
+        db1.setItem('a', { a: 1 });
+        db1.setItem('b', { b: 2 });
+        db1.setItem('same_key_diff_val', 'value 1');
+        db2.setItem('x', { x: 10 });
+        db2.setItem('y', { y: 11 });
+        db2.setItem('same_key_diff_val', 'value 2');
+
+        assert.deepEqual(db1.getKeys(), ['a', 'b', 'same_key_diff_val']);
+        assert.deepEqual(db2.getKeys(), ['x', 'y', 'same_key_diff_val']);
+        assert.strictEqual(db1.getItem('same_key_diff_val'), 'value 1');
+        assert.strictEqual(db2.getItem('same_key_diff_val'), 'value 2');
+
+        db1.clearItems();
+        db2.clearItems();
+        assert.deepEqual(db1.getKeys(), []);
+        assert.deepEqual(db2.getKeys(), []);
+    });
+});

--- a/addons/point_of_sale/views/pos_assets_common.xml
+++ b/addons/point_of_sale/views/pos_assets_common.xml
@@ -18,6 +18,7 @@
     <script type="text/javascript" src="/point_of_sale/static/src/js/PosContext.js"></script>
     <script type="text/javascript" src="/point_of_sale/static/src/js/ComponentRegistry.js"></script>
     <script type="text/javascript" src="/point_of_sale/static/src/js/Registries.js"></script>
+    <script type="text/javascript" src="/point_of_sale/static/src/js/SimpleCollectionDB.js"></script>
     <script type="text/javascript" src="/point_of_sale/static/src/js/db.js"></script>
     <script type="text/javascript" src="/point_of_sale/static/src/js/models.js"></script>
     <script type="text/javascript" src="/point_of_sale/static/src/js/keyboard.js"></script>

--- a/addons/point_of_sale/views/pos_assets_qunit.xml
+++ b/addons/point_of_sale/views/pos_assets_qunit.xml
@@ -51,6 +51,7 @@
 <template id="point_of_sale.qunit_suite_tests">
     <script type="text/javascript" src="/point_of_sale/static/tests/unit/test_ComponentRegistry.js"></script>
     <script type="text/javascript" src="/point_of_sale/static/tests/unit/test_NumberBuffer.js"></script>
+    <script type="text/javascript" src="/point_of_sale/static/tests/unit/test_SimpleCollectionDB.js"></script>
     <script type="text/javascript" src="/point_of_sale/static/tests/unit/test_ChromeWidgets.js"></script>
     <script type="text/javascript" src="/point_of_sale/static/tests/unit/test_ProductScreen.js"></script>
     <script type="text/javascript" src="/point_of_sale/static/tests/unit/test_PaymentScreen.js"></script>

--- a/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
@@ -118,6 +118,9 @@ odoo.define('pos_restaurant.TicketScreen', function (require) {
                     args: [serverId],
                 });
             }
+            hideDeleteButton(order) {
+                return super.hideDeleteButton(order) || this.getStatus(order) === 'Tipping';
+            }
         };
 
     Registries.Component.extend(TicketScreen, PosResTicketScreen);

--- a/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
@@ -87,7 +87,7 @@ odoo.define('pos_restaurant.TicketScreen', function (require) {
                     }
 
                     if (!amount) {
-                        await this.setNoTip();
+                        await this.setNoTip(serverId);
                     } else {
                         order.finalized = false;
                         order.set_tip(amount);
@@ -109,7 +109,7 @@ odoo.define('pos_restaurant.TicketScreen', function (require) {
                     return confirmed;
                 }
             }
-            async setNoTip() {
+            async setNoTip(serverId) {
                 await this.rpc({
                     method: 'set_no_tip',
                     model: 'pos.order',

--- a/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
@@ -68,13 +68,15 @@ odoo.define('pos_restaurant.TicketScreen', function (require) {
                 // set tip in each order
                 for (const order of this.filteredOrderList) {
                     const tipAmount = parse.float(order.uiState.TipScreen.state.inputTipAmount || '0');
-                    const serverId = this.env.pos.validated_orders_name_server_id_map[order.name];
+                    const serverId = this.env.pos.db.server_ids.getItem(order.name);
                     if (!serverId) {
                         console.warn(`${order.name} is not yet sync. Sync it to server before setting a tip.`);
                     } else {
                         const result = await this.setTip(order, serverId, tipAmount);
                         if (!result) break;
                     }
+                    this.env.pos.db.orders_to_tip.removeItem(order.name);
+                    this.env.pos.db.server_ids.removeItem(order.name);
                 }
             }
             async setTip(order, serverId, amount) {

--- a/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
@@ -99,7 +99,7 @@ odoo.define('pos_restaurant.TicketScreen', function (require) {
                             args: [serverId, tip_line.export_as_JSON()],
                         });
                     }
-                    order.finalize();
+                    order.destroy({ reason: 'abandon' });
                     return true;
                 } catch (error) {
                     const { confirmed } = await this.showPopup('ConfirmPopup', {

--- a/addons/pos_restaurant/static/src/js/Screens/TipScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/TipScreen.js
@@ -13,6 +13,8 @@ odoo.define('pos_restaurant.TipScreen', function (require) {
             this._totalAmount = this.currentOrder.get_total_with_tax();
         }
         mounted () {
+            const order = this.currentOrder;
+            this.env.pos.db.orders_to_tip.setItem(order.name, order.export_as_JSON());
             this.printTipReceipt();
         }
         get overallAmountStr() {
@@ -38,7 +40,7 @@ odoo.define('pos_restaurant.TipScreen', function (require) {
         async validateTip() {
             const amount = parse.float(this.state.inputTipAmount) || 0;
             const order = this.env.pos.get_order();
-            const serverId = this.env.pos.validated_orders_name_server_id_map[order.name];
+            const serverId = this.env.pos.db.server_ids.getItem(order.name);
 
             if (!serverId) {
                 this.showPopup('ErrorPopup', {
@@ -86,6 +88,9 @@ odoo.define('pos_restaurant.TipScreen', function (require) {
                 model: 'pos.order',
                 args: [serverId, tip_line.export_as_JSON()],
             });
+
+            this.env.pos.db.server_ids.removeItem(order.name);
+            this.env.pos.db.orders_to_tip.removeItem(order.name);
             this.goNextScreen();
         }
         goNextScreen() {

--- a/addons/pos_restaurant/static/src/js/Screens/TipScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/TipScreen.js
@@ -89,7 +89,7 @@ odoo.define('pos_restaurant.TipScreen', function (require) {
             this.goNextScreen();
         }
         goNextScreen() {
-            this.env.pos.get_order().finalize();
+            this.env.pos.delete_current_order();
             const { name, props } = this.nextScreen;
             this.showScreen(name, props);
         }

--- a/addons/pos_restaurant/static/src/js/Screens/TipScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/TipScreen.js
@@ -60,7 +60,7 @@ odoo.define('pos_restaurant.TipScreen', function (require) {
                 return;
             }
 
-            if (amount > 0.25 * this.totalAmount) {
+            if (this.env.pos.amountCompare(amount, 0.25 * this.totalAmount) > 0) {
                 const { confirmed } = await this.showPopup('ConfirmPopup', {
                     title: 'Are you sure?',
                     body: `${this.env.pos.format_currency(
@@ -152,6 +152,10 @@ odoo.define('pos_restaurant.TipScreen', function (require) {
                     ),
                 });
             }
+        }
+
+        setInputTipAmount(tip) {
+            this.state.inputTipAmount = this.env.pos.roundAmountStr(tip.amount);
         }
     }
     TipScreen.template = 'pos_restaurant.TipScreen';

--- a/addons/pos_restaurant/static/src/js/floors.js
+++ b/addons/pos_restaurant/static/src/js/floors.js
@@ -94,6 +94,13 @@ models.Order = models.Order.extend({
 // if there is none.
 var _super_posmodel = models.PosModel.prototype;
 models.PosModel = models.PosModel.extend({
+    get_orders_to_load() {
+        return [..._super_posmodel.get_orders_to_load.call(this), ...this.db.orders_to_tip.getItems()];
+    },
+    beforeLoadServerData: function() {
+        _super_posmodel.beforeLoadServerData.call(this);
+        this.db.registerNameSpace('orders_to_tip');
+    },
     after_load_server_data: async function() {
         var res = await _super_posmodel.after_load_server_data.call(this);
         if (this.config.iface_floorplan) {

--- a/addons/pos_restaurant/static/src/xml/Screens/TipScreen.xml
+++ b/addons/pos_restaurant/static/src/xml/Screens/TipScreen.xml
@@ -31,7 +31,7 @@
                     <div class="tip-amount-options">
                         <div class="percentage-amounts">
                             <t t-foreach="percentageTips" t-as="tip" t-key="tip.percentage">
-                                <div class="button" t-on-click="state.inputTipAmount = tip.amount.toFixed(2)">
+                                <div class="button" t-on-click="setInputTipAmount(tip)">
                                     <div class="percentage">
                                         <t t-esc="tip.percentage"></t>
                                     </div>

--- a/addons/pos_restaurant/static/src/xml/Screens/TipScreen.xml
+++ b/addons/pos_restaurant/static/src/xml/Screens/TipScreen.xml
@@ -6,7 +6,8 @@
             <div class="pos-receipt-container"/>
             <div class="screen-content">
                 <div class="top-content">
-                    <span class="button back" t-on-click="showScreen('FloorScreen')">
+                    <span t-if="env.pos.config.module_pos_restaurant and env.pos.config.iface_floorplan"
+                          class="button back" t-on-click="showScreen('FloorScreen')">
                         <i class="fa fa-angle-double-left"></i>
                         <span> </span>
                         <span>Back</span>


### PR DESCRIPTION
We introduced a new wrapper to localStorage which exposes method
such as `getItems`. It serves as name spacing for the PosDB. In this
abstraction, we store each item by key, instead of by collection
of objects saved in single key, e.g. unpaid_orders. Here, the idea
is to have faster access to the saved item, without the need
to recreate the whole object that contains the collection. The
`getItems` method returns the list of items saved in the localStorage
for the given SimpleCollectionDB instance.

We used the introduced localStorage wrapper to save the `server_ids`
of validated orders and the `orders_to_tip` locally. Having them in the
localStorage is beneficial so that in case of error or forced restart
of pos, the orders to tip are recovered.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
