### PR TITLE
[FIX] account, account_payment, sale : add support of new 'reversed' payment_state

### DIFF
--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -60,6 +60,9 @@
                             <t t-if="invoice.state == 'posted' and invoice.payment_state == 'paid'">
                                 <span class="badge badge-pill badge-success"><i class="fa fa-fw fa-check" aria-label="Paid" title="Paid" role="img"></i><span class="d-none d-md-inline"> Paid</span></span>
                             </t>
+                            <t t-if="invoice.state == 'posted' and invoice.payment_state == 'reversed'">
+                                <span class="badge badge-pill badge-success"><i class="fa fa-fw fa-check" aria-label="Reversed" title="Reversed" role="img"></i><span class="d-none d-md-inline"> Reversed</span></span>
+                            </t>
                             <t t-if="invoice.state == 'cancel'">
                                 <span class="badge badge-pill badge-warning"><i class="fa fa-fw fa-remove" aria-label="Cancelled" title="Cancelled" role="img"></i><span class="d-none d-md-inline"> Cancelled</span></span>
                             </t>

--- a/addons/account_payment/views/account_portal_templates.xml
+++ b/addons/account_payment/views/account_portal_templates.xml
@@ -28,6 +28,9 @@
                 <t t-if="invoice.state == 'posted' and invoice.payment_state == 'paid' or last_tx.state == 'done'">
                     <span class="badge badge-pill badge-success"><i class="fa fa-fw fa-check"></i><span class="d-none d-md-inline"> Paid</span></span>
                 </t>
+                <t t-if="invoice.state == 'posted' and invoice.payment_state == 'reversed' or last_tx.state == 'done'">
+                    <span class="badge badge-pill badge-success"><i class="fa fa-fw fa-check"></i><span class="d-none d-md-inline"> Reversed</span></span>
+                </t>
                 <t t-if="invoice.state == 'cancel'">
                     <span class="badge badge-pill badge-danger"><i class="fa fa-fw fa-remove"></i><span class="d-none d-md-inline"> Cancelled</span></span>
                 </t>

--- a/addons/sale/models/sales_team.py
+++ b/addons/sale/models/sales_team.py
@@ -80,7 +80,7 @@ class CrmTeam(models.Model):
             FROM account_move move
             LEFT JOIN account_move_line line ON line.move_id = move.id
             WHERE move.type IN ('out_invoice', 'out_refund', 'in_invoice', 'in_refund')
-            AND move.payment_state IN ('in_payment', 'paid')
+            AND move.payment_state IN ('in_payment', 'paid', 'reversed')
             AND move.state = 'posted'
             AND move.team_id IN %s
             AND move.date BETWEEN %s AND %s


### PR DESCRIPTION
Add handling of reversed payment state in portal templates and sales_team.