### PR TITLE
[FIX] project: reintroduce partner_email in task form

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -672,6 +672,7 @@
                         <group>
                             <field name="active" invisible="1"/>
                             <field name="partner_id" class="o_task_customer_field"/>
+                            <field name="partner_email" widget="email" invisible="1"/>
                             <field name="partner_phone" widget="phone" attrs="{'invisible': [('partner_id', '=', False)]}"/>
                             <field name="legend_blocked" invisible="1"/>
                             <field name="legend_normal" invisible="1"/>


### PR DESCRIPTION
Fix field removal introduced in bed22b10322882802cb0435088f9731ebbdf634e

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
