### PR TITLE
[FIX] product: deletion of attributes values

### DIFF
--- a/addons/product/models/product_attribute.py
+++ b/addons/product/models/product_attribute.py
@@ -79,6 +79,8 @@ class ProductAttribute(models.Model):
                     _("You cannot delete the attribute %s because it is used on the following products:\n%s") %
                     (pa.display_name, ", ".join(pa.product_tmpl_ids.mapped('display_name')))
                 )
+            for value in pa.value_ids:
+                value.unlink()
         return super(ProductAttribute, self).unlink()
 
 


### PR DESCRIPTION
If a user has deleted some product attributes and tries to reimport
them, an error message is displayed

To reproduce the error:
(Need sale_management)
1. Sales > Configuration > Attributes
2. Favorites, Import records
3. Load File
	- Select a file with product attributes
	- (Hint: an example is provided in the ticket)
4. Import
5. Back to Attributes, select the imported ones
6. Action, Delete, OK
7. Repeat steps 1-3
8. Click on "Test"

=> An error is raised.

It should be possible to reimport some deleted attributes.

OPW-2409649