### PR TITLE
[FIX] purchase: product lead time on PO line

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1027,18 +1027,18 @@ class PurchaseOrderLine(models.Model):
             params=params)
 
         if seller or not self.date_planned:
-            self.date_planned = self.order_id.date_planned or self._get_date_planned(seller).strftime(DEFAULT_SERVER_DATETIME_FORMAT)
+            self.date_planned = self._get_date_planned(seller, po=self.order_id).strftime(DEFAULT_SERVER_DATETIME_FORMAT)
 
         if not seller:
             self.price_unit = self.product_id.standard_price
             return
 
-        price_unit = self.env['account.tax']._fix_tax_included_price_company(seller.price, self.product_id.supplier_taxes_id, self.taxes_id, self.company_id) if seller else 0.0
-        if price_unit and seller and self.order_id.currency_id and seller.currency_id != self.order_id.currency_id:
+        price_unit = self.env['account.tax']._fix_tax_included_price_company(seller.price, self.product_id.supplier_taxes_id, self.taxes_id, self.company_id)
+        if price_unit and self.order_id.currency_id and seller.currency_id != self.order_id.currency_id:
             price_unit = seller.currency_id._convert(
                 price_unit, self.order_id.currency_id, self.order_id.company_id, self.date_order or fields.Date.today())
 
-        if seller and self.product_uom and seller.product_uom != self.product_uom:
+        if self.product_uom and seller.product_uom != self.product_uom:
             price_unit = seller.product_uom._compute_price(price_unit, self.product_uom)
 
         self.price_unit = price_unit


### PR DESCRIPTION
Before this commit, if a product has a lead time delay on a vendor, this delay wasn't took when computing the PO line `date_planned`.

How to reproduce:
  - For a product, create a vendor line with a delivery lead time;
  - Creates a Purchase Order with the same vendor;
  - Creates a PO line for this product:
   -> The PO line delivery date is equal to the PO receipt date and hadn't take the vendor delay we set.

task-2367605