### PR TITLE
[FIX] account: on premise bill gateway

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -7032,6 +7032,11 @@ msgid "Layout"
 msgstr ""
 
 #. module: account
+#: model_terms:ir.ui.view,arch_db:account.account_tour_upload_bill
+msgid "Learn how to do it."
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields,help:account.field_account_journal__sale_activity_user_id
 msgid "Leave empty to assign the Salesperson of the invoice."
 msgstr ""
@@ -7072,6 +7077,13 @@ msgstr ""
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.dashboard_onboarding_bill_step
 msgid "Let's start!"
+msgstr ""
+
+#. module: account
+#. openerp-web
+#: code:addons/account/static/src/js/tours/account.js:0
+#, python-format
+msgid "Let’s go back to the dashboard."
 msgstr ""
 
 #. module: account
@@ -7950,7 +7962,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/account/static/src/js/tours/account.js:0
 #, python-format
-msgid "Once everything is as you want it, validate."
+msgid "Once everything is as you want, press SAVE."
 msgstr ""
 
 #. module: account
@@ -8141,6 +8153,18 @@ msgstr ""
 #: model:ir.model.fields,field_description:account.field_account_payment_term_line__option
 #: model_terms:ir.ui.view,arch_db:account.tax_adjustments_wizard
 msgid "Options"
+msgstr ""
+
+#. module: account
+#: code:addons/account/wizard/account_tour_upload_bill.py:0
+#, python-format
+msgid "Or send a bill by email"
+msgstr ""
+
+#. module: account
+#: code:addons/account/wizard/account_tour_upload_bill.py:0
+#, python-format
+msgid "Or send a bill to %s@%s"
 msgstr ""
 
 #. module: account
@@ -12670,6 +12694,12 @@ msgid "Transfers"
 msgstr ""
 
 #. module: account
+#: code:addons/account/wizard/account_tour_upload_bill.py:0
+#, python-format
+msgid "Try a sample vendor bill"
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__user_type_id
 #: model:ir.model.fields,field_description:account.field_account_account_template__user_type_id
 #: model:ir.model.fields,field_description:account.field_account_account_type__type
@@ -12866,6 +12896,12 @@ msgstr ""
 #: code:addons/account/static/src/xml/bills_tree_upload_views.xml:0
 #, python-format
 msgid "Upload"
+msgstr ""
+
+#. module: account
+#: code:addons/account/wizard/account_tour_upload_bill.py:0
+#, python-format
+msgid "Upload your own bill"
 msgstr ""
 
 #. module: account
@@ -13730,6 +13766,11 @@ msgid "You don't have the access rights to post an invoice."
 msgstr ""
 
 #. module: account
+#: model_terms:ir.ui.view,arch_db:account.account_tour_upload_bill
+msgid "You email server is not set up."
+msgstr ""
+
+#. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_move_form
 msgid "You have"
 msgstr ""
@@ -13794,6 +13835,7 @@ msgstr ""
 
 #. module: account
 #: code:addons/account/models/account_move.py:0
+#: code:addons/account/wizard/account_automatic_entry_wizard.py:0
 #: code:addons/account/wizard/account_automatic_entry_wizard.py:0
 #, python-format
 msgid "[Not set]"

--- a/addons/account/static/src/js/tours/account.js
+++ b/addons/account/static/src/js/tours/account.js
@@ -25,7 +25,7 @@ tour.register('account_tour', {
     }, {
         trigger: "button[name=document_layout_save]",
         extra_trigger: "a.o_onboarding_step_action[data-method=action_open_base_document_layout]",
-        content: _t("Once everything is as you want it, validate."),
+        content: _t("Once everything is as you want, press SAVE."),
     }, {
         trigger: "a.o_onboarding_step_action[data-method=action_open_account_onboarding_create_invoice]",
         content: _t("Now, we'll create your first invoice."),
@@ -85,6 +85,10 @@ tour.register('account_tour', {
         trigger: "button[name=send_and_print_action]",
         extra_trigger: "[name=move_type][raw-value=out_invoice]",
         content: _t("Let's send the invoice."),
+    }, {
+        trigger: '.o_menu_brand',
+        content: _t('Let’s go back to the dashboard.'),
+        position: 'bottom',
     }
 ]);
 

--- a/addons/account/wizard/account_tour_upload_bill.py
+++ b/addons/account/wizard/account_tour_upload_bill.py
@@ -1,9 +1,16 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, api, _
+from odoo import fields, models, _
+from odoo.tools.misc import format_date, file_open
 from odoo.modules.module import get_resource_path
+
 import base64
+import io
+from PyPDF2 import PdfFileReader, PdfFileWriter
+from reportlab.pdfgen import canvas
+from datetime import timedelta
+
 
 class AccountTourUploadBill(models.TransientModel):
     _name = 'account.tour.upload.bill'
@@ -23,18 +30,88 @@ class AccountTourUploadBill(models.TransientModel):
     )
 
     def _selection_values(self):
+        values = [
+            ('sample', _('Try a sample vendor bill')),
+            ('upload', _('Upload your own bill')),
+        ]
         journal_alias = self.env['account.journal'] \
             .search([('type', '=', 'purchase'), ('company_id', '=', self.env.company.id)], limit=1)
+        if journal_alias.alias_domain:
+            values += [('email', _('Or send a bill to %s@%s', journal_alias.alias_name, journal_alias.alias_domain))]
+        else:
+            values += [('noemail', _('Or send a bill by email'))]
 
-        return [('sample', 'Try a sample vendor bill'),
-                ('upload', 'Upload your own bill'),
-                ('email', 'Or send a bill to %s@%s' % (journal_alias.alias_name, journal_alias.alias_domain))]
+        return values
 
     def _compute_sample_bill_image(self):
         """ Retrieve sample bill with facturx to speed up onboarding """
+        def addAddress(can, x, y, partner):
+            can.setFillColorRGB(1, 1, 1)
+            can.rect(x, y, width*0.3, height*0.1, fill=1, stroke=0)
+            can.setFillColorRGB(0.4, 0.4, 0.4)
+            for i, line in enumerate(partner.split('\n')):
+                if i == 0:
+                    can.setFont("Helvetica-Bold", height/80)
+                if i == 1:
+                    can.setFont("Helvetica", height/80)
+                can.drawString(x + width*0.01, y + height*0.09 - i*height/70, line)
+
+        def addDate(can, x, y, date):
+            can.setFillColorRGB(1, 1, 1)
+            can.rect(x, y, width*0.1, height*0.0166, fill=1, stroke=0)
+            can.setFont("Helvetica", height/80)
+            can.setFillColorRGB(0.52, 0.52, 0.52)
+            can.drawString(x + width/500, y + height/250, date)
+
         try:
-            path = get_resource_path('account_edi_facturx', 'data/files', 'Invoice.pdf')
-            self.sample_bill_preview = base64.b64encode(open(path, 'rb').read()) if path else False
+            file = file_open('account_edi_facturx/data/files/Invoice.pdf', 'rb')
+            pdf_reader = PdfFileReader(file)
+            pdf_writer = PdfFileWriter()
+            page = pdf_reader.getPage(0)
+            canvas_stream = io.BytesIO()
+            can = canvas.Canvas(canvas_stream)
+            width = float(abs(page.mediaBox.getWidth()))
+            height = float(abs(page.mediaBox.getHeight()))
+            # Vendor address
+            addAddress(can, width*0.15, height*0.88, (
+                "Odoo\n"
+                "Chaussée de Namur, 40\n"
+                "1367 Grand-Rosière\n"
+                "Belgium"
+            ))
+            # Client address
+            addAddress(can, width*0.58, height*0.765, (
+                "{name}\n"
+                "{street}\n"
+                "{street2}\n"
+                "{zip} {city}\n"
+                "{country}\n"
+                "{vat}"
+            ).format(
+                name=self.env.company.name or "",
+                street=self.env.company.street or "",
+                street2=self.env.company.street2 or "",
+                zip=self.env.company.zip or "",
+                city=self.env.company.city or "",
+                country=self.env.company.country_id.name or "",
+                vat=self.env.company.vat or "",
+            ))
+            # Invoice Date
+            addDate(can, width*0.05, height*0.675, format_date(self.env, fields.Date.today()))
+            # Due Date
+            addDate(can, width*0.182, height*0.675, format_date(self.env, fields.Date.today() + timedelta(days=7)))
+            can.save()
+            overlay = PdfFileReader(canvas_stream, overwriteWarnings=False).getPage(0)
+
+            for i in range(pdf_reader.getNumPages()):
+                page = pdf_reader.getPage(i)
+                page.mergePage(overlay)
+                pdf_writer.addPage(page)
+
+            original_stream = io.BytesIO()
+            pdf_writer.write(original_stream)
+            self.sample_bill_preview = base64.b64encode(original_stream.getvalue())
+            file.close()
         except (IOError, OSError):
             self.sample_bill_preview = False
         return

--- a/addons/account/wizard/account_tour_upload_bill.xml
+++ b/addons/account/wizard/account_tour_upload_bill.xml
@@ -19,6 +19,14 @@
                             <group attrs="{'invisible': [('selection', '!=', 'upload')]}">
                                 <field name="attachment_ids" widget="many2many_binary" string="Attach a file" nolabel="1" colspan="2"/>
                             </group>
+                            <group attrs="{'invisible': [('selection', '!=', 'noemail')]}" col="1">
+                                <p>You email server is not set up.</p>
+                                <p>
+                                    <a href="https://www.odoo.com/documentation/user/13.0/discuss/advanced/email_servers.html" target="_blank">
+                                        Learn how to do it.
+                                    </a>
+                                </p>
+                            </group>
                         </group>
                     </sheet>
                     <footer>


### PR DESCRIPTION
Task [2338171](https://www.odoo.com/web#id=2338171&action=333&active_id=967&model=project.task&view_type=form&cids=1&menu_id=4720)
* Manage the alias for on premise users and show configuration help page
  - Only show the send by email option if there is an alias configured
  - If there is no alias configured, show a link to the documentation
* Dynamic vendor bill:
  - dynamic date
  - dynamic customer (the owner of the db)
  This has been done like this to avoid the load time of wkhtmltopdf.
  Blazing fast.
* Close send and print wizard when Print is checked.
  - `close_on_report_download` was removed from the action, stoping the
  fact that the Send & Print wizard was closed after printing.
  - We can now end the tour and show the rainbowman properly.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
