### PR TITLE
[FIX-IMP] (sale_)stock, mrp: forcasted report and json_forcasted changes

### DIFF
--- a/addons/mrp/report/report_stock_forecasted.xml
+++ b/addons/mrp/report/report_stock_forecasted.xml
@@ -3,15 +3,15 @@
     <template id="mrp_report_product_product_replenishment" inherit_id="stock.report_product_product_replenishment">
         <xpath expr="//tr[@name='draft_picking_in']" position="after">
             <tr t-if="docs['draft_production_qty']['in']" name="draft_mo_in">
-                <td colspan="2">Draft MO</td>
+                <td colspan="2">Production of Draft MO</td>
                 <td t-esc="docs['draft_production_qty']['in']" class="text-right"/>
                 <td t-esc="docs['uom']" groups="uom.group_uom"/>
             </tr>
         </xpath>
         <xpath expr="//tr[@name='draft_picking_out']" position="after">
             <tr t-if="docs['draft_production_qty']['out']" name="draft_mo_out">
-                <td colspan="2">Draft MO</td>
-                <td t-esc="docs['draft_production_qty']['out']" class="text-right"/>
+                <td colspan="2">Component of Draft MO</td>
+                <td t-esc="-docs['draft_production_qty']['out']" class="text-right"/>
                 <td t-esc="docs['uom']" groups="uom.group_uom"/>
             </tr>
         </xpath>

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -372,25 +372,21 @@ class SaleOrderLine(models.Model):
         # compute
         precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
         for so_line in self:
+            # If all related stock move is available => reservedAvailability = Available
             if any(move.state == 'done' for move in so_line.move_ids) or not so_line.move_ids.picking_id:
                 qty_delivered = float_repr(so_line.qty_delivered, precision)
                 so_line.json_forecast = json.dumps({'reservedAvailability': qty_delivered})
+            elif all(move.state == 'assigned' for move in so_line.move_ids):
+                so_line.json_forecast = json.dumps({'reservedAvailability': _("Available")})
             else:
-                # For waiting deliveries, take the info from the report line.
-                delivery = so_line.move_ids.picking_id.filtered(lambda picking: picking.state in ['confirmed', 'waiting'])
-                if delivery.exists():
-                    moves_to_process = so_line.move_ids.filtered(lambda move: move.id in delivery.move_lines.ids and move.state not in ['cancel', 'done'])
-                    if moves_to_process.exists():
-                        so_line.json_forecast = moves_to_process[0].json_forecast
-                else:
-                    # For assigned deliveries, take the delivery's date.
-                    delivery = so_line.move_ids.picking_id.filtered(lambda picking: picking.state == 'assigned')
-                    if delivery.exists():
-                        date_expected = delivery.scheduled_date
-                        so_line.json_forecast = json.dumps({
-                            'expectedDate': format_date(self.env, date_expected),
-                            'isLate': date_expected > so_line.order_id.expected_date,
-                        })
+                move_json_forecast = so_line.move_ids.mapped("json_forecast")
+                move_datetimes_expected = [json.loads(m).get('sortingDate') for m in move_json_forecast]
+                datetime_expected = fields.Datetime.to_datetime(max(move_datetimes_expected)) if move_datetimes_expected else False
+                so_deadline = self.order_id.commitment_date or so_line._expected_date() or False
+                so_line.json_forecast = json.dumps({
+                    'expectedDate': format_date(self.env, datetime_expected.date()) if datetime_expected else False,
+                    'isLate': datetime_expected > so_deadline if datetime_expected and so_deadline else datetime_expected is False,
+                })
 
     @api.depends('product_id')
     def _compute_qty_delivered_method(self):

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -289,52 +289,11 @@ class SaleOrderLine(models.Model):
 
     @api.depends('product_id', 'customer_lead', 'product_uom_qty', 'product_uom', 'order_id.commitment_date')
     def _compute_qty_at_date(self):
-        """ Compute the quantity forecasted of product at delivery date. There are
-        two cases:
-         1. The quotation has a commitment_date, we take it as delivery date
-         2. The quotation hasn't commitment_date, we compute the estimated delivery
-            date based on lead time"""
-        qty_processed_per_product = defaultdict(lambda: 0)
-        grouped_lines = defaultdict(lambda: self.env['sale.order.line'])
-        # We first loop over the SO lines to group them by warehouse and schedule
-        # date in order to batch the read of the quantities computed field.
-        for line in self:
-            if not (line.product_id and line.display_qty_widget):
-                continue
-            if line.order_id.commitment_date:
-                date = line.order_id.commitment_date
-            else:
-                date = line._expected_date()
-            grouped_lines[(line.warehouse_id.id, date)] |= line
-
-        treated = self.browse()
-        for (warehouse, scheduled_date), lines in grouped_lines.items():
-            product_qties = lines.mapped('product_id').with_context(to_date=scheduled_date, warehouse=warehouse).read([
-                'qty_available',
-                'free_qty',
-                'virtual_available',
-            ])
-            qties_per_product = {
-                product['id']: (product['qty_available'], product['free_qty'], product['virtual_available'])
-                for product in product_qties
-            }
-            for line in lines:
-                line.scheduled_date = scheduled_date
-                qty_available_today, free_qty_today, virtual_available_at_date = qties_per_product[line.product_id.id]
-                line.qty_available_today = qty_available_today - qty_processed_per_product[line.product_id.id]
-                line.free_qty_today = free_qty_today - qty_processed_per_product[line.product_id.id]
-                line.virtual_available_at_date = virtual_available_at_date - qty_processed_per_product[line.product_id.id]
-                if line.product_uom and line.product_id.uom_id and line.product_uom != line.product_id.uom_id:
-                    line.qty_available_today = line.product_id.uom_id._compute_quantity(line.qty_available_today, line.product_uom)
-                    line.free_qty_today = line.product_id.uom_id._compute_quantity(line.free_qty_today, line.product_uom)
-                    line.virtual_available_at_date = line.product_id.uom_id._compute_quantity(line.virtual_available_at_date, line.product_uom)
-                qty_processed_per_product[line.product_id.id] += line.product_uom_qty
-            treated |= lines
-        remaining = (self - treated)
-        remaining.virtual_available_at_date = False
-        remaining.scheduled_date = False
-        remaining.free_qty_today = False
-        remaining.qty_available_today = False
+        # TODO : remove completly this feature in master (replace by forcasted widget), now keep it for rental in stable.
+        self.virtual_available_at_date = 0.0
+        self.scheduled_date = False
+        self.free_qty_today = 0.0
+        self.qty_available_today = 0.0
 
     @api.depends('product_id', 'route_id', 'order_id.warehouse_id', 'product_id.route_ids')
     def _compute_is_mto(self):
@@ -492,6 +451,12 @@ class SaleOrderLine(models.Model):
             }
             return {'warning': warning_mess}
         return {}
+
+    def action_product_forecast_report(self):
+        self.ensure_one()
+        action = self.product_id.action_product_forecast_report()
+        action['context'] = {'active_model': 'product.product', 'active_id': self.product_id.id}
+        return action
 
     def _prepare_procurement_values(self, group_id=False):
         """ Prepare specific key for moves or other components that will be created from a stock rule

--- a/addons/sale_stock/report/report_stock_forecasted.xml
+++ b/addons/sale_stock/report/report_stock_forecasted.xml
@@ -4,7 +4,7 @@
         <xpath expr="//tr[@name='draft_picking_out']" position="after">
             <tr t-if="docs['draft_sale_qty']" name="draft_so_out">
                 <td colspan="2">Draft SO</td>
-                <td t-esc="docs['draft_sale_qty']" class="text-right"/>
+                <td t-esc="-docs['draft_sale_qty']" class="text-right"/>
                 <td t-esc="docs['uom']" groups="uom.group_uom"/>
             </tr>
         </xpath>

--- a/addons/sale_stock/views/sale_order_views.xml
+++ b/addons/sale_stock/views/sale_order_views.xml
@@ -57,7 +57,7 @@
                     <attribute name="attrs">{'column_invisible': [('parent.state', 'not in', ['cancel', 'done'])]}</attribute>
                 </xpath>
                 <xpath expr="//field[@name='order_line']/tree/field[@name='qty_delivered']" position="after">
-                    <field name="json_forecast" string="Delivered" widget="forecast_widget" attrs="{'column_invisible': [('parent.state', 'in', ['cancel', 'done'])]}"/>
+                    <field name="json_forecast" string="Delivered" widget="forecast_widget" attrs="{'column_invisible': [('parent.state', '!=', 'sale')]}"/>
                 </xpath>
            </field>
         </record>

--- a/addons/sale_stock/views/sale_order_views.xml
+++ b/addons/sale_stock/views/sale_order_views.xml
@@ -111,7 +111,10 @@
                     <field name="qty_to_deliver" invisible="1"/>
                     <field name="is_mto" invisible="1"/>
                     <field name="display_qty_widget" invisible="1"/>
-                    <widget name="qty_at_date_widget" width="0.1"/>
+                    <!-- TODO Clean in master : remove the qty_at_date_widget --> 
+                    <widget name="qty_at_date_widget" width="0.1" invisible="1"/>
+                    <button name="action_product_forecast_report" icon="fa-area-chart" type="object"
+                        attrs="{'column_invisible': [('parent.state', 'not in', ('draft', 'sent'))], 'invisible': [('product_type', '!=', 'product')]}"/>
                 </xpath>
             </field>
         </record>

--- a/addons/stock/report/report_stock_forecasted.py
+++ b/addons/stock/report/report_stock_forecasted.py
@@ -124,8 +124,6 @@ class ReplenishmentReport(models.AbstractModel):
             'uom_id': product.uom_id,
             'receipt_date': format_datetime(self.env, move_in.date, timezone, 'medium') if move_in else False,
             'delivery_date': format_datetime(self.env, move_out.date, timezone, 'medium') if move_out else False,
-            'receipt_date_short': format_date(self.env, move_in.date) if move_in else False,
-            'delivery_date_short': format_date(self.env, move_out.date) if move_out else False,
             'is_late': is_late,
             'quantity': quantity,
             'move_out': move_out,
@@ -168,10 +166,10 @@ class ReplenishmentReport(models.AbstractModel):
                         lines.append(self._prepare_report_line(taken_from_in, move_in=in_[1], move_out=out))
                         ins_per_product[out.product_id.id][index][0] -= taken_from_in
                         if ins_per_product[out.product_id.id][index][0] <= 0:
-                            index_to_remove.insert(0, index)
+                            index_to_remove.append(index)
                         if float_is_zero(demand, precision_rounding=product.uom_id.rounding):
                             break
-                    for index in index_to_remove:
+                    for index in index_to_remove[::-1]:
                         ins_per_product[out.product_id.id].pop(index)
                 # Not reconciled.
                 if not float_is_zero(demand, precision_rounding=product.uom_id.rounding):

--- a/addons/stock/report/report_stock_forecasted.xml
+++ b/addons/stock/report/report_stock_forecasted.xml
@@ -117,7 +117,7 @@
                             <td t-esc="line['receipt_date'] or ''"
                                 t-attf-class="#{line['is_late'] and 'o_grid_warning'}"/>
                             <td t-if="docs['multiple_product']" t-esc="line['product']['display_name']"/>
-                            <td t-esc="line['quantity']" class="text-right"/>
+                            <td class="text-right"><t t-if="not line['replenishment_filled']">- </t><t t-esc="line['quantity']"/></td>
                             <td t-esc="line['uom_id'].name" groups="uom.group_uom"/>
                             <td t-attf-class="#{not line['replenishment_filled'] and 'o_grid_warning'}">
                                 <a t-if="line['document_out']"
@@ -136,30 +136,16 @@
                             <td t-esc="docs['virtual_available']" class="text-right"/>
                             <td t-esc="docs['uom']" groups="uom.group_uom"/>
                         </tr>
-                        <tr t-if="docs['qty']['in']" class="bg-light">
-                            <td colspan="2">Pending Incoming Documents</td>
-                            <td t-esc="docs['qty']['in']" class="text-right"/>
-                            <td t-esc="docs['uom']"  groups="uom.group_uom"/>
-                        </tr>
                     </thead>
                     <tbody t-if="docs['qty']['in']">
                         <tr t-if="docs['draft_picking_qty']['in']" name="draft_picking_in">
-                            <td colspan="2">Draft Transfer</td>
+                            <td colspan="2">Incoming Draft Transfer</td>
                             <td t-esc="docs['draft_picking_qty']['in']" class="text-right"/>
                             <td t-esc="docs['uom']" groups="uom.group_uom"/>
                         </tr>
-                    </tbody>
-                    <thead t-if="docs['qty']['out']">
-                        <tr class="bg-light">
-                            <td colspan="2">Pending Outgoing Documents</td>
-                            <td t-esc="docs['qty']['out']" class="text-right"/>
-                            <td t-esc="docs['uom']"  groups="uom.group_uom"/>
-                        </tr>
-                    </thead>
-                    <tbody t-if="docs['qty']['out']">
                         <tr t-if="docs['draft_picking_qty']['out']" name="draft_picking_out">
-                            <td colspan="2">Draft Transfer</td>
-                            <td t-esc="docs['draft_picking_qty']['out']" class="text-right"/>
+                            <td colspan="2">Outgoing Draft Transfer</td>
+                            <td t-esc="-docs['draft_picking_qty']['out']" class="text-right"/>
                             <td t-esc="docs['uom']" groups="uom.group_uom"/>
                         </tr>
                     </tbody>


### PR DESCRIPTION
[FIX] sale_stock: fix json_forcast attrs in SO line

[FIX] (sale_)stock: SO line delivered refactor

In SO line, refactor json_forecast ('Delivered') computation:

"Available" if related stock move is assigned, (already available).
"Exp ", if the product will be available at "date". in Red if
the deadline of SO exceeded, else orange.
"No Available", if the product won't be available in the current
situation.
Change the computation of json_forcast of stock move to add a info
about expected date on partially available moves.
[IMP] (sale_)stock,mrp: improve forcasted report.

Add a minus before quanity if it describes a output move.
Remove intermediate section "Pending Incoming Documents" and
"Pending Outgoing Documents".
task-2324039