### PR TITLE
[FIX] calendar: Can't group by custom fields

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -107,8 +107,13 @@ class Meeting(models.Model):
         return {'start', 'stop', 'start_date', 'stop_date'}
 
     @api.model
+    def _get_custom_fields(self):
+        all_fields = self.fields_get(attributes=['manual'])
+        return {fname for fname in all_fields if all_fields[fname]['manual']}
+
+    @api.model
     def _get_public_fields(self):
-        return self._get_recurrent_fields() | self._get_time_fields() | {
+        return self._get_recurrent_fields() | self._get_time_fields() | self._get_custom_fields() | {
             'id', 'active', 'allday',
             'duration', 'user_id', 'interval',
             'count', 'rrule', 'recurrence_id', 'show_as'}


### PR DESCRIPTION
Issue

	- Install "Calendar" and "Studio" modules
	- Go to Calendar app an open any event
	- Switch to Studio mode
	- Add a selection field X in the form then close Studio
	- Go to list view and try group by X

	Error message : "Grouping by X is not allowed."

Cause

	`_get_public_fields` does not get custom fields created with studio.

Solution

	Add custom fields to public fields.

opw-2402667