### PR TITLE
[FIX] purchase: Wrong UOM conversion when creating a vendor bill

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1080,7 +1080,7 @@ class PurchaseOrderLine(models.Model):
             'name': '%s: %s' % (self.order_id.name, self.name),
             'product_id': self.product_id.id,
             'product_uom_id': self.product_uom.id,
-            'quantity': self.qty_to_invoice,
+            'quantity': self.product_id.uom_po_id._compute_quantity(self.qty_to_invoice, self.product_uom),
             'price_unit': self.price_unit,
             'tax_ids': [(6, 0, self.taxes_id.ids)],
             'analytic_account_id': self.account_analytic_id.id,


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a product P with purchase UOM = Unit
- Let's consider a UOM called Box such as 1 Box = Units
- P is invoiced according to its ordered quantity
- Create a PO for 1 Box of P and confirm it
- Create the bill B from PO

Bug:

The quantity of B was 10 and its UOM was Box

Introduced by: d0455ae

To keep the coherence with model sale.order.line where qty_to_invoice is always expressed in the uom
of the product

opw:2391243