### PR TITLE
[FIX] pos_restaurant: Impossible to print bill

### DIFF
--- a/addons/pos_restaurant/static/src/xml/Screens/BillScreen.xml
+++ b/addons/pos_restaurant/static/src/xml/Screens/BillScreen.xml
@@ -26,7 +26,7 @@
                         <span>Print</span>
                     </div>
                     <div class="pos-receipt-container">
-                        <OrderReceipt order="currentOrder" isBill="true"/>
+                        <OrderReceipt order="currentOrder" isBill="true" t-ref="order-receipt"/>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Steps to reproduce the bug:

1. Install PoS
2. Change the Shop type to "Bar/restaurant" (into its setting) then save
3. Go into the newly created "Bar" settings
4. Enable "Direct devices" (with any IP)
5. Open a session on Bar
6. Pick a table
7. Ignore the "Connection to the printer Failed" error
8. Take a coca
9. Click on the "Bill" button
10. On the Bill Printing screen, pick "Print"

Bug:

A traceback was raised

opw:2382350