### PR TITLE
[IMP] web_tour: improve tour tip responsiveness and visibility

### DIFF
--- a/addons/web_tour/static/src/js/tip.js
+++ b/addons/web_tour/static/src/js/tip.js
@@ -191,7 +191,7 @@ var Tip = Widget.extend({
      * @param {boolean} [forceReposition=false]
      */
     _updatePosition: function (forceReposition = false) {
-        if (this.info.hidden) {
+        if (this.info.hidden || this.isDestroyed()) {
             return;
         }
         let halfHeight = 0;
@@ -487,6 +487,9 @@ var Tip = Widget.extend({
         }
     },
     _build_bubble_mode: function () {
+        if (this.isDestroyed()) {
+            return;
+        }
         clearTimeout(this.timerOut);
         this.timerOut = undefined;
 

--- a/addons/web_tour/static/src/js/tour_manager.js
+++ b/addons/web_tour/static/src/js/tour_manager.js
@@ -236,7 +236,7 @@ return core.Class.extend(mixins.EventDispatcherMixin, ServicesMixin, {
             setTimeout(function () {
                 self._check_for_tooltip(self.active_tooltips[tour_name], tour_name);
             });
-        } else {
+        } else if (this.active_tooltips) {
             const sortedTooltips = Object.keys(this.active_tooltips).sort(
                 (a, b) => this.tours[a].sequence - this.tours[b].sequence
             );

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1304,13 +1304,17 @@ class HttpCaseCommon(BaseCase):
             return [t for t in threading.enumerate() if t.name.startswith('odoo.service.http.request.')]
 
         start_time = time.time()
+        max_time = start_time + timeout
         request_threads = get_http_request_threads()
-        self._logger.info('waiting for threads: %s', request_threads)
 
-        for thread in request_threads:
-            thread.join(timeout - (time.time() - start_time))
+        while request_threads and time.time() < max_time:
+            self._logger.info('waiting for threads: %s', request_threads)
 
-        request_threads = get_http_request_threads()
+            for thread in request_threads:
+                thread.join(max_time - time.time())
+
+            request_threads = get_http_request_threads()
+
         for thread in request_threads:
             self._logger.info("Stop waiting for thread %s handling request for url %s",
                                     thread.name, getattr(thread, 'url', '<UNKNOWN>'))


### PR DESCRIPTION
Because it was sometimes difficult to notice the tour tip, added a border to the tour tip icon and made it displayed earlier.

Description of the issue/feature this PR addresses: 
task-2357170

Current behavior before PR:
- the tour tip icon had no extra border
- tour tip display was delayed by an additional 750ms whenever some mutation happened within the DOM (e.g. clicking on the BLOCK header of the options panel contiuously prevented the tip from ever being displayed)

Desired behavior after PR is merged:
- the tour tip icon has an extra border that fades between light and dark gray to make it visible on any background
- DOM mutations are grouped in a first time interval of 750ms, further bursts within the next 750ms are triggered right away but prevent any new triggering within the new 750ms

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
