### PR TITLE
[FIX] Fix wrong Italian translation that prevented errors to be prope…

### DIFF
--- a/odoo/addons/base/i18n/it.po
+++ b/odoo/addons/base/i18n/it.po
@@ -30,7 +30,8 @@
 # Léonie Bouchat <lbo@odoo.com>, 2020
 # Martin Trigaux, 2020
 # Sergio Zanchetta <primes2h@gmail.com>, 2020
-# 
+# Silvio Gregorini <silviogregorini@openforce.it>, 2020
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
@@ -14144,7 +14145,7 @@ msgstr "Il campo \"Type\" non può essere modificato nei modelli."
 #: code:addons/base/models/ir_ui_view.py:0
 #, python-format
 msgid "Field %r used in attributes must be present in view but is missing:"
-msgstr "Campo % usato negli attributi mancante, è obbligatorio nella vista:"
+msgstr "Campo %r usato negli attributi mancante, è obbligatorio nella vista:"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_ir_model_fields__help


### PR DESCRIPTION
…rly displayed when updating views

Description of the issue/feature this PR addresses:
Translation mismanagement that causes a wrong error message

Current behavior before PR:
When updating a broken `ir.ui.view` arch definition, an error message should be raised. However, the Italian translation of such error does not match the expected format for Python strings, and so another error is raised, hiding the original one:
```
odoo.tools.convert.ParseError: "%u format: a number is required, not str"
```

Desired behavior after PR is merged:
The error message is correctly parsed and translated in Italian.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
