### PR TITLE
[FIX] portal: if no user photo, display placeholder

### DIFF
--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -70,7 +70,11 @@
         <t t-set="is_connected" t-value="not user_id._is_public()"/>
         <li t-if="is_connected" t-attf-class="#{_item_class} o_no_autohide_item">
             <a href="#" role="button" data-toggle="dropdown" t-attf-class="dropdown-toggle #{_link_class}">
-                <img t-if="_avatar" t-att-src="image_data_uri(user_id.image_256)" t-attf-class="rounded-circle #{_avatar_class}" width="24" height="24" alt="" loading="eager"/>
+                <t t-if="_avatar">
+                    <t t-if="user_id.image_256" t-set="avatar_source" t-value="image_data_uri(user_id.image_256)"/>
+                    <t t-else="" t-set="avatar_source" t-value="'/web/static/src/img/placeholder.png'"/>
+                    <img t-att-src="avatar_source" t-attf-class="rounded-circle #{_avatar_class}" width="24" height="24" alt="" loading="eager"/>
+                </t>
                 <i t-if="_icon" t-attf-class="fa fa-1x fa-fw fa-user-circle-o #{_icon_class}"/>
                 <span t-if="_user_name" t-attf-class="#{_user_name_class}" t-esc="user_id.name[:23] + '...' if user_id.name and len(user_id.name) &gt; 25 else user_id.name"/>
             </a>


### PR DESCRIPTION
If the website header template uses the user's photo, and if this one does not exist, a 500-error is returned.

To reproduce the error:
(Need website)
1. Go to the website
2. Edit
3. Change the header template
	- Select one that uses the user's photo
4. Save
5. Go to Settings > Users & Companies > Users
6. Select your account
7. Edit
8. Remove your photo, Save
9. Go back to the website

=> 500 error

When the user doesn't have any photo, the template uses the placeholder image.

OPW-2378269
