### PR TITLE
[FIX] calendar: compute stop when needed

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -328,7 +328,8 @@ class Meeting(models.Model):
         for event in self:
             # Round the duration (in hours) to the minute to avoid weird situations where the event
             # stops at 4:19:59, later displayed as 4:19.
-            event.stop = event.start + timedelta(minutes=round((event.duration or 1.0) * 60))
+            if event.start:
+                event.stop = event.start + timedelta(minutes=round((event.duration or 1.0) * 60))
             if event.allday:
                 event.stop -= timedelta(seconds=1)
 


### PR DESCRIPTION
Before this commit there would be trackback (TypeError: unsupported operand type(s) for +: 'bool' and 'datetime.timedelta') when you will try to remove field `Starting At`

With this commit, We will compute `stop` if `start` is present.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
