### PR TITLE
[FIX] point_of_sale: run POS from another company

### DIFF
--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -48,7 +48,7 @@ class PosController(http.Controller):
             return werkzeug.utils.redirect('/web#action=point_of_sale.action_client_pos_menu')
         # The POS only work in one company, so we enforce the one of the session in the context
         session_info = request.env['ir.http'].session_info()
-        session_info['user_context']['allowed_company_ids'] = pos_session.company_id.ids
+        session_info['user_context']['pos_session_company_ids'] = pos_session.company_id.ids
         context = {
             'session_info': session_info,
             'login_number': pos_session.login(),

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -174,7 +174,7 @@ exports.PosModel = Backbone.Model.extend({
     },{
         model:  'res.company',
         fields: [ 'currency_id', 'email', 'website', 'company_registry', 'vat', 'name', 'phone', 'partner_id' , 'country_id', 'state_id', 'tax_calculation_rounding_method'],
-        ids:    function(self){ return [session.user_context.allowed_company_ids[0]]; },
+        ids:    function(self){ return [session.user_context.pos_session_company_ids[0]]; },
         loaded: function(self,companies){ self.company = companies[0]; },
     },{
         model:  'decimal.precision',


### PR DESCRIPTION
In a multicompany configuration, when starting a POS of another company
than the current one, the loading will freeze.

To reproduce the error:
1. Create 2 companies C1 and C2
2. Make sure C1 has taxes
3. Create one POS per company: POS_C1 and POS_C2
4. Go on Point of Sale dashboard
5. On top right (the companies list):
	Check the two companies (so that you can see POS_C1 and POS_C2)
	If not already done, select C1
6. Start a new session with POS_C2

=> The loading will be blocked on "account.tax" step. While loading
POS_C2, the system actually tries to load C1 taxes but does not have the
corresponding access rights.
The issue was supposed to be fixed thanks to 29db04e, but this line https://github.com/odoo/odoo/blob/2c01da189a4f79cd72372442562bf7187ebda34c/addons/web/static/src/js/chrome/abstract_web_client.js#L132 overrides the `allow_companies_ids` defined in RPC response https://github.com/odoo/odoo/blob/1d1281bcc5717b7319a489d042a49cf82119a592/addons/point_of_sale/controllers/main.py#L51

A specific key (`pos_session_company_ids`) is now defined to circumvent
this behavior.

OPW-2388210