### PR TITLE
make calendar popover content scrollable

### DIFF
--- a/addons/web/static/src/scss/web_calendar.scss
+++ b/addons/web/static/src/scss/web_calendar.scss
@@ -677,6 +677,7 @@ $o-cw-filter-avatar-size: 20px;
     .o_cw_popover_fields_secondary {
         max-height: 170px; // Fallback for old browsers
         max-height: 25vh;
+        overflow-y: auto;
 
         &::-webkit-scrollbar {
             background: gray('200');


### PR DESCRIPTION
PURPOSE
Calendar popover content should be scrollable.

SPEC
Buttons should be always available, no matter how many attendees there are.
Suggestion: have the popover content scrollable, and the buttons in a footer, always visible

TASK 2334817


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
