### PR TITLE
[FIX] l10n_id_efaktur: generate efaktur

### DIFF
--- a/addons/l10n_id_efaktur/models/account_move.py
+++ b/addons/l10n_id_efaktur/models/account_move.py
@@ -280,7 +280,7 @@ class AccountMove(models.Model):
     def _generate_efaktur(self, delimiter):
         if self.filtered(lambda x: not x.l10n_id_kode_transaksi):
             raise UserError(_('Some documents don\'t have a transaction code'))
-        if self.filtered(lambda x: x.type != 'out_invoice'):
+        if self.filtered(lambda x: x.move_type != 'out_invoice'):
             raise UserError(_('Some documents are not Customer Invoices'))
 
         output_head = self._generate_efaktur_invoice(delimiter)


### PR DESCRIPTION
When generating an efaktur, an error is raised

To reproduce the error:
(Use empty DB)
1. Set the company's country to Indonesia
2. Install Accounting (account_accountant)
3. Accounting > Customers > e-Faktur
4. Create & Save
5. Accounting > Customers > Customers
6. Create a customer
	- Set country to Indonesia
	- Add a TVA number
7. Accounting > Customers > Invoices
8. Create one for this customer
	- Add a product
9. Save & Confirm
10. In Action, "Download e-faktur"

=> An error is raised.

OPW-2387843