### PR TITLE
[FIX] fields: Better error for invalid @depends

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -632,8 +632,10 @@ class Field(MetaField('DummyField', (object,), {})):
                 try:
                     field = Model._fields[fname]
                 except KeyError:
-                    msg = "Field %s cannot find dependency %r on model %r."
-                    raise ValueError(msg % (self, fname, model_name))
+                    raise ValueError(
+                        f"Wrong @depends on '{self.compute}' (compute method of field {self}). "
+                        f"Dependency field '{fname}' not found in model {model_name}."
+                    )
                 if field is self and index:
                     self.recursive = True
 


### PR DESCRIPTION
Create a model as follow:

    class FooModel(models.Model):
        _name = 'foo'
        bar = fields.Char(compute="compute_bar")

        @depends('bazz')  # wrong dependency, bazz does not exist
        def compute_bar(self):
            for rec in self:
                rec.bar = "Babar raconte des beaux bobards."

Uppon -u foo_module, a ValueError is rose for the invalid dependency
with the following message:

> Field foo.bar cannot find dependency bazz on model foo.

We had feedback the error message was not very clear to some users,
the new error message is:

> Wrong @depends on 'compute_bar' (compute method of field foo.bar).
> Dependency field 'bazz' not found in model foo.

Task: 2366612
