### PR TITLE
[FIX] survey: no block on return to certification


### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -358,8 +358,12 @@ class Survey(http.Controller):
         if access_data['validity_code'] is not True:
             return self._redirect_with_error(access_data, access_data['validity_code'])
 
+        answer_sudo = access_data['answer_sudo']
+        if answer_sudo.state != 'done' and answer_sudo.survey_time_limit_reached:
+            answer_sudo._mark_done()
+
         return request.render('survey.survey_page_fill',
-            self._prepare_survey_data(access_data['survey_sudo'], access_data['answer_sudo'], **post))
+            self._prepare_survey_data(access_data['survey_sudo'], answer_sudo, **post))
 
     @http.route('/survey/get_background_image/<string:survey_token>/<string:answer_token>', type='http', auth="public", website=True, sitemap=False)
     def survey_get_background(self, survey_token, answer_token):


### PR DESCRIPTION

steps to reproduce:

- start a certification with time limit
- close it and go to it back after time limit +10 seconds is passed

=> an "There was an error during the validation of the survey." appear
   that prevent to finish the survey or do it a second time until the
   ongoing survey.user_input of the user is deleted.

This was done to prevent people from cheating by answering after the
time limit end. With this changeset, when we go back to the survey after
its end, we will finish it without saving the answers.

opw-2390623
