### PR TITLE
[FIX] l10n_fr_fec: follow CompAuxNum for CompAuxLib

### DIFF
--- a/addons/l10n_fr_fec/wizard/account_fr_fec.py
+++ b/addons/l10n_fr_fec/wizard/account_fr_fec.py
@@ -243,7 +243,10 @@ class AccountFrFec(models.TransientModel):
             ELSE ''
             END
             AS CompAuxNum,
-            COALESCE(replace(rp.name, '|', '/'), '') AS CompAuxLib,
+            CASE WHEN aat.type IN ('receivable', 'payable')
+            THEN COALESCE(replace(rp.name, '|', '/'), '')
+            ELSE ''
+            END AS CompAuxLib,
             '-' AS PieceRef,
             %s AS PieceDate,
             '/' AS EcritureLib,
@@ -305,7 +308,10 @@ class AccountFrFec(models.TransientModel):
             ELSE ''
             END
             AS CompAuxNum,
-            COALESCE(replace(replace(rp.name, '|', '/'), '\t', ''), '') AS CompAuxLib,
+            CASE WHEN aat.type IN ('receivable', 'payable')
+            THEN COALESCE(replace(replace(rp.name, '|', '/'), '\t', ''), '')
+            ELSE ''
+            END AS CompAuxLib,
             CASE WHEN am.ref IS null OR am.ref = ''
             THEN '-'
             ELSE replace(replace(am.ref, '|', '/'), '\t', '')


### PR DESCRIPTION
Thos two fields shoulb be the same, following
https://github.com/odoo/odoo/pull/43985




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
