### PR TITLE
[FIX] portal: display mobile menu text left aligned

### DIFF
--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -15,8 +15,7 @@
                         <span class="navbar-toggler-icon"/>
                     </button>
                     <div class="collapse navbar-collapse" id="top_menu_collapse">
-                        <!-- FIXME We want menu to open to the right by default (except cases handled in JS) -->
-                        <ul class="nav navbar-nav ml-auto text-right" id="top_menu">
+                        <ul class="nav navbar-nav ml-auto text-md-right" id="top_menu">
                             <li class="nav-item divider" t-ignore="true" t-if="not user_id._is_public()"/>
                             <li class="nav-item dropdown" t-ignore="true" t-if="not user_id._is_public()">
                                 <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
display mobile menu text left aligned and still open the menus to the right on larger devices

Current behavior before PR:
Currently the menu on the website for mobile displays text to the right while submenus still display text to the left, which makes it kinda look strange.

Desired behavior after PR is merged:
Mobile menu text is aligned to the left consistently.

Mobile menu in 11.0:
[<img src="https://user-images.githubusercontent.com/38032588/100715368-61562780-33b7-11eb-8839-b0b5a02e5588.png" height="500">](https://user-images.githubusercontent.com/38032588/100715368-61562780-33b7-11eb-8839-b0b5a02e5588.png)

Mobile menu in migrated 13.0:
[<img src="https://user-images.githubusercontent.com/38032588/100715431-7af76f00-33b7-11eb-8576-5a1d6b2229e6.png" height="500">](https://user-images.githubusercontent.com/38032588/100715431-7af76f00-33b7-11eb-8576-5a1d6b2229e6.png)

Mobile menu in fixed 13.0:
[<img src="https://user-images.githubusercontent.com/38032588/100715512-96fb1080-33b7-11eb-825e-434f6f3ea65e.png" height="500">](https://user-images.githubusercontent.com/38032588/100715512-96fb1080-33b7-11eb-825e-434f6f3ea65e.png)

@qsm-odoo is this about the fix you where mentioning in https://github.com/odoo/odoo/commit/09f40036b9c14161db90c6128861369c91c8c64e#diff-823e5db841dca1798ff1300e243059a4e1c93343598d2be5a1d1dcd1d2d0c273R36 with `<!-- FIXME We want menu to open to the right by default (except cases handled in JS) -->` or would that be something completely unrelated?

Info @wt-io-it

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
