### PR TITLE
[FIX] pos_restaurant: error on adding product after print bill

### DIFF
--- a/addons/pos_restaurant/static/src/js/printbill.js
+++ b/addons/pos_restaurant/static/src/js/printbill.js
@@ -24,6 +24,11 @@ var BillScreenWidget = screens.ReceiptScreenWidget.extend({
         this._super();
         this.$('.receipt-change').remove();
     },
+    print: function() {
+        this._super();
+        // Do not tag as printed when printing as bill.
+        this.this.pos.get_order()._printed = false;
+    },
 });
 
 gui.define_screen({name:'bill', widget: BillScreenWidget});


### PR DESCRIPTION
To reproduce:
1. Make an order with a product.
2. Print bill.
3. Add new product. (Error)

The error is caused by flagging the order as `_printed` which
destroys the order when adding new product. In this commit,
we set the flag to false after printing the bill.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
