### PR TITLE
[FIX] mail: attach the dropzone to the chatter

### DIFF
--- a/addons/mail/static/src/component_hooks/use_drag_visible_dropzone/use_drag_visible_dropzone.js
+++ b/addons/mail/static/src/component_hooks/use_drag_visible_dropzone/use_drag_visible_dropzone.js
@@ -1,7 +1,7 @@
 odoo.define('mail/static/src/component_hooks/use_drag_visible_dropzone/use_drag_visible_dropzone.js', function (require) {
 'use strict';
 
-const { useRef, useState, onMounted, onWillUnmount } = owl.hooks;
+const { useState, onMounted, onWillUnmount } = owl.hooks;
 
 /**
  * This hook handle the visibility of the dropzone based on drag & drop events.
@@ -18,7 +18,6 @@ function useDragVisibleDropZone() {
      * value accessible from `.value`
      */
     const isVisible = useState({ value: false });
-    const dropzoneRef = useRef('dropzone');
 
     /**
      * Counts how many drag enter/leave happened globally. This is the only
@@ -31,12 +30,20 @@ function useDragVisibleDropZone() {
         document.addEventListener('dragenter', _onDragenterListener, true);
         document.addEventListener('dragleave', _onDragleaveListener, true);
         document.addEventListener('drop', _onDropListener, true);
+
+        // Thoses Events prevent the browser to open or download the file if
+        // it's dropped outside of the dropzone
+        window.addEventListener('dragover', ev => ev.preventDefault());
+        window.addEventListener('drop', ev => ev.preventDefault());
     });
 
     onWillUnmount(() => {
         document.removeEventListener('dragenter', _onDragenterListener, true);
         document.removeEventListener('dragleave', _onDragleaveListener, true);
         document.removeEventListener('drop', _onDropListener, true);
+
+        window.removeEventListener('dragover', ev => ev.preventDefault());
+        window.removeEventListener('drop', ev => ev.preventDefault());
     });
 
     //--------------------------------------------------------------------------

--- a/addons/mail/static/src/components/chatter/chatter.scss
+++ b/addons/mail/static/src/components/chatter/chatter.scss
@@ -3,6 +3,7 @@
 // ------------------------------------------------------------------
 
 .o_Chatter {
+    position: relative;
     display: flex;
     flex: 1 1 auto;
     flex-direction: column;

--- a/addons/mail/static/src/components/drop_zone/drop_zone.scss
+++ b/addons/mail/static/src/components/drop_zone/drop_zone.scss
@@ -5,8 +5,8 @@
 .o_DropZone {
     display: flex;
     position: absolute;
+    top: 0;
     left: 0;
-    bottom: 0;
     height: 100%;
     width: 100%;
     z-index: 1;


### PR DESCRIPTION
Before this commit the dropzone was relative to div.content. This would create
some bad position where the dropzone was covering the form view but not the
chatter.

task-2389929