### PR TITLE
[FIX] calendar, google_calendar, hr_holidays: lost attendees after sync

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -475,12 +475,11 @@ class Meeting(models.Model):
                 added_partner_ids += [command[1]] if command[1] not in self.partner_ids.ids else []
             # commands 0 and 1 not supported
 
-        if removed_partner_ids:
-            attendees_to_unlink = self.env['calendar.attendee'].search([
-                ('event_id', 'in', self.ids),
-                ('partner_id', 'in', removed_partner_ids),
-            ])
-            attendee_commands += [[2, attendee.id] for attendee in attendees_to_unlink]  # Removes and delete
+        attendees_to_unlink = self.env['calendar.attendee'].search([
+            ('event_id', 'in', self.ids),
+            ('partner_id', 'in', removed_partner_ids),
+        ])
+        attendee_commands += [[2, attendee.id] for attendee in attendees_to_unlink]  # Removes and delete
 
         attendee_commands += [
             [0, 0, dict(partner_id=partner_id)]
@@ -700,9 +699,8 @@ class Meeting(models.Model):
                                 activity_vals['user_id'] = user_id
                             values['activity_ids'] = [(0, 0, activity_vals)]
 
-        self_partner_id = [(4, self.env.user.partner_id.id)]
         vals_list = [
-            dict(vals, attendee_ids=self._attendees_values(vals.get('partner_ids', self_partner_id)))
+            dict(vals, attendee_ids=self._attendees_values(vals['partner_ids'])) if 'partner_ids' in vals else vals
             for vals in vals_list
         ]
         recurrence_fields = self._get_recurrent_fields()

--- a/addons/calendar/tests/test_attendees.py
+++ b/addons/calendar/tests/test_attendees.py
@@ -11,12 +11,12 @@ class TestEventNotifications(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.user = new_test_user(cls.env, 'xav', email='em@il.com', notification_type='inbox')
-        cls.event = cls.env['calendar.event'].with_user(cls.user).create({
+        cls.event = cls.env['calendar.event'].create({
             'name': "Doom's day",
             'start': datetime(2019, 10, 25, 8, 0),
             'stop': datetime(2019, 10, 27, 18, 0),
         }).with_context(mail_notrack=True)
+        cls.user = new_test_user(cls.env, 'xav', email='em@il.com', notification_type='inbox')
         cls.partner = cls.user.partner_id
 
     def test_attendee_added(self):

--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -167,7 +167,6 @@ class Meeting(models.Model):
             'method': "email" if alarm.alarm_type == "email" else "popup",
             'minutes': alarm.duration_minutes
         } for alarm in self.alarm_ids]
-        attendee_ids = self.attendee_ids.filtered(lambda a: a.partner_id != self.env.user.partner_id)
         values = {
             'id': self.google_id,
             'start': start,
@@ -177,7 +176,7 @@ class Meeting(models.Model):
             'location': self.location or '',
             'guestsCanModify': True,
             'organizer': {'email': self.user_id.email, 'self': self.user_id == self.env.user},
-            'attendees': [{'email': attendee.email, 'responseStatus': attendee.state} for attendee in attendee_ids],
+            'attendees': [{'email': attendee.email, 'responseStatus': attendee.state} for attendee in self.attendee_ids],
             'extendedProperties': {
                 'shared': {
                     '%s_odoo_id' % self.env.cr.dbname: self.id,

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -895,7 +895,6 @@ class HolidaysRequest(models.Model):
                 'privacy': 'confidential',
                 'event_tz': holiday.user_id.tz,
                 'activity_ids': [(5, 0, 0)],
-                'partner_ids': [],
             }
             # Add the partner_id (if exist) as an attendee
             if holiday.user_id and holiday.user_id.partner_id:

--- a/addons/hr_holidays/tests/test_company_leave.py
+++ b/addons/hr_holidays/tests/test_company_leave.py
@@ -313,7 +313,7 @@ class TestCompanyLeave(SavepointCase):
         })
         company_leave._compute_date_from_to()
 
-        count = 863
+        count = 865
         with self.assertQueryCount(__system__=count, admin=count):
             # Original query count: 1987
             # Without tracking/activity context keys: 5154


### PR DESCRIPTION
What are the steps to reproduce your issue ?

    1. Install "google_calendar"
    2. Log in with "admin"
    3. Create an eventX with "admin" and "demo" has attendees
    4. Run "Google Calendar Synchronization" from "Scheduled Actions"

What is currently happening ?

    eventX is successfully added to Google but without admin
    if you sync Odoo to Google one more time, Google will overwrite eventX
    and it will remove admin from attendees

What are you expecting to happen ?

    Sync Odoo to Google and Google to Odoo without lost attendees

Why is this happening ?

    Because there is a filter that prevent addition of current user to the attendees

How to fix the bug ?

    Remove the filter

This reverts commit 287ee0f83ae6fd457e5356860c8a8ab5a4e66754.

opw-2382443

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
