### PR TITLE
[FIX] l10n_id: download e-fatkur

### DIFF
--- a/addons/l10n_id_efaktur/models/account_move.py
+++ b/addons/l10n_id_efaktur/models/account_move.py
@@ -280,7 +280,7 @@ class AccountMove(models.Model):
     def _generate_efaktur(self, delimiter):
         if self.filtered(lambda x: not x.l10n_id_kode_transaksi):
             raise UserError(_('Some documents don\'t have a transaction code'))
-        if self.filtered(lambda x: x.type != 'out_invoice'):
+        if self.filtered(lambda x: x.move_type != 'out_invoice'):
             raise UserError(_('Some documents are not Customer Invoices'))
 
         output_head = self._generate_efaktur_invoice(delimiter)


### PR DESCRIPTION
- Install accounting app with l10n_id localization
- Create an indonesian customer with vat number
- Configure e-fatkur number
- Create an invoice and confirm it
- Download e-fatfur

A traceback occurs because the `type` field in model `account.move` has changed to `move_type` in v14

opw-2387843
