### PR TITLE
[IMP][13.0] website_livechat: opening live chat window in client, no need refreshing pages

### DIFF
--- a/addons/website_livechat/models/mail_channel.py
+++ b/addons/website_livechat/models/mail_channel.py
@@ -81,4 +81,18 @@ class MailChannel(models.Model):
         visitor = self.livechat_visitor_id
         if len(self) == 1 and visitor and message_author_id != self.livechat_operator_id:
             visitor._update_visitor_last_visit()
+        if len(self.channel_message_ids) == 1 and self.sudo().livechat_visitor_id:
+            cookie_info = {
+                    'folded': False,
+                    'id': self.id,
+                    'message_unread_counter': 0,
+                    'operator_pid': [
+                        self.livechat_operator_id.id,
+                        self.livechat_operator_id.display_name
+                    ],
+                    'name': self.name,
+                    'uuid': self.uuid,
+                    'type': 'chat_request'
+                }
+            self.env['bus.bus'].sendone(self.sudo().livechat_visitor_id.access_token, cookie_info)
         return message

--- a/addons/website_livechat/static/src/js/im_livechat.js
+++ b/addons/website_livechat/static/src/js/im_livechat.js
@@ -25,7 +25,40 @@ LivechatButton.include({
         }
         return this._super();
     },
+	
+	/**
+     * @override
+     * opening a longpolling to listen message post from backend
+	*/
+	start: function () {
+        this._super();
+		this.call('bus_service', 'addChannel', utils.get_cookie('visitor_uuid'));
+		this.call('bus_service', 'startPolling');
+    },
+	
+	_openlivechatImmediate: function (notification) {
+		self = this 
+		var channel = notification[0];
+		var cookie_info = notification[1];
+		if (channel === utils.get_cookie('visitor_uuid')){
+			this._messages = [];
+			utils.set_cookie('im_livechat_session', utils.unaccent(JSON.stringify(cookie_info)), 60*60*24);
+			this.willStart().then(function () {
+             if (self._history) {
+            _.each(self._history.reverse(), self._addMessage.bind(self));
+            self._openChat();
+        }});
+	};
 
+	},
+	
+    _onNotification: function (notifications) {
+        var self = this;
+        _.each(notifications, function (notification) {
+		self._openlivechatImmediate(notification);
+        });
+		this._super(notifications);
+		},
     /**
      * @override
      * Called when the visitor closes the livechat chatter


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
close #59684
Current behavior before PR:
Client cannot see new livechat messages until page refresh
Desired behavior after PR is merged:
opening live chat window in frontend as soon as internal users sent a chat request to website visitors


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
