### PR TITLE
[IMP] account: Set accounting date to today when posting before lock date

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1538,8 +1538,8 @@ class AccountMove(models.Model):
             if move._affect_tax_report() and move.company_id.tax_lock_date and move.date and move.date <= move.company_id.tax_lock_date:
                 move.tax_lock_date_message = _(
                     "The accounting date is set prior to the tax lock date which is set on %s. "
-                    "Hence, the accounting date will be changed to the next available date when posting.",
-                    format_date(self.env, move.company_id.tax_lock_date))
+                    "Hence, the accounting date will be changed to %s.",
+                    format_date(self.env, move.company_id.tax_lock_date), format_date(self.env, fields.Date.context_today(self)))
             else:
                 move.tax_lock_date_message = False
 
@@ -2441,11 +2441,11 @@ class AccountMove(models.Model):
                 move.invoice_date = fields.Date.context_today(self)
                 move.with_context(check_move_validity=False)._onchange_invoice_date()
 
-            # When the accounting date is prior to the tax lock date, move it automatically to the next available date.
+            # When the accounting date is prior to the tax lock date, move it automatically to today.
             # /!\ 'check_move_validity' must be there since the dynamic lines will be recomputed outside the 'onchange'
             # environment.
             if (move.company_id.tax_lock_date and move.date <= move.company_id.tax_lock_date) and (move.line_ids.tax_ids or move.line_ids.tax_tag_ids):
-                move.date = move.company_id.tax_lock_date + timedelta(days=1)
+                move.date = fields.Date.context_today(self)
                 move.with_context(check_move_validity=False)._onchange_currency()
 
         # Create the analytic lines in batch is faster as it leads to less cache invalidation.

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -7,6 +7,7 @@ from odoo.exceptions import UserError
 
 from unittest.mock import patch
 from datetime import timedelta
+from freezegun import freeze_time
 
 
 @tagged('post_install', '-at_install')
@@ -2138,8 +2139,9 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
                 'amount_total': 1430.0,
             })
 
+    @freeze_time('2017-01-15')
     def test_out_invoice_post_2(self):
-        ''' Check the date will be set automatically at the next available post date due to the tax lock date. '''
+        ''' Check the date will be set automatically at today due to the tax lock date. '''
         # Create an invoice with rate 1/3.
         move = self.env['account.move'].create({
             'move_type': 'out_invoice',
@@ -2183,7 +2185,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         })
 
         # Set the tax lock date:
-        # - The date must be set automatically at the date after the tax_lock_date.
+        # - The date must be set automatically at the date of today (2017-01-15).
         # - As the date changed, the currency rate has changed (1/3 => 1/2).
         move.company_id.tax_lock_date = fields.Date.from_string('2016-12-31')
 
@@ -2237,7 +2239,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             **self.move_vals,
             'payment_reference': move.name,
             'currency_id': self.currency_data['currency'].id,
-            'date': fields.Date.from_string('2017-01-01'),
+            'date': fields.Date.from_string('2017-01-15'),
             'amount_untaxed': 1200.0,
             'amount_tax': 230.0,
             'amount_total': 1430.0,


### PR DESCRIPTION
When posting an account move before the tax lock date, Odoo will
automatically set its accounting date to the lock date + 1.

This can cause the chronology to be broken, which is not something we
want when automatically setting the date.

This will change that behavior to set the accounting date to today in
such case.

Task id #2411150

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
