### PR TITLE
[IMP] account: Improve the validation process thanks to the "to check" boolean

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -152,7 +152,7 @@ class AccountMove(models.Model):
         ], string='Type', required=True, store=True, index=True, readonly=True, tracking=True,
         default="entry", change_default=True)
     type_name = fields.Char('Type Name', compute='_compute_type_name')
-    to_check = fields.Boolean(string='To Check', default=False,
+    to_check = fields.Boolean(string='To Check', default=False, tracking=True,
         help='If this checkbox is ticked, it means that the user was not sure of all the related information at the time of the creation of the move and that the move needs to be checked again.')
     journal_id = fields.Many2one('account.journal', string='Journal', required=True, readonly=True,
         states={'draft': [('readonly', False)]},
@@ -2556,6 +2556,10 @@ class AccountMove(models.Model):
             'res_id': new_wizard.id,
             'views': [[view_id, 'form']],
         }
+
+    def button_set_checked(self):
+        for move in self:
+            move.to_check = False
 
     def button_draft(self):
         AccountMoveLine = self.env['account.move.line']

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -405,6 +405,7 @@
                     <field name="amount_total_signed" sum="Total Amount" string="Total" decoration-bf="1"/>
                     <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-success="state == 'posted'"/>
                     <field name="currency_id" invisible="1"/>
+                    <field name="to_check" optional="hide" widget="boolean_toggle"/>
                 </tree>
             </field>
         </record>
@@ -444,6 +445,7 @@
                     <field name="state" widget="badge" decoration-success="state == 'posted'" decoration-info="state == 'draft'" optional="show"/>
                     <field name="payment_state" widget="badge" decoration-danger="payment_state == 'not_paid'" decoration-warning="payment_state in ('partial', 'in_payment')" decoration-success="payment_state in ('paid', 'reversed')" attrs="{'invisible': [('payment_state', 'in', ('invoicing_legacy'))]}"/>
                     <field name="move_type" invisible="context.get('default_move_type', True)"/>
+                    <field name="to_check" optional="hide" widget="boolean_toggle"/>
                   </tree>
             </field>
         </record>
@@ -567,9 +569,14 @@
                                 attrs="{'invisible': ['|', ('move_type', 'not in', ('out_invoice', 'in_invoice')), ('state', '!=', 'posted')]}"/>
                         <!-- Cancel -->
                         <button name="button_cancel" string="Cancel Entry" type="object" groups="account.group_account_invoice"
-                                attrs="{'invisible' : ['|', ('id', '=', False), ('state', '!=', 'draft')]}"/>
+                                attrs="{'invisible' : ['|', '|', ('id', '=', False), ('state', '!=', 'draft'),('move_type', '!=', 'entry')]}"/>
+                        <button name="button_cancel" string="Cancel" type="object" groups="account.group_account_invoice"
+                                attrs="{'invisible' : ['|', '|', ('id', '=', False), ('state', '!=', 'draft'),('move_type', '==', 'entry')]}"/>
                         <button name="button_draft" string="Reset to Draft" type="object" groups="account.group_account_invoice"
                                 attrs="{'invisible' : [('show_reset_to_draft_button', '=', False)]}"/>
+                        <!-- Set as Checked -->
+                        <button name="button_set_checked" string="Set as Checked" type="object" groups="account.group_account_invoice"
+                                attrs="{'invisible' : [('to_check', '=', False)]}"/>
                         <field name="state" widget="statusbar" statusbar_visible="draft,posted"/>
                     </header>
                     <!-- Invoice outstanding credits -->

--- a/addons/mail/static/src/components/message/message.js
+++ b/addons/mail/static/src/components/message/message.js
@@ -295,6 +295,13 @@ class Message extends Component {
                     value.new_value =
                         moment(value.new_value).local().format('LL');
                 }
+            } else if (value.field_type === 'boolean') {
+                if (value.old_value !== undefined){
+                    value.old_value = value.old_value ? this.env._t("True") : this.env._t("False");
+                }
+                if (value.new_value !== undefined){
+                    value.new_value = value.new_value ? this.env._t("True") : this.env._t("False");
+                }
             }
             return value;
         });

--- a/addons/mail/static/src/components/message/message_tests.js
+++ b/addons/mail/static/src/components/message/message_tests.js
@@ -1141,7 +1141,7 @@ QUnit.test('rendering of tracked field with change of value from true to false',
     await this.createMessageComponent(message);
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
-        "Is Ready:truefalse",
+        "Is Ready:TrueFalse",
         "should display the correct content of tracked field with change of value from true to false (Is Ready: true -> false)"
     );
 });
@@ -1163,7 +1163,7 @@ QUnit.test('rendering of tracked field with change of value from false to true',
     await this.createMessageComponent(message);
     assert.strictEqual(
         document.querySelector('.o_Message_trackingValue').textContent,
-        "Is Ready:falsetrue",
+        "Is Ready:FalseTrue",
         "should display the correct content of tracked field with change of value from false to true (Is Ready: false -> true)"
     );
 });

--- a/addons/web/static/src/scss/views.scss
+++ b/addons/web/static/src/scss/views.scss
@@ -82,6 +82,10 @@
         }
     }
 
+    .custom-checkbox {
+        pointer-events: none !important;
+    }
+
     .o_nocontent_help {
         border-radius: 20%;
         background-color: #f9f9f9;


### PR DESCRIPTION
- keep track of to_check changes in chatter
- add "set as checked" button
- make the "to_check" field optional in list view
- vendor bill / customer invoice : remove "entry" from "cancel entry" button.

Task: 2389849