### PR TITLE
[FIX] account_edi_ubl: fix exporting of taxes with UBL

### DIFF
--- a/addons/account_edi_ubl/data/ubl_templates.xml
+++ b/addons/account_edi_ubl/data/ubl_templates.xml
@@ -69,6 +69,7 @@
         Render an invoice's line to be added to the UBL xml document.
         -->
         <template id="export_ubl_invoice_line">
+            <t t-set="line" t-value="line_values['line']"/>
             <cac:InvoiceLine
                 xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
                 xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
@@ -78,13 +79,23 @@
                 <cbc:InvoicedQuantity t-esc="line.quantity"/>
                 <cbc:LineExtensionAmount
                     t-att-currencyID="line.currency_id.name or invoice.currency_id.name"
-                    t-esc="format_monetary(line.price_subtotal)"/>
+                    t-esc="format_monetary(line.price_subtotal, currency)"/>
                 <cac:TaxTotal
                     t-foreach="line.tax_ids.compute_all(line.price_unit, quantity=line.quantity, product=line.product_id, partner=invoice.partner_id)['taxes']"
                     t-as="tax">
                     <cbc:TaxAmount
                         t-att-currencyID="line.currency_id.name or invoice.currency_id.name"
-                        t-esc="format_monetary(tax['amount'])"/>
+                        t-esc="format_monetary(tax['amount'], currency)"/>
+                        <t t-foreach="line_values['taxes']" t-as="taxes">
+                            <cac:TaxSubtotal>
+                                <cbc:TaxAmount
+                                    t-esc="taxes['tax_amount']"/>
+                                <cbc:TaxableAmount
+                                    t-esc="taxes['tax_base_amount']"/>
+                                <cbc:Percent
+                                    t-esc="taxes['tax'].amount"/>
+                            </cac:TaxSubtotal>
+                        </t>
                 </cac:TaxTotal>
                 <cac:Item>
                     <cbc:Description t-if="line.name" t-esc="line.name.replace('\n', ', ')"/>
@@ -96,7 +107,7 @@
                 <cac:Price>
                     <cbc:PriceAmount
                         t-att-currencyID="line.currency_id.name or invoice.currency_id.name"
-                        t-esc="format_monetary(line.price_unit)"/>
+                        t-esc="format_monetary(line.price_unit, currency)"/>
                 </cac:Price>
             </cac:InvoiceLine>
         </template>
@@ -105,6 +116,7 @@
         Render an invoice to be added to the UBL xml document.
         -->
         <template id="export_ubl_invoice">
+            <t t-set="currency" t-value="invoice.currency_id or invoice.company_currency_id"/>
             <Invoice
                 xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
                 xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
@@ -114,7 +126,7 @@
                 <cbc:IssueDate t-esc="invoice.invoice_date"/>
                 <cbc:InvoiceTypeCode t-esc="type_code"/>
                 <cbc:Note t-esc="invoice.narration"/>
-                <cbc:DocumentCurrencyCode t-esc="invoice.currency_id.name"/>
+                <cbc:DocumentCurrencyCode t-esc="currency.name"/>
                 <cac:AccountingSupplierParty t-call="account_edi_ubl.export_ubl_invoice_partner">
                     <t t-set="partner" t-value="invoice.company_id.partner_id.commercial_partner_id"/>
                 </cac:AccountingSupplierParty>
@@ -136,31 +148,45 @@
                 <cac:PaymentTerms t-if="invoice.invoice_payment_term_id">
                     <cbc:Note t-esc="invoice.invoice_payment_term_id.name"/>
                 </cac:PaymentTerms>
-                <cac:TaxTotal t-if="not invoice.currency_id.is_zero(invoice.amount_tax)">
+                <cac:TaxTotal t-if="not currency.is_zero(invoice.amount_tax)">
                     <cbc:TaxAmount
-                        t-att-currencyID="invoice.currency_id.name"
-                        t-esc="format_monetary(invoice.amount_tax)"/>
+                        t-att-currencyID="currency.name"
+                        t-esc="format_monetary(invoice.amount_tax, currency)"/>
+                    <t t-foreach="tax_details" t-as="tax_vals">
+                        <t t-set="tax_line" t-value="tax_vals['line']"/>
+                        <cac:TaxSubtotal>
+                            <cbc:TaxAmount
+                                t-att-currencyID="currency.name"
+                                t-esc="format_monetary(tax_vals['tax_amount'], currency)"/>
+                            <cbc:TaxableAmount
+                                t-att-currencyID="currency.name"
+                                t-esc="format_monetary(tax_vals['tax_base_amount'], currency)"/>
+                            <cbc:Percent
+                                t-if="tax_line.tax_line_id.amount_type == 'percent'"
+                                t-esc="tax_line.tax_line_id.amount"/>
+                        </cac:TaxSubtotal>
+                    </t>
                 </cac:TaxTotal>
                 <cac:LegalMonetaryTotal>
                     <cbc:LineExtensionAmount
                         t-att-currencyID="invoice.currency_id.name"
-                        t-esc="format_monetary(invoice.amount_untaxed)"/>
+                        t-esc="format_monetary(invoice.amount_untaxed, currency)"/>
                     <cbc:TaxExclusiveAmount
                         t-att-currencyID="invoice.currency_id.name"
-                        t-esc="format_monetary(invoice.amount_untaxed)"/>
+                        t-esc="format_monetary(invoice.amount_untaxed, currency)"/>
                     <cbc:TaxInclusiveAmount
                         t-att-currencyID="invoice.currency_id.name"
-                        t-esc="format_monetary(invoice.amount_total)"/>
+                        t-esc="format_monetary(invoice.amount_total, currency)"/>
                     <cbc:PrepaidAmount
                         t-att-currencyID="invoice.currency_id.name"
-                        t-esc="format_monetary(invoice.amount_total - invoice.amount_residual)"/>
+                        t-esc="format_monetary(invoice.amount_total - invoice.amount_residual, currency)"/>
                     <cbc:PayableAmount
                         t-att-currencyID="invoice.currency_id.name"
-                        t-esc="format_monetary(invoice.amount_residual)"/>
+                        t-esc="format_monetary(invoice.amount_residual, currency)"/>
                 </cac:LegalMonetaryTotal>
                 <t t-call="account_edi_ubl.export_ubl_invoice_line"
-                   t-foreach="invoice.invoice_line_ids"
-                   t-as="line"/>
+                   t-foreach="invoice_line_values"
+                   t-as="line_values"/>
             </Invoice>
         </template>
     </data>

--- a/addons/account_edi_ubl/models/account_move.py
+++ b/addons/account_edi_ubl/models/account_move.py
@@ -10,9 +10,47 @@ class AccountMove(models.Model):
     def _get_ubl_values(self):
         self.ensure_one()
 
-        def format_monetary(amount):
+        def format_monetary(amount, currency):
             # Format the monetary values to avoid trailing decimals (e.g. 90.85000000000001).
-            return float_repr(amount, self.currency_id.decimal_places)
+            return float_repr(amount, currency.decimal_places)
+
+        invoice_line_values = []
+
+        # Tax lines.
+        aggregated_taxes_details = {line.tax_line_id.id: {
+            'line': line,
+            'tax_amount': -line.amount_currency,
+            'tax_base_amount': 0.0,
+        } for line in self.line_ids.filtered('tax_line_id')}
+
+        # Invoice lines.
+        for line in self.invoice_line_ids.filtered(lambda l: not l.display_type):
+            price_unit_with_discount = line.price_unit * (1 - (line.discount / 100.0))
+            taxes_res = line.tax_ids.compute_all(
+                price_unit_with_discount,
+                currency=line.currency_id,
+                quantity=line.quantity,
+                product=line.product_id,
+                partner=self.partner_id,
+                is_refund=line.move_id.move_type in ('in_refund', 'out_refund'),
+            )
+
+            line_template_values = {
+                'line': line,
+                'taxes': [],
+            }
+
+            for tax_res in taxes_res['taxes']:
+                tax = self.env['account.tax'].browse(tax_res['id'])
+                line_template_values['taxes'].append({
+                    'tax': tax,
+                    'tax_amount': tax_res['amount'],
+                    'tax_base_amount': tax_res['base'],
+                })
+                if tax.id in aggregated_taxes_details:
+                    aggregated_taxes_details[tax.id]['tax_base_amount'] += tax_res['base']
+
+            invoice_line_values.append(line_template_values)
 
         return {
             'invoice': self,
@@ -20,4 +58,6 @@ class AccountMove(models.Model):
             'type_code': 380 if self.move_type == 'out_invoice' else 381,
             'payment_means_code': 42 if self.journal_id.bank_account_id else 31,
             'format_monetary': format_monetary,
+            'tax_details': list(aggregated_taxes_details.values()),
+            'invoice_line_values': invoice_line_values
         }


### PR DESCRIPTION
When printing an invoice in the UBL format, the exported XML does not
contains all the necessary information to allows reimporting later
with the taxes correctly set.

With this commit, the XML will contain the percentage for each line,
as well as the totals for each tax percentage.

task id #2350481

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
