### PR TITLE
[FIX] website: fix megamenu snippet editor behavior

### DIFF
--- a/addons/website/static/src/js/editor/mega_menu.js
+++ b/addons/website/static/src/js/editor/mega_menu.js
@@ -69,8 +69,8 @@ snippetsEditor.SnippetsMenu.include({
      */
     toggleMegaMenuSnippets: function (show) {
         setTimeout(() => this._enableLastEditor());
-
-        $('#snippet_mega_menu').toggleClass('d-none', !show);
+        this._showMegaMenuSnippets = show;
+        this._filterSnippets();
     },
 
     //--------------------------------------------------------------------------
@@ -87,6 +87,15 @@ snippetsEditor.SnippetsMenu.include({
         $dropzone.attr('data-editor-sub-message', $hookParent.attr('data-editor-sub-message'));
         return $dropzone;
     },
-});
 
+    /**
+     * @override
+     */
+    _filterSnippets() {
+        this._super(...arguments);
+        if (!this._showMegaMenuSnippets) {
+            this.el.querySelector('#snippet_mega_menu').classList.add('d-none');
+        }
+    },
+});
 });


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Megamenu snippet should appear in the snippet editor "block" section ONLY if a megamenu element is selected.
Current behavior before PR:
In the current version, trying to filter snippets would make the megamenu snippet block appear.
Desired behavior after PR is merged:
Megamenu snippets do not appear unless a megamenu element is selected.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
