### PR TITLE
[FIX] web / js : action new window duplicates action buttons

### DIFF
--- a/addons/web/static/src/js/chrome/action_manager.js
+++ b/addons/web/static/src/js/chrome/action_manager.js
@@ -392,6 +392,9 @@ var ActionManager = Widget.extend({
             return dialog.open().opened(function () {
                 self.currentDialogController = controller;
 
+                // Since the buttons are added in the footer, we clear the buttons in the control panel.
+                widget.$el.find('.o_cp_buttons').empty();
+
                 dom.append(dialog.$el, widget.$el, {
                     in_DOM: true,
                     callbacks: [{widget: dialog}, {widget: controller.widget}],


### PR DESCRIPTION
When a window action was set to new, the dialog would wear a footer
containing the action buttons (add, discard, import, ...). The same
buttons we can find in the control panel. This creates redundancy.

This commit removes the buttons from the control panel in this case.
It simply empties the dom element wrapping the buttons.

Task id 2300515