### PR TITLE
[FIX] stock: limit access to replenishment menu

### DIFF
--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -236,7 +236,8 @@
     <menuitem
         id="menu_reordering_rules_replenish"
         action="action_replenishment"
-        name="Replenishment" parent="menu_stock_warehouse_mgmt" sequence="10"/>
+        name="Replenishment" parent="menu_stock_warehouse_mgmt" sequence="10"
+        groups="stock.group_stock_manager"/>
     <menuitem
         id="menu_reordering_rules_config"
         action="action_orderpoint"


### PR DESCRIPTION
The replenishment menu is available even for users that are not allowed
to use it. This causes the click_all test to fail with a warning.
