### PR TITLE
support readonly boolean_toggle widget

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -2239,6 +2239,9 @@ var BooleanToggle = FieldBoolean.extend({
      */
     _onClick: function (event) {
         event.stopPropagation();
+        if (this.$el.hasClass('o_readonly_modifier')) {
+            return;
+        }
         this._setValue(!this.value);
         this.$el.closest(".o_data_row").toggleClass('text-muted', this.value);
     },

--- a/addons/web/static/src/scss/webclient.scss
+++ b/addons/web/static/src/scss/webclient.scss
@@ -100,7 +100,9 @@ div.o_boolean_toggle.custom-control.custom-checkbox {
             height: ceil($circle-width / 1rem * $o-root-font-size);
             border-radius: 100px;
             background-color: $white;
-            cursor: pointer;
+            &:not(.o_readonly_modifier) {
+                cursor: pointer;
+            }
         }
     }
     > input.custom-control-input:checked + label.custom-control-label {

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -376,6 +376,31 @@ QUnit.module('basic_fields', {
         form.destroy();
     });
 
+    QUnit.test('boolean_toggle widget in form view with readonly attribute', function (assert) {
+        assert.expect(4);
+
+        var form = createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: '<form><field name="bar" widget="boolean_toggle" readonly="True"/></form>',
+            res_id: 2,
+        });
+
+        assert.strictEqual(form.$(".o_boolean_toggle").length, 1,
+            "Boolean toggle widget applied to boolean field");
+        assert.strictEqual(form.$('.o_boolean_toggle input:checked').length, 1,
+            "checkbox should be checked");
+        assert.strictEqual(form.$(".o_boolean_toggle.o_readonly_modifier").length, 1,
+            "Boolean toggle contains o_readonly_modifier class");
+
+        form.$('.o_boolean_toggle').click();
+        assert.strictEqual(form.$('.o_boolean_toggle input:checked').length, 1,
+            "checkbox should still be checked");
+
+        form.destroy();
+    });
+
     QUnit.module('FieldToggleButton');
 
     QUnit.test('use toggle_button in list view', function (assert) {


### PR DESCRIPTION
PURPOSE
Applying readonly attribute on  boolean_toggle widget does not make widget readonly

SPEC
When readonly attribute on  boolean_toggle widget then it should not be clickable.

TASK 2339962


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
