### PR TITLE
[FIX] hr_holidays @ 13.0: Fixing creating new allocation with no allo…

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -150,6 +150,13 @@ class HolidaysAllocation(models.Model):
         ('interval_number_check', "CHECK(interval_number > 0)", "The interval number should be greater than 0"),
     ]
 
+    @api.constrains('holiday_status_id')
+    def _check_allocation_type(self):
+        for rec in self:
+            if rec.env.context.get('force_allocation_type', []) and rec.holiday_status_id.allocation_type == "no":
+                raise ValidationError(
+                    "This time of type \"{0}\" does not require allocation because \"No Allocation Needed\" set in Allocation mode.".format(self.name))
+
     @api.model
     def _update_accrual(self):
         """

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -355,7 +355,7 @@
         <field name="name">All Allocations</field>
         <field name="res_model">hr.leave.allocation</field>
         <field name="view_mode">tree,kanban,form,activity</field>
-        <field name="context">{}</field>
+        <field name="context">{'force_allocation_type':1}</field>
         <field name="domain">[]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">


### PR DESCRIPTION
…cation needed.

Before it was possible to create a new allocation with No Allocation Needed as the mode type of the allocation type.
A check was added when saving to prevent this from happening.

Task: https://www.odoo.com/web#id=2251943&action=4043&model=project.task&view_type=form&cids=1&menu_id=4720




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
