### PR TITLE
[FIX] documents: search panel update after using list view action dropdown

### DIFF
--- a/addons/web/static/src/js/views/basic/basic_controller.js
+++ b/addons/web/static/src/js/views/basic/basic_controller.js
@@ -264,7 +264,13 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
         } else {
             await this.model.actionUnarchive(ids, this.handle);
         }
-        return this.update({}, {reload: false});
+        return this.update({}, {reload: false})
+            .then((ret) => {
+                if (this.withSearchPanel) {
+                    this.searchPanelProps.searchModel.dispatch();
+                }
+                return ret;
+            });
     },
     /**
      * When the user clicks on a 'action button', this function determines what
@@ -560,7 +566,11 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
      * @param {string[]} ids list of deleted ids (basic model local handles)
      */
     _onDeletedRecords: function (ids) {
-        this.update({});
+        this.update({}).then(() => {
+            if (this.withSearchPanel) {
+                this.searchPanelProps.searchModel.dispatch();
+            }
+        });
     },
     /**
      * Saves the record whose ID is given, if necessary. Automatically leaves

--- a/addons/web/static/src/js/views/list/list_controller.js
+++ b/addons/web/static/src/js/views/list/list_controller.js
@@ -334,6 +334,9 @@ var ListController = BasicController.extend({
                 this.do_notify(false, msg);
             }
             this.reload();
+            if (this.withSearchPanel) {
+                this.searchPanelProps.searchModel.dispatch();
+            }
         };
         if (this.confirmOnDelete) {
             Dialog.confirm(this, _t("Are you sure you want to delete these records ?"), {


### PR DESCRIPTION
After using archive/unarchive or delete from the action dropdown on top of the view list, the search panel filters counts were not updated, this commit aims to solve this for documents, even though the effect should be visible in all list views with a search panel.

modified:

web.list_controller.js
web.basic_controller.js
task: 2295919

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
