### PR TITLE
[FIX] point_of_sale: Difference in POS closing cash removed after validating

### DIFF
--- a/addons/point_of_sale/views/pos_session_view.xml
+++ b/addons/point_of_sale/views/pos_session_view.xml
@@ -79,7 +79,7 @@
                                             <field style="text-align:right;margin:0;padding:0;" name="cash_register_total_entry_encoding" widget="monetary" options="{'currency_field': 'currency_id'}" string="+ Transactions"/>
                                         </group>
                                         <group style="margin:0;padding:0;" attrs="{'invisible' : [('state', 'in', ['new_session', 'opening_control'])]}">
-                                            <field style="text-align:right;margin:0;padding:0;" name="cash_register_balance_end" widget="monetary" options="{'currency_field': 'currency_id'}" string="= Expected in Cash"/>
+                                            <field style="text-align:right;margin:0;padding:0;" name="cash_register_balance_end_to_show" widget="monetary" options="{'currency_field': 'currency_id'}" string="= Expected in Cash"/>
                                         </group>
                                         <group style="margin:0;padding:0;" attrs="{'invisible' : [('state', 'in', ['new_session', 'opening_control'])]}">
                                             <field style="text-align:right;margin:0;padding:0;" name="cash_register_balance_end_real" widget="monetary" options="{'currency_field': 'currency_id'}" string="Actual in Cash"/>


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a POS session P set with cash control
- Set to P an initial balance of 50€
- Open P and make a transaction of 100€
- The expected cash is 150€
- Set the closing cash of P to 50€
- The cash difference is computed and equal to -100€
- Validate and post the entries

Bug:

The cash difference was equal to 0€ instead of keeping -100€

PS: In saas-13.1, this issue has been solved with 0d6332f because the field balance_end_real (=cash_register_balance_end_real)
on account.bank.statement is computed by a new function called _compute_ending_balance that  makes:

```statement.balance_end_real = statement.previous_statement_id.balance_end_real + total_entry_encoding```

where ```total_entry_encoding = sum([line.amount for line in statement.line_ids])```

So making:

```session.cash_register_difference = session.cash_register_balance_end_real - session.cash_register_balance_end```

keeps the the cash difference when the session is closed.

opw:2341816