### PR TITLE
[IMP] ir_ui_view: Refine error message

### DIFF
--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -2353,7 +2353,7 @@ class TestViews(ViewCase):
                 'arch': arch,
             })
         message = str(catcher.exception.args[0])
-        self.assertIn('\nView name: %s\nError context:\n' % name, message)
+        self.assertEqual(catcher.exception.context['name'], name)
         if expected_message:
             self.assertIn(expected_message, message)
         else:
@@ -2368,7 +2368,8 @@ class TestViews(ViewCase):
             })
         self.assertEqual(len(log_catcher.output), 1, "Exactly one warning should be logged")
         message = log_catcher.output[0]
-        self.assertIn('\nView name: %s\nError context:\n' % name, message)
+        self.assertIn('View error context', message)
+        self.assertIn("'name': '%s'" % name, message)
         if expected_message:
             self.assertIn(expected_message, message)
 


### PR DESCRIPTION
When installing/upgrading a module with broken xml views, the module
installation fails with an error message that should help the developer
locate and correct the error.

Before this commit, a 3-level traceback was thrown at the developer:

1. The initial ValueError containing the original error message and some
   view context information.
2. The noisy re-cast of the ValueError to a ValidationError with no
   additionnal information.
3. An additionnal re-cast of the exception to add the original source
   file path plus the entire XML source code that failed to be parsed.

We argue the error contains too much noise as developers are mostly
interrested in correcting their erronous tag of their view, they are not
interrested in `ir_ui_view` internals.

The new exception report is much less talkative, the two tracebacks from
`ir_ui_view` are logged at the `DEBUG` level. The new exception still
contains the original error message with some context on the view record
and the original source file path but it only show 5 lines of XML around
the erronous tag.

Task: 2366612

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
