### PR TITLE
[IMP] survey: mandatory validation error message

### DIFF
--- a/addons/survey/views/survey_question_views.xml
+++ b/addons/survey/views/survey_question_views.xml
@@ -124,7 +124,7 @@
                                             <field name="validation_max_date" attrs="{'invisible': [('question_type', '!=', 'date')]}"/>
                                             <field name="validation_min_datetime" widget="datetime" attrs="{'invisible': [('question_type', '!=', 'datetime')]}"/>
                                             <field name="validation_max_datetime" widget="datetime" attrs="{'invisible': [('question_type', '!=', 'datetime')]}"/>
-                                            <field name="validation_error_msg"/>
+                                            <field name="validation_error_msg" attrs="{'required': [('validation_required', '=', True)]}"/>
                                         </group>
                                     </div>
                                 </div>


### PR DESCRIPTION
Before this commit *Validation Error message* was not required for Questions with *Validate Required* which will display as `False` if *Validation Error message* is empty.

With this commit we make *Validation Error message* required for these types of questions which requires validation.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
