### PR TITLE
[FIX] base: company not deleted on linked partners

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -546,7 +546,7 @@ class Partner(models.Model):
             vals['website'] = self._clean_website(vals['website'])
         if vals.get('parent_id'):
             vals['company_name'] = False
-        if vals.get('company_id'):
+        if 'company_id' in vals:
             company = self.env['res.company'].browse(vals['company_id'])
             for partner in self:
                 if partner.user_ids:


### PR DESCRIPTION
Steps:
- Install Contacts
- Have Multi-Companies enabled
- Go to a Contact of type "Company"
- Click "Sales & Purchases"
- Assign it the company you're on
- Save and Edit again
- Remove the assigned company
- Go to a contact of type "Individual" linked to this company
- Click "Sales & Purchases"

Bug:
The company has not been deleted on the linked Individual

Explanation:
When we delete the company of a contact, the value of `vals.get('company_id')` is `False`.
This is why it didn't enter the propagation process.

opw:2391464