### PR TITLE
discard value of many2one on create and edit

### DIFF
--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -534,6 +534,7 @@ var FieldMany2One = AbstractField.extend({
                     var createAndEditAction = function () {
                         // Clear the value in case the user clicks on discard
                         self.$('input').val('');
+                        self.reinitialize(false);
                         return self._searchCreatePopup("form", false, self._createContext(search_val));
                     };
                     values.push({


### PR DESCRIPTION
PURPOSE
Opening the Create and Edit dialog should remove value as well as make m2o non dirty so saving form later should keep value in m2o field.

SPEC
Make m2o field non dirty and clear value of m2o field when opening Create and Edit dialog.

TASK 2363268

Fixes https://github.com/odoo/odoo/issues/51273
Closes https://github.com/odoo/odoo/issues/51273




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
