### PR TITLE
[FIX] purchase: Wrong UOM conversion when creating a vendor bill

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -862,7 +862,7 @@ class PurchaseOrderLine(models.Model):
             # compute qty_to_invoice
             if line.order_id.state in ['purchase', 'done']:
                 if line.product_id.purchase_method == 'purchase':
-                    line.qty_to_invoice = line.product_uom_qty - line.qty_invoiced
+                    line.qty_to_invoice = line.product_qty - line.qty_invoiced
                 else:
                     line.qty_to_invoice = line.qty_received - line.qty_invoiced
             else:


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a product P with purchase UOM = Unit
- Let's consider a UOM called Box such as 1 Box = Units
- P is invoiced according to its ordered quantity
- Create a PO for 1 Box of P and confirm it
- Create the bill B from PO

Bug:

The quantity of B was 10 and its UOM was Box

PS: When creating a bill from a PO, by default the quantities on the lines of B are always expected
in the UOM of their respective PO line

Introduced by: d0455ae

opw:2391243