### PR TITLE
[FIX] web: deal with null column th

### DIFF
--- a/addons/web/static/src/js/views/list/list_editable_renderer.js
+++ b/addons/web/static/src/js/views/list/list_editable_renderer.js
@@ -574,7 +574,7 @@ ListRenderer.include({
         const relativeWidths = [];
         this.columns.forEach(column => {
             const th = this._getColumnHeader(column);
-            if (th.offsetParent === null) {
+            if (th === null || th.offsetParent === null) {
                 relativeWidths.push(false);
             } else {
                 const width = this._getColumnWidth(column);


### PR DESCRIPTION
In case we have a X2M editable list into a form view and a column who is invisible under some conditions, it could happen it tries to define the column width before the column was properly rendered.

For example:
  - Go to Inventory > Operations > Transfers, and create a new one.
    In the `move_ids_without_packages`, we had a field, `reserved_availability`, who can be invisible.
  - Change the Operation Type for a Receipt:
    -> The `reserved_availability` is now invisible.
  - Change the Operation Type for a Delivery this time:
    -> Traceback when it tries to compute the `reserved_availability` column width.

task-2315149