### PR TITLE
[FIX] rating: Change last rating value group operator to avg

### DIFF
--- a/addons/rating/models/rating_mixin.py
+++ b/addons/rating/models/rating_mixin.py
@@ -53,7 +53,7 @@ class RatingMixin(models.AbstractModel):
     _description = "Rating Mixin"
 
     rating_ids = fields.One2many('rating.rating', 'res_id', string='Rating', groups='base.group_user', domain=lambda self: [('res_model', '=', self._name)], auto_join=True)
-    rating_last_value = fields.Float('Rating Last Value', groups='base.group_user', compute='_compute_rating_last_value', compute_sudo=True, store=True)
+    rating_last_value = fields.Float('Rating Last Value', groups='base.group_user', compute='_compute_rating_last_value', compute_sudo=True, store=True, group_operator='avg')
     rating_last_feedback = fields.Text('Rating Last Feedback', groups='base.group_user', related='rating_ids.feedback')
     rating_last_image = fields.Binary('Rating Last Image', groups='base.group_user', related='rating_ids.rating_image')
     rating_count = fields.Integer('Rating count', compute="_compute_rating_stats", compute_sudo=True)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When doing group-by or pivot views, it makes sense to average the rating values rather than the default which is to sum.

Current behavior before PR:

Last rating value will sum in group-by.

Desired behavior after PR is merged:

Last rating value will average in group-by.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
