### PR TITLE
[FIX] stock: cannot remove attribute value

### DIFF
--- a/addons/stock/models/stock_inventory.py
+++ b/addons/stock/models/stock_inventory.py
@@ -283,7 +283,7 @@ class InventoryLine(models.Model):
     product_id = fields.Many2one(
         'product.product', 'Product', check_company=True,
         domain=lambda self: self._domain_product_id(),
-        index=True, required=True)
+        index=True, required=True, ondelete='cascade')
     product_uom_id = fields.Many2one(
         'uom.uom', 'Product Unit of Measure',
         required=True, readonly=True)

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -46,6 +46,7 @@ class StockMove(models.Model):
         'product.product', 'Product',
         check_company=True,
         domain="[('type', 'in', ['product', 'consu']), '|', ('company_id', '=', False), ('company_id', '=', company_id)]", index=True, required=True,
+        ondelete='cascade',
         states={'done': [('readonly', True)]})
     description_picking = fields.Text('Description of Picking')
     product_qty = fields.Float(

--- a/addons/stock_account/models/stock_valuation_layer.py
+++ b/addons/stock_account/models/stock_valuation_layer.py
@@ -15,7 +15,7 @@ class StockValuationLayer(models.Model):
 
     active = fields.Boolean(related='product_id.active')
     company_id = fields.Many2one('res.company', 'Company', readonly=True, required=True)
-    product_id = fields.Many2one('product.product', 'Product', readonly=True, required=True, check_company=True)
+    product_id = fields.Many2one('product.product', 'Product', readonly=True, required=True, check_company=True, ondelete='cascade')
     categ_id = fields.Many2one('product.category', related='product_id.categ_id')
     product_tmpl_id = fields.Many2one('product.template', related='product_id.product_tmpl_id')
     quantity = fields.Float('Quantity', digits=0, help='Quantity', readonly=True)


### PR DESCRIPTION
Steps:
- Go to Inventory > Mater Data > Products
- Edit "Customizable Desk (CONFIG)"
- Click "Variants" and remove a color (A)
- Go to Inventory > Configuration > Products > Attributes
- Edit "Color"
- Try to remove the same color as the one mentioned earlier (A)

Bug:
Model: Unknown (Unknown), Constraint: product_variant_combination_product_template_attribute_val_fkey

Explanation:
To solve this problem, the existing (archived) variant should be deleted. However it's not possible to do so since it's linked to multiple models through a foreign key.
This fix still prevents the variant from being deleted if its quantity is not zero.

opw:2390395