### PR TITLE
[IMP] fleet: improve ux + fix contracts/services archive bug

### DIFF
--- a/addons/fleet/__manifest__.py
+++ b/addons/fleet/__manifest__.py
@@ -32,6 +32,7 @@ Main Features
         'security/fleet_security.xml',
         'security/ir.model.access.csv',
         'views/fleet_vehicle_model_views.xml',
+        'views/assets.xml',
         'views/fleet_vehicle_views.xml',
         'views/fleet_vehicle_cost_views.xml',
         'views/fleet_board_view.xml',

--- a/addons/fleet/data/fleet_demo.xml
+++ b/addons/fleet/data/fleet_demo.xml
@@ -436,26 +436,6 @@
         <field name="color" eval="8"/>
       </record>
 
-      <record id="model_astra" model="fleet.vehicle.model">
-          <field name="manager_id" ref="base.user_admin"/>
-      </record>
-
-      <record id="model_corsa" model="fleet.vehicle.model">
-          <field name="manager_id" ref="base.user_admin"/>
-      </record>
-
-      <record id="model_serie1" model="fleet.vehicle.model">
-          <field name="manager_id" ref="base.user_admin"/>
-      </record>
-
-      <record id="model_a1" model="fleet.vehicle.model">
-          <field name="manager_id" ref="base.user_admin"/>
-      </record>
-
-      <record id="model_classa" model="fleet.vehicle.model">
-          <field name="manager_id" ref="base.user_admin"/>
-      </record>
-
       <record id="vehicle_1" model="fleet.vehicle">
           <field name="license_plate">1-ACK-205</field>
           <field name="vin_sn">5454541</field>

--- a/addons/fleet/models/fleet_vehicle_cost.py
+++ b/addons/fleet/models/fleet_vehicle_cost.py
@@ -150,11 +150,11 @@ class FleetVehicleLogServices(models.Model):
         default=lambda self: self.env.ref('fleet.type_service_service_8', raise_if_not_found=False),
     )
     state = fields.Selection([
-        ('todo', 'To Do'),
+        ('new', 'New'),
         ('running', 'Running'),
         ('done', 'Done'),
         ('cancelled', 'Cancelled'),
-    ], default='todo', string='Stage')
+    ], default='new', string='Stage', group_expand='_expand_states')
 
     def _get_odometer(self):
         self.odometer = 0
@@ -187,3 +187,6 @@ class FleetVehicleLogServices(models.Model):
     def _compute_purchaser_id(self):
         for service in self:
             service.purchaser_id = service.vehicle_id.driver_id
+
+    def _expand_states(self, states, domain, order):
+        return [key for key, dummy in type(self).state.selection]

--- a/addons/fleet/models/fleet_vehicle_model.py
+++ b/addons/fleet/models/fleet_vehicle_model.py
@@ -12,8 +12,6 @@ class FleetVehicleModel(models.Model):
     name = fields.Char('Model name', required=True)
     brand_id = fields.Many2one('fleet.vehicle.model.brand', 'Manufacturer', required=True, help='Manufacturer of the vehicle')
     vendors = fields.Many2many('res.partner', 'fleet_vehicle_model_vendors', 'model_id', 'partner_id', string='Vendors')
-    manager_id = fields.Many2one('res.users', 'Fleet Manager', default=lambda self: self.env.uid,
-                                 domain=lambda self: [('groups_id', 'in', self.env.ref('fleet.fleet_group_manager').id)])
     image_128 = fields.Image(related='brand_id.image_128', readonly=True)
     active = fields.Boolean(default=True)
     vehicle_type = fields.Selection([('car', 'Car'), ('bike', 'Bike')], default='car', required=True)
@@ -27,14 +25,6 @@ class FleetVehicleModel(models.Model):
                 name = record.brand_id.name + '/' + name
             res.append((record.id, name))
         return res
-
-    def write(self, vals):
-        if 'manager_id' in vals:
-            old_manager = self.manager_id.id if self.manager_id else None
-
-            self.env['fleet.vehicle'].search([('model_id', '=', self.id), ('manager_id', '=', old_manager)]).write({'manager_id': vals['manager_id']})
-
-        return super(FleetVehicleModel, self).write(vals)
 
 
 class FleetVehicleModelBrand(models.Model):

--- a/addons/fleet/static/src/js/fleet_form.js
+++ b/addons/fleet/static/src/js/fleet_form.js
@@ -1,0 +1,44 @@
+odoo.define('fleet.FleetForm', function(require) {
+    "use strict";
+
+    const FormController = require('web.FormController');
+    const FormView = require('web.FormView');
+    const viewRegistry = require('web.view_registry');
+    const Dialog = require('web.Dialog');
+
+    const core = require('web.core');
+    const _t = core._t;
+
+    const FleetFormController = FormController.extend({
+        /**
+         * @override
+         * @private
+         **/
+        _getActionMenuItems: function (state) {
+            if (!this.hasActionMenus || this.mode === 'edit') {
+                return null;
+            }
+            var menuItems = this._super.apply(this, arguments);
+            var archiveAction = _.find(menuItems.items.other, (actionItem) => {return actionItem.description === _t("Archive");});
+            if (archiveAction) {
+                archiveAction.callback = () => {
+                    Dialog.confirm(this, _t("Each Services and contracts of this vehicle will be considered as Archived. Are you sure that you want to archive this record?"), {
+                        confirm_callback: () => this._toggleArchiveState(true),
+                    });
+                };
+            }
+            return menuItems;
+        },
+
+    });
+
+    var FleetFormView = FormView.extend({
+        config: _.extend({}, FormView.prototype.config, {
+            Controller: FleetFormController,
+        }),
+    });
+
+    viewRegistry.add('fleet_form', FleetFormView);
+
+    return FleetFormView;
+});

--- a/addons/fleet/views/assets.xml
+++ b/addons/fleet/views/assets.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="assets_backend" inherit_id="web.assets_backend">
+        <xpath expr="script[last()]" position="after">
+            <script type="text/javascript" src="/fleet/static/src/js/fleet_form.js"/>
+        </xpath>
+    </template>
+</odoo>

--- a/addons/fleet/views/fleet_vehicle_cost_views.xml
+++ b/addons/fleet/views/fleet_vehicle_cost_views.xml
@@ -255,7 +255,7 @@
                 <field name="notes" optional="show" />
                 <field name="amount" sum="Total" widget="monetary"/>
                 <field name="currency_id" invisible="1"/>
-                <field name="state" readonly="1" widget="badge" decoration-success="state == 'done'" decoration-warning="state == 'todo'"  decoration-info="state == 'running'" />
+                <field name="state" readonly="1" widget="badge" decoration-success="state == 'done'" decoration-warning="state == 'new'"  decoration-info="state == 'running'" />
             </tree>
         </field>
     </record>
@@ -264,23 +264,46 @@
         <field name="name">fleet.vehicle.log.services.kanban</field>
         <field name="model">fleet.vehicle.log.services</field>
         <field name="arch" type="xml">
-            <kanban class="o_kanban_mobile">
+            <kanban default_group_by="state">
                 <field name="currency_id"/>
+                <field name="activity_ids"/>
+                <field name="activity_state"/>
+                <field name="purchaser_id"/>
+                <field name="vendor_id"/>
+                <field name="amount"/>
+                <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                 <templates>
                     <t t-name="kanban-box">
-                        <div t-attf-class="oe_kanban_global_click">
-                            <div>
-                                <strong>
-                                    <field name="vehicle_id" widget="res_partner_many2one"/>
-                                    <span class="float-right"><field name="date"/></span>
-                                </strong>
-                            </div>
-                            <div>
-                                <field name="purchaser_id" widget="res_partner_many2one"/>
-                            </div>
-                            <div>
-                                <span><field name="vendor_id" widget="res_partner_many2one"/></span>
-                                <span class="float-right"><field name="amount" widget="monetary"/></span>
+                        <div t-attf-class="oe_kanban_global_click container" class="o_kanban_record_has_image_fill">
+                            <div class="oe_kanban_details">
+                                <div class="o_kanban_record_top">
+                                    <img t-att-src="kanban_image('fleet.vehicle', 'image_128', record.vehicle_id.raw_value)" t-att-alt="record.vehicle_id.value" class="o_image_24_cover float-left"/>
+                                    <div class="o_kanban_record_headings pl-2 pr-2">
+                                        <div class="text-truncate o_kanban_record_title">
+                                            <strong>
+                                                <span class="float-right"><field name="date"/></span>
+                                                <field name="vehicle_id"/>
+                                            </strong>
+                                        </div>
+                                        <div class="text-truncate">
+                                            <em><field name="service_type_id"/></em>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="text-truncate">
+                                    <field name="purchaser_id"/>
+                                </div>
+                                <div class="text-truncate">
+                                    <field name="vendor_id"/>
+                                </div>
+                                <div class="o_kanban_record_bottom">
+                                    <div class="oe_kanban_bottom_left">
+                                        <field name="amount" widget="monetary" options="{'currency_field': 'currency_id'}"/>
+                                    </div>
+                                    <div class="oe_kanban_bottom_right">
+                                        <field name="activity_ids" widget="kanban_activity"/>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </t>

--- a/addons/fleet/views/fleet_vehicle_model_views.xml
+++ b/addons/fleet/views/fleet_vehicle_model_views.xml
@@ -22,7 +22,6 @@
                         <group>
                             <field name="active" invisible="1"/>
                             <field name="vehicle_type"/>
-                            <field name="manager_id" groups="fleet.fleet_group_manager"/>
                         </group>
                     </group>
                     <notebook>

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -5,8 +5,13 @@
         <field name="name">fleet.vehicle.form</field>
         <field name="model">fleet.vehicle</field>
         <field name="arch" type="xml">
-            <form string="Vehicle">
+            <form string="Vehicle" js_class="fleet_form">
                 <header>
+                    <button string="Apply New Driver"
+                        class="btn btn-primary"
+                        type="object"
+                        name="action_accept_driver_change"
+                        attrs="{'invisible': [('future_driver_id', '=', False)]}"/>
                     <field name="state_id"  widget="statusbar" options="{'clickable': '1'}"/>
                 </header>
                 <sheet>
@@ -22,7 +27,7 @@
                             type="object"
                             class="oe_stat_button"
                             icon="fa-book"
-                            context="{'xml_id':'fleet_vehicle_log_contract_action'}"
+                            context="{'xml_id':'fleet_vehicle_log_contract_action', 'search_default_inactive': not active}"
                             help="show the contract for this vehicle">
                             <field name="contract_count" widget="statinfo" string="Contracts"/>
                         </button>
@@ -30,7 +35,7 @@
                             type="object"
                             class="oe_stat_button"
                             icon="fa-wrench"
-                            context="{'xml_id':'fleet_vehicle_log_services_action'}"
+                            context="{'xml_id':'fleet_vehicle_log_services_action', 'search_default_inactive': not active}"
                             help="show the services logs for this vehicle" >
                             <field name="service_count" widget="statinfo" string="Services"/>
                         </button>
@@ -63,15 +68,7 @@
                             <field name="active" invisible="1"/>
                             <field name="vehicle_type" invisible="1"/>
                             <field name="driver_id" domain="['|', ('company_id', '=', False ), ('company_id', '=', company_id)]"/>
-                            <label for="future_driver_id"/>
-                            <div class="o_row">
-                                <field name="future_driver_id"/>
-                                <button string="Apply Change"
-                                    class="btn btn-primary"
-                                    type="object"
-                                    name="action_accept_driver_change"
-                                    attrs="{'invisible': [('future_driver_id', '=', False)]}"/>
-                            </div>
+                            <field name="future_driver_id"/>
                             <field name="plan_to_change_car" groups="fleet.fleet_group_manager" attrs="{'invisible': [('vehicle_type', '!=', 'car')]}"/>
                             <field name="plan_to_change_bike" groups="fleet.fleet_group_manager"  attrs="{'invisible': [('vehicle_type', '!=', 'bike')]}"/>
                             <field name="next_assignation_date"/>
@@ -176,6 +173,8 @@
                 <field string="Status" name="state_id"/>
                 <filter string="Available" name="available"
                     domain="['&amp;', ('future_driver_id', '=', False), '|', ('driver_id', '=', False), '|', '&amp;', ('plan_to_change_car', '=', True), ('vehicle_type', '=', 'car'), '&amp;', ('plan_to_change_bike', '=', True), ('vehicle_type', '=', 'bike')]"/>
+                <filter string="Bikes" name="bikes" domain="[('vehicle_type', '=', 'bike')]"/>
+                <filter string="Cars" name="cars" domain="[('vehicle_type', '=', 'car')]"/>
                 <filter name="planned" string="Planned for Change" domain="['|', '&amp;', ('vehicle_type', '=', 'bike'), ('plan_to_change_bike', '=', True), '&amp;', ('vehicle_type', '=', 'car'), ('plan_to_change_car', '=', True)]"/>
                 <separator/>
                 <filter string="Need Action" name="alert_true" domain="['|', ('contract_renewal_due_soon', '=', True), ('contract_renewal_overdue', '=', True)]"/>


### PR DESCRIPTION
Revamp the kanban view of fleet.vehicle.log.services.

Add some ux improvements (new filters, better naming,..).

Fix bug where contracts/services of archived fleet.vehicle were
not counted in statinfo.

When a fleet.vehicle is archived, archive its related contracts/services too.

Task ID: 2389823

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
