### PR TITLE
[FIX] account_payment: Online invoice button has "Pending" instead of "Pay Now"

### DIFF
--- a/addons/account_payment/views/account_portal_templates.xml
+++ b/addons/account_payment/views/account_portal_templates.xml
@@ -7,7 +7,7 @@
             <td class="text-center">
                 <t t-set="tx_ids" t-value="invoice.transaction_ids.filtered(lambda tx: tx.state in ('pending', 'authorized', 'done'))"/>
                 <t t-set="pending_manual_txs" t-value="tx_ids.filtered(lambda tx: tx.state == 'pending' and tx.acquirer_id.provider in ('transfer', 'manual'))"/>
-                <a t-if="invoice.state == 'posted' and invoice.invoice_payment_state == 'not_paid' and invoice.amount_total and invoice.type == 'out_invoice' and (pending_manual_txs or not tx_ids)"
+                <a t-if="invoice.state == 'posted' and invoice.invoice_payment_state == 'not_paid' and invoice.amount_total and invoice.type == 'out_invoice' and (pending_manual_txs or not tx_ids or invoice.amount_residual)"
                     t-att-href="invoice.get_portal_url(anchor='portal_pay')" title="Pay Now" aria-label="Pay now" class="btn btn-sm btn-primary" role="button">
                     <i class="fa fa-arrow-circle-right"/><span class='d-none d-md-inline'> Pay Now</span>
                 </a>
@@ -36,7 +36,7 @@
     </template>
 
     <template id="portal_invoice_payment" name="Invoice Payment">
-        <div class="row" t-if="not tx_ids and invoice.state == 'posted' and invoice.invoice_payment_state == 'not_paid' and invoice.amount_total" id="portal_pay">
+        <div class="row" t-if="(invoice.amount_residual or not tx_ids) and invoice.state == 'posted' and invoice.invoice_payment_state == 'not_paid' and invoice.amount_total" id="portal_pay">
             <div class="modal fade" id="pay_with" role="dialog">
                 <div class="modal-dialog">
                     <div class="modal-content">
@@ -71,11 +71,11 @@
             <t t-set="tx_ids" t-value="invoice.transaction_ids.filtered(lambda tx: tx.state in ('pending', 'authorized', 'done'))"/>
             <t t-set="pending_manual_txs" t-value="tx_ids.filtered(lambda tx: tx.state == 'pending' and tx.acquirer_id.provider in ('transfer', 'manual'))"/>
             <div>
-                <a href="#" t-if="invoice.state == 'posted' and invoice.invoice_payment_state == 'not_paid' and invoice.amount_total and invoice.type == 'out_invoice' and (pending_manual_txs or not tx_ids)"
+                <a href="#" t-if="invoice.state == 'posted' and invoice.invoice_payment_state == 'not_paid' and invoice.amount_total and invoice.type == 'out_invoice' and (pending_manual_txs or not tx_ids or invoice.amount_residual)"
                     class="btn btn-primary btn-block mb-2" data-toggle="modal" data-target="#pay_with">
                     <i class="fa fa-fw fa-arrow-circle-right"/> Pay Now
                 </a>
-                <div t-if="tx_ids and not pending_manual_txs and invoice.invoice_payment_state != 'paid'" class="alert alert-info py-1 mb-2" >
+                <div t-if="tx_ids and not pending_manual_txs and not invoice.amount_residual and invoice.invoice_payment_state != 'paid'" class="alert alert-info py-1 mb-2" >
                     <i class="fa fa-fw fa-check-circle"/> Pending
                 </div>
                 <div t-if="invoice.invoice_payment_state == 'paid'" class="alert alert-success py-1 mb-2" >
@@ -91,7 +91,7 @@
                 </t>
             </div>
             <t t-set="tx_ids" t-value="invoice.transaction_ids.filtered(lambda tx: tx.state in ('authorized', 'done'))"/>
-            <div t-if="not tx_ids and invoice.state == 'posted' and invoice.invoice_payment_state == 'not_paid' and invoice.amount_total" id="portal_pay">
+            <div t-if="(invoice.amount_residual or not tx_ids) and invoice.state == 'posted' and invoice.invoice_payment_state == 'not_paid' and invoice.amount_total" id="portal_pay">
                 <div t-if="pms or acquirers" id="payment_method">
                     <t t-call="account_payment.portal_invoice_payment"/>
                 </div>


### PR DESCRIPTION
Issue

	- Create SO
	- Send quote to customer
	- Customer pays via CC (payment should be in "done" stage and SO is confirmed)
	- Add shipping to the SO
	- Create invoice and send invoice via email

	Customer does not see a pay button in the preview, instead they see "pending".

Cause

	Does not check if still residual amount in the invoice.

Solution

	If still residual amount, show 'Pay button' and allow to pay.

opw-2392401