### PR TITLE
fix optional dropdown hide behind listview table

### DIFF
--- a/addons/web/static/src/js/views/list/list_renderer.js
+++ b/addons/web/static/src/js/views/list/list_renderer.js
@@ -986,7 +986,7 @@ var ListRenderer = BasicRenderer.extend({
             if (self.optionalColumns.length) {
                 self.$el.addClass('o_list_optional_columns');
                 self.$('table').append($('<i class="o_optional_columns_dropdown_toggle fa fa-ellipsis-v"/>'));
-                self.$('table').append(self._renderOptionalColumnsDropdown());
+                self.$el.append(self._renderOptionalColumnsDropdown());
             }
 
             if (self.selection.length) {
@@ -1136,6 +1136,13 @@ var ListRenderer = BasicRenderer.extend({
         // default, which is why we need to toggle the dropdown manually.
         ev.stopPropagation();
         this.$('.o_optional_columns .dropdown-toggle').dropdown('toggle');
+        // Explicitly set left of the optional column dropdown as it is pushed inside
+        // this.$el, so we need to position it at the end of top right/left corner based
+        // on language direction.
+        var left = _t.database.parameters.direction === 'rtl' ?
+            this.$('.o_optional_columns .o_optional_columns_dropdown').width() :
+            this.$("table").width();
+        this.$('.o_optional_columns').css("left", left);
     },
     /**
      * Manages the keyboard events on the list. If the list is not editable, when the user navigates to

--- a/addons/web/static/src/scss/form_view_extra.scss
+++ b/addons/web/static/src/scss/form_view_extra.scss
@@ -17,7 +17,6 @@
             border: 1px solid #c8c8d3;
             box-shadow: 0 4px 20px rgba(0,0,0,0.15);
             background: white;
-            overflow: hidden;
 
             margin: $o-sheet-vpadding*0.2 auto;
             @include media-breakpoint-up(md) {

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -8530,10 +8530,10 @@ QUnit.module('Views', {
         assert.containsOnce(list.$('table'), '.o_optional_columns_dropdown_toggle',
             "should have the optional columns dropdown toggle inside the table");
 
-        const optionalFieldsToggler = list.el.querySelector('table').lastElementChild.previousSibling;
+        const optionalFieldsToggler = list.el.querySelector('table').lastElementChild;
         assert.ok(optionalFieldsToggler.classList.contains('o_optional_columns_dropdown_toggle'),
             'The optional fields toggler is the second last element');
-        const optionalFieldsDropdown = list.el.querySelector('table').lastElementChild;
+        const optionalFieldsDropdown = list.el.querySelector('.o_list_view').lastElementChild;
         assert.ok(optionalFieldsDropdown.classList.contains('o_optional_columns'),
             'The optional fields dropdown is the last element');
 
@@ -8598,10 +8598,10 @@ QUnit.module('Views', {
         assert.containsOnce(list.$('table'), '.o_optional_columns_dropdown_toggle',
             "should have the optional columns dropdown toggle inside the table");
 
-        const optionalFieldsToggler = list.el.querySelector('table').lastElementChild.previousSibling;
+        const optionalFieldsToggler = list.el.querySelector('table').lastElementChild;
         assert.ok(optionalFieldsToggler.classList.contains('o_optional_columns_dropdown_toggle'),
             'The optional fields toggler is the last element');
-        const optionalFieldsDropdown = list.el.querySelector('table').lastElementChild;
+        const optionalFieldsDropdown = list.el.querySelector('.o_list_view').lastElementChild;
         assert.ok(optionalFieldsDropdown.classList.contains('o_optional_columns'),
             'The optional fields is the last element');
 


### PR DESCRIPTION
PURPOSE
Currently in embedded listview in o2m if there is no records and user opens optional dropdown and if optional dropdown is bigger then it is hidden behind listview, optional dropdown should open on top of listview.

SPEC
in a embedded listview, the optional fields dropdown should be 'on top of' (i.e. outside) the listview

TASK 2370860
Fixes https://github.com/odoo/odoo/issues/62681
Closes https://github.com/odoo/odoo/issues/62681



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
