### PR TITLE
[FIX] account: forbid resequencing secured journal entries

### DIFF
--- a/addons/account/wizard/account_resequence.py
+++ b/addons/account/wizard/account_resequence.py
@@ -30,6 +30,8 @@ class ReSequenceWizard(models.TransientModel):
             active_move_ids = self.env['account.move'].browse(self.env.context['active_ids'])
         if len(active_move_ids.journal_id) > 1:
             raise UserError(_('You can only resequence items from the same journal'))
+        if active_move_ids.filtered("inalterable_hash"):
+            raise UserError(_('Some or all of the entries are secured and cannot be modified'))
         if active_move_ids.journal_id.refund_sequence and len(set(active_move_ids.mapped('move_type')) - {'out_receipt', 'in_receipt'}) > 1:
             raise UserError(_('The sequences of this journal are different for Invoices and Refunds but you selected some of both types.'))
         values['move_ids'] = [(6, 0, active_move_ids.ids)]


### PR DESCRIPTION
STEPS:

* install l10n_fr/l10n_fr_pos_cert
* create journal entries
* in "Journal Entries" menu select some records and click "[Action] >
Resequence"

BEFORE: you can modify secured records

AFTER: you see error message

---

opw-2381859

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
