### PR TITLE
[FIX] stock_account@12.0 : add a post init hook to recompute stock move valuation

### DIFF
--- a/addons/stock_account/__init__.py
+++ b/addons/stock_account/__init__.py
@@ -6,6 +6,22 @@ from . import wizard
 
 from odoo import api, SUPERUSER_ID, _, tools
 
+
+def _post_init_hook(cr, registry):
+    _configure_journals(cr, registry)
+    _compute_stock_move_valuation(cr, registry)
+
+
+def _compute_stock_move_valuation(cr, registry):
+
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    stock_moves = env['stock.move'].search([])
+    for move in stock_moves:
+        if move.state == 'done' and move.quantity_done:
+            move._run_valuation(quantity=move.quantity_done)
+
+
 def _configure_journals(cr, registry):
     """Setting journal and property field (if needed)"""
 

--- a/addons/stock_account/__manifest__.py
+++ b/addons/stock_account/__manifest__.py
@@ -36,5 +36,5 @@ Dashboard / Reports for Warehouse Management includes:
     ],
     'installable': True,
     'auto_install': True,
-    'post_init_hook': '_configure_journals',
+    'post_init_hook': '_post_init_hook',
 }


### PR DESCRIPTION
As `account` and `stock` apps are installed before `stock_account`, some info on
stock moves are wrong and especially their valuation.

This commit adds a new post init hook to recompute stock moves valuation when their
state is 'done'.

NOT YET DONE

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
