### PR TITLE
[12.0][FIX] sale: Complete untaxed_amount_to_invoice computation

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1368,7 +1368,12 @@ class SaleOrderLine(models.Model):
                     # As included taxes are not excluded from the computed subtotal, `compute_all()` method
                     # has to be called to retrieve the subtotal without them.
                     # `price_reduce_taxexcl` cannot be used as it is computed from `price_subtotal` field. (see upper Note)
-                    price_subtotal = line.tax_id.compute_all(price_subtotal)['total_excluded']
+                    price_subtotal = line.tax_id.compute_all(
+                        price_subtotal,
+                        currency_id=line.order_id.currency_id,
+                        quantity=line.product_uom_qty,
+                        product=line.product_id,
+                        partner=line.order_id.partner_shipping_id)['total_excluded']
 
                 amount_to_invoice = price_subtotal - line.untaxed_amount_invoiced
             line.untaxed_amount_to_invoice = amount_to_invoice


### PR DESCRIPTION
Due to 14cb0693b7dec7a8d8eb46a3d34eae2af63cfb70,
some fields are not passed in parameters.

Fixes https://github.com/odoo/odoo/pull/58974

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
