### PR TITLE
[FIX] web: fix error on translating fields in x2many lines

### DIFF
--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -1905,7 +1905,9 @@ var BasicModel = AbstractModel.extend({
         var view = fieldInfo.views && fieldInfo.views[fieldInfo.mode];
         var def, rec;
         var defs = [];
-        list._changes = list._changes || [];
+        if (_.isEmpty(list._changes)){
+            list._changes = [];
+        }
 
         switch (command.operation) {
             case 'ADD':


### PR DESCRIPTION
STEPS:
* activate second language
* install l10n_ch
* Go to Accounting > Configuration > Management > Tax report
* Open the tax report for CH and click edit
* Open a line, add a new subline with Name and Tag Name fields
* Save
* Refresh
* Open the same line and subline
* close and click Edit
* Open the same line and subline
* Make translation for Name and Tag Name fields
* Click save

BEFORE: error

    TypeError: list._changes.push is not a function

    at Class._applyX2ManyChange (https://5087560-14-0.runbot53.odoo.com/web/content/2153-b405c82/web.assets_backend.js:1440:115)

    at Class._applyChange (https://5087560-14-0.runbot53.odoo.com/web/content/2153-b405c82/web.assets_backend.js:1416:274)

    at https://5087560-14-0.runbot53.odoo.com/web/content/1758-736a26e/web.assets_common.js:4625:607

AFTER: no error

WHY: `list._changes` may be an empty object at this point, but `{} || []` is
`{}`, so we get that error

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
