### PR TITLE
[FIX] board: fix error when switching layouts

### DIFF
--- a/addons/board/static/src/js/board_view.js
+++ b/addons/board/static/src/js/board_view.js
@@ -82,7 +82,7 @@ var BoardController = FormController.extend({
         var boardController = this;
 
         this._rpc({
-            route: 'web/view/create_custom',
+            route: '/web/view/create_custom',
             params: {
                 view_id: this.viewID,
                 arch: arch,

--- a/addons/board/static/tests/dashboard_tests.js
+++ b/addons/board/static/tests/dashboard_tests.js
@@ -139,6 +139,12 @@ QUnit.test('basic functionality, with one sub action', async function (assert) {
                     'orderedBy is present in the search read when specified on the custom action'
                 );
             }
+            if (route === '/web/view/create_custom') {
+                assert.step('create custom');
+                return Promise.resolve({
+                    id: 1,
+                });
+            }
             if (route === '/web/view/edit_custom') {
                 assert.step('edit custom');
                 return Promise.resolve(true);
@@ -171,7 +177,7 @@ QUnit.test('basic functionality, with one sub action', async function (assert) {
     await testUtils.dom.click(form.$('.oe_fold'));
 
     assert.ok(form.$('.oe_content').is(':visible'), "content is visible again");
-    assert.verifySteps(['load action', 'edit custom', 'edit custom']);
+    assert.verifySteps(['load action', 'create custom', 'edit custom']);
 
     assert.strictEqual($('.modal').length, 0, "should have no modal open");
 
@@ -443,9 +449,11 @@ QUnit.test('can drag and drop a view', async function (assert) {
                     views: [[4, 'list']],
                 });
             }
-            if (route === '/web/view/edit_custom') {
-                assert.step('edit custom');
-                return Promise.resolve(true);
+            if (route === '/web/view/create_custom') {
+                assert.step('create custom');
+                return Promise.resolve({
+                    id: 2,
+                });
             }
             return this._super.apply(this, arguments);
         },
@@ -464,7 +472,7 @@ QUnit.test('can drag and drop a view', async function (assert) {
         "initial action is not in column 0");
     assert.containsOnce(form, 'td.index_1 .oe_action',
         "initial action is in in column 1");
-    assert.verifySteps(['edit custom']);
+    assert.verifySteps(['create custom']);
 
     form.destroy();
 });

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1353,6 +1353,27 @@ class DataSet(http.Controller):
 
 class View(http.Controller):
 
+    @http.route('/web/view/create_custom', type='json', auth="user")
+    def create_custom(self, view_id, arch):
+        """
+        Create a custom view
+
+        :param int view_id: the id of the source view
+        :param str arch: the arch of the custom view
+        :returns: dict with two keys: result (the acknowledged operation, set
+                  to True) and id (the new custom view ID)
+        """
+        custom_view = request.env['ir.ui.view.custom'].create({
+            'user_id': request.session.uid,
+            'ref_id': view_id,
+            'arch': arch,
+        })
+
+        return {
+            'result': True,
+            'id': custom_view.id,
+        }
+
     @http.route('/web/view/edit_custom', type='json', auth="user")
     def edit_custom(self, custom_id, arch):
         """


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fixes the error "TypeError: edit_custom() missing 1 required positional argument: 'custom_id'" when switching layouts.

Current behavior before PR:
A stack trace due to a TypeError is being shown when trying to switch layouts.

Desired behavior after PR is merged:
The button for switching layouts is usable again.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
