### PR TITLE
[FIX] mrp_subcontracting: add picking info on the finished move

### DIFF
--- a/addons/mrp_subcontracting_account/models/stock_picking.py
+++ b/addons/mrp_subcontracting_account/models/stock_picking.py
@@ -23,3 +23,15 @@ class StockPicking(models.Model):
         if bom.product_tmpl_id.cost_method in ('fifo', 'average'):
             vals = dict(vals, extra_cost=subcontract_move._get_price_unit())
         return vals
+
+
+class StockMove(models.Model):
+    _inherit = 'stock.move'
+
+    def _prepare_common_svl_vals(self):
+        # if we are subcontracting we want to have the receipt move
+        # on the svl, not the MO
+        vals = super()._prepare_common_svl_vals()
+        if self.move_dest_ids and self.move_dest_ids[0].is_subcontract:
+            vals['stock_move_id'] = self.move_dest_ids[0].id
+        return vals

--- a/addons/mrp_subcontracting_account/tests/test_subcontracting_account.py
+++ b/addons/mrp_subcontracting_account/tests/test_subcontracting_account.py
@@ -53,6 +53,5 @@ class TestAccountSubcontractingFlows(TestMrpSubcontractingCommon):
         picking_receipt.move_lines.quantity_done = 1.0
         picking_receipt.action_done()
 
-        mo = picking_receipt._get_subcontracted_productions()
-        self.assertEqual(mo.move_finished_ids.stock_valuation_layer_ids.value, 60)
-        self.assertEqual(mo.move_finished_ids.product_id.value_svl, 60)
+        self.assertEqual(picking_receipt.move_lines.stock_valuation_layer_ids.value, 60)
+        self.assertEqual(picking_receipt.move_lines.product_id.value_svl, 60)


### PR DESCRIPTION
1) create a storable product with category costing method FIFO and
inventory valuation automated
2) Make a subcontracting type bill of material for this product and set
the vendor
3) Create the purchase order for this product
4) Receive the product
5) Create a vendor bill with a landed cost product and create the landed
costs
6) On the landed cost entry, you are not able to select the receipt
transfer for the subcontracted product

This occur because during 3) the stock moves for the product are
created, but the picking is not recorded on the finished move (but on
the receipt move)
At thep 6) the system will look for candidate moves which have an
associated picking, so it will not find the entry

opw-2380634

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
