### PR TITLE
[FIX] *: add missig groups_id attribute

### DIFF
--- a/addons/account/views/res_partner_bank_views.xml
+++ b/addons/account/views/res_partner_bank_views.xml
@@ -18,6 +18,7 @@
         <record id="action_new_bank_setting" model="ir.actions.server">
             <field name="name">Add a Bank Account</field>
             <field name="model_id" ref="model_res_company"/>
+            <field name="groups_id" eval="[(4, ref('account.group_account_manager'))]"/>
             <field name="state">code</field>
             <field name="code">
 action = model.setting_init_bank_account_action()


### PR DESCRIPTION
- action_new_bank_setting is called from the menu
  menu_action_account_bank_journal_form which has
  group_account_manager restriction
