### PR TITLE
[13.0][FIX] purchase: use a company consistent sequence numbering.

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -176,10 +176,11 @@ class PurchaseOrder(models.Model):
     @api.model
     def create(self, vals):
         if vals.get('name', 'New') == 'New':
+            company_id = vals.get("company_id", self.env.company.id)
             seq_date = None
             if 'date_order' in vals:
                 seq_date = fields.Datetime.context_timestamp(self, fields.Datetime.to_datetime(vals['date_order']))
-            vals['name'] = self.env['ir.sequence'].next_by_code('purchase.order', sequence_date=seq_date) or '/'
+            vals['name'] = self.env['ir.sequence'].with_context(force_company=company_id).next_by_code('purchase.order', sequence_date=seq_date) or '/'
         return super(PurchaseOrder, self).create(vals)
 
     def write(self, vals):


### PR DESCRIPTION
If a RFQ/PO is created with a specific company, its number must
be assigning using the sequence defined for that company with
disregard to current environment company. E.g. This issue can
easily arise when using aliases to create RFQ's.

@ForgeFlow

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
