### PR TITLE
[FIX] web: readonly attribute does not work on boolean_favorite widget

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -2115,8 +2115,11 @@ var FavoriteWidget = AbstractField.extend({
      * @private
      */
     _render: function () {
+        var isReadonly = this.record.evalModifiers(this.attrs.modifiers).readonly;
         var tip = this.value ? _t('Remove from Favorites') : _t('Add to Favorites');
-        var template = this.attrs.nolabel ? '<a href="#"><i class="fa %s" title="%s" aria-label="%s" role="img"></i></a>' : '<a href="#"><i class="fa %s" role="img" aria-label="%s"></i> %s</a>';
+        var template = this.attrs.nolabel || isReadonly ?
+            '<a><i class="fa %s" title="%s" aria-label="%s" role="img"></i></a>' :
+            '<a><i class="fa %s" role="img" aria-label="%s"></i> %s</a>';
         this.$el.empty().append(_.str.sprintf(template, this.value ? 'fa-star' : 'fa-star-o', tip, tip));
     },
 
@@ -2133,6 +2136,9 @@ var FavoriteWidget = AbstractField.extend({
     _setFavorite: function (event) {
         event.preventDefault();
         event.stopPropagation();
+        if (this.$el.hasClass('o_readonly_modifier')) {
+            return;
+        }
         this._setValue(!this.value);
     },
 });

--- a/addons/web/static/src/scss/fields.scss
+++ b/addons/web/static/src/scss/fields.scss
@@ -224,6 +224,9 @@
 
     // Favorite
     &.o_favorite {
+        &:not(.o_readonly_modifier) {
+            cursor: pointer;
+        }
         i.fa {
             font-size: 16px;
         }

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -4884,6 +4884,52 @@ QUnit.module('basic_fields', {
         form.destroy();
     });
 
+    QUnit.test('favorite widget in form view with readonly modifiers', function (assert) {
+        assert.expect(8);
+
+        var form = createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: '<form string="Partners">' +
+                    '<sheet>' +
+                        '<group>' +
+                            '<field name="bar" widget="boolean_favorite" readonly="1" />' +
+                        '</group>' +
+                    '</sheet>' +
+                '</form>',
+            res_id: 1,
+        });
+
+        assert.strictEqual(form.$('.o_field_widget.o_favorite > a i.fa.fa-star').length, 1,
+            'should be favorite');
+        assert.strictEqual(form.$('.o_field_widget.o_favorite > a').text(), '',
+            'the label should be nothing as it is readonly');
+        assert.strictEqual(form.$('.o_field_widget.o_favorite.o_readonly_modifier').length, 1,
+            'should have o_readonly_modifier class');
+        assert.strictEqual(form.$('.o_field_widget.o_favorite > a > i').attr("title"), 'Remove from Favorites',
+            'the title should be "Remove from Favorites"');
+
+        // click on favorite
+        form.$('.o_field_widget.o_favorite').click();
+        assert.strictEqual(form.$('.o_field_widget.o_favorite > a i.fa.fa-star').length, 1,
+            'click should not change value as it is readonly, it should be favorite');
+
+        // switch to edit mode
+        form.$buttons.find('.o_form_button_edit').click();
+        assert.strictEqual(form.$('.o_field_widget.o_favorite > a i.fa.fa-star').length, 1,
+            'should be favorite');
+
+        // click on favorite
+        form.$('.o_field_widget.o_favorite').click();
+        assert.strictEqual(form.$('.o_field_widget.o_favorite > a i.fa.fa-star').length, 1,
+            'click should not have any effect as it is readonly, it should be favorite');
+        assert.strictEqual(form.$('.o_field_widget.o_favorite > a > i').attr("title"), 'Remove from Favorites',
+            'the title should be "Remove from Favorites"');
+
+        form.destroy();
+    });
+
     QUnit.test('favorite widget in editable list view without label', function (assert) {
         assert.expect(4);
 
@@ -4905,7 +4951,7 @@ QUnit.module('basic_fields', {
             'should be favorite');
 
         // click on favorite
-        list.$('.o_data_row:first .o_field_widget.o_favorite').click();
+        list.$('.o_data_row:first .o_field_widget.o_favorite > a').click();
         assert.strictEqual(list.$('.o_data_row:first .o_field_widget.o_favorite > a i.fa.fa-star').length, 0,
             'should not be favorite');
 


### PR DESCRIPTION
**PURPOSE**
Applying readonly attribute on 'boolean_favorite' field should not display
'Add to Favorites' and 'Remove from Favorites' tip and click on that should
not change the value as well.

**SPEC**
we are not allowing to click and display tooltip if the field having 'boolean_favorite' 
field widget and readonly attribute.

Task : 2339987