### PR TITLE
[FIX] digest: images broken if db expired

### DIFF
--- a/addons/digest/tests/__init__.py
+++ b/addons/digest/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_digest_mail

--- a/addons/digest/tests/test_digest_mail.py
+++ b/addons/digest/tests/test_digest_mail.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from base64 import b64encode
+
+from odoo.tests.common import TransactionCase
+from odoo.addons.mail.tests.common import MailCommon
+from odoo.modules.module import get_module_resource
+
+class TestDigestMail(TransactionCase, MailCommon):
+
+    def test_digest_image_base64(self):
+        """ Check that local images' src are replaced with their
+        respective base64 data src
+        """
+        digest = self.env['digest.digest'].create({
+            'name': 'test digest mail',
+            'user_ids': [(6)],
+        })
+
+        image_local_link = '/digest/static/src/img/avatar.gif'
+
+        digest_tip = self.env['digest.tip'].create({
+            'name': 'test digest tip',
+            'tip_description': f'''
+                <div>
+                    <p class="tip_title">Tip: Click on an avatar to chat with a user</p>
+                    <p class="tip_content">Have a question about a document? Click on the responsible user's picture to start a conversation. If his avatar has a green dot, he is online.</p>
+                    <img src="{image_local_link}" class="illustration_border" />
+                </div>''',
+            'user_ids': [(1)],
+        })
+
+        img_base64_data_src = False
+        with open(get_module_resource('digest', 'static/src/img/avatar.gif'), 'rb') as f:
+            img_base_64 = b64encode(f.read()).decode('ascii')
+            img_base64_data_src = f'data:image/gif;base64,{img_base_64}'
+
+        new_img_src = f'<img src="{img_base64_data_src}" class="illustration_border">'
+
+        with self.mock_mail_gateway():
+            digest.action_send()
+
+        for mail in self._new_mails:
+            self.assertIn(new_img_src, mail.body_html, "correct src with base64 data should be available in mail body")
+            self.assertNotIn(image_local_link, mail.body_html, "local src should not be there in mail body")

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -709,7 +709,7 @@ class MassMailing(models.Model):
             [('group_id.category_id', '=', self.env.ref('base.module_category_marketing_email_marketing').id)]
         )
         if random_tip:
-            random_tip = random.choice(random_tip).tip_description
+            random_tip = self.env['digest.digest']._replace_digest_img_src_with_base64(random.choice(random_tip).tip_description)
 
         formatted_date = tools.format_datetime(
             self.env, self.sent_date, self.user_id.tz, 'MMM dd, YYYY',  self.user_id.lang


### PR DESCRIPTION
Purpose

image should be display in digest mail, even if database get expires.

Specifications 
create a database then you will receive a digest email and everything looks good,
wait a few days when the database get expires, now if you will open the email
it's broken because images can't be called from the database anymore. in this case
the image should be kept forever in the email.

PR#61127
task-id: 2372195


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
