### PR TITLE
[IMP] stock,mrp: replenishment qty using PO and MO UoM

### DIFF
--- a/addons/mrp/models/stock_orderpoint.py
+++ b/addons/mrp/models/stock_orderpoint.py
@@ -75,6 +75,16 @@ class StockWarehouseOrderpoint(models.Model):
             res[orderpoint.id] = orderpoint.product_id.uom_id._compute_quantity(product_qty, orderpoint.product_uom, round=False)
         return res
 
+    def _get_qty_multiple_to_order(self):
+        """ Calculates the minimum quantity that can be ordered according to the qty and UoM of the BoM
+        """
+        self.ensure_one()
+        qty_multiple_to_order = super()._get_qty_multiple_to_order()
+        if 'manufacture' in self.rule_ids.mapped('action'):
+            bom = self.env['mrp.bom']._bom_find(product=self.product_id, bom_type='normal')
+            return bom.product_uom_id._compute_quantity(bom.product_qty, self.product_uom)
+        return qty_multiple_to_order
+
     def _set_default_route_id(self):
         route_id = self.env['stock.rule'].search([
             ('action', '=', 'manufacture')

--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -153,6 +153,8 @@
                     <group>
                         <group>
                             <field name="active" invisible="1"/>
+                            <field name="allowed_route_ids" invisible="1"/>
+                            <field name="route_id" invisible="1"/>
                             <field name="product_id"/>
                             <label for="product_min_qty"/>
                             <div class="o_row">


### PR DESCRIPTION
The replenishement creation currently calculates the quantity to order using the product UoM. If the product is actually purchased in another UoM (f.ex. a roll of 50 meters that is after sold meter by meter), it is preferable to set the quantity to order according to the purchase UoM (50 meters instead of 1 meter) or according to the UoM of the BoM in case of manufacturing.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
