### PR TITLE
[FIX] stock_landed_costs: tag account-dependent tests as post_install

### DIFF
--- a/addons/stock_landed_costs/tests/test_stockvaluationlayer.py
+++ b/addons/stock_landed_costs/tests/test_stockvaluationlayer.py
@@ -8,6 +8,7 @@ from odoo.addons.stock_account.tests.test_stockvaluationlayer import TestStockVa
 from odoo.addons.stock_account.tests.test_stockvaluation import _create_accounting_data
 
 
+@tagged('post_install', '-at_install')
 class TestStockValuationLC(TestStockValuationCommon):
     @classmethod
     def setUpClass(cls):
@@ -76,6 +77,7 @@ class TestStockValuationLC(TestStockValuationCommon):
         return lc
 
 
+@tagged('post_install', '-at_install')
 class TestStockValuationLCFIFO(TestStockValuationLC):
     def setUp(self):
         super(TestStockValuationLCFIFO, self).setUp()
@@ -191,6 +193,7 @@ class TestStockValuationLCFIFO(TestStockValuationLC):
         self.assertEqual(move2.stock_valuation_layer_ids.value, -115)
 
 
+@tagged('post_install', '-at_install')
 class TestStockValuationLCAVCO(TestStockValuationLC):
     def setUp(self):
         super(TestStockValuationLCAVCO, self).setUp()
@@ -233,6 +236,7 @@ class TestStockValuationLCAVCO(TestStockValuationLC):
         self.assertEqual(self.product1.quantity_svl, 19)
 
 
+@tagged('post_install', '-at_install')
 class TestStockValuationLCFIFOVB(TestStockValuationLC):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
WHY: chart of account may not be setup right after module installation

---

opw-2382456

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
