### PR TITLE
[IMP] crm[_sms]: align crm list view with "My Activities" view

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -619,6 +619,19 @@
         <!--
             MASS MAILING
         -->
+        <record id="action_lead_mail_compose" model="ir.actions.act_window">
+            <field name="name">Send email</field>
+            <field name="res_model">mail.compose.message</field>
+            <field name="view_mode">form</field>
+            <field name="target">new</field>
+            <field name="context" eval="{
+    'default_composition_mode': 'comment',
+    'default_use_template': False,
+                }"/>
+            <field name="binding_model_id" ref="model_crm_lead"/>
+            <field name="binding_view_types">form</field>
+        </record>
+
         <record id="action_lead_mass_mail" model="ir.actions.act_window">
             <field name="name">Send email</field>
             <field name="res_model">mail.compose.message</field>
@@ -642,6 +655,9 @@
             <field name="priority">1</field>
             <field name="arch" type="xml">
                 <tree string="Opportunities" sample="1" multi_edit="1">
+                    <header>
+                        <button name="%(crm.action_lead_mass_mail)d" type="action" string="Email" />
+                    </header>
                     <field name="date_deadline" invisible="1"/>
                     <field name="create_date" optional="hide"/>
                     <field name="name" string="Opportunity" readonly="1"/>
@@ -654,7 +670,7 @@
                     <field name="state_id" optional="hide"/>
                     <field name="country_id" optional="hide" options="{'no_open': True, 'no_create': True}"/>
                     <field name="user_id" widget="many2one_avatar_user" optional="show" domain="[('share', '=', False)]"/>
-                    <field name="team_id" optional="show"/>
+                    <field name="team_id" optional="hide"/>
                     <field name="priority" optional="hide"/>
                     <field name="activity_ids" widget="list_activity"/>
                     <field name="activity_user_id" optional="hide" string="Activity by" widget="many2one_avatar_user"/>
@@ -673,6 +689,9 @@
                     <field name="tag_ids" optional="hide" widget="many2many_tags" options="{'color_field': 'color'}"/>
                     <field name="referred" invisible="1"/>
                     <field name="message_needaction" invisible="1"/>
+                    <button name="action_snooze" class="text-warning" type="object" string="Snooze 7d" icon="fa-bell-slash"
+                        attrs="{'invisible': [('activity_date_deadline_my', '=', False)]}"/>
+                    <button name="%(crm.action_lead_mail_compose)d" type="action" string="Email" icon="fa-envelope"/>
                 </tree>
             </field>
         </record>
@@ -687,20 +706,11 @@
                 <xpath expr="//tree" position="attributes">
                     <attribute name="default_order">activity_date_deadline_my</attribute>
                 </xpath>
-                <xpath expr="//tree" position="inside">
-                    <header>
-                        <button name="%(crm.action_lead_mass_mail)d" type="action" string="Email" />
-                    </header>
-                </xpath>
                 <field name="user_id" position="attributes">
                     <attribute name="optional">hide</attribute>
                 </field>
                 <field name="team_id" position="attributes">
                     <attribute name="optional">hide</attribute>
-                </field>
-                <field name="message_needaction" position="after">
-                    <button name="action_snooze" class="text-warning" type="object" string="Snooze 7d" icon="fa-bell-slash" />
-                    <button name="%(crm.action_lead_mass_mail)d" type="action" string="Email" icon="fa-envelope"/>
                 </field>
             </field>
         </record>

--- a/addons/crm_sms/__manifest__.py
+++ b/addons/crm_sms/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'SMS in CRM',
-    'version': '1.0',
+    'version': '1.1',
     'category': 'Sales/CRM',
     'summary': 'Add SMS capabilities to CRM',
     'description': "",

--- a/addons/crm_sms/views/crm_lead_views.xml
+++ b/addons/crm_sms/views/crm_lead_views.xml
@@ -27,15 +27,15 @@
         <field name="binding_view_types">form</field>
     </record>
 
-    <record id="crm_lead_view_list_activities" model="ir.ui.view">
-        <field name="name">crm.lead.view.list.activities.inherit.sms</field>
+    <record id="crm_case_tree_view_oppor" model="ir.ui.view">
+        <field name="name">crm.lead.tree.opportunity.inherit.sms</field>
         <field name="model">crm.lead</field>
-        <field name="inherit_id" ref="crm.crm_lead_view_list_activities"/>
+        <field name="inherit_id" ref="crm.crm_case_tree_view_oppor"/>
         <field name="arch" type="xml">
             <xpath expr="//header" position="inside">
                 <button name="%(crm_sms.crm_lead_act_window_sms_composer_single)d" type="action" string="SMS" />
             </xpath>
-            <xpath expr="//button[@name='%(crm.action_lead_mass_mail)d']" position="after">
+            <xpath expr="//button[@name='%(crm.action_lead_mail_compose)d']" position="after">
                 <button name="%(crm_sms.crm_lead_act_window_sms_composer_multi)d" type="action" string="SMS" icon="fa-comments" />
             </xpath>
         </field>


### PR DESCRIPTION
Some of the feature of the "My Activities" list view of the crm app were not
available on the regular crm tree view.

This commit aligns the 2 views by sharing these features, notably:
- You can "snooze" your next activity if there is one
- You can contact the lead by email with a direct button on the row
- You can contact the lead by sms with a direct button on the row

The "team_id" column is now optional="hide" since not required most of the time
when you go to check your own leads (and can be activated in a few clicks if
needed).

Finally, the "Email" action at the end of the tree row is now in "single" mode
to allow adding contacts on the fly. This implied re-introducing an action that
was recently removed in 8c65d7c
Further demonstrating that R&D is just an eternal loop.

Task 2390500