### PR TITLE
[FIX] stock_picking_batch: show availability

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -3,7 +3,7 @@
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-from odoo.tools.float_utils import float_compare, float_is_zero, float_round
+from odoo.tools.float_utils import float_compare
 
 class StockPickingBatch(models.Model):
     _inherit = ['mail.thread', 'mail.activity.mixin']
@@ -87,7 +87,7 @@ class StockPickingBatch(models.Model):
         for batch in self:
             batch.move_ids = batch.picking_ids.move_lines
             batch.move_line_ids = batch.picking_ids.move_line_ids
-            batch.show_check_availability = any(m.state not in ['assigned', 'done'] for m in batch.move_ids)
+            batch.show_check_availability = any(m.state not in ['assigned', 'cancel', 'done'] for m in batch.move_ids)
 
     @api.depends('picking_ids', 'picking_ids.state')
     def _compute_state(self):
@@ -239,4 +239,3 @@ class StockPickingBatch(models.Model):
         if 'state' in init_values:
             return self.env.ref('stock_picking_batch.mt_batch_state')
         return super()._track_subtype(init_values)
-


### PR DESCRIPTION
Before this commit, if a picking batch contains a canceled picking, the "Show Availability" button is showed, even if it makes no sense (for receipts or when all reservable qty. are already reserved).
Also, removes unused import.