### PR TITLE
[13.0][IMP] l10n_latam_invoice_document: journal use document constraint bypass

### DIFF
--- a/addons/l10n_latam_invoice_document/models/account_journal.py
+++ b/addons/l10n_latam_invoice_document/models/account_journal.py
@@ -27,7 +27,7 @@ class AccountJournal(models.Model):
 
     @api.constrains('l10n_latam_use_documents')
     def check_use_document(self):
-        for rec in self:
+        for rec in self.filtered(lambda journal: not journal.env.context.get("allow_documents", False)):
             if rec.env['account.move'].search([('journal_id', '=', rec.id), ('state', '!=', 'draft')], limit=1):
                 raise ValidationError(_(
                     'You can not modify the field "Use Documents?" if there are validated invoices in this journal!'))


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Allow bypass journals `l10n_latam_use_documents` field constraint using a "allow_documents" key in the context.

**Current behavior before PR:**
Can't set journals for sales or purchase as "use document" after migrate database from v12 to v13

**Desired behavior after PR is merged:**
Have a bypass option to be used, for example, on a script to fill all fields included on **l10n_latam_invoice_document** module, which needs `l10n_latam_use_documents` boolean to be set to `True`.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
