### PR TITLE
[14.0][FIX] better error catching

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1228,8 +1228,16 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                 try:
                     dbid = int(record['.id'])
                 except ValueError:
-                    # in case of overridden id column
-                    dbid = record['.id']
+                    if self._fields["id"].type != "integer":
+                        # in case of overridden id column
+                        dbid = record['.id']
+                    else:
+                        log(dict(extras,
+                            type='error',
+                            record=stream.index,
+                            field='.id',
+                            message=_(u"Invalid database identifier '%s'") % dbid))
+
                 if not self.search([('id', '=', dbid)]):
                     log(dict(extras,
                         type='error',


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When having a custom module that reuse the load method (here is the project : https://github.com/shopinvader/pattern-import-export.


Current behavior before PR:
If you pass an invalid type of field for the id the error is not catched correctly and you have a pg traceback

Desired behavior after PR is merged:
If you pass an invalid type of field for the id the error is catched correctly.

@rco-odoo 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
