### PR TITLE
[FIX] account: mandatory field account in payment

### DIFF
--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -209,7 +209,7 @@
                                 <field name="partner_id" context="{'default_is_company': True}"
                                        attrs="{'readonly': ['|', ('state', '!=', 'draft'), ('is_internal_transfer', '=', True)]}"/>
                                 <field name="destination_account_id"
-                                       options="{'no_create': True}"
+                                       options="{'no_create': True}" required="1"
                                        attrs="{'readonly': ['|', ('state', '!=', 'draft'), ('is_internal_transfer', '=', True)]}"/>
                                 <field name="is_internal_transfer"
                                        attrs="{'readonly': [('state', '!=', 'draft')]}"/>


### PR DESCRIPTION
Before this commit, `destination_account_id` field was not required on model/view, Creating record without `destination_account_id` is not allowed since it is required on `account.move`.

Now field is required.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
