### PR TITLE
[FIX] link_tracker: cannot change mail template

### DIFF
--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -120,11 +120,7 @@ class LinkTracker(models.Model):
         else:
             create_vals['url'] = VALIDATE_URL(vals['url'])
 
-        search_domain = []
-        for fname, value in create_vals.items():
-            search_domain.append((fname, '=', value))
-
-        result = self.search(search_domain, limit=1)
+        result = self._search_and_update(create_vals)
 
         if result:
             return result
@@ -184,6 +180,15 @@ class LinkTracker(models.Model):
                 body = body.replace(original_url, shortened_url, 1)
 
         return body
+
+    def _search_and_update(self, vals):
+        """ Could update a record in case of uniqueness conflict in mass_mailing
+        """
+        search_domain = []
+        for fname, value in vals.items():
+            search_domain.append((fname, '=', value))
+
+        return self.search(search_domain, limit=1)
 
     def action_view_statistics(self):
         action = self.env['ir.actions.act_window'].for_xml_id('link_tracker', 'link_tracker_click_action_statistics')

--- a/addons/mass_mailing/models/link_tracker.py
+++ b/addons/mass_mailing/models/link_tracker.py
@@ -9,6 +9,27 @@ class LinkTracker(models.Model):
 
     mass_mailing_id = fields.Many2one('mailing.mailing', string='Mass Mailing')
 
+    def _search_and_update(self, vals):
+        """ We override this method as searching with mass_mailing_id will not find the linked record.
+            If the linked record is found, we then update its mass_mailing_id.
+        """
+        search_vals = vals.copy()
+        has_mass_mailing = 'mass_mailing_id' in vals
+
+        if has_mass_mailing:
+            mass_mailing_id = search_vals.pop('mass_mailing_id')
+
+        search_domain = []
+        for fname, value in search_vals.items():
+            search_domain.append((fname, '=', value))
+
+        result = self.search(search_domain, limit=1)
+
+        if result and has_mass_mailing:
+            result.write({'mass_mailing_id': mass_mailing_id})
+
+        return result
+
 
 class LinkTrackerClick(models.Model):
     _inherit = "link.tracker.click"


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a new campaign in Marketing Automation
- Add a new activity
- Launch a test
- Run the test (click on the "play" icon)
- Go back in the campaign and edit it
- Pick a new Mail Template and save
- Launch a test again
- Run the test

Bug:
Traceback: a record already exists for the PG unique constraint.

Closes #57144

opw:2335523