### PR TITLE
[FIX] Live Chat: Can't add a second livechat

### DIFF
--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -64,13 +64,14 @@ class ImLivechatChannel(models.Model):
             "dbname": self._cr.dbname,
         }
         for record in self:
-            values["channel_id"] = record.id
-            record.script_external = view._render(values)
+            if record.id:
+                values["channel_id"] = record.id
+            record.script_external = view._render(values) if record.id else False
 
     def _compute_web_page_link(self):
         base_url = self.env['ir.config_parameter'].sudo().get_param('web.base.url')
         for record in self:
-            record.web_page = "%s/im_livechat/support/%i" % (base_url, record.id)
+            record.web_page = ("%s/im_livechat/support/%i" % (base_url, record.id)) if record.id else False
 
     @api.depends('channel_ids')
     def _compute_nbr_channel(self):


### PR DESCRIPTION
Issue

    - Install "Live Chat"
    - Create a second live chat channel

Cause

    The flag %i expects a number but receives a NewId because the record is not yet created so the id is not initialized.

Solution

    Add a condition that checks the id before using it. If it is not, set script_external and web_page to False

opw-2350463