### PR TITLE
[FIX] web_editor: remove white border on selected color

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -1451,8 +1451,7 @@ body.editor_enable.editor_has_snippets {
                 position: relative;
 
                 &.selected {
-                    box-shadow: inset 0 0 0 1px $o-we-sidebar-content-field-colorpicker-dropdown-bg,
-                                inset 0 0 0 3px $o-we-accent,
+                    box-shadow: inset 0 0 0 2px $o-we-accent,
                                 inset 0 0 0 4px white;
                 }
 


### PR DESCRIPTION
**PURPOSE**
Remove white border on a selected color in color picker

**LINKS**
TaskID: 2347755
Closes: https://github.com/odoo/odoo/pull/60082
