### PR TITLE
[FIX] Fix journal dashboard late counter

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -272,7 +272,7 @@ class account_journal(models.Model):
                     company_id
                 FROM account_move move
                 WHERE journal_id = %s
-                AND date <= %s
+                AND invoice_date_due <= %s
                 AND state = 'posted'
                 AND payment_state in ('not_paid', 'partial')
                 AND move_type IN ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt');


### PR DESCRIPTION
This is the port for 14.0 of the PR #60956

Problem: The journal dashboard show wrong values for the late invoices.
Details:
The filter for the "Late" invoices is this:
```xml
                    <filter name="late" string="Overdue" domain="['&amp;', ('invoice_date_due', '&lt;', time.strftime('%%Y-%%m-%%d')), ('state', '=', 'posted'), ('invoice_payment_state', '=', 'not_paid')]" help="Overdue invoices, maturity date passed"/>
```
But the SQL query in the background of the journal dashboard filters for a different date field:
```sql
SELECT
                    (CASE WHEN type IN ('out_refund', 'in_refund') THEN -1 ELSE 1 END) * amount_residual AS amount_total,
                    currency_id AS currency,
                    type,
                    invoice_date,
                    company_id
                FROM account_move move
                WHERE journal_id = %s
                AND date <= %s
                AND state = 'posted'
                AND invoice_payment_state = 'not_paid'
                AND type IN ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt');
```

Solution:
Need to change the date field in the SQL code.

Journal dashboard before:
![before](https://user-images.githubusercontent.com/210099/97556287-8da60f00-19d9-11eb-8040-b37721b17900.jpg)


After:
![after](https://user-images.githubusercontent.com/210099/97556299-91d22c80-19d9-11eb-913a-e4ab45eaffd5.jpg)


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
