### PR TITLE
[IMP] web_editor: handle long dropdown overflow

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -907,6 +907,15 @@ const SelectUserValueWidget = BaseSelectionUserValueWidget.extend({
         if (activeButton) {
             this.menuEl.scrollTop = activeButton.el.offsetTop - (this.menuEl.offsetHeight / 2);
         }
+        // Calculate the distance to viewport & check if dropdown will overflow.
+        const distanceToViewportBottom = window.innerHeight - this.menuEl.getBoundingClientRect().top;
+        this.maxHeight = distanceToViewportBottom - 10;
+        let targetMenuEl = this.menuEl;
+        // This will handle the "SelectPagerUserValueWidget" widget that extends "SelectUserValueWidget".
+        if (this.el.classList.contains('o_we_select_pager')) {
+            targetMenuEl = this.el.querySelector("we-select-page");
+        }
+        targetMenuEl.style.maxHeight = _.str.sprintf("%fpx", this.maxHeight);
     },
 });
 

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -632,6 +632,12 @@ body.editor_enable.editor_has_snippets {
                 &:not(.o_we_has_pager) {
                     max-height: 600px;
                     overflow-y: auto;
+                    border-radius: 3px;
+                    -ms-overflow-style: none;
+                    scrollbar-width: none;
+                    &::-webkit-scrollbar {
+                        display: none;
+                    }
                 }
 
                 > we-title {


### PR DESCRIPTION
Dropdown on the editor goes may be long (e.g. image Filter).
Making lower items less accessible, the whole left panel will scroll down.

The main goal of this PR is to add dynamic sizing to long dropdown lists
to prevent viewport overflow.

task-2327025