### PR TITLE
[FIX] documents: search panel update after delete and archive actions…

### DIFF
--- a/addons/web/static/src/js/views/basic/basic_controller.js
+++ b/addons/web/static/src/js/views/basic/basic_controller.js
@@ -559,7 +559,11 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
      * @param {string[]} ids list of deleted ids (basic model local handles)
      */
     _onDeletedRecords: function (ids) {
-        this.update({});
+        if (this._searchPanel) {
+            this._searchPanel._notifyDomainUpdated();
+        } else {
+            this.update({});
+        }
     },
     /**
      * Saves the record whose ID is given, if necessary. Automatically leaves

--- a/addons/web/static/src/js/views/list/list_controller.js
+++ b/addons/web/static/src/js/views/list/list_controller.js
@@ -277,11 +277,11 @@ var ListController = BasicController.extend({
         if (archive) {
             return this.model
                 .actionArchive(ids, this.handle)
-                .then(this.update.bind(this, {}, {reload: false}));
+                .then(this._searchPanel ? this._searchPanel._notifyDomainUpdated() : this.update.bind(this, {}, {reload: false}));
         } else {
             return this.model
                 .actionUnarchive(ids, this.handle)
-                .then(this.update.bind(this, {}, {reload: false}));
+                .then(this._searchPanel ? this._searchPanel._notifyDomainUpdated() : this.update.bind(this, {}, {reload: false}));
         }
     },
     /**


### PR DESCRIPTION
… in list view

After using archive/unarchive or delete from the action dropdown on top of the view list, the search panel filters counts were not updated, this commit aims to solve this for documents, even though the effect should be visible in all list views with a search panel.

modified:
- web.list_controller.js
- web.basic_controller.js

task: 2295919

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
