### PR TITLE
[FIX] payment_paypal: suffix tx reference key with item number

### DIFF
--- a/addons/payment_paypal/controllers/main.py
+++ b/addons/payment_paypal/controllers/main.py
@@ -56,7 +56,7 @@ class PaypalController(http.Controller):
         Once data is validated, process it. """
         res = False
         post['cmd'] = '_notify-validate'
-        reference = post.get('item_number')
+        reference = post.get('item_number%s' % post.get('num_cart_items', ''))
         tx = None
         if reference:
             tx = request.env['payment.transaction'].sudo().search([('reference', '=', reference)])

--- a/addons/payment_paypal/models/payment.py
+++ b/addons/payment_paypal/models/payment.py
@@ -126,7 +126,7 @@ class TxPaypal(models.Model):
 
     @api.model
     def _paypal_form_get_tx_from_data(self, data):
-        reference, txn_id = data.get('item_number'), data.get('txn_id')
+        reference, txn_id = data.get('item_number%s' % data.get('num_cart_items', '')), data.get('txn_id')
         if not reference or not txn_id:
             error_msg = _('Paypal: received data with missing reference (%s) or txn_id (%s)') % (reference, txn_id)
             _logger.info(error_msg)


### PR DESCRIPTION
Fix for https://github.com/odoo/odoo/issues/56434

> If this is a shopping cart transaction, PayPal will append the number of the item. For example, item_number1, item_number2, and so on.

Description of the issue/feature this PR addresses:
Odoo doesn't parse answer from Paypal correctly

Current behavior before PR:
Succesful payment at Paypal triggers an error message.

Desired behavior after PR is merged:
Succesful payment at Paypal triggers a green success message.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
