### PR TITLE
[FIX] stock: remove leftover print statement

### DIFF
--- a/addons/stock/tests/test_packing.py
+++ b/addons/stock/tests/test_packing.py
@@ -759,7 +759,6 @@ class TestPacking(TestPackingCommon):
             with picking_form.package_level_ids_details.edit(0) as package_level:
                 package_level.is_done = True
         action = picking.button_validate()
-        print(action)
 
         self.assertEqual(action, True, 'Should not open wizard')
 


### PR DESCRIPTION
Leftover from commit b5e39fc7c1897b548134edcbf0f6057b8f6a22f0 (https://github.com/odoo/odoo/pull/61771)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
