### PR TITLE
[FIX] account: allow to bypass sync of date/sequence before date

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -11671,8 +11671,8 @@ msgstr ""
 #: code:addons/account/models/sequence_mixin.py:0
 #, python-format
 msgid ""
-"The date (%(date)s) doesn't match the sequence number (%(sequence)s).\n"
-"You might want to remove the sequence before proceeding with the change of the date."
+"The %(date_field)s (%(date)s) doesn't match the %(sequence_field)s (%(sequence)s).\n"
+"You might want to clear the field %(sequence_field)s before proceeding with the change of the date."
 msgstr ""
 
 #. module: account

--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -2,6 +2,7 @@
 
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
+from odoo.tools.misc import format_date
 
 import re
 from psycopg2 import sql
@@ -49,22 +50,29 @@ class SequenceMixin(models.AbstractModel):
         return super().__init__(pool, cr)
 
     def _constrains_date_sequence(self):
+        # Make it possible to bypass the constraint to allow edition of already messed up documents.
+        # /!\ Do not use this to completely disable the constraint as it will make this mixin unreliable.
+        constraint_date = fields.Date.to_date(self.env['ir.config_parameter'].sudo().get_param(
+            'sequence.mixin.constraint_start_date',
+            '1970-01-01'
+        ))
         for record in self:
             date = fields.Date.to_date(record[record._sequence_date_field])
             sequence = record[record._sequence_field]
-            if sequence and date:
+            if sequence and date and date > constraint_date:
                 format_values = record._get_sequence_format_param(sequence)[1]
                 if (
                     format_values['year'] and format_values['year'] != date.year % 10**len(str(format_values['year']))
                     or format_values['month'] and format_values['month'] != date.month
                 ):
                     raise ValidationError(_(
-                        "The date (%(date)s) doesn't match the sequence number (%(sequence)s).\n"
-                        "You might want to remove the sequence before proceeding with the change of the date."
-                    ) % {
-                        'date': date,
-                        'sequence': sequence,
-                    })
+                        "The %(date_field)s (%(date)s) doesn't match the %(sequence_field)s (%(sequence)s).\n"
+                        "You might want to clear the field %(sequence_field)s before proceeding with the change of the date.",
+                        date=format_date(self.env, date),
+                        sequence=sequence,
+                        date_field=record._fields[record._sequence_date_field]._description_string(self.env),
+                        sequence_field=record._fields[record._sequence_field]._description_string(self.env),
+                    ))
 
     @api.depends(lambda self: [self._sequence_field])
     def _compute_split_sequence(self):


### PR DESCRIPTION
Databases that already have issues are not able to fix the issues
because it is impossible to reset the items to draft in order to change
the date/sequence. Or do anything else, really.
By allowing to bypass the constraint before a certain date, users can
now edit problematic documents.

Disabling the constraint will however make it possible to entirely
break the sequences; use it with the lowest possible date.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
