### PR TITLE
do not show selected records in select dialog

### DIFF
--- a/addons/web/static/src/js/views/calendar/calendar_renderer.js
+++ b/addons/web/static/src/js/views/calendar/calendar_renderer.js
@@ -25,6 +25,11 @@ var SidebarFilterM2O = relational_fields.FieldMany2One.extend({
     _getSearchBlacklist: function () {
         return this._super.apply(this, arguments).concat(this.filter_ids || []);
     },
+    _getSearchCreatePopupOptions(view, ids, context, dynamicFilters) {
+        const options = this._super(...arguments);
+        options['domain'] = options['domain'].concat(["!", ["id", "in", this.filter_ids]]);
+        return options;
+    },
 });
 
 var SidebarFilter = Widget.extend(FieldManagerMixin, {


### PR DESCRIPTION
PURPOSE
Calendar sidebar m2o search more dialog shows already selected records, which should not be displayed, it doesn't make sense to display already selected records as we can not select same record twice.

SPEC
When there are some selected records in calendar sidebar and when 'Search More' dialog is opened then do not display selected records in dialog.

TASK 2393810


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
