### PR TITLE
[FIX] sale_timesheet: allow project timesheets to be updated

### DIFF
--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -119,7 +119,7 @@ class Project(models.Model):
         return res
 
     def _get_not_billed_timesheets(self):
-        return self.mapped('timesheet_ids').filtered(
+        return self.sudo(False).mapped('timesheet_ids').filtered(
             lambda t: not t.timesheet_invoice_id or t.timesheet_invoice_id.state == 'cancel')
 
     def _update_timesheets_sale_line_id(self):


### PR DESCRIPTION
Before this commit:

    - If the user did not have sufficient rights (only group_hr_timesheet_user),
      then the update of the SOL on the task did not trigger an update on all
      not invoiced timesheets but only on the one of the user.
    - An exception was raised when updating the sale_line_id of the
      sale_line_employee_ids of a project as it tries to update
      the related employees project timesheets (which can be different
      from the current user).

After this commit:

    - All the not invoiced timesheets of the task are updated when changing
      the task SOL.
    - The exception will not be thrown as the write opperation is made
      with sudo rights.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
