### PR TITLE
[FIX] web: ignore menu add bank account in click all

### DIFF
--- a/addons/web/static/src/js/tools/test_menus.js
+++ b/addons/web/static/src/js/tools/test_menus.js
@@ -8,7 +8,7 @@
     var viewUpdateCount = 0;
     var testedApps;
     var testedMenus;
-    var blackListedMenus = ['base.menu_theme_store', 'base.menu_third_party'];
+    var blackListedMenus = ['base.menu_theme_store', 'base.menu_third_party', 'account.menu_action_account_bank_journal_form'];
     var appsMenusOnly = false;
     let isEnterprise = odoo.session_info.server_version_info[5] === 'e';
 


### PR DESCRIPTION
Since odoo/enterprise@93ac6e5116 a the `Add Bank Account` menu is using
an new proxy server. As it's an external service, it's not desirable to
click on this menu during the test.
