### PR TITLE
[FIX] requirements.txt: Fix maximum recursion in gevent

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,10 @@ decorator==4.0.10
 docutils==0.12
 ebaysdk==2.1.5
 feedparser==5.2.1
-gevent==1.1.2 ; sys_platform != 'win32' and python_version < '3.7'
-gevent==1.5.0 ; python_version >= '3.7'
-greenlet==0.4.10 ; python_version < '3.7'
-greenlet==0.4.14 ; python_version >= '3.7'
+gevent==1.1.2 ; sys_platform != 'win32' and python_version < '3.6'
+gevent==1.5.0 ; python_version >= '3.6'
+greenlet==0.4.10 ; python_version < '3.6'
+greenlet==0.4.14 ; python_version >= '3.6'
 html2text==2016.9.19
 Jinja2==2.10.1
 libsass==0.12.3


### PR DESCRIPTION
Using py3.6 and gevent==1.1.2 the following error could be reproduced
in corner cases:

    File "/usr/lib/python3.6/ssl.py", line 485, in verify_mode
        super(SSLContext, SSLContext).verify_mode.__set__(self, value)
    File "/usr/lib/python3.6/ssl.py", line 485, in verify_mode
        super(SSLContext, SSLContext).verify_mode.__set__(self, value)
    File "/usr/lib/python3.6/ssl.py", line 485, in verify_mode
        super(SSLContext, SSLContext).verify_mode.__set__(self, value)
    [Previous line repeated 281 more times]
    RecursionError: maximum recursion depth exceeded

But using any version gevent>1.1.2 the issue is not reproduced
even gevent==1.2.0

The corner case to reproduced is the following:
 - Use py3.6
 - install gevent==1.1.2
 - Configure the reverse proxy
   - Use proxy e.g. nginx
   - `--longpolling-port`
   - `--workers>2`
 - Use Odoo>=12.0
 - Install and configure [sentry module of the OCA](https://github.com/OCA/server-tools/tree/12.0/sentry)
 - Reload the /web page 2 times
 - See the logger error of maximum recursion
 - Now, install gevent==1.2.0 or gevent==1.5.0
 - Restart odoo-bin service
 - Reload the /web page 2 times again
 - See the logger and now it is not reproduced

The gevent 1.1.2 version was assigned to be used in python3.5
But maybe for python3.6 we need bump it like python3.7

Issues related:
 - https://github.com/OCA/server-tools/issues/1499
 - https://github.com/gevent/gevent/issues/1016
 - https://github.com/getsentry/sentry/issues/3384
 - https://github.com/odoo/odoo/pull/50861
   - It was another corner case using py3.7 but they rolling backed
      to python 3.5 but maybe it could be reproduced in py3.6 too