### PR TITLE
[FIX] web: skip adyen account menu entry

### DIFF
--- a/addons/web/static/src/js/tools/test_menus.js
+++ b/addons/web/static/src/js/tools/test_menus.js
@@ -8,7 +8,7 @@
     var viewUpdateCount = 0;
     var testedApps;
     var testedMenus;
-    var blackListedMenus = ['base.menu_theme_store', 'base.menu_third_party', 'account.menu_action_account_bank_journal_form'];
+    var blackListedMenus = ['base.menu_theme_store', 'base.menu_third_party', 'account.menu_action_account_bank_journal_form', 'pos_adyen.menu_pos_adyen_account'];
     var appsMenusOnly = false;
     let isEnterprise = odoo.session_info.server_version_info[5] === 'e';
 


### PR DESCRIPTION
The `Adyen Account` menu entry leads to an external page.
This cannot be tested by the click_all test.
