### PR TITLE
[13.0][FIX] point_of_sale: worker serves invalid index page

### DIFF
--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -6,6 +6,7 @@ import werkzeug.utils
 from odoo import http
 from odoo.http import request
 from odoo.osv.expression import AND
+from odoo.tools import config
 
 _logger = logging.getLogger(__name__)
 
@@ -53,6 +54,15 @@ class PosController(http.Controller):
             'session_info': session_info,
             'login_number': pos_session.login(),
         }
+
+        # we commit the assetbundles attachments to make sure
+        # that this worker's cached version of point_of_sale.index
+        # remains valid even in case of concurrency error
+        if not config['test_enable']:
+            ctx = dict(request.context)
+            ctx['commit_assetsbundle'] = True
+            request.context = ctx
+
         return request.render('point_of_sale.index', qcontext=context)
 
     @http.route('/pos/sale_details_report', type='http', auth='user')


### PR DESCRIPTION
**Issue**

In some corner cases, user faces a black screen when opening the POS:

![pos_404](https://user-images.githubusercontent.com/511258/99261500-63fd3c80-284f-11eb-9046-f30409a591ae.png)

Reloading the page might save him, but not always as the worker initially involved will continue to serve an invalid cached version of the POS page index.

**Steps to reproduce**

- Delete pos assetbundles from db: `DELETE FROM ir_attachment WHERE url LIKE '/web/content/%/point_of_sale.%'` (to simulate a situation where they would need to be regenerated)
- Restart instance (to get fresh workers with no qweb cache)
- Open the same POS twice in parallel: `/pos/web?config_id=1#action=pos.ui&cids=1`

One of the tab will show you the black screen above.

This is because the request faced a concurrency error:

```
2020-11-16 12:34:38,302 39 INFO v13c_native werkzeug: 172.18.0.1 - - [16/Nov/2020 12:34:38] "GET /pos/web?config_id=1 HTTP/1.0" 200 -
2020-11-16 12:34:38,304 40 ERROR v13c_native odoo.sql_db: bad query: UPDATE "pos_session" SET "write_uid"=2,"login_number"=2,"write_date"=(now() at t
ime zone 'UTC') WHERE id IN (1)
ERROR: could not serialize access due to concurrent update

2020-11-16 12:34:38,304 40 INFO v13c_native odoo.service.model: SERIALIZATION_FAILURE, retry 1/5 in 0.4020 sec...
2020-11-16 12:34:38,755 40 INFO v13c_native werkzeug: 172.18.0.1 - - [16/Nov/2020 12:34:38] "GET /pos/web?config_id=1 HTTP/1.0" 200 -
```

On POS opening, [`login_number` is incremented on the `pos.session`](https://github.com/odoo/odoo/blob/1d1281bc/addons/point_of_sale/controllers/main.py#L54), so this concurrency error is normal. And as expected, the call is retried.

But because the qweb cache has not been cleared before second try, the response will serve a bogus cached version of `_get_asset_nodes` for the `point_of_sale` assetbundles. This version contain references to attachments that have not been committed to the db, hence the 404 errors:

```
2020-11-16 12:34:46,166 40 INFO v13c_native werkzeug: 172.18.0.1 - - [16/Nov/2020 12:34:46] "GET /web/content/749-382da9f/point_of_sale.assets.css HTT
P/1.0" 404 -
2020-11-16 12:34:46,174 40 INFO v13c_native werkzeug: 172.18.0.1 - - [16/Nov/2020 12:34:46] "GET /web/content/750-382da9f/point_of_sale.assets.js HTTP
/1.0" 404 -
(...)
```

Note that other scenarios can lead to the same outcome:
- a user opens the POS
- while in parallel, the same `pos.session` is being manipulated, e.g. with [`cash_journal_id`, `cash_register_id` being recomputed and stored](https://github.com/odoo/odoo/blob/1d1281bc/addons/point_of_sale/models/pos_session.py#L55).

**Solution**

- It would not be efficient to clear qweb caches every time there is a concurrency error.
- Doing it based on the path could be an option, in [checked_call()](https://github.com/odoo/odoo/blob/1d1281bc/odoo/http.py#L335)
```
if self.httprequest.path == "/pos/web":
    self.env["ir.qweb"].clear_caches()
```
- But this PR implements a more satisfying solution: commit the assetbundles to the db.
  - No invalid cache anymore.
  - There might be redundant attachments in the db for the same bundles until next regeneration, but it's not a big deal and it's [properly handled by odoo](https://github.com/odoo/odoo/blob/1d1281bc/odoo/addons/base/models/assetsbundle.py#L244).

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
