### PR TITLE
[FIX] account, stock_account: invoice in multi-currency

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1230,7 +1230,7 @@ class AccountMove(models.Model):
             currencies = set()
 
             for line in move.line_ids:
-                if line.currency_id:
+                if line.currency_id and line in move._get_lines_onchange_currency():
                     currencies.add(line.currency_id)
 
                 if move.is_invoice(include_receipts=True):

--- a/addons/stock_account/tests/__init__.py
+++ b/addons/stock_account/tests/__init__.py
@@ -1,3 +1,4 @@
+from . import test_account_move
 from . import test_anglo_saxon_valuation_reconciliation_common
 from . import test_stockvaluation
 from . import test_stockvaluationlayer

--- a/addons/stock_account/tests/test_account_move.py
+++ b/addons/stock_account/tests/test_account_move.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.stock_account.tests.test_stockvaluation import _create_accounting_data
+from odoo.tests.common import tagged, Form
+
+
+@tagged("post_install", "-at_install")
+class TestAccountMove(AccountTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        (
+            cls.stock_input_account,
+            cls.stock_output_account,
+            cls.stock_valuation_account,
+            cls.expense_account,
+            cls.stock_journal,
+        ) = _create_accounting_data(cls.env)
+
+        cls.product_A = cls.env["product.product"].create(
+            {
+                "name": "Product A",
+                "type": "product",
+                "default_code": "prda",
+                "categ_id": cls.env.ref("product.product_category_all").id,
+                "taxes_id": [(5, 0, 0)],
+                "supplier_taxes_id": [(5, 0, 0)],
+                "lst_price": 100.0,
+                "standard_price": 10.0,
+                "property_account_income_id": cls.company_data["default_account_revenue"].id,
+                "property_account_expense_id": cls.company_data["default_account_expense"].id,
+            }
+        )
+        cls.product_A.categ_id.write(
+            {
+                "property_stock_account_input_categ_id": cls.stock_input_account.id,
+                "property_stock_account_output_categ_id": cls.stock_output_account.id,
+                "property_stock_valuation_account_id": cls.stock_valuation_account.id,
+                "property_stock_journal": cls.stock_journal.id,
+                "property_valuation": "real_time",
+                "property_cost_method": "standard",
+            }
+        )
+
+    def test_standard_perpetual_01_mc_01(self):
+        rate = self.currency_data["rates"].sorted()[0].rate
+
+        move_form = Form(self.env["account.move"].with_context(default_move_type="out_invoice"))
+        move_form.partner_id = self.partner_a
+        move_form.currency_id = self.currency_data["currency"]
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = self.product_A
+            line_form.tax_ids.clear()
+        invoice = move_form.save()
+
+        self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_total)
+        self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_residual)
+        self.assertEqual(len(invoice.mapped("line_ids")), 2)
+        self.assertEqual(len(invoice.mapped("line_ids.currency_id")), 1)
+
+        invoice._post()
+
+        self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_total)
+        self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_residual)
+        self.assertEqual(len(invoice.mapped("line_ids")), 4)
+        self.assertEqual(len(invoice.mapped("line_ids").filtered("is_anglo_saxon_line")), 2)
+        self.assertEqual(len(invoice.mapped("line_ids.currency_id")), 2)
+
+    def test_fifo_perpetual_01_mc_01(self):
+        self.product_A.categ_id.property_cost_method = "fifo"
+        rate = self.currency_data["rates"].sorted()[0].rate
+
+        move_form = Form(self.env["account.move"].with_context(default_move_type="out_invoice"))
+        move_form.partner_id = self.partner_a
+        move_form.currency_id = self.currency_data["currency"]
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = self.product_A
+            line_form.tax_ids.clear()
+        invoice = move_form.save()
+
+        self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_total)
+        self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_residual)
+        self.assertEqual(len(invoice.mapped("line_ids")), 2)
+        self.assertEqual(len(invoice.mapped("line_ids.currency_id")), 1)
+
+        invoice._post()
+
+        self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_total)
+        self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_residual)
+        self.assertEqual(len(invoice.mapped("line_ids")), 4)
+        self.assertEqual(len(invoice.mapped("line_ids").filtered("is_anglo_saxon_line")), 2)
+        self.assertEqual(len(invoice.mapped("line_ids.currency_id")), 2)
+
+    def test_average_perpetual_01_mc_01(self):
+        self.product_A.categ_id.property_cost_method = "average"
+        rate = self.currency_data["rates"].sorted()[0].rate
+
+        move_form = Form(self.env["account.move"].with_context(default_move_type="out_invoice"))
+        move_form.partner_id = self.partner_a
+        move_form.currency_id = self.currency_data["currency"]
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = self.product_A
+            line_form.tax_ids.clear()
+        invoice = move_form.save()
+
+        self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_total)
+        self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_residual)
+        self.assertEqual(len(invoice.mapped("line_ids")), 2)
+        self.assertEqual(len(invoice.mapped("line_ids.currency_id")), 1)
+
+        invoice._post()
+
+        self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_total)
+        self.assertAlmostEqual(self.product_A.lst_price * rate, invoice.amount_residual)
+        self.assertEqual(len(invoice.mapped("line_ids")), 4)
+        self.assertEqual(len(invoice.mapped("line_ids").filtered("is_anglo_saxon_line")), 2)
+        self.assertEqual(len(invoice.mapped("line_ids.currency_id")), 2)


### PR DESCRIPTION
- Activate Anglo-Saxon accounting
- Set a foreign currency rate to 2.0
- Create a product A:
  Inventory Valuation: 'Automated'
  Costing Method: 'Standard Price'
  Cost: 10.0
  Public Price: 100.0
- Create an invoice in foreign currency
- Add 1 unit of A => the total amount is 200.0
- Confirm the invoice

The Amount Due is 100.0 instead of 200.0.

This happens because the Anglo-Saxon lines have the company currency,
while the other lines have the foreign currency. Because of this, the
`_compute_amount` method considers the move as multi-currency to compute
the various amount. However, the Anglo-Saxon lines should be neglected.

This happens from 14.0 because all lines have a currency. In previous
versions, lines in the company currency didn't have the `currency_id`
set.

opw-2390107

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
