### PR TITLE
[FIX] website_mass_mailing: use the correct action to obtain token

### DIFF
--- a/addons/website_mass_mailing/static/src/js/website_mass_mailing.js
+++ b/addons/website_mass_mailing/static/src/js/website_mass_mailing.js
@@ -79,7 +79,7 @@ publicWidget.registry.subscribe = publicWidget.Widget.extend({
             return false;
         }
         this.$target.removeClass('o_has_error').find('.form-control').removeClass('is-invalid');
-        const tokenObj = await this._recaptcha.getToken('website_form');
+        const tokenObj = await this._recaptcha.getToken('website_mass_mailing_subscribe');
         if (tokenObj.error) {
             self.displayNotification({
                 type: 'danger',


### PR DESCRIPTION
Before this commit the "subscribe to newsletter" form was using the
action of the website form to obtain its reCaptcha token, while the
validation of the token was done on a specific subscribe action.

After this commit the "subscribe to newsletter" form is using its own
action that matches the one used for validation.

Fixes https://github.com/odoo/odoo/issues/62504

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
