### PR TITLE
[FIX] website: Save button overlaps on edit menu

### DIFF
--- a/addons/website/static/src/scss/website.wysiwyg.scss
+++ b/addons/website/static/src/scss/website.wysiwyg.scss
@@ -29,6 +29,11 @@
     height: $o-we-sidebar-top-height;
     background-color: $o-we-sidebar-tabs-bg;
 
+    .o_we_external_history_buttons, .ml-auto {
+        flex: 1 1 auto;
+        display: flex;
+    }
+
     .btn-group, .btn {
         height: 100%;
     }
@@ -39,7 +44,9 @@
         font-size: $o-we-font-size;
         font-family: $o-we-font-family;
         font-weight: 400;
+        flex: 1 1 auto;
         line-height: 1;
+        padding: 0;
 
         &.btn-primary {
             @include button-variant($o-brand-primary, $o-brand-primary);


### PR DESCRIPTION
What are the steps to reproduce your issue ?

    1. Install 'website' and 'theme-bistro'
    2. Try to edit 'website'

What is currently happening ?

    In French the button contains the text 'Sauvegarder' which causes an overlap.
![Screenshot from 2020-11-20 11-17-02](https://user-images.githubusercontent.com/39504376/99789395-cfcaf800-2b22-11eb-9da0-4e9cd121c804.png)
What are you expecting to happen ?

    Display the button correctly

Why is this happening ?

    Because the margin is too big.

How to fix the bug ?

    Use the default margin

The problem is present on 'bistro', 'monglia', 'treehouse' and 'vehicle'
opw-2379544