### PR TITLE
[IMP] base: relax api keys env check

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1568,7 +1568,14 @@ class APIKeysUser(models.Model):
         return False
 
     def _check_credentials(self, password, user_agent_env):
-        if user_agent_env['interactive']:
+        user_agent_env = user_agent_env or {}
+        if user_agent_env.get('interactive', True):
+            if 'interactive' not in user_agent_env:
+                _logger.warning(
+                    "_check_credentials without 'interactive' env key, assuming interactive login. \
+                    Check calls and overrides to ensure the 'interactive' key is properly set in \
+                    all _check_credentials environments"
+                )
             return super()._check_credentials(password, user_agent_env)
 
         if not self.env.user._rpc_api_keys_only():


### PR DESCRIPTION
Before this change, the apikeys' `_check_credentials` override would hard-check the `'interactive'` key. This turns out to be less than ideal for compatibility with older code which might not properly forward the environment (or might call `_check_credentials` from a non-override and pass in an empty env) as it straight crashes.

Update the override to assume an interactive login if the information is missing (as that seems like the more secure option: it ignores apikeys and takes 2FA in account if enabled). Also trigger a warning if the key was missing from the environment, such that the maintainer hopefully takes a look at the issue.

Also allow a `user_agent_env` of `None`, this will also trigger the warning so seems OK.
