### PR TITLE
[FIX] stock: set default lot company

### DIFF
--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -51,7 +51,7 @@
                                 <field name="qty_done"/>
                                 <field name="product_uom_id" options="{'no_create': True}" string="Unit of Measure" groups="uom.group_uom"/>
                             </div>
-                            <field name="lot_id" groups="stock.group_production_lot" context="{'default_product_id': product_id, 'active_picking_id': picking_id}" attrs="{'invisible': [('lot_id', '=', False),('lot_name', '!=', False)]}"/>
+                            <field name="lot_id" groups="stock.group_production_lot" context="{'default_product_id': product_id, 'active_picking_id': picking_id, 'default_company_id': company_id}" attrs="{'invisible': [('lot_id', '=', False),('lot_name', '!=', False)]}"/>
                             <field name="lot_name" groups="stock.group_production_lot" attrs="{'invisible': ['|',('lot_id', '!=', False),('lot_name', '=', False)]}"/>
                             <field name="package_id" string="Source Package" groups="product.group_stock_packaging"/>
                             <field name="result_package_id" string="Destination Package" groups="stock.group_tracking_lot"/>


### PR DESCRIPTION
On a mobile, when editing a transfer operation, it is not possible to create a new lot/serial number.

To reproduce the error:
(Need a single company configuration)
1. Inventory > Configuration > Settings
2. Enable "Lots & Serial Numbers"
3. Inventory > Products > Products
4. Create a new one
    - Set "Tracking" to "By Lots"
5. Operations > Transfers
6. Create a new one
    - Add the product and set a demand
7. Save & Mark as todo
8. Enable the mobile mode of your browser & Refresh the page
9. Edit the transfer
10. On the product line previously added, click on details (to set the quantitiy done)
11. Click on "Add"
12. Click on "Lot/Serial Number" field
13. Create
14. Save

=> Validation Error (field Company is missing)

OPW-2389965