### PR TITLE
[FIX] hr: chat icon should be hidden when employees in edit mode

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -77,7 +77,7 @@
                         <div class="oe_title">
                             <h1>
                                 <field name="name" placeholder="Employee's Name" required="True"/>
-                                <a title="Chat" icon="fa-comments" href="#" class="ml8 o_employee_chat_btn" invisible="not context.get('chat_icon')" attrs="{'invisible': [('user_id','=', False)]}" role="button"><i class="fa fa-comments"/></a>
+                                <a title="Chat" icon="fa-comments" href="#" class="ml8 o_employee_chat_btn oe_read_only" invisible="not context.get('chat_icon')" attrs="{'invisible': [('user_id','=', False)]}" role="button"><i class="fa fa-comments"/></a>
                             </h1>
                             <h2>
                                 <field name="job_title" placeholder="Job Position" />


### PR DESCRIPTION
Currently, the chat icon is displayed underneath the name when employees record is in edit mode.

So in this commit, when employee record is in edit mode the chat icon should be hidden.

Links
PR #58320
TaskID: 2344588