### PR TITLE
[FIX] base_address_city : find by zip, helper if you have city with same name

### DIFF
--- a/addons/base_address_city/models/res_city.py
+++ b/addons/base_address_city/models/res_city.py
@@ -7,10 +7,37 @@ from odoo import fields, models
 class City(models.Model):
     _name = 'res.city'
     _description = 'City'
-    _order = 'name'
+    _order = 'name, zipcode, state_id, country_id, id'
 
     name = fields.Char("Name", required=True, translate=True)
     zipcode = fields.Char("Zip")
     country_id = fields.Many2one('res.country', string='Country', required=True)
     state_id = fields.Many2one(
         'res.country.state', 'State', domain="[('country_id', '=', country_id)]")
+    
+    def name_get(self):
+        if not self.env.context.get('helper_search_city'):
+            return super().name_get()
+        res = []
+        for city in self:
+            name = [city.name]
+            if city.zipcode:
+                name.append(city.zipcode)
+            if city.state_id:
+                name.append(city.state_id.name)
+            if city.country_id:
+                name.append(city.country_id.name)
+            res.append((city.id, ', '.join(name)))
+         return res
+
+    @api.model
+    def name_search(self, name='', args=None, operator='ilike', limit=100):
+        self = self.with_context(helper_search_city=True)
+        if args is None:
+            args = []
+        if name and operator == 'ilike':
+            recs = self.search(
+                [('zipcode', 'ilike', name)] + args, limit=limit)
+            if recs:
+                return recs.name_get()
+        return super(City, self).name_search(name=name, args=args, operator=operator, limit=limit)

--- a/addons/base_address_city/models/res_city.py
+++ b/addons/base_address_city/models/res_city.py
@@ -28,7 +28,7 @@ class City(models.Model):
             if city.country_id:
                 name.append(city.country_id.name)
             res.append((city.id, ', '.join(name)))
-         return res
+        return res
 
     @api.model
     def name_search(self, name='', args=None, operator='ilike', limit=100):

--- a/addons/base_address_city/models/res_city.py
+++ b/addons/base_address_city/models/res_city.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import fields, models, api
 
 
 class City(models.Model):


### PR DESCRIPTION
In France, you can have some city with same name but with a different zip code, exemple :
PARIS 75001, France
PARIS 75002, France
Paris, MI, 49338, USA

When you search Paris (in field city_id of a partner), you don't witch Paris it is. This PR add the full name of city (with zip and country, when you search).
Before:
![image](https://user-images.githubusercontent.com/16716992/100932544-518c2f80-34ec-11eb-8813-ab66f6bd1f2a.png)

After:
![image](https://user-images.githubusercontent.com/16716992/100932609-6799f000-34ec-11eb-8e4d-2fe59a4f4ce7.png)


And you can search by zipcode a city.
![image](https://user-images.githubusercontent.com/16716992/100932658-7da7b080-34ec-11eb-8a16-9a9f14afee94.png)


@tivisse 
@alexis-via 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
