### PR TITLE
[FIX] account : show older first

### DIFF
--- a/addons/account/views/account_bank_statement_views.xml
+++ b/addons/account/views/account_bank_statement_views.xml
@@ -326,7 +326,7 @@
             <field name="model">account.bank.statement.line</field>
             <field name="priority">8</field>
             <field name="arch" type="xml">
-                <tree string="Statement lines" create="false">
+                <tree string="Statement lines" create="false" default_order="date desc, sequence, id desc">
                     <!-- Invisible fields -->
                     <field name="state" invisible="1"/>
                     <field name="sequence" readonly="1" invisible="1"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Go to account overview (in Odoo Enterprise)
- On bank journal, click on the menu button, then select Opération (account.bank.statement.line)
--> Issue you see older first.

It is more logical to see newest first (like account.move.line).

@oco-odoo 
@nim-odoo

Note this issue existing in V12,13

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
