### PR TITLE
[IMP] auth_signup: fix small design glitch in user form

### DIFF
--- a/addons/auth_signup/views/res_users_views.xml
+++ b/addons/auth_signup/views/res_users_views.xml
@@ -19,7 +19,7 @@
 
                 <xpath expr="//sheet" position="before">
                     <div class="alert alert-success text-center o_form_header" attrs="{'invisible': [('signup_valid', '!=', True)]}" role="status">
-                        <a class="close" data-dismiss="alert" href="#" aria-label="Close">x</a>
+                        <a class="close" data-dismiss="alert" href="#" aria-label="Close"><i title="Close" class="small fa fa-times"/></a>
                         <div attrs="{'invisible': [('state', '!=', 'active')]}">
                             <strong>A password reset has been requested for this user. An email containing the following link has been sent:</strong>
                         </div>


### PR DESCRIPTION
This commit fixes a small design glitch in the user form by replacing a "X"
character to close an alert by an actual close icon.
Which looks better, the "X" really sticks out from the rest of the design.

Task n°2393814

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
