### PR TITLE
[FIX] coupon: domain selector visibility in modal

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -3215,6 +3215,10 @@ var FieldDomain = AbstractField.extend({
             });
             def = this.domainSelector.prependTo(this.$el);
         } else {
+            // allows field selector to overflow
+            if (this.el.offsetParent) {
+                this.el.offsetParent.style.overflow = 'visible';
+            }
             def = this.domainSelector.setDomain(value);
         }
         // ... then replace the other content (matched records, etc)


### PR DESCRIPTION
before this commit,
the domain selector popover displayed behind the modal body

this commit fixes the issues by adding overflow property in the modal body
due to that, it will always display on top of the modal.

task - 2225272