### PR TITLE
Need to change Pillow==7.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ num2words==0.5.6
 ofxparse==0.19
 passlib==1.7.1
 Pillow==5.4.1 ; python_version < '3.7' or sys_platform != 'win32'
-Pillow==6.1.0 ; sys_platform == 'win32' and python_version >= '3.7'
+Pillow==7.1.0 ; sys_platform == 'win32' and python_version >= '3.7' 
 polib==1.1.0
 psutil==5.6.6
 psycopg2==2.7.7; sys_platform != 'win32' and python_version < '3.8'


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Need Pillow upgraded and there are also security alerts on Pillow 6.1.0
Current behavior before PR:
" 2020-10-31 03:40:18,485 1147 WARNING ? py.warnings: /usr/local/lib/python3.8/dist-packages/PIL/Image.py:812: DeprecationWarning: PY_SSIZE_T_CLEAN will be required for '#' formats
  s = d.decode(data)
 
2020-10-31 03:40:18,485 1147 WARNING ? py.warnings: /usr/local/lib/python3.8/dist-packages/PIL/Image.py:477: DeprecationWarning: PY_SSIZE_T_CLEAN will be required for '#' formats
  return encoder(mode, *args + extra)"
![Screenshot from 2020-10-31 10-00-46](https://user-images.githubusercontent.com/13909949/97770822-008dc200-1b61-11eb-9290-91e63d468571.png)

Desired behavior after PR is merged:
There is no more warning after upgrading to 7.1.0
![Screenshot from 2020-10-31 10-00-25](https://user-images.githubusercontent.com/13909949/97770837-1a2f0980-1b61-11eb-823c-3cefaa090062.png)

--
I confirm I have signed the CLA under @MjAbuz and read the PR guidelines at www.odoo.com/submit-pr
