### PR TITLE
[FIX] l10n_pt: wrong P&L, fix account types

### DIFF
--- a/addons/l10n_pt/data/l10n_pt_chart_data.xml
+++ b/addons/l10n_pt/data/l10n_pt_chart_data.xml
@@ -681,217 +681,217 @@
     <record id="chart_311" model="account.account.template">
       <field name="code">311</field>
       <field name="name">Mercadorias</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_312" model="account.account.template">
       <field name="code">312</field>
       <field name="name">Matérias primas, subsidiárias e de consumo</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
     
     <record id="chart_313" model="account.account.template">
       <field name="code">313</field>
       <field name="name">Activos biológicos</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_317" model="account.account.template">
       <field name="code">317</field>
       <field name="name">Devoluções de compras</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_318" model="account.account.template">
       <field name="code">318</field>
       <field name="name">Descontos e abatimentos em compras</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_325" model="account.account.template">
       <field name="code">325</field>
       <field name="name">Mercadorias em trânsito</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_326" model="account.account.template">
       <field name="code">326</field>
       <field name="name">Mercadorias em poder de terceiros</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_329" model="account.account.template">
       <field name="code">329</field>
       <field name="name">Perdas por imparidade acumuladas</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_331" model="account.account.template">
       <field name="code">331</field>
       <field name="name">Matérias primas</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_332" model="account.account.template">
       <field name="code">332</field>
       <field name="name">Matérias subsidiárias</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_333" model="account.account.template">
       <field name="code">333</field>
       <field name="name">Embalagens</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_334" model="account.account.template">
       <field name="code">334</field>
       <field name="name">Materiais diversos</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_335" model="account.account.template">
       <field name="code">335</field>
       <field name="name">Matérias em trânsito</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_339" model="account.account.template">
       <field name="code">339</field>
       <field name="name">Perdas por imparidade acumuladas</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_346" model="account.account.template">
       <field name="code">346</field>
       <field name="name">Produtos em poder de terceiros</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_349" model="account.account.template">
       <field name="code">349</field>
       <field name="name">Perdas por imparidade acumuladas</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_351" model="account.account.template">
       <field name="code">351</field>
       <field name="name">Subprodutos</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_352" model="account.account.template">
       <field name="code">352</field>
       <field name="name">Desperdícios, resíduos e refugos</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_359" model="account.account.template">
       <field name="code">359</field>
       <field name="name">Perdas por imparidade acumuladas</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_36" model="account.account.template">
       <field name="code">36</field>
       <field name="name">Produtos e trabalhos em curso</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_3711" model="account.account.template">
       <field name="code">3711</field>
       <field name="name">Animais</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_3712" model="account.account.template">
       <field name="code">3712</field>
       <field name="name">Plantas</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_3721" model="account.account.template">
       <field name="code">3721</field>
       <field name="name">Animais</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_3722" model="account.account.template">
       <field name="code">3722</field>
       <field name="name">Plantas</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_382" model="account.account.template">
       <field name="code">382</field>
       <field name="name">Mercadorias</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_383" model="account.account.template">
       <field name="code">383</field>
       <field name="name">Matérias primas, subsidiárias e de consumo</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_384" model="account.account.template">
       <field name="code">384</field>
       <field name="name">Produtos acabados e intermédios</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_385" model="account.account.template">
       <field name="code">385</field>
       <field name="name">Subprodutos, desperdícios, resíduos e refugos</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_386" model="account.account.template">
       <field name="code">386</field>
       <field name="name">Produtos e trabalhos em curso</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_387" model="account.account.template">
       <field name="code">387</field>
       <field name="name">Activos biológicos</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_39" model="account.account.template">
       <field name="code">39</field>
       <field name="name">Adiantamentos por conta de compras</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
@@ -1626,21 +1626,21 @@
     <record id="chart_641" model="account.account.template">
       <field name="code">641</field>
       <field name="name">Propriedades de investimento</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_depreciation" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_642" model="account.account.template">
       <field name="code">642</field>
       <field name="name">Activos fixos tangíveis</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_depreciation" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 
     <record id="chart_643" model="account.account.template">
       <field name="code">643</field>
       <field name="name">Activos intangíveis</field>
-      <field name="user_type_id" ref="account.data_account_type_expenses" />
+      <field name="user_type_id" ref="account.data_account_type_depreciation" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
 


### PR DESCRIPTION
# Description of the issue/feature this PR addresses:

Inventory (31*) and Depreciation accounts (64*) are wrongly presented in the P&L report.

# Current behavior before PR:

Inventory accounts show up in the P&L report.
Depreciation accounts show up along expenses, and should be in the depreciation group.

# Desired behavior after PR is merged:

Inventory accounts show up in the Balance Sheet as Current Assets.
Depreciation accounts show up in the P&L as Depreciation.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
