### PR TITLE
[FIX] web / js: reference field calls name_create

### DIFF
--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -1583,7 +1583,8 @@ var BasicModel = AbstractModel.extend({
 
         const field = record.fields[fieldName];
         const coModel = field.type === 'reference' ? data.model : field.relation;
-        if (field.type === 'many2one' && !data.id && data.display_name) {
+        const allowedTypes = ['many2one', 'reference'];
+        if (allowedTypes.includes(field.type) && !data.id && data.display_name) {
             // only display_name given -> do a name_create
             const result = await this._rpc({
                 model: coModel,

--- a/addons/web/static/tests/fields/relational_fields_tests.js
+++ b/addons/web/static/tests/fields/relational_fields_tests.js
@@ -2568,6 +2568,38 @@ QUnit.module('relational_fields', {
 
     QUnit.module('FieldReference');
 
+    QUnit.test('Reference field can quick create models', async function (assert) {
+        assert.expect(3);
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: `<form><field name="reference"/></form>`,
+            mockRPC(route, args) {
+                const result = this._super.apply(this, arguments);
+                if (args.method === 'name_create') {
+                    assert.step('name_create');
+                }
+                return result;
+            },
+        });
+
+        await testUtils.fields.editSelect(form.$('select'), 'partner');
+        await testUtils.fields.editInput(form.$('input'), 'new partner');
+
+        // The "create new partner" should be highlighted
+        assert.ok($('a.ui-state-active').text().includes('"new partner"'),
+            'The create new partner should be highlighted');
+
+        await testUtils.dom.click($('a.ui-state-active'));
+
+        assert.verifySteps(['name_create'],
+            "The name_create method should have been called");
+
+        form.destroy();
+    });
+
     QUnit.test('Reference field in modal readonly mode', async function (assert) {
         assert.expect(4);
 


### PR DESCRIPTION
An older commit had refactor part of the basic field _applyX2ManyOperations.
During this refactor, the reference field was forgotten to be included
in a condition that made the field no longer do the quick create behavior.
The name_create function in the backend was no longer called.

Adds a test for the reference field checking the call to the name_create
function and fixes the problem.

Task id 2322048