### PR TITLE
[FIX] core: fix conversion of ORM value with milliseconds to datetime

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1818,7 +1818,14 @@ class Datetime(Field):
             return datetime.combine(value, time.min)
 
         # TODO: fix data files
-        return datetime.strptime(value, DATETIME_FORMAT[:len(value)-2])
+        try:
+            return datetime.strptime(value, DATETIME_FORMAT[:len(value)-2])
+        except ValueError as e:
+            # ignore milliseconds part if there is one
+            splitted_value = value.split('.')
+            if len(splitted_value) == 2:
+                return datetime.strptime(splitted_value[0], DATETIME_FORMAT[:len(splitted_value[0]) - 2])
+            raise e
 
     # kept for backwards compatibility, but consider `from_string` as deprecated, will probably
     # be removed after V12


### PR DESCRIPTION
- Install Studio
- Go to Settings > Users & Companies > Users
- Activate Studio and create a Report
- In Report tab, create a Paper format
- Once created, go back to Dashboard and export Cuztomizations
- /!\ The exported paperformat has a datetime field with milliseconds (i.e. 2020-12-02 08:00:00.123456)
- Try to import Cuztomizations in another DB (in this use case, the datetime field is handled on the second try)
A ValueError (unconverted data remains: .123456) is raised.

The ORM method converting string to datetime does not support milliseconds.

opw-2379754

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
