### PR TITLE
[FIX] hr_holidays: hide archived employee holidays

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -363,7 +363,7 @@
         <field name="view_type">form</field>
         <field name="view_mode">calendar</field>
         <field name="context">{'search_default_year': 1, 'search_default_group_employee': 1}</field>
-        <field name="domain">[('holiday_type','=','employee'), ('state', '!=', 'refuse')]</field>
+        <field name="domain">[('holiday_type','=','employee'), ('state', '!=', 'refuse'), ('user_id.active','=',True)]</field>
         <field name="search_view_id" ref="view_hr_holidays_filter"/>
     </record>
 


### PR DESCRIPTION
When going on Leaves dashboard, if an employee is archived, his leaves
are still displayed.

To reproduce the error:
1. Add time-off to an employee E
2. Archive E
3. Go back to Leaves module

=> The E's leaves are still displayed

They should be hidden.

OPW-2406702
