### PR TITLE
[FIX] web_editor: block's shapes, orientation fix

### DIFF
--- a/addons/web_editor/static/shapes/Blocks/03.svg
+++ b/addons/web_editor/static/shapes/Blocks/03.svg
@@ -1,28 +1,25 @@
-
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px"
 	 viewBox="0 0 1400 570" style="enable-background:new 0 0 1400 570;" xml:space="preserve">
 <style type="text/css">
-	.st0{opacity:0.73;fill:#3AADAA;enable-background:new    ;}
-	.st1{opacity:0.42;fill:#3AADAA;enable-background:new    ;}
+	.st0{opacity:0.73;fill:#3AADAA;enable-background:new;}
+	.st1{opacity:0.42;fill:#3AADAA;enable-background:new;}
 	.st2{fill:#3AADAA;}
-	.st3{opacity:0.81;fill:#3AADAA;enable-background:new    ;}
-	.st4{opacity:0.84;fill:#3AADAA;enable-background:new    ;}
+	.st3{opacity:0.81;fill:#3AADAA;enable-background:new;}
+	.st4{opacity:0.84;fill:#3AADAA;enable-background:new;}
 	.st5{fill:#FFFFFF;}
 </style>
 <g>
-	<polygon class="st0" points="198.8,467.2 34.9,502.1 34.9,526.4 198.8,491.5 	"/>
-	<polygon class="st1" points="87.4,567.3 251.4,532.4 251.4,515.7 87.4,550.6 	"/>
-	<polygon class="st2" points="280.8,474.1 198.8,491.5 198.8,502.6 34.9,537.4 34.9,526.4 0,533.8 0,569.2 87.4,550.6 87.4,543 
-		251.4,508.1 251.4,515.7 280.8,509.5 	"/>
-	<polygon class="st3" points="87.4,543 87.4,550.6 251.4,515.7 251.4,508.1 	"/>
-	<polygon class="st1" points="198.8,502.9 198.8,491.8 34.9,526.6 34.9,537.7 	"/>
+	<polygon class="st0" points="198.8,474 34.9,502.9 34.9,527.2 198.8,498.3"/>
+	<polygon class="st1" points="87.4,570 251.4,541.1 251.4,524.4 87.4,553.3"/>
+	<polygon class="st2" points="280.8,483.8 198.8,498.3 198.8,509.6 34.9,538.5 34.9,527.2 0,533.3 0,568.7 87.4,553.3 87.4,545.7 251.4,516.8 251.4,524.4 280.8,519.2"/>
+	<polygon class="st3" points="87.4,545.7 87.4,553.3 251.4,524.4 251.4,516.8"/>
+	<polygon class="st1" points="198.8,509.6 198.8,498.3 34.9,527.2 34.9,538.5"/>
 </g>
 <g>
-	<polygon class="st0" points="1159.2,354.5 1314.4,321.3 1314.4,291.9 1159.2,325.1 	"/>
-	<polygon class="st1" points="1314.4,235.5 1229,253.1 1229,267.4 1314.4,249.2 	"/>
-	<polygon class="st1" points="1400,231.1 1314.4,249.2 1314.4,265 1229,282.6 1229,267.4 1059.8,303.4 1059.8,346.2 1159.2,325.1 
-		1159.2,304 1314.4,270.8 1314.4,291.9 1400,273.9 	"/>
-	<polygon class="st4" points="1314.4,265 1314.4,249.2 1229,267.4 1229,282.6 	"/>
-	<polygon class="st5" points="1159.2,304 1159.2,325.1 1314.4,291.9 1314.4,270.8 	"/>
+	<polygon class="st0" points="1159.2,345.9 1314.4,318.6 1314.4,289.2 1159.2,316.5"/>
+	<polygon class="st1" points="1314.4,232.1 1229,247.1 1229,261.4 1314.4,246.4"/>
+	<polygon class="st1" points="1400,231.3 1314.4,246.4 1314.4,261.6 1229,276.6 1229,261.4 1059.8,291.3 1059.8,334.1 1159.2,316.5 1159.2,295.4 1314.4,268.1 1314.4,289.2 1400,274.1"/>
+	<polygon class="st4" points="1314.4,261.6 1314.4,246.4 1229,261.4 1229,276.6"/>
+	<polygon class="st5" points="1159.2,295.4 1159.2,316.5 1314.4,289.2 1314.4,268.1"/>
 </g>
 </svg>

--- a/addons/web_editor/static/shapes/Blocks/04.svg
+++ b/addons/web_editor/static/shapes/Blocks/04.svg
@@ -1,18 +1,31 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -830 1400 1400">
-  <polygon points="1400 268.92 0 570 0 570 1400 570 1400 268.92" style="fill: #f6f6f6"/>
-  <g>
-    <path d="M230.44,441v37.09L42.51,518V480.91l187.93-40m1.78-2.19L40.73,479.47V520.2l191.49-40.71V438.77Z" style="fill: #f6f6f6"/>
-    <polygon points="350.41 413.23 232.22 438.73 232.22 479.39 350.41 454.48 350.41 413.23" style="fill: #3aadaa"/>
-    <polygon points="0 528.86 0 570 172.62 533.47 172.62 492.16 0 528.86" style="fill: #383e45;opacity: 0.29"/>
-    <polygon points="288.34 467.42 172.62 492.16 172.62 533.47 288.34 508.73 288.34 467.42" style="fill: #7c6576"/>
-  </g>
-  <g>
-    <polygon points="1180.32 357.68 1353.06 320.95 1353.06 278.98 1180.32 315.7 1180.32 357.68" style="fill: #7c6576"/>
-    <polygon points="1353.06 320.95 1400 311.45 1400 269.48 1353.06 278.98 1353.06 320.95" style="fill: #3aadaa;opacity: 0.7000000000000001"/>
-    <g style="opacity: 0.08">
-      <path d="M1351.66,323.44v37.87l-83,17.81V341.25l83-17.81m2-2.49-87,18.67v42l87-18.67V321Z" style="fill: #383e45"/>
-    </g>
-    <polygon points="1072.17 339 1244.9 302.22 1244.9 256.89 1072.17 293.62 1072.17 339" style="fill: #383e45;opacity: 0.29"/>
-    <polygon points="1400 269.69 1400 222.53 1244.9 255.64 1244.9 302.31 1400 269.69" style="fill: #3aadaa"/>
-  </g>
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px"
+	 viewBox="0 0 1400 570" style="enable-background:new 0 0 1400 570;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#F6F6F6;}
+	.st1{fill:#7C6576;}
+	.st2{fill:#3AADAA;}
+	.st3{opacity:0.29;fill:#383E45;enable-background:new;}
+	.st4{opacity:0.4;fill:#3AADAA;}
+	.st5{opacity:8.000000e-02;}
+	.st6{fill:#383E45;}
+	.st7{opacity:8.000000e-02;enable-background:new;}
+</style>
+<polygon class="st0" points="0,569.7 1400,570 1400,323.1 0,570"/>
+<g>
+	<polygon class="st1" points="288.3,477.8 172.6,498.2 172.6,539.6 288.3,519.2"/>
+	<polygon class="st2" points="347.9,426 232.2,446.4 232.2,487.8 347.9,467.4"/>
+</g>
+<g>
+	<polygon class="st1" points="1180.3,403.9 1353.1,373.4 1353.1,331.4 1180.3,361.9"/>
+</g>
+<polygon class="st2" points="1400,323.1 1244.9,350.5 1244.9,303.8 1400,276.5"/>
+<polygon class="st3" points="1244.9,350.5 1072.2,380.9 1072.2,334.3 1244.9,303.8 "/>
+<polygon class="st4" points="1400,365.1 1353.1,373.4 1353.1,331.4 1400,323.1 "/>
+<g class="st5">
+	<path class="st6" d="M1351.1,375.8V414l-83,14.5v-38.2L1351.1,375.8 M1353.1,373.4l-87,15.2v42.2l87-15.2V373.4L1353.1,373.4z"/>
+</g>
+<polygon class="st3" points="0,528.7 172.6,498.2 172.6,539.6 0,570 "/>
+<g class="st7">
+	<path class="st6" d="M230.2,448.8v37.2l-187.4,33v-37.2L230.2,448.8 M232.2,446.4L40.7,480.2v41.3l191.4-33.7V446.4L232.2,446.4z"/>
+</g>
 </svg>


### PR DESCRIPTION
This commit will fix orientation for 'Blocks' shapes number 03 and 04.
Shapes provided by EDI.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
