### PR TITLE
[FIX] delivery: default invoicing policy

### DIFF
--- a/addons/delivery/data/delivery_data.xml
+++ b/addons/delivery/data/delivery_data.xml
@@ -13,6 +13,7 @@
             <field name="sale_ok" eval="False"/>
             <field name="purchase_ok" eval="False"/>
             <field name="list_price">0.0</field>
+            <field name="invoice_policy">order</field>
         </record>
         <record id="free_delivery_carrier" model="delivery.carrier">
             <field name="name">Free delivery charges</field>

--- a/addons/delivery/data/delivery_demo.xml
+++ b/addons/delivery/data/delivery_demo.xml
@@ -12,6 +12,7 @@
             <field name="sale_ok" eval="False"/>
             <field name="purchase_ok" eval="False"/>
             <field name="list_price">20.0</field>
+            <field name="invoice_policy">order</field>
         </record>
 
         <record id="delivery_carrier" model="delivery.carrier">

--- a/addons/delivery/views/delivery_view.xml
+++ b/addons/delivery/views/delivery_view.xml
@@ -107,7 +107,7 @@
                                 <field name="company_id" groups="base.group_multi_company"/>
                             </group>
                             <group name="delivery_details">
-                                <field name="product_id" context="{'default_type': 'service', 'default_sale_ok': False, 'default_purchase_ok': False}" />
+                                <field name="product_id" context="{'default_type': 'service', 'default_sale_ok': False, 'default_purchase_ok': False, 'default_invoice_policy': 'order'}" />
                                 <field name="invoice_policy" widget="radio" attrs="{'invisible': ['|', ('delivery_type', 'in', ('fixed', 'base_on_rule')), ('integration_level', '=', 'rate')]}"/>
                                 <label for="margin" string="Margin on Rate"/>
                                 <div>


### PR DESCRIPTION
Since commit https://github.com/odoo/odoo/commit/3ad4abe171e8e7e86ed0e7b7f000e734d8a2ad92
the default invoicing policy of a product is set to 'delivery'. This is
not ok for the delivery products: a delivery product is never delivered.

This is confusing to end users, because they do not realize that a
delivery line is not included in an invoice. This is especially true if
the delivery is free.

This commit sets the default policy to 'order' for master data and for
newly created products from the shipping form view.

opw-2387437

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
