### PR TITLE
[FIX] mail: emoji popover on mobile is opening before keyboard close

### DIFF
--- a/addons/mail/static/src/components/composer/composer.js
+++ b/addons/mail/static/src/components/composer/composer.js
@@ -110,7 +110,19 @@ class Composer extends Component {
         // emoji popover is outside but should be considered inside
         const emojisPopover = this._emojisPopoverRef.comp;
         if (emojisPopover && emojisPopover.contains(node)) {
+            this.hasTextInputFocus = false;
             return true;
+        }
+        if (this.env.device.isMobile) {
+            const emojiButton = node.matches(".o_Composer_buttonEmojis, .fa-smile-o");
+            if (!this.hasTextInputFocus && this.composer.hasFocus) {
+                this.hasTextInputFocus = true;
+            }
+            if (emojiButton && this.hasTextInputFocus) {
+                this._textInputRef.comp.focus();
+            } else if (!emojiButton && this.hasTextInputFocus && !this.composer.hasFocus) {
+                this.hasTextInputFocus = false;
+            }
         }
         return this.el.contains(node);
     }
@@ -139,6 +151,7 @@ class Composer extends Component {
             this.el.scrollIntoView();
         }
         this._textInputRef.comp.focus();
+        this.hasTextInputFocus = this.composer.hasFocus;
     }
 
     /**


### PR DESCRIPTION
**Current behavior before PR:**
The popover is opened before the mobile keyboard closes,which means there 
will be a flicker, which means trying to click on an emoji just as the keyboard is 
closing will be very confusing, or even lead to a wrong action.

**Desired behavior after PR is merged:**
When you click on Emoji popover and the keyboard is open, the keyboard will
remain open.

**LINKS:**
PR#62407
Task-2372562

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
