### PR TITLE
[FIX] mrp: UoM category mismatch

### DIFF
--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -168,7 +168,9 @@ class ProductProduct(models.Model):
                     # products have 0 qty available.
                     continue
                 uom_qty_per_kit = bom_line_data['qty'] / bom_line_data['original_qty']
-                qty_per_kit = bom_line.product_uom_id._compute_quantity(uom_qty_per_kit, bom_line.product_id.uom_id)
+                qty_per_kit = bom_line.product_uom_id._compute_quantity(uom_qty_per_kit, bom_line.product_id.uom_id, raise_if_failure=False)
+                if not qty_per_kit:
+                    continue
                 ratios_virtual_available.append(component.virtual_available / qty_per_kit)
                 ratios_qty_available.append(component.qty_available / qty_per_kit)
                 ratios_incoming_qty.append(component.incoming_qty / qty_per_kit)


### PR DESCRIPTION
- Create Product A with UOM of type Unit
- Create Product B with UOM of type Unit
- Create BOM of type Kit on Product A with Product B as a component
  with UOM of type Unit
- After saving BOM, change the UOM of Product B with UOM from another
  categories (e.g. kg) and save the product
- Try to access product list

A warning appears and prevent showing the products in any way.

It is caused by the call to `_compute_quantities`.

In this case, it is ok to skip the error. Indeed, it will raise later on
when trying to use the kit. But at least, it gives the possibility to
the user to access the product list.

opw-2393711

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
