### PR TITLE
[IMP] spreadsheet: allow filtering on all months

### DIFF
--- a/addons/web/static/src/js/control_panel/search_utils.js
+++ b/addons/web/static/src/js/control_panel/search_utils.js
@@ -530,6 +530,7 @@ odoo.define('web.searchUtils', function (require) {
         INTERVAL_OPTIONS,
         PERIOD_OPTIONS,
 
+        constructDateRange,
         constructDateDomain,
         getComparisonOptions,
         getIntervalOptions,


### PR DESCRIPTION
search_utils only allows to filter on last 3 months, in
spreadsheet we want to be able to filter on all the months
therefore we construct the datedomain manually and we need
the function constructDateRange to be able to do so.

task-id:2340623