### PR TITLE
[IMP] *: improve settings performance

### DIFF
--- a/addons/auth_password_policy/models/res_config_settings.py
+++ b/addons/auth_password_policy/models/res_config_settings.py
@@ -4,21 +4,9 @@ from odoo import api, fields, models, _
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
-    minlength = fields.Integer("Minimum Password Length", help="Minimum number of characters passwords must contain, set to 0 to disable.")
-
-    @api.model
-    def get_values(self):
-        res = super(ResConfigSettings, self).get_values()
-
-        res['minlength'] = int(self.env['ir.config_parameter'].sudo().get_param('auth_password_policy.minlength', default=0))
-
-        return res
-
-    @api.model
-    def set_values(self):
-        self.env['ir.config_parameter'].sudo().set_param('auth_password_policy.minlength', self.minlength)
-
-        super(ResConfigSettings, self).set_values()
+    minlength = fields.Integer(
+        "Minimum Password Length", config_parameter="auth_password_policy.minlength", default=0,
+        help="Minimum number of characters passwords must contain, set to 0 to disable.")
 
     @api.onchange('minlength')
     def _on_change_mins(self):

--- a/addons/website/models/res_config_settings.py
+++ b/addons/website/models/res_config_settings.py
@@ -140,9 +140,6 @@ class ResConfigSettings(models.TransientModel):
         for config in self:
             config.website_language_count = len(config.language_ids)
 
-    def set_values(self):
-        super(ResConfigSettings, self).set_values()
-
     def open_template_user(self):
         action = self.env["ir.actions.actions"]._for_xml_id("base.action_res_users")
         action['res_id'] = literal_eval(self.env['ir.config_parameter'].sudo().get_param('base.template_portal_user_id', 'False'))

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -935,6 +935,18 @@ class Module(models.Model):
             if not module.description_html:
                 _logger.warning('module %s: description is empty !', module.name)
 
+    def _get(self, name):
+        """ Return the (sudoed) `ir.module.module` record with the given name.
+        The result may be an empty recordset if the module is not found.
+        """
+        model_id = self._get_id(name) if name else False
+        return self.browse(model_id).sudo()
+
+    @tools.ormcache('name')
+    def _get_id(self, name):
+        self.env.cr.execute("SELECT id FROM ir_module_module WHERE name=%s", (name,))
+        return self.env.cr.fetchone()
+
     @api.model
     @tools.ormcache()
     def _installed(self):

--- a/odoo/addons/base/models/res_config.py
+++ b/odoo/addons/base/models/res_config.py
@@ -441,7 +441,7 @@ class ResConfigSettings(models.TransientModel, ResConfigModuleInstallationMixin)
                 self._onchange_methods[name].append(method)
 
     @api.model
-    def _get_classified_fields(self):
+    def _get_classified_fields(self, fnames=None):
         """ return a dictionary with the fields classified by category::
 
                 {   'default': [('default_foo', 'model', 'foo'), ...],
@@ -454,9 +454,12 @@ class ResConfigSettings(models.TransientModel, ResConfigModuleInstallationMixin)
         IrModule = self.env['ir.module.module']
         Groups = self.env['res.groups']
         ref = self.env.ref
+        if fnames is None:
+            fnames = self._fields.keys()
 
         defaults, groups, modules, configs, others = [], [], [], [], []
-        for name, field in self._fields.items():
+        for name in fnames:
+            field = self._fields[name]
             if name.startswith('default_'):
                 if not hasattr(field, 'default_model'):
                     raise Exception("Field %s without attribute 'default_model'" % field)
@@ -493,7 +496,7 @@ class ResConfigSettings(models.TransientModel, ResConfigModuleInstallationMixin)
     def default_get(self, fields):
         IrDefault = self.env['ir.default']
         IrConfigParameter = self.env['ir.config_parameter'].sudo()
-        classified = self._get_classified_fields()
+        classified = self._get_classified_fields(fields)
 
         res = super(ResConfigSettings, self).default_get(fields)
 

--- a/odoo/addons/base/models/res_config.py
+++ b/odoo/addons/base/models/res_config.py
@@ -641,6 +641,8 @@ class ResConfigSettings(models.TransientModel, ResConfigModuleInstallationMixin)
         lm = len('module_')
         for name, module in classified['module']:
             if int(self[name]):
+                if module.state == "installed":
+                    continue
                 to_install.append((name[lm:], module))
             else:
                 if module and module.state in ('installed', 'to upgrade'):

--- a/odoo/addons/base/models/res_config.py
+++ b/odoo/addons/base/models/res_config.py
@@ -448,8 +448,13 @@ class ResConfigSettings(models.TransientModel, ResConfigModuleInstallationMixin)
                 }
         """
         IrModule = self.env['ir.module.module']
+        IrModelData = self.env['ir.model.data']
         Groups = self.env['res.groups']
-        ref = self.env.ref
+
+        def ref(xml_id):
+            res_model, res_id = IrModelData._xmlid_to_res_model_res_id(xml_id)
+            return self.env[res_model].browse(res_id)
+
         if fnames is None:
             fnames = self._fields.keys()
 


### PR DESCRIPTION
Improve the res.config.settings wizard performance, on the python side (focus on `onchange`, `create` and `execute` rpcs).

* Avoid modification of non modified settings
* Do not fetch unnecessary data:
  * Use cached methods to avoid verifying n times the existence of a given record
  * Do not compute requested defaults if not asked by the ORM.

Before this PR: on runbot with "all" modules:
onchange: 0.6 sec
create: 0.53 s
execute (call_button): 0.59 s

After:
onchange: 0.27 sec
create: 0.31 sec
execute: 0.28 sec
and up to 3* less queries

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
