### PR TITLE
[FIX] hr_expense: rename expense product

### DIFF
--- a/addons/hr_expense/data/mail_templates.xml
+++ b/addons/hr_expense/data/mail_templates.xml
@@ -17,11 +17,11 @@
                 </t>
             </p>
             <p t-if="expense.product_id">
-                Product: <t t-esc="expense.product_id.name"/>
+                Category: <t t-esc="expense.product_id.name"/>
             </p>
             <div t-else="">
-                <p>Product: not found</p>
-                <p>The first word of the email subject did not correspond to any product code. You'll have to set the product manually on the expense.</p>
+                <p>Category: not found</p>
+                <p>The first word of the email subject did not correspond to any category code. You'll have to set the category manually on the expense.</p>
             </div>
             <p>
                 Price: <t t-esc="expense.unit_amount"/><t t-esc="expense.currency_id.symbol"/>

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -318,7 +318,7 @@
                         domain="[('activity_ids.date_deadline', '&gt;', context_today().strftime('%Y-%m-%d'))]"/>
                     <group expand="0" string="Group By">
                         <filter string="Employee" name="employee" domain="[]" context="{'group_by': 'employee_id'}"/>
-                        <filter string="Product" name="product" domain="[]" context="{'group_by': 'product_id'}"/>
+                        <filter string="Category" name="product" domain="[]" context="{'group_by': 'product_id'}"/>
                         <filter string="Analytic Account" name="analyticacc" domain="[]" context="{'group_by': 'analytic_account_id'}" groups="analytic.group_analytic_accounting"/>
                         <filter string="Status" name="status" domain="[]" context="{'group_by': 'state'}"/>
                         <filter string="Expense Date" name="expensesmonth" domain="[]" context="{'group_by': 'date'}" help="Expense Date"/>

--- a/addons/hr_expense/views/res_config_settings_views.xml
+++ b/addons/hr_expense/views/res_config_settings_views.xml
@@ -13,7 +13,7 @@
                         <div class="row mt16 o_settings_container" name="expenses_setting_container">
                             <div class="col-xs-12 col-md-6 o_setting_box"
                                 id="create_expense_setting"
-                                title="Send an email to this email alias with the receipt in attachment to create an expense in one click. If the first word of the mail subject contains the product's internal reference or the product name, the corresponding product will automatically be set. Type the expense amount in the mail subject to set it on the expense too.">
+                                title="Send an email to this email alias with the receipt in attachment to create an expense in one click. If the first word of the mail subject contains the category's internal reference or the category name, the corresponding category will automatically be set. Type the expense amount in the mail subject to set it on the expense too.">
                                 <div class="o_setting_left_pane">
                                     <field name="use_mailgateway"/>
                                 </div>

--- a/addons/sale_expense/models/hr_expense.py
+++ b/addons/sale_expense/models/hr_expense.py
@@ -12,7 +12,7 @@ class Expense(models.Model):
         # NOTE: only confirmed SO can be selected, but this domain in activated throught the name search with the `sale_expense_all_order`
         # context key. So, this domain is not the one applied.
         domain="[('state', '=', 'sale'), ('company_id', '=', company_id)]",
-        help="If the product has an expense policy, it will be reinvoiced on this sales order")
+        help="If the category has an expense policy, it will be reinvoiced on this sales order")
     can_be_reinvoiced = fields.Boolean("Can be reinvoiced", compute='_compute_can_be_reinvoiced')
     analytic_account_id = fields.Many2one(compute='_compute_analytic_account_id', store=True, readonly=False)
 


### PR DESCRIPTION
Currently at odoo we use expense product terminology
just because it's set up using product. Inside the
expense app, there is no reason of not using category

So in this commit, rename the product into category

TaskId: 2391433

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
