### PR TITLE
[FIX] web: Unable to create a new record with warning message

### DIFF
--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -4342,6 +4342,7 @@ var BasicModel = AbstractModel.extend({
                     fieldsInfo: element.fieldsInfo,
                     fields: element.fields,
                     viewType: element.viewType,
+                    allowWarning: true,
                 };
                 return this._makeDefaultRecord(element.model, params);
             }

--- a/addons/web/static/tests/views/form_tests.js
+++ b/addons/web/static/tests/views/form_tests.js
@@ -4765,6 +4765,45 @@ QUnit.module('Views', {
         form.destroy();
     });
 
+    QUnit.test('open new record even with warning message', async function (assert) {
+        assert.expect(3);
+
+        this.data.partner.onchanges = { foo: true };
+
+        var form = createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: '<form string="Partners">' +
+                    '<group><field name="foo"/></group>' +
+                '</form>',
+            res_id: 2,
+            mockRPC: function (route, args) {
+                if (args.method === 'onchange') {
+                    return $.when({
+                        warning: {
+                            title: "Warning",
+                            message: "Any warning."
+                        }
+                    });
+                }
+                return this._super.apply(this, arguments);
+            },
+
+        });
+
+        form.$buttons.find('.o_form_button_edit').click();
+        assert.strictEqual(form.$('input').val(), 'blip', 'input should contain record value');
+        form.$('input').first().val("tralala").trigger('input');
+        assert.strictEqual(form.$('input').val(), 'tralala', 'input should contain new value');
+
+        form.reload({ currentId: false });
+        assert.strictEqual(form.$('input').val(), 'My little Foo Value',
+            'input should contain default value after reload');
+
+        form.destroy();
+    });
+
     QUnit.test('render stat button with string inline', function (assert) {
         assert.expect(1);
 


### PR DESCRIPTION
Issue

	- Install Sales
	- In Sales > Configuration > Settings -> Enable "Sale Warnings"
	- Go to Sales > Orders > Customers
	- Pick a customer/company
	- Go in Edit mode and go to "Internal Notes" tab
	- Switch "Warning on the Sales Order" from "No Message" to "Warning" and add any warning message then save
	- Press the "$ X Sales" smart button
	- Create a new Quotation
	- Validate the warning message
	- Go back to the previous menu (using the breadcrumb) or save the quotation
	- Create a new quotation

	The quotation form editor does not appear.

Cause

	If we use the breadcrumb (or save then create), it will call the `_reload` function
	(instead of `load` when the form view hasn't been opened yet).
	In this case, creating a new record, it will call `_makeDefaultRecord` without
	setting `allowWarning` param to true (like it is done in the ref. commit bellow).

Solution

	Set `allowWarning` param to true before calling `_makeDefaultRecord`.

related commit : https://github.com/odoo/odoo/commit/a41db9a2cf410bb233b021651a5633180eaddf18

opw-2374857