### PR TITLE
[FIX] point_of_sale: Unable to print receipts in POS

### DIFF
--- a/addons/point_of_sale/static/src/css/pos.css
+++ b/addons/point_of_sale/static/src/css/pos.css
@@ -1701,7 +1701,7 @@ td {
         top: 0;
         left: 0;
     }
-    .pos .receipt-screen .pos-receipt-container * {
+    .pos .receipt-screen .pos-receipt-container, .pos .receipt-screen .pos-receipt-container  * {
         visibility: visible;
         background: white !important;
         color: black !important;


### PR DESCRIPTION
Steps to reproduce the bug:

- Connect to Odoo on Safari
- Go in the POS
- Make an order O
- Pay O
- Print the receipt of O

Bug:

Nothing was displayed on the receipt

opw:2391810