### PR TITLE
[FIX] mail: typo in check_access_rule

### DIFF
--- a/addons/mail/models/mail_followers.py
+++ b/addons/mail/models/mail_followers.py
@@ -75,7 +75,7 @@ class Followers(models.Model):
                 obj.check_access_rule('write')
                 subject = record.channel_id or record.partner_id
                 subject.check_access_rights('read')
-                subject.check_access_rule('read ')
+                subject.check_access_rule('read')
             else:
                 obj.check_access_rights('read')
                 obj.check_access_rule('read')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
There is a typo in the _check_rights method. `'read '` (with a space) is passed to `check_access_rule` instead of `'read'`. This results in an error if it is triggered.

Current behavior before PR:
an error is raised
```
  File "/opt/odoo/odoo/odoo/addons/base/models/ir_rule.py", line 119, in _get_rules
    raise ValueError('Invalid mode: %r' % (mode,))
ValueError: Invalid mode: 'read '
```

Desired behavior after PR is merged:
No error is raised.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
