### PR TITLE
[IMP]project,rating,sale_timesheet: Improve the reporting of project …

### DIFF
--- a/addons/project/views/rating_views.xml
+++ b/addons/project/views/rating_views.xml
@@ -187,7 +187,14 @@
                 Let's wait for your customers to manifest themselves.
             </p>
         </field>
-        <field name="context">{}</field>
+        <field name="context">{'search_default_rating_last_30_days': 1, 'search_default_responsible': 1}</field>
+    </record>
+
+    <record id="rating_rating_action_project_report_kanban" model="ir.actions.act_window.view">
+        <field name="sequence" eval="5"/>
+        <field name="view_mode">kanban</field>
+        <field name="act_window_id" ref="rating_rating_action_project_report"/>
+        <field name="view_id" ref="rating.rating_rating_view_kanban"/>
     </record>
 
     <record id="rating_rating_action_project_report_tree" model="ir.actions.act_window.view">

--- a/addons/rating/views/rating_rating_views.xml
+++ b/addons/rating/views/rating_rating_views.xml
@@ -6,12 +6,12 @@
             <field name="model">rating.rating</field>
             <field name="arch" type="xml">
                 <tree string="Rating" create="false" edit="false" sample="1">
-                    <field name="res_name"/>
-                    <field name="parent_res_name"/>
+                    <field name="rating_text" decoration-danger="rating_text == 'highly_dissatisfied'" decoration-warning="rating_text == 'not_satisfied'" decoration-success="rating_text == 'satisfied'" class="font-weight-bold"/>
+                    <field name="feedback"/>
                     <field name="rated_partner_id"/>
                     <field name="partner_id"/>
-                    <field name="rating_text" decoration-danger="rating_text == 'highly_dissatisfied'" decoration-warning="rating_text == 'not_satisfied'" decoration-success="rating_text == 'satisfied'"/>
-                    <field name="feedback"/>
+                    <field name="res_name"/>
+                    <field name="parent_res_name"/>
                     <field name="create_date"/>
                 </tree>
             </field>
@@ -62,35 +62,39 @@
                     <templates>
                         <t t-name="kanban-box">
                             <div class="oe_kanban_global_click">
-                                <div class="o_kanban_image">
-                                    <field name="rating_image" widget="image"/>
-                                </div>
-                                <div class="oe_kanban_details">
-                                    <strong>
-                                        <field name="rated_partner_id" />
-                                    </strong>
-                                    <ul>
-                                        <li t-if="record.partner_id.value">
-                                            <span class="o_text_overflow">
-                                                by
-                                                <span t-att-title="record.partner_id.value">
-                                                    <field name="partner_id" />
+                                <div class="row oe_kanban_details">
+                                    <div class="col-4 o_kanban_image my-auto">
+                                        <field name="rating_image" widget="image"/>
+                                    </div>
+                                    <div class="col-8 pl-1">
+                                        <strong>
+                                            <field name="rated_partner_id" />
+                                        </strong>
+                                        <ul>
+                                            <li t-if="record.partner_id.value">
+                                                <span class="o_text_overflow">
+                                                    by
+                                                    <span t-att-title="record.partner_id.value">
+                                                        <field name="partner_id" />
+                                                    </span>
                                                 </span>
-                                            </span>
-                                        </li>
-                                        <li>
-                                            <span class="o_text_overflow">
-                                                for
-                                                <a type="object" name="action_open_rated_object" t-att-title="record.res_name.raw_value">
-                                                    <field name="res_name" />
-                                                </a>
-                                            </span>
-                                        </li>
-                                        <li>
-                                            on <field name="create_date" />
-                                        </li>
-                                    </ul>
-                                    <i t-if="record.feedback.raw_value" class="fa fa-comment float-right mt4" t-att-title="record.feedback.raw_value"  t-att-aria-label="record.feedback.raw_value" role="img"/>
+                                            </li>
+                                            <li>
+                                                <span class="o_text_overflow">
+                                                    for
+                                                    <a type="object" name="action_open_rated_object" t-att-title="record.res_name.raw_value">
+                                                        <field name="res_name" />
+                                                    </a>
+                                                </span>
+                                            </li>
+                                            <li>
+                                                on <field name="create_date" />
+                                            </li>
+                                            <li t-if="record.feedback.raw_value" class="o_text_overflow" t-att-title="record.feedback.raw_value">
+                                                <field name="feedback"/>
+                                            </li>
+                                        </ul>
+                                </div>
                                 </div>
                             </div>
                         </t>

--- a/addons/sale_timesheet/data/sale_timesheet_filters.xml
+++ b/addons/sale_timesheet/data/sale_timesheet_filters.xml
@@ -7,8 +7,7 @@
         <field name="user_id" eval="False"/>
         <field name="is_default" eval="True"/>
         <field name="context">{
-            'group_by': ['line_date'],
-            'pivot_measures': ['amount_untaxed_to_invoice', 'amount_untaxed_invoiced', 'timesheet_cost', 'timesheet_unit_amount']
+            'pivot_measures': ['amount_untaxed_to_invoice', 'amount_untaxed_invoiced', 'timesheet_cost', 'margin']
         }</field>
     </record>
 

--- a/addons/sale_timesheet/report/project_profitability_report_analysis.py
+++ b/addons/sale_timesheet/report/project_profitability_report_analysis.py
@@ -13,6 +13,7 @@ class ProfitabilityAnalysis(models.Model):
 
     analytic_account_id = fields.Many2one('account.analytic.account', string='Analytic Account', readonly=True)
     project_id = fields.Many2one('project.project', string='Project', readonly=True)
+    task_id = fields.Many2one('project.task', string='Task', readonly=True)
     currency_id = fields.Many2one('res.currency', string='Project Currency', readonly=True)
     company_id = fields.Many2one('res.company', string='Project Company', readonly=True)
     user_id = fields.Many2one('res.users', string='Project Manager', readonly=True)
@@ -28,10 +29,10 @@ class ProfitabilityAnalysis(models.Model):
     sale_order_id = fields.Many2one('sale.order', string='Sale Order', readonly=True)
     product_id = fields.Many2one('product.product', string='Product', readonly=True)
 
-    amount_untaxed_to_invoice = fields.Float("Untaxed Amount to Invoice", digits=(16, 2), readonly=True, group_operator="sum")
-    amount_untaxed_invoiced = fields.Float("Untaxed Amount Invoiced", digits=(16, 2), readonly=True, group_operator="sum")
-    expense_amount_untaxed_to_invoice = fields.Float("Untaxed Amount to Re-invoice", digits=(16, 2), readonly=True, group_operator="sum")
-    expense_amount_untaxed_invoiced = fields.Float("Untaxed Amount Re-invoiced", digits=(16, 2), readonly=True, group_operator="sum")
+    amount_untaxed_to_invoice = fields.Float("Amount to Invoice", digits=(16, 2), readonly=True, group_operator="sum")
+    amount_untaxed_invoiced = fields.Float("Amount Invoiced", digits=(16, 2), readonly=True, group_operator="sum")
+    expense_amount_untaxed_to_invoice = fields.Float("Amount to Re-invoice", digits=(16, 2), readonly=True, group_operator="sum")
+    expense_amount_untaxed_invoiced = fields.Float("Amount Re-invoiced", digits=(16, 2), readonly=True, group_operator="sum")
     other_revenues = fields.Float("Other Revenues", digits=(16, 2), readonly=True, group_operator="sum",
                                   help="All revenues that are not from timesheets and that are linked to the analytic account of the project.")
     margin = fields.Float("Margin", digits=(16, 2), readonly=True, group_operator="sum")
@@ -43,6 +44,7 @@ class ProfitabilityAnalysis(models.Model):
                 SELECT
                     sub.id as id,
                     sub.project_id as project_id,
+                    sub.task_id as task_id,
                     sub.user_id as user_id,
                     sub.sale_line_id as sale_line_id,
                     sub.analytic_account_id as analytic_account_id,
@@ -71,6 +73,7 @@ class ProfitabilityAnalysis(models.Model):
                         P.id AS project_id,
                         P.user_id AS user_id,
                         SOL.id AS sale_line_id,
+                        SOL.task_id AS task_id,
                         P.analytic_account_id AS analytic_account_id,
                         P.partner_id AS partner_id,
                         C.id AS company_id,

--- a/addons/sale_timesheet/report/project_profitability_report_analysis_views.xml
+++ b/addons/sale_timesheet/report/project_profitability_report_analysis_views.xml
@@ -10,6 +10,7 @@
                 <field name="amount_untaxed_to_invoice" type="measure"/>
                 <field name="amount_untaxed_invoiced" type="measure"/>
                 <field name="timesheet_cost" type="measure"/>
+                <field name="margin" type="measure"/>
             </pivot>
         </field>
     </record>
@@ -44,6 +45,7 @@
                 <group expand="1" string="Group By">
                     <filter string="Project" name="group_by_project" context="{'group_by':'project_id'}"/>
                     <filter string="Project Manager" name="group_by_user_id" context="{'group_by':'user_id'}"/>
+                    <filter string="Task" name="group_by_task_id" context="{'group_by':'task_id'}"/>
                     <filter string="Customer" name="group_by_partner_id" context="{'group_by':'partner_id'}"/>
                     <filter string="Company" name="group_by_company" context="{'group_by':'company_id'}" groups="base.group_multi_company"/>
                     <filter string="Date" name="group_by_line_date" context="{'group_by':'line_date'}"/>
@@ -58,7 +60,9 @@
         <field name="view_mode">pivot,graph</field>
         <field name="search_view_id" ref="project_profitability_report_view_search"/>
         <field name="context">{
+            'pivot_row_groupby': ['line_date:month'],
             'group_by_no_leaf':1,
+            'graph_groupbys': ['project_id'],
             'group_by':[],
             'sale_show_order_product_name': 1,
         }</field>


### PR DESCRIPTION
…module

Purpose of this task is to improve the reporting of Project module by various
improvements.

In this commit done the below changes:
- Project Costs & Revenues:
 - Pivot view
  - apply a group by > month by default
  - remove the 'timesheet duration' measure and display the 'margin' mesure by
    default instead
 - Graph view
  - apply a group by > project
  - add a group by > task (not applied by default)
 - change the labels as follows:
  - Untaxed Amount Invoiced -> Amount Invoiced
  - Untaxed Amount Re-Invoiced -> Amount Re-Invoiced
  - Untaxed Amount to Invoice -> Amount to Invoice
  - Untaxed Amount to Re-Invoice -> Amount to Re-invoice
- Customer Ratings:
 - list view
  - change the order of the fields as follows: 1) Rating 2) Assigned to
    3) Customer 4) Task 5) Project 6) Submitted on 7) Comment
  - display the rating in bold
  - apply the 'last 30 days' filter by default
  - apply a group by 'rated user' by default
  - switch the default view to the kanban view
 - kanban view
  - the smiley should be centered vertically
  - display the full comment below(crop it after x characters if it is too long)

LINKS
PR: #62294
TaskID: 2307111

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
