### PR TITLE
[FIX] website_sale: misleading warning on checkout page.

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1191,10 +1191,10 @@
                                 <t t-if="mode[1] == 'shipping'">
                                     <h2 class="o_page_header mt8">Shipping Address </h2>
                                 </t>
-                                <t t-if="partner_id == website_sale_order.partner_shipping_id.id == website_sale_order.partner_invoice_id.id">
+                                <t t-if="partner_id == website_sale_order.partner_shipping_id.id == website_sale_order.partner_invoice_id.id and not only_services" groups="sale.group_delivery_invoice_address">
                                     <div class="alert alert-warning" role="alert">
                                         <h4 class="alert-heading">Be aware!</h4>
-                                        <p t-if="not only_services" groups="sale.group_delivery_invoice_address">
+                                        <p>
                                             You are editing your <b>billing and shipping</b> addresses at the same time!<br/>
                                             If you want to modify your shipping address, create a <a href='/shop/address'>new address</a>.
                                         </p>


### PR DESCRIPTION
With the current conditions, the user could end in a case where
only the `<h4>` was displayed, thus making the warning talk like
Jean-Claude Van Damme.

[![image](https://user-images.githubusercontent.com/34744917/91718660-1a784c00-eb94-11ea-83a6-33fb73fae75e.png)](https://www.youtube.com/watch?time_continue=36&v=o0ib4oWSOH0)
