### PR TITLE
[FIX] web: mock all name_get behaviors

### DIFF
--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -1209,12 +1209,18 @@ var MockServer = Class.extend({
      */
     _mockNameGet: function (model, args) {
         var ids = args[0];
+        if (!args.length) {
+            throw new Error("name_get: expected one argument");
+        }
+        else if (!ids) {
+            return []
+        }
         if (!_.isArray(ids)) {
             ids = [ids];
         }
         var records = this.data[model].records;
         var names = _.map(ids, function (id) {
-            return [id, _.findWhere(records, {id: id}).display_name];
+            return id ? [id, _.findWhere(records, {id: id}).display_name] : [null, "False"];
         });
         return names;
     },

--- a/addons/web/static/tests/mockserver_tests.js
+++ b/addons/web/static/tests/mockserver_tests.js
@@ -51,5 +51,85 @@ QUnit.module("MockServer", {
         assert.strictEqual(_.difference(expectedFields, Object.keys(result[0])).length, 0,
             "should contains all the fields");
     });
+
+    QUnit.test("performRpc: name_get with no args", async function (assert) {
+        assert.expect(2);
+        const server = new MockServer(this.data, {});
+        try {
+            await server.performRpc("", {
+                model: "res.partner",
+                method: "name_get",
+                args: [],
+                kwargs: {},
+            });
+        } catch (error) {
+            assert.step("name_get failed")
+        }
+        assert.verifySteps(["name_get failed"])
+    });
+
+    QUnit.test("performRpc: name_get with undefined arg", async function (assert) {
+        assert.expect(1);
+        const server = new MockServer(this.data, {});
+        const result = await server.performRpc("", {
+            model: "res.partner",
+            method: "name_get",
+            args: [undefined],
+            kwargs: {},
+        });
+        assert.deepEqual(result, [])
+    });
+
+    QUnit.test("performRpc: name_get with a single id", async function (assert) {
+        assert.expect(1);
+        const server = new MockServer(this.data, {});
+        const result = await server.performRpc("", {
+            model: "res.partner",
+            method: "name_get",
+            args: [1],
+            kwargs: {},
+        });
+        assert.deepEqual(result, [[1, "Jean-Michel"]]);
+    });
+
+    QUnit.test("performRpc: name_get with array of ids", async function (assert) {
+        assert.expect(1);
+        const server = new MockServer(this.data, {});
+        const result = await server.performRpc("", {
+            model: "res.partner",
+            method: "name_get",
+            args: [[1]],
+            kwargs: {},
+        });
+        assert.deepEqual(result, [[1, "Jean-Michel"]]);
+    });
+
+    QUnit.test("performRpc: name_get with invalid id", async function (assert) {
+        assert.expect(2);
+        const server = new MockServer(this.data, {});
+        try {
+            await server.performRpc("", {
+                model: "res.partner",
+                method: "name_get",
+                args: [11111],
+                kwargs: {},
+            });
+        } catch (error) {
+            assert.step("name_get failed")
+        }
+        assert.verifySteps(["name_get failed"])
+    });
+
+    QUnit.test("performRpc: name_get with id and undefined id", async function (assert) {
+        assert.expect(1);
+        const server = new MockServer(this.data, {});
+        const result = await server.performRpc("", {
+            model: "res.partner",
+            method: "name_get",
+            args: [[undefined, 1]],
+            kwargs: {},
+        });
+        assert.deepEqual(result, [[null, "False"], [1, "Jean-Michel"]]);
+    });
 });
 });


### PR DESCRIPTION
The mock implementation of `name_get` does not fully reflect
the real server implementation.

The real implementation is described in tests added in
this commit.

This was spotted with https://github.com/odoo/enterprise/pull/14990 where the qunit test failed to have the same behavior as
a real world test.

Note: in my wildest dreams, the mock server tests would be run
against the real *and* the mock implementation to ensure they
do not diverge.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
