### PR TITLE
[FIX] fleet: Fleet Management Report

### DIFF
--- a/addons/fleet/report/fleet_report.py
+++ b/addons/fleet/report/fleet_report.py
@@ -111,7 +111,7 @@ SELECT
     fuel_type,
     date_start,
     COST,
-    cost_type
+    'service' as cost_type
 FROM
     service_costs sc
 UNION ALL (
@@ -124,7 +124,7 @@ UNION ALL (
         fuel_type,
         date_start,
         COST,
-        cost_type
+        'contract' as cost_type
     FROM
         contract_costs cc)
 """

--- a/addons/fleet/views/fleet_board_view.xml
+++ b/addons/fleet/views/fleet_board_view.xml
@@ -37,7 +37,7 @@
         <field name="name">fleet.vehicle.cost.view.graph</field>
         <field name="model">fleet.vehicle.cost.report</field>
         <field name="arch" type="xml">
-            <graph string="Fleet Costs Analysis" type="bar" sample="1" disable_linking="True">
+            <graph string="Fleet Costs Analysis" type="bar" sample="1" disable_linking="1">
                 <field name="date_start" type="row" interval="month"/>
                 <field name="cost_type" type="row"/>
                 <field name="cost" type="measure"/>


### PR DESCRIPTION
Fine tuning of https://github.com/odoo/odoo/commit/bf80334699773f080f41dc234ac170a384c75ea4

disable_linking="True" doesn't work on graph view

Error in view fleet.vehicle.cost.report

could not determine which collation to use for view column "cost_type"

opw:2360528