### PR TITLE
[FIX] point_of_sale: run POS from another company

### DIFF
--- a/addons/stock/report/report_stock_quantity.py
+++ b/addons/stock/report/report_stock_quantity.py
@@ -26,91 +26,103 @@ class ReportStockQuantity(models.Model):
         tools.drop_view_if_exists(self._cr, 'report_stock_quantity')
         query = """
 CREATE or REPLACE VIEW report_stock_quantity AS (
+WITH forecast_qty AS (
+    SELECT
+        m.id,
+        m.product_id,
+        CASE
+            WHEN (whs.id IS NOT NULL AND whd.id IS NULL) OR ls.usage = 'transit' THEN 'out'
+            WHEN (whs.id IS NULL AND whd.id IS NOT NULL) OR ld.usage = 'transit' THEN 'in'
+        END AS state,
+        m.date_expected::date AS date,
+        CASE
+            WHEN (whs.id IS NOT NULL AND whd.id IS NULL) OR ls.usage = 'transit' THEN -product_qty
+            WHEN (whs.id IS NULL AND whd.id IS NOT NULL) OR ld.usage = 'transit' THEN product_qty
+        END AS product_qty,
+        m.company_id,
+        CASE
+            WHEN (whs.id IS NOT NULL AND whd.id IS NULL) OR ls.usage = 'transit' THEN whs.id
+            WHEN (whs.id IS NULL AND whd.id IS NOT NULL) OR ld.usage = 'transit' THEN whd.id
+        END AS warehouse_id
+    FROM
+        stock_move m
+    LEFT JOIN stock_location ls on (ls.id=m.location_id)
+    LEFT JOIN stock_location ld on (ld.id=m.location_dest_id)
+    LEFT JOIN stock_warehouse whs ON ls.parent_path like concat('%/', whs.view_location_id, '/%')
+    LEFT JOIN stock_warehouse whd ON ld.parent_path like concat('%/', whd.view_location_id, '/%')
+    LEFT JOIN product_product pp on pp.id=m.product_id
+    LEFT JOIN product_template pt on pt.id=pp.product_tmpl_id
+    WHERE
+        pt.type = 'product' AND
+        product_qty != 0 AND
+        (whs.id IS NULL or whd.id IS NULL OR whs.id != whd.id) AND
+        m.state NOT IN ('cancel', 'draft', 'done')
+    UNION
+    SELECT
+        -q.id as id,
+        q.product_id,
+        'forecast' as state,
+        date.*::date,
+        q.quantity as product_qty,
+        q.company_id,
+        wh.id as warehouse_id
+    FROM
+        GENERATE_SERIES((now() at time zone 'utc')::date - interval '3month',
+        (now() at time zone 'utc')::date + interval '3 month', '1 day'::interval) date,
+        stock_quant q
+    LEFT JOIN stock_location l on (l.id=q.location_id)
+    LEFT JOIN stock_warehouse wh ON l.parent_path like concat('%/', wh.view_location_id, '/%')
+    WHERE
+        l.usage = 'internal'
+    UNION
+    SELECT
+        m.id,
+        m.product_id,
+        'forecast' as state,
+        GENERATE_SERIES(
+        CASE
+            WHEN m.state = 'done' THEN (now() at time zone 'utc')::date - interval '3month'
+            ELSE m.date_expected::date
+        END,
+        CASE
+            WHEN m.state != 'done' THEN (now() at time zone 'utc')::date + interval '3 month'
+            ELSE m.date::date - interval '1 day'
+        END, '1 day'::interval)::date date,
+        CASE
+            WHEN ((whs.id IS NOT NULL AND whd.id IS NULL) OR ls.usage = 'transit') AND m.state = 'done' THEN product_qty
+            WHEN ((whs.id IS NULL AND whd.id IS NOT NULL) OR ld.usage = 'transit') AND m.state = 'done' THEN -product_qty
+            WHEN (whs.id IS NOT NULL AND whd.id IS NULL) OR ls.usage = 'transit' THEN -product_qty
+            WHEN (whs.id IS NULL AND whd.id IS NOT NULL) OR ld.usage = 'transit' THEN product_qty
+        END AS product_qty,
+        m.company_id,
+        CASE
+            WHEN (whs.id IS NOT NULL AND whd.id IS NULL) OR ls.usage = 'transit' THEN whs.id
+            WHEN (whs.id IS NULL AND whd.id IS NOT NULL) OR ld.usage = 'transit' THEN whd.id
+        END AS warehouse_id
+    FROM
+        stock_move m
+    LEFT JOIN stock_location ls on (ls.id=m.location_id)
+    LEFT JOIN stock_location ld on (ld.id=m.location_dest_id)
+    LEFT JOIN stock_warehouse whs ON ls.parent_path like concat('%/', whs.view_location_id, '/%')
+    LEFT JOIN stock_warehouse whd ON ld.parent_path like concat('%/', whd.view_location_id, '/%')
+    LEFT JOIN product_product pp on pp.id=m.product_id
+    LEFT JOIN product_template pt on pt.id=pp.product_tmpl_id
+    WHERE
+        pt.type = 'product' AND
+        product_qty != 0 AND
+        (whs.id IS NULL or whd.id IS NULL OR whs.id != whd.id) AND
+        m.state NOT IN ('cancel', 'draft')
+)
 SELECT
-    m.id,
-    m.product_id,
-    CASE
-        WHEN (whs.id IS NOT NULL AND whd.id IS NULL) OR ls.usage = 'transit' THEN 'out'
-        WHEN (whs.id IS NULL AND whd.id IS NOT NULL) OR ld.usage = 'transit' THEN 'in'
-    END AS state,
-    m.date_expected::date AS date,
-    CASE
-        WHEN (whs.id IS NOT NULL AND whd.id IS NULL) OR ls.usage = 'transit' THEN -product_qty
-        WHEN (whs.id IS NULL AND whd.id IS NOT NULL) OR ld.usage = 'transit' THEN product_qty
-    END AS product_qty,
-    m.company_id,
-    CASE
-        WHEN (whs.id IS NOT NULL AND whd.id IS NULL) OR ls.usage = 'transit' THEN whs.id
-        WHEN (whs.id IS NULL AND whd.id IS NOT NULL) OR ld.usage = 'transit' THEN whd.id
-    END AS warehouse_id
-FROM
-    stock_move m
-LEFT JOIN stock_location ls on (ls.id=m.location_id)
-LEFT JOIN stock_location ld on (ld.id=m.location_dest_id)
-LEFT JOIN stock_warehouse whs ON ls.parent_path like concat('%/', whs.view_location_id, '/%')
-LEFT JOIN stock_warehouse whd ON ld.parent_path like concat('%/', whd.view_location_id, '/%')
-LEFT JOIN product_product pp on pp.id=m.product_id
-LEFT JOIN product_template pt on pt.id=pp.product_tmpl_id
-WHERE
-    pt.type = 'product' AND
-    product_qty != 0 AND
-    (whs.id IS NULL or whd.id IS NULL OR whs.id != whd.id) AND
-    m.state NOT IN ('cancel', 'draft', 'done')
-UNION
-SELECT
-    -q.id as id,
-    q.product_id,
-    'forecast' as state,
-    date.*::date,
-    q.quantity as product_qty,
-    q.company_id,
-    wh.id as warehouse_id
-FROM
-    GENERATE_SERIES((now() at time zone 'utc')::date - interval '3month',
-    (now() at time zone 'utc')::date + interval '3 month', '1 day'::interval) date,
-    stock_quant q
-LEFT JOIN stock_location l on (l.id=q.location_id)
-LEFT JOIN stock_warehouse wh ON l.parent_path like concat('%/', wh.view_location_id, '/%')
-WHERE
-    l.usage = 'internal'
-UNION
-SELECT
-    m.id,
-    m.product_id,
-    'forecast' as state,
-    GENERATE_SERIES(
-    CASE
-        WHEN m.state = 'done' THEN (now() at time zone 'utc')::date - interval '3month'
-        ELSE m.date_expected::date
-    END,
-    CASE
-        WHEN m.state != 'done' THEN (now() at time zone 'utc')::date + interval '3 month'
-        ELSE m.date::date - interval '1 day'
-    END, '1 day'::interval)::date date,
-    CASE
-        WHEN ((whs.id IS NOT NULL AND whd.id IS NULL) OR ls.usage = 'transit') AND m.state = 'done' THEN product_qty
-        WHEN ((whs.id IS NULL AND whd.id IS NOT NULL) OR ld.usage = 'transit') AND m.state = 'done' THEN -product_qty
-        WHEN (whs.id IS NOT NULL AND whd.id IS NULL) OR ls.usage = 'transit' THEN -product_qty
-        WHEN (whs.id IS NULL AND whd.id IS NOT NULL) OR ld.usage = 'transit' THEN product_qty
-    END AS product_qty,
-    m.company_id,
-    CASE
-        WHEN (whs.id IS NOT NULL AND whd.id IS NULL) OR ls.usage = 'transit' THEN whs.id
-        WHEN (whs.id IS NULL AND whd.id IS NOT NULL) OR ld.usage = 'transit' THEN whd.id
-    END AS warehouse_id
-FROM
-    stock_move m
-LEFT JOIN stock_location ls on (ls.id=m.location_id)
-LEFT JOIN stock_location ld on (ld.id=m.location_dest_id)
-LEFT JOIN stock_warehouse whs ON ls.parent_path like concat('%/', whs.view_location_id, '/%')
-LEFT JOIN stock_warehouse whd ON ld.parent_path like concat('%/', whd.view_location_id, '/%')
-LEFT JOIN product_product pp on pp.id=m.product_id
-LEFT JOIN product_template pt on pt.id=pp.product_tmpl_id
-WHERE
-    pt.type = 'product' AND
-    product_qty != 0 AND
-    (whs.id IS NULL or whd.id IS NULL OR whs.id != whd.id) AND
-    m.state NOT IN ('cancel', 'draft')
+    MIN(id) as id,
+    product_id,
+    state,
+    date,
+    sum(product_qty) as product_qty,
+    company_id,
+    warehouse_id
+FROM forecast_qty
+GROUP BY product_id, state, date, company_id, warehouse_id
 );
 """
         self.env.cr.execute(query)

--- a/addons/stock/tests/__init__.py
+++ b/addons/stock/tests/__init__.py
@@ -17,3 +17,4 @@ from . import test_packing_neg
 from . import test_proc_rule
 from . import test_wise_operator
 from . import test_report
+from . import test_report_stock_quantity

--- a/addons/stock/tests/test_report_stock_quantity.py
+++ b/addons/stock/tests/test_report_stock_quantity.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import fields, tests
+
+
+class TestReportStockQuantity(tests.TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.product1 = self.env['product.product'].create({
+            'name': 'Mellohi',
+            'default_code': 'C418',
+            'type': 'product',
+            'categ_id': self.env.ref('product.product_category_all').id,
+            'tracking': 'lot',
+            'barcode': 'scan_me'
+        })
+        wh = self.env['stock.warehouse'].create({
+            'name': 'Base Warehouse',
+            'code': 'TESTWH'
+        })
+        self.categ_unit = self.env.ref('uom.product_uom_categ_unit')
+        self.uom_unit = self.env['uom.uom'].search([('category_id', '=', self.categ_unit.id), ('uom_type', '=', 'reference')], limit=1)
+        self.customer_location = self.env.ref('stock.stock_location_customers')
+        self.supplier_location = self.env.ref('stock.stock_location_suppliers')
+        # replenish
+        self.move1 = self.env['stock.move'].create({
+            'name': 'test_in_1',
+            'location_id': self.supplier_location.id,
+            'location_dest_id': wh.lot_stock_id.id,
+            'product_id': self.product1.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 100.0,
+            'state': 'done',
+            'date': fields.Datetime.now(),
+        })
+        self.quant1 = self.env['stock.quant'].create({
+            'product_id': self.product1.id,
+            'location_id': wh.lot_stock_id.id,
+            'quantity': 100.0,
+        })
+        # ship
+        self.move2 = self.env['stock.move'].create({
+            'name': 'test_out_1',
+            'location_id': wh.lot_stock_id.id,
+            'location_dest_id': self.customer_location.id,
+            'product_id': self.product1.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 120.0,
+            'state': 'partially_available',
+            'date': fields.Datetime.add(fields.Datetime.now(), days=3),
+            'date_expected': fields.Datetime.add(fields.Datetime.now(), days=3),
+        })
+        self.env['base'].flush()
+
+    def test_report_stock_quantity(self):
+        from_date = fields.Date.to_string(fields.Date.add(fields.Date.today(), days=-1))
+        to_date = fields.Date.to_string(fields.Date.add(fields.Date.today(), days=4))
+        report = self.env['report.stock.quantity'].read_group(
+            [('date', '>=', from_date), ('date', '<=', to_date), ('product_id', '=', self.product1.id)],
+            ['product_qty', 'date', 'product_id', 'state'],
+            ['date:day', 'product_id', 'state'],
+            lazy=False)
+        forecast_report = [x['product_qty'] for x in report if x['state'] == 'forecast']
+        self.assertEqual(forecast_report, [0, 100, 100, 100, -20, -20])
+
+    def test_report_stock_quantity_with_product_qty_filter(self):
+        from_date = fields.Date.to_string(fields.Date.add(fields.Date.today(), days=-1))
+        to_date = fields.Date.to_string(fields.Date.add(fields.Date.today(), days=4))
+        report = self.env['report.stock.quantity'].read_group(
+            [('product_qty', '<', 0), ('date', '>=', from_date), ('date', '<=', to_date), ('product_id', '=', self.product1.id)],
+            ['product_qty', 'date', 'product_id', 'state'],
+            ['date:day', 'product_id', 'state'],
+            lazy=False)
+        forecast_report = [x['product_qty'] for x in report if x['state'] == 'forecast']
+        self.assertEqual(forecast_report, [-20, -20])

--- a/addons/web/static/src/js/chrome/abstract_web_client.js
+++ b/addons/web/static/src/js/chrome/abstract_web_client.js
@@ -128,8 +128,8 @@ var AbstractWebClient = Widget.extend(ServiceProviderMixin, KeyboardNavigationMi
             state.cids = String(current_company_id);
             stateCompanyIDS = [current_company_id]
         }
-        // Update the user context with this configuration
-        session.user_context.allowed_company_ids = stateCompanyIDS;
+        // If undefined, update the user context with this configuration
+        session.user_context.allowed_company_ids = session.user_context.allowed_company_ids || stateCompanyIDS;
         $.bbq.pushState(state);
         // Update favicon
         $("link[type='image/x-icon']").attr('href', '/web/image/res.company/' + String(stateCompanyIDS[0]) + '/favicon/')


### PR DESCRIPTION
In a multicompany configuration, when starting a POS of another company
than the current one, the loading will freeze

To reproduce the error:
1. Create 2 companies C1 and C2
2. Make sure C1 has taxes
3. Create one POS per company: POS_C1 and POS_C2
4. Go on Point of Sale dashboard
5. On top right (the companies list)
	- Check the two companies (so that you can see POS_C1 and
POS_C2)
	- If not already done, select C1
6. Start a new session with POS_C2

=> The loading will be blocked on "account.tax" step

OPW-2388210