### PR TITLE
[FIX] account,sale: let a user print his invoices

### DIFF
--- a/addons/account/security/account_security.xml
+++ b/addons/account/security/account_security.xml
@@ -260,6 +260,13 @@
         <field name="groups" eval="[(4, ref('account.group_account_invoice'))]"/>
     </record>
 
+    <record id="account_invoice_send_rule_group_invoice" model="ir.rule">
+        <field name="name">Readonly Invoice Send and Print</field>
+        <field name="model_id" ref="model_account_invoice_send"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('account.group_account_invoice'))]"/>
+    </record>
+
     <!-- account analytic default-->
     <record id="analytic_default_comp_rule" model="ir.rule">
         <field name="name">Analytic Default multi company rule</field>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -529,13 +529,11 @@
                                 type="object"
                                 string="Send &amp; Print"
                                 attrs="{'invisible':['|', '|', ('state', '!=', 'posted'), ('is_move_sent', '=', True), ('move_type', 'not in', ('out_invoice', 'out_refund'))]}"
-                                class="oe_highlight"
-                                groups="account.group_account_invoice"/>
+                                class="oe_highlight"/>
                         <button name="action_invoice_sent"
                                 type="object"
                                 string="Send &amp; Print"
-                                attrs="{'invisible':['|', '|', ('state', '!=', 'posted'), ('is_move_sent', '=', False), ('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund'))]}"
-                                groups="account.group_account_invoice"/>
+                                attrs="{'invisible':['|', '|', ('state', '!=', 'posted'), ('is_move_sent', '=', False), ('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund'))]}"/>
                         <!-- Register Payment (only invoices / receipts) -->
                         <button name="action_register_payment" id="account_invoice_payment_btn"
                                 type="object" class="oe_highlight"

--- a/addons/sale/security/ir.model.access.csv
+++ b/addons/sale/security/ir.model.access.csv
@@ -14,6 +14,7 @@ access_account_account_tag_sale_salesman,account.account.tag.sale.salesman,accou
 access_account_account_type_sale_salesman,account.account.type.sale.salesman,account.model_account_account_type,sales_team.group_sale_salesman,1,0,0,0
 access_account_analytic_tag_sale_salesman,account.analytic.tag.sale.salesman,analytic.model_account_analytic_tag,sales_team.group_sale_salesman,1,0,0,0
 access_account_analytic_account_salesman,account_analytic_account salesman,analytic.model_account_analytic_account,sales_team.group_sale_salesman,1,1,1,0
+access_account_invoice_send_salesman,access.account.invoice.send.salesman,account.model_account_invoice_send,sales_team.group_sale_salesman,1,1,1,0
 access_sale_order_manager,sale.order.manager,model_sale_order,sales_team.group_sale_manager,1,1,1,1
 access_sale_order_readonly,sale.order.accountant,model_sale_order,account.group_account_readonly,1,0,0,0
 access_sale_order_accountant,sale.order.accountant,model_sale_order,account.group_account_user,1,1,0,0

--- a/addons/sale/security/sale_security.xml
+++ b/addons/sale/security/sale_security.xml
@@ -193,6 +193,20 @@
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
     </record>
 
+    <record id="account_invoice_send_rule_see_personal" model="ir.rule">
+        <field name="name">Personal Invoice Send and Print</field>
+        <field name="model_id" ref="account.model_account_invoice_send"/>
+        <field name="domain_force">[('invoice_ids.move_type', 'in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund')), '|', ('invoice_ids.invoice_user_id', '=', user.id), ('invoice_ids.invoice_user_id', '=', False)]</field>
+        <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
+    </record>
+
+    <record id="account_invoice_send_rule_see_all" model="ir.rule">
+        <field name="name">All Invoice Send and Print</field>
+        <field name="model_id" ref="account.model_account_invoice_send"/>
+        <field name="domain_force">[('invoice_ids.move_type', 'in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund'))]</field>
+        <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
+    </record>
+
     <!-- Wizard access rules -->
     <record id="sale_payment_acquirer_onboarding_wizard_rule" model="ir.rule">
         <field name="name">Payment Acquier Onboarding Wizard Rule</field>


### PR DESCRIPTION
If a user has no access to Invoicing module, he can not send and print his invoices.

To reproduce the error:
(Need sale_management,account)
1. Connect with admin account
2. Settings > Users & Companies
3. Create/Edit a salesman
	- Remove access rights to Invoicing module
4. Connect with this user
5. Create & Confirm a SO
6. Edit the SO and fill in the "Delivered" field, Save
7. Click on "Create Invoice", "Create Invoice"
7. Connect with admin account
8. Invoicing > Go to the previously created invoice
9. Confirm it
10. Connect with the user account
11. Sales > previously created SO > "1 Invoices"

=> The user can read the invoice, but he can not send and print it. This is an error.

OPW-2389428