### PR TITLE
[IMP] mail: Rename temporary to uploading in attachments related content

### DIFF
--- a/addons/mail/static/src/components/attachment/attachment.js
+++ b/addons/mail/static/src/components/attachment/attachment.js
@@ -39,13 +39,12 @@ class Attachment extends Component {
     }
 
     /**
-     * Return the url of the attachment. Temporary attachments, a.k.a. uploading
-     * attachments, do not have an url.
+     * Return the url of the attachment. Uploading attachments do not have an url.
      *
      * @returns {string}
      */
     get attachmentUrl() {
-        if (this.attachment.isTemporary) {
+        if (this.attachment.isUploading) {
             return '';
         }
         return this.env.session.url('/web/content', {

--- a/addons/mail/static/src/components/attachment/attachment.xml
+++ b/addons/mail/static/src/components/attachment/attachment.xml
@@ -7,7 +7,7 @@
                 'o-downloadable': props.isDownloadable,
                 'o-editable': props.isEditable,
                 'o-has-card-details': detailsMode === 'card',
-                'o-temporary': attachment and attachment.isTemporary,
+                'o-isUploading': attachment and attachment.isUploading,
                 'o-viewable': attachment and attachment.isViewable,
             }" t-att-title="attachment ? attachment.displayName : undefined" t-att-data-attachment-local-id="attachment ? attachment.localId : undefined"
         >
@@ -49,7 +49,7 @@
                                     </div>
                                 </t>
                                 <!-- Download button -->
-                                <t t-if="props.isDownloadable and !attachment.isTemporary" t-key="'download'">
+                                <t t-if="props.isDownloadable and !attachment.isUploading" t-key="'download'">
                                     <div class="o_Attachment_action o_Attachment_actionDownload" t-on-click="_onClickDownload" title="Download">
                                         <i class="fa fa-download"/>
                                     </div>
@@ -77,13 +77,13 @@
                 <t t-if="detailsMode !== 'hover' and (props.isDownloadable or props.isEditable)">
                     <div class="o_Attachment_aside" t-att-class="{ 'o-has-multiple-action': props.isDownloadable and props.isEditable }">
                         <!-- Uploading icon -->
-                        <t t-if="attachment.isTemporary and attachment.isLinkedToComposer">
+                        <t t-if="attachment.isUploading and attachment.isLinkedToComposer">
                             <div class="o_Attachment_asideItem o_Attachment_asideItemUploading" title="Uploading">
                                 <i class="fa fa-spin fa-spinner"/>
                             </div>
                         </t>
                         <!-- Uploaded icon -->
-                        <t t-if="!attachment.isTemporary and attachment.isLinkedToComposer">
+                        <t t-if="!attachment.isUploading and attachment.isLinkedToComposer">
                             <div class="o_Attachment_asideItem o_Attachment_asideItemUploaded" title="Uploaded">
                                 <i class="fa fa-check"/>
                             </div>
@@ -95,7 +95,7 @@
                             </div>
                         </t>
                         <!-- Download button -->
-                        <t t-if="props.isDownloadable and !attachment.isTemporary">
+                        <t t-if="props.isDownloadable and !attachment.isUploading">
                             <div class="o_Attachment_asideItem o_Attachment_asideItemDownload" t-on-click="_onClickDownload" title="Download">
                                 <i class="fa fa-download"/>
                             </div>

--- a/addons/mail/static/src/components/composer/composer_tests.js
+++ b/addons/mail/static/src/components/composer/composer_tests.js
@@ -1749,7 +1749,7 @@ QUnit.test('composer: send button is disabled if attachment upload is not finish
     );
     assert.containsOnce(
         document.body,
-        '.o_Attachment.o-temporary',
+        '.o_Attachment.o-isUploading',
         "attachment displayed is being uploaded"
     );
     assert.containsOnce(
@@ -1771,7 +1771,7 @@ QUnit.test('composer: send button is disabled if attachment upload is not finish
     );
     assert.containsNone(
         document.body,
-        '.o_Attachment.o-temporary',
+        '.o_Attachment.o-isUploading',
         "attachment displayed should be uploaded"
     );
     assert.containsOnce(
@@ -1841,7 +1841,7 @@ QUnit.test('warning on send with shortcut when attempting to post message with s
     );
     assert.containsOnce(
         document.body,
-        '.o_Attachment.o-temporary',
+        '.o_Attachment.o-isUploading',
         "attachment displayed is being uploaded"
     );
     assert.containsOnce(
@@ -1936,7 +1936,7 @@ QUnit.test('remove an uploading attachment', async function (assert) {
     );
     assert.containsOnce(
         document.body,
-        '.o_Composer .o_Attachment.o-temporary',
+        '.o_Attachment.o-isUploading',
         "should have an uploading attachment"
     );
 
@@ -1945,7 +1945,7 @@ QUnit.test('remove an uploading attachment', async function (assert) {
     assert.containsNone(
         document.body,
         '.o_Composer .o_Attachment',
-        "should not have any attachment left after unlinking temporary one"
+        "should not have any attachment left after unlinking uploading one"
     );
 });
 

--- a/addons/mail/static/src/components/file_uploader/file_uploader.js
+++ b/addons/mail/static/src/components/file_uploader/file_uploader.js
@@ -36,7 +36,7 @@ class FileUploader extends Component {
      */
     async uploadFiles(files) {
         await this._unlinkExistingAttachments(files);
-        this._createTemporaryAttachments(files);
+        this._createUploadingAttachments(files);
         await this._performUpload(files);
         this._fileInputRef.el.value = '';
     }
@@ -81,11 +81,11 @@ class FileUploader extends Component {
      * @private
      * @param {FileList|Array} files
      */
-    _createTemporaryAttachments(files) {
+    _createUploadingAttachments(files) {
         for (const file of files) {
             this._createAttachment({
                 filename: file.name,
-                isTemporary: true,
+                isUploading: true,
                 name: file.name
             });
         }
@@ -98,7 +98,7 @@ class FileUploader extends Component {
     async _performUpload(files) {
         for (const file of files) {
             const uploadingAttachment = this.env.models['mail.attachment'].find(attachment =>
-                attachment.isTemporary &&
+                attachment.isUploading &&
                 attachment.filename === file.name
             );
             if (!uploadingAttachment) {
@@ -158,12 +158,12 @@ class FileUploader extends Component {
                     type: 'danger',
                     message: owl.utils.escape(error),
                 });
-                const relatedTemporaryAttachments = this.env.models['mail.attachment']
+                const relatedUploadingAttachments = this.env.models['mail.attachment']
                     .find(attachment =>
                         attachment.filename === filename &&
-                        attachment.isTemporary
+                        attachment.isUploading
                     );
-                for (const attachment of relatedTemporaryAttachments) {
+                for (const attachment of relatedUploadingAttachments) {
                     attachment.delete();
                 }
                 return;

--- a/addons/mail/static/src/models/attachment/attachment_tests.js
+++ b/addons/mail/static/src/models/attachment/attachment_tests.js
@@ -40,7 +40,7 @@ QUnit.test('create (txt)', async function (assert) {
     assert.strictEqual(this.env.models['mail.attachment'].find(attachment => attachment.id === 750), attachment);
     assert.strictEqual(attachment.filename, "test.txt");
     assert.strictEqual(attachment.id, 750);
-    assert.notOk(attachment.isTemporary);
+    assert.notOk(attachment.isUploading);
     assert.strictEqual(attachment.mimetype, 'text/plain');
     assert.strictEqual(attachment.name, "test.txt");
 });

--- a/addons/mail/static/src/models/composer/composer.js
+++ b/addons/mail/static/src/models/composer/composer.js
@@ -532,7 +532,7 @@ function factory(dependencies) {
          * @returns {boolean}
          */
         _computeHasUploadingAttachment() {
-            return this.attachments.some(attachment => attachment.isTemporary);
+            return this.attachments.some(attachment => attachment.isUploading);
         }
 
         /**
@@ -930,14 +930,13 @@ function factory(dependencies) {
             inverse: 'composers',
         }),
         /**
-         * This field watches the uploading (= temporary) status of attachments
-         * linked to this composer.
+         * This field watches the uploading status of attachments linked to this composer.
          *
          * Useful to determine whether there are some attachments that are being
          * uploaded.
          */
-        attachmentsAreTemporary: attr({
-            related: 'attachments.isTemporary',
+        attachmentsAreUploading: attr({
+            related: 'attachments.isUploading',
         }),
         canPostMessage: attr({
             compute: '_computeCanPostMessage',
@@ -986,7 +985,7 @@ function factory(dependencies) {
             compute: '_computeHasUploadingAttachment',
             dependencies: [
                 'attachments',
-                'attachmentsAreTemporary',
+                'attachmentsAreUploading',
             ],
         }),
         hasFocus: attr({

--- a/addons/mail/static/src/models/message/message_tests.js
+++ b/addons/mail/static/src/models/message/message_tests.js
@@ -93,7 +93,7 @@ QUnit.test('create', async function (assert) {
     assert.ok(attachment);
     assert.strictEqual(attachment.filename, "test.txt");
     assert.strictEqual(attachment.id, 750);
-    assert.notOk(attachment.isTemporary);
+    assert.notOk(attachment.isUploading);
     assert.strictEqual(attachment.mimetype, 'text/plain');
     assert.strictEqual(attachment.name, "test.txt");
     const channel = this.env.models['mail.thread'].find(thread =>

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -1012,10 +1012,10 @@ function factory(dependencies) {
             const allAttachments = [...new Set(this.originThreadAttachments.concat(this.attachments))]
                 .sort((a1, a2) => {
                     // "uploading" before "uploaded" attachments.
-                    if (!a1.isTemporary && a2.isTemporary) {
+                    if (!a1.isUploading && a2.isUploading) {
                         return 1;
                     }
-                    if (a1.isTemporary && !a2.isTemporary) {
+                    if (a1.isUploading && !a2.isUploading) {
                         return -1;
                     }
                     // "most-recent" before "oldest" attachments.

--- a/addons/mail/static/tests/tours/mail_full_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_full_composer_test_tour.js
@@ -40,7 +40,7 @@ tour.register('mail/static/tests/tours/mail_full_composer_test_tour.js', {
 }, {
     content: "Open full composer",
     trigger: '.o_Composer_buttonFullComposer',
-    extra_trigger: '.o_Attachment:not(.o-temporary)' // waiting the attachment to be uploaded
+    extra_trigger: '.o_Attachment:not(.o-isUploading)' // waiting the attachment to be uploaded
 }, {
     content: "Check the earlier provided attachment is listed",
     trigger: '.o_attachment[title="text.txt"]',


### PR DESCRIPTION
This commit renames "temporary" into "uploading" in attachments content

task-2337268

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
