### PR TITLE
[FIX] requirements: adapt greenlet and gevent versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,9 @@ decorator==4.3.0
 docutils==0.14
 ebaysdk==2.1.5
 feedparser==5.2.1
-gevent==1.1.2 ; sys_platform != 'win32' and python_version < '3.7'
+gevent==1.3.7 ; python_version < '3.7'
 gevent==1.5.0 ; python_version >= '3.7'
-gevent==1.4.0 ; sys_platform == 'win32'
-greenlet==0.4.10 ; python_version < '3.7'
-greenlet==0.4.15 ; python_version >= '3.7'
+greenlet==0.4.15
 html2text==2018.1.9
 Jinja2==2.10.1
 libsass==0.17.0


### PR DESCRIPTION
In 42391761e the gevent version was bumped to 1.3.7 alongside with
greenlet 0.4.10. This was reverted in 9b48876bed8 as it was the root
cause of a CPU overload on runbot running builds.

While investigating the log files, it appeared that gevent 1.3.7
requires a greenlet version >= 0.4.14. This was causing a traceback and
a constant reload of the gevent process alongside with a significant log
file size increase.

With this commit, both greenlet and gevent versions are bumped to the
Debian buster versions.
