### PR TITLE
[FIX] point_of_sale: error in pos.config form when editing/discarding

### DIFF
--- a/addons/point_of_sale/static/src/js/web_overrides/pos_config_form.js
+++ b/addons/point_of_sale/static/src/js/web_overrides/pos_config_form.js
@@ -8,7 +8,7 @@ odoo.define('point_of_sale.pos_config_form', function (require) {
     var PosConfigFormController = FormController.extend({
         _enableButtons: function (changedFields) {
             let shouldReload = false;
-            for (let field of changedFields) {
+            for (let field of (changedFields || [])) {
                 if (
                     field.startsWith('module_') ||
                     field.startsWith('group_') ||


### PR DESCRIPTION
Prior to 28762b79e3398dc883af9e0caef7c86cc5c051e0, `_enableButtons`
method is mainly called after saving changes in the record,
now, it is also called when discarding such that its argument can
become `undefined`. This causes error in pos.config form because it
uses a custom form which hooked to the said method in order to
reload the window when a module_ or group_ field is modified.

This commit prevents this error by having a fallback empty array
when `changedFields` is `undefined`.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
