### PR TITLE
replace create_text node options with attribute

### DIFF
--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -336,7 +336,7 @@
                             <field name="move_ids_without_package" mode="tree,kanban"
                                 attrs="{'readonly': ['&amp;', ('state', '=', 'done'), ('is_locked', '=', True)]}"
                                 context="{'default_company_id': company_id, 'default_date': scheduled_date, 'default_date_deadline': date_deadline, 'picking_type_code': picking_type_code, 'default_picking_id': id, 'form_view_ref':'stock.view_move_form', 'address_in_id': partner_id, 'default_picking_type_id': picking_type_id, 'default_location_id': location_id, 'default_location_dest_id': location_dest_id}"
-                                options="{'create_text':'Add a Product'}">
+                                add-label="Add a Product">
                                 <tree decoration-danger="not parent.immediate_transfer and state != 'done' and quantity_done > reserved_availability and show_reserved_availability" decoration-muted="scrapped == True or state == 'cancel' or (state == 'done' and is_locked == True)" string="Stock Moves" editable="bottom">
                                     <field name="company_id" invisible="1"/>
                                     <field name="name" invisible="1"/>

--- a/addons/web/static/src/legacy/js/fields/relational_fields.js
+++ b/addons/web/static/src/legacy/js/fields/relational_fields.js
@@ -1112,9 +1112,7 @@ var FieldX2Many = AbstractField.extend(WidgetAdapterMixin, {
      */
     init: function (parent, name, record, options) {
         this._super.apply(this, arguments);
-        this.nodeOptions = _.defaults(this.nodeOptions, {
-            create_text: _t('Add'),
-        });
+        this.createText = this.attrs['add-label'] || _t('Add');
         this.operations = [];
         this.isReadonly = this.mode === 'readonly';
         this.view = this.attrs.views[this.attrs.mode];
@@ -1381,7 +1379,7 @@ var FieldX2Many = AbstractField.extend(WidgetAdapterMixin, {
     _getButtonsRenderingContext() {
         return {
             btnClass: 'btn-secondary',
-            create_text: this.nodeOptions.create_text,
+            create_text: this.createText,
         };
     },
     /**

--- a/addons/web/static/tests/legacy/fields/relational_fields/field_many2many_tests.js
+++ b/addons/web/static/tests/legacy/fields/relational_fields/field_many2many_tests.js
@@ -269,7 +269,7 @@ QUnit.module('fields', {}, function () {
             form.destroy();
         });
 
-        QUnit.test('many2many kanban(editable): properly handle create_text node option', async function (assert) {
+        QUnit.test('many2many kanban(editable): properly handle add-label node attribute', async function (assert) {
             assert.expect(1);
 
             this.data.partner.records[0].timmy = [12];
@@ -279,7 +279,7 @@ QUnit.module('fields', {}, function () {
                 model: 'partner',
                 data: this.data,
                 arch: '<form string="Partners">' +
-                    '<field name="timmy" options="{\'create_text\': \'Add timmy\'}" mode="kanban">' +
+                    '<field name="timmy" add-label="Add timmy" mode="kanban">' +
                     '<kanban>' +
                     '<templates>' +
                     '<t t-name="kanban-box">' +

--- a/addons/web/static/tests/legacy/fields/relational_fields/field_one2many_tests.js
+++ b/addons/web/static/tests/legacy/fields/relational_fields/field_one2many_tests.js
@@ -2497,7 +2497,7 @@ QUnit.module('fields', {}, function () {
             form.destroy();
         });
 
-        QUnit.test('one2many kanban (editable): properly handle create_text node option', async function (assert) {
+        QUnit.test('one2many kanban (editable): properly handle add-label node attribute', async function (assert) {
             assert.expect(1);
 
             var form = await createView({
@@ -2505,7 +2505,7 @@ QUnit.module('fields', {}, function () {
                 model: 'partner',
                 data: this.data,
                 arch: '<form string="Partners">' +
-                    '<field name="turtles" options="{\'create_text\': \'Add turtle\'}" mode="kanban">' +
+                    '<field name="turtles" add-label="Add turtle" mode="kanban">' +
                     '<kanban>' +
                     '<templates>' +
                     '<t t-name="kanban-box">' +

--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -120,7 +120,7 @@
                         </group>
                     </group>
                     <group name="product_template_images" string="Extra Product Media">
-                        <field name="product_template_image_ids" class="o_website_sale_image_list" context="{'default_name': name}" mode="kanban" options="{'create_text':'Add a Media'}" nolabel="1"/>
+                        <field name="product_template_image_ids" class="o_website_sale_image_list" context="{'default_name': name}" mode="kanban" add-label="Add a Media" nolabel="1"/>
                     </group>
                 </page>
             </xpath>
@@ -134,7 +134,7 @@
         <field name="arch" type="xml">
             <sheet position="inside">
                 <group name="product_variant_images" string="Extra Variant Media">
-                    <field name="product_variant_image_ids" class="o_website_sale_image_list" context="{'default_name': name}" mode="kanban" options="{'create_text':'Add a Media'}" nolabel="1"/>
+                    <field name="product_variant_image_ids" class="o_website_sale_image_list" context="{'default_name': name}" mode="kanban" add-label="Add a Media" nolabel="1"/>
                 </group>
             </sheet>
         </field>

--- a/odoo/addons/base/rng/common.rng
+++ b/odoo/addons/base/rng/common.rng
@@ -269,6 +269,7 @@
             <rng:optional><rng:attribute name="filter_field" /></rng:optional>
             <rng:optional><rng:attribute name="text" /></rng:optional>
             <rng:optional><rng:attribute name="optional" /></rng:optional>
+            <rng:optional><rng:attribute name="add-label"/></rng:optional>
             <rng:optional><rng:attribute name="decoration-bf"/></rng:optional>
             <rng:optional><rng:attribute name="decoration-it"/></rng:optional>
             <rng:optional><rng:attribute name="decoration-danger"/></rng:optional>

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -147,7 +147,7 @@ TRANSLATED_ELEMENTS = {
 # Which attributes must be translated. This is a dict, where the value indicates
 # a condition for a node to have the attribute translatable.
 TRANSLATED_ATTRS = dict.fromkeys({
-    'string', 'help', 'sum', 'avg', 'confirm', 'placeholder', 'alt', 'title', 'aria-label',
+    'string', 'add-label', 'help', 'sum', 'avg', 'confirm', 'placeholder', 'alt', 'title', 'aria-label',
     'aria-keyshortcuts', 'aria-placeholder', 'aria-roledescription', 'aria-valuetext',
     'value_label',
 }, lambda e: True)


### PR DESCRIPTION
PURPOSE
The option "create_text" implies that the text cannot be translated as it is passed as node options

SPEC
Pass create_text as field node attribute so that it is parsed by translate.py

TASK 1923433



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
