### PR TITLE
do not close select create dialog on escape

### DIFF
--- a/addons/web/static/src/js/views/view_dialogs.js
+++ b/addons/web/static/src/js/views/view_dialogs.js
@@ -462,9 +462,9 @@ var SelectCreateDialog = ViewDialog.extend({
                     display_name: record.data.display_name || record.data.name,
                 }];
                 self.on_selected(values);
+                self.close();
             },
         })).open();
-        dialog.on('closed', this, this.close);
         return dialog;
     },
     /**

--- a/addons/web/static/src/js/views/view_dialogs.js
+++ b/addons/web/static/src/js/views/view_dialogs.js
@@ -146,7 +146,7 @@ var FormViewDialog = ViewDialog.extend({
                         text: _t("Save & New"),
                         classes: "btn-primary",
                         click: function () {
-                            this._save().then(self.form_view.createRecord.bind(self.form_view, self.parentID));
+                            this._save(true).then(self.form_view.createRecord.bind(self.form_view, self.parentID));
                         },
                     });
                 }
@@ -259,7 +259,7 @@ var FormViewDialog = ViewDialog.extend({
      * @private
      * @returns {Deferred}
      */
-    _save: function () {
+    _save: function (saveAndNew) {
         var self = this;
         return this.form_view.saveRecord(this.form_view.handle, {
             stayInEdit: true,
@@ -270,7 +270,7 @@ var FormViewDialog = ViewDialog.extend({
             // record might have been changed by the save (e.g. if this was a new record, it has an
             // id now), so don't re-use the copy obtained before the save
             var record = self.form_view.model.get(self.form_view.handle);
-            self.on_saved(record, !!changedFields.length);
+            self.on_saved(record, !!changedFields.length, saveAndNew);
         });
     },
 });
@@ -456,13 +456,18 @@ var SelectCreateDialog = ViewDialog.extend({
     create_edit_record: function () {
         var self = this;
         var dialog = new FormViewDialog(this, _.extend({}, this.options, {
-            on_saved: function (record) {
+            on_saved: function (record, changed, saveAndNew) {
                 var values = [{
                     id: record.res_id,
                     display_name: record.data.display_name || record.data.name,
                 }];
                 self.on_selected(values);
-                self.close();
+                // don't close the dialog if Save & New is clicked from from dialog
+                // else SelectCreateDialog will destroyed and due to which Save & New
+                // dialog will not appear
+                if (!saveAndNew) {
+                    self.close();
+                }
             },
         })).open();
         return dialog;

--- a/addons/web/static/tests/views/view_dialogs_tests.js
+++ b/addons/web/static/tests/views/view_dialogs_tests.js
@@ -309,6 +309,56 @@ QUnit.module('Views', {
         parent.destroy();
     });
 
+    QUnit.test('Create from SelectCreateDialog and Save & New should open new form dialog', function (assert) {
+        assert.expect(5);
+
+        var form = createView({
+            View: FormView,
+            model: 'instrument',
+            data: this.data,
+            arch: '<form>' +
+                    '<field name="name"/>' +
+                    '<field name="badassery"/>' +
+                '</form>',
+            archs: {
+                'badassery,false,form': '<form>' +
+                                            '<field name="level"/>' +
+                                        '</form>',
+
+                'badassery,false,list': '<tree>' +
+                                            '<field name="level"/>' +
+                                        '</tree>',
+
+                'badassery,false,search': '<search>' +
+                                                '<field name="level"/>' +
+                                            '</search>',
+            },
+        });
+
+        form.$('.o_field_x2many_list_row_add a').click();
+        var $modal = $('.modal-lg');
+        assert.equal($modal.length, 1, 'There should be one modal');
+
+        // click on Create button
+        $modal.find('.modal-footer button:eq(1)').click();
+        assert.equal($('.modal-lg').length, 2, 'There should be two modals');
+
+        var $formModal = $('.modal-lg:eq(1)');
+        $formModal.find('input[name="level"]').val('Bagha');
+        // Click on Save & New button should keep form dialog again and keep Select dialog open
+        $formModal.find('.modal-footer button:eq(1)').click();
+        assert.equal($('.modal-lg').length, 2, 'There should be two modal');
+        var m2mRecords = form.$('.o_field_many2many.o_field_widget.o_field_x2many.o_field_x2many_list .o_data_row');
+        assert.equal(m2mRecords.length, 1,
+            'should have 1 added record in many2many field');
+
+        $formModal = $('.modal-lg:eq(1)');
+        $formModal.find('.modal-footer button:eq(2)').click();
+        assert.equal($('.modal-lg').length, 1, 'There should be one modal');
+
+        form.destroy();
+    });
+
     QUnit.test('SelectCreateDialog cascade x2many in create mode', function (assert) {
         assert.expect(5);
 

--- a/addons/web/static/tests/views/view_dialogs_tests.js
+++ b/addons/web/static/tests/views/view_dialogs_tests.js
@@ -272,6 +272,43 @@ QUnit.module('Views', {
         parent.destroy();
     });
 
+    QUnit.test('Create from SelectCreateDialog and close dialog using Escape', function (assert) {
+        assert.expect(3);
+
+        var parent = createParent({
+            data: this.data,
+            archs: {
+                'partner,false,form':
+                    '<form>' +
+                        '<field name="display_name"/>' +
+                        '<field name="foo"/>' +
+                    '</form>',
+                'partner,false,list':
+                    '<tree string="Partner" editable="bottom">' +
+                        '<field name="display_name"/>' +
+                        '<field name="foo"/>' +
+                    '</tree>',
+                'partner,false,search': '<search/>'
+            },
+        });
+
+        new dialogs.SelectCreateDialog(parent, {
+            res_model: 'partner',
+        }).open();
+
+        var $modal = $('.modal-lg');
+        assert.equal($modal.length, 1, 'There should be one modal');
+        // click on Create button
+        $modal.find('.modal-footer button:eq(1)').click();
+
+        assert.equal($('.modal-lg').length, 2, 'There should be two modals');
+        // trigger keydown ESCAPE in the modal
+        $('.modal:eq(1)').trigger({ type: 'keydown', which: $.ui.keyCode.ESCAPE });
+        assert.equal($('.modal-lg').length, 1, 'There should be one modal');
+
+        parent.destroy();
+    });
+
     QUnit.test('SelectCreateDialog cascade x2many in create mode', function (assert) {
         assert.expect(5);
 


### PR DESCRIPTION
PURPOSE
Opening Formview dialog from Select create dialog of m2m and pressing Escape on form dialog should not close Select dialog, it should only close Form dialog which is top on Select dialog.

SPEC
Pressing Escape on Form dialog which is opened on top of Select dialog should close only Form dialog.

TASK 2376292



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
