### PR TITLE
[FIX] base_address_extended: split street after install

### DIFF
--- a/addons/base_address_extended/__init__.py
+++ b/addons/base_address_extended/__init__.py
@@ -2,3 +2,20 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import models
+
+from odoo import api, SUPERUSER_ID
+
+
+def _split_street_after_install(cr, registry):
+    """Re-run _split_street after processing the data files to handle
+    contacts with a specific format"""
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    countries = env['res.country'].search([
+        ('street_format', '!=', models.base_address_extended.DEFAULT_STREET_FORMAT),
+    ])
+    partners = env['res.partner'].search([
+        ('country_id', 'in', countries.ids),
+        ('street', '!=', ''),
+    ])
+    partners._split_street()

--- a/addons/base_address_extended/__manifest__.py
+++ b/addons/base_address_extended/__manifest__.py
@@ -20,4 +20,5 @@ with the street name, the house number, and room number.
         'data/base_address_extended_data.xml',
     ],
     'depends': ['base'],
+    'post_init_hook': '_split_street_after_install'
 }

--- a/addons/base_address_extended/models/base_address_extended.py
+++ b/addons/base_address_extended/models/base_address_extended.py
@@ -7,7 +7,7 @@ from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 
 STREET_FIELDS = ['street_name', 'street_number', 'street_number2']
-
+DEFAULT_STREET_FORMAT = '%(street_number)s/%(street_number2)s %(street_name)s'
 
 class ResCountry(models.Model):
     _inherit = 'res.country'
@@ -20,7 +20,7 @@ class ResCountry(models.Model):
              "\n%(street_name)s: the name of the street"
              "\n%(street_number)s: the house number"
              "\n%(street_number2)s: the door number",
-        default='%(street_number)s/%(street_number2)s %(street_name)s', required=True)
+        default=DEFAULT_STREET_FORMAT, required=True)
 
 class Partner(models.Model):
     _inherit = ['res.partner']


### PR DESCRIPTION
The `_split_street` method is called directly after creating the new
street columns on res.partner but before the data file
`base_address_extended_data.xml` is processed.
The issue is that before the file is processed, every country still
has the default value for the `street_format`.
In a `post_init_hook`, rerun for all countries with a different format.

Fixes odoo/odoo#59977
