### PR TITLE
[FIX] website_slides: fix quiz karma won

### DIFF
--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -632,6 +632,7 @@ class Slide(models.Model):
         ])
         if quiz_attempts_inc and existing_sudo:
             sql.increment_field_skiplock(existing_sudo, 'quiz_attempts_count')
+            SlidePartnerSudo.invalidate_cache(fnames=['quiz_attempts_count'], ids=existing_sudo.ids)
 
         new_slides = self_sudo - existing_sudo.mapped('slide_id')
         return SlidePartnerSudo.create([{


### PR DESCRIPTION
- Install website_slides
- Connect with an user (i.e. Mitchell Admin)
- Go to Website and open a Course quiz for the first time
(i.e. "Test Yourself" from "Basics of Furniture Creation" Course)
- Answer correctly
The number of won karma is the one from the last attempt reward and is not saved
in user's total xp.

When submitting the quiz, quiz_attempts_count is incremented via a SQL query,
but its value is not updated in cache directly.
When the karma gain is computed from the attempts count, the value used is the
old one in cache.

opw-2389969

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
