### PR TITLE
[FIX]: google_calendar: check write_date when syncing with google

### DIFF
--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -163,7 +163,8 @@ class GoogleSync(models.AbstractModel):
             # This could be dangerous if google server time and odoo server time are different
             updated = parse(gevent.updated)
             odoo_record = self.browse(gevent.odoo_id(self.env))
-            if updated >= pytz.utc.localize(odoo_record.write_date):
+            # Migration from 13.4 does not fill write_date. Therefore, we force the update from Google.
+            if not odoo_record.write_date or updated >= pytz.utc.localize(odoo_record.write_date):
                 vals = dict(self._odoo_values(gevent, default_reminders), need_sync=False)
                 odoo_record.write(vals)
                 synced_records |= odoo_record


### PR DESCRIPTION
When the database is migrated from 13.3 to 14.0, the write_date is not set on the 'calendar.event' records.
During the syncing with google api, the write-date is compared to take the more recent values, leading to an inevitable crash for recently migrated databases.

taskid: 2389374





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
