### PR TITLE
[FIX] portal: relying on module install order is not safe

### DIFF
--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -36,7 +36,7 @@
     </template>
 
     <!-- Added by another template so that it can be disabled if needed -->
-    <template id="footer_language_selector" inherit_id="portal.frontend_layout" name="Footer Language Selector">
+    <template id="footer_language_selector" inherit_id="portal.frontend_layout" name="Footer Language Selector" priority="15'">
         <xpath expr="//*[hasclass('o_footer_copyright_name')]" position="after">
             <t id="language_selector_call" t-call="portal.language_selector">
                 <t t-set="_div_classes" t-value="(_div_classes or '') + ' dropup'"/>


### PR DESCRIPTION
Especially from the migration point of view