### PR TITLE
[FIX] hr_holidays: Remove contraint

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -549,12 +549,6 @@ class HolidaysRequest(models.Model):
             else:
                 holiday.can_approve = True
 
-    @api.constrains('date_from', 'date_to')
-    def _check_number_of_days(self):
-        leaves = self.filtered(lambda l: l.employee_id and not l.number_of_days)
-        if leaves:
-            raise ValidationError(_('The following employees are not supposed to work during that period:\n %s') % ','.join(leaves.mapped('employee_id.name')))
-
     @api.constrains('date_from', 'date_to', 'employee_id')
     def _check_date(self):
         for holiday in self.filtered('employee_id'):
@@ -985,6 +979,10 @@ class HolidaysRequest(models.Model):
 
     def action_validate(self):
         current_employee = self.env.user.employee_id
+        leaves = self.filtered(lambda l: l.employee_id and not l.number_of_days)
+        if leaves:
+            raise ValidationError(_('The following employees are not supposed to work during that period:\n %s') % ','.join(leaves.mapped('employee_id.name')))
+
         if any(holiday.state not in ['confirm', 'validate1'] and holiday.validation_type != 'no_validation' for holiday in self):
             raise UserError(_('Time off request must be confirmed in order to approve it.'))
 

--- a/addons/hr_holidays/tests/test_automatic_leave_dates.py
+++ b/addons/hr_holidays/tests/test_automatic_leave_dates.py
@@ -26,16 +26,15 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
         employee = self.employee_emp
         employee.resource_calendar_id = calendar
 
-        with self.assertRaises(ValidationError):
-            with Form(self.env['hr.leave'].with_context(default_employee_id=employee.id)) as leave_form:
-                leave_form.holiday_status_id = self.leave_type
-                leave_form.request_date_from = date(2019, 9, 2)
-                leave_form.request_date_to = date(2019, 9, 2)
-                leave_form.request_unit_half = True
-                leave_form.request_date_from_period = 'am'
+        with Form(self.env['hr.leave'].with_context(default_employee_id=employee.id)) as leave_form:
+            leave_form.holiday_status_id = self.leave_type
+            leave_form.request_date_from = date(2019, 9, 2)
+            leave_form.request_date_to = date(2019, 9, 2)
+            leave_form.request_unit_half = True
+            leave_form.request_date_from_period = 'am'
 
-                self.assertEqual(leave_form.number_of_days_display, 0)
-                self.assertEqual(leave_form.number_of_hours_text, '0.0 Hours')
+            self.assertEqual(leave_form.number_of_days_display, 0)
+            self.assertEqual(leave_form.number_of_hours_text, '0.0 Hours')
 
     def test_single_attendance_on_morning_and_afternoon(self):
         calendar = self.env['resource.calendar'].create({
@@ -166,19 +165,18 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
         employee = self.employee_emp
         employee.resource_calendar_id = calendar
 
-        with self.assertRaises(ValidationError):
-            with Form(self.env['hr.leave'].with_context(default_employee_id=employee.id)) as leave_form:
-                leave_form.holiday_status_id = self.leave_type
-                leave_form.request_date_from = date(2019, 9, 2)
-                leave_form.request_date_to = date(2019, 9, 2)
-                leave_form.request_unit_half = True
-                leave_form.request_date_from_period = 'am'
+        with Form(self.env['hr.leave'].with_context(default_employee_id=employee.id)) as leave_form:
+            leave_form.holiday_status_id = self.leave_type
+            leave_form.request_date_from = date(2019, 9, 2)
+            leave_form.request_date_to = date(2019, 9, 2)
+            leave_form.request_unit_half = True
+            leave_form.request_date_from_period = 'am'
 
 
-                self.assertEqual(leave_form.number_of_days_display, 0)
-                self.assertEqual(leave_form.number_of_hours_text, '0.0 Hours')
-                self.assertEqual(leave_form.date_from, datetime(2019, 9, 2, 6, 0, 0))
-                self.assertEqual(leave_form.date_to, datetime(2019, 9, 2, 10, 0, 0))
+            self.assertEqual(leave_form.number_of_days_display, 0)
+            self.assertEqual(leave_form.number_of_hours_text, '0.0 Hours')
+            self.assertEqual(leave_form.date_from, datetime(2019, 9, 2, 6, 0, 0))
+            self.assertEqual(leave_form.date_to, datetime(2019, 9, 2, 10, 0, 0))
 
     def test_attendance_previous_day(self):
         self.env.user.tz = 'Europe/Brussels'
@@ -196,19 +194,18 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
         employee = self.employee_emp
         employee.resource_calendar_id = calendar
 
-        with self.assertRaises(ValidationError):
-            with Form(self.env['hr.leave'].with_context(default_employee_id=employee.id)) as leave_form:
-                leave_form.holiday_status_id = self.leave_type
-                leave_form.request_date_from = date(2019, 9, 3)
-                leave_form.request_date_to = date(2019, 9, 3)
-                leave_form.request_unit_half = True
-                leave_form.request_date_from_period = 'am'
+        with Form(self.env['hr.leave'].with_context(default_employee_id=employee.id)) as leave_form:
+            leave_form.holiday_status_id = self.leave_type
+            leave_form.request_date_from = date(2019, 9, 3)
+            leave_form.request_date_to = date(2019, 9, 3)
+            leave_form.request_unit_half = True
+            leave_form.request_date_from_period = 'am'
 
 
-                self.assertEqual(leave_form.number_of_days_display, 0)
-                self.assertEqual(leave_form.number_of_hours_text, '0.0 Hours')
-                self.assertEqual(leave_form.date_from, datetime(2019, 9, 3, 6, 0, 0))
-                self.assertEqual(leave_form.date_to, datetime(2019, 9, 3, 10, 0, 0))
+            self.assertEqual(leave_form.number_of_days_display, 0)
+            self.assertEqual(leave_form.number_of_hours_text, '0.0 Hours')
+            self.assertEqual(leave_form.date_from, datetime(2019, 9, 3, 6, 0, 0))
+            self.assertEqual(leave_form.date_to, datetime(2019, 9, 3, 10, 0, 0))
 
     def test_2weeks_calendar(self):
         self.env.user.tz = 'Europe/Brussels'
@@ -280,16 +277,15 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
         employee = self.employee_emp
         employee.resource_calendar_id = calendar
 
-        with self.assertRaises(ValidationError):
-            with Form(self.env['hr.leave'].with_context(default_employee_id=employee.id)) as leave_form:
-                leave_form.holiday_status_id = self.leave_type
-                # even week, does not work
-                leave_form.request_date_from = date(2019, 9, 2)
-                leave_form.request_date_to = date(2019, 9, 2)
-                leave_form.request_unit_half = True
-                leave_form.request_date_from_period = 'am'
+        with Form(self.env['hr.leave'].with_context(default_employee_id=employee.id)) as leave_form:
+            leave_form.holiday_status_id = self.leave_type
+            # even week, does not work
+            leave_form.request_date_from = date(2019, 9, 2)
+            leave_form.request_date_to = date(2019, 9, 2)
+            leave_form.request_unit_half = True
+            leave_form.request_date_from_period = 'am'
 
-                self.assertEqual(leave_form.number_of_days_display, 0)
-                self.assertEqual(leave_form.number_of_hours_text, '0.0 Hours')
-                self.assertEqual(leave_form.date_from, datetime(2019, 9, 2, 6, 0, 0))
-                self.assertEqual(leave_form.date_to, datetime(2019, 9, 2, 10, 0, 0))
+            self.assertEqual(leave_form.number_of_days_display, 0)
+            self.assertEqual(leave_form.number_of_hours_text, '0.0 Hours')
+            self.assertEqual(leave_form.date_from, datetime(2019, 9, 2, 6, 0, 0))
+            self.assertEqual(leave_form.date_to, datetime(2019, 9, 2, 10, 0, 0))


### PR DESCRIPTION
Purpose
=======

The goal of this contraint is to prevent employees to take a time off
when he's not supposed to work (example: after the end of his contract).

But, in some conditions (example: we change the contract end date), the
number_of_days is not recomputed, and the constraint is raised
when unlinking the time off.

Move the chunk of code at the validation level, to prevent validating
a time off if the employee is not supposed to work.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
