### PR TITLE
[FIX] web_editor: video in columns is not correctly displayed

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -360,6 +360,9 @@ table.table_desc tr td {
 // Three columns
 
 .s_three_columns {
+    .card .media_iframe_video {
+        width: 100%;
+    }
     .align-items-stretch .card {
         height: 100%;
     }


### PR DESCRIPTION
Steps:
- In Website, click "Go to website"
- Click "Edit" in the corner
- Add the block "Three columns"
- Double-click on one of the three images
- In the modal, click "Video"
- Put a link to a video in the "Video code" field
- Save

Bug:
Unlike the other images, the video does not entirely fill the column in width.

opw:2381928