### PR TITLE
[FIX] sale_coupon: Not modify the subject and the email_from when generate coupon.

### DIFF
--- a/addons/sale_coupon/wizard/sale_coupon_generate.py
+++ b/addons/sale_coupon/wizard/sale_coupon_generate.py
@@ -30,7 +30,6 @@ class SaleCouponGenerate(models.TransientModel):
             for partner in self.env['res.partner'].search(safe_eval(self.partners_domain)):
                 vals.update({'partner_id': partner.id})
                 coupon = self.env['sale.coupon'].create(vals)
-                subject = '%s, a coupon has been generated for you' % (partner.name)
                 template = self.env.ref('sale_coupon.mail_template_sale_coupon', raise_if_not_found=False)
                 if template:
-                    template.send_mail(coupon.id, email_values={'email_to': partner.email, 'email_from': self.env.user.email or '', 'subject': subject,})
+                    template.send_mail(coupon.id, email_values={'email_to': partner.email})


### PR DESCRIPTION
When coupons are generated with the assistant, it is not necessary to change the subject of the template or the sender, since otherwise the client will not receive what I put together in the template to send, and if I send it manually the msg is different. You should keep the values ​​as they come from the template when sending the mail automatically.






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
