### PR TITLE
[IMP] hr_timesheet: update default string for graph coherence

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -48,6 +48,8 @@ class AccountAnalyticLine(models.Model):
     employee_id = fields.Many2one('hr.employee', "Employee", domain=_domain_employee_id)
     department_id = fields.Many2one('hr.department', "Department", compute='_compute_department_id', store=True, compute_sudo=True)
     encoding_uom_id = fields.Many2one('uom.uom', compute='_compute_encoding_uom_id')
+    unit_amount = fields.Float('Duration', default=0.0)
+    amount = fields.Monetary('Timesheet Costs', required=True, default=0.0)
 
     def _compute_encoding_uom_id(self):
         for analytic_line in self:

--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -57,7 +57,7 @@
                     <field name="employee_id" type="row"/>
                     <field name="date" interval="month" type="col"/>
                     <field name="unit_amount" type="measure" widget="timesheet_uom"/>
-                    <field name="amount" string="Timesheet Costs"/>
+                    <field name="amount"/>
                 </pivot>
             </field>
         </record>
@@ -70,7 +70,7 @@
                     <field name="task_id" type="row"/>
                     <field name="project_id" type="row"/>
                     <field name="unit_amount" type="measure" widget="timesheet_uom"/>
-                    <field name="amount" string="Timesheet Costs"/>
+                    <field name="amount"/>
                 </graph>
             </field>
         </record>


### PR DESCRIPTION
Before this commit, the string associated with the fields unit_amount and amount were the values inherited from 'account.analytic.line': 'Quantity' and 'Amount' respectively. These were inconsistent with the strings in the different views: "Duration (encoding_uom_id.name)" and "Timesheet Cost".

taskid: 2264636



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
