### PR TITLE
[FIX] account: wrong number of statement lines to check in dashboard

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -431,7 +431,7 @@ class account_journal(models.Model):
     def to_check_ids(self):
         self.ensure_one()
         domain = self.env['account.move.line']._get_suspense_moves_domain()
-        domain.append(('journal_id', '=', self.id))
+        domain += [('journal_id', '=', self.id),('statement_line_id.is_reconciled', '=', False)]
         statement_line_ids = self.env['account.move.line'].search(domain).mapped('statement_line_id')
         return statement_line_ids
 


### PR DESCRIPTION
On the accounting dashboard, for bank and cash journals, we are
displaying the number of items to check. Since commit https://github.com/odoo/enterprise/commit/b2dd65b9a9c054570d5796a81f2c390c4d8cb6c4,
when getting bank statement data, we are filtering the ones that
are not reconciled. We should also include is_reconciled = False
when getting dashboard data.

Description of the issue/feature this PR addresses:
opw-2378876

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
