### PR TITLE
[IMP] Account: allow to displays the line currency when exporting to csv

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2878,6 +2878,8 @@ class AccountMoveLine(models.Model):
     date_maturity = fields.Date(string='Due Date', index=True, tracking=True,
         help="This field is used for payable and receivable journal entries. You can put the limit date for the payment of this line.")
     currency_id = fields.Many2one('res.currency', string='Currency', required=True)
+    currency_symbol = fields.Char(related='currency_id.symbol', string='Line currency', readonly=True,
+                                  help='The currency of this line. Can be used to display it when exporting to csv.')
     partner_id = fields.Many2one('res.partner', string='Partner', ondelete='restrict')
     product_uom_id = fields.Many2one('uom.uom', string='Unit of Measure', domain="[('category_id', '=', product_uom_category_id)]")
     product_id = fields.Many2one('product.product', string='Product')

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -153,6 +153,7 @@
                     <field name="debit" sum="Total Debit"/>
                     <field name="credit" sum="Total Credit"/>
                     <field name="amount_currency" groups="base.group_multi_currency" optional="hide"/>
+                    <field name="currency_symbol" groups="base.group_multi_currency" optional="hide"/>
                     <field name="tax_tag_ids" widget="many2many_tags" width="0.5" optional="hide"/>
                     <field name="matching_number" optional="show"/>
                     <field name="reconcile_model_id" invisible="1"/>
@@ -191,6 +192,7 @@
                     <field name="credit" sum="Total Credit" readonly="1"/>
                     <field name="balance" sum="Total Balance" readonly="1" optional="hide"/>
                     <field name="amount_currency" readonly="1" groups="base.group_multi_currency"/>
+                    <field name="currency_symbol" groups="base.group_multi_currency" optional="hide"/>
                     <field name="currency_id" readonly="1" invisible="1" />
                     <field name="company_currency_id" invisible="1"/>
                     <field name="parent_state" invisible="1"/>


### PR DESCRIPTION
Currently, when exporting move lines via for example the partner ledger,
 we are not displaying the currency in any way in the CSV.

This will add an optional field in the list view of the aml which
contains the currency symbol, which will then be exported into the CSV.

task id #2381355

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
