### PR TITLE
[FIX] product: archiving last variant must archive product template

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -374,7 +374,7 @@ class ProductTemplate(models.Model):
     def write(self, vals):
         tools.image_resize_images(vals)
         res = super(ProductTemplate, self).write(vals)
-        if 'attribute_line_ids' in vals or vals.get('active'):
+        if 'attribute_line_ids' in vals or (vals.get('active') and not self.product_variant_ids):
             self.create_variant_ids()
         if 'active' in vals and not vals.get('active'):
             self.with_context(active_test=False).mapped('product_variant_ids').write({'active': vals.get('active')})

--- a/addons/product/tests/test_variants.py
+++ b/addons/product/tests/test_variants.py
@@ -175,6 +175,32 @@ class TestVariants(common.TestProductCommon):
             })]
         })
 
+    def test_archive_all_variants(self):
+        template = self.env['product.template'].create({
+            'name': 'template'
+        })
+        self.assertEqual(len(template.product_variant_ids), 1)
+
+        template.write({
+            'attribute_line_ids': [(0, False, {
+                'attribute_id': self.size_attr.id,
+                'value_ids': [
+                    (4, self.size_attr.value_ids[0].id, self.size_attr_value_s),
+                    (4, self.size_attr.value_ids[1].id, self.size_attr_value_m)
+                ],
+            })]
+        })
+        self.assertEqual(len(template.product_variant_ids), 2)
+        variant_1 = template.product_variant_ids[0]
+        variant_2 = template.product_variant_ids[1]
+        template.product_variant_ids.toggle_active()
+        self.assertFalse(variant_1.active, 'Should archive all variants')
+        self.assertFalse(template.active, 'Should archive related template')
+        variant_1.toggle_active()
+        self.assertTrue(variant_1.active, 'Should activate variant')
+        self.assertFalse(variant_2.active, 'Should not re-activate other variant')
+        self.assertTrue(template.active, 'Should re-activate template')
+
 
 class TestVariantsNoCreate(common.TestProductCommon):
 


### PR DESCRIPTION
Behavior prior to this fix:

When archiving the last variant on a template, the product template
stays active.

Behavior after the fix:

When archiving the last variant on a template, the product template is
archived.  When un-archiving that variant, the product template is
unarchived as well, without un-archiving the other variants.

Note: backport of 01160ee5e7f726f3035c566a13e26825236dedfd, but had to
be done a bit differently since the UI does not use `toggle_active`

opw-2349862


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
