### PR TITLE
[FIX] web: don't select all records when 1 group selected


### DIFF
--- a/addons/web/static/src/js/views/list/list_renderer.js
+++ b/addons/web/static/src/js/views/list/list_renderer.js
@@ -1038,7 +1038,8 @@ var ListRenderer = BasicRenderer.extend({
         this.selection = [];
         var self = this;
         var $inputs = this.$('tbody .o_list_record_selector input:visible:not(:disabled)');
-        var allChecked = $inputs.length > 0;
+        var $closedHeaders = this.$('tbody .o_group_header.o_group_has_content:not(.o_group_open)');
+        var allChecked = $inputs.length > 0 && $closedHeaders.length === 0;
         $inputs.each(function (index, input) {
             if (input.checked) {
                 self.selection.push($(input).closest('tr').data('id'));

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -1335,8 +1335,8 @@ QUnit.module('Views', {
 
         await testUtils.dom.click(list.$('.o_group_header:first()'));
 
-        assert.ok(list.$('thead .o_list_record_selector input')[0].checked,
-            "Head selector should be checked");
+        assert.ok(!list.$('thead .o_list_record_selector input')[0].checked,
+            "Head selector should be unchecked");
 
         list.destroy();
     });


### PR DESCRIPTION

In the grouped list view, when you select all report of the only opened
group (but other group are closed):

- in 12.0: you will only select the selected records
- in 13.0: you will select all records
- in 14.0: you will only select the selected records and there is a way
  to select them all, eg. "1 selected -> Select all 42"

With this changeset, we make a special case in 13.0 so only the selected
records are selected.

Without the change, added test fails with:

 "Head selector should be unchecked"

after we select only 1 out of the 4 records.

opw-2399935
