### PR TITLE
[FIX] base: do not distribute branding from wrapped nodes

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -670,6 +670,8 @@ actual arch.
                     for loc in spec.xpath(".//*[text()='$0']"):
                         loc.text = ''
                         loc.append(copy.deepcopy(node))
+                        if self._context.get('inherit_branding'):
+                            loc.set('meta-oe-xpath-wrapping', 'True')
                     if node.getparent() is None:
                         source = copy.deepcopy(spec[0])
                     else:
@@ -1277,7 +1279,8 @@ actual arch.
         if not e.get('data-oe-model'):
             return
 
-        if {'t-esc', 't-raw'}.intersection(e.attrib):
+        is_replace_wrapping_el = e.attrib.pop('meta-oe-xpath-wrapping', None)
+        if is_replace_wrapping_el or {'t-esc', 't-raw'}.intersection(e.attrib):
             # nodes which fully generate their content and have no reason to
             # be branded because they can not sensibly be edited
             self._pop_view_branding(e)


### PR DESCRIPTION
Before this commit, nodes which were wrapped thanks to an xpath
position="replace" using the $0 magic trick were still branded.

For example, in 13.0 we have an example for the event searchbar, defined
as a primary inheritance of the website searchbar using
```xml
<xpath expr="//div[@role=\'search\']" position="replace">
    <form t-attf-class="o_wevent_event_searchbar_form o_wait_lazy_js my-1 my-lg-0 #{_classes}" t-att-action="action if action else \'/event\'" method="get">
        <t t-set="search" t-value="search or _searches and _searches[\'search\']"/>
        <t>$0</t>
        <t t-foreach="_searches" t-as="search">
            <input t-if="search != \'search\' and search_value != \'all\'" type="hidden" t-att-name="search" t-att-value="search_value"/>
        </t>
        <t t-raw="0"/>
    </form>
</xpath>
```

So wrapping the website searchbar using `<t>$0</t>`. In that case,
the wrapped content was receiving the branding with an xpath like
`/data/xpath[1]/form/t[2]/div[1]/div[1]` where `t[2]` is the wrapping
node... the problem was that we were not able to match the remaining
`/div[1]/div[1]` part after it being changed in edit mode (so it crashed
if edited then saved).

This commit solves the problem by simply not branding wrapped nodes
and wrapped content anymore, the same way as t-esc and t-raw content
are not branded either.

Note: the 'meta-oe-xpath-wrapping' key used by the implementation was
chosen as so as its purpose kinda match the 'meta-oe-xpath-replacing'
key chosen by another similar fix.

Closes 47642
