### PR TITLE
fix issue of graph height in studio mode

### DIFF
--- a/addons/web/static/src/scss/graph_view.scss
+++ b/addons/web/static/src/scss/graph_view.scss
@@ -1,10 +1,16 @@
-.o_graph {
-    .o_graph_container {
+// To fix height issue in studio mode
+.o_graph_container {
+    height: 100%;
+    .o_graph_svg_container {
         height: 100%;
+    }
+}
+.o_graph {
+    height: 100%;
+    .o_graph_container {
         overflow: auto;
         .o_graph_svg_container {
             direction: ltr#{"/*rtl:ignore*/"};
-            height: 100%;
             overflow: auto;
             svg {
                 background-color: $o-view-background-color;


### PR DESCRIPTION
PURPOSE
Show graph view with full space in studio mode.

SPEC
Graph view should take full space in studio mode.

TASK 2334622



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
