### PR TITLE
[FIX] mail,sale,hr_expense: schedule activity

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -743,9 +743,11 @@ class HrExpenseSheet(models.Model):
         return self.env['res.users']
 
     def activity_update(self):
-        for expense_report in self.filtered(lambda hol: hol.state == 'submit'):
-            self.activity_schedule(
-                'hr_expense.mail_act_expense_approval',
-                user_id=expense_report.sudo()._get_responsible_for_approval().id or self.env.user.id)
+        mail_act_expense_approval = self.sudo().env.ref('hr_expense.mail_act_expense_approval', raise_if_not_found=False)
+        if mail_act_expense_approval and mail_act_expense_approval.active:
+            for expense_report in self.filtered(lambda hol: hol.state == 'submit'):
+                self.activity_schedule(
+                    'hr_expense.mail_act_expense_approval',
+                    user_id=expense_report.sudo()._get_responsible_for_approval().id or self.env.user.id)
         self.filtered(lambda hol: hol.state == 'approve').activity_feedback(['hr_expense.mail_act_expense_approval'])
         self.filtered(lambda hol: hol.state == 'cancel').activity_unlink(['hr_expense.mail_act_expense_approval'])

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -667,7 +667,10 @@ class MailActivityMixin(models.AbstractModel):
         if isinstance(date_deadline, datetime):
             _logger.warning("Scheduled deadline should be a date (got %s)", date_deadline)
         if act_type_xmlid:
-            activity_type = self.sudo().env.ref(act_type_xmlid)
+            activity_type = self.sudo().env.ref(act_type_xmlid, raise_if_not_found=False)
+            if not activity_type:
+                _logger.error("Can't schedule activity, external ID does not exist in database (%s).", act_type_xmlid)
+                return self.env['mail.activity']
         else:
             activity_type = self.env['mail.activity.type'].sudo().browse(act_values['activity_type_id'])
 

--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -410,7 +410,8 @@ class SaleOrder(models.Model):
             return super(SaleOrder, self)._write(values)
 
         if 'invoice_status' in values:
-            if values['invoice_status'] == 'upselling':
+            mail_act_sale_upsell = self.sudo().env.ref('sale.mail_act_sale_upsell', raise_if_not_found=False)
+            if values['invoice_status'] == 'upselling' and mail_act_sale_upsell and mail_act_sale_upsell.active:
                 filtered_self = self.search([('id', 'in', self.ids),
                                              ('user_id', '!=', False),
                                              ('invoice_status', '!=', 'upselling')])


### PR DESCRIPTION
1. mail:

    Issue

            Traceback raised when trying to schedule an invalid activity.
    
    Cause
    
            No check is made when scheduling to verify if "xml_id" of the activity
            is available in database.
    
    Solution
    
            If "xml_id" not available, log an error and continue process without
            scheduling the activity.

    issue: Traceback raised when trying to schedule an activity. 

2. hr_expense, sale:

     Issue
   
            Activity type archived X is scheduled.
    
    Cause
    
            No check is made to verify if activity type is active or archived.
    
    Solution
    
            Check if activity type active, if not, do not schedule new activity.