### PR TITLE
[IMP] account : show newest statement lines first when opening bank journal

### DIFF
--- a/addons/account/views/account_view.xml
+++ b/addons/account/views/account_view.xml
@@ -752,7 +752,7 @@
             <field name="model">account.bank.statement.line</field>
             <field name="priority">8</field>
             <field name="arch" type="xml">
-                <tree string="Statement lines" create="false">
+                <tree string="Statement lines" create="false" default_order="date desc, statement_id desc, sequence desc, id desc">
                     <field name="sequence" readonly="1" invisible="1"/>
                     <field name="statement_id" />
                     <field name="journal_id" invisible="1" />


### PR DESCRIPTION
When opening all the statement lines from a bank journal, the default sequence was used. We change that for a more user-friendly ordering.

Backported and improved version from https://github.com/odoo/odoo/pull/62286