### PR TITLE
[REF][13.0] l10n_do : deleting and adding journals, adding missing taxes.

### DIFF
--- a/addons/l10n_do/data/account.tax.template.xml
+++ b/addons/l10n_do/data/account.tax.template.xml
@@ -1179,7 +1179,7 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('do_niif_21030308'),
+                    'account_id': ref('do_niif_11080302'),
                 }),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5,0,0),
@@ -1190,7 +1190,7 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('do_niif_21030308'),
+                    'account_id': ref('do_niif_11080302'),
                 }),
             ]"/>
         </record>
@@ -1259,6 +1259,109 @@
             <field name="type_tax_use">purchase</field>
             <field eval="[(6, 0, [ref('tax_18_purch'), ref('tax_tip_purch')])]" name="children_tax_ids"/>
             <field name="tax_group_id" ref="group_ret"/>
+        </record>
+
+        <record id="tax_18_10_total_mount" model="account.tax.template">
+            <field name="chart_template_id" ref="do_chart_template"/>
+            <field name="name">18% ITBIS sobre el 10% del Monto Total</field>
+            <field name="description">18% del 10%</field>
+            <field name="amount">1.8</field>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field eval="0" name="price_include"/>
+            <field name="tax_group_id" ref="group_itbis"/>
+            <field name="invoice_repartition_line_ids" eval="[(5,0,0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('do_niif_11080102'),
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5,0,0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('do_niif_11080102'),
+                }),
+            ]"/>
+        </record>
+
+        <record id="tax_18_property_cost" model="account.tax.template">
+            <field name="chart_template_id" ref="do_chart_template"/>
+            <field name="name">18% ITBIS llevado al Costo Bienes</field>
+            <field name="description">18%</field>
+            <field name="amount">18</field>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field eval="0" name="price_include"/>
+            <field name="tax_group_id" ref="group_itbis"/>
+            <field name="invoice_repartition_line_ids" eval="[(5,0,0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('do_niif_51010500'),
+                    'plus_report_line_ids': [ref('account_tax_report_itbs_pgdo_locales')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5,0,0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('do_niif_51010500'),
+                    'plus_report_line_ids': [ref('account_tax_report_itbs_pgdo_locales')],
+                }),
+            ]"/>
+        </record>
+
+        <record id="tax_18_serv_cost" model="account.tax.template">
+            <field name="chart_template_id" ref="do_chart_template"/>
+            <field name="name">18% ITBIS llevado al Costo Servicios</field>
+            <field name="description">18%</field>
+            <field name="amount">18</field>
+            <field name="amount_type">percent</field>
+            <field name="type_tax_use">purchase</field>
+            <field eval="0" name="price_include"/>
+            <field name="tax_group_id" ref="group_itbis"/>
+            <field name="invoice_repartition_line_ids" eval="[(5,0,0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('do_niif_51010500'),
+                    'plus_report_line_ids': [ref('account_tax_report_itbs_pgdo_locales')],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5,0,0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('do_niif_51010500'),
+                    'plus_report_line_ids': [ref('account_tax_report_itbs_pgdo_locales')],
+                }),
+            ]"/>
         </record>
 
     </data>

--- a/addons/l10n_do/models/chart_template.py
+++ b/addons/l10n_do/models/chart_template.py
@@ -29,26 +29,20 @@ class AccountChartTemplate(models.Model):
                 journal['name'] = _('Compras Fiscales')
         res += [{
             'type': 'purchase',
-            'name': _('Compras Informales'),
-            'code': 'CINF',
-            'company_id': company.id,
-            'show_on_dashboard': True
-        }, {
-            'type': 'purchase',
-            'name': _('Gastos Menores'),
-            'code': 'GASM',
-            'company_id': company.id,
-            'show_on_dashboard': True
-        }, {
-            'type': 'purchase',
-            'name': _('Compras al Exterior'),
-            'code': 'CEXT',
-            'company_id': company.id,
-            'show_on_dashboard': True
-        }, {
-            'type': 'purchase',
             'name': _('Gastos No Deducibles'),
             'code': 'GASTO',
+            'company_id': company.id,
+            'show_on_dashboard': True
+        }, {
+            'type': 'purchase',
+            'name': _('Migración CxP'),
+            'code': 'CXP',
+            'company_id': company.id,
+            'show_on_dashboard': True
+        }, {
+            'type': 'sale',
+            'name': _('Migración CxC'),
+            'code': 'CXC',
             'company_id': company.id,
             'show_on_dashboard': True
         }]

--- a/doc/cla/individual/rfiguereo.md
+++ b/doc/cla/individual/rfiguereo.md
@@ -1,0 +1,11 @@
+Dominican Republic, 2020-11-25
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Fernando Rubier Figuereo Roa fernandorfr02@gmail.com https://github.com/FernandoRFR02


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Deleted Journals:
1- Compras informales.
2- Gastos menores.
3- Compras al exterior.

With the inclusion of l10n_latam_invoice_document module is not longer necessary to split purchase invoices in many journals, as an unique one can handle distinct document types.

Added Journals:
1- Migracion CXC
2- Migracion CXP

These two journals are used to load the invoices of sales and purchases of the initial load of Accounts Receivable and Accounts Payable 

Missing taxes were added which are:
1- 18% ITBIS sobre el 10% del Monto Total
2- 18% ITBIS llevado al Costo Bienes
3- 18% ITBIS llevado al Costo Servicios

The correct account was assigned to:

Retención 5% ISR Gubernamentales [21030308  -->  11080302]

Current behavior before PR:

The journals that are being eliminated are not being used because the "Taxpayer Type" field replaces them.

Lack of CXP and CXC journals for initial loading of accounts receivable and accounts payable.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
