### PR TITLE
[FIX] web: field selector popover visibility in wizard

### DIFF
--- a/addons/web/static/src/js/widgets/domain_selector.js
+++ b/addons/web/static/src/js/widgets/domain_selector.js
@@ -564,6 +564,10 @@ var DomainSelector = DomainTree.extend({
      * node
      */
     _onAddFirstButtonClick: function () {
+        // allows field selector to overflow
+        if (this.$el.closest('.modal-body').length) {
+            this.$el.closest('.modal-body').css('overflow', 'visible');
+        }
         this._addChild(this.options.default || [["id", "=", 1]]);
     },
     /**


### PR DESCRIPTION
before this commit,
the field selector popover displayed behind the modal body

this commit fixes the issues by adding overflow property in the modal body
due to that, it will always display on top of the modal.

task - 2225272