### PR TITLE
[13.0 stock_account] FIX: access for read on stock.valuation.layer

### DIFF
--- a/addons/stock_account/security/ir.model.access.csv
+++ b/addons/stock_account/security/ir.model.access.csv
@@ -2,4 +2,5 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_account_account_stock_manager,account.account stock manager,account.model_account_account,stock.group_stock_manager,1,0,0,0
 access_stock_picking_invoicing_payments,stock.picking,stock.model_stock_picking,account.group_account_invoice,1,1,1,0
 access_stock_move_invoicing_payments,stock.move,model_stock_move,account.group_account_invoice,1,1,1,0
+access_stock_valuation_layer_all,access_stock_valuation_layer_all,model_stock_valuation_layer,base.group_user,1,0,0,0
 access_stock_valuation_layer,access_stock_valuation_layer,model_stock_valuation_layer,stock.group_stock_manager,1,1,1,0


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Create 1 user only with Groups: purchase user, inventory user, sale user

![image](https://user-images.githubusercontent.com/7775116/100920996-f1749980-34a9-11eb-972f-4403cc83940a.png)

Create 1 product with Internal category as Valuation automatic and Cost method AVG

![image](https://user-images.githubusercontent.com/7775116/100921039-018c7900-34aa-11eb-905e-de5dcb88f11c.png)

Create a purchase order and receive product

Create a Sale order with new product and confirm

To Validate picking get following error
![image](https://user-images.githubusercontent.com/7775116/100920930-d3a73480-34a9-11eb-97d7-64e42064d9b6.png)


**Current behavior before PR:**

**Desired behavior after PR is merged:**


@sle-odoo can you help me with this PR please??


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
