### PR TITLE
[FIX] account: label required in invoice lines but still can save account move with no label

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3367,7 +3367,7 @@ class AccountMoveLine(models.Model):
                         taxes,
                         move.type,
                     ))
-                    if move.type in ['out_invoice','out_refund'] and vals.get('product_id') and not vals.get('name'):
+                    if not vals.get('name') and move.type in ['out_invoice','out_refund'] and vals.get('product_id'):
                         vals['name'] = self.env['product.product'].browse(vals.get('product_id')).name
                 elif any(vals.get(field) for field in BUSINESS_FIELDS):
                     vals.update(self._get_price_total_and_subtotal_model(

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3367,6 +3367,8 @@ class AccountMoveLine(models.Model):
                         taxes,
                         move.type,
                     ))
+                    if move.type in ['out_invoice','out_refund'] and vals.get('product_id') and not vals.get('name'):
+                        vals['name'] = self.env['product.product'].browse(vals.get('product_id')).name
                 elif any(vals.get(field) for field in BUSINESS_FIELDS):
                     vals.update(self._get_price_total_and_subtotal_model(
                         vals.get('price_unit', 0.0),


### PR DESCRIPTION
Solves #56773

Description of the issue/feature this PR addresses:
Saving invoice line without label is possible , required is enabled but still null value reflects

Current behavior before PR:

Label field shows null value

Desired behavior after PR is merged:

Label will be assigned with product name


![screenshot--2020 10 09-00_20_42(1)](https://user-images.githubusercontent.com/56474164/95501057-5f7a7400-09c5-11eb-92f2-62bdd7cb49a2.png)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
