### PR TITLE
[IMP] l10n_de: add a logic for the different accounts according to ta…

### DIFF
--- a/addons/l10n_de/models/datev.py
+++ b/addons/l10n_de/models/datev.py
@@ -33,3 +33,25 @@ class AccountMove(models.Model):
                             raise UserError(_('Account %s does not authorize to have tax %s specified on the line. \
                                 Change the tax used in this invoice or remove all taxes from the account') % (account_name, tax.name))
         return super()._post(soft)
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    def _get_product_accounts(self):
+        """ As taxes with a different rate need a different income/expense account, we add this logic in case people only use
+         invoicing to not be blocked by the above constraint"""
+        result = super(ProductTemplate, self)._get_product_accounts()
+        company = self.env.company
+        if company.country_id.code == "DE":
+            if not self.property_account_income_id:
+                taxes = self.taxes_id.filtered(lambda t: t.company_id == company)
+                if not result['income'] or (result['income'].tax_ids and taxes and taxes[0] not in result['income'].tax_ids):
+                    result['income'] = self.env['account.account'].search([('internal_group', '=', 'income'), ('deprecated', '=', False),
+                                                                   ('tax_ids', 'in', taxes.ids)], limit=1)
+            if not self.property_account_expense_id:
+                supplier_taxes = self.supplier_taxes_id.filtered(lambda t: t.company_id == company)
+                if not result['expense'] or (result['expense'].tax_ids and supplier_taxes and supplier_taxes[0] not in result['expense'].tax_ids):
+                    result['expense'] = self.env['account.account'].search([('internal_group', '=', 'expense'), ('deprecated', '=', False),
+                                                                   ('tax_ids', 'in', supplier_taxes.ids)], limit=1)
+        return result


### PR DESCRIPTION
…x rates

Before, when only invoicing is installed (e.g. in case of the PoS), a
not so easy to surpass error would be triggered when using products
with a lower tax rate, e.g. drinks are only at 7% instead of 19%.
Because there is a constraint, upon validation of the invoice, that the
accounts used must correspond with the tax rate and you can not set a
specific account in case of only invoicing, an error will be raised when
you try to validate the generated invoice.

We solve it by inheriting the method searching for the product accounts and
when no income/expense account on the product is set, but a tax is, to suggest
the account corresponding to the tax and its rate.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
