### PR TITLE
[FIX] stock: retry inventory adjustment on concurrent update

### DIFF
--- a/addons/stock/models/stock_inventory.py
+++ b/addons/stock/models/stock_inventory.py
@@ -195,7 +195,7 @@ class Inventory(models.Model):
         # The inventory is posted as a single step which means quants cannot be moved from an internal location to another using an inventory
         # as they will be moved to inventory loss, and other quants will be created to the encoded quant location. This is a normal behavior
         # as quants cannot be reuse from inventory location (users can still manually move the products before/after the inventory if they want).
-        self.mapped('move_ids').filtered(lambda move: move.state != 'done')._action_done()
+        self.mapped('move_ids').filtered(lambda move: move.state != 'done').with_context(retry_on_concurent_update=True)._action_done()
         return True
 
     def action_check(self):


### PR DESCRIPTION
STEPS:
* create new product
* update quantity on hand: 35 on location A
* make internal transfer: 50 from location A to location B
* update odoo code: add a sleep at the end of stock.picking::action_assign

     import time; time.sleep(10)

* prepare new inventory adjustment for the product: real quatity 30 on location A
* open internal transfer in a new tab, click "mark as todo", click "check availability"
* while it's loading, validate the inventory adjustment

BEFORE: internal transfer has 35 reserved products

AFTER:  internal transfer has 30 reserved products

---

fixes #62139
opw-2388684

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
