### PR TITLE
[IMP] fleet: Fleet Improvements on Mobile UI

### DIFF
--- a/addons/fleet/__manifest__.py
+++ b/addons/fleet/__manifest__.py
@@ -38,6 +38,7 @@ Main Features
         'views/fleet_board_view.xml',
         'views/mail_activity_views.xml',
         'views/res_config_settings_views.xml',
+        'views/assets.xml',
         'data/fleet_cars_data.xml',
         'data/fleet_data.xml',
         'data/mail_data.xml',

--- a/addons/fleet/static/src/js/fleet_kanban.js
+++ b/addons/fleet/static/src/js/fleet_kanban.js
@@ -1,0 +1,20 @@
+odoo.define('fleet.fleet_kanban', function (require) {
+    'use strict';
+
+    const KanbanRecord = require('web.KanbanRecord');
+
+    KanbanRecord.include({
+
+        /**
+         * @override
+         * @private
+         */
+        _openRecord() {
+            if (this.modelName === 'fleet.vehicle.model.brand' && this.$(".oe_kanban_fleet_model").length) {
+                this.$('.oe_kanban_fleet_model').first().click();
+            } else {
+                this._super.apply(this, arguments);
+            }
+        },
+    });
+});

--- a/addons/fleet/views/assets.xml
+++ b/addons/fleet/views/assets.xml
@@ -3,6 +3,7 @@
     <template id="assets_backend" inherit_id="web.assets_backend">
         <xpath expr="script[last()]" position="after">
             <script type="text/javascript" src="/fleet/static/src/js/fleet_form.js"/>
+            <script type="text/javascript" src="/fleet/static/src/js/fleet_kanban.js"/>
         </xpath>
     </template>
 </odoo>

--- a/addons/fleet/views/fleet_vehicle_cost_views.xml
+++ b/addons/fleet/views/fleet_vehicle_cost_views.xml
@@ -107,7 +107,8 @@
                                 </strong>
                             </div>
                             <div>
-                                <field name="start_date"/> - <field name="expiration_date"/>
+                                <t t-if="new Date(record.expiration_date.raw_value) &lt; (new Date())" t-set="expiration_class" t-value="'oe_kanban_text_red'"/>
+                                <span t-att-class="expiration_class"><field name="start_date"/> - <field name="expiration_date"/></span>
                             </div>
                             <div>
                                 <field name="insurer_id" widget="res_partner_many2one"/>
@@ -222,8 +223,8 @@
                             <field name="purchaser_id"/>
                             <label for="odometer"/>
                             <div class="o_row">
-                                <field name="odometer"/>
-                                <field name="odometer_unit"/>
+                                <field name="odometer" class="oe_inline"/>
+                                <field name="odometer_unit" class="pl-1 pl-sm-0"/>
                             </div>
                         </group>
                     </group>
@@ -281,8 +282,10 @@
                                     <div class="o_kanban_record_headings pl-2 pr-2">
                                         <div class="text-truncate o_kanban_record_title">
                                             <strong>
-                                                <span class="float-right"><field name="date"/></span>
                                                 <field name="vehicle_id"/>
+                                                <span t-attf-class="float-right badge #{['todo', 'running'].indexOf(record.state.raw_value) > -1 ? 'badge-secondary' : ['cancelled'].indexOf(record.state.raw_value) > -1 ? 'badge-danger' : 'badge-success'}">
+                                                    <field name="state"/>
+                                                </span>
                                             </strong>
                                         </div>
                                         <div class="text-truncate">
@@ -292,6 +295,7 @@
                                 </div>
                                 <div class="text-truncate">
                                     <field name="purchaser_id"/>
+                                    <span class="float-right"><field name="date"/></span>
                                 </div>
                                 <div class="text-truncate">
                                     <field name="vendor_id"/>

--- a/addons/fleet/views/fleet_vehicle_model_views.xml
+++ b/addons/fleet/views/fleet_vehicle_model_views.xml
@@ -141,27 +141,33 @@
         <field name="name">fleet.vehicle.model.brandkanban</field>
         <field name="model">fleet.vehicle.model.brand</field>
         <field name="arch" type="xml">
-            <kanban>
+            <kanban default_order="name">
                 <field name="id"/>
                 <field name="name" />
                 <templates>
                     <t t-name="kanban-box">
                         <div class="oe_kanban_vignette oe_semantic_html_override oe_kanban_global_click">
-                            <a type="open" href="#" class="o_kanban_image oe_kanban_action">
-                                <img alt="Open" t-att-src="kanban_image('fleet.vehicle.model.brand', 'image_128', record.id.raw_value)" class="img-fluid" style="width:100px;"/>
-                            </a>
+                            <div class="o_dropdown_kanban dropdown">
+                                <a class="dropdown-toggle o-no-caret btn" role="button" data-toggle="dropdown" href="#" aria-label="Dropdown menu" title="Dropdown menu">
+                                    <span class="fa fa-ellipsis-v"/>
+                                </a>
+                                <div class="dropdown-menu" role="menu">
+                                    <a role="menuitem" type="open" class="dropdown-item">Properties</a>
+                                </div>
+                            </div>
+                            <div class="o_kanban_image">
+                                <img alt="img" t-att-src="kanban_image('fleet.vehicle.model.brand', 'image_128', record.id.raw_value)" class="o_image_64_max" height="52"/>
+                            </div>
                             <div class="oe_kanban_details">
                                 <h4 class="oe_partner_heading">
                                     <a type="open" class="o_kanban_record_title">
                                         <field name="name"/>
                                     </a>
                                 </h4>
-                            </div>
-                            <div class="o_kanban_button">
-                                <a type="object" name="action_brand_model" class="oe_kanban_action oe_kanban_action_a">
-                                    <field name="model_count"/>
-                                MODELS
-                                </a>
+                                <div>
+                                    <a type="object" name="action_brand_model" class="oe_kanban_fleet_model"/>
+                                    <field name="model_count"/> MODELS
+                                </div>
                             </div>
                         </div>
                     </t>

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -309,10 +309,15 @@
             <form string="Odometer Logs">
                 <sheet>
                     <group>
-                        <field name="vehicle_id"/>
-                        <field name="value" class="oe_inline"/>
-                        <field name="unit" class="oe_inline"/>
-                        <field name="date" />
+                        <group>
+                            <field name="vehicle_id"/>
+                            <label for="value"/>
+                            <div class="o_row">
+                                <field name="value" class="oe_inline"/>
+                                <field name="unit" class="ml-2"/>
+                            </div>
+                            <field name="date"/>
+                        </group>
                     </group>
                 </sheet>
             </form>
@@ -343,12 +348,12 @@
                         <div t-attf-class="oe_kanban_global_click">
                             <div>
                                 <strong>
-                                    <field name="vehicle_id" widget="res_partner_many2one"/>
+                                    <field name="vehicle_id"/>
                                     <span class="float-right"><field name="date"/></span>
                                 </strong>
                             </div>
                             <div>
-                                <span><field name="driver_id" widget="res_partner_many2one"/></span>
+                                <span><field name="driver_id"/></span>
                                 <span class="float-right"><field name="value"/> Km</span>
                             </div>
                         </div>

--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -972,16 +972,16 @@
     </table>
 </form>
 <t t-name="GraphView.buttons">
-    <div class="btn-group" role="toolbar" aria-label="Main actions"/>
-    <div class="btn-group" role="toolbar" aria-label="Change graph">
+    <div class="btn-group mb-2 mb-sm-auto" role="toolbar" aria-label="Main actions"/>
+    <div class="btn-group o_graph_align mb-2 mb-sm-auto" role="toolbar" aria-label="Change graph">
         <button class="btn btn-secondary fa fa-bar-chart-o o_graph_button" title="Bar Chart" aria-label="Bar Chart" data-mode="bar"/>
         <button class="btn btn-secondary fa fa-area-chart o_graph_button" title="Line Chart" aria-label="Line Chart" data-mode="line"/>
         <button class="btn btn-secondary fa fa-pie-chart o_graph_button" title="Pie Chart" aria-label="Pie Chart" data-mode="pie"/>
     </div>
-    <div class="btn-group" role="toolbar" aria-label="Change graph">
+    <div class="btn-group o_stack_align mb-2 mb-sm-auto" role="toolbar" aria-label="Change graph">
         <button class="btn btn-secondary fa fa-database o_graph_button" title="Stacked" aria-label="Stacked" data-mode="stack"/>
     </div>
-    <div class="btn-group" role="toolbar" aria-label="Sort graph">
+    <div class="btn-group o_sort_align mb-2 mb-sm-auto" role="toolbar" aria-label="Sort graph">
         <button class="btn btn-secondary fa fa-sort-amount-desc o_graph_button" title="Descending" aria-label="Descending" data-order="desc"/>
         <button class="btn btn-secondary fa fa-sort-amount-asc o_graph_button" title="Ascending" aria-label="Ascending" data-order="asc"/>
     </div>


### PR DESCRIPTION
Purpose of the task is to improve the mobile UI.

Services kanban view, Odometers kanban view:

The kanban card in services and odometers should not have any record
with link.

So in this commit, removed the widget applied on that field.

Contracts kanban view:

The date on kanban card of contracts should be in red when the
contract expired.

So in this commit, applied qweb conditional directive and the kanban class
on the date field.

Odometer form view:

In mobile view the unit value is displayed on the right side instead
its should be below unit field.

In this commit, added the bootstrap class to fix the position of that
field value.

Settings > Manufactures kanban view:

If we click on kanban card, go to the list of models instead of
form view. And add a button to go to the manufacturer form.

In this commit, added a dropdown menu to go to manufacturer form and
applied click binding on kanban card to go to list of models.

Vehicles form:

In mobile view of vehicle form the apply change button have to be on
right.

In this commit, added a bootstrap css class on the button to move the
button right.

TaskId: 2348332

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
