### PR TITLE
[IMP] website_sale: add custom rec_name

### DIFF
--- a/addons/website_sale/models/product.py
+++ b/addons/website_sale/models/product.py
@@ -12,6 +12,7 @@ from odoo.osv import expression
 class ProductRibbon(models.Model):
     _name = "product.ribbon"
     _description = 'Product ribbon'
+    _rec_name = 'html'
 
     html = fields.Char(string='Ribbon html', required=True)
     bg_color = fields.Char(string='Ribbon background color', required=False)


### PR DESCRIPTION
Model `product.ribbon` doesn't have 'name' field or '_rec_name' which displays record like `product.ribbon,1` in list.

Now, we are using `html` field for display.

Fixes #60204

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
