### PR TITLE
[FIX] rdtraining: Typo

### DIFF
--- a/doc/reference/views.rst
+++ b/doc/reference/views.rst
@@ -1574,7 +1574,7 @@ Possible children elements of the list view are:
 
     <groupby name="partner_id">
       <field name="name"/> <!-- name of partner_id -->
-        <button type="edit" name"edit" string="Edit/>
+        <button type="edit" name="edit" string="Edit"/>
         <button type="object" name="my_method" string="Button1"
           attrs="{'invisible': [('name', '=', 'Georges')]}"/>
     </groupby>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR: typo

Desired behavior after PR is merged: no typo




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
