### PR TITLE
Change for Expected Duration in Structure & Cost report 

### DIFF
--- a/addons/mrp/report/mrp_report_bom_structure.py
+++ b/addons/mrp/report/mrp_report_bom_structure.py
@@ -170,7 +170,7 @@ class ReportBomStructure(models.AbstractModel):
         total = 0.0
         for operation in routing.operation_ids:
             operation_cycle = float_round(qty / operation.workcenter_id.capacity, precision_rounding=1, rounding_method='UP')
-            duration_expected = operation_cycle * operation.time_cycle + operation.workcenter_id.time_stop + operation.workcenter_id.time_start
+            duration_expected = operation_cycle * operation.time_cycle * 100.0 / operation.workcenter_id.time_efficiency + operation.workcenter_id.time_stop + operation.workcenter_id.time_start
             total = ((duration_expected / 60.0) * operation.workcenter_id.costs_hour)
             operations.append({
                 'level': level or 0,

--- a/doc/cla/individual/sngnt.md
+++ b/doc/cla/individual/sngnt.md
@@ -1,0 +1,9 @@
+Vietnam, 2020-11-27
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Son Nguyen Hong sonnh2009@gmail.com https://github.com/sngnt


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
The Expected Duration value is the difference between Work Order and BoM Structure & Cost

Desired behavior after PR is merged:

Synchronize the values of the two calculation results above


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
