### PR TITLE
[FIX] web: Fix timepicker direction in rtl

### DIFF
--- a/addons/web/static/src/scss/ui.scss
+++ b/addons/web/static/src/scss/ui.scss
@@ -35,7 +35,7 @@
 }
 
 // This is rtl language specific fix
-// It will fix the extra space in ui-autocomplete class
+// It will fix the extra space in ui-autocomplete class and the time picker direction
 // and flip the next and previous symbols of jquery ui.
 .o_rtl {
     .ui-autocomplete {
@@ -47,6 +47,9 @@
         -webkit-transform: rotate(180deg);
          -o-transform: rotate(180deg);
         transform: rotate(180deg);
+    }
+    .timepicker{
+        direction: rtl;
     }
 }
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Class `timepicker` was added to the div of the time picker in
[(web/static/lib/tempusdominus/tempusdominus.js) line 1804](https://github.com/odoo/odoo/blob/13.0/addons/web/static/lib/tempusdominus/tempusdominus.js#L1804)
This commit will fix the timepicker direction in rtl.

Current behavior before PR:
`timepicker` direction is wrong
![image](https://user-images.githubusercontent.com/48803268/100463741-99feb400-30cc-11eb-8c50-bc9b837176b9.png)

Desired behavior after PR is merged:
`timepicker` direction will be fixed.
![image](https://user-images.githubusercontent.com/48803268/100463010-78e99380-30cb-11eb-99e2-7684d3d49855.png)






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
