### PR TITLE
[FIX] doc: corrected cr.execute example

### DIFF
--- a/doc/reference/orm.rst
+++ b/doc/reference/orm.rst
@@ -518,7 +518,7 @@ cursor for the current database transaction and allows executing SQL directly,
 either for queries which are difficult to express using the ORM (e.g. complex
 joins) or for performance reasons::
 
-    self.env.cr.execute("some_sql", param1, param2, param3)
+    self.env.cr.execute("some_sql", params)
 
 Because models use the same cursor and the :class:`~odoo.api.Environment`
 holds various caches, these caches must be invalidated when *altering* the


### PR DESCRIPTION
For SQL parameters `execute` takes a single argument with a list, tuple
or dict, not multiple arguments.

`execute` isn't explicitly documented here, and that might have been on purpose, so I did not expand further on its arguments. That being said, if we were to document it properly, this might be a good spot. Thoughts?