### PR TITLE
dicard changes confirmation dialog improvement

### DIFF
--- a/addons/web/static/src/js/components/pager.js
+++ b/addons/web/static/src/js/components/pager.js
@@ -83,6 +83,7 @@ odoo.define('web.Pager', function (require) {
          */
         async _changeSelection(direction) {
             try {
+                debugger;
                 await this.props.validate();
             } catch (err) {
                 return;

--- a/addons/web/static/src/js/components/pager.js
+++ b/addons/web/static/src/js/components/pager.js
@@ -83,7 +83,6 @@ odoo.define('web.Pager', function (require) {
          */
         async _changeSelection(direction) {
             try {
-                debugger;
                 await this.props.validate();
             } catch (err) {
                 return;

--- a/addons/web/static/src/js/views/basic/basic_controller.js
+++ b/addons/web/static/src/js/views/basic/basic_controller.js
@@ -124,11 +124,12 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
                                 }
                                 resolve({ needDiscard: true, forceAbandon: canBeAbandoned });
                                 self.discardingDef = null;
-                            }, () => {
-                                reject();
-                                self._enableButtons();
-                                self.discardingDef = null;
                             });
+                            // , () => {
+                            //     reject();
+                            //     self._enableButtons();
+                            //     self.discardingDef = null;
+                            // });
                         },
                     },
                     {

--- a/addons/web/static/src/js/views/basic/basic_controller.js
+++ b/addons/web/static/src/js/views/basic/basic_controller.js
@@ -110,7 +110,7 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
                         click: () => {
                             self._disableButtons();
                             const canBeAbandoned = self.model.canBeAbandoned(recordID);
-                            return self.saveRecord().then(() => {
+                            return self.saveRecord(recordID).then(() => {
                                 self._enableButtons();
                                 resolve({ needDiscard: true, forceAbandon: canBeAbandoned });
                                 self.discardingDef = null;

--- a/addons/web/static/src/js/views/basic/basic_controller.js
+++ b/addons/web/static/src/js/views/basic/basic_controller.js
@@ -119,6 +119,9 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
                             const prom = options.saveFunction ? options.saveFunction() : self.saveRecord(recordID);
                             return prom.then(() => {
                                 self._enableButtons();
+                                if (options.onSaved) {
+                                    options.onSaved();
+                                }
                                 resolve({ needDiscard: true, forceAbandon: canBeAbandoned });
                                 self.discardingDef = null;
                             });

--- a/addons/web/static/src/js/views/basic/basic_controller.js
+++ b/addons/web/static/src/js/views/basic/basic_controller.js
@@ -90,18 +90,41 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
             return Promise.resolve(false);
         }
 
-        var message = _t("The record has been modified, your changes will be discarded. Do you want to proceed?");
+        var message = _t("Would you like to save your changes?");
         this.discardingDef = new Promise(function (resolve, reject) {
             var dialog = Dialog.confirm(self, message, {
-                title: _t("Warning"),
-                confirm_callback: () => {
-                    resolve(true);
-                    self.discardingDef = null;
-                },
-                cancel_callback: () => {
-                    reject();
-                    self.discardingDef = null;
-                },
+                title: _t("Unsaved changes"),
+                buttons: [
+                    {
+                        text: _t("Save"),
+                        classes: 'btn-primary',
+                        close: true,
+                        click: () => {
+                            self._disableButtons();
+                            self.saveRecord().then(() => {
+                                resolve(true);
+                                self._enableButtons();
+                                self.discardingDef = null;
+                            });
+                        },
+                    },
+                    {
+                        text: _t("Discard"),
+                        close: true,
+                        click: () => {
+                            resolve(true);
+                            self.discardingDef = null;
+                        },
+                    },
+                    {
+                        text: _t("Stay Here"),
+                        close: true,
+                        click: () => {
+                            reject();
+                            self.discardingDef = null;
+                        },
+                    }
+                ],
             });
             dialog.on('closed', self.discardingDef, reject);
         });

--- a/addons/web/static/src/js/views/basic/basic_controller.js
+++ b/addons/web/static/src/js/views/basic/basic_controller.js
@@ -124,12 +124,11 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
                                 }
                                 resolve({ needDiscard: true, forceAbandon: canBeAbandoned });
                                 self.discardingDef = null;
+                            }, () => {
+                                self._enableButtons();
+                                reject();
+                                self.discardingDef = null;
                             });
-                            // , () => {
-                            //     reject();
-                            //     self._enableButtons();
-                            //     self.discardingDef = null;
-                            // });
                         },
                     },
                     {
@@ -426,6 +425,9 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
         options = options || {};
         return this.canBeDiscarded(recordID, options)
             .then(function (result) {
+                if (!result) {
+                    return;
+                }
                 if (options.readonlyIfRealDiscard && !result.needDiscard) {
                     return;
                 }

--- a/addons/web/static/src/js/views/basic/basic_controller.js
+++ b/addons/web/static/src/js/views/basic/basic_controller.js
@@ -124,6 +124,10 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
                                 }
                                 resolve({ needDiscard: true, forceAbandon: canBeAbandoned });
                                 self.discardingDef = null;
+                            }, () => {
+                                reject();
+                                self._enableButtons();
+                                self.discardingDef = null;
                             });
                         },
                     },

--- a/addons/web/static/src/js/views/basic/basic_controller.js
+++ b/addons/web/static/src/js/views/basic/basic_controller.js
@@ -80,7 +80,7 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
      *          if there is something to discard or not
      *          rejected otherwise
      */
-    canBeDiscarded: function (recordID) {
+    canBeDiscarded: function (recordID, options) {
         var self = this;
         if (this.discardingDef) {
             // discard dialog is already open
@@ -110,7 +110,8 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
                         click: () => {
                             self._disableButtons();
                             const canBeAbandoned = self.model.canBeAbandoned(recordID);
-                            return self.saveRecord(recordID).then(() => {
+                            const prom = options.saveFunction ? options.saveFunction() : self.saveRecord(recordID);
+                            return prom.then(() => {
                                 self._enableButtons();
                                 resolve({ needDiscard: true, forceAbandon: canBeAbandoned });
                                 self.discardingDef = null;
@@ -409,7 +410,7 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
         var self = this;
         recordID = recordID || this.handle;
         options = options || {};
-        return this.canBeDiscarded(recordID)
+        return this.canBeDiscarded(recordID, options)
             .then(function (result) {
                 if (options.readonlyIfRealDiscard && !result.needDiscard) {
                     return;

--- a/addons/web/static/src/js/views/basic/basic_controller.js
+++ b/addons/web/static/src/js/views/basic/basic_controller.js
@@ -94,10 +94,16 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
         this.discardingDef = new Promise(function (resolve, reject) {
             const confirmCallback = () => {
                 resolve({ needDiscard: true});
+                // enable buttons if user first save which fails because of required field missed
+                // and then confirm discard changes dialog
+                self._enableButtons();
                 self.discardingDef = null;
             };
             const cancelCallback = () => {
                 reject();
+                // enable buttons if user first save which fails because of required field missed
+                // and then cancel confirmation dialog
+                self._enableButtons();
                 self.discardingDef = null;
             };
             var dialog = Dialog.confirm(self, message, {

--- a/addons/web/static/src/js/views/basic/basic_controller.js
+++ b/addons/web/static/src/js/views/basic/basic_controller.js
@@ -115,14 +115,6 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
                                 resolve({ needDiscard: true, forceAbandon: canBeAbandoned });
                                 self.discardingDef = null;
                             });
-                            // resolve({
-                            //     needDiscard: true,
-                            //     saveCallback: () => {
-                            //         return self.saveRecord().then(() => {
-                            //             self._enableButtons();
-                            //         });
-                            //     },
-                            // });
                         },
                     },
                     {
@@ -136,8 +128,7 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
                         click: cancelCallback,
                     }
                 ],
-                confirm_callback: confirmCallback,
-                cancel_callback: cancelCallback,
+                onForceClose: cancelCallback,
             });
             dialog.on('closed', self.discardingDef, reject);
         });
@@ -420,19 +411,10 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
         options = options || {};
         return this.canBeDiscarded(recordID)
             .then(function (result) {
-                debugger;
                 if (options.readonlyIfRealDiscard && !result.needDiscard) {
                     return;
                 }
                 const canBeAbandoned = self.model.canBeAbandoned(recordID);
-                // if (result.saveCallback) {
-                //     result.saveCallback().then(() => {
-                //         if (!options.noAbandon && canBeAbandoned) {
-                //             self._abandonRecord(recordID);
-                //         }
-                //     });
-                //     return;
-                // }
                 self.model.discardChanges(recordID);
                 if (options.noAbandon) {
                     return;
@@ -442,9 +424,6 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
                     return;
                 }
                 return self._confirmSave(recordID);
-            }, function (result) {
-                debugger;
-                console.log("Inside fail............... ");
             });
     },
     /**

--- a/addons/web/static/src/js/views/form/form_controller.js
+++ b/addons/web/static/src/js/views/form/form_controller.js
@@ -181,7 +181,7 @@ var FormController = BasicController.extend({
             return null;
         }
         return Object.assign(this._super(...arguments), {
-            validate: this.canBeDiscarded.bind(this),
+            validate: this.canBeDiscarded.bind(this, this.handle),
         });
     },
     /**

--- a/addons/web/static/src/js/views/list/list_controller.js
+++ b/addons/web/static/src/js/views/list/list_controller.js
@@ -741,15 +741,16 @@ var ListController = BasicController.extend({
                 this._saveMultipleRecords(this.lastFieldChangedEvent.data.dataPointID, target.__node, this.lastFieldChangedEvent.data.changes);
             return this.multipleRecordsSavingPromise;
         };
+        const onSaved = () => {
+            this.reload();
+        };
         const recordID = this.lastFieldChangedEvent && this.lastFieldChangedEvent.data.dataPointID;
         if (recordID && this.renderer.isInMultipleRecordEdition(recordID)) {
-            this._discardChanges(false, { saveFunction: saveMulti }).then(() => {
+            this._discardChanges(false, { saveFunction: saveMulti, onSaved: onSaved }).then(() => {
                 this.fieldChangedPrevented = false;
             });
         } else {
-            this._discardChanges().then(() => {
-                this.reload();
-            });
+            this._discardChanges(false, { onSaved: onSaved });
         }
     },
     /**

--- a/addons/web/static/src/js/views/list/list_controller.js
+++ b/addons/web/static/src/js/views/list/list_controller.js
@@ -741,8 +741,8 @@ var ListController = BasicController.extend({
                 this._saveMultipleRecords(this.lastFieldChangedEvent.data.dataPointID, target.__node, this.lastFieldChangedEvent.data.changes);
             return this.multipleRecordsSavingPromise;
         };
-        const recordID = this.lastFieldChangedEvent.data.dataPointID;
-        if (this.renderer.isInMultipleRecordEdition(recordID)) {
+        const recordID = this.lastFieldChangedEvent && this.lastFieldChangedEvent.data.dataPointID;
+        if (recordID && this.renderer.isInMultipleRecordEdition(recordID)) {
             this._discardChanges(false, { saveFunction: saveMulti }).then(() => {
                 this.fieldChangedPrevented = false;
             });
@@ -762,9 +762,6 @@ var ListController = BasicController.extend({
      */
     _onDiscardMousedown: function (ev) {
         var self = this;
-        // make this.fieldChangedPrevented to true if it is not set, Discard and cancel will
-        // remove last field changed information, this way we will set fieldChangedPrevented
-        // to true only first time
         this.fieldChangedPrevented = true;
         window.addEventListener('mouseup', function (mouseupEvent) {
             var preventedEvent = self.fieldChangedPrevented;

--- a/addons/web/static/src/js/views/list/list_controller.js
+++ b/addons/web/static/src/js/views/list/list_controller.js
@@ -742,8 +742,6 @@ var ListController = BasicController.extend({
         };
         this._discardChanges(false, { saveFunction: saveMulti }).then(() => {
             this.fieldChangedPrevented = false;
-        }, () => {
-            this.fieldChangedPrevented = false;
         });
     },
     /**
@@ -756,7 +754,12 @@ var ListController = BasicController.extend({
      */
     _onDiscardMousedown: function (ev) {
         var self = this;
-        this.fieldChangedPrevented = true;
+        // make this.fieldChangedPrevented to true if it is not set, Discard and cancel will
+        // remove last field changed information, this way we will set fieldChangedPrevented
+        // to true only first time
+        if (!this.fieldChangedPrevented) {
+            this.fieldChangedPrevented = true;
+        }
         window.addEventListener('mouseup', function (mouseupEvent) {
             var preventedEvent = self.fieldChangedPrevented;
             // If the user starts clicking (mousedown) on the button and stops clicking

--- a/addons/web/static/tests/chrome/action_manager_tests.js
+++ b/addons/web/static/tests/chrome/action_manager_tests.js
@@ -3265,7 +3265,7 @@ QUnit.module('ActionManager', {
     });
 
     QUnit.test('ask for confirmation when leaving a "dirty" view', async function (assert) {
-        assert.expect(4);
+        assert.expect(5);
 
         var actionManager = await createActionManager({
             actions: this.actions,
@@ -3285,11 +3285,13 @@ QUnit.module('ActionManager', {
         await testUtils.dom.click($('.o_control_panel .breadcrumb-item:first a'));
 
         assert.strictEqual($('.modal .modal-body').text(),
-            "The record has been modified, your changes will be discarded. Do you want to proceed?",
+            "Would you like to save your changes?",
             "should display a modal dialog to confirm discard action");
+        assert.containsN($('.modal'), '.modal-footer button', 3,
+            "should have 3 buttons");
 
         // cancel
-        await testUtils.dom.click($('.modal .modal-footer button.btn-secondary'));
+        await testUtils.dom.click($('.modal .modal-footer button.btn-secondary:eq(1)'));
 
         assert.containsOnce(actionManager, '.o_form_view',
             "should still be in form view");
@@ -3298,7 +3300,7 @@ QUnit.module('ActionManager', {
         await testUtils.dom.click($('.o_control_panel .breadcrumb-item:first a'));
 
         // confirm discard
-        await testUtils.dom.click($('.modal .modal-footer button.btn-primary'));
+        await testUtils.dom.click($('.modal .modal-footer button.btn-secondary:eq(0)'));
 
         assert.containsNone(actionManager, '.o_form_view',
             "should no longer be in form view");
@@ -3767,7 +3769,7 @@ QUnit.module('ActionManager', {
         assert.containsOnce($('body'), '.modal'); // confirm discard dialog
 
         // confirm discard changes
-        await testUtils.dom.click($('.modal .modal-footer .btn-primary'));
+        await testUtils.dom.click($('.modal .modal-footer .btn-secondary:eq(0)'));
 
         assert.containsOnce(actionManager, '.o_form_view.o_form_readonly');
         assert.strictEqual(actionManager.$('.o_control_panel .breadcrumb-item').text(),

--- a/addons/web/static/tests/fields/relational_fields/field_one2many_tests.js
+++ b/addons/web/static/tests/fields/relational_fields/field_one2many_tests.js
@@ -1103,7 +1103,7 @@ QUnit.module('fields', {}, function () {
             assert.equal(form.$('.o_field_one2many .o_list_char').text(), "blurp#21#22#23#24#25#26#27#28#29",
                 "should display the records in order with the changes");
 
-            await testUtils.dom.click($('.modal .modal-footer button:first'));
+            await testUtils.dom.click($('.modal .modal-footer button:eq(1)'));
 
             assert.equal(form.$('.o_field_one2many .o_list_char').text(), "#20#21#22#23#24#25#26#27#28#29",
                 "should cancel changes and display the records in order");
@@ -1135,7 +1135,7 @@ QUnit.module('fields', {}, function () {
             assert.equal(form.$('.o_field_one2many .o_list_char').text(), "#20#39#40#41#42#43#44#45#46#47",
                 "should display the records in order after resequence");
 
-            await testUtils.dom.click($('.modal .modal-footer button:first'));
+            await testUtils.dom.click($('.modal .modal-footer button:eq(1)'));
 
             assert.equal(form.$('.o_field_one2many .o_list_char').text(), "#20#21#22#23#24#25#26#27#28#29",
                 "should cancel changes and display the records in order");
@@ -2090,7 +2090,7 @@ QUnit.module('fields', {}, function () {
             await testUtils.form.clickDiscard(form);
             assert.strictEqual(form.$('.o_field_one2many tbody td').first().text(), 'new value',
                 "changes shouldn't have been discarded yet, waiting for user confirmation");
-            await testUtils.dom.click($('.modal .modal-footer .btn-primary'));
+            await testUtils.dom.click($('.modal .modal-footer .btn-secondary:eq(0)'));
             assert.strictEqual(form.$('.o_field_one2many tbody td').first().text(), 'relational record 1',
                 "display name of first record in o2m list should be 'relational record 1'");
 
@@ -2768,7 +2768,7 @@ QUnit.module('fields', {}, function () {
 
             // cancel the edition
             await testUtils.form.clickDiscard(form);
-            await testUtils.dom.click($('.modal-footer button.btn-primary').first());
+            await testUtils.dom.click($('.modal-footer button.btn-secondary:eq(0)').first());
             assert.containsOnce(form, 'tr.o_data_row',
                 "should have 1 data rows");
 
@@ -2921,7 +2921,7 @@ QUnit.module('fields', {}, function () {
             await testUtils.form.clickDiscard(form);
 
             // confirm the discard operation
-            await testUtils.dom.click($('.modal .modal-footer .btn-primary'));
+            await testUtils.dom.click($('.modal .modal-footer .btn-secondary:eq(0)'));
 
             assert.isVisible(form.$('.o_field_widget[name=turtles] .o_pager'));
             assert.strictEqual(form.$('.o_field_widget[name=turtles] .o_pager').text().trim(), '1-3 / 4',
@@ -2997,7 +2997,7 @@ QUnit.module('fields', {}, function () {
                 "pager should still display the correct total");
 
             // click on cancel
-            await testUtils.dom.click($('.modal .modal-footer .btn-secondary'));
+            await testUtils.dom.click($('.modal .modal-footer .btn-secondary:eq(1)'));
 
             assert.strictEqual(form.$('.o_field_widget[name=turtles] .o_pager').text().trim(), '1-3 / 4',
                 "pager should again display the correct total");
@@ -3037,7 +3037,7 @@ QUnit.module('fields', {}, function () {
 
             // discard
             await testUtils.form.clickDiscard(form);
-            await testUtils.dom.click($('.modal .modal-footer .btn-primary'));
+            await testUtils.dom.click($('.modal .modal-footer .btn-secondary:eq(0)'));
 
             assert.containsOnce(form, 'tr.o_data_row');
             assert.containsNone(form, '.o_field_widget[name=turtles] .o_pager');
@@ -3086,13 +3086,13 @@ QUnit.module('fields', {}, function () {
                 'a confirmation model should be opened');
 
             // click on cancel, the line should still be selected
-            await testUtils.dom.click($('.modal .modal-footer button.btn-secondary'));
+            await testUtils.dom.click($('.modal .modal-footer button.btn-secondary:eq(1)'));
             assert.containsOnce(form, 'tr.o_data_row.o_selected_row',
                 "should still have 1 selected data row");
 
             // click elsewhere, and click on ok (on the confirmation dialog)
             await testUtils.dom.click(form.$('label.o_form_label'));
-            await testUtils.dom.click($('.modal .modal-footer button.btn-primary'));
+            await testUtils.dom.click($('.modal .modal-footer button.btn-secondary:eq(0)'));
             assert.containsNone(form, 'tr.o_data_row',
                 "should have 0 data rows (invalid line has been discarded");
 

--- a/addons/web/static/tests/views/form_tests.js
+++ b/addons/web/static/tests/views/form_tests.js
@@ -2952,7 +2952,7 @@ QUnit.module('Views', {
     });
 
     QUnit.test('buttons are enabled on close of discard changes dialog after save fail from discard changes dialog', async function (assert) {
-        assert.expect(7);
+        assert.expect(5);
 
         this.data.partner.fields.foo.required = true;
         this.data.partner.fields.foo.default = undefined;
@@ -2992,12 +2992,7 @@ QUnit.module('Views', {
 
         // try to save without filling required fields
         await testUtils.dom.click($('.modal .modal-footer button.btn-primary'));
-        assert.containsN(form.$buttons, 'button:disabled', 4,
-            "control panel buttons should be disabled");
-        assert.containsOnce(document.body, '.modal',
-            "should have a confirmation modal dialog still open to confirm discard action");
 
-        await testUtils.dom.click($('.modal .modal-footer button.btn-secondary:eq(1)'));
         assert.containsNone(form.$buttons, 'button:disabled',
             "control panel buttons should be enabled");
         form.destroy();

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -7757,8 +7757,6 @@ QUnit.module('Views', {
 
         // Simulates an actual click (event chain is: mousedown > change > blur > focus > mouseup > click)
         await testUtils.dom.triggerEvents($discardButton, ['mousedown']);
-        // await testUtils.dom.triggerEvents(list.$('.o_data_row:first() .o_data_cell:first() input'),
-        //     ['change', 'blur', 'focusout']);
         await testUtils.dom.triggerEvents($discardButton, ['focus']);
         $discardButton[0].dispatchEvent(new MouseEvent('mouseup'));
         await testUtils.dom.click($discardButton);

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -6506,7 +6506,7 @@ QUnit.module('Views', {
         assert.strictEqual($('.modal:visible').length, 1,
             "a modal to ask for discard should be visible");
 
-        await testUtils.dom.click($('.modal:visible .btn-primary'));
+        await testUtils.dom.click($('.modal:visible .btn-secondary:eq(0)'));
         assert.strictEqual(list.$('.o_data_cell:first').text(), "yop",
             "first cell should still contain 'yop'");
 
@@ -7641,8 +7641,8 @@ QUnit.module('Views', {
         $discardButton[0].dispatchEvent(new MouseEvent('mouseup'));
         await testUtils.dom.click($discardButton);
 
-        assert.ok($('.modal').text().includes("Warning"), "Modal should ask to discard changes");
-        await testUtils.dom.click($('.modal .btn-primary'));
+        assert.ok($('.modal').text().includes("Unsaved changes"), "Modal should ask to discard changes");
+        await testUtils.dom.click($('.modal .btn-secondary:eq(0)'));
 
         assert.strictEqual(list.$('.o_data_row:first() .o_data_cell:first()').text(), "yop");
 
@@ -9074,7 +9074,7 @@ QUnit.module('Views', {
         await testUtils.fields.editAndTrigger(list.$('tr.o_selected_row .o_data_cell:first input[name="foo"]'), 'new_value', 'input');
         // discard by pressing ESC
         await testUtils.fields.triggerKeydown(list.$('input[name="foo"]'), 'escape');
-        await testUtils.dom.click($('.modal .modal-footer .btn-primary'));
+        await testUtils.dom.click($('.modal .modal-footer .btn-secondary:eq(0)'));
 
         assert.containsOnce(list, 'tbody tr td:contains(yop)');
         assert.containsN(list, 'tr.o_data_row', 3);
@@ -9626,7 +9626,7 @@ QUnit.module('Views', {
 
         assert.hasClass($('body'), 'modal-open',
             'record has been modified, are you sure modal should be opened');
-        await testUtils.dom.click($('body .modal button span:contains(Ok)'));
+        await testUtils.dom.click($('body .modal button span:contains(Discard)'));
 
         assert.doesNotHaveClass(list.$('tr.o_data_row:eq(1)'), 'o_selected_row',
             'second row should be closed');

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -7654,9 +7654,9 @@ QUnit.module('Views', {
 
         const list = await createView({
             arch: `
-            <tree editable="top" multi_edit="1">
-                <field name="foo"/>
-            </tree>`,
+                <tree editable="top" multi_edit="1">
+                    <field name="foo"/>
+                </tree>`,
             data: this.data,
             model: 'foo',
             View: ListView,
@@ -7687,6 +7687,75 @@ QUnit.module('Views', {
 
         assert.ok($('.modal').text().includes("Unsaved changes"), "Modal should ask to discard changes");
         await testUtils.dom.click($('.modal .btn-primary'));
+
+        // Note: there will be two modal, first for confirmation dialog for discard change second
+        // for confimation dialog about number of records get changed, here checking second dialog
+        const modalText = $('.modal-body:eq(1)').text()
+            .split(" ").filter(w => w.trim() !== '').join(" ")
+            .split("\n").join('');
+        assert.strictEqual(modalText,
+            "Are you sure you want to perform the following update on those 2 records ? " +
+            "Field: Foo Update to: oof");
+
+        // click primary button of second confirmation dialog which checks number of record going to write
+        await testUtils.dom.click($('.modal:eq(1) .btn-primary'));
+        assert.strictEqual(list.$('.o_data_row:first() .o_data_cell:first()').text(), "oof");
+        assert.strictEqual(list.$('.o_data_row:eq(1) .o_data_cell:first()').text(), "oof");
+
+        list.destroy();
+    });
+
+    QUnit.test('editable list view: click on Discard button in multi edition and Cancel and again click Discard and Save', async function (assert) {
+        assert.expect(7);
+
+        const list = await createView({
+            arch: `
+                <tree editable="top" multi_edit="1">
+                    <field name="foo"/>
+                </tree>`,
+            data: this.data,
+            model: 'foo',
+            View: ListView,
+            mockRPC: function (route, args) {
+                if (args.method === "write") {
+                    assert.ok("write should called");
+                }
+                return this._super(...arguments);
+            },
+        });
+
+        // select two records
+        await testUtils.dom.click(list.$('.o_data_row:eq(0) .o_list_record_selector input'));
+        await testUtils.dom.click(list.$('.o_data_row:eq(1) .o_list_record_selector input'));
+
+        await testUtils.dom.click(list.$('.o_data_row:first() .o_data_cell:first()'));
+        list.$('.o_data_row:first() .o_data_cell:first() input').val("oof");
+
+        const $discardButton = list.$buttons.find('.o_list_button_discard');
+
+        // Simulates an actual click (event chain is: mousedown > change > blur > focus > mouseup > click)
+        await testUtils.dom.triggerEvents($discardButton, ['mousedown']);
+        await testUtils.dom.triggerEvents(list.$('.o_data_row:first() .o_data_cell:first() input'),
+            ['change', 'blur', 'focusout']);
+        await testUtils.dom.triggerEvents($discardButton, ['focus']);
+        $discardButton[0].dispatchEvent(new MouseEvent('mouseup'));
+        await testUtils.dom.click($discardButton);
+
+        assert.ok($('.modal').text().includes("Unsaved changes"), "Modal should ask to discard changes");
+
+        await testUtils.dom.click($('.modal .btn-secondary:eq(1)')); // Click on Stay Here
+        assert.containsNone($('body'), '.modal', "should not have a modal");
+
+        // Simulates an actual click (event chain is: mousedown > change > blur > focus > mouseup > click)
+        await testUtils.dom.triggerEvents($discardButton, ['mousedown']);
+        // await testUtils.dom.triggerEvents(list.$('.o_data_row:first() .o_data_cell:first() input'),
+        //     ['change', 'blur', 'focusout']);
+        await testUtils.dom.triggerEvents($discardButton, ['focus']);
+        $discardButton[0].dispatchEvent(new MouseEvent('mouseup'));
+        await testUtils.dom.click($discardButton);
+
+        assert.ok($('.modal').text().includes("Unsaved changes"), "Modal should ask to discard changes");
+        await testUtils.dom.click($('.modal .btn-primary')); // Click on Save
 
         // Note: there will be two modal, first for confirmation dialog for discard change second
         // for confimation dialog about number of records get changed, here checking second dialog

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -10,6 +10,7 @@ var basicFields = require('web.basic_fields');
 var fieldRegistry = require('web.field_registry');
 var fieldRegistryOwl = require('web.field_registry_owl');
 var FormView = require('web.FormView');
+const ListController = require('web.ListController');
 var ListRenderer = require('web.ListRenderer');
 var ListView = require('web.ListView');
 var mixins = require('web.mixins');
@@ -7650,7 +7651,14 @@ QUnit.module('Views', {
     });
 
     QUnit.test('editable list view: clicking on Discard button in multi edition and Save', async function (assert) {
-        assert.expect(5);
+        assert.expect(6);
+
+        testUtils.mock.patch(ListController, {
+            _saveMultipleRecords() {
+                assert.ok('_saveMultipleRecords called.');
+                return this._super(...arguments);
+            },
+        });
 
         const list = await createView({
             arch: `
@@ -7703,6 +7711,7 @@ QUnit.module('Views', {
         assert.strictEqual(list.$('.o_data_row:eq(1) .o_data_cell:first()').text(), "oof");
 
         list.destroy();
+        testUtils.mock.unpatch(ListController);
     });
 
     QUnit.test('editable list view: click on Discard button in multi edition and Cancel and again click Discard and Save', async function (assert) {

--- a/odoo/addons/base/static/tests/base_settings_tests.js
+++ b/odoo/addons/base/static/tests/base_settings_tests.js
@@ -222,7 +222,7 @@ QUnit.module('base_settings_tests', {
         await testUtils.dom.click(actionManager.$('button[name="4"]'));
         assert.containsOnce(document.body, '.modal', "should open a warning dialog");
 
-        await testUtils.dom.click($('.modal button:contains(Ok)'));
+        await testUtils.dom.click($('.modal button:contains(Discard)'));
         assert.containsOnce(actionManager, '.o_list_view', "should be open list view");
 
         await testUtils.dom.click($('.o_control_panel .breadcrumb-item a'));
@@ -233,7 +233,7 @@ QUnit.module('base_settings_tests', {
         await testUtils.dom.click(actionManager.$('button[name="4"]'));
         assert.containsOnce(document.body, '.modal', "should open a warning dialog");
 
-        await testUtils.dom.click($('.modal button:contains(Cancel)'));
+        await testUtils.dom.click($('.modal button:contains(Stay Here)'));
         assert.containsOnce(actionManager, '.o_form_view' ,"should be remain on form view");
 
         await testUtils.dom.click(actionManager.$("button[name='execute']"));

--- a/odoo/addons/test_new_api/static/tests/tours/x2many.js
+++ b/odoo/addons/test_new_api/static/tests/tours/x2many.js
@@ -330,7 +330,7 @@ odoo.define('web.test.x2many', function (require) {
         run: 'click',
     }, {
         content: "confirm cancel change",
-        trigger: '.modal-footer button:contains(Ok)',
+        trigger: '.modal-footer button:contains(Discard)',
     },
 
     /////////////////////////////////////////////////////////////////////////////////////////////
@@ -503,6 +503,6 @@ odoo.define('web.test.x2many', function (require) {
         run: 'click',
     }, {
         content: "confirm cancel change",
-        trigger: '.modal-footer button:contains(Ok)',
+        trigger: '.modal-footer button:contains(Discard)',
     }]);
 });


### PR DESCRIPTION
PURPOSE
Currently, if there are unsaved changes when 'leaving' a record, the following prompt is raised

Warning
    The record has been modified, your changes will be discarded. Do you want to proceed?
    [Ok] [Cancel]

This prompt only allows the user to leave without saving, or stay on the record. But he doesn't allow him to actually save the changes.

The purpose of this task is to:

    make this prompt clearer
    allow the user to save the changes

SPEC
Improve confirmation dialog.
Title: Unsaved changes
Body: Would you like to save your changes?
Buttons > [Save] [Discard] [Stay Here]

[Save] saves unsaved changes and leaves the record
[Discard] discard unsaved changes and leaves the record (the current 'ok' button)
[Stay Here] closes the prompt (the current 'cancel' button)

TASK 2366905



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
