### PR TITLE
[FIX] base, website: fix no web translation on duplicates

### DIFF
--- a/odoo/addons/base/models/ir_translation.py
+++ b/odoo/addons/base/models/ir_translation.py
@@ -101,9 +101,18 @@ class IrTranslationImport(object):
                            WHERE type = 'code'
                            AND noupdate IS NOT TRUE
                            ON CONFLICT (type, lang, md5(src)) WHERE type = 'code'
-                            DO UPDATE SET (name, lang, res_id, src, type, value, module, state, comments) = (EXCLUDED.name, EXCLUDED.lang, EXCLUDED.res_id, EXCLUDED.src, EXCLUDED.type, EXCLUDED.value, EXCLUDED.module, EXCLUDED.state, EXCLUDED.comments)
+                            DO UPDATE SET
+                              name=EXCLUDED.name,
+                              lang=EXCLUDED.lang,
+                              res_id=EXCLUDED.res_id,
+                              src=EXCLUDED.src,
+                              type=EXCLUDED.type,
+                              value=EXCLUDED.value,
+                              module=EXCLUDED.module,
+                              state=EXCLUDED.state,
+                              comments=CASE WHEN %s.comments='' THEN EXCLUDED.comments ELSE %s.comments END
                             WHERE EXCLUDED.value IS NOT NULL AND EXCLUDED.value != '';
-                       """ % (self._model_table, self._table))
+                       """ % (self._model_table, self._table, self._model_table, self._model_table))
             count += cr.rowcount
             cr.execute(""" INSERT INTO %s(name, lang, res_id, src, type, value, module, state, comments)
                            SELECT name, lang, res_id, src, type, value, module, state, comments


### PR DESCRIPTION
TLDR: if we have a term in python and js code, then js translation may not work

STEPS:

* install point_of_sale
* activate and switch to French translation
* go to "Point of sale >> Reporting >> Orders"
* Click "Time Ranges >> Range"

BEFORE: "This Week" is not translated

AFTER: All terms are translated

WHY:

* Translation imports merges translation if they have same src

  https://github.com/odoo/odoo/blob/1e39a2d3b8060963073a39d99ba3a14b07d03333/odoo/addons/base/models/ir_translation.py#L196
  https://github.com/odoo/odoo/blob/1e39a2d3b8060963073a39d99ba3a14b07d03333/odoo/addons/base/models/ir_translation.py#L111

  So, we get either js term for "This Week" or py term, but not both

* web/webclient/translations loads only translation with comments==openerp-web

  https://github.com/odoo/odoo/blob/1e39a2d3b8060963073a39d99ba3a14b07d03333/odoo/addons/base/models/ir_translation.py#L900

  So, if we don't have js term, then the translation is not loaded to UI

* This only fix problem of no translation, but doesn't fix overriden
translation (i.e. when same english term, e.g. Free, has different translation
in frontend and backend). This part can be fixed by changing english term to
something more unambiguous.
---

opw-2357399

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
