### PR TITLE
[FIX] website: use currentTarget onLangChangeClick

### DIFF
--- a/addons/website/static/src/js/content/website_root.js
+++ b/addons/website/static/src/js/content/website_root.js
@@ -102,7 +102,7 @@ var WebsiteRoot = publicRootData.PublicRoot.extend({
     _onLangChangeClick: function (ev) {
         ev.preventDefault();
 
-        var $target = $(ev.target);
+        var $target = $(ev.currentTarget);
         // retrieve the hash before the redirect
         var redirect = {
             lang: $target.data('url_code'),


### PR DESCRIPTION
Before this commit, in case of Google Translate is enable, some content
can be wrapped in extra node.

Use currentTarget is more secure to get the right element clicked.

**Steps to reproduce:**
1. Add a website and multiple language
2. Create a page in 2 languages
3. Visit the website in Chrome and enable the translation by Google translate
4. Change the language and you should get an error similar to:

Error:
Uncaught TypeError: Cannot read property 'replace' of undefined

Courtesy of @pfranck

This commit closes #61116

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
