### PR TITLE
[FIX] project, rating: remove subtype description for ratings

### DIFF
--- a/addons/project/data/project_data.xml
+++ b/addons/project/data/project_data.xml
@@ -50,7 +50,6 @@
             <field name="name">Task Rating</field>
             <field name="res_model">project.task</field>
             <field name="default" eval="True"/>
-            <field name="description">Ratings</field>
         </record>
         <!-- Project-related subtypes for messaging / Chatter -->
         <record id="mt_project_task_new" model="mail.message.subtype">

--- a/addons/rating/models/rating_mixin.py
+++ b/addons/rating/models/rating_mixin.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from datetime import timedelta
 
-from odoo import api, fields, models, tools
+from odoo import api, fields, models, tools, _
 from odoo.addons.rating.models.rating import RATING_LIMIT_SATISFIED, RATING_LIMIT_OK, RATING_LIMIT_MIN
 from odoo.osv import expression
 
@@ -193,8 +193,8 @@ class RatingMixin(models.AbstractModel):
             if hasattr(self, 'message_post'):
                 feedback = tools.plaintext2html(feedback or '')
                 self.message_post(
-                    body="<img src='/rating/static/src/img/rating_%s.png' alt=':%s/10' style='width:18px;height:18px;float:left;margin-right: 5px;'/>%s"
-                    % (rate, rate, feedback),
+                    body="<span style='float:left;margin-right: 5px;'>%s:</span><img src='/rating/static/src/img/rating_%s.png' alt=':%s/10' style='width:18px;height:18px;float:left;margin-right: 5px;'/>%s"
+                    % (_("Rating"), rate, rate, feedback),
                     subtype_xmlid=subtype_xmlid or "mail.mt_comment",
                     author_id=rating.partner_id and rating.partner_id.id or None  # None will set the default author in mail_thread.py
                 )


### PR DESCRIPTION
**Before this commit:**
For an example, when task is going to 'Done' state at that time mail is sent to
customer for feedback, answering of that mail contain smiley face plus subtype
description in chatter.

**After this commit:**
Append "Rating:" before the smiley face and removed subtype description from
message.

**Links**
PR https://github.com/odoo/odoo/pull/62517
Task-2373127
