### PR TITLE
[IMP] l10n_ar: Add the codes of the ND for FCE invoices that is necessary to show the bank account in the report.

### DIFF
--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -236,7 +236,7 @@
                     <br/><strong>Currency: </strong><span t-esc="'%s - %s' % (o.currency_id.name, o.currency_id.currency_unit_label)"/>
                     <br/><strong>Exchange rate: </strong> <span t-field="o.l10n_ar_currency_rate"/>
                 </t>
-                <t t-if="o.l10n_latam_document_type_id.code in ['201', '206', '211']">
+                <t t-if="o.l10n_latam_document_type_id.code in ['201', '202', '206', '207', '211', '212']">
                     <br/><strong>CBU for payment: </strong><span t-esc="o.invoice_partner_bank_id.acc_number or '' if o.invoice_partner_bank_id.acc_type == 'cbu' else ''"/>
                 </t>
 
@@ -409,7 +409,7 @@
                     <br/><strong>Currency: </strong><span t-esc="'%s - %s' % (o.currency_id.name, o.currency_id.currency_unit_label)"/>
                     <br/><strong>Exchange rate: </strong> <span t-field="o.l10n_ar_currency_rate"/>
                 </t>
-                <t t-if="o.l10n_latam_document_type_id.code in ['201', '206', '211']">
+                <t t-if="o.l10n_latam_document_type_id.code in ['201', '202', '206', '207', '211', '212']">
                     <br/><strong>CBU for payment: </strong><span t-esc="o.invoice_partner_bank_id.acc_number or '' if o.invoice_partner_bank_id.acc_type == 'cbu' else ''"/>
                 </t>
 


### PR DESCRIPTION

This way we show in the invoice and debit note FCE documents the bank account in the invoice report.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
