### PR TITLE
[FIX] tests: fix variable referenced before assignment

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -613,6 +613,7 @@ class ChromeBrowser():
         url = werkzeug.urls.url_join('http://%s:%s/' % (HOST, self.devtools_port), command)
         self._logger.info('Url : %s', url)
         delay = 0.1
+        res = dict()
         while timeout > 0:
             try:
                 r = requests.get(url, timeout=3)


### PR DESCRIPTION
From time to times, in ChromeBrowser, requests fails to decode json and
the error is catch. As a result, the `res` variable that should
contain the json as a dict is not defined.

With this commit, the res variable is initialized with an empty
dictionary.
