### PR TITLE
[FIX] survey: Change certificates design

### DIFF
--- a/addons/survey/static/src/scss/survey_reports.scss
+++ b/addons/survey/static/src/scss/survey_reports.scss
@@ -128,7 +128,7 @@
             .certification-bg-dark {
                 display: inline-block;
                 background-color: #223541;
-                color: white;
+                background: rgba(34, 53, 65, 0.1);
             }
 
             .certification-top {
@@ -140,7 +140,6 @@
                 }
 
                 .certification-company-wrapper {
-                    background-color: rgba(white, 0.9);
                     padding: 1mm 2mm;
 
                     img {


### PR DESCRIPTION
This PR decreases the opacity of dark squares and remove the white
background of the logo in the certification templates to make it look better

<details>
  <summary>Before</summary>

![Screenshot from 2020-11-27 11-53-41](https://user-images.githubusercontent.com/39504376/100442114-ceac4480-30a7-11eb-9156-877ec6a36c0b.png)

</details>

<details>
  <summary>After</summary>

![Screenshot from 2020-11-27 11-54-51](https://user-images.githubusercontent.com/39504376/100441845-6198af00-30a7-11eb-8054-ea40c7d2239e.png)

</details>

opw-2387563
https://www.odoo.com/web#id=2387563&action=4043&model=project.task&view_type=form&cids=1&menu_id=4720
