### PR TITLE
[REM] (sale_)stock: remove old json forecasted fields

### DIFF
--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -276,7 +276,6 @@ class SaleOrderLine(models.Model):
     qty_to_deliver = fields.Float(compute='_compute_qty_to_deliver', digits='Product Unit of Measure')
     is_mto = fields.Boolean(compute='_compute_is_mto')
     display_qty_widget = fields.Boolean(compute='_compute_qty_to_deliver')
-    json_forecast = fields.Char('JSON data for the forecast widget', compute='_compute_json_forecast')
 
     @api.depends('product_type', 'product_uom_qty', 'qty_delivered', 'state', 'move_ids')
     def _compute_qty_to_deliver(self):
@@ -382,11 +381,6 @@ class SaleOrderLine(models.Model):
                 line.is_mto = True
             else:
                 line.is_mto = False
-
-    @api.depends('move_ids', 'order_id.expected_date', 'qty_delivered')
-    def _compute_json_forecast(self):
-        self.json_forecast = False
-        # TODO: remove this fields in master -> computation done in _compute_qty_at_date
 
     @api.depends('product_id')
     def _compute_qty_delivered_method(self):

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -176,10 +176,8 @@ class StockMove(models.Model):
     next_serial = fields.Char('First SN')
     next_serial_count = fields.Integer('Number of SN')
     orderpoint_id = fields.Many2one('stock.warehouse.orderpoint', 'Original Reordering Rule', check_company=True)
-    # TODO : remove `json_forecast` in master, use forcast_ fields instead
-    json_forecast = fields.Char('JSON data for the forecast widget', compute='_compute_json_forecast')
-    forecast_availability = fields.Float('Forcast Availability', compute='_compute_json_forecast', digits='Product Unit of Measure')
-    forecast_expected_date = fields.Datetime('Forcasted Expected date', compute='_compute_json_forecast')
+    forecast_availability = fields.Float('Forcast Availability', compute='_compute_forecast_information', digits='Product Unit of Measure')
+    forecast_expected_date = fields.Datetime('Forcasted Expected date', compute='_compute_forecast_information')
     lot_ids = fields.Many2many('stock.production.lot', compute='_compute_lot_ids', inverse='_set_lot_ids', string='Serial Numbers', readonly=False)
 
     @api.onchange('product_id', 'picking_type_id')
@@ -409,9 +407,8 @@ class StockMove(models.Model):
                 move.availability = min(move.product_qty, total_availability)
 
     @api.depends('product_id', 'picking_type_id', 'picking_id', 'reserved_availability', 'priority', 'state', 'product_uom_qty')
-    def _compute_json_forecast(self):
+    def _compute_forecast_information(self):
         """ Compute forecasted information of the related product by warehouse."""
-        self.json_forecast = False
         self.forecast_availability = False
         self.forecast_expected_date = False
 


### PR DESCRIPTION
- Remove fields `json_forecast` of `stock.move`
- Remove fields `json_forecast` of `sale.order.line`

odoo/upgrade#1783