### PR TITLE
[13.0][IMP] product: Add search function on product_variant_count

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -7,6 +7,7 @@ import logging
 from odoo import api, fields, models, tools, _, SUPERUSER_ID
 from odoo.exceptions import ValidationError, RedirectWarning, UserError
 from odoo.osv import expression
+from odoo.addons.stock.models.product import OPERATORS
 
 _logger = logging.getLogger(__name__)
 
@@ -139,7 +140,7 @@ class ProductTemplate(models.Model):
     product_variant_id = fields.Many2one('product.product', 'Product', compute='_compute_product_variant_id')
 
     product_variant_count = fields.Integer(
-        '# Product Variants', compute='_compute_product_variant_count')
+        '# Product Variants', compute='_compute_product_variant_count', search="_search_product_variant_count")
 
     # related to display product product information if is_product_variant
     barcode = fields.Char('Barcode', related='product_variant_ids.barcode', readonly=False)
@@ -325,6 +326,26 @@ class ProductTemplate(models.Model):
         for template in self:
             # do not pollute variants to be prefetched when counting variants
             template.product_variant_count = len(template.with_prefetch().product_variant_ids)
+
+    @api.model
+    def _search_product_variant_count(self, operator, value):
+        if operator not in OPERATORS:
+            raise UserError(_('Invalid domain operator %s') % operator)
+        if not isinstance(value, (float, int)):
+            raise UserError(_('Invalid domain right operand %s') % value)
+        self.env["product.product"].flush(["active", "product_tmpl_id"])
+        self.env.cr.execute(
+            r"""SELECT pt.id, count(pp.id)
+            FROM product_template pt
+            LEFT JOIN product_product pp ON pt.id = pp.product_tmpl_id
+            AND pp.active = TRUE
+            GROUP BY pt.id;"""
+        )
+        query_res = self.env.cr.fetchall()
+        res = [
+            tpl[0] for tpl in query_res if OPERATORS[operator](tpl[1], value)
+        ]
+        return [('id', 'in', res)]
 
     @api.depends('product_variant_ids', 'product_variant_ids.default_code')
     def _compute_default_code(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

We need to search the number of product variants per template.

Current behavior before PR:

Impossible to search on field `product.template.product_variant_count`

Desired behavior after PR is merged:

Possible to search on field `product.template.product_variant_count`


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
