### PR TITLE
[FIX] stock: Set default product on update qty wizard from variant

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -741,7 +741,7 @@ class ProductTemplate(models.Model):
         if (self.env.user.user_has_groups(','.join(advanced_option_groups))):
             return self.action_open_quants()
         else:
-            default_product_id = len(self.product_variant_ids) == 1 and self.product_variant_id.id
+            default_product_id = self.env.context.get('default_product_id', len(self.product_variant_ids) == 1 and self.product_variant_id.id)
             action = self.env.ref('stock.action_change_product_quantity').read()[0]
             action['context'] = dict(
                 self.env.context,


### PR DESCRIPTION
Currently, when we update the Quantity from the 'Update quantity'
button on a variant formview the product_id is not set due to
reset of the context for product template.

so in this commit, set the default product_id on update quantity
wizard when open through the product form view and also keep
default behaviour when called from product template.

TaskID: 2387310

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
