### PR TITLE
[FIX] mrp: carry over origin from source move in 3-step mfr

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -118,9 +118,13 @@ class StockRule(models.Model):
         }
         if location_id.get_warehouse().manufacture_steps == 'pbm_sam':
             # Use the procurement group created in _run_pull mrp override
+            # Preserve the origin from the original stock move, if available
+            if len(values.get('move_dest_ids', [])) == 1 and values['move_dest_ids'][0].origin:
+                origin = values['move_dest_ids'][0].origin
             mo_values.update({
                 'name': values['group_id'].name,
                 'procurement_group_id': values['group_id'].id,
+                'origin': origin,
             })
         return mo_values
 

--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -149,11 +149,14 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
             'location_id': self.warehouse.wh_output_stock_loc_id.id,
             'location_dest_id': self.customer_location,
             'procure_method': 'make_to_order',
+            'origin': 'SOURCEDOCUMENT',
             'state': 'draft',
         })
         picking_customer.action_confirm()
         production_order = self.env['mrp.production'].search([('product_id', '=', self.finished_product.id)])
         self.assertTrue(production_order)
+        self.assertEqual(production_order.origin, 'SOURCEDOCUMENT', 'The MO origin should be the SO name')
+        self.assertNotEqual(production_order.name, 'SOURCEDOCUMENT', 'The MO name should not be the origin of the move')
 
         picking_stock_preprod = self.env['stock.move'].search([
             ('product_id', '=', self.raw_product.id),
@@ -172,6 +175,8 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         self.assertTrue(picking_stock_postprod)
         self.assertEqual(picking_stock_preprod.state, 'confirmed')
         self.assertEqual(picking_stock_postprod.state, 'waiting')
+        self.assertEqual(picking_stock_preprod.origin, production_order.name, 'The pre-prod origin should be the MO name')
+        self.assertEqual(picking_stock_postprod.origin, 'SOURCEDOCUMENT', 'The post-prod origin should be the SO name')
 
         picking_stock_preprod.action_assign()
         picking_stock_preprod.move_line_ids.qty_done = 4


### PR DESCRIPTION
Behavior prior to this commit:

- when the warehouse uses a 3-step manufacturing process, if I create a Sales Order, the MO generated does not show the SO# as "Source", instead it shows the MO#

Behavior after this commit:

- the MO source shows the SO# (similar to how it works when using the 2-step or the 1-step manufacturing process)

Implementation note:

- the `origin` gets overwritten when the group is generated in `_run_pull`, because the group name is used as default origin in the [base `StockMove` model](https://github.com/odoo/odoo/blob/a8224115d8254b4200416f552fc86f6e9e68223c/addons/stock/models/stock_move.py#L1030). But we need that group to correctly tie the moves to the MO. So instead we go back to look at the dest move on the MO to get its origin.

opw-2380717


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
