### PR TITLE
[FIX] purchase_stock: use max() to compute purchase date

### DIFF
--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -266,6 +266,7 @@ class StockRule(models.Model):
 
         procurement_date_planned = min(dates)
         schedule_date = (procurement_date_planned - relativedelta(days=company_id.po_lead))
+        supplier_delay = max([int(value['supplier'].delay) for value in values])
 
         # Since the procurements are grouped if they share the same domain for
         # PO but the PO does not exist. In this case it will create the PO from
@@ -273,7 +274,7 @@ class StockRule(models.Model):
         # arbitrary procurement. In this case the first.
         values = values[0]
         partner = values['supplier'].name
-        purchase_date = schedule_date - relativedelta(days=int(values['supplier'].delay))
+        purchase_date = schedule_date - relativedelta(days=supplier_delay)
 
         fpos = self.env['account.fiscal.position'].with_context(force_company=company_id.id).get_fiscal_position(partner.id)
 


### PR DESCRIPTION
STEPS:
* Create a BoM with two components purchased the same vendor, but with
different "Delivery Lead Time". First component must have lower value
* Create Manufactoring order, Mark as ToDo
* Open created purchase order

BEFORE: Order Date	is equal "MO planned day MINUS delivery lead time for the first project"
AFTER: Order Date	is equal "MO planned day MINUS maximum amout delivery lead
time for the products"

---

opw-2388031

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
