### PR TITLE
do not show string twice on percentpit widget

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -2292,6 +2292,10 @@ var FieldPercentPie = AbstractField.extend({
     template: 'FieldPercentPie',
     supportedFieldTypes: ['integer', 'float'],
 
+    init: function () {
+        this._super.apply(this, arguments);
+        this.showString = 'show_string' in this.nodeOptions ? this.nodeOptions.showString : true;
+    },
     /**
      * Register some useful references for later use throughout the widget.
      *

--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -897,7 +897,7 @@
             <div class="o_mask"/>
             <div class="o_pie_value"/>
         </div>
-        <span t-if="widget.string"><t t-esc="widget.string"/></span>
+        <span t-if="widget.showString &amp;&amp; widget.string"><t t-esc="widget.string"/></span>
     </div>
 </t>
 <t t-name="FieldStatus.content">

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -5282,6 +5282,29 @@ QUnit.module('basic_fields', {
         form.destroy();
     });
 
+    QUnit.test('percentpie widget should not display string if show_string option passed to false', function (assert) {
+        assert.expect(2);
+
+        var form = createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: '<form string="Partners">' +
+                    '<sheet>' +
+                        '<field name="int_field" widget="percentpie" options="{\'show_string\': false}"/>' +
+                    '</sheet>' +
+                '</form>',
+            res_id: 1,
+        });
+
+        assert.strictEqual(form.$('.o_field_percent_pie.o_field_widget .o_pie').length, 1,
+            "should have a pie chart");
+        assert.strictEqual(form.$('.o_field_percent_pie span').length, 0,
+            "should not have a string after pie");
+
+        form.destroy();
+    });
+
     QUnit.test('percentpie widget in form view with value > 50%', function (assert) {
         assert.expect(12);
 


### PR DESCRIPTION
PURPOSE
Widget percentpie should not display string twice.

SPEC
Do not display percentpie string twice if options show_string is passed false.

task-2368832



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
