### PR TITLE
[FIX] account_check_printing: print check of payment group

### DIFF
--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -205,7 +205,7 @@ class AccountPayment(models.Model):
 
         multi_stub = self.company_id.account_check_printing_multi_stub
 
-        invoices = self.move_id._get_reconciled_invoices().sorted(key=lambda r: r.invoice_date_due)
+        invoices = self.move_id._get_reconciled_invoices().sorted(key=lambda r: r.invoice_date_due or fields.Date.context_today(self))
         debits = invoices.filtered(lambda r: r.move_type == 'in_invoice')
         credits = invoices.filtered(lambda r: r.move_type == 'in_refund')
 


### PR DESCRIPTION
When some bills are not paid, some with due date, some without, when registering the payment of these bills as a group payment with checks, it is not possible to print the check

To reproduce the error:
(Need account)
1. Go to Invoicing > Vendors > Bills
2. Create a new one
    - Add at least one line
    - Add the Payment Terms
3. Save & Post
4. Duplicate it, then Save & Post
5. Go back to Bills
6. Select the two bills
7. Click on Action > Register Payment
8. Select Checks, enable Group Payment
9. Click on Create Payment
10. Click on Print Check
11. Click on Print

=> An Odoo Error is raised

The user should be able to print it.

OPW-2389368

(Manual Forward-Port-Of #62168)
