### PR TITLE
[FIX] base: fix no web translation on duplicates

### DIFF
--- a/addons/website/models/ir_translation.py
+++ b/addons/website/models/ir_translation.py
@@ -26,7 +26,7 @@ class IrTranslation(models.Model):
         # Add specific view translations
         self.env.cr.execute("""
             INSERT INTO ir_translation(name, lang, res_id, src, type, value, module, state, comments)
-            SELECT DISTINCT ON (specific.id, t.lang, md5(src)) t.name, t.lang, specific.id, t.src, t.type, t.value, t.module, t.state, t.comments
+            SELECT DISTINCT ON (specific.id, t.lang, md5(src), is_web) t.name, t.lang, specific.id, t.src, t.type, t.value, t.module, t.state, t.comments
               FROM ir_translation t
              INNER JOIN ir_ui_view generic
                 ON t.type = 'model_terms' AND t.name = 'ir.ui.view,arch_db' AND t.res_id = generic.id
@@ -35,7 +35,7 @@ class IrTranslation(models.Model):
              WHERE t.lang IN %s and t.module IN %s
                AND generic.website_id IS NULL AND generic.type = 'qweb'
                AND specific.website_id IS NOT NULL""" + conflict_clause.format(
-                   "(type, name, lang, res_id, md5(src))"
+                   "(type, name, lang, res_id, md5(src), is_web)"
         ), (tuple(langs), tuple(modules)))
 
         default_menu = self.env.ref('website.main_menu', raise_if_not_found=False)


### PR DESCRIPTION
TLDR: if we have a term in python and js code, then js translation may not work

STEPS:

* install point_of_sale
* activate and switch to French translation
* go to "Point of sale >> Reporting >> Orders"
* Click "Time Ranges >> Range"

BEFORE: "This Week" is not translated

AFTER: All terms are translated

WHY:

* Translation imports merges translation if they have same src

  https://github.com/odoo/odoo/blob/1e39a2d3b8060963073a39d99ba3a14b07d03333/odoo/addons/base/models/ir_translation.py#L196
  https://github.com/odoo/odoo/blob/1e39a2d3b8060963073a39d99ba3a14b07d03333/odoo/addons/base/models/ir_translation.py#L111

  So, we get either js term for "This Week" or py term, but not both

* web/webclient/translations loads only translation with comments==openerp-web

  https://github.com/odoo/odoo/blob/1e39a2d3b8060963073a39d99ba3a14b07d03333/odoo/addons/base/models/ir_translation.py#L900

  So, if we don't have js term, then the translation is not loaded to UI

---

opw-2357399

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
