### PR TITLE
[FIX] web_editor: views that extend oe_structure sections are always extension views

### DIFF
--- a/addons/web_editor/models/ir_ui_view.py
+++ b/addons/web_editor/models/ir_ui_view.py
@@ -80,6 +80,7 @@ class IrUiView(models.Model):
 
         vals = {
             'inherit_id': self.id,
+            'mode': 'extension',
             'name': '%s (%s)' % (self.name, el.get('id')),
             'arch': self._pretty_arch(arch),
             'key': '%s_%s' % (self.key, el.get('id')),


### PR DESCRIPTION
STR:

1. Install an addon that creates base view A1.
2. Install an addon that creates extension view A2, which adds a `<div id="oe_structure_a2" class="oe_structure"/>` somewhere.
3. Edit that view with the website editor, adding content into that new `oe_structure_a2` hook.

Before patch: Odoo creates a new view called `A2 (oe_structure_a2)`, but that view is created with `mode="primary"` and never is displayed on the website.

After patch: That new view is created with `mode="extension"` and behaves as expected.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
@Tecnativa TT26798