### PR TITLE
[13.0][IMP] stock_landed_costs - allow inheritance on cost line vals

### DIFF
--- a/addons/stock_landed_costs/models/__init__.py
+++ b/addons/stock_landed_costs/models/__init__.py
@@ -9,3 +9,4 @@ from . import stock_landed_cost
 from . import account_move
 from . import stock_valuation_layer
 
+from . import account_move_line

--- a/addons/stock_landed_costs/models/account_move.py
+++ b/addons/stock_landed_costs/models/account_move.py
@@ -27,13 +27,7 @@ class AccountMove(models.Model):
 
         landed_costs = self.env['stock.landed.cost'].create({
             'vendor_bill_id': self.id,
-            'cost_lines': [(0, 0, {
-                'product_id': l.product_id.id,
-                'name': l.product_id.name,
-                'account_id': l.product_id.product_tmpl_id.get_product_accounts()['stock_input'].id,
-                'price_unit': l.currency_id._convert(l.price_subtotal, l.company_currency_id, l.company_id, l.move_id.date),
-                'split_method': 'equal',
-            }) for l in landed_costs_lines],
+            'cost_lines': [(0, 0, l._get_cost_line_vals()) for l in landed_costs_lines],
         })
         action = self.env.ref('stock_landed_costs.action_stock_landed_cost').read()[0]
         return dict(action, view_mode='form', res_id=landed_costs.id, views=[(False, 'form')])

--- a/addons/stock_landed_costs/models/account_move_line.py
+++ b/addons/stock_landed_costs/models/account_move_line.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models, _
+
+
+class AccountMoveLine(models.Model):
+
+    _inherit = 'account.move.line'
+
+    def _get_cost_line_vals(self):
+        self.ensure_one()
+        return {
+            'product_id': self.product_id.id,
+            'name': self.product_id.name,
+            'account_id': self.product_id.product_tmpl_id.get_product_accounts()[
+                'stock_input'].id,
+            'price_unit': self.currency_id._convert(
+                self.price_subtotal,
+                self.company_currency_id,
+                self.company_id,
+                self.move_id.date),
+            'split_method': 'equal',
+        }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When creating landed costs from a vendor bill, it is impossible at the moment to add values to the new cost lines. This pr fixes this.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
