### PR TITLE
[FIX] base: fix `populate.randint` tool

### DIFF
--- a/odoo/addons/test_populate/models.py
+++ b/odoo/addons/test_populate/models.py
@@ -17,6 +17,7 @@ class TestPopulateModel(models.Model):
     some_ref = fields.Integer('Reference')
     dependant_field_1 = fields.Char('Dependant 1')
     dependant_field_2 = fields.Char('Dependant 2')
+    sequence = fields.Integer("Sequence")
 
     _populate_dependencies = ['test.populate.category']
 
@@ -53,6 +54,7 @@ class TestPopulateModel(models.Model):
             ('_dependant', generate_dependant),
             ('name', populate.compute(get_name)),
             ('category_id', populate.randomize([False] + category_ids)),
+            ('sequence', populate.randint(1, 10))
         ]
 
 class TestPopulateDependencyModel(models.Model):

--- a/odoo/addons/test_populate/tests/test_populate.py
+++ b/odoo/addons/test_populate/tests/test_populate.py
@@ -47,6 +47,7 @@ class TestPopulate(common.TransactionCase):
         self.assertEqual(records.mapped('some_ref')[5:20], [
             1, 0, 2, 4, 4, 3, 4, 1, 2, 2, 2, 4, 4, 1, 2
         ])
+        self.assertEqual(records.mapped('sequence')[:20], [6, 10, 1, 1, 1, 3, 8, 9, 1, 5, 9, 5, 7, 3, 5, 3, 6, 4, 9, 2])  # Test randint
 
     @mute_logger('odoo.cli.populate')
     def test_populate_inherit(self):

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6220,8 +6220,9 @@ Fields:
 
             It is the responsibility of the generator to handle the field_name correctly.
             The generator could generate values for multiple fields together. In this case,
-            the field_name should be more a "field_group", covering the different fields
-            updated by the generator (e.g. "_address" for a generator updating multiple address fields).
+            the field_name should be more a "field_group" (should be begin by a "_"), covering
+            the different fields updated by the generator (e.g. "_address" for a generator
+            updating multiple address fields).
         """
         return []
 

--- a/odoo/tools/populate.py
+++ b/odoo/tools/populate.py
@@ -146,5 +146,5 @@ def randint(a, b, seed=None):
     :rtype: function (iterator, str, str) -> dict
     """
     def get_rand_int(random=None, **kwargs):
-        random.randint(a, b)
+        return random.randint(a, b)
     return compute(get_rand_int, seed=seed)


### PR DESCRIPTION
The randint generator generated always `None`
because the `return` was forget in method of `populate.compute`.
- Add a test for the randint tool, and fix the issue.
- Change the documentation of `_populate_factories` to be more
explicit about the custom generator.
