### PR TITLE
Close dropdown menu of window mousedown event

### DIFF
--- a/addons/web/static/src/js/components/dropdown_menu.js
+++ b/addons/web/static/src/js/components/dropdown_menu.js
@@ -36,6 +36,7 @@ odoo.define('web.DropdownMenu', function (require) {
 
             this.symbol = this.env.device.isMobile ? 'fa fa-chevron-right float-right mt4' : false;
 
+            useExternalListener(window, 'mousedown', this._onWindowClick);
             useExternalListener(window, 'click', this._onWindowClick);
             useExternalListener(window, 'keydown', this._onWindowKeydown);
         }


### PR DESCRIPTION
PURPOSE
When dropdown is opened and click on another dropdown previous dropdown was not closed.

SPEC
Close dropdown menu on mousedown on window

TASK 2278157



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
