### PR TITLE
[IMP] project : Project revamp : Refactor subtasks

### DIFF
--- a/addons/hr_timesheet/views/project_views.xml
+++ b/addons/hr_timesheet/views/project_views.xml
@@ -73,11 +73,18 @@
             <field name="inherit_id" ref="project.view_task_form2" />
             <field name="groups_id" eval="[(6,0, (ref('hr_timesheet.group_hr_timesheet_user'),))]"/>
             <field name="arch" type="xml">
+                <xpath expr="//field[@name='child_ids']/tree/field[@name='kanban_state']" position="after">
+                    <field name="planned_hours" widget="timesheet_uom_no_toggle" sum="Initially Planned Hours" optional="hide"/>
+                    <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="hide"/>
+                    <field name="remaining_hours" widget="timesheet_uom" sum="Remaining Hours" optional="hide" decoration-danger="progress &gt;= 100" decoration-warning="progress &gt;= 80 and progress &lt; 100"/>
+                    <field name="progress" widget="progressbar" optional="hide"/>
+                </xpath>
                 <xpath expr="//notebook/page[@name='description_page']" position="after">
                     <field name="analytic_account_active" invisible="1"/>
                     <field name="allow_timesheets" invisible="1"/>
                     <field name="allow_subtasks" invisible="1"/>
                     <field name="encode_uom_in_days" invisible="1"/>
+                    <field name="subtask_count" invisible="1"/>
                     <page string="Timesheets" id="timesheets_tab" attrs="{'invisible': [('allow_timesheets', '=', False)]}">
                         <group>
                             <group>

--- a/addons/project/models/digest.py
+++ b/addons/project/models/digest.py
@@ -20,7 +20,8 @@ class Digest(models.Model):
                 ('stage_id.fold', '=', False),
                 ('create_date', '>=', start),
                 ('create_date', '<', end),
-                ('company_id', '=', company.id)
+                ('company_id', '=', company.id),
+                ('display_project_id', '!=', False),
             ])
 
     def _compute_kpis_actions(self, company, user):

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import ast
+from collections import defaultdict
 from datetime import timedelta, datetime
 from random import randint
 
@@ -115,10 +116,16 @@ class Project(models.Model):
             ])
 
     def _compute_task_count(self):
-        task_data = self.env['project.task'].read_group([('project_id', 'in', self.ids), '|', '&', ('stage_id.is_closed', '=', False), ('stage_id.fold', '=', False), ('stage_id', '=', False)], ['project_id'], ['project_id'])
-        result = dict((data['project_id'][0], data['project_id_count']) for data in task_data)
+        task_data = self.env['project.task'].read_group(['|', '&', ('stage_id.is_closed', '=', False), ('stage_id.fold', '=', False), ('stage_id', '=', False)],
+                                                        ['project_id', 'display_project_id:count'], ['project_id'])
+        result_wo_subtask = defaultdict(int)
+        result_with_subtasks = defaultdict(int)
+        for data in task_data:
+            result_wo_subtask[data['project_id'][0]] += data['display_project_id']
+            result_with_subtasks[data['project_id'][0]] += data['project_id_count']
         for project in self:
-            project.task_count = result.get(project.id, 0)
+            project.task_count = result_wo_subtask[project.id]
+            project.task_count_with_subtasks = result_with_subtasks[project.id]
 
     def attachment_tree_view(self):
         action = self.env['ir.actions.act_window']._for_xml_id('base.action_attachment')
@@ -186,6 +193,7 @@ class Project(models.Model):
         related='company_id.resource_calendar_id')
     type_ids = fields.Many2many('project.task.type', 'project_task_type_rel', 'project_id', 'type_id', string='Tasks Stages')
     task_count = fields.Integer(compute='_compute_task_count', string="Task Count")
+    task_count_with_subtasks = fields.Integer(compute='_compute_task_count')
     task_ids = fields.One2many('project.task', 'project_id', string='Tasks',
                                domain=['|', ('stage_id.fold', '=', False), ('stage_id', '=', False)])
     color = fields.Integer(string='Color Index')
@@ -215,8 +223,6 @@ class Project(models.Model):
     doc_count = fields.Integer(compute='_compute_attached_docs_count', string="Number of Documents Attached")
     date_start = fields.Date(string='Start Date')
     date = fields.Date(string='Expiration Date', index=True, tracking=True)
-    subtask_project_id = fields.Many2one('project.project', string='Sub-task Project', ondelete="restrict",
-        help="Project in which sub-tasks of the current project will be created. It can be the current project itself.")
     allow_subtasks = fields.Boolean('Sub-tasks', default=lambda self: self.env.user.has_group('project.group_subtask_project'))
     allow_recurring_tasks = fields.Boolean('Recurring Tasks', default=lambda self: self.env.user.has_group('project.group_project_recurring_tasks'))
     allow_task_dependencies = fields.Boolean('Task Dependencies', default=lambda self: self.env.user.has_group('project.group_project_task_dependencies'))
@@ -339,8 +345,6 @@ class Project(models.Model):
         if not default.get('name'):
             default['name'] = _("%s (copy)") % (self.name)
         project = super(Project, self).copy(default)
-        if self.subtask_project_id == self:
-            project.subtask_project_id = project
         for follower in self.message_follower_ids:
             project.message_subscribe(partner_ids=follower.partner_id.ids, subtype_ids=follower.subtype_ids.ids)
         if 'tasks' not in default:
@@ -352,8 +356,6 @@ class Project(models.Model):
         # Prevent double project creation
         self = self.with_context(mail_create_nosubscribe=True)
         project = super(Project, self).create(vals)
-        if not vals.get('subtask_project_id'):
-            project.subtask_project_id = project.id
         if project.privacy_visibility == 'portal' and project.partner_id.user_ids:
             project.allowed_user_ids |= project.partner_id.user_ids
         return project
@@ -598,6 +600,11 @@ class Task(models.Model):
     project_id = fields.Many2one('project.project', string='Project',
         compute='_compute_project_id', store=True, readonly=False,
         index=True, tracking=True, check_company=True, change_default=True)
+    # Defines in which project the task will be displayed / taken into account in statistics.
+    # Example: 1 task A with 1 subtask B in project P
+    # A -> project_id=P, display_project_id=P
+    # B -> project_id=P (to inherit from ACL/security rules), display_project_id=False
+    display_project_id = fields.Many2one('project.project', index=True)
     planned_hours = fields.Float("Initially Planned Hours", help='Time planned to achieve this task (including its sub-tasks).', tracking=True)
     subtask_planned_hours = fields.Float("Sub-tasks Planned Hours", compute='_compute_subtask_planned_hours',
         help="Sum of the time planned of all the sub-tasks linked to this task. Usually less than or equal to the initially planned time of this task.")
@@ -634,7 +641,7 @@ class Task(models.Model):
     is_closed = fields.Boolean(related="stage_id.is_closed", string="Closing Stage", readonly=True, related_sudo=False)
     parent_id = fields.Many2one('project.task', string='Parent Task', index=True)
     child_ids = fields.One2many('project.task', 'parent_id', string="Sub-tasks", context={'active_test': False})
-    subtask_project_id = fields.Many2one('project.project', related="project_id.subtask_project_id", string='Sub-task Project', readonly=True)
+    child_text = fields.Char(compute="_compute_child_text")
     allow_subtasks = fields.Boolean(string="Allow Sub-tasks", related="project_id.allow_subtasks", readonly=True)
     subtask_count = fields.Integer("Sub-task Count", compute='_compute_subtask_count')
     email_from = fields.Char(string='Email From', help="These people will receive email.", index=True,
@@ -940,6 +947,16 @@ class Task(models.Model):
             task.subtask_planned_hours = sum(child_task.planned_hours + child_task.subtask_planned_hours for child_task in task.child_ids)
 
     @api.depends('child_ids')
+    def _compute_child_text(self):
+        for task in self:
+            if not task.subtask_count:
+                task.child_text = False
+            elif task.subtask_count == 1:
+                task.child_text = _("(+ 1 task)")
+            else:
+                task.child_text = _("(+ %(child_count)s tasks)", child_count=task.subtask_count)
+
+    @api.depends('child_ids')
     def _compute_subtask_count(self):
         for task in self:
             task.subtask_count = len(task._get_all_subtasks())
@@ -963,6 +980,11 @@ class Task(models.Model):
                         ('fold', '=', False), ('is_closed', '=', False)])
             else:
                 task.stage_id = False
+
+    @api.constrains('recurring_task')
+    def _check_recurring_task(self):
+        if self.filtered(lambda task: task.parent_id and task.recurring_task):
+            raise ValidationError(_("A sub-task cannot be a recurring task. Please consider making its parent task, a recurring task."))
 
     @api.returns('self', lambda value: value.id)
     def copy(self, default=None):
@@ -1066,6 +1088,8 @@ class Task(models.Model):
                         default_project_id=project_id
                     ).default_get(['stage_id']).get('stage_id')
                 vals["stage_id"] = default_stage[project_id]
+            if project_id and "display_project_id" not in vals and not vals.get('parent_id'):
+                vals["display_project_id"] = project_id
             # user_id change: update date_assign
             if vals.get('user_id'):
                 vals['date_assign'] = fields.Datetime.now()
@@ -1103,6 +1127,8 @@ class Task(models.Model):
         # user_id change: update date_assign
         if vals.get('user_id') and 'date_assign' not in vals:
             vals['date_assign'] = now
+        if vals.get('display_project_id') and 'project_id' not in vals:
+            vals['project_id'] = vals['display_project_id']
 
         # recurrence fields
         rec_fields = vals.keys() & self._get_recurrence_fields()
@@ -1134,6 +1160,12 @@ class Task(models.Model):
         # rating on stage
         if 'stage_id' in vals and vals.get('stage_id'):
             self.filtered(lambda x: x.project_id.rating_active and x.project_id.rating_status == 'stage')._send_task_rating_mail(force_send=True)
+        if 'project_id' in vals and 'display_project_id' not in vals:
+            for task in self.filtered(lambda self: self.display_project_id or self.project_id != self.parent_id.project_id):
+                task.display_project_id = task.project_id
+        if 'display_project_id' in vals and not vals['display_project_id']:
+            for task in self:
+                task.project_id = task.parent_id.project_id
         return result
 
     def update_date_end(self, stage_id):
@@ -1151,6 +1183,11 @@ class Task(models.Model):
     # ---------------------------------------------------
     # Subtasks
     # ---------------------------------------------------
+
+    @api.depends('parent_id.user_id')
+    def _compute_user_id(self):
+        for task in self:
+            task.user_id = task.user_id or task.parent_id.user_id or self.env.uid
 
     @api.depends('parent_id.partner_id', 'project_id.partner_id')
     def _compute_partner_id(self):
@@ -1172,11 +1209,11 @@ class Task(models.Model):
         for task in self:
             task.email_from = task.partner_id.email or ((task.partner_id or task.parent_id) and task.email_from) or task.parent_id.email_from
 
-    @api.depends('parent_id.project_id.subtask_project_id')
+    @api.depends('parent_id.project_id')
     def _compute_project_id(self):
         for task in self:
-            if not task.project_id:
-                task.project_id = task.parent_id.project_id.subtask_project_id
+            if not task.project_id or not task.display_project_id:
+                task.project_id = task.parent_id.project_id
 
     # ---------------------------------------------------
     # Mail gateway
@@ -1218,7 +1255,7 @@ class Task(models.Model):
         project_user_group_id = self.env.ref('project.group_project_user').id
 
         group_func = lambda pdata: pdata['type'] == 'user' and project_user_group_id in pdata['groups']
-        if self.project_id.privacy_visibility == 'followers':
+        if self.project_privacy_visibility == 'followers':
             allowed_user_ids = self.project_id.allowed_internal_user_ids.partner_id.ids
             group_func = lambda pdata: pdata['type'] == 'user' and project_user_group_id in pdata['groups'] and pdata['id'] in allowed_user_ids
         new_group = ('group_project_user', group_func, {})
@@ -1356,31 +1393,18 @@ class Task(models.Model):
             'res_model': 'project.task',
             'res_id': self.parent_id.id,
             'type': 'ir.actions.act_window',
-            'context': dict(self._context, create=False)
+            'context': self._context
         }
 
-    def action_subtask(self):
-        action = self.env["ir.actions.actions"]._for_xml_id("project.project_task_action_sub_task")
-
-        # display all subtasks of current task
-        action['domain'] = [('id', 'child_of', self.id), ('id', '!=', self.id)]
-
-        # update context, with all default values as 'quick_create' does not contains all field in its view
-        if self._context.get('default_project_id'):
-            default_project = self.env['project.project'].browse(self.env.context['default_project_id'])
-        else:
-            default_project = self.project_id.subtask_project_id or self.project_id
-        ctx = dict(self.env.context)
-        ctx = {k: v for k, v in ctx.items() if not k.startswith('search_default_')}
-        ctx.update({
-            'default_name': self.env.context.get('name', self.name) + ':',
-            'default_parent_id': self.id,  # will give default subtask field in `default_get`
-            'default_company_id': default_project.company_id.id if default_project else self.env.company.id,
-        })
-
-        action['context'] = ctx
-
-        return action
+    def action_open_task(self):
+        return {
+            'name': _('View Task'),
+            'view_mode': 'form',
+            'res_model': 'project.task',
+            'res_id': self.id,
+            'type': 'ir.actions.act_window',
+            'context': self._context
+        }
 
     # ------------
     # Actions

--- a/addons/project/models/project_task_recurrence.py
+++ b/addons/project/models/project_task_recurrence.py
@@ -208,7 +208,7 @@ class ProjectTaskRecurrence(models.Model):
         create_values = {
             field: value[0] if isinstance(value, tuple) else value for field, value in task_values.items()
         }
-        create_values['stage_id'] = task.project_id.type_ids[0].id if task.project_id.type_ids else task.stage_id
+        create_values['stage_id'] = task.project_id.type_ids[0].id if task.project_id.type_ids else task.stage_id.id
         create_values['user_id'] = False
         return create_values
 

--- a/addons/project/static/src/css/project.css
+++ b/addons/project/static/src/css/project.css
@@ -66,6 +66,11 @@
   border-color: var(--danger);
 }
 
+.o_kanban_project_tasks .o_field_one2many_sub_task {
+  margin-top:2px;
+  margin-right: 6px;
+}
+
 .o_form_project_tasks .ribbon:not(.o_invisible_modifier) + div > h1 > div[name="kanban_state"] {
   margin-right: 150px;
   padding-left: 1rem;
@@ -87,4 +92,7 @@
 .o_project_portal_warning_dd {
     width: 96%;
     float: left;
+}
+.o_btn_onhover {
+    margin-left: -1rem;
 }

--- a/addons/project/static/src/js/project_form.js
+++ b/addons/project/static/src/js/project_form.js
@@ -94,9 +94,8 @@ odoo.define('project.ProjectFormView', function (require) {
                 }),
             }).open();
         }
-
     });
-    
+
     const ProjectFormView = FormView.extend({
         config: _.extend({}, FormView.prototype.config, {
             Controller: ProjectFormController,

--- a/addons/project/static/src/js/project_name_with_subtask_count_widget.js
+++ b/addons/project/static/src/js/project_name_with_subtask_count_widget.js
@@ -1,0 +1,23 @@
+odoo.define('project.name_with_subtask_count', function (require) {
+    "use strict";
+
+    const fieldRegistry = require('web.field_registry');
+    const FieldChar = require('web.basic_fields').FieldChar;
+
+    const FieldNameWithSubTaskCount = FieldChar.extend({
+        _render: function () {
+            let result = this._super.apply(this, arguments);
+            if (this.recordData.child_text) {
+                this.$el.append($('<span>')
+                        .addClass("text-muted ml-2")
+                        .text(this.recordData.child_text)
+                        .css('font-weight', 'normal'));
+            }
+            return result;
+        }
+    });
+
+    fieldRegistry.add('name_with_subtask_count', FieldNameWithSubTaskCount);
+
+    return FieldNameWithSubTaskCount;
+});

--- a/addons/project/tests/test_project_flow.py
+++ b/addons/project/tests/test_project_flow.py
@@ -138,6 +138,7 @@ class TestProjectFlow(TestProjectCommon):
             'name': 'Task Child with project',
             'parent_id': parent_task.id,
             'project_id': self.project_goats.id,
+            'display_project_id': self.project_goats.id,
             'planned_hours': 3,
         })
 
@@ -146,6 +147,7 @@ class TestProjectFlow(TestProjectCommon):
             'name': 'Task Child without project',
             'parent_id': parent_task.id,
             'project_id': self.project_pigs.id,
+            'display_project_id': self.project_pigs.id,
             'planned_hours': 5,
         })
 

--- a/addons/project/views/project_assets.xml
+++ b/addons/project/views/project_assets.xml
@@ -7,6 +7,7 @@
                 <script type="text/javascript" src="/project/static/src/js/project_kanban.js"></script>
                 <script type="text/javascript" src="/project/static/src/js/project_list.js"></script>
                 <script type="text/javascript" src="/project/static/src/js/project_rating_reporting.js"></script>
+                <script type="text/javascript" src="/project/static/src/js/project_name_with_subtask_count_widget.js"></script>
                 <script type="text/javascript" src="/project/static/src/js/project_task_kanban_examples.js"></script>
                 <script type="text/javascript" src="/project/static/src/js/tours/project.js"></script>
                 <script type="text/javascript" src="/project/static/src/js/project_calendar.js"></script>

--- a/addons/project/views/project_portal_templates.xml
+++ b/addons/project/views/project_portal_templates.xml
@@ -54,7 +54,7 @@
                         </td>
                         <td class="text-right">
                             <a t-attf-href="/my/tasks?{{keep_query(filterby=project.id)}}">
-                                <t t-esc="project.task_count" />
+                                <t t-esc="project.task_count_with_subtasks" />
                                 <t t-esc="project.label_tasks" />
                             </a>
                         </td>
@@ -79,7 +79,7 @@
                         <span class="float-right">
                             <a role="button" t-attf-href="/my/tasks?filterby=#{project.id}" class="btn btn-sm btn-secondary">
                                 <span class="fa fa-tasks" role="img" aria-label="Tasks" title="Tasks"/>
-                                <span t-esc="project.task_count" />
+                                <span t-esc="project.task_count_with_subtasks" />
                                 <span t-field="project.label_tasks" />
                             </a>
                         </span>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -21,8 +21,7 @@
                     <field name="user_id"/>
                     <field name="partner_id" operator="child_of"/>
                     <field name="stage_id"/>
-                    <field name="project_id"/>
-                    <field name="parent_id" groups="project.group_subtask_project"/>
+                    <field string="Project" name="display_project_id"/>
                     <filter string="My Tasks" name="my_tasks" domain="[('user_id', '=', uid)]"/>
                     <filter string="Followed Tasks" name="my_followed_tasks" domain="[('message_is_follower', '=', True)]" />
                     <filter string="Unassigned" name="unassigned" domain="[('user_id', '=', False)]"/>
@@ -56,27 +55,12 @@
             <field name="name">Tasks</field>
             <field name="res_model">project.task</field>
             <field name="view_mode">kanban,tree,form,calendar,pivot,graph,activity</field>
-            <field name="domain">[('project_id', '=', active_id)]</field>
+            <field name="domain">[('display_project_id', '=', active_id)]</field>
             <field name="context">{
                 'pivot_row_groupby': ['user_id'],
                 'default_project_id': active_id,
             }</field>
             <field name="search_view_id" ref="view_task_search_form"/>
-            <field name="help" type="html">
-                <p class="o_view_nocontent_smiling_face">
-                    No tasks found. Let's create one!
-                </p><p>
-                    To get things done, use activities and status on tasks.<br/>
-                    Chat in real time or by email to collaborate efficiently.
-                </p>
-            </field>
-        </record>
-
-        <record id="project_task_action_sub_task" model="ir.actions.act_window">
-            <field name="name">Sub-tasks</field>
-            <field name="res_model">project.task</field>
-            <field name="view_mode">tree,kanban,form,calendar,pivot,graph,activity</field>
-            <field name="search_view_id" ref="project.view_task_search_form"/>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     No tasks found. Let's create one!
@@ -366,10 +350,6 @@
                                         <div class="text-muted">
                                             Split your tasks to organize your work into sub-milestones
                                         </div>
-                                        <div class="mt8" attrs="{'invisible': [('allow_subtasks', '=', False)]}">
-                                            <label for="subtask_project_id" />
-                                            <field name="subtask_project_id" />
-                                        </div>
                                     </div>
                                 </div>
                                 <div class="col-lg-6 o_setting_box"  id="recurring_tasks_setting" groups="project.group_project_recurring_tasks">
@@ -441,7 +421,6 @@
                     <field name="partner_id" optional="show" string="Customer"/>
                     <field name="analytic_account_id" optional="hide"/>
                     <field name="privacy_visibility" optional="hide"/>
-                    <field name="subtask_project_id" optional="hide"/>
                     <field name="label_tasks" optional="hide"/>
                     <field name="company_id" optional="show"  groups="base.group_multi_company"/>
                 </tree>
@@ -664,7 +643,7 @@
                     <header>
                         <button name="action_assign_to_me" string="Assign to Me" type="object" class="oe_highlight"
                             attrs="{'invisible' : [('user_id', '!=', False)]}"/>
-                        <field name="stage_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" attrs="{'invisible': [('project_id', '=', False)]}"/>
+                        <field name="stage_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" attrs="{'invisible': [('project_id', '=', False), ('stage_id', '=', False)]}"/>
                     </header>
                     <div class="alert alert-info oe_edit_only" role="status" attrs="{'invisible': ['|', ('recurring_task', '=', False), ('recurrence_id', '=', False)]}">
                         <p>Edit recurring task</p>
@@ -672,10 +651,7 @@
                     </div>
                     <sheet string="Task">
                     <div class="oe_button_box" name="button_box">
-                        <button name="action_subtask" type="object" class="oe_stat_button" icon="fa-tasks"
-                            attrs="{'invisible' : ['|', ('allow_subtasks', '=', False), ('id', '=', False)]}" context="{'default_user_id': user_id, 'default_parent_id': id, 'default_project_id': subtask_project_id}">
-                            <field string="Sub-tasks" name="subtask_count" widget="statinfo"/>
-                        </button>
+                        <button name="action_open_parent_task" type="object" class="oe_stat_button" icon="fa-tasks" string="Parent Task" attrs="{'invisible': [('parent_id', '=', False)]}"/>
                         <button name="%(rating_rating_action_task)d" type="action" attrs="{'invisible': [('rating_count', '=', 0)]}" class="oe_stat_button" icon="fa-smile-o" groups="project.group_project_rating">
                             <field name="rating_count" string="Rating" widget="statinfo"/>
                         </button>
@@ -699,18 +675,19 @@
                     </div>
                     <group>
                         <group>
-                            <field name="project_id" required="1" domain="[('active', '=', True), ('company_id', '=', company_id)]"/>
+                            <field name="project_id" attrs="{'required': [('parent_id', '=', False)], 'invisible': [('parent_id', '!=', False)]}" domain="[('active', '=', True), ('company_id', '=', company_id)]"/>
+                            <field name="display_project_id" string="Project" attrs="{'invisible': [('parent_id', '=', False)]}" domain="[('active', '=', True), ('company_id', '=', company_id)]"/>
                             <field name="user_id"
                                 class="o_task_user_field"
                                 options="{'no_open': True}"
                                 widget="many2one_avatar_user"
                                 domain="[('share', '=', False)]"/>
-                            <field
-                                name="parent_id"
+                            <field name="parent_id"
                                 domain="[('parent_id', '=', False)]"
                                 attrs="{'invisible' : [('allow_subtasks', '=', False)]}"
+                                groups="base.group_no_one"
                             />
-                            <field name="recurring_task" attrs="{'invisible': [('allow_recurring_tasks', '=', False)]}" />
+                            <field name="recurring_task" attrs="{'invisible': ['|', ('allow_recurring_tasks', '=', False), ('parent_id', '!=', False)]}" />
                         </group>
                         <group>
                             <field name="active" invisible="1"/>
@@ -726,6 +703,26 @@
                     <notebook>
                         <page name="description_page" string="Description">
                             <field name="description" type="html"/>
+                        </page>
+                        <page name="sub_tasks_page" string="Sub-tasks" attrs="{'invisible': [('allow_subtasks', '=', False)]}">
+                            <field name="child_ids" context="{'default_project_id': project_id, 'default_user_id': user_id}">
+                                <tree editable="bottom">
+                                    <field name="project_id" invisible="1"/>
+                                    <field name="is_closed" invisible="1"/>
+                                    <field name="sequence" widget="handle"/>
+                                    <field name="name"/>
+                                    <field name="display_project_id" string="Project" optional="hide"/>
+                                    <field name="partner_id" optional="hide"/>
+                                    <field name="user_id" widget="many2one_avatar_user" optional="show"/>
+                                    <field name="company_id" groups="base.group_multi_company" optional="hide"/>
+                                    <field name="activity_ids" widget="list_activity" optional="hide"/>
+                                    <field name="date_deadline" attrs="{'invisible': [('is_closed', '=', True)]}" optional="show"/>
+                                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
+                                    <field name="kanban_state" widget="state_selection" optional="hide"/>
+                                    <field name="stage_id" optional="show"/>
+                                    <button name="action_open_task" type="object" title="View Task" string="View Task" class="btn btn-link pull-right"/>
+                                </tree>
+                            </field>
                         </page>
                         <page name="recurrence" string="Recurrence" attrs="{'invisible': [('recurring_task', '=', False)]}">
                             <group>
@@ -780,8 +777,6 @@
                                     <field name="project_privacy_visibility" groups="base.group_no_one"/>
                                     <field name="allowed_user_ids" widget="many2many_tags"
                                            groups="base.group_no_one" attrs="{'invisible': [('project_privacy_visibility', 'not in', ('followers', 'portal'))]}"/>
-                                    <field name="child_ids" invisible="1" />
-                                    <field name="subtask_project_id" invisible="1" />
                                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
                                     <field name="displayed_image_id" groups="base.group_no_one"/>
                                 </group>
@@ -854,7 +849,7 @@
                         <field name="name" string = "Task Title"/>
                         <field name="user_id" options="{'no_open': True,'no_create': True}" domain="[('share', '=', False)]"/>
                         <field name="company_id" invisible="1"/>
-                        <field name="parent_id" invisible="1"/>
+                        <field name="parent_id" invisible="1" groups="base.group_no_one"/>
                     </group>
                 </form>
             </field>
@@ -884,6 +879,8 @@
                     <field name="rating_last_value"/>
                     <field name="rating_ids"/>
                     <field name="active"/>
+                    <field name="allow_subtasks"/>
+                    <field name="child_text"/>
                     <progressbar field="kanban_state" colors='{"done": "success", "blocked": "danger", "normal": "muted"}'/>
                     <templates>
                     <t t-name="kanban-box">
@@ -892,8 +889,8 @@
                                 <div class="o_kanban_record_top">
                                     <div class="o_kanban_record_headings">
                                         <strong class="o_kanban_record_title">
-                                            <s t-if="!record.active.raw_value"><field name="name"/></s>
-                                            <t t-else=""><field name="name"/></t>
+                                            <s t-if="!record.active.raw_value"><field name="name" widget="name_with_subtask_count"/></s>
+                                            <t t-else=""><field name="name" widget="name_with_subtask_count"/></t>
                                         </strong>
                                         <span  invisible="context.get('default_project_id', False) or context.get('fsm_mode', False)"><br/><field name="project_id" required="1"/></span>
                                         <br />
@@ -966,11 +963,13 @@
                 <tree string="Tasks" multi_edit="1" sample="1" js_class="project_list">
                     <field name="message_needaction" invisible="1" readonly="1"/>
                     <field name="is_closed" invisible="1" />
+                    <field name="allow_subtasks" invisible="1" />
                     <field name="sequence" invisible="1" readonly="1"/>
-                    <field name="name"/>
+                    <field name="name" widget="name_with_subtask_count"/>
+                    <field name="child_text" invisible="1"/>
                     <field name="project_id" optional="show" readonly="1"/>
                     <field name="partner_id" optional="hide"/>
-                    <field name="parent_id" groups="project.group_subtask_project" optional="hide"/>
+                    <field name="parent_id" optional="hide" attrs="{'invisible': [('allow_subtasks', '=', False)]}" groups="base.group_no_one"/>
                     <field name="user_id" optional="show" widget="many2one_avatar_user"/>
                     <field name="company_id" groups="base.group_multi_company" optional="show"/>
                     <field name="activity_ids" widget="list_activity" optional="show"/>
@@ -1062,6 +1061,7 @@
             <field name="res_model">project.task</field>
             <field name="view_mode">kanban,tree,form,calendar,pivot,graph,activity</field>
             <field name="context">{'search_default_my_tasks': 1}</field>
+            <field name="domain">[('display_project_id', '!=', False)]</field>
             <field name="search_view_id" ref="view_task_search_form"/>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
@@ -1114,7 +1114,7 @@
             <field name="name">Overpassed Tasks</field>
             <field name="res_model">project.task</field>
             <field name="view_mode">tree,form,calendar,graph,kanban</field>
-            <field name="domain">[('is_closed', '=', False), ('date_deadline','&lt;',time.strftime('%Y-%m-%d'))]</field>
+            <field name="domain">[('is_closed', '=', False), ('date_deadline','&lt;',time.strftime('%Y-%m-%d')), ('display_project_id', '!=', False)]</field>
             <field name="filter" eval="True"/>
             <field name="search_view_id" ref="view_task_search_form"/>
         </record>
@@ -1142,6 +1142,7 @@
             <field name="res_model">project.task</field>
             <field name="view_mode">tree,form,calendar,graph</field>
             <field name="context">{'search_default_user_id': [active_id], 'default_user_id': active_id}</field>
+            <field name="domain">[('display_project_id', '!=', False)]</field>
             <field name="binding_model_id" ref="base.model_res_users"/>
             <field name="binding_view_types">form</field>
         </record>

--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -23,7 +23,7 @@ class SaleOrder(models.Model):
     @api.depends('order_line.product_id.project_id')
     def _compute_tasks_ids(self):
         for order in self:
-            order.tasks_ids = self.env['project.task'].search(['|', ('sale_line_id', 'in', order.order_line.ids), ('sale_order_id', '=', order.id)])
+            order.tasks_ids = self.env['project.task'].search(['&', ('display_project_id', '!=', 'False'), '|', ('sale_line_id', 'in', order.order_line.ids), ('sale_order_id', '=', order.id)])
             order.tasks_count = len(order.tasks_ids)
 
     @api.depends('order_line.product_id.service_tracking')

--- a/addons/sale_timesheet/tests/common.py
+++ b/addons/sale_timesheet/tests/common.py
@@ -111,7 +111,6 @@ class TestCommonSaleTimesheet(TestSaleCommon):
             'allow_timesheets': True,
             'allow_billable': False,
             'partner_id': False,
-            'subtask_project_id': cls.project_subtask.id,
         })
 
         # Create service products

--- a/addons/sale_timesheet/tests/test_project_billing.py
+++ b/addons/sale_timesheet/tests/test_project_billing.py
@@ -3,7 +3,6 @@
 from odoo.addons.sale_timesheet.tests.common import TestCommonSaleTimesheet
 from odoo.tests import tagged
 
-
 @tagged('post_install', '-at_install')
 class TestProjectBilling(TestCommonSaleTimesheet):
     """ This test suite provide checks for miscellaneous small things. """
@@ -85,7 +84,6 @@ class TestProjectBilling(TestCommonSaleTimesheet):
         cls.project_employee_rate.write({
             'sale_order_id': cls.sale_order_1.id,
             'partner_id': cls.sale_order_1.partner_id.id,
-            'subtask_project_id': cls.project_subtask.id,
         })
         cls.project_employee_rate_manager = cls.env['project.sale.line.employee.map'].create({
             'project_id': cls.project_employee_rate.id,
@@ -265,7 +263,7 @@ class TestProjectBilling(TestCommonSaleTimesheet):
         self.assertEqual(self.project_employee_rate_manager.project_id, timesheet1.project_id, "The timesheet should be linked to the project of the map entry")
 
         # create a subtask
-        subtask = Task.with_context(default_project_id=self.project_employee_rate.subtask_project_id.id).create({
+        subtask = Task.with_context(default_project_id=self.project_subtask.id).create({
             'name': 'first subtask task',
             'parent_id': task.id,
         })
@@ -342,9 +340,6 @@ class TestProjectBilling(TestCommonSaleTimesheet):
         Task = self.env['project.task'].with_context(tracking_disable=True)
         Timesheet = self.env['account.analytic.line']
 
-        # set subtask project on task rate project
-        self.project_task_rate.write({'subtask_project_id': self.project_subtask.id})
-
         # create a task
         task = Task.with_context(default_project_id=self.project_task_rate.id).create({
             'name': 'first task',
@@ -366,7 +361,7 @@ class TestProjectBilling(TestCommonSaleTimesheet):
         self.assertEqual(task.sale_line_id, timesheet1.so_line, "The timesheet should be linked to the SOL associated to the task since the pricing type of the project is task rate.")
 
         # create a subtask
-        subtask = Task.with_context(default_project_id=self.project_task_rate.subtask_project_id.id).create({
+        subtask = Task.with_context(default_project_id=self.project_subtask.id).create({
             'name': 'first subtask task',
             'parent_id': task.id,
         })

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -907,7 +907,7 @@ tour.stepUtils.mobileModifier(tour.stepUtils.autoExpandMoreButtons('.o_control_p
     auto: true,
 }, {
     mobile: true,
-    trigger: ".o_kanban_record .o_kanban_record_title :contains('the_flow.service')",
+    trigger: ".o_kanban_record:has(.o_kanban_record_title :contains('the_flow.service'))",
     extra_trigger: ".modal:not(.o_inactive_modal) .modal-title:contains('Task')",
     content: _t("Select the the_flow.vendor"),
     position: "bottom",


### PR DESCRIPTION
Description of the feature this PR addresses:
Improve sub-tasks to ease user experience.

Current behavior before PR:
- Subtask can only be used if the sub task global setting is set.
- Subtasks have the same workflow and lifecycle as an other task despite the fact that their have a parent_id.
Their parent id, is only used to set some default values (e.g. : Company id, Sale Order id).
- The project id is required on every task.
- From their parent task, subtasks are accessible using a Stat button.
- The user assigned to a sub task is the current user by default.
- A default sub task project can be set to always create sub tasks in this default project (and not in the parent task project).

Desired behavior after PR is merged:
- Subtask can only be used if the sub task global setting is set.
- Once subtasks are enabled globally, subtasks are enabled by default and can be disabled by project.
- Subtasks are, by default, part of their parent task. Subtasks have the same project, company than their parent task.
Subtasks have no informal_project_id if they are in the same project as their parent.
- There are no more stat button regarding subtasks on task form view.
- The user assigned to a sub task is the parent task assignee by default.
- The number of subtasks linked to a task is shown on both tree and kanban view.
- There is no more sub task project.
- Informal_project_id is used to achieve some domain tuning and is displayed in some views in order to show or not the project for UX reasons.

Note :
- Subtask project configuration was discussed in PR :
            - odoo-dev@66a0e5a
            - odoo-dev@b709e22
            - We do no longer use this subtask_project_id as the workflow may be tuned differently.

Task-2388034
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
