### PR TITLE
[IMP] stock: delivery slip quantities

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -706,20 +706,66 @@ class StockMoveLine(models.Model):
         returns: dictionary {product_id+name+description+uom: {product, name, description, qty_done, product_uom}, ...}
         """
         aggregated_move_lines = {}
-        for move_line in self:
-            name = move_line.product_id.display_name
-            description = move_line.move_id.description_picking
-            if description == name or description == move_line.product_id.name:
+
+        def get_aggregated_properties(move_line=False, move=False):
+            move = move or move_line.move_id
+            uom = move_line and move_line.product_uom_id or move.product_uom
+            name = move.product_id.display_name
+            description = move.description_picking
+            if description == name or description == move.product_id.name:
                 description = False
-            uom = move_line.product_uom_id
-            line_key = str(move_line.product_id.id) + "_" + name + (description or "") + "uom " + str(uom.id)
+            product = move.product_id
+            line_key = f'{product.id}_{product.display_name}_{description or ""}_{uom.id}'
+            return (line_key, name, description, uom)
+
+        # Loops to get backorders, backorders' backorders, and so and so...
+        backorders = self.env['stock.picking']
+        pickings = self.picking_id
+        while pickings.backorder_ids:
+            backorders |= pickings.backorder_ids
+            pickings = pickings.backorder_ids
+
+        for move_line in self:
+            line_key, name, description, uom = get_aggregated_properties(move_line=move_line)
 
             if line_key not in aggregated_move_lines:
+                qty_ordered = move_line.move_id.product_uom_qty
+                if backorders:
+                    # Filters on the aggregation key (product, description and uom) to add the
+                    # quantities delayed to backorders to retrieve the original ordered qty.
+                    following_move_lines = backorders.move_line_ids.filtered(
+                        lambda ml: get_aggregated_properties(move=ml.move_id)[0] == line_key
+                    )
+                    qty_ordered += sum(following_move_lines.move_id.mapped('product_uom_qty'))
                 aggregated_move_lines[line_key] = {'name': name,
                                                    'description': description,
                                                    'qty_done': move_line.qty_done,
+                                                   'qty_ordered': qty_ordered,
                                                    'product_uom': uom.name,
                                                    'product': move_line.product_id}
             else:
                 aggregated_move_lines[line_key]['qty_done'] += move_line.qty_done
+
+        # Does the same for empty move line to retrieve the ordered qty. for partially done moves
+        # (as they are splitted when the transfer is done and empty moves don't have move lines).
+        pickings = (self.picking_id | backorders)
+        for empty_move in pickings.move_lines.filtered(
+            lambda m: m.state == "cancel" and m.product_uom_qty
+            and float_is_zero(m.quantity_done, precision_rounding=m.product_uom.rounding)
+        ):
+            line_key, name, description, uom = get_aggregated_properties(move=empty_move)
+
+            if line_key not in aggregated_move_lines:
+                qty_ordered = empty_move.product_uom_qty
+                aggregated_move_lines[line_key] = {
+                    'name': name,
+                    'description': description,
+                    'qty_done': False,
+                    'qty_ordered': qty_ordered,
+                    'product_uom': uom.name,
+                    'product': empty_move.product_id,
+                }
+            else:
+                aggregated_move_lines[line_key]['qty_ordered'] += empty_move.product_uom_qty
+
         return aggregated_move_lines

--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -204,7 +204,8 @@
                 </p>
             </td>
             <td class="text-center" name="move_line_aggregated_qty_done">
-                <span t-esc="aggregated_lines[line]['qty_done']"/>
+                <span t-esc="aggregated_lines[line]['qty_done']"
+                    t-options="{'widget': 'float', 'decimal_precision': 'Product Unit of Measure'}"/>
                 <span t-esc="aggregated_lines[line]['product_uom']"/>
             </td>
         </tr>

--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -35,7 +35,8 @@
                         <thead>
                             <tr>
                                 <th name="th_sm_product"><strong>Product</strong></th>
-                                <th name="th_sm_quantity"><strong>Quantity</strong></th>
+                                <th name="th_sm_ordered"><strong>Ordered</strong></th>
+                                <th name="th_sm_quantity"><strong>Delivered</strong></th>
                             </tr>
                         </thead>
                         <tbody>
@@ -43,12 +44,16 @@
                             <tr t-foreach="lines" t-as="move">
                                 <td>
                                     <span t-field="move.product_id"/>
-                                    <p t-if="move.description_picking != move.product_id.name">
+                                    <p t-if="move.description_picking != move.product_id.name and move.description_picking != move.product_id.display_name">
                                         <span t-field="move.description_picking"/>
                                     </p>
                                 </td>
                                 <td>
                                     <span t-field="move.product_uom_qty"/>
+                                    <span t-field="move.product_uom"/>
+                                </td>
+                                <td>
+                                    <span t-field="move.quantity_done"/>
                                     <span t-field="move.product_uom"/>
                                 </td>
                             </tr>
@@ -65,7 +70,10 @@
                                         Lot/Serial Number
                                     </th>
                                 </t>
-                                <th name="th_sml_quantity" class="text-center"><strong>Quantity</strong></th>
+                                <th name="th_sml_qty_ordered" class="text-center" t-if="not has_serial_number">
+                                    <strong>Ordered</strong>
+                                </th>
+                                <th name="th_sml_quantity" class="text-center"><strong>Delivered</strong></th>
                             </tr>
                         </thead>
                         <tbody>
@@ -119,20 +127,21 @@
                                 <!-- If not printing lots/serial numbers => merge lines with same product -->
                                 <t t-else="" name="aggregated_move_lines">
                                     <t t-set="aggregated_lines" t-value="o.move_line_ids._get_aggregated_product_quantities()"/>
-                                        <t t-call="stock.stock_report_delivery_aggregated_move_lines"/>
+                                    <t t-call="stock.stock_report_delivery_aggregated_move_lines"/>
                                 </t>
                             </t>
                         </tbody>
                     </table>
                     <t t-set="backorders" t-value="o.backorder_ids.filtered(lambda x: x.state not in ('done', 'cancel'))"/>
                     <t t-if="o.backorder_ids and backorders">
-                        <p>
-                            <span>All items couldn't be shipped, the following items will be shipped as soon as they become available.</span>
+                        <p class="mt-5">
+                            <span>Remaining quantities not yet delivered:</span>
                         </p>
-                        <table class="table table-sm" name="stock_backorder_table">
+                        <table class="table table-sm" name="stock_backorder_table" style="table-layout: fixed;">
                             <thead>
                                 <tr>
                                     <th name="th_sb_product"><strong>Product</strong></th>
+                                    <th/>
                                     <th name="th_sb_quantity" class="text-center"><strong>Quantity</strong></th>
                                 </tr>
                             </thead>
@@ -140,13 +149,14 @@
                                 <t t-foreach="backorders" t-as="backorder">
                                     <t t-set="bo_lines" t-value="backorder.move_lines.filtered(lambda x: x.product_uom_qty)"/>
                                     <tr t-foreach="bo_lines" t-as="bo_line">
-                                        <td>
+                                        <td class="w-auto">
                                             <span t-field="bo_line.product_id"/>
-                                            <p t-if="bo_line.description_picking != bo_line.product_id.name">
+                                            <p t-if="bo_line.description_picking != bo_line.product_id.name and bo_line.description_picking != bo_line.product_id.display_name">
                                                 <span t-field="bo_line.description_picking"/>
                                             </p>
                                         </td>
-                                        <td class="text-center">
+                                        <td/>
+                                        <td class="text-center w-auto">
                                             <span t-field="bo_line.product_uom_qty"/>
                                             <span t-field="bo_line.product_uom"/>
                                         </td>
@@ -203,10 +213,17 @@
                     <span t-esc="aggregated_lines[line]['description']"/>
                 </p>
             </td>
-            <td class="text-center" name="move_line_aggregated_qty_done">
-                <span t-esc="aggregated_lines[line]['qty_done']"
+            <td class="text-center" name="move_line_aggregated_qty_ordered">
+                <span t-esc="aggregated_lines[line]['qty_ordered']"
                     t-options="{'widget': 'float', 'decimal_precision': 'Product Unit of Measure'}"/>
                 <span t-esc="aggregated_lines[line]['product_uom']"/>
+            </td>
+            <td class="text-center" name="move_line_aggregated_qty_done">
+                <t t-if="aggregated_lines[line]['qty_done']">
+                    <span t-esc="aggregated_lines[line]['qty_done']"
+                        t-options="{'widget': 'float', 'decimal_precision': 'Product Unit of Measure'}"/>
+                    <span t-esc="aggregated_lines[line]['product_uom']"/>
+                </t>
             </td>
         </tr>
     </template>


### PR DESCRIPTION
[IMP] stock: delivery slip quantities

Some changes in the delivery slip layout:
  - For delivered products, replaces the Quantity column by two other columns: Ordered and Delivered;
  - Shows the non-delivered products even when the delivery is done and haven't any backorder.

Also, fix a little inconsistency in the way float values were displayed in the delivery slip.

task-2373833