### PR TITLE
[FIX] crm: clear breadcrumb when redirecting to activities from systray

### DIFF
--- a/addons/crm/static/src/js/systray_activity_menu.js
+++ b/addons/crm/static/src/js/systray_activity_menu.js
@@ -46,7 +46,8 @@ ActivityMenu.include({
             // So, duplicates are faking the count and "Load more" doesn't show up
             context['force_search_count'] = 1;
             this.do_action('crm.crm_lead_action_my_activities', {
-                additional_context: context
+                additional_context: context,
+                clear_breadcrumbs: true,
             });
         } else {
             this._super.apply(this, arguments);


### PR DESCRIPTION
Current behavior before PR:

When accessing activities from the systray, any existing breadcrumb-item should
be clearer.

Desired behavior after PR is merged:

Clear breadcrumb-item when access activities from the systray.

LINKS

PR https://github.com/odoo/odoo/pull/58513
Task-2342246