### PR TITLE
[FIX] website_blog: not include new tags in existing tags list

### DIFF
--- a/addons/website_blog/static/src/js/website_blog.editor.js
+++ b/addons/website_blog/static/src/js/website_blog.editor.js
@@ -367,7 +367,8 @@ options.registry.BlogPostTagSelection = options.Class.extend({
         }
         const $select = $(uiFragment.querySelector('we-select[data-name="blog_existing_tag_opt"]'));
         for (const [key, tag] of Object.entries(this.allTagsByID)) {
-            if (this.tagIDs.includes(parseInt(key))) {
+            if (this.tagIDs.includes(parseInt(key)) || this.tagIDs.includes(key)) {
+                // saved tag keys are numbers, new tag keys are strings
                 continue;
             }
             $select.prepend(qweb.render('website_blog.TagSelectItem', {


### PR DESCRIPTION
Before this commit the existing tags list contained the unsaved newly
added tags.

After this commit the existing tags list does not contain the unsaved
newly added tags.

Fixes https://github.com/odoo/odoo/issues/62647

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
