### PR TITLE
[FIX] l10n_be_edi: various fixes

### DIFF
--- a/addons/account_edi/tests/common.py
+++ b/addons/account_edi/tests/common.py
@@ -34,6 +34,15 @@ class AccountEdiTestCommon(AccountTestInvoicingCommon):
     def edi_cron(self):
         self.env['account.edi.document'].sudo().with_context(edi_test_mode=True).search([('state', 'in', ('to_send', 'to_cancel'))])._process_documents_web_services()
 
+    def _create_empty_vendor_bill(self):
+        invoice = self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'journal_id': self.company_data['default_journal_purchase'].id,
+        })
+        if 'extract_state' in invoice._fields:
+            invoice.extract_state = 'done'  # prevent ocr
+        return invoice
+
     def update_invoice_from_file(self, module_name, subfolder, filename, invoice):
         file_path = get_module_resource(module_name, subfolder, filename)
         file = open(file_path, 'rb').read()
@@ -58,7 +67,7 @@ class AccountEdiTestCommon(AccountTestInvoicingCommon):
         })
 
         journal_id = self.company_data['default_journal_sale']
-        invoice = journal_id.with_context(default_move_type='in_invoice')._create_invoice_from_single_attachment(attachment)
+        journal_id.with_context(default_move_type='in_invoice')._create_invoice_from_single_attachment(attachment)
 
     def assert_generated_file_equal(self, invoice, expected_values, applied_xpath=None):
         invoice.action_post()

--- a/addons/account_edi_facturx/tests/test_facturx.py
+++ b/addons/account_edi_facturx/tests/test_facturx.py
@@ -214,7 +214,7 @@ class TestAccountEdiFacturx(AccountEdiTestCommon):
     ####################################################
 
     def test_invoice_edi_pdf(self):
-        invoice = self.env['account.move'].with_context(default_move_type='in_invoice').create({})
+        invoice = self._create_empty_vendor_bill()
         invoice_count = len(self.env['account.move'].search([]))
         self.update_invoice_from_file('account_edi_facturx', 'test_file', 'test_facturx.pdf', invoice)
 
@@ -227,7 +227,7 @@ class TestAccountEdiFacturx(AccountEdiTestCommon):
         self.assertEqual(len(self.env['account.move'].search([])), invoice_count + 1)
 
     def test_invoice_edi_xml(self):
-        invoice = self.env['account.move'].with_context(default_move_type='in_invoice').create({})
+        invoice = self._create_empty_vendor_bill()
         invoice_count = len(self.env['account.move'].search([]))
         self.update_invoice_from_file('account_edi_facturx', 'test_file', 'test_facturx.xml', invoice)
 

--- a/addons/account_edi_ubl/models/account_edi_format.py
+++ b/addons/account_edi_ubl/models/account_edi_format.py
@@ -120,11 +120,12 @@ class AccountEdiFormat(models.Model):
                 attachment_name = element.xpath('cbc:ID', namespaces=namespaces)
                 attachment_data = element.xpath('cac:Attachment//cbc:EmbeddedDocumentBinaryObject', namespaces=namespaces)
                 if attachment_name and attachment_data:
+                    text = attachment_data[0].text
                     attachments |= self.env['ir.attachment'].create({
                         'name': attachment_name[0].text,
                         'res_id': invoice.id,
                         'res_model': 'account.move',
-                        'datas': attachment_data[0].text,
+                        'datas': text + '=' * (len(text) % 3),  # Fix incorrect padding
                         'type': 'binary',
                     })
             if attachments:

--- a/addons/l10n_be_edi/__manifest__.py
+++ b/addons/l10n_be_edi/__manifest__.py
@@ -11,7 +11,7 @@ invoices. The UBL standard became the `ISO/IEC 19845
 (cf the `official announce <http://www.prweb.com/releases/2016/01/prweb13186919.htm>`_).
 Belgian e-invoicing uses the UBL 2.0 using the e-fff protocol.
     """,
-    'depends': ['l10n_be', 'account_edi'],
+    'depends': ['l10n_be', 'account_edi_ubl'],
     'data': [
         'data/account_edi_data.xml'
     ],

--- a/addons/l10n_be_edi/tests/test_ubl.py
+++ b/addons/l10n_be_edi/tests/test_ubl.py
@@ -10,7 +10,7 @@ class TestUBL(AccountEdiTestCommon):
         cls.partner_a.vat = 'BE0123456789'
 
     def test_invoice_edi_xml(self):
-        invoice = self.env['account.move'].with_context(default_move_type='in_invoice').create({})
+        invoice = self._create_empty_vendor_bill()
         invoice_count = len(self.env['account.move'].search([]))
         self.update_invoice_from_file('l10n_be_edi', 'test_xml_file', 'efff_test.xml', invoice)
 


### PR DESCRIPTION
Because the Belgian edi format is UBL and therefore dependent of the base module

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
