### PR TITLE
[FIX] mass_mailing, mass_mailing_sms: various mailing views issues

### DIFF
--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -157,7 +157,7 @@
                         <group>
                             <field name="active" invisible="1"/>
                             <field name="mailing_type" widget="radio" options="{'horizontal': true}" invisible="1"
-                                attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
+                                attrs="{'readonly': [('state', '!=', 'draft')]}" force_save="1"/>
                             <field name="subject" string="Subject" attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}" widget="char_emojis" placeholder="e.g. New Sale on all T-shirts"/>
                             <field name="preview" string="Preview Text" attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}" widget="char_emojis" placeholder="e.g. Check it out before it's too late!"/>
                             <label for="mailing_model_id" string="Recipients"/>

--- a/addons/mass_mailing_sms/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_mailing_views.xml
@@ -110,7 +110,8 @@
             </xpath>
             <xpath expr="//page[@name='mail_body']" position="after">
                 <page string="SMS Content" name="sms_body" attrs="{'invisible': [('mailing_type', '!=', 'sms')]}">
-                    <field name="body_plaintext" widget="sms_widget" attrs="{'required': [('mailing_type', '=', 'sms')]}" 
+                    <field name="body_plaintext" widget="sms_widget"
+                        attrs="{'required': [('mailing_type', '=', 'sms')], 'readonly': [('state', 'in', ('sending', 'done'))]}"
                         options='{"enable_emojis": True}'/>
                     <group>
                         <field name="sms_force_send" invisible="1"/>


### PR DESCRIPTION
sms content is made readonly while sent.
Currently sms content can be edited in sent state in mass_mailing.
We should not be able to edit a message content that is once sent
so it is made readonly.

another issue was we shouldnt be able to switch between sms and
email in the mailing type once the draft state is changed. earlier
one can easily turn a sms in queue, sending and done to email also.

task-id: 2390284





