### PR TITLE
dropdown not closed on window click in dialog

### DIFF
--- a/addons/web/static/src/js/components/dropdown_menu.js
+++ b/addons/web/static/src/js/components/dropdown_menu.js
@@ -128,7 +128,7 @@ odoo.define('web.DropdownMenu', function (require) {
             ) {
                 if (document.body.classList.contains("modal-open")) {
                     // retrieve the active modal and check if the dropdown is a child of this modal
-                    const modal = document.querySelector('.modal:not(.o_inactive_modal)');
+                    const modal = document.querySelector('.modal.o_technical_modal:not(.o_inactive_modal)');
                     if (!modal.contains(this.el)) {
                         return;
                     }


### PR DESCRIPTION
PURPOSE
When dropdown is opened inside dialog which is opened from another dialog and previous dialog has html field then clicking on window do not closes dropdown.

SPEC
Clicking on window should close open dropdown.

TASK 2391872



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
