### PR TITLE
[FIX] point_of_sale: Fix delay barcode scanner

### DIFF
--- a/addons/point_of_sale/static/src/js/barcode_reader.js
+++ b/addons/point_of_sale/static/src/js/barcode_reader.js
@@ -141,7 +141,7 @@ var BarcodeReader = core.Class.extend({
                         self.remote_active = 0;
                         return;
                     }
-                    setTimeout(waitforbarcode,5000);
+                    waitforbarcode();
                 });
         }
         waitforbarcode();


### PR DESCRIPTION
When we make a request to /hw_proxy/sanner there are a timeout of 7,5 sec
After this timeout we wait for 5 sec before send another request.
And we clean the queue of barcode in IoT Box after 5 sec.

So if a cashier scan a product between this "gap" the product is not added to the POS

With this commit we remove the delay before send another request.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
