### PR TITLE
[FIX] web,website_event,l10n_ar/cl/de: fix value of no_marker option

### DIFF
--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -177,7 +177,7 @@
 
                     <!-- (15) Domicilio Comercial -->
                     <br/>
-                    <span t-field="o.partner_id" t-options="{'widget': 'contact', 'fields': ['address'], 'no_marker': true, 'no_tag_br': True}"/>
+                    <span t-field="o.partner_id" t-options="{'widget': 'contact', 'fields': ['address'], 'no_marker': True, 'no_tag_br': True}"/>
 
                     <!-- (16) Responsabilidad AFIP -->
                     <strong>VAT Cond: </strong><span t-field="o.partner_id.l10n_ar_afip_responsibility_type_id"/>

--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -107,7 +107,7 @@
                 <br/>
                 <strong>Address:</strong>
                 <span t-field="o.partner_id"
-                      t-options="{'widget': 'contact', 'fields': ['address'], 'no_marker': true, 'no_tag_br': True}"/>
+                      t-options="{'widget': 'contact', 'fields': ['address'], 'no_marker': True, 'no_tag_br': True}"/>
 
                 <strong>Payment Terms:</strong>
                 <span t-esc="o.invoice_payment_term_id.name or ''"/>

--- a/addons/l10n_de/report/din5008_report.xml
+++ b/addons/l10n_de/report/din5008_report.xml
@@ -79,7 +79,7 @@
                             </div>
 
                             <span t-field="company.partner_id"
-                                t-options='{"widget": "contact", "fields": ["address"], "no_marker": true}'/>
+                                t-options='{"widget": "contact", "fields": ["address"], "no_marker": True}'/>
                             <t t-if="information_block">
                                 <div class="address">
                                     <t t-raw="information_block"/>

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -345,7 +345,7 @@
                     <strong t-field="company.partner_id.name"/>
                 </div>
                 <span t-field="company.partner_id"
-                    t-options='{"widget": "contact", "fields": ["address"], "no_marker": true}'/>
+                    t-options='{"widget": "contact", "fields": ["address"], "no_marker": True}'/>
             </div>
             <div class="clearfix mb8"/>
             </div>
@@ -386,7 +386,7 @@
                     <h4 class="mt0" t-field="company.report_header"/>
                     <div name="company_address" class="float-right mb4">
                         <span class="company_address" t-field="company.partner_id"
-                            t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'/>
+                            t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
                     </div>
                 </div>
             </div>
@@ -449,7 +449,7 @@
                 </div>
                 <div class="col-4 text-right">
                     <span class="company_address" t-field="company.partner_id"
-                        t-options='{"widget": "contact", "fields": ["address"], "no_marker": true}'/>
+                        t-options='{"widget": "contact", "fields": ["address"], "no_marker": True}'/>
                 </div>
                 <div class="col-4">
                     <h4 class="mt0 mb0 text-uppercase" t-field="company.report_header"/>
@@ -479,7 +479,7 @@
             <div class="row">
                 <div class="col-6" name="company_address">
                     <div t-field="company.partner_id"
-                        t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'
+                        t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'
                     />
                 </div>
             </div>

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -203,7 +203,7 @@
                                 <span t-field="event.with_context(tz=event.date_tz).date_begin" t-options="{'time_only': 'true', 'format': 'short'}"/>
                             </time>
                             <!-- Location -->
-                            <div itemprop="location" t-field="event.address_id" t-options="{'widget': 'contact', 'fields': ['city'], 'no_marker': 'true'}"/>
+                            <div itemprop="location" t-field="event.address_id" t-options="{'widget': 'contact', 'fields': ['city'], 'no_marker': True}"/>
                             <div class="mt8 d-flex align-items-center">
                                 <t t-foreach="event.tag_ids" t-as="tag">
                                     <span t-if="tag.color"


### PR DESCRIPTION
- Install Studio
- Enable debug mode
- Go to Apps
- Activate Studio & go to Reports
- Create an External Reports
- Click on Company address
The following error is raised:
"Error: Invalid Prop 'value' in component 'CustomCheckbox'"

"no_marker" option has "true" as value, which is not correctly converted to True Boolean value.

opw-2393926

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
