### PR TITLE
[FIX] stock: violating stock_warehouse_warehouse_name_uniq constraint

### DIFF
--- a/addons/stock/models/res_company.py
+++ b/addons/stock/models/res_company.py
@@ -110,7 +110,7 @@ class Company(models.Model):
         when module stock is installed.
         """
         company_ids  = self.env['res.company'].search([])
-        company_with_warehouse = self.env['stock.warehouse'].search([]).mapped('company_id')
+        company_with_warehouse = self.env['stock.warehouse'].with_context(active_test=False).search([]).mapped('company_id')
         company_without_warehouse = company_ids - company_with_warehouse
         for company in company_without_warehouse:
             self.env['stock.warehouse'].create({


### PR DESCRIPTION
You may have inactive warehouses for some companies and then, when recreating missing warehouses, you try to create same warehouses for those companies, but you can't because there is an unique constraint.

We should avoid violating that constraint due to having inactive warehouses.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr