### PR TITLE
[FIX] web_editor: fix one pixel line below flip y shapes

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.frontend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.frontend.scss
@@ -74,3 +74,6 @@
 .o_we_flip_x.o_we_flip_y {
     transform: scale(-1);
 }
+.o_we_shape.o_we_flip_x, .o_we_shape.o_we_flip_y {
+    height: calc(100% + 0.25px); // fix browser issue when rendering SVG background image with CSS transform
+}


### PR DESCRIPTION
Before this commit, there was a 0.25 pixel line below shapes when flip
x or y was applied on it. This is actually a browser issue when
rendering SVG background with CSS transform.

Adding 0.25px on the shape div height fix the issue.

task-2327741

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
