### PR TITLE
[FIX] pos_hr: selection popup that is not centered

### DIFF
--- a/addons/pos_hr/static/src/css/pos.css
+++ b/addons/pos_hr/static/src/css/pos.css
@@ -101,11 +101,6 @@
         border-color: #00A09D;
         height: 38px;
     }
-    .pos .popups .popup-selection {
-        width: 90%;
-        left: initial;
-        right: initial;
-    }
     .pos .login-barcode-text {
         color: #adb5bd;
         margin-top: 8px;


### PR DESCRIPTION
To reproduce:
1. Install Point of Sale.
2. Open a session in mobile view.
3. Click the category button to change category.
4. Selection popup is centered in screen. (correct behavior)
5. Install pos_hr.
6. Do steps 2 & 3.
7. Selection popup is not centered anymore. (bug)

We fix the issue by removing the custom styling for the selection
popup when in mobile view.

TASK-ID: 2355025

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
