### PR TITLE
[FIX] l10n_it_edi: use pec addresses to test mail server

### DIFF
--- a/addons/l10n_it_edi/models/ir_mail_server.py
+++ b/addons/l10n_it_edi/models/ir_mail_server.py
@@ -359,6 +359,19 @@ class FetchmailServer(models.Model):
 class IrMailServer(models.Model):
     _name = "ir.mail_server"
     _inherit = "ir.mail_server"
+    def _get_test_email_addresses(self):
+        self.ensure_one()
+        company = self.env["res.company"].search([("l10n_it_mail_pec_server_id", "=", self.id)], limit=1)
+        if not company:
+            # it's not a PEC server
+            return super()._get_test_email_addresses()
+        email_from = self.smtp_user
+        if not email_from:
+            raise UserError(_('Please configure Username for this Server PEC'))
+        email_to = company.l10n_it_address_recipient_fatturapa
+        if not email_to:
+            raise UserError(_('Please configure Government PEC-mail	in company settings'))
+        return email_from, email_to
 
     def build_email(self, email_from, email_to, subject, body, email_cc=None, email_bcc=None, reply_to=False,
                 attachments=None, message_id=None, references=None, object_id=False, subtype='plain', headers=None,

--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -102,16 +102,21 @@ class IrMailServer(models.Model):
                                                                   "is used. Default priority is 10 (smaller number = higher priority)")
     active = fields.Boolean(default=True)
 
+    def _get_test_email_addresses(self):
+        self.ensure_one()
+        email_from = self.env.user.email
+        if not email_from:
+            raise UserError(_('Please configure an email on the current user to simulate '
+                              'sending an email message via this outgoing server'))
+        return email_from, 'noreply@odoo.com'
+
     def test_smtp_connection(self):
         for server in self:
             smtp = False
             try:
                 smtp = self.connect(mail_server_id=server.id)
                 # simulate sending an email from current user's address - without sending it!
-                email_from, email_to = self.env.user.email, 'noreply@odoo.com'
-                if not email_from:
-                    raise UserError(_('Please configure an email on the current user to simulate '
-                                      'sending an email message via this outgoing server'))
+                email_from, email_to = server._get_test_email_addresses()
                 # Testing the MAIL FROM step should detect sender filter problems
                 (code, repl) = smtp.mail(email_from)
                 if code != 250:


### PR DESCRIPTION
WHY: PEC server rejects default addresses, so you cannot test connection

---

opw-2371431

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
