### PR TITLE
[FIX] point_of_sale: Fix cash control popup

### DIFF
--- a/addons/point_of_sale/static/src/js/Popups/CashOpeningPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/CashOpeningPopup.js
@@ -28,8 +28,6 @@ odoo.define('point_of_sale.CashOpeningPopup', function(require) {
         }
 
         startSession() {
-            if(!parseFloat(this.cashBoxValue))
-                return;
             this.env.pos.bank_statement.balance_start = parseFloat(this.cashBoxValue);
             this.env.pos.pos_session.state = 'opened';
             this.rpc({
@@ -61,7 +59,6 @@ odoo.define('point_of_sale.CashOpeningPopup', function(require) {
             }
             this.render();
         }
-
     }
 
     CashOpeningPopup.template = 'CashOpeningPopup';


### PR DESCRIPTION
It was impossible to validate the cash control popup if the value was 0.
Now it's possible to validate any amount, including 0.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
