### PR TITLE
listview in wizard without breadcrumb and buttons in header

### DIFF
--- a/addons/web/static/src/js/chrome/action_manager.js
+++ b/addons/web/static/src/js/chrome/action_manager.js
@@ -396,6 +396,7 @@ var ActionManager = Widget.extend({
                     in_DOM: true,
                     callbacks: [{widget: dialog}, {widget: controller.widget}],
                 });
+                controller.widget.$('.o_cp_buttons > div').remove();
                 widget.renderButtons(dialog.$footer);
                 dialog.rebindButtonBehavior();
 

--- a/addons/web/static/src/js/chrome/action_manager.js
+++ b/addons/web/static/src/js/chrome/action_manager.js
@@ -396,7 +396,7 @@ var ActionManager = Widget.extend({
                     in_DOM: true,
                     callbacks: [{widget: dialog}, {widget: controller.widget}],
                 });
-                controller.widget.$('.o_cp_buttons > div').remove();
+                // controller.widget.$('.o_cp_buttons > div').remove();
                 widget.renderButtons(dialog.$footer);
                 dialog.rebindButtonBehavior();
 

--- a/addons/web/static/src/js/views/abstract_controller.js
+++ b/addons/web/static/src/js/views/abstract_controller.js
@@ -55,6 +55,7 @@ var AbstractController = mvc.Controller.extend(ActionMixin, {
         this.initialState = params.initialState;
         this.bannerRoute = params.bannerRoute;
         this.isMultiRecord = params.isMultiRecord;
+        this.withControlPanelButtons = params.withControlPanelButtons;
         this.actionViews = params.actionViews;
         this.viewType = params.viewType;
         // use a DropPrevious to correctly handle concurrent updates
@@ -353,7 +354,9 @@ var AbstractController = mvc.Controller.extend(ActionMixin, {
             $pager: $('<div>'),
         };
 
-        this.renderButtons(elements.$buttons);
+        if (this.withControlPanelButtons) {
+            this.renderButtons(elements.$buttons);
+        }
         var sidebarProm = this.renderSidebar(elements.$sidebar);
         var pagerProm = this.renderPager(elements.$pager);
 

--- a/addons/web/static/src/js/views/abstract_view.js
+++ b/addons/web/static/src/js/views/abstract_view.js
@@ -46,6 +46,8 @@ var AbstractView = Factory.extend({
     viewType: undefined,
     // determines if a search bar is available
     withSearchBar: true,
+    // determines if a buttons are available
+    withControlPanelButtons: true,
     // determines the search menus available and their orders
     searchMenuTypes: ['filter', 'groupBy', 'favorite'],
     // determines if a control panel should be instantiated
@@ -143,6 +145,7 @@ var AbstractView = Factory.extend({
             isMultiRecord: this.multi_record,
             modelName: params.modelName,
             viewType: this.viewType,
+            withControlPanelButtons: params.withControlPanelButtons,
         };
 
         var controllerState = params.controllerState || {};
@@ -282,6 +285,7 @@ var AbstractView = Factory.extend({
     _extractParamsFromAction: function (action) {
         action = action || {};
         var context = action.context || {};
+        var inDialog = action.target === 'new';
         var inline = action.target === 'inline';
         return {
             actionId: action.id || false,
@@ -299,6 +303,7 @@ var AbstractView = Factory.extend({
             withBreadcrumbs: 'no_breadcrumbs' in context ? !context.no_breadcrumbs : true,
             withControlPanel: this.withControlPanel,
             withSearchBar: inline ? false : this.withSearchBar,
+            withControlPanelButtons: inDialog ? false : this.withControlPanelButtons,
         };
     },
     /**

--- a/addons/web/static/src/js/views/list/list_view.js
+++ b/addons/web/static/src/js/views/list/list_view.js
@@ -94,7 +94,7 @@ var ListView = BasicView.extend({
         var inDialog = action.target === 'new';
         var inline = action.target === 'inline';
         params.hasSidebar = !inDialog && !inline;
-        params.withControlPanel = !inDialog;
+        params.withBreadcrumbs = !inDialog;
         return params;
     },
     /**

--- a/addons/web/static/src/js/views/list/list_view.js
+++ b/addons/web/static/src/js/views/list/list_view.js
@@ -94,6 +94,7 @@ var ListView = BasicView.extend({
         var inDialog = action.target === 'new';
         var inline = action.target === 'inline';
         params.hasSidebar = !inDialog && !inline;
+        params.withControlPanel = !inDialog;
         return params;
     },
     /**

--- a/addons/web/static/tests/chrome/action_manager_tests.js
+++ b/addons/web/static/tests/chrome/action_manager_tests.js
@@ -3540,6 +3540,38 @@ QUnit.module('ActionManager', {
         actionManager.destroy();
     });
 
+    QUnit.test('buttons are displayed in dialog footer and breadcrumb not displayed when view type is list', async function (assert) {
+        assert.expect(4);
+
+        this.actions.push({
+            id: 21,
+            name: 'Partner List',
+            res_model: 'partner',
+            target: 'new',
+            type: 'ir.actions.act_window',
+            views: [[false, 'list']],
+        });
+
+        var actionManager = await createActionManager({
+            actions: this.actions,
+            archs: this.archs,
+            data: this.data,
+        });
+        await actionManager.doAction(21);
+
+        assert.strictEqual($('.o_technical_modal .modal-body .o_control_panel .breadcrumb-item').length, 0,
+            "the breadcrumbs should not be in the body");
+        assert.strictEqual($('.o_technical_modal .modal-body .o_list_buttons').length, 0,
+            "the button should not be in the body");
+        assert.strictEqual($('.o_technical_modal .modal-footer .o_list_buttons').length, 1,
+            "the button should be in the footer");
+        // footer should containt Create, Import, Save and Discard buttons
+        assert.strictEqual($('.o_technical_modal .modal-footer button').length, 4,
+            "the modal footer should contain four button");
+
+        actionManager.destroy();
+    });
+
     QUnit.test('on_attach_callback is called for actions in target="new"', async function (assert) {
         assert.expect(4);
 


### PR DESCRIPTION
PURPOSE
Have an action in target new, spawning a full blown list view inside a modal, The create button is at two places: in the controlPanel, and in the modal's footer, buttons should be only in footer.

SPEC
Do not display buttons at footer and control panel, only display buttons at wizard dialog footer.

TASK-2300515


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
