### PR TITLE
[FIX] website_hr_recruitment: remove fa-fw classes in rating snippets

### DIFF
--- a/addons/website_hr_recruitment/data/hr_job_demo.xml
+++ b/addons/website_hr_recruitment/data/hr_job_demo.xml
@@ -24,11 +24,11 @@
                                 <h6 class="s_rating_title">Customer Relationship</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
                                     </span>
@@ -38,11 +38,11 @@
                                 <h6 class="s_rating_title">Personal Evolution</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
                                     </span>
@@ -52,13 +52,13 @@
                                 <h6 class="s_rating_title">Autonomy</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
-                                        <i class="fa fa-fw fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
                                     </span>
                                 </div>
                             </div>
@@ -66,13 +66,13 @@
                                 <h6 class="s_rating_title">Administrative Work</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
-                                        <i class="fa fa-fw fa-star-o"/>
-                                        <i class="fa fa-fw fa-star-o"/>
-                                        <i class="fa fa-fw fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
                                     </span>
                                 </div>
                             </div>
@@ -80,11 +80,11 @@
                                 <h6 class="s_rating_title">Technical Expertise</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
                                     </span>
@@ -251,11 +251,11 @@
                                 <h6 class="s_rating_title">Customer Relationship</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
                                     </span>
@@ -265,11 +265,11 @@
                                 <h6 class="s_rating_title">Personal Evolution</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
                                     </span>
@@ -279,13 +279,13 @@
                                 <h6 class="s_rating_title">Autonomy</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
-                                        <i class="fa fa-fw fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
                                     </span>
                                 </div>
                             </div>
@@ -293,13 +293,13 @@
                                 <h6 class="s_rating_title">Administrative Work</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
-                                        <i class="fa fa-fw fa-star-o"/>
-                                        <i class="fa fa-fw fa-star-o"/>
-                                        <i class="fa fa-fw fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
                                     </span>
                                 </div>
                             </div>
@@ -307,11 +307,11 @@
                                 <h6 class="s_rating_title">Technical Expertise</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
                                     </span>
@@ -478,11 +478,11 @@
                                 <h6 class="s_rating_title">Customer Relationship</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
                                     </span>
@@ -492,11 +492,11 @@
                                 <h6 class="s_rating_title">Personal Evolution</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
                                     </span>
@@ -506,13 +506,13 @@
                                 <h6 class="s_rating_title">Autonomy</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
-                                        <i class="fa fa-fw fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
                                     </span>
                                 </div>
                             </div>
@@ -520,13 +520,13 @@
                                 <h6 class="s_rating_title">Administrative Work</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
-                                        <i class="fa fa-fw fa-star-o"/>
-                                        <i class="fa fa-fw fa-star-o"/>
-                                        <i class="fa fa-fw fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
                                     </span>
                                 </div>
                             </div>
@@ -534,11 +534,11 @@
                                 <h6 class="s_rating_title">Technical Expertise</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
                                     </span>
@@ -704,11 +704,11 @@
                                 <h6 class="s_rating_title">Customer Relationship</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
                                     </span>
@@ -718,11 +718,11 @@
                                 <h6 class="s_rating_title">Personal Evolution</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
                                     </span>
@@ -732,13 +732,13 @@
                                 <h6 class="s_rating_title">Autonomy</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
-                                        <i class="fa fa-fw fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
                                     </span>
                                 </div>
                             </div>
@@ -746,13 +746,13 @@
                                 <h6 class="s_rating_title">Administrative Work</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
-                                        <i class="fa fa-fw fa-star-o"/>
-                                        <i class="fa fa-fw fa-star-o"/>
-                                        <i class="fa fa-fw fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
                                     </span>
                                 </div>
                             </div>
@@ -760,11 +760,11 @@
                                 <h6 class="s_rating_title">Technical Expertise</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
                                     </span>
@@ -930,11 +930,11 @@
                                 <h6 class="s_rating_title">Customer Relationship</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
                                     </span>
@@ -944,11 +944,11 @@
                                 <h6 class="s_rating_title">Personal Evolution</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
                                     </span>
@@ -958,13 +958,13 @@
                                 <h6 class="s_rating_title">Autonomy</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
-                                        <i class="fa fa-fw fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
                                     </span>
                                 </div>
                             </div>
@@ -972,13 +972,13 @@
                                 <h6 class="s_rating_title">Administrative Work</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
-                                        <i class="fa fa-fw fa-star-o"/>
-                                        <i class="fa fa-fw fa-star-o"/>
-                                        <i class="fa fa-fw fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
                                     </span>
                                 </div>
                             </div>
@@ -986,11 +986,11 @@
                                 <h6 class="s_rating_title">Technical Expertise</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
                                     </span>
@@ -1156,11 +1156,11 @@
                                 <h6 class="s_rating_title">Customer Relationship</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
                                     </span>
@@ -1170,11 +1170,11 @@
                                 <h6 class="s_rating_title">Personal Evolution</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
                                     </span>
@@ -1184,13 +1184,13 @@
                                 <h6 class="s_rating_title">Autonomy</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
-                                        <i class="fa fa-fw fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
                                     </span>
                                 </div>
                             </div>
@@ -1198,13 +1198,13 @@
                                 <h6 class="s_rating_title">Administrative Work</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
-                                        <i class="fa fa-fw fa-star-o"/>
-                                        <i class="fa fa-fw fa-star-o"/>
-                                        <i class="fa fa-fw fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
                                     </span>
                                 </div>
                             </div>
@@ -1212,11 +1212,11 @@
                                 <h6 class="s_rating_title">Technical Expertise</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
                                     </span>
@@ -1382,11 +1382,11 @@
                                 <h6 class="s_rating_title">Customer Relationship</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
                                     </span>
@@ -1396,11 +1396,11 @@
                                 <h6 class="s_rating_title">Personal Evolution</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
                                     </span>
@@ -1410,13 +1410,13 @@
                                 <h6 class="s_rating_title">Autonomy</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
-                                        <i class="fa fa-fw fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
                                     </span>
                                 </div>
                             </div>
@@ -1424,13 +1424,13 @@
                                 <h6 class="s_rating_title">Administrative Work</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
-                                        <i class="fa fa-fw fa-star-o"/>
-                                        <i class="fa fa-fw fa-star-o"/>
-                                        <i class="fa fa-fw fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
+                                        <i class="fa fa-star-o"/>
                                     </span>
                                 </div>
                             </div>
@@ -1438,11 +1438,11 @@
                                 <h6 class="s_rating_title">Technical Expertise</h6>
                                 <div class="s_rating_icons o_not_editable">
                                     <span class="s_rating_active_icons text-primary">
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
-                                        <i class="fa fa-fw fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
+                                        <i class="fa fa-star"/>
                                     </span>
                                     <span class="s_rating_inactive_icons text-primary">
                                     </span>

--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -257,11 +257,11 @@
                         <h6 class="s_rating_title">Customer Relationship</h6>
                         <div class="s_rating_icons o_not_editable">
                             <span class="s_rating_active_icons text-primary">
-                                <i class="fa fa-fw fa-star"/>
-                                <i class="fa fa-fw fa-star"/>
-                                <i class="fa fa-fw fa-star"/>
-                                <i class="fa fa-fw fa-star"/>
-                                <i class="fa fa-fw fa-star"/>
+                                <i class="fa fa-star"/>
+                                <i class="fa fa-star"/>
+                                <i class="fa fa-star"/>
+                                <i class="fa fa-star"/>
+                                <i class="fa fa-star"/>
                             </span>
                             <span class="s_rating_inactive_icons text-primary">
                             </span>
@@ -271,11 +271,11 @@
                         <h6 class="s_rating_title">Personal Evolution</h6>
                         <div class="s_rating_icons o_not_editable">
                             <span class="s_rating_active_icons text-primary">
-                                <i class="fa fa-fw fa-star"/>
-                                <i class="fa fa-fw fa-star"/>
-                                <i class="fa fa-fw fa-star"/>
-                                <i class="fa fa-fw fa-star"/>
-                                <i class="fa fa-fw fa-star"/>
+                                <i class="fa fa-star"/>
+                                <i class="fa fa-star"/>
+                                <i class="fa fa-star"/>
+                                <i class="fa fa-star"/>
+                                <i class="fa fa-star"/>
                             </span>
                             <span class="s_rating_inactive_icons text-primary">
                             </span>
@@ -285,13 +285,13 @@
                         <h6 class="s_rating_title">Autonomy</h6>
                         <div class="s_rating_icons o_not_editable">
                             <span class="s_rating_active_icons text-primary">
-                                <i class="fa fa-fw fa-star"/>
-                                <i class="fa fa-fw fa-star"/>
-                                <i class="fa fa-fw fa-star"/>
-                                <i class="fa fa-fw fa-star"/>
+                                <i class="fa fa-star"/>
+                                <i class="fa fa-star"/>
+                                <i class="fa fa-star"/>
+                                <i class="fa fa-star"/>
                             </span>
                             <span class="s_rating_inactive_icons text-primary">
-                                <i class="fa fa-fw fa-star-o"/>
+                                <i class="fa fa-star-o"/>
                             </span>
                         </div>
                     </div>
@@ -299,13 +299,13 @@
                         <h6 class="s_rating_title">Administrative Work</h6>
                         <div class="s_rating_icons o_not_editable">
                             <span class="s_rating_active_icons text-primary">
-                                <i class="fa fa-fw fa-star"/>
-                                <i class="fa fa-fw fa-star"/>
+                                <i class="fa fa-star"/>
+                                <i class="fa fa-star"/>
                             </span>
                             <span class="s_rating_inactive_icons text-primary">
-                                <i class="fa fa-fw fa-star-o"/>
-                                <i class="fa fa-fw fa-star-o"/>
-                                <i class="fa fa-fw fa-star-o"/>
+                                <i class="fa fa-star-o"/>
+                                <i class="fa fa-star-o"/>
+                                <i class="fa fa-star-o"/>
                             </span>
                         </div>
                     </div>
@@ -313,11 +313,11 @@
                         <h6 class="s_rating_title">Technical Expertise</h6>
                         <div class="s_rating_icons o_not_editable">
                             <span class="s_rating_active_icons text-primary">
-                                <i class="fa fa-fw fa-star"/>
-                                <i class="fa fa-fw fa-star"/>
-                                <i class="fa fa-fw fa-star"/>
-                                <i class="fa fa-fw fa-star"/>
-                                <i class="fa fa-fw fa-star"/>
+                                <i class="fa fa-star"/>
+                                <i class="fa fa-star"/>
+                                <i class="fa fa-star"/>
+                                <i class="fa fa-star"/>
+                                <i class="fa fa-star"/>
                             </span>
                             <span class="s_rating_inactive_icons text-primary">
                             </span>


### PR DESCRIPTION
In a previous commit, fa-fw classes have been removed from the rating
snippet but we forgot to remove it also in the job descriptions
templates.

task-2312878

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
