### PR TITLE
[FIX] web: fix inverted resize of list view column in RTL

### DIFF
--- a/addons/web/static/src/js/views/list/list_editable_renderer.js
+++ b/addons/web/static/src/js/views/list/list_editable_renderer.js
@@ -1705,7 +1705,8 @@ ListRenderer.include({
         const resizeHeader = ev => {
             ev.preventDefault();
             ev.stopPropagation();
-            const delta = ev.pageX - initialX;
+            const isRTL = _t.database.parameters.direction === 'rtl';
+            const delta = isRTL ? initialX - ev.pageX : ev.pageX - initialX;
             const newWidth = Math.max(10, initialWidth + delta);
             const tableDelta = newWidth - initialWidth;
             th.style.width = `${newWidth}px`;


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fixes #57933 

Current behavior before PR:
Resizing a list view column in a RTL language (eg. Arabic) is inverted.

Desired behavior after PR is merged:
Resizing a list view column in a RTL language behaves as expected.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
