### PR TITLE
change selection value on operator change in custom filter

### DIFF
--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -382,6 +382,7 @@
                         <option t-foreach="fields[condition.field].selection" t-as="option" t-key="option_index"
                             t-att-value="option[0]"
                             t-esc="option[1]"
+                            t-att-selected="option[0] === condition.value"
                         />
                     </select>
                     <input t-elif="fieldType === 'float'"

--- a/addons/web/static/tests/control_panel/custom_filter_item_tests.js
+++ b/addons/web/static/tests/control_panel/custom_filter_item_tests.js
@@ -71,7 +71,7 @@ odoo.define('web.filter_menu_generator_tests', function (require) {
         });
 
         QUnit.test('selection field: default and updated value', async function (assert) {
-            assert.expect(4);
+            assert.expect(7);
 
             let expectedFilters;
             class MockedSearchModel extends ActionModel {
@@ -108,6 +108,20 @@ odoo.define('web.filter_menu_generator_tests', function (require) {
             await cpHelpers.toggleAddCustomFilter(cfi);
             await testUtils.fields.editSelect(cfi.el.querySelector('.o_generator_menu_field'), 'color');
             await testUtils.fields.editSelect(cfi.el.querySelector('.o_generator_menu_value select'), 'white');
+            await cpHelpers.applyFilter(cfi);
+
+            // Test value resets on operator change
+            expectedFilters = [{
+                description: 'Color is not "black"',
+                domain: '[["color","!=","black"]]',
+                type: 'filter',
+            }];
+            await cpHelpers.toggleAddCustomFilter(cfi);
+            await testUtils.fields.editSelect(cfi.el.querySelector('.o_generator_menu_field'), 'color');
+            await testUtils.fields.editSelect(cfi.el.querySelector('.o_generator_menu_value select'), 'white');
+            await testUtils.fields.editSelect(cfi.el.querySelector('.o_generator_menu_operator'), '!=');
+            const selectValue = cfi.el.querySelector('.o_generator_menu_value select')
+            assert.strictEqual(selectValue.selectedIndex, 0, "first options should be selected");
             await cpHelpers.applyFilter(cfi);
 
             cfi.destroy();


### PR DESCRIPTION
PURPOSE
If we add a custom filter and change the operator, the value should reset

SPEC
For other widgets when operator is changed then changed value of that filter also reflect in UI but this is not the case with selection field, when operator changed, selection value remains as it is(while in internally value is changed but UI is not reflected), selection field should also work like other widgets.

TASK 2363143



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
