### PR TITLE
[FIX] mail: when adding an attachment, do not discard changes

### DIFF
--- a/addons/mail/static/src/js/chatter.js
+++ b/addons/mail/static/src/js/chatter.js
@@ -602,7 +602,7 @@ var Chatter = Widget.extend({
      */
     _onReloadAttachmentBox: function () {
         if (this.reloadOnUploadAttachment) {
-            this.trigger_up('reload');
+            this.trigger_up('reload', { keepChanges: true });
         }
         this._reloadAttachmentBox();
     },


### PR DESCRIPTION
Behavior prior to this commit:

- edit an existing invoice
- add a line, but do not save
- add an attachment - the attachment uploads and the new line stays visible
- save the record: the line now disappears

Behavior after this commit:

- do not discard changes when reloading after adding an attachment

opw-2369162


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
