### PR TITLE
[FIX] coupon: domain selector visibility in modal

### DIFF
--- a/addons/coupon/__manifest__.py
+++ b/addons/coupon/__manifest__.py
@@ -11,6 +11,7 @@
         'wizard/coupon_generate_views.xml',
         'security/ir.model.access.csv',
         'security/coupon_security.xml',
+        'views/assets.xml',
         'views/coupon_views.xml',
         'views/coupon_program_views.xml',
         'report/coupon_report.xml',

--- a/addons/coupon/static/src/js/coupon.js
+++ b/addons/coupon/static/src/js/coupon.js
@@ -1,0 +1,30 @@
+odoo.define("coupon.CouponGenerateWizard", function (require) {
+    "use strict";
+
+    const FormController = require('web.FormController');
+    const FormView = require('web.FormView');
+    const viewRegistry = require('web.view_registry');
+
+    const CouponGenerateFormController = FormController.extend({
+
+        /**
+         * Display the domain selector popover outside the modal without scroll on modal.
+         * @override
+         */
+        on_attach_callback() {
+            this._super(...arguments);
+            this.el.closest('.modal-body').style.overflow = 'visible';
+        },
+    });
+
+    const couponGenerateWizard = FormView.extend({
+        config: _.extend({}, FormView.prototype.config, {
+            Controller: CouponGenerateFormController,
+        }),
+    });
+
+    viewRegistry.add('coupons_generate_form', couponGenerateWizard);
+
+    return couponGenerateWizard;
+
+});

--- a/addons/coupon/views/assets.xml
+++ b/addons/coupon/views/assets.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="assets_backend" name="coupen assets backend" inherit_id="web.assets_backend">
+        <xpath expr="." position="inside">
+            <script type="text/javascript" src="/coupon/static/src/js/coupon.js"/>
+        </xpath>
+    </template>
+
+</odoo>

--- a/addons/coupon/wizard/coupon_generate_views.xml
+++ b/addons/coupon/wizard/coupon_generate_views.xml
@@ -4,7 +4,7 @@
         <field name="name">coupon.generate.wizard.form</field>
         <field name="model">coupon.generate.wizard</field>
         <field name="arch" type="xml">
-            <form string="Generate Coupons">
+            <form string="Generate Coupons" js_class="coupons_generate_form">
                 <group>
                     <field name="has_partner_email" invisible="1"/>
                     <field name="generation_type" widget="radio"/>


### PR DESCRIPTION
before this commit,
the domain selector popover displayed behind the modal body

this commit fixes the issues by adding overflow property in the modal body
due to that, it will always display on top of the modal.

task - 2225272