### PR TITLE
[FIX] project: show "View Task" to portal customers

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1237,9 +1237,12 @@ class Task(models.Model):
                 {}
             ))
 
+        portal_privacy = self.project_id.privacy_visibility == 'portal'
         for group_name, group_method, group_data in groups:
-            if group_name in ('customer', 'portal_customer', 'user'):
+            if group_name in ('customer', 'user') or group_name == 'portal_customer' and not portal_privacy:
                 group_data['has_button_access'] = False
+            elif group_name == 'portal_customer' and portal_privacy:
+                group_data['has_button_access'] = True
 
         return groups
 


### PR DESCRIPTION
Since commit 62024ca the portal customer of a task were missing the
"View Task" button.

TaskID: 2393286

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
