### PR TITLE
[FIX] website_sale_comparison: Compare product with single variant

### DIFF
--- a/addons/website_sale_comparison/static/src/js/website_sale_comparison.js
+++ b/addons/website_sale_comparison/static/src/js/website_sale_comparison.js
@@ -105,7 +105,8 @@ var ProductComparison = publicWidget.Widget.extend(VariantMixin, {
                 $elem.closest('form').find('.product_template_id').val(),
                 false
             ).then(function (productId) {
-                productId = parseInt(productId, 10);
+                var defaultProductId = parseInt($elem.data('product-product-id'), 10)
+                productId = parseInt(productId, 10) || defaultProductId;
                 if (!productId) {
                     return;
                 }


### PR DESCRIPTION
What are the steps to reproduce your issue ?

    1. Install "website_sale_comparison"
    2. Create a product with only one variant with one attribut
    3. Click on "Go to website" smart button
    4. Enable "Customize/List View Variant"
    5. Click on "Compare" button

What is currently happening ?

    Nothing

What are you expecting to happen ?

    Add product to the comparison list

Why is this happening ?

    Because the product has just one variant and attribut so odoo don't
    display it on the product page. The system cannot find the ids as
    they are not on the page

How to fix the bug ?

    Specify the product id in this case

opw-2377711
https://www.odoo.com/web#id=2377711&action=4043&model=project.task&view_type=form&cids=1&menu_id=4720