### PR TITLE
[FIX] mail: keep changes when adding a follower

### DIFF
--- a/addons/mail/static/src/js/followers.js
+++ b/addons/mail/static/src/js/followers.js
@@ -219,7 +219,7 @@ var Followers = AbstractField.extend({
         });
     },
     _reload: function () {
-        this.trigger_up('reload', {fieldNames: [this.name]});
+        this.trigger_up('reload', {fieldNames: [this.name], keepChanges: true});
     },
     _follow: function () {
         var kwargs = {


### PR DESCRIPTION
Behavior prior to this commit:

When adding a follower on a record that is currently being edited the
edits are discarded, even though we only do a partial reload (just the
follower_ids field)

Behavior after this commit:

Keep the current changes when reloading the record

opw-2372962



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
