### PR TITLE
[FIX] mail: prevent auto-scroll from disabling itself

### DIFF
--- a/addons/mail/static/src/models/thread_view/thread_view.js
+++ b/addons/mail/static/src/models/thread_view/thread_view.js
@@ -143,6 +143,8 @@ function factory(dependencies) {
          * @private
          */
         _onThreadCacheChanged() {
+            // clear obsolete hints
+            this.update({ componentHintList: [] });
             this.addComponentHint('change-of-thread-cache');
             if (this.threadCache) {
                 this.threadCache.update({ isCacheRefreshRequested: true });
@@ -236,7 +238,9 @@ function factory(dependencies) {
          * a new message. Detection of new message is done through the component
          * hint `message-received`.
          */
-        hasAutoScrollOnMessageReceived: attr(),
+        hasAutoScrollOnMessageReceived: attr({
+            default: true,
+        }),
         /**
          * Last message in the context of the currently displayed thread cache.
          */


### PR DESCRIPTION
1. remove smooth scrolling to ensure scroll event is handled at most one
   setTimeout after the event is triggered

task-2333535

2. split the auto-scroll check and disable it before programmatic scrolling

task-2388676