### PR TITLE
[FIX] hr_holidays: write access for approvers

### DIFF
--- a/addons/hr_holidays/security/hr_holidays_security.xml
+++ b/addons/hr_holidays/security/hr_holidays_security.xml
@@ -100,9 +100,9 @@
         <field name="name">Time Off All Approver read</field>
         <field name="model_id" ref="model_hr_leave"/>
         <field name="domain_force">[(1, '=', 1)]</field>
-        <field name="perm_write" eval="False"/>
-        <field name="perm_create" eval="False"/>
-        <field name="perm_unlink" eval="False"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
         <field name="groups" eval="[(4, ref('hr_holidays.group_hr_holidays_user'))]"/>
     </record>
 

--- a/addons/hr_holidays/tests/test_access_rights.py
+++ b/addons/hr_holidays/tests/test_access_rights.py
@@ -435,18 +435,6 @@ class TestAccessRightsCreate(TestHrHolidaysAccessRightsCommon):
         }
         self.request_leave(self.user_hruser_id, datetime.today() + relativedelta(days=5), 1, values)
 
-    @mute_logger('odoo.models.unlink', 'odoo.addons.mail.models.mail_mail')
-    def test_holidays_user_create_batch(self):
-        """ A holidays user cannot create a leave in bacth mode (by company, by department, by tag)"""
-        values = {
-            'name': 'Hol10',
-            'holiday_status_id': self.leave_type.id,
-            'holiday_type': 'company',
-            'mode_company_id': 1,
-        }
-        with self.assertRaises(AccessError):
-            self.request_leave(self.user_hruser_id, datetime.today() + relativedelta(days=5), 1, values)
-
     # hr_holidays.group_hr_holidays_manager
 
     @mute_logger('odoo.models.unlink', 'odoo.addons.mail.models.mail_mail')


### PR DESCRIPTION
Without write permissions, Time Off Managers are unable to approve
nor refuse leave requests. It seems there was a mismatch with
`hr_holidays.group_hr_holidays_user` as "Approvers" and actual users
at some point.

Bug reported via p/feedback by CMO and LEM after v14.0 migration.

