### PR TITLE
[IMP] Removed OrderedSet on record ids set operations

### DIFF
--- a/doc/cla/corporate/archeti.md
+++ b/doc/cla/corporate/archeti.md
@@ -1,0 +1,15 @@
+Canada, 2019-12-23
+
+ArcheTI agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Loïc Faure-Lacroix llacroix@archeti.com https://github.com/llacroix
+
+List of contributors:
+
+Loïc Faure-Lacroix llacroix@archeti.com https://github.com/llacroix

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5553,7 +5553,7 @@ Fields:
         if not isinstance(other, BaseModel) or self._name != other._name:
             raise TypeError("Mixing apples and oranges: %s & %s" % (self, other))
         other_ids = set(other._ids)
-        return self.browse(OrderedSet(id for id in self._ids if id in other_ids))
+        return self.browse([id for id in self._ids if id in other_ids])
 
     def __or__(self, other):
         """ Return the union of two recordsets.
@@ -5569,8 +5569,8 @@ Fields:
         for arg in args:
             if not (isinstance(arg, BaseModel) and arg._name == self._name):
                 raise TypeError("Mixing apples and oranges: %s.union(%s)" % (self, arg))
-            ids.extend(arg._ids)
-        return self.browse(OrderedSet(ids))
+            ids.extend([id for id in arg._ids if id not in ids])
+        return self.browse(ids)
 
     def __eq__(self, other):
         """ Test whether two recordsets are equivalent (up to reordering). """


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Test in 13.0 the changes as tests break on Sass-13.5 on 10.0

See:
https://github.com/odoo/odoo/pull/56697

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
