### PR TITLE
[FIX] board: fix layout view when switching layouts

### DIFF
--- a/addons/board/static/src/js/board_view.js
+++ b/addons/board/static/src/js/board_view.js
@@ -177,11 +177,11 @@ var BoardRenderer = FormRenderer.extend({
         if (current_layout !== layout) {
             var clayout = current_layout.split('-').length,
                 nlayout = layout.split('-').length,
-                column_diff = clayout - nlayout;
+                column_diff = Math.abs(clayout - nlayout);
             if (column_diff > 0) {
                 var $last_column = $();
                 $dashboard.find('.oe_dashboard_column').each(function (k, v) {
-                    if (k >= nlayout) {
+                    if (k >= (nlayout - 1)) {
                         $(v).find('.oe_action').appendTo($last_column);
                     } else {
                         $last_column = $(v);

--- a/addons/board/static/src/scss/dashboard.scss
+++ b/addons/board/static/src/scss/dashboard.scss
@@ -53,6 +53,8 @@
     // Dashboard content
     .oe_dashboard {
         width: 100%;
+        table-layout: fixed;
+
         .oe_action {
             margin: 0 8px 8px 0;
             background-color: white;
@@ -168,8 +170,6 @@
 
 @include media-breakpoint-down(sm) {
     .o_dashboard .oe_dashboard {
-        table-layout: fixed;
-
         .oe_action .oe_header .oe_header_text {
             display: none;
         }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fixes the view when switching layouts. The columns didn't add up. Also, their size was, in some cases, not accurate, sometimes going down to 0px.

Current behavior before PR:
Unpredictable behavior when switching layouts. Columns are sometimes missing.

Desired behavior after PR is merged:
The layouts work as displayed in the switch popup.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
