### PR TITLE
[FIX] mail: call check_access_rule correctly

### DIFF
--- a/addons/mail/models/mail_followers.py
+++ b/addons/mail/models/mail_followers.py
@@ -76,7 +76,7 @@ class Followers(models.Model):
                 obj.check_access_rule('write')
                 subject = record.channel_id or record.partner_id
                 subject.check_access_rights('read')
-                subject.check_access_rule('read ')
+                subject.check_access_rule('read')
             else:
                 obj.check_access_rights('read')
                 obj.check_access_rule('read')


### PR DESCRIPTION
Before this commit there was an option to get an error because there is a space after read.
This mistake was introduced by xmo-odoo at 443517005639aaab0c5859d26b161848f7c5cf00

Description of the issue/feature this PR addresses: Fixes a invalid move 'read' error.

Current behavior before PR: In https://github.com/odoo/odoo/commit/443517005639aaab0c5859d26b161848f7c5cf00 @xmo-odoo introduce a bug with there is an invalid space in there. This causes an error:
![image](https://user-images.githubusercontent.com/6352350/100995763-80d88600-3558-11eb-834c-8ff5841e5bc3.png)


Desired behavior after PR is merged: The code works fine again and no read error is thrown :)


Fixes https://github.com/odoo/odoo/issues/62710
Closes https://github.com/odoo/odoo/issues/62710


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
