### PR TITLE
[FIX] hr_attendance: correct company on kiosk mode

### DIFF
--- a/addons/hr_attendance/static/src/js/kiosk_mode.js
+++ b/addons/hr_attendance/static/src/js/kiosk_mode.js
@@ -25,7 +25,7 @@ var KioskMode = AbstractAction.extend({
         var def = this._rpc({
                 model: 'res.company',
                 method: 'search_read',
-                args: [[['id', '=', this.session.company_id]], ['name']],
+                args: [[['id', '=', this.session.user_context.allowed_company_ids && this.session.user_context.allowed_company_ids[0] || this.session.company_id]], ['name']],
             })
             .then(function (companies){
                 self.company_name = companies[0].name;


### PR DESCRIPTION
Before this commit, It was using User's current company from session on kiosk mode.

Now we are using correct company based on context.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
