### PR TITLE
[FIX] pad: valid field parameters for pad mixin

### DIFF
--- a/addons/pad/models/pad.py
+++ b/addons/pad/models/pad.py
@@ -20,6 +20,9 @@ class PadCommon(models.AbstractModel):
     _name = 'pad.common'
     _description = 'Pad Common'
 
+    def _valid_field_parameter(self, field, name):
+        return name == 'pad_content_field' or super()._valid_field_parameter(field, name)
+
     @api.model
     def pad_is_configured(self):
         return bool(self.env.company.pad_server)


### PR DESCRIPTION
Field parameters validation was introduced some months ago and recently fixed in https://github.com/odoo/odoo/pull/60402 but some modules have not been covered by the fix, probably due to runbot restrictions.

This PR updates the validation to support the parameter `pad_content_field``used by the `pad.common` mixin.

COM PR: https://github.com/odoo/odoo/pull/62335
ENT PR: https://github.com/odoo/enterprise/pull/14982

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
