### PR TITLE
[FIX] website: remove old code

### DIFF
--- a/addons/website/static/src/js/content/website_root.js
+++ b/addons/website/static/src/js/content/website_root.js
@@ -246,7 +246,6 @@ var WebsiteRoot = BodyManager.extend({
     _onPublishBtnClick: function (ev) {
         ev.preventDefault();
 
-        var self = this;
         var $data = $(ev.currentTarget).parents(".js_publish_management:first");
         this._rpc({
             route: $data.data('controller') || '/website/publish',
@@ -259,19 +258,6 @@ var WebsiteRoot = BodyManager.extend({
             $data.toggleClass("css_unpublished css_published");
             $data.find('input').prop("checked", result);
             $data.parents("[data-publish]").attr("data-publish", +result ? 'on' : 'off');
-        })
-        .fail(function (err, data) {
-            return new Dialog(self, {
-                title: data.data ? data.data.arguments[0] : "",
-                $content: $('<div/>', {
-                    html: (data.data ? data.data.arguments[1] : data.statusText)
-                        + '<br/>'
-                        + _.str.sprintf(
-                            _t('It might be possible to edit the relevant items or fix the issue in <a href="%s">the classic Odoo interface</a>'),
-                            '/web#return_label=Website&model=' + $data.data('object') + '&id=' + $data.data('id')
-                        ),
-                }),
-            }).open();
         });
     },
     /**


### PR DESCRIPTION
This code is a leftover of https://github.com/odoo/odoo/commit/2972976962617d4b8a0113bae58c640ab41cdff8#diff-70e782021bdfee46734a7fc7dbcad3104f7f985dd37f9320f1480d424581d67fL191
- We should not get info from the `err` and `data` parameters, those are not
the same as the it was before the code got migrated, `data.data` never exists.
- The fact that we handle the fail on this call is also a leftover of that
refactoring where the error was done through a generic template.
- We should not handle an error on publish action. We never handle that kind of
error if the action should not fail by default. This is typically the case
when loading the menu through "Edit Menu" or the page properties.
- This is especially true with later version as error raised are already
handled globaly

![aaa](https://user-images.githubusercontent.com/30048408/100373264-cbaf4680-300a-11eb-8a21-742953d3b42f.png)


Closes #60041
