### PR TITLE
[FIX] mail: fix mail.mail default values collision

### DIFF
--- a/addons/test_mail/tests/test_mail_followers.py
+++ b/addons/test_mail/tests/test_mail_followers.py
@@ -218,6 +218,51 @@ class AdvancedFollowersTest(common.BaseFunctionalTest):
             all_defaults)
 
 
+class AdvancedResponsibleNotifiedTest(common.BaseFunctionalTest):
+    def setUp(self):
+        super(AdvancedResponsibleNotifiedTest, self).setUp()
+
+        # patch registry to simulate a ready environment so that _message_auto_subscribe_notify
+        # will be executed with the associated notification
+        old = self.env.registry.ready
+        self.env.registry.ready = True
+        self.addCleanup(setattr, self.env.registry, 'ready', old)
+
+    def test_auto_subscribe_notify_email(self):
+        """ Responsible is notified when assigned """
+        partner = self.env['res.partner'].create({"name": "demo1", "email": "demo1@test.com"})
+        notified_user = self.env['res.users'].create({
+            'login': 'demo1',
+            'partner_id': partner.id,
+            'notification_type': 'email',
+        })
+
+        # TODO master: add a 'state' selection field on 'mail.test.track' with a 'done' value to have a complete test
+        # check that 'default_state' context does not collide with mail.mail default values
+        sub = self.env['mail.test.track'].with_user(self.user_employee).with_context({
+            'default_state': 'done',
+            'mail_notify_force_send': False
+        }).create({
+            'name': 'Test',
+            'user_id': notified_user.id,
+        })
+
+        self.assertEqual(sub.message_partner_ids, (self.user_employee.partner_id | notified_user.partner_id))
+        # fetch created "You have been assigned to 'Test'" mail.message
+        mail_message = self.env['mail.message'].search([
+            ('model', '=', 'mail.test.track'),
+            ('res_id', '=', sub.id),
+            ('partner_ids', 'in', partner.id),
+        ])
+        self.assertEqual(1, len(mail_message))
+
+        # verify that a mail.mail is attached to it with the correct state ('outgoing')
+        mail_notification = mail_message.notification_ids
+        self.assertEqual(1, len(mail_notification))
+        self.assertTrue(bool(mail_notification.mail_id))
+        self.assertEqual('outgoing', mail_notification.mail_id.state)
+
+
 @tagged('post_install', '-at_install')
 class DuplicateNotificationTest(common.BaseFunctionalTest):
     def test_no_duplicate_notification(self):


### PR DESCRIPTION
This commit forces the default value of the mail.mail 'state' field to
'outgoing' (the default field value), when notifying the record by email.

Without this change, there can be a collision when the ORM tries to compute
default values for this state field. For example:
- Model "A" has a 'state' field ;
- Create an action that redirects to model "A" form view, setting some default
  values in the context such as {'default_state': 'done'} ;
- Model "A" has an inherit on 'mail.thread' and a 'user_id' field to set a
  responsible user ;
- Model "A" record is created with a responsible user, who is automatically
  notified by email that the record "has been assigned to him" ;
  (see mail_thread#_message_auto_subscribe_notify)
- A 'mail.mail' is in turn created ;
- The 'mail.mail' model ALSO has a 'state' field, and the context is propagated
  so the ORM will try to assign 'done' to that field, which is an incorrect
  value ;
- -> Crash.

If we ensure that the value of the state is set to 'outgoing' for that record,
we bypass the default values computation for the 'state' field and everything
works fine.

A test was added to make sure this works properly.

Task 2393259

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
