### PR TITLE
[FIX] base: ignore user lang when comparing with arch

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1641,13 +1641,13 @@ class ResetViewArchWizard(models.TransientModel):
         if soft:
             arch_to_compare = self.view_id.arch_prev
         elif not soft and self.view_id.arch_fs:
-            arch_to_compare = self.view_id.with_context(read_arch_from_file=True).arch
+            arch_to_compare = self.view_id.with_context(read_arch_from_file=True, lang=None).arch
 
         diff = False
         if arch_to_compare:
             diff = HtmlDiff(tabsize=2).make_table(
                 arch_to_compare.splitlines(),
-                self.view_id.arch.splitlines(),
+                self.view_id.with_context(lang=None).arch.splitlines(),
                 _("Previous Arch") if soft else _("File Arch"),
                 _("Current Arch"),
                 context=True,  # Show only diff lines, not all the code


### PR DESCRIPTION
Without this commit, when the compare/reset view feature was reading the arch,
it would translate it.

2 issues :
- When reading from file (hard reset), it would translate the file version
- When reading current arch, it would translate it
