### PR TITLE
[IMP] account_edi : Do not overwrite taxes when using the EDI

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3467,7 +3467,7 @@ class AccountMoveLine(models.Model):
         ''' Recompute 'tax_ids' based on 'account_id'.
         /!\ Don't remove existing taxes if there is no explicit taxes set on the account.
         '''
-        if not self.display_type and (self.account_id.tax_ids or not self.tax_ids):
+        if not self.display_type and self.account_id.tax_ids:
             taxes = self._get_computed_taxes()
 
             if taxes and self.move_id.fiscal_position_id:

--- a/addons/account_edi_facturx/models/account_edi_format.py
+++ b/addons/account_edi_facturx/models/account_edi_format.py
@@ -292,4 +292,10 @@ class AccountEdiFormat(models.Model):
                     invoice_line_form.quantity = 1
                     invoice_line_form.price_unit = amount_total_import
 
+            self._force_tax_values(invoice_form, tree,
+                                   tax_group_node='//ram:ApplicableHeaderTradeSettlement/ram:ApplicableTradeTax',
+                                   percent_node='.//ram:RateApplicablePercent',
+                                   value_node='.//ram:CalculatedAmount',
+                                   namespaces=tree.nsmap)
+
         return invoice_form.save()

--- a/addons/account_edi_ubl/models/account_edi_format.py
+++ b/addons/account_edi_ubl/models/account_edi_format.py
@@ -153,4 +153,10 @@ class AccountEdiFormat(models.Model):
                         if tax:
                             invoice_line_form.tax_ids.add(tax)
 
+            self._force_tax_values(invoice_form, tree,
+                                   tax_group_node='cac:TaxTotal/cac:TaxSubtotal',
+                                   percent_node='cbc:Percent',
+                                   value_node='cbc:TaxAmount',
+                                   namespaces=namespaces)
+
         return invoice_form.save()

--- a/addons/l10n_it_edi/models/account_edi_format.py
+++ b/addons/l10n_it_edi/models/account_edi_format.py
@@ -441,6 +441,11 @@ class AccountEdiFormat(models.Model):
                         invoice_line_form_discount.name = discount["name"]
                         invoice_line_form_discount.price_unit = discount["amount"]
 
+                self._force_tax_values(invoice_form, body_tree,
+                                       tax_group_node='DatiBeniServizi/DatiRiepilogo',
+                                       percent_node='AliquotaIVA',
+                                       value_node='Imposta')
+
             new_invoice = invoice_form.save()
             new_invoice.l10n_it_send_state = "other"
 


### PR DESCRIPTION
When importing an invoice or bill from the EDI, Odoo is calculating
all the totals himself instead of getting them from the XML.

While it usually would not be an issue it can become one when taxes are
being rounded in the wrong way.

This will change that and make sure that we are always using the same
taxes than the XML.

Task id #2289153
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
