### PR TITLE
[FIX] project: avoid inconsistent task's stage and its project's stages

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -588,6 +588,13 @@ class Task(models.Model):
             else:
                 task.kanban_state_label = task.legend_done
 
+    @api.depends('project_id', 'stage_id')
+    def _check_project_stage_consistance(self):
+        for task in self:
+            if task.stage_id and task.project_id.type_ids and task.stage_id.id not in task.project_id.type_ids.ids:
+                raise UserError(_("You cannot move the task %s to the stage %s while the stage does not belong to the corresponding project of the task.")
+                                % (task.name, task.stage_id.name))
+
     def _compute_access_url(self):
         super(Task, self)._compute_access_url()
         for task in self:


### PR DESCRIPTION
Before this, user can move a task from a stage to another stage that
does not belong to the corresponding project of the task. This usually
happens when users working on a task kanban view of multiple projects.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
