### PR TITLE
[FIX] pos_restaurant: wrong split bill behavior when order is synced

### DIFF
--- a/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
@@ -45,13 +45,11 @@ odoo.define('pos_restaurant.TicketScreen', function (require) {
                 });
             }
             _setOrder(order) {
-                if (!this.env.pos.config.iface_floorplan) {
-                    super._setOrder(order);
-                } else if (order !== this.env.pos.get_order()) {
-                    // Only call set_table if the order is not the same as the current order.
-                    // This is to prevent syncing to the server because syncing is only intended
-                    // when going back to the floorscreen or opening a table.
+                if (this.env.pos.config.iface_floorplan && this.env.pos.table !== order.table) {
+                    // call set_table when the order's table is different from the active table.
                     this.env.pos.set_table(order.table, order);
+                } else {
+                    super._setOrder(order);
                 }
             }
             get showNewTicketButton() {

--- a/addons/pos_restaurant/static/tests/tours/SplitBillScreen.tour.js
+++ b/addons/pos_restaurant/static/tests/tours/SplitBillScreen.tour.js
@@ -2,6 +2,7 @@ odoo.define('pos_restaurant.tour.SplitBillScreen', function (require) {
     'use strict';
 
     const { PaymentScreen } = require('point_of_sale.tour.PaymentScreenTourMethods');
+    const { ReceiptScreen } = require('point_of_sale.tour.ReceiptScreenTourMethods');
     const { Chrome } = require('pos_restaurant.tour.ChromeTourMethods');
     const { FloorScreen } = require('pos_restaurant.tour.FloorScreenTourMethods');
     const { ProductScreen } = require('pos_restaurant.tour.ProductScreenTourMethods');
@@ -18,6 +19,13 @@ odoo.define('pos_restaurant.tour.SplitBillScreen', function (require) {
     ProductScreen.exec.addOrderline('Water', '5', '2', '10.0');
     ProductScreen.exec.addOrderline('Minute Maid', '3', '2', '6.0');
     ProductScreen.exec.addOrderline('Coca-Cola', '1', '2', '2.0');
+
+    // Sync order before proceeding
+    Chrome.do.backToFloor();
+    FloorScreen.check.orderCountSyncedInTableIs('T2', '1');
+
+    // Go back to the order in T2
+    FloorScreen.do.clickTable('T2');
     ProductScreen.do.clickSplitBillButton();
 
     // Check if the screen contains all the orderlines
@@ -41,6 +49,13 @@ odoo.define('pos_restaurant.tour.SplitBillScreen', function (require) {
     PaymentScreen.do.clickBack();
     ProductScreen.do.clickOrderline('Water', '3.0')
     ProductScreen.do.clickOrderline('Coca-Cola', '1.0')
+
+    // Pay the splitted order
+    ProductScreen.do.clickPayButton();
+    PaymentScreen.do.clickPaymentMethod('Bank');
+    PaymentScreen.check.validateButtonIsHighlighted(true);
+    PaymentScreen.do.clickValidate();
+    ReceiptScreen.check.isShown();
 
     // go back to the original order and see if the order is changed
     Chrome.do.clickTicketButton();


### PR DESCRIPTION
When an order is synced, the split bill workflow doesn't take into account
the splitted lines from the original order. Instead, the original order
remains unchanged when access directly from the ticket screen.

To reproduce, perform the following:
1. Open bar pos session.
2. Create an order with multiple items.
3. Go back to floor screen to sync.
4. Open the order by clicking the table.
5. Split an item from the order.
6. Pay the splitted order but keep the screen in Receipt screen.
7. Open ticket screen and select the Ongoing order (the original order).
8. (Bug) The order still contains the splitted items.

This is because when setting order from the ticket screen, `set_table`
is always called when the selected order is different from the current
order. This logic is flawed. We should only call `set_table` when the
order's table is different from the active table which is the 'table'
field of pos.

This commit fixes this issue and consequently adapts the test to take
into account the described workflow.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
