### PR TITLE
[FIX] base: respect reset password configuration

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1487,6 +1487,11 @@ class CheckIdentity(models.TransientModel):
 
     request = fields.Char(readonly=True, groups=fields.NO_ACCESS)
     password = fields.Char()
+    reset_password_enabled = fields.Boolean(compute="_compute_reset_password_enabled")
+
+    def _compute_reset_password_enabled(self):
+        self.reset_password_enabled = self.env["ir.config_parameter"].sudo().get_param("auth_signup.reset_password",
+                                                                                       False)
 
     def run_check(self):
         assert request, "This method can only be accessed over HTTP"

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -41,6 +41,7 @@
             <field name="arch" type="xml">
                 <form string="Security Control">
                     <sheet clas="bg-primary">
+                        <field name="reset_password_enabled" invisible="1"/>
                         <h3><strong>Please confirm your password to continue</strong></h3>
                         <p>This is necessary for security-related changes. The authorization will last for a few minutes.</p>
                         <div>
@@ -51,7 +52,7 @@
                     <footer>
                         <button string="Confirm Password" type="object" name="run_check" class="btn btn-primary"/>
                         <button string="Cancel" special="cancel" class="btn btn-secondary"/>
-                        <a href="/web/reset_password/" class="btn btn-link" role="button">Forgot password?</a>
+                        <a attrs="{'invisible': [('reset_password_enabled', '=', False)]}" href="/web/reset_password/" class="btn btn-link" role="button">Forgot password?</a>
                     </footer>
                 </form>
             </field>


### PR DESCRIPTION
Before this commit, Reset Password option was always visible on Identity Check wizard even "Reset Password" Option is not enabled from settings.
which leads users on unexisting web page.

Now, Reset Password option will be displayed if it is enabled from Settings.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
