### PR TITLE
[IMP] acc: post entries from the dedicated journal only

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1023,7 +1023,10 @@ class AccountMove(models.Model):
     @api.depends('company_id', 'invoice_filter_type_domain')
     def _compute_suitable_journal_ids(self):
         for m in self:
-            domain = [('company_id', '=', m.company_id.id), ('type', '=?', m.invoice_filter_type_domain)]
+            if m.move_type == 'entry':
+                domain = [('company_id', '=', m.company_id.id), ('type', 'not in', ['purchase', 'sale', 'bank'])]
+            else:
+                domain = [('company_id', '=', m.company_id.id), ('type', '=?', m.invoice_filter_type_domain)]
             m.suitable_journal_ids = self.env['account.journal'].search(domain)
 
     @api.depends('posted_before', 'state', 'journal_id', 'date')


### PR DESCRIPTION
To avoid any unnecessary user errors when posting, we need to block
the user from posting journal entries from any view that is not the
dedicated one.

This is done by blocking the selection of purchase/sale/bank journals
when manually creating a journal entry.

task id #2358954

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
