### PR TITLE
[IMP] mass_mailing : improve auto generated mailing name and utm source name

### DIFF
--- a/addons/mass_mailing_sms/data/mailing_demo.xml
+++ b/addons/mass_mailing_sms/data/mailing_demo.xml
@@ -3,6 +3,7 @@
     <record id="mailing_sms_0" model="mailing.mailing">
         <field name="name">XMas Promo</field>
         <field name="subject">XMas Promo</field>
+        <field name="name">XMas Promo</field>
         <field name="mailing_type">sms</field>
         <field name="state">done</field>
         <field name="user_id" ref="base.user_admin"/>
@@ -112,6 +113,7 @@
     <record id="mailing_sms_1" model="mailing.mailing">
         <field name="name">Extra Promo</field>
         <field name="subject">Extra Promo</field>
+        <field name="name">Extra Promo</field>
         <field name="mailing_type">sms</field>
         <field name="state">done</field>
         <field name="user_id" ref="base.user_admin"/>


### PR DESCRIPTION
PURPOSE
=======

This commit improves the auto generated name of the mailings and of the UTM source.
Currently, this name is auto generated but is not very user-friendly.

SPECIFICATIONS
=======

We want to have a unique mailing/source name.

When no name is given, we automatically generate one with the following format
"<subject> (Mailing created on <date>)".

If the name is duplicated, we add a counter after it ("<name> [X]").

Update the demo data to not auto-generate the name and to avoid creating unnecessary
i18n lines.

LINKS
=======

Task 2245823