### PR TITLE
[FIX] sale_timesheet,project: Removed links to the documents

### DIFF
--- a/addons/project/views/res_config_settings_views.xml
+++ b/addons/project/views/res_config_settings_views.xml
@@ -38,7 +38,6 @@
                                 </div>
                                 <div class="o_setting_right_pane">
                                     <label for="group_project_rating"/>
-                                    <a href="https://www.odoo.com/documentation/user/14.0/project/advanced/feedback.html" title="Documentation" class="o_doc_link" target="_blank"></a>
                                     <div class="text-muted">
                                         Track customer satisfaction on tasks
                                     </div>

--- a/addons/sale_timesheet/views/res_config_settings_views.xml
+++ b/addons/sale_timesheet/views/res_config_settings_views.xml
@@ -13,7 +13,6 @@
                     <div class="col-12 col-lg-6 o_setting_box" id="time_billing_setting">
                         <div class="o_setting_right_pane">
                             <span class="o_form_label">Time Billing</span>
-                            <a href="https://www.odoo.com/documentation/user/14.0/project/advanced/so_to_task.html" title="Documentation" class="o_doc_link" target="_blank"></a>
                             <div class="text-muted">
                                 Sell services and invoice time spent
                             </div>


### PR DESCRIPTION
In this commit the links to Time Billing and Customer Rating's documents
in timesheet and project respectively are removed.

TaskID:2411098

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
