### PR TITLE
[FIX] account: Make move partner required in most cases

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -605,7 +605,8 @@
                                             'res_partner_search_mode': (context.get('default_type', 'entry') in ('out_invoice', 'out_refund', 'out_receipt') and 'customer') or (context.get('default_type', 'entry') in ('in_invoice', 'in_refund', 'in_receipt') and 'supplier') or False,
                                             'show_address': 1, 'default_is_company': True, 'show_vat': True}"
                                        options='{"always_reload": True, "no_quick_create": True}'
-                                       attrs="{'invisible': [('type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt'))]}"/>
+                                       attrs="{'invisible': [('type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt'))],
+                                       'required': [('type', 'not in', ('in_invoice', 'in_refund', 'in_receipt'))]}"/>
 
                                 <field name="ref"/>
                                 <field name="invoice_vendor_bill_id"


### PR DESCRIPTION
Account move partners were made non-required in order to cope with the
OCR when importing a vendor bill.

But this impacts not only vendor-bills but all other types of account
move. This commit will partially reverse that to mark the field required
based on its move type.

Task id #2368894

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
