### PR TITLE
[FIX] *, don't force mail_post_autofollow

### DIFF
--- a/addons/l10n_ch/models/account_invoice.py
+++ b/addons/l10n_ch/models/account_invoice.py
@@ -317,7 +317,7 @@ class AccountMove(models.Model):
     def message_post(self, **kwargs):
         if self.env.context.get('l10n_ch_mark_isr_as_sent'):
             self.filtered(lambda inv: not inv.l10n_ch_isr_sent).write({'l10n_ch_isr_sent': True})
-        return super(AccountMove, self.with_context(mail_post_autofollow=True)).message_post(**kwargs)
+        return super(AccountMove, self.with_context(mail_post_autofollow=self.env.context.get('mail_post_autofollow', True))).message_post(**kwargs)
 
     def _get_invoice_reference_ch_invoice(self):
         """ This sets ISR reference number which is generated based on customer's `Bank Account` and set it as

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -1082,7 +1082,7 @@ class MailActivityMixin(models.AbstractModel):
         template = self.env['mail.template'].browse(template_id).exists()
         if not template:
             return False
-        for record in self.with_context(mail_post_autofollow=True):
+        for record in self.with_context(mail_post_autofollow=self.env.context.get('mail_post_autofollow', True)):
             record.message_post_with_template(
                 template_id,
                 composition_mode='comment'

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -1082,7 +1082,7 @@ class MailActivityMixin(models.AbstractModel):
         template = self.env['mail.template'].browse(template_id).exists()
         if not template:
             return False
-        for record in self.with_context(mail_post_autofollow=self.env.context.get('mail_post_autofollow', True)):
+        for record in self:
             record.message_post_with_template(
                 template_id,
                 composition_mode='comment'

--- a/addons/portal/wizard/portal_share.py
+++ b/addons/portal/wizard/portal_share.py
@@ -59,7 +59,7 @@ class PortalShare(models.TransientModel):
             saved_lang = self.env.lang
             self = self.with_context(lang=partner.lang)
             template = self.env.ref('portal.portal_share_template', False)
-            active_record.with_context(mail_post_autofollow=True).message_post_with_view(template,
+            active_record.with_context(mail_post_autofollow=self.env.context.get('mail_post_autofollow', True)).message_post_with_view(template,
                 values={'partner': partner, 'note': self.note, 'record': active_record,
                         'share_link': share_link},
                 subject=_("You are invited to access %s", active_record.display_name),
@@ -75,7 +75,7 @@ class PortalShare(models.TransientModel):
             saved_lang = self.env.lang
             self = self.with_context(lang=partner.lang)
             template = self.env.ref('portal.portal_share_template', False)
-            active_record.with_context(mail_post_autofollow=True).message_post_with_view(template,
+            active_record.with_context(mail_post_autofollow=self.env.context.get('mail_post_autofollow', True)).message_post_with_view(template,
                 values={'partner': partner, 'note': self.note, 'record': active_record,
                         'share_link': share_link},
                 subject=_("You are invited to access %s", active_record.display_name),

--- a/addons/portal/wizard/portal_share.py
+++ b/addons/portal/wizard/portal_share.py
@@ -59,7 +59,7 @@ class PortalShare(models.TransientModel):
             saved_lang = self.env.lang
             self = self.with_context(lang=partner.lang)
             template = self.env.ref('portal.portal_share_template', False)
-            active_record.with_context(mail_post_autofollow=self.env.context.get('mail_post_autofollow', True)).message_post_with_view(template,
+            active_record.message_post_with_view(template,
                 values={'partner': partner, 'note': self.note, 'record': active_record,
                         'share_link': share_link},
                 subject=_("You are invited to access %s", active_record.display_name),
@@ -75,7 +75,7 @@ class PortalShare(models.TransientModel):
             saved_lang = self.env.lang
             self = self.with_context(lang=partner.lang)
             template = self.env.ref('portal.portal_share_template', False)
-            active_record.with_context(mail_post_autofollow=self.env.context.get('mail_post_autofollow', True)).message_post_with_view(template,
+            active_record.message_post_with_view(template,
                 values={'partner': partner, 'note': self.note, 'record': active_record,
                         'share_link': share_link},
                 subject=_("You are invited to access %s", active_record.display_name),
@@ -83,4 +83,9 @@ class PortalShare(models.TransientModel):
                 email_layout_xmlid='mail.mail_notification_light',
                 partner_ids=[(6, 0, partner.ids)])
             self = self.with_context(lang=saved_lang)
+
+        # subscribe all recipients so that they receive future communication (better than
+        # using autofollow as more precise)
+        active_record.message_subscribe(partner_ids=self.partner_ids.ids)
+
         return {'type': 'ir.actions.act_window_close'}

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -406,7 +406,7 @@ class PurchaseOrder(models.Model):
     def message_post(self, **kwargs):
         if self.env.context.get('mark_rfq_as_sent'):
             self.filtered(lambda o: o.state == 'draft').write({'state': 'sent'})
-        return super(PurchaseOrder, self.with_context(mail_post_autofollow=True)).message_post(**kwargs)
+        return super(PurchaseOrder, self.with_context(mail_post_autofollow=self.env.context.get('mail_post_autofollow', True))).message_post(**kwargs)
 
     def print_quotation(self):
         self.write({'state': "sent"})

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -895,7 +895,7 @@ class SaleOrder(models.Model):
     def message_post(self, **kwargs):
         if self.env.context.get('mark_so_as_sent'):
             self.filtered(lambda o: o.state == 'draft').with_context(tracking_disable=True).write({'state': 'sent'})
-        return super(SaleOrder, self.with_context(mail_post_autofollow=True)).message_post(**kwargs)
+        return super(SaleOrder, self.with_context(mail_post_autofollow=self.env.context.get('mail_post_autofollow', True))).message_post(**kwargs)
 
     def _sms_get_number_fields(self):
         """ No phone or mobile field is available on sale model. Instead SMS will

--- a/addons/website_sale/models/mail_compose_message.py
+++ b/addons/website_sale/models/mail_compose_message.py
@@ -16,5 +16,4 @@ class MailComposeMessage(models.TransientModel):
                 ('cart_recovery_email_sent', '=', False),
                 ('is_abandoned_cart', '=', True)
             ]).write({'cart_recovery_email_sent': True})
-            self = self.with_context(mail_post_autofollow=self.env.context.get('mail_post_autofollow', True))
         return super(MailComposeMessage, self).send_mail(auto_commit=auto_commit)

--- a/addons/website_sale/models/mail_compose_message.py
+++ b/addons/website_sale/models/mail_compose_message.py
@@ -16,5 +16,5 @@ class MailComposeMessage(models.TransientModel):
                 ('cart_recovery_email_sent', '=', False),
                 ('is_abandoned_cart', '=', True)
             ]).write({'cart_recovery_email_sent': True})
-            self = self.with_context(mail_post_autofollow=True)
+            self = self.with_context(mail_post_autofollow=self.env.context.get('mail_post_autofollow', True))
         return super(MailComposeMessage, self).send_mail(auto_commit=auto_commit)


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

In action server write `env['purchase.order'].browse(an id).with_context(mail_post_autofollow=False).message_post(self, partner_id=x,body='hello'):`

the partner x is add in follower.

@mart-e 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
