### PR TITLE
[FIX] mrp: allow to use operation on BoM kit

### DIFF
--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -98,7 +98,7 @@
                         </page>
                         <page string="Operations"
                             name="operations"
-                            attrs="{'invisible': [('type', '!=', 'normal')]}"
+                            attrs="{'invisible': [('type', 'not in',('normal','phantom'))]}"
                             groups="mrp.group_mrp_routings">
                                 <field name="operation_ids"
                                     attrs="{'invisible': [('type','not in',('normal','phantom'))]}"


### PR DESCRIPTION
revert of commit 2027721601890870e14b396ae4bb8b6c6dea1ac0
I tried to remove the BoM feature since mrp refactoring it would
probably create some issue and I thought that the feature was not
used. However it seems that it's write in the documentation and
some people really use it so.

opw-2393302
