### PR TITLE
[FIX] stock_account : don't use svl with zero quantity

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -104,6 +104,7 @@ class ProductProduct(models.Model):
         domain = [
             ('product_id', 'in', self.ids),
             ('company_id', '=', company_id),
+            ('quantity', '!=', 0),
         ]
         if self.env.context.get('to_date'):
             to_date = fields.Datetime.to_datetime(self.env.context['to_date'])


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
After a migration V12 -> V13, some slc come from dropshipping have quantity = 0.
It make a wrong compute of value_svl.

![image](https://user-images.githubusercontent.com/16716992/100231613-941b9e00-2f27-11eb-9bad-72960341fd37.png)

![image](https://user-images.githubusercontent.com/16716992/100231686-a8f83180-2f27-11eb-92e3-c191acaeff05.png)


After the fix it is googd (4400 / 4 = 1100)
![image](https://user-images.githubusercontent.com/16716992/100231949-fbd1e900-2f27-11eb-9d3e-2d1e0f3e60cf.png)


@nim-odoo


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
