### PR TITLE
[IMP] web: display nocontenthelp message in graph view

### DIFF
--- a/addons/web/static/src/xml/graph.xml
+++ b/addons/web/static/src/xml/graph.xml
@@ -9,8 +9,11 @@
                 <t t-set="description" t-value="noContentHelperData.description"/>
             </t>
             <t t-else="">
-                <t t-if="props.isSample and !props.isEmbedded and props.noContentHelp" t-call="web.ActionHelper">
-                    <t t-set="noContentHelp" t-value="props.noContentHelp"/>
+                <t t-if="props.isSample and !props.isEmbedded">
+                    <t t-if="props.noContentHelp" t-call="web.ActionHelper">
+                        <t t-set="noContentHelp" t-value="props.noContentHelp"/>
+                    </t>
+                    <t t-else="" t-call="web.NoContentHelper"/>
                 </t>
                 <div class="o_graph_canvas_container" t-ref="container">
                     <canvas t-ref="canvas"/>


### PR DESCRIPTION
Currently, graph view display the blank chart when the sample data is set and the noContentHelp message is empty. 

so in this commit, graph view display the sample data with noContentHelp message even if the noContentHelp message is empty.

TaskID-2347554