### PR TITLE
[FIX] website_form,website_crm: Contact us Form builder have always default parameters

### DIFF
--- a/addons/website_crm/__init__.py
+++ b/addons/website_crm/__init__.py
@@ -3,3 +3,10 @@
 
 from . import controllers
 from . import models
+
+from odoo import api, SUPERUSER_ID
+
+def uninstall_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    model = env['ir.model'].search([('website_form_key', '=', "create_lead")])
+    model.write({'website_form_access' : False})

--- a/addons/website_crm/__manifest__.py
+++ b/addons/website_crm/__manifest__.py
@@ -23,4 +23,5 @@ This module includes contact phone and mobile numbers validation.""",
     'qweb': ['static/src/xml/*.xml'],
     'installable': True,
     'auto_install': True,
+    'uninstall_hook': "uninstall_hook",
 }

--- a/addons/website_crm/views/website_crm_templates.xml
+++ b/addons/website_crm/views/website_crm_templates.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
         <template id="contactus_form" name="Contact Form (Opportunity)" inherit_id="website_form.contactus_form" customize_show="True">
-            <xpath expr="//form[@id='contactus_form']" position="replace">
+            <xpath expr="//div[@id='contactus_form_section']" position="replace">
                 <div t-ignore="true">
                     <form action="/website_form/" method="post" data-model_name="crm.lead" data-success_page="/contactus-thank-you" class="s_website_form container-fluid mt32" enctype="multipart/form-data" data-editable-form="false">
                         <div class="form-group row form-field o_website_form_required_custom">

--- a/addons/website_form/views/website_form_templates.xml
+++ b/addons/website_form/views/website_form_templates.xml
@@ -3,70 +3,72 @@
 
     <template id="contactus_form" name="Contact Form" inherit_id="website.contactus" customize_show="True">
         <xpath expr="//div[@name='mail_button']" position="replace">
-            <form id="contactus_form" t-ignore="true" action="/website_form/" method="post" data-model_name="mail.mail" class="s_website_form container-fluid mt32" enctype="multipart/form-data" data-success_page="/contactus-thank-you">
-                <div class="form-group row form-field o_website_form_custom o_website_form_required_custom">
-                    <div class="col-lg-3 col-md-4">
-                        <label class="col-form-label" for="Name">Your Name</label>
+            <div id="contactus_form_section" t-ignore="true">
+                <form id="contactus_form" action="/website_form/" method="post" data-model_name="mail.mail" class="s_website_form container-fluid mt32" enctype="multipart/form-data" data-success_page="/contactus-thank-you">
+                    <div class="form-group row form-field o_website_form_custom o_website_form_required_custom">
+                        <div class="col-lg-3 col-md-4">
+                            <label class="col-form-label" for="Name">Your Name</label>
+                        </div>
+                        <div class="col-lg-7 col-md-8">
+                            <input type="text" class="form-control o_website_form_input" name="Name" required=""/>
+                        </div>
                     </div>
-                    <div class="col-lg-7 col-md-8">
-                        <input type="text" class="form-control o_website_form_input" name="Name" required=""/>
+                    <div class="form-group row form-field o_website_form_custom">
+                        <div class="col-lg-3 col-md-4">
+                            <label class="col-form-label" for="Phone">Phone Number</label>
+                        </div>
+                        <div class="col-lg-7 col-md-8">
+                            <input type="text" class="form-control o_website_form_input" name="Phone"/>
+                        </div>
                     </div>
-                </div>
-                <div class="form-group row form-field o_website_form_custom">
-                    <div class="col-lg-3 col-md-4">
-                        <label class="col-form-label" for="Phone">Phone Number</label>
+                    <div class="form-group row form-field o_website_form_required_custom">
+                        <div class="col-lg-3 col-md-4">
+                            <label class="col-form-label" for="email_from">Email</label>
+                        </div>
+                        <div class="col-lg-7 col-md-8">
+                            <input type="email" class="form-control o_website_form_input" name="email_from" required=""/>
+                        </div>
                     </div>
-                    <div class="col-lg-7 col-md-8">
-                        <input type="text" class="form-control o_website_form_input" name="Phone"/>
+                    <div class="form-group row form-field o_website_form_custom">
+                        <div class="col-lg-3 col-md-4">
+                            <label class="col-form-label" for="Partner Name">Your Company</label>
+                        </div>
+                        <div class="col-lg-7 col-md-8">
+                            <input type="text" class="form-control o_website_form_input" name="Partner Name"/>
+                        </div>
                     </div>
-                </div>
-                <div class="form-group row form-field o_website_form_required_custom">
-                    <div class="col-lg-3 col-md-4">
-                        <label class="col-form-label" for="email_from">Email</label>
+                    <div class="form-group row form-field o_website_form_required_custom">
+                        <div class="col-lg-3 col-md-4">
+                            <label class="col-form-label" for="subject">Subject</label>
+                        </div>
+                        <div class="col-lg-7 col-md-8">
+                            <input type="text" class="form-control o_website_form_input" name="subject" required=""/>
+                        </div>
                     </div>
-                    <div class="col-lg-7 col-md-8">
-                        <input type="email" class="form-control o_website_form_input" name="email_from" required=""/>
+                    <div class="form-group row form-field o_website_form_custom o_website_form_required_custom">
+                        <div class="col-lg-3 col-md-4">
+                            <label class="col-form-label" for="Description">Your Question</label>
+                        </div>
+                        <div class="col-lg-7 col-md-8">
+                            <textarea class="form-control o_website_form_input" name="Description" required=""></textarea>
+                        </div>
                     </div>
-                </div>
-                <div class="form-group row form-field o_website_form_custom">
-                    <div class="col-lg-3 col-md-4">
-                        <label class="col-form-label" for="Partner Name">Your Company</label>
+                    <div class="form-group row form-field d-none">
+                        <div class="col-lg-3 col-md-4">
+                            <label class="col-form-label" for="email_to">Email To</label>
+                        </div>
+                        <div class="col-lg-7 col-md-8">
+                            <input type="hidden" class="form-control o_website_form_input" name="email_to" t-att-value="res_company.email"/>
+                        </div>
                     </div>
-                    <div class="col-lg-7 col-md-8">
-                        <input type="text" class="form-control o_website_form_input" name="Partner Name"/>
+                    <div class="form-group row">
+                        <div class="offset-lg-3 offset-md-4 col-md-8 col-lg-7">
+                            <a href="#" class="btn btn-primary btn-lg o_website_form_send">Send</a>
+                            <span id="o_website_form_result"></span>
+                        </div>
                     </div>
-                </div>
-                <div class="form-group row form-field o_website_form_required_custom">
-                    <div class="col-lg-3 col-md-4">
-                        <label class="col-form-label" for="subject">Subject</label>
-                    </div>
-                    <div class="col-lg-7 col-md-8">
-                        <input type="text" class="form-control o_website_form_input" name="subject" required=""/>
-                    </div>
-                </div>
-                <div class="form-group row form-field o_website_form_custom o_website_form_required_custom">
-                    <div class="col-lg-3 col-md-4">
-                        <label class="col-form-label" for="Description">Your Question</label>
-                    </div>
-                    <div class="col-lg-7 col-md-8">
-                        <textarea class="form-control o_website_form_input" name="Description" required=""></textarea>
-                    </div>
-                </div>
-                <div class="form-group row form-field d-none">
-                    <div class="col-lg-3 col-md-4">
-                        <label class="col-form-label" for="email_to">Email To</label>
-                    </div>
-                    <div class="col-lg-7 col-md-8">
-                        <input type="hidden" class="form-control o_website_form_input" name="email_to" t-att-value="res_company.email"/>
-                    </div>
-                </div>
-                <div class="form-group row">
-                    <div class="offset-lg-3 offset-md-4 col-md-8 col-lg-7">
-                        <a href="#" class="btn btn-primary btn-lg o_website_form_send">Send</a>
-                        <span id="o_website_form_result"></span>
-                    </div>
-                </div>
-            </form>
+                </form>
+            </div>
         </xpath>
     </template>
 


### PR DESCRIPTION
Issue

	- Install 'Ecommerce' module
	- Go to "Contact us" page
	- Open Editor and click on form to edit it
	- On sidebar, click on "Change Form Parameters"
	- Change "Action" to "Sales Order"
	- Save the changes
	- Edit the page again
	- On sidebar, click again on "Change Form Parameters"

	"Action" is to to the default value ("Send an E-mail")

Cause

	't-ignore' is set to 'true' on the form and therefore doesn't update
	the 'data-model_name' attribute who got the ref model to set the right action.

Solution

	Set 't-ignore' on a div around the form and remove it from the form.

opw-2393241