### PR TITLE
[FIX] point_of_sale: Post reset hook

### DIFF
--- a/addons/point_of_sale/tools/posbox/configuration/posbox_update.sh
+++ b/addons/point_of_sale/tools/posbox/configuration/posbox_update.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+PATH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 sudo mount -o remount,rw /
 
 sudo service led-status stop
@@ -14,16 +16,8 @@ git fetch "${localremote}" "${localbranch}" --depth=1
 git reset "${localremote}"/"${localbranch}" --hard
 
 git clean -df
-cp -a /home/pi/odoo/addons/point_of_sale/tools/posbox/overwrite_after_init/home/pi/odoo/* /home/pi/odoo/
-rm -r /home/pi/odoo/addons/point_of_sale/tools/posbox/overwrite_after_init
 
-sudo find / -type f -name "*.iotpatch" 2> /dev/null | while read iotpatch; do
-    DIR=$(dirname "${iotpatch}")
-    BASE=$(basename "${iotpatch%.iotpatch}")
-    sudo find "${DIR}" -type f -name "${BASE}" ! -name "*.iotpatch" | while read file; do
-        sudo patch -f "${file}" < "${iotpatch}"
-    done
-done
+sudo ${PATH_DIR}/post_reset_hook.sh
 
 sudo mount -o remount,ro /
 sudo mount -o remount,rw /root_bypass_ramdisks/etc/cups

--- a/addons/point_of_sale/tools/posbox/configuration/post_reset_hook.sh
+++ b/addons/point_of_sale/tools/posbox/configuration/post_reset_hook.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+cp -a /home/pi/odoo/addons/point_of_sale/tools/posbox/overwrite_after_init/home/pi/odoo/* /home/pi/odoo/
+rm -r /home/pi/odoo/addons/point_of_sale/tools/posbox/overwrite_after_init
+
+sudo find / -type f -name "*.iotpatch" 2> /dev/null | while read iotpatch; do
+    DIR=$(dirname "${iotpatch}")
+    BASE=$(basename "${iotpatch%.iotpatch}")
+    sudo find "${DIR}" -type f -name "${BASE}" ! -name "*.iotpatch" | while read file; do
+        sudo patch -f "${file}" < "${iotpatch}"
+    done
+done


### PR DESCRIPTION
After the checkout of the IoT Box to the branch of the connected DB,
some tasks need to be performed. For example, this is the moment we
apply the `*.iotpatch` diffs.

The tasks to perform depend on the new branch, not the previous one.
The code to be executed at this point should then come from the new
branch. As the `posbox_update.sh` file isn't updated while being
executed, we need to move this code to a separate file,

E.g.: We now want to change the location of the `*.iotpatch` files in
master but we can't as the `posbox_update.sh` file will use their path
from the previous branch.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
