### PR TITLE
[FIX] stock: avoid commit when validating a delivery

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -4,10 +4,11 @@
 from ast import literal_eval
 from datetime import date
 from itertools import groupby
+import functools
 from operator import itemgetter
 import time
 
-from odoo import api, fields, models, SUPERUSER_ID, _
+from odoo import api, fields, models, SUPERUSER_ID, _, registry
 from odoo.osv import expression
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
 from odoo.tools.float_utils import float_compare, float_is_zero, float_round
@@ -730,9 +731,29 @@ class Picking(models.Model):
         return True
 
     def _send_confirmation_email(self):
-        for stock_pick in self.filtered(lambda p: p.company_id.stock_move_email_validation and p.picking_type_id.code == 'outgoing'):
-            delivery_template_id = stock_pick.company_id.stock_mail_confirmation_template_id.id
-            stock_pick.with_context(force_send=True).message_post_with_template(delivery_template_id, email_layout_xmlid='mail.mail_notification_light')
+        picking_ids = self.filtered(lambda p: p.company_id.stock_move_email_validation and p.picking_type_id.code == 'outgoing').ids
+        if picking_ids:
+
+            def _send_confirmation_email_after_commit(dbname, context, picking_ids):
+                db_registry = registry(dbname)
+                with api.Environment.manage(), db_registry.cursor() as cr:
+                    env = api.Environment(cr, SUPERUSER_ID, context)
+                    for picking in env["stock.picking"].browse(picking_ids):
+                        delivery_template_id = picking.company_id.stock_mail_confirmation_template_id.id
+                        picking.with_context(force_send=True).message_post_with_template(
+                            delivery_template_id,
+                            email_layout_xmlid='mail.mail_notification_light'
+                        )
+
+            self.env.cr.after(
+                'commit',
+                functools.partial(
+                    _send_confirmation_email_after_commit,
+                    self.env.cr.dbname,
+                    self._context,
+                    picking_ids
+                )
+            )
 
     @api.depends('state', 'move_lines', 'move_lines.state', 'move_lines.package_level_id', 'move_lines.move_line_ids.package_level_id')
     def _compute_move_without_package(self):


### PR DESCRIPTION
TLDR: this commit postpone email sending to after commit stage, because mail
system may call cr.comit() in the middle of stock workflow

STEPS to see unwanted commit() call in odoo shell:

```
>>> import types
>>> def fake_commit(self):
...     print("==== FAKE COMMIT! ====")
...     __import__("traceback").print_stack()
...
>>> env.cr.commit = types.MethodType(fake_commit, env.cr)
>>> picking = env["stock.picking"].browse(21)
>>> picking.state
'assigned'
>>> for move_line in picking.move_line_ids:
...     move_line.qty_done = move_line.product_uom_qty
```

BEFORE: cr.commit() is called in save_attachment method (see logs below)

AFTER: messages are sent (i.e. commit() is called) only after successful
finishing of main transaction

EXPLANATION:

When validating a delivery, the `action_done` method calls the
`_send_confirmation_email` method which is charged (if delivery email
is configured) to send an email with the delivery slip as attachment.

It happens that when the delivery slip is generated, QWeb assets are
also generated (if they were not available) and the current transaction is
force-committed due to these parts of code:

- `ir.actions.report.render_qweb_pdf`: https://github.com/odoo/odoo/blob/0f885721d9902140c9feca4025e2b35698f9d1b9/odoo/addons/base/models/ir_actions_report.py#L675-L685
- `AssetsBundle.save_attachment`: https://github.com/odoo/odoo/blob/0f885721d9902140c9feca4025e2b35698f9d1b9/odoo/addons/base/models/assetsbundle.py#L304-L305

LOGS:

```
  ==== FAKE COMMIT! ====
  File "/usr/local/bin/odoo", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/odoo/src/setup/odoo", line 8, in <module>
    odoo.cli.main()
  File "/odoo/src/odoo/cli/command.py", line 60, in main
    o.run(args)
  File "/odoo/src/odoo/cli/shell.py", line 125, in run
    self.shell(config['db_name'])
  File "/odoo/src/odoo/cli/shell.py", line 118, in shell
    self.console(local_vars)
  File "/odoo/src/odoo/cli/shell.py", line 82, in console
    return getattr(self, shell)(local_vars)
  File "/odoo/src/odoo/cli/shell.py", line 102, in python
    Console(locals=local_vars).interact()
  File "/usr/lib/python3.7/code.py", line 232, in interact
    more = self.push(line)
  File "/usr/lib/python3.7/code.py", line 258, in push
    more = self.runsource(source, self.filename)
  File "/usr/lib/python3.7/code.py", line 74, in runsource
    self.runcode(code)
  File "/usr/lib/python3.7/code.py", line 90, in runcode
    exec(code, self.locals)
  File "<console>", line 1, in <module>
  File "/odoo/src/addons/stock/models/stock_picking.py", line 729, in action_done
    self._send_confirmation_email()
  File "/odoo/src/addons/stock_sms/models/stock_picking.py", line 41, in _send_confirmation_email
    super(Picking, self)._send_confirmation_email()
  File "/odoo/src/addons/stock/models/stock_picking.py", line 735, in _send_confirmation_email
    stock_pick.with_context(force_send=True).message_post_with_template(delivery_template_id, email_layout_xmlid='mail.mail_notification_light')
  File "/odoo/src/addons/mail/models/mail_thread.py", line 1978, in message_post_with_template
    update_values = composer.onchange_template_id(template_id, kwargs['composition_mode'], self._name, res_id)['value']
  File "/odoo/src/addons/mail/wizard/mail_compose_message.py", line 405, in onchange_template_id
    values = self.generate_email_for_composer(template_id, [res_id])[res_id]
  File "/odoo/src/addons/mail/wizard/mail_compose_message.py", line 538, in generate_email_for_composer
    template_values = self.env['mail.template'].with_context(tpl_partners_only=True).browse(template_id).generate_email(res_ids, fields=fields)
  File "/odoo/src/addons/mail/models/mail_template.py", line 437, in generate_email
    result, format = report.render_qweb_pdf([res_id])
  File "/odoo/src/odoo/addons/base/models/ir_actions_report.py", line 734, in render_qweb_pdf
    html = self.with_context(context).render_qweb_html(res_ids, data=data)[0]
  File "/odoo/src/odoo/addons/base/models/ir_actions_report.py", line 774, in render_qweb_html
    return self.render_template(self.report_name, data), 'html'
  File "/odoo/src/odoo/addons/base/models/ir_actions_report.py", line 548, in render_template
    return view_obj.render_template(template, values)
  File "/odoo/src/odoo/addons/base/models/ir_ui_view.py", line 1177, in render_template
    return self.browse(self.get_view_id(template)).render(values, engine)
  File "/odoo/src/addons/web_editor/models/ir_ui_view.py", line 27, in render
    return super(IrUiView, self).render(values=values, engine=engine, minimal_qcontext=minimal_qcontext)
  File "/odoo/src/odoo/addons/base/models/ir_ui_view.py", line 1185, in render
    return self.env[engine].render(self.id, qcontext)
  File "/odoo/src/odoo/addons/base/models/ir_qweb.py", line 58, in render
    result = super(IrQWeb, self).render(id_or_xml_id, values=values, **context)
  File "/odoo/src/odoo/addons/base/models/qweb.py", line 260, in render
    self.compile(template, options)(self, body.append, values or {})
  File "/odoo/src/odoo/addons/base/models/qweb.py", line 332, in _compiled_fn
    return compiled(self, append, new, options, log)
  File "<template>", line 1, in template_stock_report_deliveryslip_5
  File "<template>", line 2, in foreach_4
  File "/odoo/src/odoo/addons/base/models/qweb.py", line 332, in _compiled_fn
    return compiled(self, append, new, options, log)
  File "<template>", line 1, in template_stock_report_delivery_document_34
  File "/odoo/src/odoo/addons/base/models/qweb.py", line 332, in _compiled_fn
    return compiled(self, append, new, options, log)
  File "<template>", line 1, in template_web_html_container_87
  File "/odoo/src/odoo/addons/base/models/qweb.py", line 332, in _compiled_fn
    return compiled(self, append, new, options, log)
  File "<template>", line 1, in template_web_report_layout_90
  File "<decorator-gen-54>", line 2, in _get_asset_nodes
  File "/odoo/src/odoo/tools/cache.py", line 90, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "/odoo/src/odoo/addons/base/models/ir_qweb.py", line 299, in _get_asset_nodes
    return remains + asset.to_node(css=css, js=js, debug=debug, async_load=async_load, defer_load=defer_load, lazy_load=lazy_load)
  File "/odoo/src/odoo/addons/base/models/assetsbundle.py", line 151, in to_node
    css_attachments = self.css() or []
  File "/odoo/src/odoo/addons/base/models/assetsbundle.py", line 332, in css
    self.save_attachment("css", css)
  File "/odoo/src/odoo/addons/base/models/assetsbundle.py", line 305, in save_attachment
    self.env.cr.commit()
```

---

Closes #58804
opw-2348526
