### PR TITLE
badge background removed on list sort

### DIFF
--- a/addons/web/static/src/js/fields/abstract_field_owl.js
+++ b/addons/web/static/src/js/fields/abstract_field_owl.js
@@ -87,6 +87,8 @@ odoo.define('web.AbstractFieldOwl', function (require) {
             const res = super.__patch(...arguments);
             this.el.setAttribute('name', this.name);
             this.el.classList.add('o_field_widget');
+            // Find better way to fix this issue
+            this._applyDecorations();
             return res;
         }
         /**

--- a/addons/web/static/src/js/views/basic/basic_renderer.js
+++ b/addons/web/static/src/js/views/basic/basic_renderer.js
@@ -647,6 +647,12 @@ var BasicRenderer = AbstractRenderer.extend(WidgetAdapterMixin, {
 
         return modifiersData.evaluatedModifiers[record.id];
     },
+    recursiveCallMounted(component) {
+        for (const key in component.__owl__.children) {
+            this.recursiveCallMounted(component.__owl__.children[key]);
+        }
+        component.__callMounted();
+    },
     /**
      * @override
      */
@@ -889,6 +895,19 @@ var BasicRenderer = AbstractRenderer.extend(WidgetAdapterMixin, {
         delete this.defs;
 
         return Promise.all(defs);
+    },
+    async updateState(state, params) {
+        await this._super(...arguments);
+        if (!params.noRender) {
+            // re-rendering will destory old widgets and create new instances of field widgets
+            for (const id in this.allFieldWidgets) {
+                for (const widget of this.allFieldWidgets[id]) {
+                    if (widget instanceof owl.Component) {
+                        this.recursiveCallMounted(widget);
+                    }
+                }
+            }
+        }
     },
 
     //--------------------------------------------------------------------------

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -7438,6 +7438,35 @@ QUnit.module('basic_fields', {
 
         list.destroy();
     });
+
+    QUnit.test("FieldBadge component with decoration-xxx attributes and sorting list", async function (assert) {
+        assert.expect(6);
+
+        this.data.partner.fields.foo.sortable = true;
+
+        const list = await createView({
+            View: ListView,
+            model: "partner",
+            data: this.data,
+            arch: `
+                <list>
+                    <field name="selection"/>
+                    <field name="foo" widget="badge" decoration-danger="selection == 'done'" decoration-warning="selection == 'blocked'"/>
+                </list>`,
+        });
+
+        assert.containsN(list, '.o_field_badge[name="foo"]', 5);
+        assert.containsOnce(list, '.o_field_badge[name="foo"].bg-danger-light');
+        assert.containsOnce(list, '.o_field_badge[name="foo"].bg-warning-light');
+
+        // Sorting list view
+        await testUtils.dom.click(list.$('th.o_column_sortable:contains("Foo")'));
+        assert.containsN(list, '.o_field_badge[name="foo"]', 5);
+        assert.containsOnce(list, '.o_field_badge[name="foo"].bg-danger-light');
+        assert.containsOnce(list, '.o_field_badge[name="foo"].bg-warning-light');
+
+        list.destroy();
+    });
 });
 });
 });


### PR DESCRIPTION
PURPOSE
Sorting listview should not remove background in badge widget.

SPEC
When sorting, applying a filter, or adding/remvoing columns in a list view, the class (e.g. .bg-success-light, .bg-info-light) that handles the background-color of the status badges are being removed somehow, making the default .o_field_widget.o_field_badge background-color apply to all status badges.


TASK 2336440



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
