### PR TITLE
[REF] make onchange inheritable

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1248,10 +1248,9 @@ class SaleOrderLine(models.Model):
             line.tax_id = fpos.map_tax(taxes, line.product_id, line.order_id.partner_shipping_id)
 
     @api.model
-    def _prepare_add_missing_fields(self, values):
+    def _prepare_add_missing_fields(self, values, onchange_fields):
         """ Deduce missing required fields from the onchange """
         res = {}
-        onchange_fields = ['name', 'price_unit', 'product_uom', 'tax_id']
         if values.get('order_id') and values.get('product_id') and any(f not in values for f in onchange_fields):
             line = self.new(values)
             line.product_id_change()
@@ -1266,7 +1265,7 @@ class SaleOrderLine(models.Model):
             if values.get('display_type', self.default_get(['display_type'])['display_type']):
                 values.update(product_id=False, price_unit=0, product_uom_qty=0, product_uom=False, customer_lead=0)
 
-            values.update(self._prepare_add_missing_fields(values))
+            values.update(self._prepare_add_missing_fields(values, ['name', 'price_unit', 'product_uom', 'tax_id']))
 
         lines = super().create(vals_list)
         for line in lines:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The fields used for the onchange are not inheritable, this lead to complex code in custom module

Current behavior before PR:

Not inheritable

Desired behavior after PR is merged:

Inheritable



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
