### PR TITLE
disable listview buttons on click and enable it once actio…

### DIFF
--- a/addons/web/static/src/js/views/list/list_renderer.js
+++ b/addons/web/static/src/js/views/list/list_renderer.js
@@ -600,12 +600,15 @@ var ListRenderer = BasicRenderer.extend({
 
         if (record.res_id) {
             // TODO this should be moved to a handler
-            $button.on("click", function (e) {
-                e.stopPropagation();
+            const debouncedClick = _.debounce(() => {
                 self.trigger_up('button_clicked', {
                     attrs: node.attrs,
                     record: record,
                 });
+            }, 500, true);
+            $button.on("click", (e) => {
+                e.stopPropagation();
+                debouncedClick();
             });
         } else {
             if (node.attrs.options.warn) {

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -611,6 +611,39 @@ QUnit.module('Views', {
         list.destroy();
     });
 
+    QUnit.test('list view: buttons handler is called once on double click', async function (assert) {
+        assert.expect(2);
+
+        const executeActionDef = testUtils.makeTestPromise();
+        const list = await createView({
+            View: ListView,
+            model: 'foo',
+            data: this.data,
+            arch: `
+            <tree>
+                <field name="foo" />
+                <button name="x" type="object" class="do_something" string="Do Something"/>
+            </tree>`,
+            intercepts: {
+                async execute_action(ev) {
+                    assert.step('execute_action');
+                    const { on_success } = ev.data;
+                    await executeActionDef;
+                    on_success();
+                }
+            },
+        });
+
+        await testUtils.dom.click(list.$('tbody .o_list_button:first > button'));
+        await testUtils.dom.click(list.$('tbody .o_list_button:first > button'));
+
+        executeActionDef.resolve();
+        await testUtils.nextTick();
+        assert.verifySteps(['execute_action']);
+
+        list.destroy();
+    });
+
     QUnit.test('list view: action button executes action on click: correct parameters', async function (assert) {
         assert.expect(4);
 


### PR DESCRIPTION
PURPOSE
It aims at prevent the following use case:
    A user double clicks on a 'send email' listview button and sends the email twice.
Listview buttons should be disabled on click until the action is resolved (i.e. longer than the time it takes to double click)

SPEC
When clicking on a button in listview, disable the clicked button until the action is resolved/done.
NB: do not disable the whole row or list, but just the clicked button

TASK 2391298




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
