### PR TITLE
[FiX] google_calendar: Sync with google without lost attendees

### DIFF
--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -155,7 +155,6 @@ class Meeting(models.Model):
             'method': "email" if alarm.alarm_type == "email" else "popup",
             'minutes': alarm.duration_minutes
         } for alarm in self.alarm_ids]
-        attendee_ids = self.attendee_ids.filtered(lambda a: a.partner_id != self.env.user.partner_id)
         values = {
             'id': self.google_id,
             'start': start,
@@ -165,7 +164,7 @@ class Meeting(models.Model):
             'location': self.location or '',
             'guestsCanModify': True,
             'organizer': {'email': self.user_id.email, 'self': self.user_id == self.env.user},
-            'attendees': [{'email': attendee.email, 'responseStatus': attendee.state} for attendee in attendee_ids],
+            'attendees': [{'email': attendee.email, 'responseStatus': attendee.state} for attendee in self.attendee_ids],
             'extendedProperties': {
                 'shared': {
                     '%s_odoo_id' % self.env.cr.dbname: self.id,


### PR DESCRIPTION
What are the steps to reproduce your issue ?

    1. Install "google_calendar"
    2. Log in with "admin"
    3. Create an eventX with "admin" and "demo" has attendees
    4. Run "Google Calendar Synchronization" from "Scheduled Actions"

What is currently happening ?

    eventX is successfully added to google but without admin
    if you sync odoo to google one more time, google will overwrite eventX
    and it will remove admin from attendees

What are you expecting to happen ?

    Sync odoo to google and google to odoo without lost attendees

Why is this happening ?

    Because there is a filter that prevent addition of current user to the attendees

How to fix the bug ?

    Remove the filter

Introduced with https://github.com/odoo/odoo/pull/57793
Task: https://www.odoo.com/web#id=2334943&action=3531&model=project.task&view_type=form&cids=1&menu_id=4720

opw-2382443