### PR TITLE
[FIX] hr_contract: use context_today instead of today

### DIFF
--- a/addons/hr_contract/models/hr_contract.py
+++ b/addons/hr_contract/models/hr_contract.py
@@ -22,7 +22,7 @@ class Contract(models.Model):
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]", string="Department")
     job_id = fields.Many2one('hr.job', compute='_compute_employee_contract', store=True, readonly=False,
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]", string='Job Position')
-    date_start = fields.Date('Start Date', required=True, default=fields.Date.today, tracking=True,
+    date_start = fields.Date('Start Date', required=True, default=fields.Date.context_today, tracking=True,
         help="Start date of the contract.")
     date_end = fields.Date('End Date', tracking=True,
         help="End date of the contract (if it's a fixed-term contract).")


### PR DESCRIPTION
Use correct default date from `context_today` instead of `today`.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
