### PR TITLE
[FIX] mrp_workorder: Start and pause work order without attached PDF

### DIFF
--- a/addons/mrp/models/mrp_routing.py
+++ b/addons/mrp/models/mrp_routing.py
@@ -23,7 +23,7 @@ class MrpRoutingWorkcenter(models.Model):
         'res.company', 'Company', default=lambda self: self.env.company)
     worksheet_type = fields.Selection([
         ('pdf', 'PDF'), ('google_slide', 'Google Slide'), ('text', 'Text')],
-        string="Work Sheet", default="pdf",
+        string="Work Sheet", default="text",
         help="Defines if you want to use a PDF or a Google Slide as work sheet."
     )
     note = fields.Text('Description', help="Text worksheet description")

--- a/addons/mrp/views/mrp_routing_views.xml
+++ b/addons/mrp/views/mrp_routing_views.xml
@@ -48,8 +48,8 @@
                             <page string="Work Sheet" name="worksheet">
                                 <group>
                                     <field name="worksheet_type" widget="radio"/>
-                                    <field name="worksheet" help="Upload your PDF file." widget="pdf_viewer" attrs="{'invisible':  [('worksheet_type', '!=', 'pdf')]}"/>
-                                    <field name="worksheet_google_slide" placeholder="Google Slide Link" widget="embed_viewer" attrs="{'invisible':  [('worksheet_type', '!=', 'google_slide')]}"/>
+                                    <field name="worksheet" help="Upload your PDF file." widget="pdf_viewer" attrs="{'invisible':  [('worksheet_type', '!=', 'pdf')], 'required':  [('worksheet_type', '=', 'pdf')]}"/>
+                                    <field name="worksheet_google_slide" placeholder="Google Slide Link" widget="embed_viewer" attrs="{'invisible':  [('worksheet_type', '!=', 'google_slide')], 'required': [('worksheet_type', '=', 'google_slide')]}"/>
                                     <field name="note" attrs="{'invisible':  [('worksheet_type', '!=', 'text')]}"/>
                                 </group>
                             </page>


### PR DESCRIPTION
What are the steps to reproduce your issue ?

    1. Install 'Manufacture' and enable 'Work Order' in settings
    2. Create product 'ProductA', enable 'Manufacture' in 'Inventory' tab
    3. Create a BOM for 'ProductA'
    4. For that BOM, create a new operation called 'OperationA' with PDF worksheet but don't attach any PDF
    4. Go to 'Manufacture' and create a MO with 'ProductA', the 'OperationA' is automatically set in 'Work Orders'
    5. Start the work order

What is currently happening ?

    When you try to pause, an error is raised.
    'TypeError: Cannot read property 'pdfViewer' of undefined'

What are you expecting to happen ?

    Start and pause the work order even without attached PDF.

Why is this happening ?

    'this.pdfViewer = existing.data('PDFViewerApplication').pdfViewer'
    When there is no pdf attached. The data 'PDFViewerApplication' does not exist.

How to fix the bug ?

    Change worksheet default value to text, and make the field mandatory in case of a PDF type

opw-2387428
Fix in enterprise: https://github.com/odoo/enterprise/pull/14973