### PR TITLE
[IMP] improve performance of `_compute_forecast_information`

### DIFF
--- a/addons/mrp/__init__.py
+++ b/addons/mrp/__init__.py
@@ -5,6 +5,7 @@ from . import models
 from . import wizard
 from . import report
 from . import controller
+from . import populate
 
 from odoo import api, SUPERUSER_ID
 

--- a/addons/mrp/populate/__init__.py
+++ b/addons/mrp/populate/__init__.py
@@ -1,7 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import controllers
-from . import models
-from . import report
-from . import populate
+from . import mrp

--- a/addons/mrp/populate/mrp.py
+++ b/addons/mrp/populate/mrp.py
@@ -1,0 +1,382 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+from collections import defaultdict
+
+from odoo import models
+from odoo.tools import populate, OrderedSet
+from odoo.addons.stock.populate.stock import COMPANY_NB_WITH_STOCK
+
+_logger = logging.getLogger(__name__)
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    def _populate_factories(self):
+        return super()._populate_factories() + [
+            ('manufacturing_lead', populate.randint(0, 2)),
+        ]
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    def _populate_factories(self):
+        return super()._populate_factories() + [
+            ('produce_delay', populate.randint(1, 4)),
+        ]
+
+
+class Warehouse(models.Model):
+    _inherit = 'stock.warehouse'
+
+    def _populate_factories(self):
+        return super()._populate_factories() + [
+            ('manufacture_steps', populate.iterate(['mrp_one_step', 'pbm', 'pbm_sam'], [0.6, 0.2, 0.2]))
+        ]
+
+
+# TODO : stock picking type manufacturing
+
+
+class MrpBom(models.Model):
+    _inherit = 'mrp.bom'
+
+    _populate_sizes = {'small': 100, 'medium': 2_000, 'large': 20_000}
+    _populate_dependencies = ['product.product', 'stock.location']
+
+    def _populate_factories(self):
+        company_ids = self.env.registry.populated_models['res.company'][:COMPANY_NB_WITH_STOCK]
+
+        product_tmpl_ids = self.env['product.product'].search([
+            ('id', 'in', self.env.registry.populated_models['product.product']),
+            ('type', 'in', ('product', 'consu'))
+        ]).product_tmpl_id.ids
+        # Use only a 80 % subset of the products - the 20 % remaining will leaves of the bom tree
+        random = populate.Random('subset_product_bom')
+        product_tmpl_ids = random.sample(product_tmpl_ids, int(len(product_tmpl_ids) * 0.8))
+
+        def get_product_id(values=None, random=None, **kwargs):
+            if random.random() > 0.5:  # 50 % change to target specific product.product
+                return False
+            return random.choice(self.env['product.template'].browse(values['product_tmpl_id']).product_variant_ids.ids)
+
+        return [
+            ('company_id', populate.randomize(
+                [False] + company_ids,
+                [0.9] + [0.1 / (len(company_ids) or 1.0)] * (len(company_ids))  # TODO: Inverse the weight, but need to make the bom tree by company (in bom line populate)
+            )),
+            ('product_tmpl_id', populate.randomize(product_tmpl_ids)),
+            ('product_id', populate.compute(get_product_id)),
+            ('product_qty', populate.randint(1, 5)),
+            ('sequence', populate.randint(1, 1000)),
+            ('code', populate.constant("R{counter}")),
+            ('ready_to_produce', populate.randomize(['all_available', 'asap'])),
+        ]
+
+
+class MrpBomLine(models.Model):
+    _inherit = 'mrp.bom.line'
+
+    _populate_sizes = {'small': 500, 'medium': 10_000, 'large': 100_000}
+    _populate_dependencies = ['mrp.bom']
+
+    def _populate_factories(self):
+        # TODO: tree of product by company to be more closer to the reality
+        boms = self.env['mrp.bom'].search([('id', 'in', self.env.registry.populated_models['mrp.bom'])], order='sequence, product_id')
+
+        product_manu_ids = OrderedSet()
+        for bom in boms:
+            if bom.product_id:
+                product_manu_ids.add(bom.product_id.id)
+            else:
+                for product_id in bom.product_tmpl_id.product_variant_ids:
+                    product_manu_ids.add(product_id.id)
+        product_manu_ids = list(product_manu_ids)
+        product_manu = self.env['product.product'].browse(product_manu_ids)
+        # product_no_manu is products which don't have any bom (leaves in the BoM trees)
+        product_no_manu = self.env['product.product'].browse(self.env.registry.populated_models['product.product']) - product_manu
+        product_no_manu_ids = product_no_manu.ids
+
+        def get_product_id(values, counter, random):
+            bom = self.env['mrp.bom'].browse(values['bom_id'])
+            last_product_bom = bom.product_id if bom.product_id else bom.product_tmpl_id.product_variant_ids[-1]
+            # TODO: index in list is in O(n) can be avoid by a cache dict (if performance issue)
+            index_prod = product_manu_ids.index(last_product_bom.id)
+            # Always choose a product futher in the recordset `product_manu` to avoid any loops
+            # Or used a product in the `product_no_manu`
+
+            sparsity = 0.4  # Increase the sparsity will decrease the density of the BoM trees => smaller Tree
+
+            len_remaining_manu = len(product_manu_ids) - index_prod - 1
+            len_no_manu = len(product_no_manu_ids)
+            threshold = len_remaining_manu / (len_remaining_manu + sparsity * len_no_manu)
+            if random.random() <= threshold:
+                # TODO: avoid copy the list (if performance issue)
+                return random.choice(product_manu_ids[index_prod+1:])
+            else:
+                return random.choice(product_no_manu_ids)
+
+        def get_product_uom_id(values, counter, random):
+            return self.env['product.product'].browse(values['product_id']).uom_id.id
+
+        return [
+            ('bom_id', populate.iterate(boms.ids)),
+            ('sequence', populate.randint(1, 1000)),
+            ('product_id', populate.compute(get_product_id)),
+            ('product_uom_id', populate.compute(get_product_uom_id)),
+            ('product_qty', populate.randint(1, 10)),
+        ]
+
+
+class MrpWorkcenter(models.Model):
+    _inherit = 'mrp.workcenter'
+
+    _populate_sizes = {'small': 20, 'medium': 100, 'large': 1_000}
+
+    def _populate(self, size):
+        res = super()._populate(size)
+
+        # Set alternative workcenters
+        _logger.info("Set alternative workcenters")
+        # Valid workcenters by company_id (the workcenter without company can be the alternative of all workcenter)
+        workcenters_by_company = defaultdict(OrderedSet)
+        for workcenter in res:
+            workcenters_by_company[workcenter.company_id.id].add(workcenter.id)
+        workcenters_by_company = {company_id: self.env['mrp.workcenter'].browse(workcenters) for company_id, workcenters in workcenters_by_company.items()}
+        workcenters_by_company = {
+            company_id: workcenters | workcenters_by_company.get(False, self.env['mrp.workcenter'])
+            for company_id, workcenters in workcenters_by_company.items()}
+
+        random = populate.Random('set_alternative_workcenter')
+        for workcenter in res:
+            nb_alternative = max(random.randint(0, 3), len(workcenters_by_company[workcenter.company_id.id]) - 1)
+            if nb_alternative > 0:
+                alternatives_workcenter_ids = random.sample((workcenters_by_company[workcenter.company_id.id] - workcenter).ids, nb_alternative)
+                workcenter.alternative_workcenter_ids = [(6, 0, alternatives_workcenter_ids)]
+
+        return res
+
+    def _populate_factories(self):
+        company_ids = self.env.registry.populated_models['res.company'][:COMPANY_NB_WITH_STOCK]
+        resource_calendar_no_company = self.env.ref('resource.resource_calendar_std').copy({'company_id': False})
+
+        def get_resource_calendar_id(values, counter, random):
+            if not values['company_id']:
+                return resource_calendar_no_company.id
+            return self.env['res.company'].browse(values['company_id']).resource_calendar_id.id
+
+        return [
+            ('name', populate.constant("Workcenter - {counter}")),
+            ('company_id', populate.iterate(company_ids + [False])),
+            ('resource_calendar_id', populate.compute(get_resource_calendar_id)),
+            ('active', populate.iterate([True, False], [0.9, 0.1])),
+            ('code', populate.constant("W/{counter}")),
+            ('capacity', populate.iterate([0.5, 1.0, 2.0, 5.0], [0.2, 0.4, 0.2, 0.2])),
+            ('sequence', populate.randint(1, 1000)),
+            ('color', populate.randint(1, 12)),
+            ('costs_hour', populate.randint(5, 25)),
+            ('time_start', populate.iterate([0.0, 2.0, 10.0], [0.6, 0.2, 0.2])),
+            ('time_stop', populate.iterate([0.0, 2.0, 10.0], [0.6, 0.2, 0.2])),
+            ('oee_target', populate.randint(80, 99)),
+        ]
+
+
+class MrpRoutingWorkcenter(models.Model):
+    _inherit = 'mrp.routing.workcenter'
+
+    _populate_sizes = {'small': 500, 'medium': 5_000, 'large': 50_000}
+    _populate_dependencies = ['mrp.workcenter', 'mrp.bom']
+
+    def _populate_factories(self):
+        # Take a subset (70%) of bom to have some of then without any operation
+        random = populate.Random('operation_subset_bom')
+        boms_ids = self.env.registry.populated_models['mrp.bom']
+        boms_ids = random.sample(boms_ids, int(len(boms_ids) * 0.7))
+
+        # Valid workcenters by company_id (the workcenter without company can be used by any operation)
+        workcenters_by_company = defaultdict(OrderedSet)
+        for workcenter in self.env['mrp.workcenter'].browse(self.env.registry.populated_models['mrp.workcenter']):
+            workcenters_by_company[workcenter.company_id.id].add(workcenter.id)
+        workcenters_by_company = {company_id: self.env['mrp.workcenter'].browse(workcenters) for company_id, workcenters in workcenters_by_company.items()}
+        workcenters_by_company = {
+            company_id: workcenters | workcenters_by_company.get(False, self.env['mrp.workcenter'])
+            for company_id, workcenters in workcenters_by_company.items()}
+
+        def get_company_id(values, counter, random):
+            bom = self.env['mrp.bom'].browse(values['bom_id'])
+            return bom.company_id.id
+
+        def get_workcenter_id(values, counter, random):
+            return random.choice(workcenters_by_company[values['company_id']]).id
+
+        return [
+            ('bom_id', populate.iterate(boms_ids)),
+            ('company_id', populate.compute(get_company_id)),
+            ('workcenter_id', populate.compute(get_workcenter_id)),
+            ('name', populate.constant("OP-{counter}")),
+            ('sequence', populate.randint(1, 1000)),
+            ('time_mode', populate.iterate(['auto', 'manual'])),
+            ('time_mode_batch', populate.randint(1, 100)),
+            ('time_cycle_manual', populate.randomize([1.0, 15.0, 60.0, 1440.0])),
+        ]
+
+
+class MrpProduction(models.Model):
+    _inherit = 'mrp.production'
+
+    _populate_sizes = {'small': 100, 'medium': 1_000, 'large': 10_000}
+    _populate_dependencies = ['mrp.routing.workcenter', 'mrp.bom.line']
+
+    def _populate(self, size):
+        productions = super()._populate(size)
+
+        def fill_mo_with_bom_info():
+            productions_with_bom = productions.filtered('bom_id')
+            _logger.info("Create Raw moves of MO(s) with bom (%d)" % len(productions_with_bom))
+            self.env['stock.move'].create(productions_with_bom._get_moves_raw_values())
+            _logger.info("Create Finished moves of MO(s) with bom (%d)" % len(productions_with_bom))
+            self.env['stock.move'].create(productions_with_bom._get_moves_finished_values())
+            _logger.info("Create Workorder moves of MO(s) with bom (%d)" % len(productions_with_bom))
+            productions_with_bom._create_workorder()
+
+        fill_mo_with_bom_info()
+
+        def confirm_bom_mo(sample_ratio):
+            # Confirm X % of prototype MO
+            random = populate.Random('confirm_bom_mo')
+            mo_ids = productions.filtered('bom_id').ids
+            mo_to_confirm = self.env['mrp.production'].browse(random.sample(mo_ids, int(len(mo_ids) * 0.8)))
+            _logger.info("Confirm %d MO with BoM" % len(mo_to_confirm))
+            mo_to_confirm.action_confirm()
+
+        # Uncomment this line to confirm a part of MO, can be useful to check performance
+        # confirm_bom_mo(0.8)
+
+        return productions
+
+    def _populate_factories(self):
+        company_ids = self.env.registry.populated_models['res.company'][:COMPANY_NB_WITH_STOCK]
+
+        products = self.env['product.product'].browse(self.env.registry.populated_models['product.product'])
+        product_ids = products.filtered(lambda product: product.type in ('product', 'consu')).ids
+
+        boms = self.env['mrp.bom'].browse(self.env.registry.populated_models['mrp.bom'])
+        boms_by_company = defaultdict(OrderedSet)
+        for bom in boms:
+            boms_by_company[bom.company_id.id].add(bom.id)
+        boms_by_company = {company_id: self.env['mrp.bom'].browse(boms) for company_id, boms in boms_by_company.items()}
+        boms_by_company = {
+            company_id: boms | boms_by_company.get(False, self.env['mrp.bom'])
+            for company_id, boms in boms_by_company.items()}
+
+        def get_bom_id(values, counter, random):
+            if random.random() > 0.7:  # 30 % of prototyping
+                return False
+            return random.choice(boms_by_company[values['company_id']]).id
+
+        def get_consumption(values, counter, random):
+            if not values['bom_id']:
+                return 'flexible'
+            return self.env['mrp.bom'].browse(values['bom_id']).consumption
+
+        def get_product_id(values, counter, random):
+            if not values['bom_id']:
+                return random.choice(product_ids)
+            bom = self.env['mrp.bom'].browse(values['bom_id'])
+            return bom.product_id.id or random.choice(bom.product_tmpl_id.product_variant_ids.ids)
+
+        def get_product_uom_id(values, counter, random):
+            product = self.env['product.product'].browse(values['product_id'])
+            return product.uom_id.id
+
+        # Fetch all stock picking type and group then by company_id
+        manu_picking_types = self.env['stock.picking.type'].search([('code', '=', 'mrp_operation')])
+        manu_picking_types_by_company_id = defaultdict(OrderedSet)
+        for picking_type in manu_picking_types:
+            manu_picking_types_by_company_id[picking_type.company_id.id].add(picking_type.id)
+        manu_picking_types_by_company_id = {company_id: list(picking_ids) for company_id, picking_ids in manu_picking_types_by_company_id.items()}
+
+        def get_picking_type_id(values, counter, random):
+            return random.choice(manu_picking_types_by_company_id[values['company_id']])
+
+        def get_location_src_id(values, counter, random):
+            # TODO : add some randomness
+            picking_type = self.env['stock.picking.type'].browse(values['picking_type_id'])
+            return picking_type.default_location_src_id.id
+
+        def get_location_dest_id(values, counter, random):
+            # TODO : add some randomness
+            picking_type = self.env['stock.picking.type'].browse(values['picking_type_id'])
+            return picking_type.default_location_dest_id.id
+
+        return [
+            ('company_id', populate.iterate(company_ids)),
+            ('bom_id', populate.compute(get_bom_id)),
+            ('consumption', populate.compute(get_consumption)),
+            ('product_id', populate.compute(get_product_id)),
+            ('product_uom_id', populate.compute(get_product_uom_id)),
+            ('product_qty', populate.randint(1, 10)),
+            ('picking_type_id', populate.compute(get_picking_type_id)),
+            ('location_src_id', populate.compute(get_location_src_id)),
+            ('location_dest_id', populate.compute(get_location_dest_id)),
+            ('priority', populate.iterate(['0', '1'], [0.95, 0.05])),
+        ]
+
+
+class StockMove(models.Model):
+    _inherit = 'stock.move'
+
+    _populate_dependencies = ['stock.picking', 'mrp.production']
+
+    def _populate(self, size):
+        moves = super()._populate(size)
+
+        def confirm_prototype_mo(sample_ratio):
+            # Confirm X % of prototype MO
+            random = populate.Random('confirm_prototype_mo')
+            mo_ids = moves.raw_material_production_id.ids
+            mo_to_confirm = self.env['mrp.production'].browse(random.sample(mo_ids, int(len(mo_ids) * 0.8)))
+            _logger.info("Confirm %d of prototype MO" % len(mo_to_confirm))
+            mo_to_confirm.action_confirm()
+
+        # (Un)comment this line to confirm a part of prototype MO, can be useful to check performance
+        # confirm_prototype_mo(0.8)
+
+        return moves.exists()  # Confirm Mo can unlink moves
+
+    def _populate_attach_record_weight(self):
+        fields, weight = super()._populate_attach_record_weight()
+        return fields + ['raw_material_production_id'], weight + [1]
+
+    def _populate_attach_record_generator(self):
+
+        productions = self.env['mrp.production'].browse(self.env.registry.populated_models['mrp.production'])
+        productions = productions.filtered(lambda prod: not prod.bom_id)
+
+        def next_production_id():
+            while productions:
+                yield from productions.ids
+
+        return {**super()._populate_attach_record_generator(), 'raw_material_production_id': next_production_id()}
+
+    def _populate_factories(self):
+
+        def _compute_production_values(iterator, field_name, model_name):
+            for values in iterator:
+
+                if values.get('raw_material_production_id'):
+                    production = self.env['mrp.production'].browse(values['raw_material_production_id'])
+                    values['location_id'] = production.location_src_id.id
+                    values['location_dest_id'] = production.production_location_id.id
+                    values['picking_type_id'] = production.picking_type_id.id
+                    values['name'] = production.name
+                    values['date'] = production.date_planned_start
+                    values['company_id'] = production.company_id.id
+                yield values
+
+        return super()._populate_factories() + [
+            ('_compute_production_values', _compute_production_values),
+        ]

--- a/addons/product/populate/product.py
+++ b/addons/product/populate/product.py
@@ -24,7 +24,7 @@ class ProductCategory(models.Model):
 
 class ProductProduct(models.Model):
     _inherit = "product.product"
-    _populate_sizes = {"small": 150, "medium": 5000, "large": 60000}
+    _populate_sizes = {"small": 500, "medium": 5000, "large": 60000}
 
     def _populate_factories(self):
 

--- a/addons/product/populate/product.py
+++ b/addons/product/populate/product.py
@@ -4,6 +4,7 @@ import logging
 
 from odoo import models
 from odoo.tools import populate
+from odoo.addons.stock.populate.stock import COMPANY_NB_WITH_STOCK
 
 _logger = logging.getLogger(__name__)
 
@@ -33,4 +34,35 @@ class ProductProduct(models.Model):
             ("description", populate.constant('product_template_description_{counter}')),
             ("default_code", populate.constant('product_default_code_{counter}')),
             ("active", populate.randomize([True, False], [0.8, 0.2])),
+        ]
+
+
+class SupplierInfo(models.Model):
+    _inherit = 'product.supplierinfo'
+
+    _populate_sizes = {'small': 450, 'medium': 15_000, 'large': 180_000}
+    _populate_dependencies = ['res.partner']
+
+    def _populate_factories(self):
+        random = populate.Random('product_with_supplierinfo')
+        company_ids = self.env.registry.populated_models['res.company'][:COMPANY_NB_WITH_STOCK] + [False]
+        partner_ids = self.env.registry.populated_models['res.partner']
+        product_templates_ids = self.env['product.product'].browse(self.env.registry.populated_models['product.product']).product_tmpl_id.ids
+        product_templates_ids = random.sample(product_templates_ids, int(len(product_templates_ids) * 0.95))
+
+        def get_company_id(values, counter, random):
+            partner = self.env['res.partner'].browse(values['name'])
+            if partner.company_id:
+                return partner.company_id.id
+            return random.choice(company_ids)
+
+        return [
+            ('name', populate.randomize(partner_ids)),
+            ('company_id', populate.compute(get_company_id)),
+            ('product_tmpl_id', populate.iterate(product_templates_ids)),
+            ('product_name', populate.constant("SI-{counter}")),
+            ('sequence', populate.randint(1, 10)),
+            ('min_qty', populate.randint(0, 10)),
+            ('price',  populate.randint(10, 100)),
+            ('delay',  populate.randint(1, 10)),
         ]

--- a/addons/purchase/populate/__init__.py
+++ b/addons/purchase/populate/__init__.py
@@ -1,7 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import controllers
-from . import models
-from . import report
-from . import populate
+from . import purchase

--- a/addons/purchase/populate/purchase.py
+++ b/addons/purchase/populate/purchase.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+from datetime import datetime, timedelta
+
+from odoo import models
+from odoo.tools import populate, groupby
+from odoo.addons.stock.populate.stock import COMPANY_NB_WITH_STOCK
+
+_logger = logging.getLogger(__name__)
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    def _populate_factories(self):
+        return super()._populate_factories() + [
+            ('po_lead', populate.randint(0, 2))
+        ]
+
+
+class PurchaseOrder(models.Model):
+    _inherit = 'purchase.order'
+
+    _populate_sizes = {'small': 100, 'medium': 1_500, 'large': 25_000}
+    _populate_dependencies = ['res.partner']
+
+    def _populate_factories(self):
+        now = datetime.now()
+
+        company_ids = self.env.registry.populated_models['res.company'][:COMPANY_NB_WITH_STOCK]
+        all_partners = self.env['res.partner'].browse(self.env.registry.populated_models['res.partner'])
+        partners_by_company = dict(groupby(all_partners, key=lambda par: par.company_id.id))
+        partners_inter_company = self.env['res.partner'].concat(*partners_by_company.get(False, []))
+        partners_by_company = {com: self.env['res.partner'].concat(*partners) | partners_inter_company for com, partners in partners_by_company.items() if com}
+
+        def get_date_order(values, counter, random):
+            # 95.45 % of picking scheduled between (-5, 10) days and follow a gauss distribution (only +-15% PO is late)
+            delta = random.gauss(5, 5)
+            return now + timedelta(days=delta)
+
+        def get_date_planned(values, counter, random):
+            # 95 % of PO Receipt Date between (1, 16) days after the order deadline and follow a exponential distribution
+            delta = random.expovariate(5) + 1
+            return values['date_order'] + timedelta(days=delta)
+
+        def get_partner_id(values, counter, random):
+            return random.choice(partners_by_company[values['company_id']]).id
+
+        def get_currency_id(values, counter, random):
+            company = self.env['res.company'].browse(values['company_id'])
+            return company.currency_id.id
+
+        return [
+            ('company_id', populate.randomize(company_ids)),
+            ('date_order', populate.compute(get_date_order)),
+            ('date_planned', populate.compute(get_date_planned)),
+            ('partner_id', populate.compute(get_partner_id)),
+            ('currency_id', populate.compute(get_currency_id)),
+        ]
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = 'purchase.order.line'
+
+    _populate_sizes = {'small': 500, 'medium': 7_500, 'large': 125_000}
+    _populate_dependencies = ['purchase.order', 'product.product']
+
+    def _populate_factories(self):
+
+        purchase_order_ids = self.env.registry.populated_models['purchase.order']
+        product_ids = self.env.registry.populated_models['product.product']
+
+        def get_product_uom(values, counter, random):
+            product = self.env['product.product'].browse(values['product_id'])
+            return product.uom_id.id
+
+        def get_date_planned(values, counter, random):
+            po = self.env['purchase.order'].browse(values['order_id'])
+            return po.date_planned
+
+        return [
+            ('order_id', populate.iterate(purchase_order_ids)),
+            ('name', populate.constant("PO-line-{counter}")),
+            ('product_id', populate.randomize(product_ids)),
+            ('product_uom', populate.compute(get_product_uom)),
+            ('taxes_id', populate.constant(False)),  # to avoid slow _prepare_add_missing_fields
+            ('date_planned', populate.compute(get_date_planned)),
+            ('product_qty', populate.randint(1, 10)),
+            ('price_unit', populate.randint(10, 100)),
+        ]

--- a/addons/purchase_stock/__init__.py
+++ b/addons/purchase_stock/__init__.py
@@ -3,6 +3,7 @@
 
 from . import models
 from . import report
+from . import populate
 
 from odoo import api, SUPERUSER_ID
 

--- a/addons/purchase_stock/populate/__init__.py
+++ b/addons/purchase_stock/populate/__init__.py
@@ -1,7 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import controllers
-from . import models
-from . import report
-from . import populate
+from . import purchase_stock

--- a/addons/purchase_stock/populate/purchase_stock.py
+++ b/addons/purchase_stock/populate/purchase_stock.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+
+from odoo import models
+from odoo.tools import populate, groupby
+
+_logger = logging.getLogger(__name__)
+
+
+class PurchaseOrder(models.Model):
+    _inherit = "purchase.order"
+
+    _populate_dependencies = ["res.partner", "stock.picking.type"]
+
+    def _populate_factories(self):
+        res = super()._populate_factories()
+        picking_types = self.env['stock.picking.type'].search([('code', '=', 'incoming')])
+
+        picking_types_by_company = dict(groupby(picking_types, key=lambda par: par.company_id.id))
+        picking_types_inter_company = self.env['stock.picking.type'].concat(*picking_types_by_company.get(False, []))
+        picking_types_by_company = {com: self.env['stock.picking.type'].concat(*pt) | picking_types_inter_company for com, pt in picking_types_by_company.items() if com}
+
+        def get_picking_type_id(values=None, random=None, **kwargs):
+            return random.choice(picking_types_by_company[values["company_id"]]).id
+
+        return res + [
+            ("picking_type_id", populate.compute(get_picking_type_id))
+        ]

--- a/addons/stock/__init__.py
+++ b/addons/stock/__init__.py
@@ -5,6 +5,7 @@ from . import controllers
 from . import models
 from . import report
 from . import wizard
+from . import populate
 
 
 from odoo import api, SUPERUSER_ID

--- a/addons/stock/populate/__init__.py
+++ b/addons/stock/populate/__init__.py
@@ -1,7 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import controllers
-from . import models
-from . import report
-from . import populate
+from . import stock

--- a/addons/stock/populate/stock.py
+++ b/addons/stock/populate/stock.py
@@ -1,0 +1,545 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+import math
+from datetime import datetime, timedelta
+from itertools import product as cartesian_product
+from collections import defaultdict
+
+from odoo import models, api
+from odoo.tools import populate, groupby
+
+_logger = logging.getLogger(__name__)
+
+# Take X first company to put some stock on it data (it is to focus data on these companies)
+COMPANY_NB_WITH_STOCK = 3  # Need to be smaller than 5 (_populate_sizes['small'] of company)
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    def _populate_factories(self):
+
+        def get_tracking(values, counter, random):
+            if values['type'] == 'product':
+                return random.choices(['none', 'lot', 'serial'], [0.7, 0.2, 0.1])[0]
+            else:
+                return 'none'
+
+        res = super()._populate_factories()
+        res.append(('type', populate.iterate(['consu', 'service', 'product'], [0.3, 0.2, 0.5])))
+        res.append(('tracking', populate.compute(get_tracking)))
+        return res
+
+
+class Warehouse(models.Model):
+    _inherit = 'stock.warehouse'
+
+    _populate_sizes = {'small': 6, 'medium': 12, 'large': 24}
+    _populate_dependencies = ['res.company']
+
+    def _populate_factories(self):
+        company_ids = self.env.registry.populated_models['res.company'][:COMPANY_NB_WITH_STOCK]
+
+        def get_name(values, counter, random):
+            return "WH-%d-%d" % (values['company_id'], counter)
+
+        return [
+            ('company_id', populate.iterate(company_ids)),
+            ('name', populate.compute(get_name)),
+            ('code', populate.constant("W{counter}")),
+            ('reception_steps', populate.iterate(['one_step', 'two_steps', 'three_steps'], [0.6, 0.2, 0.2])),
+            ('delivery_steps', populate.iterate(['ship_only', 'pick_ship', 'pick_pack_ship'], [0.6, 0.2, 0.2])),
+        ]
+
+
+class Location(models.Model):
+    _inherit = 'stock.location'
+
+    _populate_sizes = {'small': 50, 'medium': 2_000, 'large': 50_000}
+    _populate_dependencies = ['stock.warehouse']
+
+    def _populate(self, size):
+        locations = super()._populate(size)
+
+        random = populate.Random('stock_location_sample')
+        locations_sample = self.browse(random.sample(locations.ids, len(locations.ids)))
+
+        company_ids = self.env.registry.populated_models['res.company'][:COMPANY_NB_WITH_STOCK]
+        warehouses = self.env['stock.warehouse'].browse(self.env.registry.populated_models['stock.warehouse'])
+
+        warehouse_by_company = dict(groupby(warehouses, lambda ware: ware.company_id.id))
+        loc_ids_by_company = dict(groupby(locations_sample, lambda loc: loc.company_id.id))
+
+        scenario_index = 0
+        for company_id in company_ids:
+            loc_ids_by_company[company_id] = loc_ids_by_company[company_id][::-1]  # Inverse the order to use pop()
+            warehouses = warehouse_by_company[company_id]
+
+            nb_loc_by_warehouse = math.ceil(len(loc_ids_by_company[company_id]) / len(warehouses))
+
+            for warehouse in warehouses:
+                # Manage the ceil, the last warehouse can have less locations than others.
+                nb_loc_to_take = min(nb_loc_by_warehouse, len(loc_ids_by_company[company_id]))
+                if scenario_index % 3 == 0:
+                    # Scenario 1 : remain companies with "normal" level depth keep 4 levels max
+                    depth = 3  # Force the number of level to 3 (root doesn't count)
+                elif scenario_index % 3 == 1:
+                    # Scenario 2 : one company with very low level depth location tree (all child of root)
+                    depth = 1
+                else:
+                    # Scenario 3 : one company with high depth location tree
+                    depth = 20
+
+                nb_by_level = int(math.log(nb_loc_to_take, depth)) + 1 if depth > 1 else nb_loc_to_take  # number of loc to put by level
+
+                _logger.info("Create locations (%d) tree for one warehouse - depth : %d, width : %d" % (nb_loc_to_take, depth, nb_by_level))
+
+                # Root is the lot_stock_id of warehouse
+                root = warehouse.lot_stock_id
+
+                def link_next_locations(parent, level):
+                    if level < depth:
+                        children = []
+                        nonlocal nb_loc_to_take
+                        nb_loc = min(nb_by_level, nb_loc_to_take)
+                        nb_loc_to_take -= nb_loc
+                        for i in range(nb_loc):
+                            children.append(loc_ids_by_company[company_id].pop())
+
+                        child_locations = self.env['stock.location'].concat(*children)
+                        child_locations.location_id = parent
+                        for child in child_locations:
+                            link_next_locations(child, level + 1)
+
+                link_next_locations(root, 0)
+                scenario_index += 1
+
+        # Change 20 % the usage of some no-leaf location into 'view' (instead of 'internal')
+        to_views = locations_sample.filtered_domain([('child_ids', '!=', [])]).ids
+        random = populate.Random('stock_location_views')
+        self.browse(random.sample(to_views, int(len(to_views) * 0.2))).usage = 'view'
+
+        return locations
+
+    def _populate_factories(self):
+        company_ids = self.env.registry.populated_models['res.company'][:COMPANY_NB_WITH_STOCK]
+        removal_strategies = self.env['product.removal'].search([])
+
+        return [
+            ('name', populate.constant("Loc-{counter}")),
+            ('usage', populate.constant('internal')),
+            ('removal_strategy_id', populate.randomize(removal_strategies.ids + [False])),
+            ('company_id', populate.iterate(company_ids)),
+        ]
+
+
+class StockWarehouseOrderpoint(models.Model):
+    _inherit = 'stock.warehouse.orderpoint'
+
+    _populate_sizes = {'small': 150, 'medium': 5_000, 'large': 60_000}
+    _populate_dependencies = ['product.product', 'product.supplierinfo', 'stock.location']
+
+    def _populate_factories(self):
+
+        warehouse_ids = self.env.registry.populated_models['stock.warehouse']
+        warehouses = self.env['stock.warehouse'].browse(warehouse_ids)
+
+        location_by_warehouse = {
+            warehouse.id: self.env['stock.location'].search([('id', 'child_of', warehouse.lot_stock_id.id)]).ids
+            for warehouse in warehouses
+        }
+
+        all_product_ids = set(self.env.registry.populated_models['product.product'])
+
+        supplierinfos = self.env['product.supplierinfo'].browse(self.env.registry.populated_models['product.supplierinfo'])
+
+        # Valid product by company (a supplier info exist for this product+company_id)
+        valid_product = defaultdict(set)
+        for suplierinfo in supplierinfos:
+            products = suplierinfo.product_id or suplierinfo.product_tmpl_id.product_variant_ids
+            # Reordering rule is only on the storable product
+            if products and products[0].type == 'product':
+                valid_product[suplierinfo.company_id.id] |= set(products.ids)
+        valid_product = {company_id: product_ids | valid_product[False] for company_id, product_ids in valid_product.items() if company_id}
+        invalid_product = {company_id: list(all_product_ids - product_ids) for company_id, product_ids in valid_product.items() if company_id}
+        valid_product = {company_id: list(product_ids) for company_id, product_ids in valid_product.items()}
+
+        def get_company_id(values, counter, random):
+            warehouse = self.env['stock.warehouse'].browse(values['warehouse_id'])
+            return warehouse.company_id.id
+
+        def get_location_product(iterator, field_name, model_name):
+            random = populate.Random('get_location_product')
+
+            # To avoid raise product_location_check : product/location/company (company is assure because warehouse doesn't share location for now)
+            # Use generator to avoid cartisian product in memory
+            generator_valid_product_loc_dict = {}
+            generator_invalid_product_loc_dict = {}
+            for warehouse in warehouses:
+                # TODO: randomize cartesian product
+                generator_valid_product_loc_dict[warehouse.company_id.id] = cartesian_product(
+                    # Force to begin by the main location of the warehouse
+                    [warehouse.lot_stock_id.id] + random.sample(location_by_warehouse[warehouse.id], len(location_by_warehouse[warehouse.id])),
+                    random.sample(valid_product[warehouse.company_id.id], len(valid_product[warehouse.company_id.id]))
+                )
+                generator_invalid_product_loc_dict[warehouse.company_id.id] = cartesian_product(
+                    [warehouse.lot_stock_id.id] + random.sample(location_by_warehouse[warehouse.id], len(location_by_warehouse[warehouse.id])),
+                    random.sample(invalid_product[warehouse.company_id.id], len(invalid_product[warehouse.company_id.id]))
+                )
+
+            for values in iterator:
+                # 95 % of the orderpoint will be valid (a supplier info exist for this product + company_id)
+                if random.random() < 0.95:
+                    loc_id, product_id = next(generator_valid_product_loc_dict[values['company_id']])
+                else:
+                    loc_id, product_id = next(generator_invalid_product_loc_dict[values['company_id']])
+
+                values['product_id'] = product_id
+                values['location_id'] = loc_id
+                yield values
+
+        return [
+            ('active', populate.iterate([True, False], [0.95, 0.05])),
+            ('warehouse_id', populate.iterate(warehouse_ids)),
+            ('company_id', populate.compute(get_company_id)),
+            ('_get_location_product', get_location_product),
+            ('product_min_qty', populate.iterate([0.0, 2.0, 10.0], [0.6, 0.2, 0.2])),
+            ('product_max_qty', populate.iterate([10.0, 20.0, 100.0], [0.6, 0.2, 0.2])),
+            ('qty_multiple', populate.iterate([0.0, 1.0, 2.0, 10.0], [0.4, 0.2, 0.2, 0.2])),
+        ]
+
+
+class Inventory(models.Model):
+    _inherit = 'stock.inventory'
+
+    _populate_sizes = {'small': 5, 'medium': 10, 'large': 20}
+    _populate_dependencies = ['stock.location']
+
+    def _populate(self, size):
+        inventories = super()._populate(size)
+
+        def start_inventory_sample(sample_ratio):
+            random = populate.Random('start_inventory_sample')
+            inventories_to_start = self.browse(random.sample(inventories.ids, int(len(inventories.ids) * sample_ratio)))
+            # Start empty to let the stock.inventory.line populate create lines
+            inventories_to_start.start_empty = True
+            for inventory in inventories_to_start:
+                inventory.action_start()
+
+        # Start 80 % of adjustment inventory
+        start_inventory_sample(0.8)
+
+        return inventories
+
+    def _populate_factories(self):
+
+        company_ids = self.env.registry.populated_models['res.company'][:COMPANY_NB_WITH_STOCK]
+        valid_locations = self.env['stock.location'].search([
+            ('company_id', 'in', company_ids),
+            ('usage', 'in', ['internal', 'transit'])
+        ])
+        locations_by_company = dict(groupby(valid_locations, key=lambda loc: loc.company_id.id))
+        locations_by_company = {company_id: self.env['stock.location'].concat(*locations) for company_id, locations in locations_by_company.items()}
+        products = self.env['product.product'].browse(self.env.registry.populated_models['product.product']).filtered(lambda p: p.type == 'product')
+
+        def get_locations_ids(values, counter, random):
+            location_ids_company = locations_by_company[values['company_id']]
+            # We set locations to ease the creation of stock.inventory.line
+            # Should be larger enough to avoid the emptiness of generator_product_loc_dict
+            return random.sample(location_ids_company.ids, int(len(location_ids_company.ids) * 0.5))
+
+        def get_product_ids(values, counter, random):
+            # We set products to ease the creation of stock.inventory.line
+            # Should be larger enough to avoid the emptiness of generator_product_loc_dict
+            return random.sample(products.ids, int(len(products.ids) * 0.5))
+
+        return [
+            ('name', populate.constant("Inventory-Pop-{counter}")),
+            ('company_id', populate.iterate(company_ids)),
+            ('location_ids', populate.compute(get_locations_ids)),
+            ('product_ids', populate.compute(get_product_ids)),
+        ]
+
+
+class InventoryLine(models.Model):
+    _inherit = 'stock.inventory.line'
+
+    _populate_sizes = {'small': 500, 'medium': 5_000, 'large': 20_000}
+    _populate_dependencies = ['stock.inventory']
+
+    def _populate(self, size):
+        inventory_lines = super()._populate(size)
+
+        def create_missing_lots():
+            _logger.info("Create lot/serial for inventory line to be ready to validate")
+            lots_values = []
+            for line in inventory_lines:
+                if line.product_tracking == 'none':
+                    continue
+                lots_values.append({
+                    'name': "InLine-%d" % line.id,
+                    'product_id': line.product_id.id,
+                    'company_id': line.inventory_id.company_id.id
+                })
+            lots = self.env['stock.production.lot'].create(lots_values).ids[::-1]
+            for line in inventory_lines:
+                if line.product_tracking == 'none':
+                    continue
+                line.prod_lot_id = lots.pop()
+
+        def validate_inventory_sample(sample_ratio):
+            # Validate the inventory adjustment, useful to have a stock at beginning
+            inventories_ids = inventory_lines.inventory_id.ids
+            random = populate.Random('validate_inventory')
+            inventories_to_done = self.env['stock.inventory'].browse(random.sample(inventories_ids, int(len(inventories_ids) * sample_ratio)))
+            _logger.info("Validate %d inventory adjustment" % len(inventories_to_done))
+            for inventory in inventories_to_done:
+                inventory.action_validate()
+
+        # Create missing tracking lot/serial in batch
+        create_missing_lots()
+
+        # (Un)comment to test a DB with a current stock.
+        # validate_inventory_sample(0.8)
+
+        return inventory_lines
+
+    def _populate_factories(self):
+
+        inventories = self.env['stock.inventory'].browse(self.env.registry.populated_models['stock.inventory'])
+        inventories = inventories.filtered(lambda i: i.state == 'confirm')
+
+        def compute_product_location(iterator, field_name, model_name):
+            random = populate.Random('compute_product_location')
+
+            # To avoid create twice the same line inventory (avoid _check_no_duplicate_line) : product/location (limitation for lot)
+            # Use generator to avoid cartisian product in memory
+            generator_product_loc_dict = {}
+            for inventory in inventories:
+                # TODO: randomize cartesian product
+                generator_product_loc_dict[inventory.id] = cartesian_product(
+                    random.sample(inventory.location_ids, len(inventory.location_ids)),
+                    random.sample(inventory.product_ids, len(inventory.product_ids))
+                )
+
+            for values in iterator:
+                loc_id, product = next(generator_product_loc_dict[values['inventory_id']])
+                values['product_id'] = product.id
+                values['location_id'] = loc_id.id
+                yield values
+
+        def get_product_qty(values, counter, random):
+            product = self.env['product.product'].browse(values['product_id'])
+            if product.tracking == 'serial':
+                return 1.0
+            else:
+                return random.randint(5, 25)
+
+        return [
+            ('inventory_id', populate.iterate(inventories.ids)),
+            ('_compute_product_location', compute_product_location),
+            ('product_qty', populate.compute(get_product_qty)),
+        ]
+
+
+class PickingType(models.Model):
+    _inherit = 'stock.picking.type'
+
+    _populate_sizes = {'small': 10, 'medium': 30, 'large': 200}
+    _populate_dependencies = ['stock.location']
+
+    def _populate_factories(self):
+        company_ids = self.env.registry.populated_models['res.company'][:COMPANY_NB_WITH_STOCK]
+        internal_locations = self.env['stock.location'].search([('company_id', 'in', company_ids), ('usage', '=', 'internal')])
+
+        def get_name(values, counter, random):
+            return "%d-%s-%d" % (values['company_id'], values['code'], counter)
+
+        def _compute_default_locations(iterator, field_name, model_name):
+            random = populate.Random('_compute_default_locations')
+            locations_by_company = dict(groupby(internal_locations, key=lambda loc: loc.company_id.id))
+            locations_by_company = {company_id: self.env['stock.location'].concat(*locations) for company_id, locations in locations_by_company.items()}
+
+            for values in iterator:
+
+                locations_company = locations_by_company[values['company_id']]
+                # TODO : choice only location child of warehouse.lot_stock_id
+                inter_location = random.choice(locations_company)
+                values['warehouse_id'] = inter_location.get_warehouse().id
+                if values['code'] == 'internal':
+                    values['default_location_src_id'] = inter_location.id
+                    values['default_location_dest_id'] = random.choice(locations_company - inter_location).id
+                elif values['code'] == 'incoming':
+                    values['default_location_dest_id'] = inter_location.id
+                elif values['code'] == 'outgoing':
+                    values['default_location_src_id'] = inter_location.id
+
+                yield values
+
+        def get_show_operations(values, counter, random):
+            return values['code'] != 'incoming'  # Simulate onchange of form
+
+        def get_show_reserved(values, counter, random):
+            return values['show_operations'] and values['code'] != 'incoming'  # Simulate onchange of form
+
+        return [
+            ('company_id', populate.iterate(company_ids)),
+            ('code', populate.iterate(['incoming', 'outgoing', 'internal'], [0.3, 0.3, 0.4])),
+            ('name', populate.compute(get_name)),
+            ('sequence_code', populate.constant("PT{counter}")),
+            ('_compute_default_locations', _compute_default_locations),
+            ('show_operations', populate.compute(get_show_operations)),
+            ('show_reserved', populate.compute(get_show_reserved)),
+        ]
+
+
+class Picking(models.Model):
+    _inherit = 'stock.picking'
+
+    _populate_sizes = {'small': 100, 'medium': 2_000, 'large': 50_000}
+    _populate_dependencies = ['stock.location', 'stock.picking.type', 'res.partner']
+
+    def _populate_factories(self):
+        company_ids = self.env.registry.populated_models['res.company'][:COMPANY_NB_WITH_STOCK]
+
+        picking_types_ids = self.env['stock.picking.type'].browse(self.env.registry.populated_models['stock.picking.type']).ids
+
+        now = datetime.now()
+
+        cross_company_locations = self.env['stock.location'].search([('company_id', '=', False)])
+        locations_companies = self.env['stock.location'].search([('company_id', 'in', company_ids)])
+
+        all_partners = self.env['res.partner'].browse(self.env.registry.populated_models['res.partner'])
+        partners_by_company = dict(groupby(all_partners, key=lambda par: par.company_id.id))
+        partners_inter_company = self.env['res.partner'].concat(*partners_by_company.get(False, []))
+        partners_by_company = {com: self.env['res.partner'].concat(*partners) | partners_inter_company for com, partners in partners_by_company.items() if com}
+
+        def get_until_date(values, counter, random):
+            # 95.45 % of picking scheduled between (-10, 30) days and follow a gauss distribution (only +-15% picking is late)
+            delta = random.gauss(10, 10)
+            return now + timedelta(days=delta)
+
+        def get_partner_id(values, counter, random):
+            picking_type = self.env['stock.picking.type'].browse(values['picking_type_id'])
+            company = picking_type.company_id
+            return partners_by_company.get(company.id) and random.choice(partners_by_company[company.id]).id or False
+
+        def _compute_locations(iterator, field_name, model_name):
+            locations_out = cross_company_locations.filtered_domain([('usage', '=', 'customer')])
+            locations_in = cross_company_locations.filtered_domain([('usage', '=', 'supplier')])
+            locations_internal = locations_companies.filtered_domain([('usage', '=', 'internal')])
+            locations_by_company = dict(groupby(locations_companies, key=lambda loc: loc.company_id.id))
+            locations_by_company = {com: self.env['stock.location'].concat(*locs) for com, locs in locations_by_company.items()}
+
+            random = populate.Random('_compute_locations')
+            for values in iterator:
+                picking_type = self.env['stock.picking.type'].browse(values['picking_type_id'])
+
+                source_loc = picking_type.default_location_src_id
+                dest_loc = picking_type.default_location_dest_id
+
+                locations_company = locations_by_company[picking_type.company_id.id]
+                if not source_loc or random.random() > 0.8:
+                    if picking_type.code == 'incoming':
+                        source_loc = random.choice(locations_in)
+                    elif picking_type.code == 'outgoing':
+                        source_loc = random.choice(locations_internal & locations_company)
+                    elif picking_type.code == 'internal':
+                        source_loc = random.choice(locations_internal & locations_company)
+
+                if not dest_loc or random.random() > 0.8:
+                    if picking_type.code == 'incoming':
+                        dest_loc = random.choice(locations_internal & locations_company)
+                    elif picking_type.code == 'outgoing':
+                        dest_loc = random.choice(locations_out)
+                    elif picking_type.code == 'internal':
+                        # Need at most 2 internal locations
+                        dest_loc = random.choice((locations_internal & locations_company) - source_loc)
+
+                values['location_id'] = source_loc.id
+                values['location_dest_id'] = dest_loc.id
+                yield values
+
+        return [
+            ('priority', populate.randomize(['1', '0'], [0.05, 0.95])),
+            ('scheduled_date', populate.compute(get_until_date)),
+            ('picking_type_id', populate.iterate(picking_types_ids)),
+            ('partner_id', populate.compute(get_partner_id)),
+            ('_compute_locations', _compute_locations),
+        ]
+
+
+class StockMove(models.Model):
+    _inherit = 'stock.move'
+
+    _populate_sizes = {'small': 1_000, 'medium': 20_000, 'large': 1_000_000}
+    _populate_dependencies = ['stock.picking']
+
+    def _populate(self, size):
+        moves = super()._populate(size)
+
+        def confirm_pickings(sample_ratio):
+            # Confirm sample_ratio * 100 % of picking
+            random = populate.Random('confirm_pickings')
+            picking_ids = moves.picking_id.ids
+            picking_to_confirm = self.env['stock.picking'].browse(random.sample(picking_ids, int(len(picking_ids) * sample_ratio)))
+            _logger.info("Confirm %d of pickings" % len(picking_to_confirm))
+            picking_to_confirm.action_confirm()
+
+        # (Un)comment to test a DB with a lot of outgoing/incoming/internal confirmed moves, e.g. for testing of forecasted report
+        # confirm_pickings(0.8)
+
+        return moves.exists()  # Confirm picking can unlink some moves
+
+    @api.model
+    def _populate_attach_record_weight(self):
+        return ['picking_id'], [1]
+
+    @api.model
+    def _populate_attach_record_generator(self):
+        picking_ids = self.env['stock.picking'].browse(self.env.registry.populated_models['stock.picking'])
+
+        def next_picking_generator():
+            while picking_ids:
+                yield from picking_ids.ids
+
+        return {'picking_id': next_picking_generator()}
+
+    def _populate_factories(self):
+        product_ids = self.env['product.product'].browse(self.env.registry.populated_models['product.product']).filtered(lambda p: p.type in ('product', 'consu'))
+
+        def get_product_uom(values, counter, random):
+            return self.env['product.product'].browse(values['product_id']).uom_id.id
+
+        def _attach_to_record(iterator, field_name, model_name):
+            random = populate.Random('_attach_to_record')
+            fields, weights = self._populate_attach_record_weight()
+            fields_generator = self._populate_attach_record_generator()
+
+            for values in iterator:
+                field = random.choices(fields, weights)[0]
+                values[field] = next(fields_generator[field])
+                yield values
+
+        def _compute_picking_values(iterator, field_name, model_name):
+            for values in iterator:
+                if values.get('picking_id'):
+                    picking = self.env['stock.picking'].browse(values['picking_id'])
+                    values['picking_id'] = picking.id
+                    values['location_id'] = picking.location_id.id
+                    values['location_dest_id'] = picking.location_dest_id.id
+                    values['name'] = picking.name
+                    values['date'] = picking.scheduled_date
+                    values['company_id'] = picking.company_id.id
+                yield values
+
+        return [
+            ('product_id', populate.randomize(product_ids.ids)),
+            ('product_uom', populate.compute(get_product_uom)),
+            ('product_uom_qty', populate.randint(1, 10)),
+            ('sequence', populate.randint(1, 1000)),
+            ('_attach_to_record', _attach_to_record),
+            ('_compute_picking_values', _compute_picking_values),
+        ]

--- a/addons/stock/populate/stock.py
+++ b/addons/stock/populate/stock.py
@@ -138,7 +138,7 @@ class Location(models.Model):
 class StockWarehouseOrderpoint(models.Model):
     _inherit = 'stock.warehouse.orderpoint'
 
-    _populate_sizes = {'small': 150, 'medium': 5_000, 'large': 60_000}
+    _populate_sizes = {'small': 1, 'medium': 5_000, 'large': 60_000}
     _populate_dependencies = ['product.product', 'product.supplierinfo', 'stock.location']
 
     def _populate_factories(self):
@@ -214,7 +214,7 @@ class StockWarehouseOrderpoint(models.Model):
 class Inventory(models.Model):
     _inherit = 'stock.inventory'
 
-    _populate_sizes = {'small': 5, 'medium': 10, 'large': 20}
+    _populate_sizes = {'small': 50, 'medium': 10, 'large': 20}
     _populate_dependencies = ['stock.location']
 
     def _populate(self, size):
@@ -266,7 +266,7 @@ class Inventory(models.Model):
 class InventoryLine(models.Model):
     _inherit = 'stock.inventory.line'
 
-    _populate_sizes = {'small': 500, 'medium': 5_000, 'large': 20_000}
+    _populate_sizes = {'small': 5000, 'medium': 5_000, 'large': 20_000}
     _populate_dependencies = ['stock.inventory']
 
     def _populate(self, size):
@@ -302,7 +302,7 @@ class InventoryLine(models.Model):
         create_missing_lots()
 
         # (Un)comment to test a DB with a current stock.
-        # validate_inventory_sample(0.8)
+        validate_inventory_sample(1.0)
 
         return inventory_lines
 
@@ -386,7 +386,7 @@ class PickingType(models.Model):
 
         return [
             ('company_id', populate.iterate(company_ids)),
-            ('code', populate.iterate(['incoming', 'outgoing', 'internal'], [0.3, 0.3, 0.4])),
+            ('code', populate.iterate(['incoming', 'outgoing'], [0.3, 0.3])),  # Always incoming outgoing for test forecasted
             ('name', populate.compute(get_name)),
             ('sequence_code', populate.constant("PT{counter}")),
             ('_compute_default_locations', _compute_default_locations),
@@ -474,7 +474,7 @@ class Picking(models.Model):
 class StockMove(models.Model):
     _inherit = 'stock.move'
 
-    _populate_sizes = {'small': 1_000, 'medium': 20_000, 'large': 1_000_000}
+    _populate_sizes = {'small': 30_000, 'medium': 20_000, 'large': 1_000_000}
     _populate_dependencies = ['stock.picking']
 
     def _populate(self, size):
@@ -489,7 +489,7 @@ class StockMove(models.Model):
             picking_to_confirm.action_confirm()
 
         # (Un)comment to test a DB with a lot of outgoing/incoming/internal confirmed moves, e.g. for testing of forecasted report
-        # confirm_pickings(0.8)
+        confirm_pickings(0.8)
 
         return moves.exists()  # Confirm picking can unlink some moves
 

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -179,6 +179,7 @@
                     </header>
                     <field name="priority" optional="show" widget="priority" nolabel="1"/>
                     <field name="name" decoration-bf="1"/>
+                    <field name="products_availability"/>
                     <field name="location_id" options="{'no_create': True}" string="From" groups="stock.group_stock_multi_locations" optional="show"/>
                     <field name="location_dest_id" options="{'no_create': True}" string="To" groups="stock.group_stock_multi_locations" optional="show"/>
                     <field name="partner_id" optional="show"/>

--- a/odoo/addons/base/populate/res_partner.py
+++ b/odoo/addons/base/populate/res_partner.py
@@ -13,7 +13,7 @@ class Partner(models.Model):
     _populate_dependencies = ["res.company", "res.partner.industry"]
 
     _populate_sizes = {
-        'small': 10,
+        'small': 100,
         'medium': 2000,
         'large': 100000,
     }

--- a/odoo/addons/base/populate/res_user.py
+++ b/odoo/addons/base/populate/res_user.py
@@ -11,7 +11,7 @@ _logger = logging.getLogger(__name__)
 class Users(models.Model):
     _inherit = "res.users"
 
-    _populate_sizes = {"small": 10, "medium": 2000, "large": 10000}
+    _populate_sizes = {"small": 10, "medium": 1000, "large": 10000}
 
     _populate_dependencies = ["res.partner"]
 


### PR DESCRIPTION
Try to reactivate the "Product Availabilty" (Transfer ) and "Component Availability" (MO) in the tree view. These fields was slow to compute because of the slow computation of `_compute_forecast_information`.

With "Product Availabilty" fields in the tree, to read 10 tranfers
with 200 moves in each tranfers:
Before patch: 0.29 +-0.05 (SQL) and 3.8 +- 0.68 (Python) = +-4.09 sec
After patch: 0.22 +- 0.01 (SQL) and 0.57 +- 0.04 (Python) = +- 0.69 sec
The patch working better for bigger sample, and less with smaller sample.

WIP, it's still not enought to reactive the "Product Availability" in the tree.
