### PR TITLE
[13.0][FIX] ir.cron: check registry earlier to avoid corner case

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -97,11 +97,6 @@ class ir_cron(models.Model):
         and exception handling. Note that the user running the server action
         is the user calling this method. """
         try:
-            if self.pool != self.pool.check_signaling():
-                # the registry has changed, reload self in the new registry
-                self.env.reset()
-                self = self.env()[self._name]
-
             log_depth = (None if _logger.isEnabledFor(logging.DEBUG) else 1)
             odoo.netsvc.log(_logger, logging.DEBUG, 'cron.object.execute', (self._cr.dbname, self._uid, '*', cron_name, server_action_id), depth=log_depth)
             start_time = False
@@ -234,7 +229,7 @@ class ir_cron(models.Model):
                     _logger.info('Starting job `%s`.', job['cron_name'])
                     job_cr = db.cursor()
                     try:
-                        registry = odoo.registry(db_name)
+                        registry = odoo.registry(db_name).check_signaling()
                         registry[cls._name]._process_job(job_cr, job, lock_cr)
                         _logger.info('Job `%s` done.', job['cron_name'])
                     except Exception:


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

- start instance with `workers = 1` and `max_cron_threads = 1`
- create new db
- create 2 inactive `ir.cron`, `cronSystem` and `cronAdmin`:
```
[{"user_id":1,"interval_number":1,"interval_type":"minutes","active":false,"numbercall":-1,"state":"code","type":"ir.actions.server","name":"cronAdmin","model_id":1}, {"user_id":2,"interval_number":1,"interval_type":"minutes","active":false,"numbercall":-1,"state":"code","type":"ir.actions.server","name":"cronSystem","model_id":1}]
```
- install `im_livechat`
- activate `cronSystem`
- restart instance (to empty the cron worker's cache)
- `cronSystem` will run, and thus load the registry in the cron worker
- deactivate `cronSystem`
- uninstall `im_livechat`
- activate `cronAdmin`
- `cronAdmin` will fail to run with this traceback:

```
2020-11-02 16:21:23,695 46 ERROR v13c_cron odoo.addons.base.models.ir_cron: Unexpected exception while processing cron job {'id': 16, 'ir_actions_serv
er_id': 176, 'cron_name': 'cronAdmin', 'user_id': 2, 'active': True, 'interval_number': 1, 'interval_type': 'minutes', 'numbercall': -1, 'doall': None
, 'nextcall': datetime.datetime(2020, 11, 2, 16, 7, 45), 'lastcall': datetime.datetime(2020, 11, 2, 16, 7, 26), 'priority': 5, 'create_uid': 2, 'creat
e_date': datetime.datetime(2020, 11, 2, 8, 0, 45, 442940), 'write_uid': 2, 'write_date': datetime.datetime(2020, 11, 2, 16, 20, 50, 669605)}
Traceback (most recent call last):
  File "/opt/odoo/odoo/odoo/api.py", line 745, in get
    value = self._data[field][record._ids[0]]
KeyError: 2

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/odoo/odoo/odoo/fields.py", line 1000, in __get__
    value = env.cache.get(record, self)
  File "/opt/odoo/odoo/odoo/api.py", line 751, in get
    raise CacheMiss(record, field)
odoo.exceptions.CacheMiss: ('res.users(2,).tz', None)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/odoo/odoo/odoo/api.py", line 745, in get
    value = self._data[field][record._ids[0]]
KeyError: 2

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/odoo/odoo/odoo/fields.py", line 1000, in __get__
    value = env.cache.get(record, self)
  File "/opt/odoo/odoo/odoo/api.py", line 751, in get
    raise CacheMiss(record, field)
odoo.exceptions.CacheMiss: ('res.users(2,).partner_id', None)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/odoo/odoo/odoo/addons/base/models/ir_cron.py", line 237, in _process_jobs
    registry[cls._name]._process_job(job_cr, job, lock_cr)
  File "/opt/odoo/odoo/odoo/addons/base/models/ir_cron.py", line 138, in _process_job
    now = fields.Datetime.context_timestamp(cron, datetime.now())
  File "/opt/odoo/odoo/odoo/fields.py", line 1786, in context_timestamp
    tz_name = record._context.get('tz') or record.env.user.tz
  File "/opt/odoo/odoo/odoo/fields.py", line 1024, in __get__
    self.compute_value(recs)
  File "/opt/odoo/odoo/odoo/fields.py", line 1109, in compute_value
    records._compute_field_value(self)
  File "/opt/odoo/odoo/odoo/models.py", line 3968, in _compute_field_value
    field.compute(self)
  File "/opt/odoo/odoo/odoo/fields.py", line 567, in _compute_related
    values = [first(value[name]) for value in values]
  File "/opt/odoo/odoo/odoo/fields.py", line 567, in <listcomp>
    values = [first(value[name]) for value in values]
  File "/opt/odoo/odoo/odoo/models.py", line 5689, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "/opt/odoo/odoo/odoo/fields.py", line 2329, in __get__
    return super().__get__(records, owner)
  File "/opt/odoo/odoo/odoo/fields.py", line 1007, in __get__
    recs._fetch_field(self)
  File "/opt/odoo/odoo/odoo/models.py", line 2974, in _fetch_field
    self._read(fnames)
  File "/opt/odoo/odoo/odoo/addons/base/models/res_users.py", line 378, in _read
    super(Users, self)._read(fields)
  File "/opt/odoo/odoo/odoo/models.py", line 3046, in _read
    cr.execute(query_str, params)
  File "/opt/odoo/odoo/odoo/sql_db.py", line 173, in wrapper
    return f(self, *args, **kwargs)
  File "/opt/odoo/odoo/odoo/sql_db.py", line 250, in execute
    res = self._obj.execute(query, params)
psycopg2.ProgrammingError: column res_users.livechat_username does not exist
LINE 1: ...out_of_office_message" as "out_of_office_message","res_users...
```

This happens because:
- the uninstallation of `im_livechat` changed the `res_users` schema (dropped `livechat_username`)
- but the `res.users` record for admin is [loaded](https://github.com/odoo/odoo/blob/6c34d1996f24f1ec647e4dd12b9d7e7eea3e62d3/odoo/addons/base/models/ir_cron.py#L139) with the old registry, because the signaling check [only happens later](https://github.com/odoo/odoo/blob/6c34d1996f24f1ec647e4dd12b9d7e7eea3e62d3/odoo/addons/base/models/ir_cron.py#L100) in the `_callback()` part.

This PR makes sure the registry check is done before starting to `_process_job()`. 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
