### PR TITLE
[FIX] account: fix fiscal position deletion while already assigned in the invoice

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -180,7 +180,7 @@ class AccountMove(models.Model):
     # ==== Business fields ====
     fiscal_position_id = fields.Many2one('account.fiscal.position', string='Fiscal Position', readonly=True,
         states={'draft': [('readonly', False)]},
-        domain="[('company_id', '=', company_id)]",
+        domain="[('company_id', '=', company_id)]", ondelete="restrict",
         help="Fiscal positions are used to adapt taxes and accounts for particular customers or sales orders/invoices. "
              "The default value comes from the customer.")
     invoice_user_id = fields.Many2one('res.users', copy=False, tracking=True,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fiscal position can be deleted while already assigned on invoice

Current behaviour before PR:

Fiscal position will be deleted
Desired behaviour after PR is merged:

Should provide a warning message if current fiscal position already assigned in invoice

Fixes #61942

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
