### PR TITLE
[FIX] account: allow setting taxes on a miscellaneous journal entry

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1032,7 +1032,8 @@ class AccountMove(models.Model):
     @api.depends('company_id', 'invoice_filter_type_domain')
     def _compute_suitable_journal_ids(self):
         for m in self:
-            domain = [('company_id', '=', m.company_id.id), ('type', '=?', m.invoice_filter_type_domain)]
+            journal_type = m.invoice_filter_type_domain or 'general'
+            domain = [('company_id', '=', m.company_id.id), ('type', '=', journal_type)]
             m.suitable_journal_ids = self.env['account.journal'].search(domain)
 
     @api.depends('posted_before', 'state', 'journal_id', 'date')
@@ -1169,8 +1170,6 @@ class AccountMove(models.Model):
                 move.invoice_filter_type_domain = 'sale'
             elif move.is_purchase_document(include_receipts=True):
                 move.invoice_filter_type_domain = 'purchase'
-            elif move.move_type == 'entry':
-                move.invoice_filter_type_domain = 'general'
             else:
                 move.invoice_filter_type_domain = False
 


### PR DESCRIPTION
https://github.com/odoo/odoo/commit/1b273d4c11e3e8d8583de302b71b2522a71f4d1d added the 'general' value to invoice_filter_type_domain, neglecting that this field was used for filtering tax_ids field of account.move.line, and hence making it impossible to select any tax in that field when creating a misc. operation manually. This commit does what the initial fix intended without breaking the taxes.

