### PR TITLE
[FIX] sale_coupon: avoid double consuming of coupon

### DIFF
--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -52,6 +52,8 @@ class SaleOrder(models.Model):
         res = super(SaleOrder, self).action_cancel()
         self.generated_coupon_ids.write({'state': 'expired'})
         self.applied_coupon_ids.write({'state': 'new'})
+        self.applied_coupon_ids.sales_order_id = False
+        self.recompute_coupon_lines()
         return res
 
     def action_draft(self):

--- a/addons/sale_coupon/tests/test_program_with_code_operations.py
+++ b/addons/sale_coupon/tests/test_program_with_code_operations.py
@@ -66,6 +66,65 @@ class TestProgramWithCodeOperations(TestSaleCouponCommon):
         self.assertEqual(len(order.order_line.ids), 0)
         self.assertEqual(coupon.state, 'new')
 
+    def test_program_coupon_double_consuming(self):
+        # Test case:
+        # - Generate a coupon
+        # - add to a sale order A, cancel the sale order
+        # - add to a sale order B, confirm the order
+        # - go back to A, reset to draft and confirm
+
+        self.code_promotion_program.reward_type = 'discount'
+
+        self.env['sale.coupon.generate'].with_context(active_id=self.code_promotion_program.id).create({
+            'generation_type': 'nbr_coupon',
+            'nbr_coupons': 1,
+        }).generate_coupon()
+        coupon = self.code_promotion_program.coupon_ids
+
+        sale_order_a = self.empty_order.copy()
+        sale_order_b = self.empty_order.copy()
+
+        sale_order_a.write({'order_line': [
+            (0, False, {
+                'product_id': self.product_A.id,
+                'name': '1 Product A',
+                'product_uom': self.uom_unit.id,
+                'product_uom_qty': 1.0,
+            })
+        ]})
+        self.env['sale.coupon.apply.code'].with_context(active_id=sale_order_a.id).create({
+            'coupon_code': coupon.code
+        }).process_coupon()
+        sale_order_a.recompute_coupon_lines()
+        self.assertEqual(len(sale_order_a.order_line.ids), 2)
+        self.assertEqual(coupon.state, 'used')
+        self.assertEqual(coupon.sales_order_id, sale_order_a)
+
+        sale_order_a.action_cancel()
+
+        sale_order_b.write({'order_line': [
+            (0, False, {
+                'product_id': self.product_A.id,
+                'name': '1 Product A',
+                'product_uom': self.uom_unit.id,
+                'product_uom_qty': 1.0,
+            })
+        ]})
+        self.env['sale.coupon.apply.code'].with_context(active_id=sale_order_b.id).create({
+            'coupon_code': coupon.code
+        }).process_coupon()
+        sale_order_b.recompute_coupon_lines()
+        self.assertEqual(len(sale_order_b.order_line.ids), 2)
+        self.assertEqual(coupon.state, 'used')
+        self.assertEqual(coupon.sales_order_id, sale_order_b)
+
+        sale_order_b.action_confirm()
+
+        sale_order_a.action_draft()
+        sale_order_a.action_confirm()
+        # reward line removed automatically
+        self.assertEqual(len(sale_order_a.order_line.ids), 1)
+
     def test_coupon_code_with_pricelist(self):
         # Test case: Generate a coupon (10% discount) and apply it on an order with a specific pricelist (10% discount)
 


### PR DESCRIPTION
Create a coupon code
use it in a quote A
cancel the quote A
use it in a quote B
confirm B
go back to quote A
set to quotation
confirm

Result: you used the coupon code twice

opw-2410684

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
