### PR TITLE
[FIX] sale: Wrong lang in terms and conditions

### DIFF
--- a/addons/sale/models/account_invoice.py
+++ b/addons/sale/models/account_invoice.py
@@ -43,7 +43,7 @@ class AccountInvoice(models.Model):
         inv_type = self.type or self.env.context.get('type', 'out_invoice')
         if inv_type == 'out_invoice':
             company = self.company_id or self.env.user.company_id
-            self.comment = company.with_context(lang=self.partner_id.lang).invoice_terms or (self._origin.company_id == company and self.comment)
+            self.comment = company.with_context(lang=self.partner_id.lang or self.env.lang).invoice_terms or (self._origin.company_id == company and self.comment)
 
     @api.multi
     def action_invoice_open(self):


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a configuration with two languages L1 and L2
- Go to Settings / Accounting / Customer Invoice / Default term & condition
- Define a default text T1 and save
- Create a new customer invoice, T1 is displayed in the field narration
- Go to Settings / Accounting / Customer Invoice / Default term & condition
- Change T1 to T2 for L1, L2 and save
- Create a new customer invoice

Bug:

T2 was displayed in the field narration

opw:2388353