### PR TITLE
[FIX] Sale Coupon: Traceback with promotion program with many same product

### DIFF
--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -87,7 +87,8 @@ class SaleOrder(models.Model):
             # multipled by the reward qty
             reward_product_qty = program.reward_product_quantity * program_in_order
             # do not give more free reward than products
-            reward_product_qty = min(reward_product_qty, self.order_line.filtered(lambda x: x.product_id == program.reward_product_id).product_uom_qty)
+            best_qty = max(self.order_line.filtered(lambda x: x.product_id == program.reward_product_id).mapped('product_uom_qty'))
+            reward_product_qty = min(reward_product_qty, best_qty)
             if program.rule_minimum_amount:
                 order_total = sum(order_lines.mapped('price_total')) - (program.reward_product_quantity * program.reward_product_id.lst_price)
                 reward_product_qty = min(reward_product_qty, order_total // program.rule_minimum_amount)


### PR DESCRIPTION
Issue

    - Create promotion program with product_x
    - Create new quotation
    - Add product_x on the first line
    - Add another product_x on the second line
    - Press "Promotions" button

Cause

    The attribut reward_product_qty except singleton but order_line contain more than one element

Solution

    Take the order line with the higher quantity

opw-2350574
