### PR TITLE
[FIX] website_links: not perform a request during automated test

### DIFF
--- a/addons/website_links/static/tests/tours/website_links.js
+++ b/addons/website_links/static/tests/tours/website_links.js
@@ -29,10 +29,7 @@ tour.register('website_links_tour', {
         // 2. Visit it
         {
             content: "check that link was created and visit it",
-            // Depending of the speed of `requests.get` from `_get_title_from_url`,
-            // the link name will either be "About us" (page title) or
-            // "http://url/aboutus" (page url).
-            extra_trigger: '#o_website_links_recent_links .truncate_text:first():contains("Contact us"), #o_website_links_recent_links .truncate_text:first():contains("contactus")',
+            extra_trigger: '#o_website_links_recent_links .truncate_text:first():contains("Contact Us")',
             trigger: '#o_website_links_link_tracker_form #generated_tracked_link:contains("/r/")',
             run: function () {
                 window.location.href = $('#generated_tracked_link').text();

--- a/addons/website_links/tests/test_ui.py
+++ b/addons/website_links/tests/test_ui.py
@@ -1,10 +1,22 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from unittest.mock import patch
+
 import odoo.tests
 
 
 @odoo.tests.common.tagged('post_install', '-at_install')
 class TestUi(odoo.tests.HttpCase):
+
+    def setUp(self):
+        super(TestUi, self).setUp()
+
+        def _get_title_from_url(addr, **kw):
+            return 'Contact Us | My Website'
+
+        patcher = patch('odoo.addons.link_tracker.models.link_tracker.LinkTracker._get_title_from_url', wraps=_get_title_from_url)
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     def test_01_test_ui(self):
         self.env['link.tracker'].create({


### PR DESCRIPTION
This commit fixes the step trigger:
'#o_website_links_link_tracker_form
 #generated_tracked_link:contains("/r/")' that was taking too long
because of a call to _get_title_from_url happening during the creation
of a 'link.tracker'.

Before this commit the automated tests of website_links did trigger an
http request on the 'contactus' page which sometimes took too long to
respond and reached the test failure timeout.

After this commit the information obtained from this request is
hard-coded to avoid the unpredictable timing of the test.

This commit is a manual port of #62479.

task-2397724

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
