### PR TITLE
[FIX] web: make clean_action() allow extra properties

### DIFF
--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -175,7 +175,7 @@ class MailComposer(models.TransientModel):
     # to ensure the context is passed correctly
     def action_send_mail(self):
         self.send_mail()
-        return {'type': 'ir.actions.act_window_close', 'infos': 'mail_sent'}
+        return {'type': 'ir.actions.act_window_close'}
 
     def send_mail(self, auto_commit=False):
         """ Process the wizard content and proceed with sending the related

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -325,17 +325,30 @@ def set_cookie_and_redirect(redirect_url):
     return redirect
 
 def clean_action(action, env):
-    action.setdefault('flags', {})
     action_type = action.setdefault('type', 'ir.actions.act_window_close')
     if action_type == 'ir.actions.act_window':
         action = fix_view_modes(action)
 
-    # When returning an action, only few information are really usefull
-    return {
+    # When returning an action, keep only relevant fields/properties
+    readable_fields = env[action['type']]._get_readable_fields()
+    action_type_fields = env[action['type']]._fields.keys()
+
+    cleaned_action = {
         field: value
         for field, value in action.items()
-        if field in env[action['type']]._get_readable_fields()
+        # keep allowed fields and custom properties fields
+        if field in readable_fields or field not in action_type_fields
     }
+
+    # Warn about custom properties fields, because use is discouraged
+    action_name = action.get('name') or action
+    custom_properties = action.keys() - readable_fields - action_type_fields
+    if custom_properties:
+        _logger.warning("Action %r contains custom properties %s. Passing them "
+            "via the `params` or `context` properties is recommended instead",
+            action_name, ', '.join(map(repr, custom_properties)))
+
+    return cleaned_action
 
 # I think generate_views,fix_view_modes should go into js ActionManager
 def generate_views(action):


### PR DESCRIPTION
Some actions use 'non-standard' key in the action dict, to pass extra parameters. In that situation the filtering of keys in `clean_action()` strips valuable params, in an attempt to avoid leaking internal action data.

One example of this is the dynamic action definition returned by `open_yodlee_action()` in the account_yodlee module, which uses several non-standard properties.

This commit alters the filtering logic in order to allow extra keys by default, as long as they're not actual fields of the action model (and therefore should not cause unintended "internal data" leaks).
A warning is also added to recommend passing those extra parameters in the `context` and `params` action properties, which are explicitly designed for this, by convention.

For cases where extra properties are returned and where the warning is annoying, those properties can be explicitly _allowed_ by making them virtual action fields, through a `_get_readable_fields()` override.