### PR TITLE
[FIX] calendar, calendar_sms: stop sending wrong reminders

### DIFF
--- a/addons/calendar/models/calendar_alarm_manager.py
+++ b/addons/calendar/models/calendar_alarm_manager.py
@@ -160,23 +160,10 @@ class AlarmManager(models.AbstractModel):
 
         for meeting in self.env['calendar.event'].browse(all_meetings):
             max_delta = all_meetings[meeting.id]['max_duration']
-
-            if meeting.recurrency and meeting.recurrence_id:
-                at_least_one = False
-                last_found = False
-                for one_date in meeting.recurrence_id._get_occurrences(meeting.start):
-                    in_date_format = one_date.replace(tzinfo=None)
-                    last_found = self.do_check_alarm_for_one_date(in_date_format, meeting, max_delta, 0, 'email', after=last_notif_mail, missing=True)
-                    for alert in last_found:
-                        self.do_mail_reminder(alert)
-                        at_least_one = True  # if it's the first alarm for this recurrent event
-                    if at_least_one and not last_found:  # if the precedent event had an alarm but not this one, we can stop the search for this event
-                        break
-            else:
-                in_date_format = meeting.start
-                last_found = self.do_check_alarm_for_one_date(in_date_format, meeting, max_delta, 0, 'email', after=last_notif_mail, missing=True)
-                for alert in last_found:
-                    self.do_mail_reminder(alert)
+            in_date_format = meeting.start
+            last_found = self.do_check_alarm_for_one_date(in_date_format, meeting, max_delta, 0, 'email', after=last_notif_mail, missing=True)
+            for alert in last_found:
+                self.do_mail_reminder(alert)
 
     @api.model
     def get_next_notif(self):
@@ -191,25 +178,11 @@ class AlarmManager(models.AbstractModel):
         for event_id in all_meetings:
             max_delta = all_meetings[event_id]['max_duration']
             meeting = self.env['calendar.event'].browse(event_id)
-            if meeting.recurrency and meeting.recurrence_id:
-                b_found = False
-                last_found = False
-                for one_date in meeting.recurrence_id._get_occurrences(meeting.start):
-                    in_date_format = one_date.replace(tzinfo=None)
-                    last_found = self.do_check_alarm_for_one_date(in_date_format, meeting, max_delta, time_limit, 'notification', after=partner.calendar_last_notif_ack)
-                    if last_found:
-                        for alert in last_found:
-                            all_notif.append(self.do_notif_reminder(alert))
-                        if not b_found:  # if it's the first alarm for this recurrent event
-                            b_found = True
-                    if b_found and not last_found:  # if the precedent event had alarm but not this one, we can stop the search fot this event
-                        break
-            else:
-                in_date_format = fields.Datetime.from_string(meeting.start)
-                last_found = self.do_check_alarm_for_one_date(in_date_format, meeting, max_delta, time_limit, 'notification', after=partner.calendar_last_notif_ack)
-                if last_found:
-                    for alert in last_found:
-                        all_notif.append(self.do_notif_reminder(alert))
+            in_date_format = fields.Datetime.from_string(meeting.start)
+            last_found = self.do_check_alarm_for_one_date(in_date_format, meeting, max_delta, time_limit, 'notification', after=partner.calendar_last_notif_ack)
+            if last_found:
+                for alert in last_found:
+                    all_notif.append(self.do_notif_reminder(alert))
         return all_notif
 
     def do_mail_reminder(self, alert):

--- a/addons/calendar_sms/models/calendar.py
+++ b/addons/calendar_sms/models/calendar.py
@@ -61,20 +61,8 @@ class AlarmManager(models.AbstractModel):
 
         for event in self.env['calendar.event'].browse(events_data):
             max_delta = events_data[event.id]['max_duration']
-
-            if event.recurrency:
-                found = False
-                for event_start in event.recurrence_id._get_occurrences(event.start):
-                    event_start = event_start.replace(tzinfo=None)
-                    last_found = self.do_check_alarm_for_one_date(event_start, event, max_delta, 0, 'sms', after=last_sms_cron, missing=True)
-                    for alert in last_found:
-                        event.browse(alert['event_id'])._do_sms_reminder()
-                        found = True
-                    if found and not last_found:  # if the precedent event had an alarm but not this one, we can stop the search for this event
-                        break
-            else:
-                event_start = fields.Datetime.from_string(event.start)
-                for alert in self.do_check_alarm_for_one_date(event_start, event, max_delta, 0, 'sms', after=last_sms_cron, missing=True):
-                    event.browse(alert['event_id'])._do_sms_reminder()
+            event_start = fields.Datetime.from_string(event.start)
+            for alert in self.do_check_alarm_for_one_date(event_start, event, max_delta, 0, 'sms', after=last_sms_cron, missing=True):
+                event.browse(alert['event_id'])._do_sms_reminder()
         self.env['ir.config_parameter'].set_param('calendar_sms.last_sms_cron', now)
         return result


### PR DESCRIPTION
STEPS:
* create a recurring event:

  * date: now() - 8 weeks
  * time: now() + 1 hour + 3 minutes
  * Repeat every 1 week, until "now() + 8 weeks"
  * Reminders: "Notification-1 hour", "Email-1 hour", "SMS-1 hour"

* wait 3 minutes
* Run manually cron "Calendar: Event Reminder"
* Wait 0-5 minutes
* Check menu ``[[ Settings ]] >> Technical >> Discuss >> Messages``
* Check menu ``[[ Settings ]] >> Technical >> Phone / SMS >> SMS``

BEFORE: you get mail/sms/UI notifications for all passed dates

AFTER: you get mail/sms/UI notifications only for the comming event

WHY: in v13.0-, recurring calendar.event records were virtual, so
_get_occurrences was used to generate those virtual records. In Odoo v14+ it's not needed

---

opw-2389877

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
