### PR TITLE
[FIX] project: missing api.model on create override

### DIFF
--- a/addons/project/models/project_task_recurrence.py
+++ b/addons/project/models/project_task_recurrence.py
@@ -240,6 +240,7 @@ class ProjectTaskRecurrence(models.Model):
             recurrence.recurrence_left -= 1
         recurring_today._set_next_recurrence_date()
 
+    @api.model
     def create(self, vals):
         if vals.get('repeat_number'):
             vals['recurrence_left'] = vals.get('repeat_number')


### PR DESCRIPTION
The create won't be correctly callable over rpc if not specified as api.model.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
