### PR TITLE
[FIX] sale: Wrong lang in terms and conditions

### DIFF
--- a/addons/sale/models/account_invoice.py
+++ b/addons/sale/models/account_invoice.py
@@ -53,7 +53,7 @@ class AccountMove(models.Model):
 
         # Recompute 'narration' based on 'company.invoice_terms'.
         if self.type == 'out_invoice':
-            self.narration = self.company_id.with_context(lang=self.partner_id.lang).invoice_terms
+            self.narration = self.company_id.with_context(lang=self.partner_id.lang or self.env.lang).invoice_terms
 
         return res
 


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a configuration with two languages L1 and L2
- Go to Settings / Accounting / Customer Invoice / Default term & condition
- Define a default text T1 and save
- Create a new customer invoice, T1 is displayed in the field narration
- Go to Settings / Accounting / Customer Invoice / Default term & condition
- Change T1 to T2 for L1, L2 and save
- Create a new customer invoice

Bug:

T2 was displayed in the field narration

opw:2388353