### PR TITLE
[FIX] web: allow saving copyright footer

### DIFF
--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -502,7 +502,7 @@
                             <div class="row">
                                 <div class="col-sm text-center text-sm-left text-muted">
                                     <t t-call="web.debug_icon"/>
-                                    <span class="o_footer_copyright_name mr-2">Copyright &amp;copy; Company name</span>
+                                    <span class="o_footer_copyright_name mr-2 oe_structure">Copyright &amp;copy; Company name</span>
                                 </div>
                                 <div class="col-sm text-center text-sm-right">
                                     <t t-call="web.brand_promotion"/>


### PR DESCRIPTION
The copyright part of the footer could be edited but not saved.
Now it can be saved.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
