### PR TITLE
[FIX] web: get/set local state owl renderer

### DIFF
--- a/addons/web/static/src/js/views/renderer_wrapper.js
+++ b/addons/web/static/src/js/views/renderer_wrapper.js
@@ -4,9 +4,18 @@ odoo.define('web.RendererWrapper', function (require) {
     const { ComponentWrapper } = require('web.OwlCompatibility');
 
     class RendererWrapper extends ComponentWrapper {
-        getLocalState() { }
-        setLocalState() { }
-        giveFocus() { }
+        getLocalState() {
+            const renderer = this.componentRef.comp;
+            return renderer ? renderer.getLocalState(...arguments) : undefined;
+        }
+        setLocalState() {
+            const renderer = this.componentRef.comp;
+            return renderer ? renderer.setLocalState(...arguments) : undefined;
+        }
+        giveFocus() {
+            const renderer = this.componentRef.comp;
+            return renderer ? renderer.giveFocus(...arguments) : undefined;
+        }
     }
 
     return RendererWrapper;


### PR DESCRIPTION
Before this commit, RendererWrapper defined functions
just for compatiblity but these functions did nothing.
Now those functions redirect to the wrapped Renderer's ones.