### PR TITLE
[FIX] account: Fix unbalanced journal entry when switching payment terms

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3487,7 +3487,7 @@ class AccountMoveLine(models.Model):
             # As we can't express such synchronization as computed fields without cycling, we need to do it both
             # in onchange and in create/write. So, if something changed in accounting [resp. business] fields,
             # business [resp. accounting] fields are recomputed.
-            if any(field in cleaned_vals for field in ACCOUNTING_FIELDS):
+            if any(field in vals for field in ACCOUNTING_FIELDS):
                 balance = line.currency_id and line.amount_currency or line.debit - line.credit
                 price_subtotal = line._get_price_total_and_subtotal().get('price_subtotal', 0.0)
                 to_write = line._get_fields_onchange_balance(

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -2603,6 +2603,12 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
                 line_form.price_unit = 0.89500
         move_form.save()
 
+    def test_out_invoice_multiple_switch_payment_terms(self):
+        # assertNotUnbalancedEntryWhenSaving
+        with Form(self.invoice) as move_form:
+            move_form.partner_id = self.partner_b # Switch to 30% in advance payment terms
+            move_form.partner_id = self.partner_a # Back to immediate payment term
+
     def test_out_invoice_multi_company(self):
         ''' Ensure the properties are found on the right company.
         '''

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -2584,8 +2584,6 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             ('name', '=', self.env['account.move.line']._fields['price_unit']._digits),
         ]).digits = 5
 
-        self.env['res.currency.rate'].search([]).unlink()
-
         invoice = self.env['account.move'].create({
             'type': 'out_invoice',
             'invoice_date': '2019-01-01',
@@ -2601,7 +2599,6 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
                 line_form.account_id = self.company_data['default_account_revenue']
                 line_form.tax_ids.clear()
                 line_form.price_unit = 0.89500
-        move_form.save()
 
     def test_out_invoice_multiple_switch_payment_terms(self):
         # assertNotUnbalancedEntryWhenSaving


### PR DESCRIPTION
When switching immediate payment term to 30% advance then back to immediate payment term, the receivable line is back to its previous value.
Then, inside the `write`, debit/credit are cleaned because these fields have the same value as before.
However, in that case, accounting fields were updated based on the business fields and then, new balance for the receivable line were lost leading to an unbalanced journal entry.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
