### PR TITLE
[FIX] pos_restaurant: order remained after deletion

### DIFF
--- a/addons/pos_restaurant/static/src/js/floors.js
+++ b/addons/pos_restaurant/static/src/js/floors.js
@@ -367,7 +367,7 @@ models.PosModel = models.PosModel.extend({
             if( (reason === 'abandon' || removed_order.temporary) && order_list.length > 0){
                 this.set_order(order_list[index] || order_list[order_list.length - 1], { silent: true });
             } else if (order_list.length === 0) {
-                this.set_order(null);
+                this.table ? this.set_order(null) : this.set_table(null);
             }
         } else {
             _super_posmodel.on_removed_order.apply(this,arguments);

--- a/addons/pos_restaurant/static/src/xml/Screens/FloorScreen/TableWidget.xml
+++ b/addons/pos_restaurant/static/src/xml/Screens/FloorScreen/TableWidget.xml
@@ -4,7 +4,7 @@
     <t t-name="TableWidget" owl="1">
         <div t-if="!props.isSelected" class="table" t-on-click.stop="trigger('select-table', props.table)">
             <span class="table-cover" t-att-class="{ full: fill >= 1 }"></span>
-            <span t-if="orderCount" t-att-class="orderCountClass">
+            <span t-att-class="orderCountClass" t-att-hidden="orderCount === 0">
                 <t t-esc="orderCount" />
             </span>
             <span class="label">

--- a/addons/pos_restaurant/static/tests/tours/TicketScreen.tour.js
+++ b/addons/pos_restaurant/static/tests/tours/TicketScreen.tour.js
@@ -40,6 +40,22 @@ odoo.define('pos_restaurant.tour.TicketScreen', function (require) {
     TicketScreen.do.selectOrder('-0002');
     ProductScreen.check.totalAmountIs('2.0');
     Chrome.check.backToFloorTextIs('Main Floor', 'T2');
+    Chrome.do.backToFloor();
+
+    // Make sure that order is deleted properly.
+    FloorScreen.do.clickTable('T5');
+    ProductScreen.exec.addOrderline('Minute Maid', '1', '3');
+    ProductScreen.check.totalAmountIs('3.0');
+    Chrome.do.backToFloor();
+    FloorScreen.check.orderCountSyncedInTableIs('T5', '1');
+    Chrome.do.clickTicketButton();
+    TicketScreen.do.deleteOrder('-0004');
+    Chrome.do.confirmPopup();
+    TicketScreen.do.clickDiscard();
+    FloorScreen.check.isShown();
+    FloorScreen.check.orderCountSyncedInTableIs('T5', '0');
+    FloorScreen.do.clickTable('T5');
+    ProductScreen.check.orderIsEmpty();
 
     Tour.register('PosResTicketScreenTour', { test: true, url: '/pos/ui' }, getSteps());
 });


### PR DESCRIPTION
There is a situation in pos_restaurant such that when an order
is deleted from the ticket screen, it persists to show when the
table is opened. To reproduce:

1. Create an order in T1 then add items to it.
2. Get out of the table (back to floor).
3. Open ticket screen.
4. Delete the order in T1.
5. Close the ticket screen.
6. Open T1, the order is still there (bug).

This commit fixes this behavior such that in step 6, new order should
show and not the deleted order.

Note that we also made a change in the template in order to allow
checking the number of synced orders during testing. We want to make
sure that the table is clicked when the sync finishes to prevent
concurrency issue during testing.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
