### PR TITLE
[FIX] payment_stripe: icon without name

### DIFF
--- a/addons/payment_stripe/models/payment.py
+++ b/addons/payment_stripe/models/payment.py
@@ -74,8 +74,8 @@ class PaymentAcquirerStripe(models.Model):
             PMT('p24', ['pl'], ['eur', 'pln'], 'punctual'),
         ]
 
-        existing_icons = [icon.name.lower() for icon in self.env['payment.icon'].search([])]
-        linked_icons = [icon.name.lower() for icon in self.payment_icon_ids]
+        existing_icons = [(icon.name or '').lower() for icon in self.env['payment.icon'].search([])]
+        linked_icons = [(icon.name or '').lower() for icon in self.payment_icon_ids]
 
         # We don't filter out pmt in the case the icon doesn't exist at all as it would be **implicit** exclusion
         icon_filtered = filter(lambda pmt: pmt.name == 'card' or


### PR DESCRIPTION
The `name` field is not required on the `payment.icon` model. Therefore,
in case the payment icon name is not set, a traceback is raised due to a
`False.lower()` statement.

opw-2409755

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
