### PR TITLE
[FIX] mrp_workorder: Qualitiy point on Kit

### DIFF
--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -98,7 +98,7 @@
                         </page>
                         <page string="Operations"
                             name="operations"
-                            attrs="{'invisible': [('type','not in',('normal','phantom'))]}"
+                            attrs="{'invisible': [('type', '!=', 'normal')]}"
                             groups="mrp.group_mrp_routings">
                                 <field name="operation_ids"
                                     attrs="{'invisible': [('type','not in',('normal','phantom'))]}"


### PR DESCRIPTION
Steps to reproduce the bug:

- Create a BOM kit K with two components C1 and C2

Bug:

It was possible to set an operation on K

PS: Operation is not supported on BOM kit

opw:2393302