### PR TITLE
[IMP] website : improve countdown snippet preview

### DIFF
--- a/addons/website/static/src/snippets/s_countdown/000.js
+++ b/addons/website/static/src/snippets/s_countdown/000.js
@@ -41,6 +41,15 @@ const CountdownWidget = publicWidget.Widget.extend({
         }
         this._initTimeDiff();
 
+        // Set ending message visibility depending on the option value when the
+        // widget starts in edit mode.
+        // The message should be hidden if this.editableMode === false.
+        if (this.editableMode && this.el.dataset.endMessageVisibility === 'true') {
+            this.$('.s_countdown_end_message').removeClass("d-none");
+        } else if (!this.editableMode) {
+            this.el.dataset.endMessageVisibility = false;
+        }
+
         this._render();
 
         this.setInterval = setInterval(this._render.bind(this), 1000);

--- a/addons/website/static/src/snippets/s_countdown/000.xml
+++ b/addons/website/static/src/snippets/s_countdown/000.xml
@@ -5,9 +5,6 @@
     </t>
     <t t-name="website.s_countdown.end_message">
         <div class="s_countdown_end_message d-none">
-            <div class="text-center alert alert-info css_non_editable_mode_hidden o_not_editable" t-ignore="True" role="status">
-                The following message will become visible <strong>only</strong> once the countdown ends.
-            </div>
             <div class="oe_structure">
                 <section class="s_picture bg-200 pt48 pb24" data-snippet="s_picture">
                     <div class="container">

--- a/addons/website/static/src/snippets/s_countdown/options.js
+++ b/addons/website/static/src/snippets/s_countdown/options.js
@@ -117,6 +117,7 @@ options.registry.countdown = options.Class.extend({
         this.showEndMessage = !this.showEndMessage;
         this.$el.find(".toggle-edit-message")
             .toggleClass('text-primary', this.showEndMessage);
+        this.$target[0].dataset.endMessageVisibility = this.showEndMessage;
         this.updateUIEndMessage();
         this.trigger_up('cover_update');
     },

--- a/addons/website/views/snippets/s_countdown.xml
+++ b/addons/website/views/snippets/s_countdown.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <template id="s_countdown" name="Countdown">
-    <section class="s_countdown pt48 pb48"
+    <section class="s_countdown pt48"
         data-display="dhms" data-end-action="nothing" data-size="175"
         t-att-data-end-time="datetime.datetime.now().timestamp() + 228307"
         data-layout="circle" data-layout-background="none"


### PR DESCRIPTION
CONTEXT : selected countdown snippet with a visible ending
message [option : What should happen at the end? > Show message].

The "hover preview" on snippet options will make the visible
message disappear.

In this PR, we set the visibility of '.s_countdown_end_message'
element depending on the '.toggle-edit-message' value in edit mode.

When user exit the edit mode, the ending message content will be hidden
until the end of countdown.

Other small tweaks were made in this PR:

- Remove the blue text when the ending message content
  displayed (the option is clear to understand).

- Default bottom padding removed from snippet section to avoid
  additional spacing (we can always set bottom spacing in edit mode).

task-2345433