### PR TITLE
[FIX] calendar : 'my meetings' filter

### DIFF
--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -278,8 +278,7 @@
                 <field name="categ_ids"/>
                 <field name="user_id"/>
                 <field name="show_as"/>
-                <!-- TODO clean this filter and context key -->
-                <filter string="My Meetings" help="My Meetings" name="mymeetings" context='{"mymeetings": 1}'/>
+                <filter string="My Meetings" help="My Meetings" name="mymeetings" domain="[('partner_ids.user_ids', 'in', [uid])]"/>
                 <separator/>
                 <filter string="Date" name="filter_start_date" date="start_date"/>
                 <separator/>


### PR DESCRIPTION
When we try the 'My Meetings' filter in the Calendar module,
it can't filter out the meetings that the user is attending.

Steps to reproduce:

go to calendar > list view > filters > my meetings

Observed behavior:

the filter returns all meetings without distinction, including the ones the user
is not attending

From this commit, the filter should only return the meetings that the user
is attending

task - 2389382

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
