### PR TITLE
[IMP]sale : apply pricelist when re-invoicing at cost

### DIFF
--- a/addons/sale_timesheet/tests/test_reinvoice.py
+++ b/addons/sale_timesheet/tests/test_reinvoice.py
@@ -39,6 +39,7 @@ class TestReInvoice(TestCommonSaleTimesheet):
             'analytic_account_id': cls.analytic_account.id,
             'pricelist_id': cls.company_data['default_pricelist'].id,
         })
+        cls.partner_a.property_product_pricelist = cls.company_data['default_pricelist'].id
 
         cls.Invoice = cls.env['account.move'].with_context(mail_notrack=True, mail_create_nolog=True)
 


### PR DESCRIPTION
PURPOSE
--------
When confirming the vendor bill for a re-invoiceable product, it can be
re-invoiced:
  - at sales price (i.e. the sales price set on the product form)
  - at cost (i.e. the amount actually billed on the vendor bill line)

Assume the following:
  Product A has a sales price of 1500€ set on its product form
  Product A is billed at 1000€ and is re-invoiced on an SO
  The pricelist set on the SO offers a 20% discount on Product A

With this example, currently:
  - re-invoicing at sales price will re-invoice at 1200€
    the price list is taken into account
  - re-invoicing at cost will re-invoice at 1000€
    the price list is not taken into account

Currently, the user is not able to configure his pricelists and expenses
in order to set a margin/discount on items re-invoiced at billed cost.

After this commit, pricelists and expenses also configure in the
re-invoice product with expense_policy = 'cost'.

Task-Id: 2366928
PR: #61626

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
