### PR TITLE
[FIX] mail: refresh activity list after editing and activity.

### DIFF
--- a/addons/mail/static/src/models/activity/activity.js
+++ b/addons/mail/static/src/models/activity/activity.js
@@ -160,11 +160,15 @@ function factory(dependencies) {
                 method: 'activity_format',
                 args: [this.id],
             }, { shadow: true }));
+            let shouldDelete = false;
             if (data) {
                 this.update(this.constructor.convertData(data));
-                this.thread.refresh();
             } else {
-                this.thread.refresh();
+                shouldDelete = true;
+            }
+            this.thread.refreshActivities();
+            this.thread.refresh();
+            if (shouldDelete) {
                 this.delete();
             }
         }


### PR DESCRIPTION
It's possible to create a new activity when editing a existing activity (done
and schedule next). In this case, we must refresh the activity list, otherwise
they wont be in the chatter.

task-2389961