### PR TITLE
[FIX] mail: fix partner seen infos wrongly set as readonly

### DIFF
--- a/addons/mail/static/src/components/chat_window_manager/chat_window_manager_tests.js
+++ b/addons/mail/static/src/components/chat_window_manager/chat_window_manager_tests.js
@@ -2240,6 +2240,43 @@ QUnit.test('Textual representations of shift previous/next operations are correc
     );
 });
 
+QUnit.test('chat window should open when receiving a new DM', async function (assert) {
+    assert.expect(1);
+
+    this.data['mail.channel'].records.push({
+        channel_type: 'chat',
+        id: 11,
+        is_pinned: false,
+        members: [this.data.currentPartnerId, 11],
+        uuid: 'channel11uuid',
+    });
+    this.data['res.partner'].records.push({
+        id: 11,
+    });
+    this.data['res.users'].records.push({
+        id: 11,
+        partner_id: 11,
+    });
+    await this.start();
+
+    // simulate receiving the first message on channel 11
+    await afterNextRender(() => this.env.services.rpc({
+        route: '/mail/chat_post',
+        params: {
+            context: {
+                mockedUserId: 11,
+            },
+            message_content: "new message",
+            uuid: 'channel11uuid',
+        },
+    }));
+    assert.containsOnce(
+        document.body,
+        '.o_ChatWindow',
+        "a chat window should be open now that current user received a new message"
+    );
+});
+
 });
 });
 });

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -1889,10 +1889,13 @@ function factory(dependencies) {
         messagesAsServerChannel: many2many('mail.message', {
             inverse: 'serverChannels',
         }),
+        /**
+         * Contains the message fetched/seen indicators for all messages of this thread.
+         * FIXME This field should be readonly once task-2336946 is done.
+         */
         messageSeenIndicators: one2many('mail.message_seen_indicator', {
             inverse: 'thread',
             isCausal: true,
-            readonly: true,
         }),
         messaging: many2one('mail.messaging', {
             compute: '_computeMessaging',
@@ -2029,10 +2032,13 @@ function factory(dependencies) {
             compute: '_computeOverdueActivities',
             dependencies: ['activitiesState'],
         }),
+        /**
+         * Contains the seen information for all members of the thread.
+         * FIXME This field should be readonly once task-2336946 is done.
+         */
         partnerSeenInfos: one2many('mail.thread_partner_seen_info', {
             inverse: 'thread',
             isCausal: true,
-            readonly: true,
         }),
         /**
          * Determine if there is a pending seen message change, which is a change

--- a/addons/mail/static/tests/helpers/mock_server.js
+++ b/addons/mail/static/tests/helpers/mock_server.js
@@ -752,6 +752,12 @@ MockServer.include({
             });
             if (channel.channel_type === 'channel') {
                 delete res.members;
+            } else {
+                res['seen_partners_info'] = [{
+                    partner_id: this.currentPartnerId,
+                    seen_message_id: channel.seen_message_id,
+                    fetched_message_id: channel.fetched_message_id,
+                }];
             }
             return res;
         });


### PR DESCRIPTION
`threadPartnerSeenInfos` are updated on message received via a `convertData` & `thread.insert` but the field is `readonly` which lead to a traceback (see task).
This commit fixes it by wrongly added readonly.

task-2391981