### PR TITLE
[FIX] web,crm: fix rainbowman when lead is marked as "won"

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -771,6 +771,7 @@ class Lead(models.Model):
     def _get_rainbowman_message(self):
         message = False
         if self.user_id and self.team_id and self.expected_revenue:
+            self.flush()  # flush fields to make sure DB is up to date
             query = """
                 SELECT
                     SUM(CASE WHEN user_id = %(user_id)s THEN 1 ELSE 0 END) as total_won,

--- a/addons/crm/static/tests/tours/crm_rainbowman.js
+++ b/addons/crm/static/tests/tours/crm_rainbowman.js
@@ -19,8 +19,8 @@ odoo.define('crm.tour_crm_rainbowman', function (require) {
             content: "complete name",
             run: "text Test Lead 1",
         }, {
-            trigger: "div[name=planned_revenue] > input",
-            content: "complete planned revenue",
+            trigger: "div[name=expected_revenue] > input",
+            content: "complete expected revenue",
             run: "text 999999997",
         }, {
             trigger: "button.o_kanban_add",
@@ -30,23 +30,31 @@ odoo.define('crm.tour_crm_rainbowman', function (require) {
             content: "move to won stage",
             run: "drag_and_drop .o_opportunity_kanban .o_kanban_group:eq(3) "
         }, {
-            trigger: ".o-kanban-button-new",
+            trigger: ".o_reward_rainbow",
             extra_trigger: ".o_reward_rainbow",
-            content: "click create",
+            run: function () {} // check rainbowman is properly displayed
+        }, {
+            trigger: ".o-kanban-button-new",
+            content: "create second lead",
         }, {
             trigger: "input[name=name]",
             content: "complete name",
             run: "text Test Lead 2",
         }, {
-            trigger: "div[name=planned_revenue] > input",
-            content: "complete planned revenue",
+            trigger: "div[name=expected_revenue] > input",
+            content: "complete expected revenue",
             run: "text 999999998",
         }, {
             trigger: "button.o_kanban_add",
             content: "create lead",
         }, {
+            // move first test back to new stage to be able to test rainbowman a second time
+            trigger: ".o_kanban_record .o_kanban_record_title:contains('Test Lead 1')",
+            content: "move back to new stage",
+            run: "drag_and_drop .o_opportunity_kanban .o_kanban_group:eq(0) "
+        }, {
             trigger: ".o_kanban_record .o_kanban_record_title:contains('Test Lead 2')",
-            content: "click on lead",
+            content: "click on second lead",
         }, {
             trigger: ".o_statusbar_status button[data-value='4']",
             content: "move lead to won stage",

--- a/addons/crm/tests/test_crm_ui.py
+++ b/addons/crm/tests/test_crm_ui.py
@@ -8,3 +8,17 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_01_crm_tour(self):
         self.start_tour("/web", 'crm_tour', login="admin")
+
+    def test_02_crm_tour_rainbowman(self):
+        # we create a new user to make sure he gets the 'Congrats on your first deal!'
+        # rainbowman message.
+        self.env['res.users'].create({
+            'name': 'Temporary CRM User',
+            'login': 'temp_crm_user',
+            'password': 'temp_crm_user',
+            'groups_id': [(6, 0, [
+                    self.ref('base.group_user'),
+                    self.ref('sales_team.group_sale_salesman')
+                ])]
+        })
+        self.start_tour("/web", 'crm_rainbowman', login="temp_crm_user")

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -321,6 +321,13 @@ class IrActionsActWindowclose(models.Model):
 
     type = fields.Char(default='ir.actions.act_window_close')
 
+    def _get_readable_fields(self):
+        return super()._get_readable_fields() | {
+            # 'effect' is not a real field of ir.actions.act_window_close but is
+            # used to display the rainbowman
+            "effect"
+        }
+
 
 class IrActionsActUrl(models.Model):
     _name = 'ir.actions.act_url'


### PR DESCRIPTION
When you mark an crm.lead as "won" using the "mark as won" button, the user
will be shown a rainbowman under certain conditions.
Example: when you win your first lead.

This commit fixes the controllers 'clean_action' method to allow returning an
action with the 'effect' key, which is in turn picked up by the web client to
display the rainbowman.

At the same time, we add the tour that is testing the rainbowman of the crm app
in the test suite, since it was missing and never actually executed by the CI.
Some fixes were also necessary to make the test run properly.

Task 2394745

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
