### PR TITLE
[FIX] account: do not precompute name of payment

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -513,6 +513,17 @@ class AccountPayment(models.Model):
             pay.reconciled_statements_count = len(statement_ids)
 
     # -------------------------------------------------------------------------
+    # ONCHANGE METHODS
+    # -------------------------------------------------------------------------
+
+    @api.onchange('posted_before', 'state', 'journal_id', 'date')
+    def _onchange_journal_date(self):
+        # Before the record is created, the move_id doesn't exist yet, and the name will not be
+        # recomputed correctly if we change the journal or the date, leading to inconsitencies
+        if not self.move_id:
+            self.name = False
+
+    # -------------------------------------------------------------------------
     # CONSTRAINT METHODS
     # -------------------------------------------------------------------------
 


### PR DESCRIPTION
Reproduce:
* On a fresh db, create a payment
* Change the date to another month
* Validate

Issue:
* The name is computed before creation because it is the first of
  journal/period.
* It is not visible
* It is given to the create vals of the move_id, so it is not correctly
  recomputed
* The sequence/name  are not in sync.

opw-2390747





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
