### PR TITLE
[FIX] l10n_es: add missing tax template

### DIFF
--- a/addons/l10n_es/data/account_tax_data.xml
+++ b/addons/l10n_es/data/account_tax_data.xml
@@ -2024,6 +2024,38 @@
             }),
         ]"/>
     </record>
+    <record id="account_tax_template_p_iva0_ns_b" model="account.tax.template">
+        <field name="description">P_IVA0_NS_B</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">IVA Soportado no sujeto (Bienes)</field>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="0"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_iva_0"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+            }),
+
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+            }),
+        ]"/>
+    </record>
     <record id="account_tax_template_s_irpf9" model="account.tax.template">
         <field name="description">Retención 9%</field>
         <field name="type_tax_use">sale</field>


### PR DESCRIPTION
4268a2891e2df9c989d0374da5f8968d60a96360 adds fiscal positions. However,
it refer to a missing tax template.