### PR TITLE
[FIX] website_event_meet: fix meeting room drop-down menu

### DIFF
--- a/addons/website_event_meet/static/src/scss/event_meet_templates.scss
+++ b/addons/website_event_meet/static/src/scss/event_meet_templates.scss
@@ -42,6 +42,10 @@
     }
 }
 
+.o_wevent_meeting_room_card {
+    overflow: visible;
+}
+
 .o_wevent_meeting_room_corner_ribbon {
     width: 200px;
     background: #e43;


### PR DESCRIPTION
Bug
===
If we create a meeting room without language, summary and audience,
the drop-down menu will be cut.

Task 2204364