### PR TITLE
[FIX] hr_work_entry: Copy work entry type on calendar creation

### DIFF
--- a/addons/hr_work_entry/models/hr_work_entry.py
+++ b/addons/hr_work_entry/models/hr_work_entry.py
@@ -185,7 +185,7 @@ class HrWorkEntryType(models.Model):
     _name = 'hr.work.entry.type'
     _description = 'HR Work Entry Type'
 
-    name = fields.Char(required=True)
+    name = fields.Char(required=True, translate=True)
     code = fields.Char(required=True)
     color = fields.Integer(default=0)
     sequence = fields.Integer(default=25)

--- a/addons/hr_work_entry/models/resource.py
+++ b/addons/hr_work_entry/models/resource.py
@@ -12,8 +12,18 @@ class ResourceCalendarAttendance(models.Model):
 
     work_entry_type_id = fields.Many2one('hr.work.entry.type', 'Work Entry Type', default=_default_work_entry_type_id)
 
+    def _copy_attendance_vals(self):
+        res = super()._copy_attendance_vals()
+        res['work_entry_type_id'] = self.work_entry_type_id.id
+        return res
+
 
 class ResourceCalendarLeave(models.Model):
     _inherit = 'resource.calendar.leaves'
 
     work_entry_type_id = fields.Many2one('hr.work.entry.type', 'Work Entry Type')
+
+    def _copy_leave_vals(self):
+        res = super()._copy_leave_vals()
+        res['work_entry_type_id'] = self.work_entry_type_id.id
+        return res

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -386,6 +386,7 @@
                                 <field name="phone" widget="phone" options="{'enable_sms': false}"/>
                                 <field name="mobile" widget="phone" options="{'enable_sms': false}"/>
                                 <field name="email"/>
+                                <field name="lang"/>
                             </group>
                         </group>
                         <group string="Bank Accounts">


### PR DESCRIPTION
Purpose
=======

The global attendances / global time off are copied but not their work
entry types.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
