### PR TITLE
[FIX] account: remove tip on onboarding tour

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -5051,8 +5051,7 @@ msgstr ""
 #: code:addons/account/static/src/js/tours/account.js:0
 #, python-format
 msgid ""
-"Fill in the details of the line.<br><i>Tip: all the details can be set "
-"automatically if you configure your <b>products</b>.</i>"
+"Fill in the details of the line."
 msgstr ""
 
 #. module: account

--- a/addons/account/static/src/js/tours/account.js
+++ b/addons/account/static/src/js/tours/account.js
@@ -52,7 +52,7 @@ tour.register('account_tour', {
     }, {
         trigger: "div[name=invoice_line_ids] textarea[name=name]",
         extra_trigger: "[name=move_type][raw-value=out_invoice]",
-        content: _t("Fill in the details of the line.<br><i>Tip: all the details can be set automatically if you configure your <b>products</b>.</i>"),
+        content: _t("Fill in the details of the line."),
         position: "bottom",
     }, {
         trigger: "div[name=invoice_line_ids] input[name=price_unit]",


### PR DESCRIPTION
Task [2352493](https://www.odoo.com/web#id=2352493&action=333&active_id=967&model=project.task&view_type=form&cids=1&menu_id=4720)

When the user is asked to fill in the label on the invoice, the tooltip
tells him that the label can be auto-filled by configuring its products.
This leads the user to configure products. But then, as he doesn't fill
in the label, the tour is "broken".

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
