### PR TITLE
[FIX] website: prevent crash in RTL languages in large width

### DIFF
--- a/addons/web/static/src/js/core/dom.js
+++ b/addons/web/static/src/js/core/dom.js
@@ -527,7 +527,7 @@ var dom = {
                 return sum + computeFloatOuterWidthWithMargins(el);
             }, 0);
 
-            if (maxWidth - menuItemsWidth >= -0.001) {
+            if (maxWidth - menuItemsWidth >= -0.001 || nbItems == 0) {
                 return;
             }
 


### PR DESCRIPTION
Use some themes with no menu and a right to left language like Hebrew and
Arabic cause an "Uncaught TypeError: Cannot read property 'getBoundingClientRect' of undefined".

Some themes (Default, Loftspace, Odoo experts, TreeHouse) don't trigger the return
when there is no menu on the website.

When the hamburger button menu is display the issue is not triggering but
if you make it wider you can see the error appearing after being larger than a certain size.

opw-2369417
