### PR TITLE
[FIX] requirements: remove gevent double requirements on win32

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ ebaysdk==2.1.5
 feedparser==5.2.1
 gevent==1.1.2 ; sys_platform != 'win32' and python_version < '3.7'
 gevent==1.5.0 ; python_version >= '3.7'
-gevent==1.4.0 ; sys_platform == 'win32'
+gevent==1.4.0 ; sys_platform == 'win32' and python_version < '3.7'
 greenlet==0.4.10 ; python_version < '3.7'
 greenlet==0.4.15 ; python_version >= '3.7'
 html2text==2018.1.9


### PR DESCRIPTION
Fixes #62214
