### PR TITLE
[FIX] point_of_sale : prevent bounce effect on iPad Fullscreen

### DIFF
--- a/addons/point_of_sale/static/src/css/pos.css
+++ b/addons/point_of_sale/static/src/css/pos.css
@@ -45,6 +45,15 @@ html {
     font-family: sans-serif;
 }
 
+/* PREVENT BOUNCE EFFECT ON IPAD FULLSCREEN */
+body,
+html {
+  position: fixed;
+  width:100%;
+  height: 100%;
+  margin:0;
+}
+
 table {
     border-spacing: 0px;
     border-collapse: collapse;


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Prevent bounce effect on iPad Fullscreen




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
