### PR TITLE
[FIX] website_mass_mailing: fix newsletter popup

### DIFF
--- a/addons/website_mass_mailing/__manifest__.py
+++ b/addons/website_mass_mailing/__manifest__.py
@@ -10,7 +10,7 @@ On a simple click, your visitors can subscribe to mailing lists managed in the E
     """,
     'version': '1.0',
     'category': 'Website/Website',
-    'depends': ['website', 'mass_mailing'],
+    'depends': ['website', 'mass_mailing', 'google_recaptcha'],
     'data': [
         'security/ir.model.access.csv',
         'views/website_mass_mailing_templates.xml',


### PR DESCRIPTION
When we "Install Newsletter Popup" from website editor
(which installs the 'mass_mailing' app), the snippet popup
doesn't open after setting a Newsletter.

This is because the code at 'website_mass_mailing' module
which has the following config:
    'depends': ['website', 'mass_mailing'],
    'auto_install': True,
Requires 'google_recaptcha.ReCaptchaV3' while 'google_recaptcha'
module is not installed.

The goal of this PR is to fix this issue by setting
'google_recaptcha' as a dependency for the 'mass_mailing' module.

task-2312878

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
