### PR TITLE
[FIX] mail, gamification, calendar: use mail template values

### DIFF
--- a/addons/calendar/models/calendar_attendee.py
+++ b/addons/calendar/models/calendar_attendee.py
@@ -125,6 +125,7 @@ class Attendee(models.Model):
                                 'mimetype': 'text/calendar',
                                 'datas': base64.b64encode(ics_file)})
                     ]
+                attachment_values += [(4, attach.id) for attach in invitation_template.attachment_ids]
                 body = invitation_template.with_context(rendering_context)._render_field(
                     'body_html',
                     attendee.ids,
@@ -140,7 +141,10 @@ class Attendee(models.Model):
                     partner_ids=attendee.partner_id.ids,
                     email_layout_xmlid='mail.mail_notification_light',
                     attachment_ids=attachment_values,
-                    force_send=force_send)
+                    force_send=force_send,
+                    mail_server_id=invitation_template.mail_server_id.id,
+                    mail_auto_delete=invitation_template.auto_delete,
+                )
 
     def do_tentative(self):
         """ Makes event invitation as Tentative. """

--- a/addons/gamification/models/challenge.py
+++ b/addons/gamification/models/challenge.py
@@ -575,7 +575,8 @@ class Challenge(models.Model):
                 if not lines:
                     continue
 
-                body_html = challenge.report_template_id.with_user(user).with_context(challenge_lines=lines)._render_field('body_html', challenge.ids)[challenge.id]
+                template = challenge.report_template_id
+                body_html = template.with_user(user).with_context(challenge_lines=lines)._render_field('body_html', challenge.ids)[challenge.id]
 
                 # notify message only to users, do not post on the challenge
                 challenge.message_notify(
@@ -583,6 +584,9 @@ class Challenge(models.Model):
                     partner_ids=[user.partner_id.id],
                     subtype_xmlid='mail.mt_comment',
                     email_layout_xmlid='mail.mail_notification_light',
+                    mail_auto_delete=template.auto_delete,
+                    mail_server_id=template.mail_server_id,
+                    attachment_ids=[(4, attach.id) for attach in template.attachment_ids],
                 )
                 if challenge.report_message_group_id:
                     challenge.report_message_group_id.message_post(

--- a/addons/gamification/models/goal.py
+++ b/addons/gamification/models/goal.py
@@ -218,12 +218,17 @@ class Goal(models.Model):
             return {}
 
         # generate a reminder report
-        body_html = self.env.ref('gamification.email_template_goal_reminder')._render_field('body_html', self.ids, compute_lang=True)[self.id]
+        template = self.env.ref('gamification.email_template_goal_reminder')
+        body_html = template._render_field('body_html', self.ids, compute_lang=True)[self.id]
         self.message_notify(
             body=body_html,
             partner_ids=[self.user_id.partner_id.id],
             subtype_xmlid='mail.mt_comment',
             email_layout_xmlid='mail.mail_notification_light',
+            mail_auto_delete=template.auto_delete,
+            mail_server_id=template.mail_server_id,
+            attachment_ids=[(4, attach.id) for attach in template.attachment_ids],
+
         )
 
         return {'to_update': True}


### PR DESCRIPTION
STEPS:
* go to the menu Technical > Email > Templates
* uncheck the "Auto Delete" box of mail template:  "Calendar: Meeting Invitation"
* create an event in the calendar and add a participant
* go to the menu Technical > Email > Emails
* go to the invitation email > Advanced tab:

BEFORE: the Auto Delete box is ticked

AFTER: following fields now correspond settings in Mail Template: Auto Delete,
attachments, mail server

---

opw-2409329

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
