### PR TITLE
[FIX] web,mail: form: remove notebook flickering

### DIFF
--- a/addons/mail/static/src/widgets/form_renderer/form_renderer.js
+++ b/addons/mail/static/src/widgets/form_renderer/form_renderer.js
@@ -155,8 +155,8 @@ FormRenderer.include({
      *
      * @override
      */
-    async _renderView() {
-        await this._super(...arguments);
+    async __renderView() {
+        const $form = await this._super(...arguments);
         if (this._hasChatter()) {
             if (!this._chatterContainerComponent) {
                 this._makeChatterContainerComponent();
@@ -165,6 +165,7 @@ FormRenderer.include({
             }
             await this._mountChatterContainerComponent();
         }
+        return $form;
     },
     /**
      * @private

--- a/addons/mail/static/src/widgets/form_renderer/form_renderer.js
+++ b/addons/mail/static/src/widgets/form_renderer/form_renderer.js
@@ -149,6 +149,12 @@ FormRenderer.include({
         }
         return this._super(...arguments);
     },
+    async _render() {
+        await this._super(...arguments);
+        if (this._hasChatter()) {
+            await this._mountChatterContainerComponent();
+        }
+    },
     /**
      * Overrides the function to render the chatter once the form view is
      * rendered.
@@ -163,7 +169,6 @@ FormRenderer.include({
             } else {
                 await this._updateChatterContainerComponent();
             }
-            await this._mountChatterContainerComponent();
         }
         return $form;
     },


### PR DESCRIPTION
Before this commit, in a form view with a notebook and a chatter,
if the user clicked on edit/save when being on another tab than
the first one in the notebook, there was a flickering (the first
tab was briefly displayed before switching back to the other one).

Task 2321220

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
