### PR TITLE
[IMP] web_editor: remove message before leaving page if editor is destroy

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -450,6 +450,9 @@ var Wysiwyg = Widget.extend({
      * @override
      */
     destroy: function () {
+        // Saving the content of the editor is not possible after destroy,
+        // so there's no need to keep the pop-up warning in this case.
+        window.onbeforeunload = null;
         this.editor.stop();
         this._super();
     },


### PR DESCRIPTION
Avoid having a warning pop-up after the wysiwyg editor is closed.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
