### PR TITLE
[FIX] core: allow writing to delegated m2o fields on records

### DIFF
--- a/odoo/addons/test_inherits/tests/test_inherits.py
+++ b/odoo/addons/test_inherits/tests/test_inherits.py
@@ -138,3 +138,13 @@ class test_inherits(common.TransactionCase):
         self.assertIn('lang', Unit.display_name.depends_context)
         self.assertIn('lang', Box.display_name.depends_context)
         self.assertIn('lang', Pallet.display_name.depends_context)
+
+    def test_multi_write_m2o_inherits(self):
+        """Verify that an inherits m2o field can be written to in batch"""
+        unit_foo = self.env['test.unit'].create({'name': 'foo'})
+        boxes = self.env['test.box'].create([{'unit_id': unit_foo.id}] * 5)
+
+        unit_bar = self.env['test.unit'].create({'name': 'bar'})
+        boxes.unit_id = unit_bar
+
+        self.assertEquals(boxes.mapped('unit_id.name'), ['bar'])

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -2499,8 +2499,8 @@ class Many2one(_Relational):
         else:
             id_ = None
 
-        if self.delegate and record and not record.id:
-            # the parent record of a new record is a new record
+        if self.delegate and record and not any(record._ids):
+            # if all records are new, then so is the parent
             id_ = id_ and NewId(id_)
 
         return id_


### PR DESCRIPTION
Before this commit, it was impossible to write to a delegated m2o field
if the length of the recordset was greater than 1.

The reason was because the special case for delegated fields inside
fields.Many2one.convert_to_cache would check for `record.id` which is a
bit misleading, since record can be greater than one.

The solution is to instead check for `record.ids` which works regardless
of recordset size, the actual size of the recordset is not relevant for
the computation of the cache value.

Fixes #62069 