### PR TITLE
diable multi edit in select create dialog

### DIFF
--- a/addons/web/static/src/js/views/list/list_view.js
+++ b/addons/web/static/src/js/views/list/list_view.js
@@ -71,7 +71,8 @@ var ListView = BasicView.extend({
         this.rendererParams.selectedRecords = selectedRecords;
         this.rendererParams.addCreateLine = false;
         this.rendererParams.addCreateLineInGroups = editable && this.controllerParams.activeActions.create;
-        this.rendererParams.isMultiEditable = this.arch.attrs.multi_edit && !!JSON.parse(this.arch.attrs.multi_edit);
+        this.rendererParams.isMultiEditable = this.arch.attrs.multi_edit && !!JSON.parse(this.arch.attrs.multi_edit)
+            && ('multiEdit' in params ? params.multi_edit : true);
 
         this.modelParams.groupbys = this.groupbys;
 

--- a/addons/web/static/src/js/views/list/list_view.js
+++ b/addons/web/static/src/js/views/list/list_view.js
@@ -72,7 +72,7 @@ var ListView = BasicView.extend({
         this.rendererParams.addCreateLine = false;
         this.rendererParams.addCreateLineInGroups = editable && this.controllerParams.activeActions.create;
         this.rendererParams.isMultiEditable = this.arch.attrs.multi_edit && !!JSON.parse(this.arch.attrs.multi_edit)
-            && ('multiEdit' in params ? params.multi_edit : true);
+            && ('multiEdit' in params ? params.multiEdit : true);
 
         this.modelParams.groupbys = this.groupbys;
 

--- a/addons/web/static/src/js/views/view_dialogs.js
+++ b/addons/web/static/src/js/views/view_dialogs.js
@@ -362,6 +362,7 @@ var SelectCreateDialog = ViewDialog.extend({
             _.extend(viewOptions, {
                 hasSelectors: !this.options.disable_multiple_selection,
                 readonly: true,
+                multiEdit: false,
 
             }, this.options.list_view_options);
             selectCreateController = select_create_controllers_registry.SelectCreateListController;

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -6597,6 +6597,42 @@ QUnit.module('Views', {
         list.destroy();
     });
 
+    QUnit.test('multi edit in select create dialog should be disabled', async function (assert) {
+        assert.expect(3);
+
+        for (let i = 4; i <= 10; i++) {
+            this.data.bar.records.push({ id: i, display_name: "Value" + i });
+        }
+
+        const form = await createView({
+            arch: `
+            <form>
+                <field name="m2m" widget="many2many_tags"/>
+            </form>`,
+            archs: {
+                'bar,false,list': '<tree multi_edit="1"><field name="display_name"/></tree>',
+                'bar,false,search': '<search></search>',
+            },
+            data: this.data,
+            model: 'foo',
+            View: FormView,
+        });
+
+        await testUtils.fields.many2one.clickOpenDropdown("m2m");
+        await testUtils.fields.many2one.clickItem("m2m", "Search More");
+        assert.containsOnce(document.body, '.modal .o_list_view', "should have open the modal");
+
+        // select all records
+        await testUtils.dom.click($('.o_list_view thead .o_list_record_selector input'));
+        await testUtils.dom.click($('.o_data_row:first .o_data_cell:eq(0)'));
+        assert.containsNone(document.body, '.modal .o_list_view',
+            "should not have modal, clicking on records should select record instead of editing in dialog");
+        assert.containsN(form, '.o_field_many2manytags[name="m2m"] .badge', 1,
+            "many2many tag should now contain 1 record selected");
+
+        form.destroy();
+    });
+
     QUnit.test('list grouped by date:month', async function (assert) {
         assert.expect(1);
 


### PR DESCRIPTION
PURPOSE
Currently opening a select create dialog in many2many and selecting multiple records and if listview is multi_edit then clicking on any field allows you to edit records, while select create dialog is meant to select records not to edit records so multi edition should be disabled in that case.

SPEC
Disable multi edit in select create dialogs.

TASK 2376275


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
