### PR TITLE
[FIX] calendar: do not send updates on past events

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -668,7 +668,10 @@ class Meeting(models.Model):
         if 'partner_ids' in values:
             (current_attendees - previous_attendees)._send_mail_to_attendees('calendar.calendar_template_meeting_invitation')
         if 'start' in values:
-            (current_attendees & previous_attendees)._send_mail_to_attendees('calendar.calendar_template_meeting_changedate', ignore_recurrence=not update_recurrence)
+            start_date = fields.Datetime.to_datetime(values.get('start'))
+            # Only notify on future events
+            if start_date and start_date >= fields.Datetime.now():
+                (current_attendees & previous_attendees)._send_mail_to_attendees('calendar.calendar_template_meeting_changedate', ignore_recurrence=not update_recurrence)
 
         return True
 

--- a/addons/calendar/tests/test_event_notifications.py
+++ b/addons/calendar/tests/test_event_notifications.py
@@ -54,13 +54,13 @@ class TestEventNotifications(SavepointCase, MailCase):
             'message_type': 'user_notification',
             'subtype': 'mail.mt_note',
         }):
-            self.event.start += relativedelta(days=-1)
+            self.event.start = fields.Datetime.now() + relativedelta(days=1)
 
     def test_message_date_changed(self):
         self.event.write({
             'allday': True,
-            'start_date': date(2019, 10, 15),
-            'stop_date': date(2019, 10, 15),
+            'start_date': fields.Date.today() + relativedelta(days=7),
+            'stop_date': fields.Date.today() + relativedelta(days=8),
         })
         self.event.partner_ids = self.partner
         with self.assertSinglePostNotifications([{'partner': self.partner, 'type': 'inbox'}], {
@@ -68,6 +68,16 @@ class TestEventNotifications(SavepointCase, MailCase):
             'subtype': 'mail.mt_note',
         }):
             self.event.start_date += relativedelta(days=-1)
+
+    def test_message_date_changed_past(self):
+        self.event.write({
+            'allday': True,
+            'start_date': fields.Date.today(),
+            'stop_date': fields.Date.today() + relativedelta(days=1),
+        })
+        self.event.partner_ids = self.partner
+        with self.assertNoNotifications():
+            self.event.write({'start': date(2019, 1, 1)})
 
     def test_message_set_inactive_date_changed(self):
         self.event.write({


### PR DESCRIPTION
Before this commit, a notification was sent to all the attendees
whenever a past event was modified.

Now the notification is only sent if the event is taking place in the
future.

TaskID: 2409394

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
