### PR TITLE
[FIX] account: Fix manual reconciliation of statement line's journal …

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -617,6 +617,12 @@ class AccountPayment(models.Model):
             return
 
         for pay in self.with_context(skip_account_move_synchronization=True):
+
+            # After the migration to 14.0, the journal entry could be shared between the account.payment and the
+            # account.bank.statement.line. In that case, the synchronization will only be made with the statement line.
+            if pay.move_id.statement_line_id:
+                continue
+
             move = pay.move_id
             move_vals_to_write = {}
             payment_vals_to_write = {}


### PR DESCRIPTION
…entry after migration

In 13.0, create a statement line and process it by creating a custom journal item in any reconcile account.
At this point, a journal entry has been created and is linked to both a payment and a statement line.
Migrate to 14.0.
Now, try to reconcile manually the custom journal item with anything. Because the matching number is written on the line, it triggers the synchronization between the payment and the entry but it fails because the manual entry doesn't really look a valid payment.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
