### PR TITLE
do not display breadcrumb and buttons header in listview in wizard

### DIFF
--- a/addons/web/static/src/js/control_panel/control_panel.js
+++ b/addons/web/static/src/js/control_panel/control_panel.js
@@ -199,6 +199,8 @@ odoo.define('web.ControlPanel', function (require) {
         views: [],
         withBreadcrumbs: true,
         withSearchBar: true,
+        withViewSwitcher: true,
+
     };
     ControlPanel.props = {
         action: Object,
@@ -214,6 +216,7 @@ odoo.define('web.ControlPanel', function (require) {
         views: Array,
         withBreadcrumbs: Boolean,
         withSearchBar: Boolean,
+        withViewSwitcher: Boolean,
     };
     ControlPanel.template = 'web.ControlPanel';
 

--- a/addons/web/static/src/js/views/abstract_controller.js
+++ b/addons/web/static/src/js/views/abstract_controller.js
@@ -61,6 +61,7 @@ var AbstractController = mvc.Controller.extend(ActionMixin, {
         this.dp = new concurrency.DropPrevious();
 
         this.withControlPanel = params.withControlPanel;
+        this.withControlPanelButtons = params.withControlPanelButtons;
         this.withSearchPanel = params.withSearchPanel;
         if (params.searchModel) {
             this.searchModel = params.searchModel;

--- a/addons/web/static/src/js/views/abstract_view.js
+++ b/addons/web/static/src/js/views/abstract_view.js
@@ -54,6 +54,10 @@ var AbstractView = Factory.extend({
     searchMenuTypes: ['filter', 'groupBy', 'favorite'],
     // determines if a control panel should be instantiated
     withControlPanel: true,
+    // determines if a buttons are available
+    withControlPanelButtons: true,
+    // determines if a view switcher buttons are available
+    withViewSwitcher: true,
     // determines if a search panel could be instantiated
     withSearchPanel: true,
     // determines the MVC components to use
@@ -151,6 +155,7 @@ var AbstractView = Factory.extend({
             isEmbedded: isEmbedded,
             modelName: params.modelName,
             viewType: this.viewType,
+            withControlPanelButtons: params.withControlPanelButtons,
         };
 
         var controllerState = params.controllerState || {};
@@ -259,6 +264,7 @@ var AbstractView = Factory.extend({
                 ),
                 withBreadcrumbs: params.withBreadcrumbs,
                 withSearchBar: params.withSearchBar,
+                withViewSwitcher: params.withViewSwitcher,
             };
             this.controllerParams.controlPanel = {
                 Component: ControlPanelComponent,
@@ -386,6 +392,8 @@ var AbstractView = Factory.extend({
             searchMenuTypes: inline ? [] : this.searchMenuTypes,
             withBreadcrumbs: 'no_breadcrumbs' in context ? !context.no_breadcrumbs : true,
             withControlPanel: this.withControlPanel,
+            withControlPanelButtons: this.withControlPanelButtons,
+            withViewSwitcher: this.withViewSwitcher,
             withSearchBar: inline ? false : this.withSearchBar,
             withSearchPanel: this.withSearchPanel,
         };

--- a/addons/web/static/src/js/views/list/list_controller.js
+++ b/addons/web/static/src/js/views/list/list_controller.js
@@ -25,7 +25,6 @@ var ListController = BasicController.extend({
      */
     buttons_template: 'ListView.buttons',
     events: _.extend({}, BasicController.prototype.events, {
-        'click .o_list_export_xlsx': '_onDirectExportData',
         'click .o_list_select_domain': '_onSelectDomain',
     }),
     custom_events: _.extend({}, BasicController.prototype.custom_events, {
@@ -120,7 +119,7 @@ var ListController = BasicController.extend({
      * @override
      */
     renderButtons: function ($node) {
-        if (this.noLeaf || !this.hasButtons) {
+        if (this.noLeaf || !this.withControlPanelButtons || !this.hasButtons) {
             this.hasButtons = false;
             this.$buttons = $('<div>');
         } else {
@@ -136,6 +135,7 @@ var ListController = BasicController.extend({
             });
             this.$buttons.on('mousedown', '.o_list_button_discard', this._onDiscardMousedown.bind(this));
             this.$buttons.on('click', '.o_list_button_discard', this._onDiscard.bind(this));
+            this.$buttons.on('click', '.o_list_export_xlsx', this._onDirectExportData.bind(this));
         }
         if ($node) {
             this.$buttons.appendTo($node);

--- a/addons/web/static/src/js/views/list/list_view.js
+++ b/addons/web/static/src/js/views/list/list_view.js
@@ -121,6 +121,9 @@ var ListView = BasicView.extend({
         var inDialog = action.target === 'new';
         var inline = action.target === 'inline';
         params.hasActionMenus = !inDialog && !inline;
+        params.withBreadcrumbs = !inDialog;
+        params.withControlPanelButtons = !inDialog;
+        params.withViewSwitcher = !inDialog;
         return params;
     },
     /**

--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -73,7 +73,7 @@
                 <div class="o_cp_pager" role="search" t-ref="pager">
                     <Pager t-if="props.pager and props.pager.limit" t-props="props.pager"/>
                 </div>
-                <nav t-if="props.views.length gt 1" class="btn-group o_cp_switch_buttons" role="toolbar" aria-label="View switcher">
+                <nav t-if="props.withViewSwitcher and props.views.length gt 1" class="btn-group o_cp_switch_buttons" role="toolbar" aria-label="View switcher">
                     <t t-foreach="props.views" t-as="view" t-key="view.type">
                         <t t-call="web.ViewSwitcherButton"/>
                     </t>

--- a/addons/web/static/tests/chrome/action_manager_tests.js
+++ b/addons/web/static/tests/chrome/action_manager_tests.js
@@ -3920,6 +3920,55 @@ QUnit.module('ActionManager', {
         actionManager.destroy();
     });
 
+    QUnit.test('listview in dialog shows buttons in the dialog footer and do not show breadcrumbs', async function (assert) {
+        assert.expect(5);
+
+        this.actions.push({
+            id: 21,
+            name: 'Partner List',
+            res_model: 'partner',
+            target: 'new',
+            type: 'ir.actions.act_window',
+            views: [[1, 'list']],
+        });
+
+        this.archs['partner,1,list'] = `
+            <tree>
+                <header>
+                    <button name="test" type="object" string="Test"/>
+                </header>
+                <field name="foo"/>
+            </tree>
+        `;
+
+        const actionManager = await createActionManager({
+            actions: this.actions,
+            archs: this.archs,
+            data: this.data,
+        });
+        await actionManager.doAction(21);
+
+        // check breadcrumb in control panel in wizard in case of listview
+        assert.strictEqual($('.o_technical_modal .modal-body .o_control_panel .breadcrumb-item').length, 0,
+            "the breadcrumbs should not be in the wizard with listview");
+
+        // check view switcher in control panel in wizard in case of listview
+        assert.strictEqual($('.o_technical_modal .modal-body .o_control_panel .o_cp_switch_buttons').length, 0,
+            "the view switcher should not be in the wizard with listview");
+
+        assert.strictEqual($('.o_technical_modal .modal-body .o_list_buttons').length, 0,
+            "the button should not be in the body");
+        assert.strictEqual($('.o_technical_modal .modal-footer button').length, 0,
+            "the button should not be there in the footer initially");
+
+        // select a record
+        await testUtils.dom.click($('.o_technical_modal .o_data_row .o_list_record_selector input:first'));
+        assert.strictEqual($('.o_technical_modal .modal-footer button').length, 1,
+            "one button should be there in the footer");
+
+        actionManager.destroy();
+    });
+
     QUnit.test("Button with `close` attribute closes dialog", async function (assert) {
         assert.expect(2);
         const actions = [


### PR DESCRIPTION
PURPOSE
Have an action in target new, spawning a full blown list view inside a modal, The create button is at two places: in the controlPanel, and in the modal's footer, buttons should be only in footer.

SPEC
Do not display buttons at footer and control panel, only display buttons at wizard dialog footer.

TASK 2300515



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
