### PR TITLE
[FIX] point_of_sale: wrong use of assertAlmostEqual

### DIFF
--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -771,4 +771,4 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             ('ref', 'like', pos_session.name), ('journal_id', '=', pos_session.config_id.journal_id.id)
         ])
         diff_line = pos_session_move.line_ids.filtered(lambda line: line.name == 'Difference at closing PoS session')
-        self.assertAlmostEqual(diff_line.credit, 5.0, "Missing amount of 5.0")
+        self.assertAlmostEqual(diff_line.credit, 5.0, msg="Missing amount of 5.0")


### PR DESCRIPTION
Introduced in e25d859cd1d24404891a5c73aeb3550217c8485a,
assertAlmostEqual's third param is 'places' and not 'msg'.
We fix that by declaring the message as a keyword argument.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
