### PR TITLE
[FIX] base: allow non-admins to merge partners when auth_signup is installed

### DIFF
--- a/addons/auth_signup/models/__init__.py
+++ b/addons/auth_signup/models/__init__.py
@@ -4,3 +4,4 @@ from . import res_config_settings
 from . import ir_http
 from . import res_partner
 from . import res_users
+from . import base_partner_merge

--- a/addons/auth_signup/models/base_partner_merge.py
+++ b/addons/auth_signup/models/base_partner_merge.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class MergePartnerAutomatic(models.TransientModel):
+
+    _inherit = 'base.partner.merge.automatic.wizard'
+
+    def _get_ignorable_fields(self):
+        """Don't try to merge signup fields"""
+        return super()._get_ignorable_fields() + [
+            'signup_token', 'signup_type', 'signup_expiration',
+        ]

--- a/odoo/addons/base/tests/__init__.py
+++ b/odoo/addons/base/tests/__init__.py
@@ -46,3 +46,4 @@ from . import test_tests_tags
 from . import test_form_create
 from . import test_cloc
 from . import test_pdf
+from . import test_partner_merge

--- a/odoo/addons/base/tests/test_partner_merge.py
+++ b/odoo/addons/base/tests/test_partner_merge.py
@@ -1,0 +1,28 @@
+# coding: utf-8
+from odoo.tests.common import TransactionCase
+
+
+class TestPartnerMerge(TransactionCase):
+    def setUp(self):
+        super(TestPartnerMerge, self).setUp()
+        self.partner1 = self.env.ref('base.res_partner_4')
+        self.partner2 = self.env.ref('base.res_partner_4').copy()
+        self.user = self.env.ref('base.user_demo')
+
+    def _do_merge(self):
+        # Switch to old API due to guessing mismatch
+        wizard_obj = self.env['base.partner.merge.automatic.wizard']
+        wizard_obj._merge((self.partner1 + self.partner2).ids, self.partner2)
+
+    def test_partner_merge(self):
+        self._do_merge()
+
+    def test_partner_merge_protected_field(self):
+        """ Protecting a field with a specific group does not break merging """
+        column = self.env['res.partner']._fields['credit_limit']
+        groups_orig = getattr(column, 'groups', None)
+        column.groups = 'base.group_system'
+        try:
+            self._do_merge()
+        finally:
+            column.groups = groups_orig

--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -233,6 +233,11 @@ class MergePartnerAutomatic(models.TransientModel):
         """
         return []
 
+    def _get_ignorable_fields(self):
+        """ Returns the list of fields that should be ignored when merging partners
+        """
+        return []
+
     @api.model
     def _update_values(self, src_partners, dst_partner):
         """ Update values of dst_partner with the ones from the src_partners.
@@ -243,6 +248,7 @@ class MergePartnerAutomatic(models.TransientModel):
 
         model_fields = dst_partner.fields_get().keys()
         summable_fields = self._get_summable_fields()
+        ignorable_fields = self._get_ignorable_fields()
 
         def write_serializer(item):
             if isinstance(item, models.BaseModel):
@@ -255,6 +261,8 @@ class MergePartnerAutomatic(models.TransientModel):
             field = dst_partner._fields[column]
             if field.type not in ('many2many', 'one2many') and field.compute is None:
                 for item in itertools.chain(src_partners, [dst_partner]):
+                    if column in ignorable_fields:
+                        continue
                     if item[column]:
                         if column in summable_fields and values.get(column):
                             values[column] += write_serializer(item[column])


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Merging partners breaks for non-admins when `auth_signup` is installed

Current behavior before PR:

```
odoo.exceptions.AccessError: ('The requested operation cannot be completed due to security restrictions. Please contact your system administrator.\n\n(Document type: Contact, Operation: read) - (User: 6, Fields: signup_expiration)', None)
```

Desired behavior after PR is merged: Non-admins can merge partners also when `auth_signup` is installed




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
