### PR TITLE
[FIX] web_editor: fix overlay that is not reappearing

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -444,6 +444,7 @@ var SnippetEditor = Widget.extend({
         // Show/hide overlay in preview mode or not
         this.$el.toggleClass('oe_active', show);
         this.cover();
+        this.toggleOverlayVisibility(show);
     },
     /**
      * Displays/Hides the editor (+ parent) options and call onFocus/onBlur if


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

In some situation, the overlay does not reappear after disappearing.

Current behavior before PR:

Steps to reproduce:
1. add a title
2. add a few elements between title and footer so you can scroll title out of view
3. click title
4. scroll it out of view
5. click footer
6. scroll back up
7. click title
-> overlay is not reappearing

Desired behavior after PR is merged:

Now overlay should appear when expected.

JW feedback

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
