### PR TITLE
[FIX] account: check statement balance at each step

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -422,6 +422,7 @@ class AccountBankStatement(models.Model):
                     'res_id': statement.id
                 })
 
+        self._check_balance_end_real_same_as_computed()
         self.write({'state': 'confirm', 'date_done': fields.Datetime.now()})
 
     def button_validate_or_action(self):

--- a/addons/account/views/account_bank_statement_views.xml
+++ b/addons/account/views/account_bank_statement_views.xml
@@ -78,7 +78,7 @@
             <field name="name">account.bank.statement.tree</field>
             <field name="model">account.bank.statement</field>
             <field name="arch" type="xml">
-                <tree decoration-danger="not is_difference_zero and state=='open'" decoration-info="state=='open' and is_difference_zero" string="Statements">
+                <tree decoration-danger="not is_difference_zero" decoration-info="state=='open' and is_difference_zero" string="Statements">
                     <field name="name"/>
                     <field name="date"/>
                     <field name="journal_id"/>


### PR DESCRIPTION
Previously, the check to see if a statement ending balance is the same as the computed balance was only done when moving from draft to posted which is wrong as people can modify the balance of posted statement programmatically which is the case when using online synchronization for example. Now perform that check at each change of state: draft->posted and posted->processed. Also the indication in the view to indicate that the balance was not the same was only displayed in draft, we removed that constraints as user should always see if there is a problem.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
