### PR TITLE
[FIX] microsoft_calendar: disable Odoo emails

### DIFF
--- a/addons/microsoft_calendar/models/__init__.py
+++ b/addons/microsoft_calendar/models/__init__.py
@@ -6,3 +6,4 @@ from . import microsoft_sync
 from . import calendar
 from . import calendar_recurrence_rule
 from . import res_users
+from . import calendar_attendee

--- a/addons/microsoft_calendar/models/calendar_attendee.py
+++ b/addons/microsoft_calendar/models/calendar_attendee.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+from odoo.addons.microsoft_calendar.models.microsoft_sync import microsoft_calendar_token
+
+
+class Attendee(models.Model):
+    _name = 'calendar.attendee'
+    _inherit = 'calendar.attendee'
+
+    def _send_mail_to_attendees(self, template_xmlid, force_send=False, ignore_recurrence=False):
+        """ Override the super method
+        If not synced with Microsoft Outlook, let Odoo in charge of sending emails
+        Otherwise, Microsoft Outlook will send them
+        """
+        with microsoft_calendar_token(self.env.user.sudo()) as token:
+            if not token:
+                super()._send_mail_to_attendees(template_xmlid, force_send, ignore_recurrence)


### PR DESCRIPTION
When synced with Outlook, if a user adds an event to the Odoo Calendar,
both Outlook and Odoo will send an invitation to attendees.

To reproduce the error:
(Need calendar)
1. Set up a mail catcher
2. Clean the calendar
3. Sync with Outlook
	- [Steps](https://www.odoo.com/documentation/user/14.0/general/calendars/outlook/outlook_calendar.html)
4. In Calendar, create a new event
	- Add some attendees
5. Save

=> The attendees will receive two invitations: one from Odoo and a
second from Outlook.

When synced, Odoo should not manage the emails sending.

OPW-2387296