### PR TITLE
[FIX] hr_payroll: prevent deletion of validated payslips

### DIFF
--- a/addons/hr_payroll/i18n/hr_payroll.pot
+++ b/addons/hr_payroll/i18n/hr_payroll.pot
@@ -1513,6 +1513,12 @@ msgid "Wrong range condition defined for salary rule %s (%s)."
 msgstr ""
 
 #. module: hr_payroll
+#: code:addons/hr_payroll/models/hr_payslip.py:588
+#, python-format
+msgid "You cannot delete a payslip batch which is not draft!"
+msgstr ""
+
+#. module: hr_payroll
 #: code:addons/hr_payroll/models/hr_payslip.py:128
 #, python-format
 msgid "You cannot delete a payslip which is not draft or cancelled!"

--- a/addons/hr_payroll/models/hr_payslip.py
+++ b/addons/hr_payroll/models/hr_payslip.py
@@ -581,3 +581,11 @@ class HrPayslipRun(models.Model):
     @api.multi
     def close_payslip_run(self):
         return self.write({'state': 'close'})
+
+    @api.multi
+    def unlink(self):
+        if any(self.filtered(lambda payslip_run: payslip_run.state not in ('draft'))):
+            raise UserError(_('You cannot delete a payslip batch which is not draft!'))
+        if any(self.slip_ids.filtered(lambda payslip: payslip.state not in ('draft','cancel'))):
+            raise UserError(_('You cannot delete a payslip which is not draft or cancelled!'))
+        return super(HrPayslipRun, self).unlink()


### PR DESCRIPTION
A payslip in state done cannot be deleted. But in case it is included in a
payslip batch, we should not be able to delete it when deleting the batch.

Description of the issue/feature this PR addresses:
opw-2329268

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
