### PR TITLE
[FIX] website: Internal server errors on submenus without top parent menu

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -139,7 +139,11 @@ class Website(models.Model):
                 if menu.parent_id and menu.parent_id in menus:
                     menu.parent_id._cache['child_id'] += (menu.id,)
 
-            website.menu_id = menus and menus.filtered(lambda m: not m.parent_id)[0].id or False
+            menu_id = False
+            if menus:
+                top_parent = menus.filtered(lambda m: not m.parent_id)
+                menu_id = top_parent and top_parent[0].id
+            website.menu_id = menu_id
 
     # self.env.uid for ir.rule groups on menu
     @tools.ormcache('self.env.uid', 'self.id')


### PR DESCRIPTION
To reproduce:
 1. Install Website
 2. Go to Website > Configuration > Menus (in debug mode)
 3. Remove or set a visible groups on the top parent menu "Top Menu for Website 1"

Before this commit
Internal server error on website (`Index out of Bound` error)
As such, it is now not possible to log in, as the login page is not accessible

After this commit:
If the top parent menu is missing, ignore the submenus associated to it.

OPW-2329074

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
