### PR TITLE
[IMP] *: clear cache API

### DIFF
--- a/addons/crm_iap_lead_website/models/crm_reveal_rule.py
+++ b/addons/crm_iap_lead_website/models/crm_reveal_rule.py
@@ -84,21 +84,22 @@ class CRMRevealRule(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        self.clear_caches() # Clear the cache in order to recompute _get_active_rules
+        rules = super().create(vals_list)
+        rules and self.clear_caches() # Clear the cache in order to recompute _get_active_rules
         self._assert_geoip()
-        return super().create(vals_list)
+        return rules
 
     def write(self, vals):
         fields_set = {
             'country_ids', 'regex_url', 'active'
         }
         if set(vals.keys()) & fields_set:
-            self.clear_caches() # Clear the cache in order to recompute _get_active_rules
+            self and self.clear_caches() # Clear the cache in order to recompute _get_active_rules
         self._assert_geoip()
         return super(CRMRevealRule, self).write(vals)
 
     def unlink(self):
-        self.clear_caches() # Clear the cache in order to recompute _get_active_rules
+        self and self.clear_caches() # Clear the cache in order to recompute _get_active_rules
         return super(CRMRevealRule, self).unlink()
 
     def _compute_lead_count(self):

--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -70,7 +70,7 @@ class GoogleSync(models.AbstractModel):
     def write(self, vals):
         google_service = GoogleCalendarService(self.env['google.service'])
         if 'google_id' in vals:
-            self._from_google_ids.clear_cache(self)
+            self.clear_caches()
         synced_fields = self._get_google_synced_fields()
         if 'need_sync' not in vals and vals.keys() & synced_fields and not self.env.user.google_synchronization_stopped:
             vals['need_sync'] = True
@@ -85,7 +85,7 @@ class GoogleSync(models.AbstractModel):
     @api.model_create_multi
     def create(self, vals_list):
         if any(vals.get('google_id') for vals in vals_list):
-            self._from_google_ids.clear_cache(self)
+            self.clear_caches()
         if self.env.user.google_synchronization_stopped:
             for vals in vals_list:
                 vals.update({'need_sync': False})

--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -70,7 +70,7 @@ class GoogleSync(models.AbstractModel):
     def write(self, vals):
         google_service = GoogleCalendarService(self.env['google.service'])
         if 'google_id' in vals:
-            self.clear_caches()
+            self and self.clear_caches()
         synced_fields = self._get_google_synced_fields()
         if 'need_sync' not in vals and vals.keys() & synced_fields and not self.env.user.google_synchronization_stopped:
             vals['need_sync'] = True

--- a/addons/mail/models/mail_message_subtype.py
+++ b/addons/mail/models/mail_message_subtype.py
@@ -43,15 +43,16 @@ class MailMessageSubtype(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        self.clear_caches()
-        return super(MailMessageSubtype, self).create(vals_list)
+        subtypes = super().create(vals_list)
+        subtypes and self.clear_caches()
+        return subtypes
 
     def write(self, vals):
-        self.clear_caches()
+        self and self.clear_caches()
         return super(MailMessageSubtype, self).write(vals)
 
     def unlink(self):
-        self.clear_caches()
+        self and self.clear_caches()
         return super(MailMessageSubtype, self).unlink()
 
     @tools.ormcache('model_name')

--- a/addons/microsoft_calendar/models/microsoft_sync.py
+++ b/addons/microsoft_calendar/models/microsoft_sync.py
@@ -72,7 +72,7 @@ class MicrosoftSync(models.AbstractModel):
     def write(self, vals):
         microsoft_service = MicrosoftCalendarService(self.env['microsoft.service'])
         if 'microsoft_id' in vals:
-            self.clear_caches()
+            self and self.clear_caches()
         synced_fields = self._get_microsoft_synced_fields()
         if 'need_sync_m' not in vals and vals.keys() & synced_fields and not self.env.user.microsoft_synchronization_stopped:
             fields_to_sync = [x for x in vals.keys() if x in synced_fields]

--- a/addons/microsoft_calendar/models/microsoft_sync.py
+++ b/addons/microsoft_calendar/models/microsoft_sync.py
@@ -72,7 +72,7 @@ class MicrosoftSync(models.AbstractModel):
     def write(self, vals):
         microsoft_service = MicrosoftCalendarService(self.env['microsoft.service'])
         if 'microsoft_id' in vals:
-            self._from_microsoft_ids.clear_cache(self)
+            self.clear_caches()
         synced_fields = self._get_microsoft_synced_fields()
         if 'need_sync_m' not in vals and vals.keys() & synced_fields and not self.env.user.microsoft_synchronization_stopped:
             fields_to_sync = [x for x in vals.keys() if x in synced_fields]
@@ -94,7 +94,7 @@ class MicrosoftSync(models.AbstractModel):
     @api.model_create_multi
     def create(self, vals_list):
         if any(vals.get('microsoft_id') for vals in vals_list):
-            self._from_microsoft_ids.clear_cache(self)
+            self.clear_caches()
         if self.env.user.microsoft_synchronization_stopped:
             for vals in vals_list:
                 vals.update({'need_sync_m': False})

--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -327,15 +327,15 @@ class ProductProduct(models.Model):
     def create(self, vals_list):
         products = super(ProductProduct, self.with_context(create_product_product=True)).create(vals_list)
         # `_get_variant_id_for_combination` depends on existing variants
-        self.clear_caches()
+        products and self.clear_caches()
         return products
 
     def write(self, values):
         res = super(ProductProduct, self).write(values)
-        if 'product_template_attribute_value_ids' in values:
+        if self and 'product_template_attribute_value_ids' in values:
             # `_get_variant_id_for_combination` depends on `product_template_attribute_value_ids`
             self.clear_caches()
-        if 'active' in values:
+        if self and 'active' in values:
             # prefetched o2m have to be reloaded (because of active_test)
             # (eg. product.template: product_variant_ids)
             self.flush()
@@ -366,7 +366,7 @@ class ProductProduct(models.Model):
         # products due to ondelete='cascade'
         unlink_templates.unlink()
         # `_get_variant_id_for_combination` depends on existing variants
-        self.clear_caches()
+        (unlink_products or unlink_templates) and self.clear_caches()
         return res
 
     def _unlink_or_archive(self, check_access=True):

--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -186,8 +186,9 @@ class View(models.Model):
             for view in self.filtered(lambda view: not view.website_id):
                 specific_views += view._get_specific_views()
 
-        result = super(View, self + specific_views).unlink()
-        self.clear_caches()
+        views_to_unlink = self + specific_views
+        result = super(View, views_to_unlink).unlink()
+        views_to_unlink and self.clear_caches()
         return result
 
     def _create_website_specific_pages_for_view(self, new_view, website):

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -182,7 +182,7 @@ class Website(models.Model):
         public_user_to_change_websites = self.env['website']
         self._handle_favicon(values)
 
-        self.clear_caches()
+        self and self.clear_caches()
 
         if 'company_id' in values and 'user_id' not in values:
             public_user_to_change_websites = self.filtered(lambda w: w.sudo().user_id.company_id.id != values['company_id'])

--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -95,10 +95,12 @@ class Menu(models.Model):
     def write(self, values):
         res = super().write(values)
         if 'website_id' in values or 'group_ids' in values or 'sequence' in values:
-            self.clear_caches()
+            self and self.clear_caches()
         return res
 
     def unlink(self):
+        if not self:
+            return True
         self.clear_caches()
         default_menu = self.env.ref('website.main_menu', raise_if_not_found=False)
         menus_to_remove = self

--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -201,7 +201,7 @@ class Page(models.Model):
     def write(self, vals):
         if 'url' in vals and not vals['url'].startswith('/'):
             vals['url'] = '/' + vals['url']
-        self.clear_caches()  # write on page == write on view that invalid cache
+        self and self.clear_caches()  # write on page == write on view that invalid cache
         return super(Page, self).write(vals)
 
     def get_website_meta(self):

--- a/odoo/addons/base/models/decimal_precision.py
+++ b/odoo/addons/base/models/decimal_precision.py
@@ -35,18 +35,18 @@ class DecimalPrecision(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        res = super(DecimalPrecision, self).create(vals_list)
-        self.clear_caches()
-        return res
+        dps = super().create(vals_list)
+        dps and self.clear_caches()
+        return dps
 
     def write(self, data):
-        res = super(DecimalPrecision, self).write(data)
-        self.clear_caches()
+        res = super().write(data)
+        self and self.clear_caches()
         return res
 
     def unlink(self):
-        res = super(DecimalPrecision, self).unlink()
-        self.clear_caches()
+        res = super().unlink()
+        self and self.clear_caches()
         return res
 
     @api.onchange('digits')

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -43,25 +43,25 @@ class IrActions(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        res = super(IrActions, self).create(vals_list)
+        actions = super().create(vals_list)
         # self.get_bindings() depends on action records
-        self.clear_caches()
-        return res
+        actions and self.clear_caches()
+        return actions
 
     def write(self, vals):
-        res = super(IrActions, self).write(vals)
+        res = super().write(vals)
         # self.get_bindings() depends on action records
-        self.clear_caches()
+        self and self.clear_caches()
         return res
 
     def unlink(self):
         """unlink ir.action.todo which are related to actions which will be deleted.
            NOTE: ondelete cascade will not work on ir.actions.actions so we will need to do it manually."""
-        todos = self.env['ir.actions.todo'].search([('action_id', 'in', self.ids)])
-        todos.unlink()
-        res = super(IrActions, self).unlink()
+        if self:
+            self.env['ir.actions.todo'].search([('action_id', 'in', self.ids)]).unlink()
+        res = super().unlink()
         # self.get_bindings() depends on action records
-        self.clear_caches()
+        self and self.clear_caches()
         return res
 
     @api.model
@@ -251,15 +251,16 @@ class IrActionsActWindow(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        self.clear_caches()
         for vals in vals_list:
             if not vals.get('name') and vals.get('res_model'):
                 vals['name'] = self.env[vals['res_model']]._description
-        return super(IrActionsActWindow, self).create(vals_list)
+        actions = super().create(vals_list)
+        actions and self.clear_caches()
+        return actions
 
     def unlink(self):
-        self.clear_caches()
-        return super(IrActionsActWindow, self).unlink()
+        self and self.clear_caches()
+        return super().unlink()
 
     def exists(self):
         ids = self._existing()

--- a/odoo/addons/base/models/ir_config_parameter.py
+++ b/odoo/addons/base/models/ir_config_parameter.py
@@ -97,13 +97,14 @@ class IrConfigParameter(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        self.clear_caches()
-        return super(IrConfigParameter, self).create(vals_list)
+        params = super().create(vals_list)
+        params and self.clear_caches()
+        return params
 
     def write(self, vals):
-        self.clear_caches()
-        return super(IrConfigParameter, self).write(vals)
+        self and self.clear_caches()
+        return super().write(vals)
 
     def unlink(self):
-        self.clear_caches()
-        return super(IrConfigParameter, self).unlink()
+        self and self.clear_caches()
+        return super().unlink()

--- a/odoo/addons/base/models/ir_default.py
+++ b/odoo/addons/base/models/ir_default.py
@@ -24,18 +24,17 @@ class IrDefault(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        self.clear_caches()
-        return super(IrDefault, self).create(vals_list)
+        defaults = super().create(vals_list)
+        defaults and self.clear_caches()
+        return defaults
 
     def write(self, vals):
-        if self:
-            self.clear_caches()
-        return super(IrDefault, self).write(vals)
+        self and self.clear_caches()
+        return super().write(vals)
 
     def unlink(self):
-        if self:
-            self.clear_caches()
-        return super(IrDefault, self).unlink()
+        self and self.clear_caches()
+        return super().unlink()
 
     @api.model
     def set(self, model_name, field_name, value, user_id=False, company_id=False, condition=False):

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1943,8 +1943,8 @@ class IrModelData(models.Model):
 
     def unlink(self):
         """ Regular unlink method, but make sure to clear the caches. """
-        self.clear_caches()
-        return super(IrModelData, self).unlink()
+        self and self.clear_caches()
+        return super().unlink()
 
     def _lookup_xmlids(self, xml_ids, model):
         """ Look up the given XML ids of the given model. """

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1778,7 +1778,7 @@ class IrModelAccess(models.Model):
     @api.model
     def call_cache_clearing_methods(self):
         self.invalidate_cache()
-        self.check.clear_cache(self)    # clear the cache of check function
+        self.clear_caches()    # clear the ormcache of check function
         for model, method in self.__cache_clearing_methods:
             if model in self.env:
                 getattr(self.env[model], method)()

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -319,8 +319,8 @@ class Module(models.Model):
                 raise UserError(_('You are trying to remove a module that is installed or will be installed.'))
 
     def unlink(self):
-        self.clear_caches()
-        return super(Module, self).unlink()
+        self and self.clear_caches()
+        return super().unlink()
 
     @staticmethod
     def _check_python_external_dependency(pydep):

--- a/odoo/addons/base/models/ir_rule.py
+++ b/odoo/addons/base/models/ir_rule.py
@@ -168,11 +168,6 @@ class IrRule(models.Model):
             yield v
 
     @api.model
-    def clear_cache(self):
-        """ Deprecated, use `clear_caches` instead. """
-        self.clear_caches()
-
-    @api.model
     def domain_get(self, model_name, mode='read'):
         # this method is now unsafe, since it returns a list of tables which
         # does not contain the joins present in the generated Query object

--- a/odoo/addons/base/models/ir_rule.py
+++ b/odoo/addons/base/models/ir_rule.py
@@ -187,17 +187,17 @@ class IrRule(models.Model):
         return [], [], ['"%s"' % self.env[model_name]._table]
 
     def unlink(self):
-        res = super(IrRule, self).unlink()
-        self.clear_caches()
+        res = super().unlink()
+        self and self.clear_caches()
         return res
 
     @api.model_create_multi
     def create(self, vals_list):
-        res = super(IrRule, self).create(vals_list)
+        rules = super().create(vals_list)
         # DLE P33: tests
-        self.flush()
-        self.clear_caches()
-        return res
+        rules and self.flush()
+        rules and self.clear_caches()
+        return rules
 
     def write(self, vals):
         res = super(IrRule, self).write(vals)
@@ -205,8 +205,8 @@ class IrRule(models.Model):
         # - odoo/addons/test_access_rights/tests/test_feedback.py
         # - odoo/addons/test_access_rights/tests/test_ir_rules.py
         # - odoo/addons/base/tests/test_orm.py (/home/dle/src/odoo/master-nochange-fp/odoo/addons/base/tests/test_orm.py)
-        self.flush()
-        self.clear_caches()
+        self and self.flush()
+        self and self.clear_caches()
         return res
 
     def _make_access_error(self, operation, records):

--- a/odoo/addons/base/models/ir_ui_menu.py
+++ b/odoo/addons/base/models/ir_ui_menu.py
@@ -138,14 +138,15 @@ class IrUiMenu(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        self.clear_caches()
         for values in vals_list:
             if 'web_icon' in values:
                 values['web_icon_data'] = self._compute_web_icon_data(values.get('web_icon'))
-        return super(IrUiMenu, self).create(vals_list)
+        menus = super().create(vals_list)
+        menus and self.clear_caches()
+        return menus
 
     def write(self, values):
-        self.clear_caches()
+        self and self.clear_caches()
         if 'web_icon' in values:
             values['web_icon_data'] = self._compute_web_icon_data(values.get('web_icon'))
         return super(IrUiMenu, self).write(values)

--- a/odoo/addons/base/models/ir_ui_menu.py
+++ b/odoo/addons/base/models/ir_ui_menu.py
@@ -20,10 +20,6 @@ class IrUiMenu(models.Model):
     _order = "sequence,id"
     _parent_store = True
 
-    def __init__(self, *args, **kwargs):
-        super(IrUiMenu, self).__init__(*args, **kwargs)
-        self.pool['ir.model.access'].register_cache_clearing_method(self._name, 'clear_caches')
-
     name = fields.Char(string='Menu', required=True, translate=True)
     active = fields.Boolean(default=True)
     sequence = fields.Integer(default=10)

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -491,7 +491,7 @@ actual arch.
             values['arch_prev'] = values.get('arch_base') or values.get('arch_db') or values.get('arch')
             values.update(self._compute_defaults(values))
 
-        self.clear_caches()
+        vals_list and self.clear_caches()
         return super(View, self).create(vals_list)
 
     def write(self, vals):
@@ -506,7 +506,7 @@ actual arch.
         if custom_view:
             custom_view.unlink()
 
-        self.clear_caches()
+        self and self.clear_caches()
         if 'arch_db' in vals and not self.env.context.get('no_save_prev'):
             vals['arch_prev'] = self.arch_db
 

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1613,11 +1613,6 @@ actual arch.
         view = self.sudo().search([('key', '=', template)], limit=1)
         return view and view.id or self.env['ir.model.data'].xmlid_to_res_id(template, raise_if_not_found=True)
 
-    def clear_cache(self):
-        """ Deprecated, use `clear_caches` instead. """
-        if 'xml' not in config['dev_mode']:
-            self.clear_caches()
-
     def _contains_branded(self, node):
         return node.tag == 't'\
             or 't-raw' in node.attrib\

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -224,7 +224,7 @@ class Company(models.Model):
         return company
 
     def write(self, values):
-        self.clear_caches()
+        self and self.clear_caches()
         # Make sure that the selected currency is enabled
         if values.get('currency_id'):
             currency = self.env['res.currency'].browse(values['currency_id'])

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -192,10 +192,6 @@ class Company(models.Model):
         _logger.warning("The method '_company_default_get' on res.company is deprecated and shouldn't be used anymore")
         return self.env.company
 
-    # deprecated, use clear_caches() instead
-    def cache_restart(self):
-        self.clear_caches()
-
     @api.model
     def create(self, vals):
         if not vals.get('favicon'):

--- a/odoo/addons/base/models/res_lang.py
+++ b/odoo/addons/base/models/res_lang.py
@@ -267,7 +267,7 @@ class Lang(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        self.clear_caches()
+        vals_list and self.clear_caches()
         for vals in vals_list:
             if not vals.get('url_code'):
                 vals['url_code'] = vals.get('iso_code') or vals['code']
@@ -286,8 +286,8 @@ class Lang(models.Model):
             self.env['ir.default'].discard_values('res.partner', 'lang', lang_codes)
 
         res = super(Lang, self).write(vals)
-        self.flush()
-        self.clear_caches()
+        self and self.flush()
+        self and self.clear_caches()
         return res
 
     @api.ondelete(at_uninstall=True)
@@ -304,7 +304,7 @@ class Lang(models.Model):
     def unlink(self):
         for language in self:
             self.env['ir.translation'].search([('lang', '=', language.code)]).unlink()
-        self.clear_caches()
+        self and self.clear_caches()
         return super(Lang, self).unlink()
 
     def format(self, percent, value, grouping=False, monetary=False):

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -826,8 +826,6 @@ class Users(models.Model):
                             (SELECT res_id FROM ir_model_data WHERE module=%s AND name=%s)""",
                          (self._uid, module, ext_id))
         return bool(self._cr.fetchone())
-    # for a few places explicitly clearing the has_group cache
-    has_group.clear_cache = _has_group.clear_cache
 
     def action_show_groups(self):
         self.ensure_one()

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -225,7 +225,7 @@ class Groups(models.Model):
         # DLE P139
         if self.ids:
             self.env['ir.model.access'].call_cache_clearing_methods()
-            self.env['res.users'].has_group.clear_cache(self.env['res.users'])
+            self.clear_caches()
         return super(Groups, self).write(vals)
 
 

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -600,7 +600,7 @@ class Users(models.Model):
             *self._get_session_token_fields()
         }
         if (invalidation_fields & values.keys()) or any(key.startswith('context_') for key in values):
-            self.clear_caches()
+            self and self.clear_caches()
 
         return res
 

--- a/odoo/addons/base/tests/test_ormcache.py
+++ b/odoo/addons/base/tests/test_ormcache.py
@@ -17,7 +17,7 @@ class TestOrmcache(TransactionCase):
         miss = counter.miss
 
         # clear the cache of ir.model.data.xmlid_lookup, retrieve its key and
-        IMD.xmlid_lookup.clear_cache(IMD)
+        IMD.clear_caches()
         self.assertNotIn(key, cache)
 
         # lookup some reference


### PR DESCRIPTION
The old cached API allowed to clear the cache of a specific method
but it's not the case anymore.  The ormcache is fully cleared everytime.

Therefore, to ensure the code is not misleading, we replace those targeted cache
clears by the generic clear_caches method, which has the same result but is clearer,
showing that the whole orm cache is cleared anyway.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
