### PR TITLE
[FIX] account: suspense account type

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -166,7 +166,7 @@ class AccountChartTemplate(models.Model):
         return self.env['account.account'].create({
             'name': _("Bank Suspense Account"),
             'code': self.env['account.account']._search_new_account_code(company, code_digits, company.bank_account_code_prefix or ''),
-            'user_type_id': self.env.ref('account.data_account_type_current_assets').id,
+            'user_type_id': self.env.ref('account.data_account_type_current_liabilities').id,
             'company_id': company.id,
         })
 


### PR DESCRIPTION
The suspense account created doesn't have the type corresponding to the
domain:

https://github.com/odoo/odoo/blob/658d0fa32f35f4c4f9a1828b11fa383d3dad3b46/addons/account/models/account_journal.py#L97

opw-2387857

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
