### PR TITLE
[FIX] point of sale: Fix multiple cash in point of sale balance

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -109,9 +109,9 @@ class PosSession(models.Model):
     @api.depends('payment_method_ids', 'order_ids', 'cash_register_balance_start', 'cash_register_id')
     def _compute_cash_balance(self):
         for session in self:
-            cash_payment_method = session.payment_method_ids.filtered('is_cash_count')[:1]
-            if cash_payment_method:
-                total_cash_payment = sum(session.order_ids.mapped('payment_ids').filtered(lambda payment: payment.payment_method_id == cash_payment_method).mapped('amount'))
+            cash_payment_method_ids = session.payment_method_ids.filtered('is_cash_count')
+            if cash_payment_method_ids:
+                total_cash_payment = session._get_payment_methods_balance(cash_payment_method_ids)
                 session.cash_register_total_entry_encoding = session.cash_register_id.total_entry_encoding + (
                     0.0 if session.state == 'closed' else total_cash_payment
                 )
@@ -121,6 +121,10 @@ class PosSession(models.Model):
                 session.cash_register_total_entry_encoding = 0.0
                 session.cash_register_balance_end = 0.0
                 session.cash_register_difference = 0.0
+
+    def _get_payment_methods_balance(self, payment_method_ids):
+        self.ensure_one()
+        return sum(session.order_ids.mapped('payment_ids').filtered(lambda payment: payment.payment_method_id.id in payment_method_ids.ids).mapped('amount'))
 
     @api.depends('order_ids.payment_ids.amount')
     def _compute_total_payments_amount(self):

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -124,7 +124,7 @@ class PosSession(models.Model):
 
     def _get_payment_methods_balance(self, payment_method_ids):
         self.ensure_one()
-        return sum(session.order_ids.mapped('payment_ids').filtered(lambda payment: payment.payment_method_id.id in payment_method_ids.ids).mapped('amount'))
+        return sum(self.order_ids.mapped('payment_ids').filtered(lambda payment: payment.payment_method_id.id in payment_method_ids.ids).mapped('amount'))
 
     @api.depends('order_ids.payment_ids.amount')
     def _compute_total_payments_amount(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The point of sale only use one cash method, if there is multiple cash payment method, the point of sale only get the balace of one.

Current behavior before PR:
Only one cash payment method is used in calculations

Desired behavior after PR is merged:
Now several cash payment method are used in calculations

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
