### PR TITLE
[FIX] account: fix visibility of Lock Posted entries with hash

### DIFF
--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -102,7 +102,8 @@
                                         <div class="text-muted" colspan="2">Keep empty for no control</div>
                                         <field name="type_control_ids" widget="many2many_tags"/>
                                         <field name="account_control_ids" widget="many2many_tags"/>
-                                        <field name="restrict_mode_hash_table" groups="account.group_account_readonly" attrs="{'invisible': [('type', 'in', ['bank', 'cash'])]}"/>
+                                        <field name="restrict_mode_hash_table_visible" invisible="1"/>
+                                        <field name="restrict_mode_hash_table" groups="account.group_account_readonly" attrs="{'invisible': [('restrict_mode_hash_table_visible', '=', False)]}"/>
                                     </group>
                                     <!-- email alias -->
                                     <group class="oe_read_only" name="group_alias_ro" string="Create Invoices upon Emails" attrs="{'invisible': ['|', ('type', 'not in',  ('sale' ,'purchase')), ('alias_domain', '=', False)]}">


### PR DESCRIPTION
A bank journal must necessarily contain the information provided by the
bank institution. Therefore, activating 'Lock Posted entries with hash'
on bank journals is an undesirable constraint.

But User might not work with cash statement. He could
prefer to select the ultimate account (of type cash) in the definition
of the outstanding accounts.
In such a case, the user will never reconcile a cash statement line that
don't exist with the outstanding accounts.
So if one of the outstanding accounts is of type bank & cash, rather than
the expected "current assets", then the hash checkbox
should remain visible.

opw-2367688

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
