### PR TITLE
[FIX] web: Dialog button disabled

### DIFF
--- a/addons/web/static/src/js/core/dialog.js
+++ b/addons/web/static/src/js/core/dialog.js
@@ -309,6 +309,7 @@ var Dialog = Widget.extend({
             });
             $button.on('click', function (e) {
                 var def;
+                $button.find('button').attr('disabled', true);
                 if (buttonData.click) {
                     def = buttonData.click.call(self, e);
                 }

--- a/addons/web/static/src/js/core/dialog.js
+++ b/addons/web/static/src/js/core/dialog.js
@@ -309,7 +309,7 @@ var Dialog = Widget.extend({
             });
             $button.on('click', function (e) {
                 var def;
-                $button.find('button').attr('disabled', true);
+                self.$footer.find('button').attr('disabled', true);
                 if (buttonData.click) {
                     def = buttonData.click.call(self, e);
                 }

--- a/addons/web/static/tests/core/dialog_tests.js
+++ b/addons/web/static/tests/core/dialog_tests.js
@@ -139,8 +139,9 @@ QUnit.module('core', {}, function () {
                     click: function () {
                         if (this.$footer.find('button').attr('disabled') !== 'disabled') {
                             testPromise.reject();
+                        }else{
+                            testPromise.resolve();
                         }
-                        testPromise.resolve();
                     },
                 },
             ],

--- a/addons/web/static/tests/core/dialog_tests.js
+++ b/addons/web/static/tests/core/dialog_tests.js
@@ -124,6 +124,39 @@ QUnit.module('core', {}, function () {
 
         parent.destroy();
     });
+
+    QUnit.test("Disabled buttons after click footer button", async function (assert) {
+        assert.expect(3);
+
+        var testPromise = testUtils.makeTestPromiseWithAssert(assert, 'button callback');
+        var parent = createEmptyParent();
+        new Dialog(parent, {
+            buttons: [
+                {
+                    text: "Close",
+                    classes: 'btn-primary',
+                    close: true,
+                    click: function () {
+                        if (this.$footer.find('button').attr('disabled') !== 'disabled') {
+                            testPromise.reject();
+                        }
+                        testPromise.resolve();
+                    },
+                },
+            ],
+        }).open();
+
+        assert.verifySteps([]);
+
+        await testUtils.nextTick();
+        await testUtils.dom.click($('.modal[role="dialog"] .btn-primary'));
+
+        testPromise.then(() => {
+            assert.verifySteps(['ok button callback']);
+        });
+
+        parent.destroy();
+    });
 });
 
 });


### PR DESCRIPTION
<button name="action_put_in_queue" type="object" attrs="{'invisible': [('state', 'in', ('in_queue', 'done'))]}" class="oe_highlight" string="Send"
                            confirm="This will send the email to all recipients. Do you still want to proceed ?"/>

if employee double click the confirm button, browser will send two request.
so should disabled button when the Dialog button click.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
