### PR TITLE
[FIX] base: company not deleted on linked partners

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -546,7 +546,7 @@ class Partner(models.Model):
             vals['website'] = self._clean_website(vals['website'])
         if vals.get('parent_id'):
             vals['company_name'] = False
-        if 'company_id' in vals:
+        if vals.get('company_id'):
             company = self.env['res.company'].browse(vals['company_id'])
             for partner in self:
                 if partner.user_ids:


### PR DESCRIPTION
This reverts commit 80902bee453cf485906bb07be6af9072aee2e76f as the
backport to 12.0 did not apply.

Related: https://github.com/odoo/odoo/pull/62418