### PR TITLE
[FIX] crm: phone warning loop

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -398,9 +398,8 @@ class Lead(models.Model):
     @api.depends('email_from', 'phone', 'partner_id')
     def _compute_ribbon_message(self):
         for lead in self:
-            partner_formatted_phone = lead.partner_id.phone and self.phone_format(lead.partner_id.phone)
             will_write_email = lead.partner_id and lead.email_from != lead.partner_id.email
-            will_write_phone = lead.partner_id and lead.phone != partner_formatted_phone
+            will_write_phone = lead.partner_id and lead.phone != lead.partner_id.phone
 
             if will_write_email and will_write_phone:
                 lead.ribbon_message = _('By saving this change, the customer email and phone number will also be updated.')


### PR DESCRIPTION
in crm while editing lead demo data and saving without
any changes a warning which says that the customer phone
number will be updated shows like a loop.

This commit fixes this issue by preventing the lead partner
phone number from having mismatching format.

Task-id: 2390287