### PR TITLE
[FIX] portal_rating: translate frontend too

### DIFF
--- a/addons/portal_rating/models/__init__.py
+++ b/addons/portal_rating/models/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import ir_http
 from . import mail_message
 from . import rating

--- a/addons/portal_rating/models/ir_http.py
+++ b/addons/portal_rating/models/ir_http.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = 'ir.http'
+
+    @classmethod
+    def _get_translation_frontend_modules_name(cls):
+        mods = super(IrHttp, cls)._get_translation_frontend_modules_name()
+        return mods + ['portal_rating']


### PR DESCRIPTION
The rating_card view was not translated for a portal user
![Screenshot_2020-12-01 Escritorio personalizable (CONFIG)](https://user-images.githubusercontent.com/564822/100749390-e572d400-33e4-11eb-897c-f906e301826c.png)
