### PR TITLE
[FIX] mrp_subcontracting: Error Message with partial delivery

### DIFF
--- a/addons/mrp/models/mrp_abstract_workorder.py
+++ b/addons/mrp/models/mrp_abstract_workorder.py
@@ -267,7 +267,7 @@ class MrpAbstractWorkorder(models.AbstractModel):
                     'location_id': production_move.location_id.id,
                     'location_dest_id': location_dest_id,
                 })
-        else:
+        elif production_move:
             rounding = production_move.product_uom.rounding
             production_move._set_quantity_done(
                 float_round(self.qty_producing, precision_rounding=rounding)

--- a/addons/mrp_subcontracting/models/stock_picking.py
+++ b/addons/mrp_subcontracting/models/stock_picking.py
@@ -38,13 +38,15 @@ class StockPicking(models.Model):
     # -------------------------------------------------------------------------
 
     def action_done(self):
+        for picking in self:
+            production_move = {move.id: move.move_orig_ids.production_id for move in picking.move_lines}
         res = super(StockPicking, self).action_done()
         productions = self.env['mrp.production']
         for picking in self:
             for move in picking.move_lines:
                 if not move.is_subcontract:
                     continue
-                production = move.move_orig_ids.production_id
+                production = production_move.get(move.id, False) or move.move_orig_ids.production_id
                 if move._has_tracked_subcontract_components():
                     move.move_orig_ids.filtered(lambda m: m.state not in ('done', 'cancel')).move_line_ids.unlink()
                     move_finished_ids = move.move_orig_ids.filtered(lambda m: m.state not in ('done', 'cancel'))


### PR DESCRIPTION
Steps to reproduce:

- Create a product P with route 'Resupply subcontractor on an order'
- Let's consider a BOM for P with type 'Subcontracting'
- Create a PO with subcontractor set on that product and process with Qty > 1,
- Validate a receipt with partial Qty and no backorder

Bug:

An error was raised because no production_id was set when trying to create a mrp.product.produce

opw:2322278