### PR TITLE
3.9 compatibility: bytecode and API changes

### DIFF
--- a/addons/hw_escpos/controllers/main.py
+++ b/addons/hw_escpos/controllers/main.py
@@ -92,7 +92,7 @@ class EscposDriver(Thread):
 
     def lockedstart(self):
         with self.lock:
-            if not self.isAlive():
+            if not self.is_alive():
                 self.daemon = True
                 self.start()
     

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -391,7 +391,7 @@ class ThreadedServer(CommonServer):
         # e.g. threads that exceeded their real time,
         # but which finished before the server could restart.
         for thread in list(self.limits_reached_threads):
-            if not thread.isAlive():
+            if not thread.is_alive():
                 self.limits_reached_threads.remove(thread)
         if self.limits_reached_threads:
             self.limit_reached_time = self.limit_reached_time or time.time()
@@ -489,7 +489,7 @@ class ThreadedServer(CommonServer):
             _logger.debug('process %r (%r)', thread, thread.isDaemon())
             if (thread != me and not thread.isDaemon() and thread.ident != self.main_thread_id and
                     thread not in self.limits_reached_threads):
-                while thread.isAlive() and (time.time() - stop_time) < 1:
+                while thread.is_alive() and (time.time() - stop_time) < 1:
                     # We wait for requests to finish, up to 1 second.
                     _logger.debug('join and sleep')
                     # Need a busyloop here as thread.join() masks signals

--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -65,6 +65,7 @@ _CONST_OPCODES = set(to_opcodes([
     'BUILD_LIST', 'BUILD_MAP', 'BUILD_TUPLE', 'BUILD_SET',
     # 3.6: literal map with constant keys https://bugs.python.org/issue27140
     'BUILD_CONST_KEY_MAP',
+    'LIST_EXTEND', 'SET_UPDATE',
 ])) - _BLACKLIST
 
 # operations which are both binary and inplace, same order as in doc'
@@ -82,6 +83,9 @@ _EXPR_OPCODES = _CONST_OPCODES.union(to_opcodes([
     # comprehensions
     'LIST_APPEND', 'MAP_ADD', 'SET_ADD',
     'COMPARE_OP',
+    # specialised comparisons
+    'IS_OP', 'CONTAINS_OP',
+    'DICT_MERGE', 'DICT_UPDATE',
 ])) - _BLACKLIST
 
 _SAFE_OPCODES = _EXPR_OPCODES.union(to_opcodes([
@@ -106,6 +110,8 @@ _SAFE_OPCODES = _EXPR_OPCODES.union(to_opcodes([
     'LOAD_FAST', 'STORE_FAST', 'DELETE_FAST', 'UNPACK_SEQUENCE',
     'STORE_SUBSCR',
     'LOAD_GLOBAL',
+
+    'RERAISE', 'JUMP_IF_NOT_EXC_MATCH',
 ])) - _BLACKLIST
 
 _logger = logging.getLogger(__name__)


### PR DESCRIPTION
* 3.9 added 10 new bytecode instructions, though 2 of them seem uninteresting so I did not whitelist them
* 3.9 removed the long-deprecated `Thread.isAlive()`, which we were still using instead of the "proper" `Thread.is_alive()`

With this, test suite at least seems to pass without warning in both 3.8 and 3.9 (assuming relevant optional dependencies are installed).