### PR TITLE
[FIX] sale: confirm overpaid orders

### DIFF
--- a/addons/sale/models/payment.py
+++ b/addons/sale/models/payment.py
@@ -74,9 +74,10 @@ class PaymentTransaction(models.Model):
     def _check_amount_and_confirm_order(self):
         self.ensure_one()
         for order in self.sale_order_ids.filtered(lambda so: so.state in ('draft', 'sent')):
-            if order.currency_id.compare_amounts(self.amount, order.amount_total) == 0:
+            diff_sign = order.currency_id.compare_amounts(self.amount, order.amount_total)
+            if diff_sign != -1:
                 order.with_context(send_email=True).action_confirm()
-            else:
+            if diff_sign != 0:
                 _logger.warning(
                     '<%s> transaction AMOUNT MISMATCH for order %s (ID %s): expected %r, got %r',
                     self.acquirer_id.provider,order.name, order.id,


### PR DESCRIPTION
STEPS:

* install website_sale
* setup few delivery options
* setup online payment (e.g. paypal)
* at website add products to cart and proceed to checkout page
* select paid delivery
* slow down internet speed
* click "Pay now"
* while it's loading, set free delivery

BEFORE: once you pay, the order has draft state (Quotation), cart is not empty
and you can continue shopping with the same order

AFTER: order is confirmed

WHY: normally, we should block changing order once payment is initiated, but

* it's not always posible to make such updates in stable branch
* there may be other potential ways to get overpaid order, and if it happened, it seems
better to confirm overpaid order than having order in unexpected state

---

opw-2324543

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
