### PR TITLE
[FIX] l10n_be_edi: fix domain on search product when importing UBL

### DIFF
--- a/addons/l10n_be_edi/models/account_invoice.py
+++ b/addons/l10n_be_edi/models/account_invoice.py
@@ -156,7 +156,7 @@ class AccountInvoice(models.Model):
                     elements = eline.xpath('cac:Item/cac:StandardItemIdentification/cbc:ID[@schemeID=\'GTIN\']', namespaces=namespaces)
                     if elements:
                         product_ean13 = elements[0].text
-                        domains.append([('ean13', '=', product_ean13)])
+                        domains.append([('barcode', '=', product_ean13)])
                     if domains:
                         product = self.env['product.product'].search(expression.OR(domains), limit=1)
                         if product:


### PR DESCRIPTION
EAN13 is not a field, barcode is the correct field

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
