### PR TITLE
[IMP] .github: remove rd-images from portal in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -55,7 +55,6 @@
 
 /addons/mass_mailing/**/*.py @odoo/rd-sm
 
-/addons/portal/ @odoo/rd-images
 /addons/portal/models/ir_http.py @odoo/rd-website
 
 /addons/sms/ @odoo/rd-discuss


### PR DESCRIPTION
This rule was generating a lot of noise for very little gain.