### PR TITLE
Master web kanban view quick create buttons alignment dht

### DIFF
--- a/addons/web/static/src/scss/kanban_view.scss
+++ b/addons/web/static/src/scss/kanban_view.scss
@@ -34,6 +34,10 @@
             }
         }
 
+        .o_kanban_cancel {
+            color: gray('600'); // to make color uniform in community and enterprise
+        }
+
         &.o_disabled {
             pointer-events: none;
             opacity: 0.7;

--- a/addons/web/static/src/xml/kanban.xml
+++ b/addons/web/static/src/xml/kanban.xml
@@ -69,10 +69,12 @@
 </t>
 
 <t t-name="KanbanView.RecordQuickCreate.buttons">
-    <div>
-        <button class="btn btn-primary o_kanban_add">Add</button>
-        <button class="btn btn-primary o_kanban_edit">Edit</button>
-        <button class="btn btn-secondary o_kanban_cancel ml8">Discard</button>
+    <div class="d-flex">
+        <button class="btn btn-primary o_kanban_add mr-1 text-truncate">Add</button>
+        <button class="btn btn-primary o_kanban_edit mr-1 text-truncate">Edit</button>
+        <button class="btn btn-secondary o_kanban_cancel ml-auto">
+            <i class="fa fa-trash"/>
+        </button>
     </div>
 </t>
 


### PR DESCRIPTION
PURPOSE
All buttons of the quick create kanban card fit in a single row in all languages.
SPECIFICATIONS

Current
While everything looks nice and tidy in English.
The layout of our quick create cards quickly suffers once one switches to another language for which those words are longer.

To be
Replace the Discard button by a thrash button in grey and aligned on the right
Add some css to make sure the 3 buttons always fit in a single line => if not, crop

LINKS

PR
Task 2373130
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr