### PR TITLE
[IMP] hr_timesheet: Fix hours/days conversion in graph view

### DIFF
--- a/addons/hr_timesheet/static/src/js/timesheet_graph.js
+++ b/addons/hr_timesheet/static/src/js/timesheet_graph.js
@@ -1,0 +1,34 @@
+odoo.define('hr_timesheet.GraphView', function (require) {
+    "use strict";
+
+    const viewRegistry = require('web.view_registry');
+    const GraphView = require('web.GraphView');
+    const GraphModel = require('web.GraphModel');
+
+    const hrTimesheetGraphModel = GraphModel.extend({
+        /*
+         * Override the _processData to take into account the analytic line uom.
+         */
+        _processData: function (originIndex, rawData) {
+            this._super.apply(this, arguments);
+            const session = this.getSession();
+            if (this.chart.measure === 'unit_amount' && session.timesheet_uom_factor !== 1) {
+                // recalculate the Duration values according to the timesheet_uom_factor
+                this.chart.dataPoints.forEach(function (dataPt) {
+                    dataPt.value *= session.timesheet_uom_factor;
+                });
+            }
+        },
+    });
+
+
+    const hrTimesheetGraphView = GraphView.extend({
+        config: Object.assign({}, GraphView.prototype.config, {
+            Model: hrTimesheetGraphModel,
+        }),
+    });
+
+    viewRegistry.add('hr_timesheet_graphview', hrTimesheetGraphView);
+    return hrTimesheetGraphView;
+});
+

--- a/addons/hr_timesheet/views/assets.xml
+++ b/addons/hr_timesheet/views/assets.xml
@@ -8,6 +8,7 @@
             <script type="text/javascript" src="/hr_timesheet/static/src/js/timesheet_factor.js"/>
             <script type="text/javascript" src="/hr_timesheet/static/src/js/timesheet_config_form_view.js"/>
             <script type="text/javascript" src="/hr_timesheet/static/src/js/qr_code_action.js"/>
+            <script type="text/javascript" src="/hr_timesheet/static/src/js/timesheet_graph.js"/>
         </xpath>
     </template>
 </odoo>

--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -66,7 +66,7 @@
             <field name="name">account.analytic.line.graph</field>
             <field name="model">account.analytic.line</field>
             <field name="arch" type="xml">
-                <graph string="Timesheet" sample="1">
+                <graph string="Timesheet" sample="1" js_class="hr_timesheet_graphview">
                     <field name="task_id" type="row"/>
                     <field name="project_id" type="row"/>
                     <field name="unit_amount" type="measure" widget="timesheet_uom"/>


### PR DESCRIPTION
Before this commit, the hr_timesheet reporting graph view always displayed the amount (duration) in hours regardless the Time unit used.

taskid: 2391418



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
