### PR TITLE
[FIX] sale_timesheet: project manager cannot modify so line/employee map

### DIFF
--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -129,7 +129,7 @@ class Project(models.Model):
                 continue
             for employee_id in project.sale_line_employee_ids.filtered(lambda l: l.project_id == project).employee_id:
                 sale_line_id = project.sale_line_employee_ids.filtered(lambda l: l.project_id == project and l.employee_id == employee_id).sale_line_id
-                timesheet_ids.filtered(lambda t: t.employee_id == employee_id).so_line = sale_line_id
+                timesheet_ids.filtered(lambda t: t.employee_id == employee_id).sudo().so_line = sale_line_id
 
     def action_view_timesheet(self):
         self.ensure_one()


### PR DESCRIPTION
problem
-------
On project invoice to one customer based on employee rate
A project manager that is not a timesheet approver get the error
"You cannot access timesheets that are not yours." when he edit
the project.sale.line.employee.map because editing this object
may trigger write on account.analytic.line

solution
--------
The write trigger when a sale.line.employee.map is chaned should
be done as sudo




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
