### PR TITLE
[WIP] stock: Cancelled DO is changed to Ready status

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -417,7 +417,7 @@ class Picking(models.Model):
         - Done: if the picking is done.
         - Cancelled: if the picking is cancelled
         '''
-        for picking in self:
+        for picking in self.filtered(lambda p: p.state != 'cancel'):
             if not picking.move_lines:
                 picking.state = 'draft'
             elif any(move.state == 'draft' for move in picking.move_lines):  # TDE FIXME: should be all ?


### PR DESCRIPTION
Steps to reproduce the bug:

2 steps delivery, no specific other settings or routes:
- Pick: set a smaller quantity than the expected to "done",
don't create a backorder but duplicate the order and validate
the pick with the remaining products.
- Out: initial one does not allow the reservation, so cancel
it and duplicate.

Issue: two "Out" moves will be created. the first one is in ready and regenerated
from the previous one. Need to cancel this to reserve on the otehr products...
The "regenerated Out" is problematic, and should remain in cancel

opw:2339217