### PR TITLE
[13.0][DOC] auto_install

### DIFF
--- a/doc/reference/module.rst
+++ b/doc/reference/module.rst
@@ -86,9 +86,12 @@ Available manifest fields are:
 ``demo`` (``list(str)``)
     List of data files which are only installed or updated in *demonstration
     mode*
-``auto_install`` (``bool``, default: ``False``)
+``auto_install`` (``bool`` | ``list(str)``, default: ``False``)
     If ``True``, this module will automatically be installed if all of its
     dependencies are installed.
+
+    Alternatively, a list of dependencies in place of ``depends`` can be
+    provided here.
 
     It is generally used for "link modules" implementing synergic integration
     between two otherwise independent modules.


### PR DESCRIPTION
See https://github.com/odoo/odoo/blob/13.0/odoo/modules/module.py#L338-L354. There are examples of this usage in various odoo-enterprise module manifests: crm_enterprise, sale_enterprise, etc.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
