### PR TITLE
[FIX] crm: fill company fields in workflow without lead step

### DIFF
--- a/addons/crm/models/res_partner.py
+++ b/addons/crm/models/res_partner.py
@@ -13,6 +13,7 @@ class Partner(models.Model):
     meeting_ids = fields.Many2many('calendar.event', 'calendar_event_res_partner_rel', 'res_partner_id', 'calendar_event_id', string='Meetings', copy=False)
     opportunity_count = fields.Integer("Opportunity", compute='_compute_opportunity_count')
     meeting_count = fields.Integer("# Meetings", compute='_compute_meeting_count')
+    parent_name_default = fields.Char(compute="_compute_parent_name_default", inverse="_inverse_parent_name_default")
 
     @api.model
     def default_get(self, fields):
@@ -33,6 +34,7 @@ class Partner(models.Model):
                     state_id=lead.state_id.id,
                     country_id=lead.country_id.id,
                     zip=lead.zip,
+                    parent_name_default=lead.partner_name,
                 )
         return rec
 
@@ -46,6 +48,14 @@ class Partner(models.Model):
     def _compute_meeting_count(self):
         for partner in self:
             partner.meeting_count = len(partner.meeting_ids)
+
+    @api.depends()
+    def _compute_parent_name_default(self):
+        pass
+
+    @api.depends()
+    def _inverse_parent_name_default(self):
+        pass
 
     @api.multi
     def schedule_meeting(self):

--- a/addons/crm/views/res_partner_views.xml
+++ b/addons/crm/views/res_partner_views.xml
@@ -119,4 +119,18 @@
             </field>
         </record>
 
+        <!-- Add parent_name_default. TODO in master: move to base module -->
+        <record id="view_partner_simple_form_crm" model="ir.ui.view">
+            <field name="name">view.res.partner.simplified.form.crm.inherited</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base.view_partner_simple_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='parent_id']" position="attributes">
+                    <attribute name="context">{'default_is_company': True, 'show_vat': True, 'default_name': parent_name_default}</attribute>
+                </xpath>
+                <xpath expr="//field[@name='parent_id']" position="after">
+                    <field name="parent_name_default" invisible="1"/>
+                </xpath>
+            </field>
+        </record>
 </odoo>


### PR DESCRIPTION
TLDR: "Convert to Opportunity" button fills Company field in partner, while with
disabled Lead step the partner is created without Company value

STEPS:

* install crm
* disable Lead step in Settings
* create opportunity with fields: Opportunity name, Customer Name (Company),
Contact name, Email, but without Customer field (this is equal to creating a
lead via website_crm)
* send a message to get popup "Please complete customer's informations"

BEFORE: company value is not set

AFTER: company value contains newly created company record

WHY:

* ``with_context(active_model=None, active_id=None)``: to avoid infinite loop
with creating parents
* ``vals["email"] = False``: otherwise *Customer* value is set to Company
record, rather than to Contact record
* this way we have another problem, but I don't see how to easily fix it in
stable branch. The problem:
  * if creating *Contact* is canceled, then we have created company, but not a
Contact.
  * trying to send message again will create another company record

---

opw-2365942

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
