### PR TITLE
[FIX] mail, test_mail: fix inbox (needaction) query 

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -160,9 +160,9 @@ class Message(models.Model):
 
     @api.model
     def _search_needaction(self, operator, operand):
-        if operator == '=' and operand:
-            return ['&', ('notification_ids.res_partner_id', '=', self.env.user.partner_id.id), ('notification_ids.is_read', '=', False)]
-        return ['&', ('notification_ids.res_partner_id', '=', self.env.user.partner_id.id), ('notification_ids.is_read', '=', True)]
+        is_read = False if operator == '=' and operand else True
+        notification_ids = self.env['mail.notification']._search([('res_partner_id', '=', self.env.user.partner_id.id), ('is_read', '=', is_read)])
+        return [('notification_ids', 'in', notification_ids)]
 
     def _compute_has_error(self):
         error_from_notification = self.env['mail.notification'].sudo().search([

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -145,6 +145,28 @@ class TestDiscuss(TestMailCommon, TestRecipients):
             (False, 'cc2@example.com', 'CC Email'),
         ], 'cc should be in suggestions')
 
+    def test_inbox_message_fetch_needaction(self):
+        user1 = self.env['res.users'].create({'login': 'user1', 'name': 'User 1'})
+        user1.notification_type = 'inbox'
+        user2 = self.env['res.users'].create({'login': 'user2', 'name': 'User 2'})
+        user2.notification_type = 'inbox'
+        message1 = self.test_record.with_user(self.user_admin).message_post(body='Message 1', partner_ids=[user1.partner_id.id, user2.partner_id.id])
+        message2 = self.test_record.with_user(self.user_admin).message_post(body='Message 2', partner_ids=[user1.partner_id.id, user2.partner_id.id])
+
+        # both notified users should have the 2 messages in Inbox initially
+        messages = self.env['mail.message'].with_user(user1).message_fetch(domain=[['needaction', '=', True]])
+        self.assertEqual(len(messages), 2)
+        messages = self.env['mail.message'].with_user(user2).message_fetch(domain=[['needaction', '=', True]])
+        self.assertEqual(len(messages), 2)
+
+        # first user is marking one message as done: the other message is still Inbox, while the other user still has the 2 messages in Inbox
+        message1.with_user(user1).set_message_done()
+        messages = self.env['mail.message'].with_user(user1).message_fetch(domain=[['needaction', '=', True]])
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0].get('id'), message2.id)
+        messages = self.env['mail.message'].with_user(user2).message_fetch(domain=[['needaction', '=', True]])
+        self.assertEqual(len(messages), 2)
+
 
 @tagged('-at_install', 'post_install')
 class TestMultiCompany(HttpCase):


### PR DESCRIPTION
Message search with `needaction` in domain should only return messages with
`needaction` for the current user.

Follow up on https://github.com/odoo/odoo/pull/52403 that changed how
sub-queries were built. The current fix using `_search` is a non-ideal solution
until task-2366651 brings a new domain operator for this use case.

task-2388843
task-2389933