### PR TITLE
[FIX] l10n_latam_invoice_document: Add credit note to invoice

### DIFF
--- a/addons/l10n_latam_invoice_document/wizards/account_move_reversal.py
+++ b/addons/l10n_latam_invoice_document/wizards/account_move_reversal.py
@@ -19,6 +19,8 @@ class AccountMoveReversal(models.TransientModel):
             move = rec.move_ids[0]
             if move.journal_id and move.journal_id.l10n_latam_use_documents:
                 rec.l10n_latam_manual_document_number = self.env['account.move']._is_manual_document_number(move.journal_id)
+            else:
+                rec.l10n_latam_manual_document_number = 0
 
     @api.model
     def _reverse_type_map(self, move_type):


### PR DESCRIPTION
Issue

    - Install "l10n_latam_invoice_document"
    - Try to add a credit note to any invoice

Cause

    "l10n_latam_manual_document_number" is unitialized when
    "l10n_latam_use_documents" is equal to False

Solution

    Init "l10n_latam_manual_document_number to 0

opw-2366298