### PR TITLE
[FIX] website_slides: correctly add points after submitting the quiz

### DIFF
--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -632,6 +632,7 @@ class Slide(models.Model):
         ])
         if quiz_attempts_inc and existing_sudo:
             sql.increment_field_skiplock(existing_sudo, 'quiz_attempts_count')
+            existing_sudo.invalidate_cache(fnames=['quiz_attempts_count'])
 
         new_slides = self_sudo - existing_sudo.mapped('slide_id')
         return SlidePartnerSudo.create([{


### PR DESCRIPTION
Bug
===
Since d92e61e89f468c2db2fbd68b2f0d6b36c77f1065 , if you submit a quiz
without reading all the slides, you might get the minimum amount of
points.

The reason for that is because "quiz_attempts_count" is zero (because we
increment the value in SQL, and then we read the old value in the cache)
and so when we get the number of point with `gain[attempts-1]`
(expecting having attempts >= 1) we take the last value of the array,
so the minimal amount of point.

Task 2393688