### PR TITLE
[FIX] purchase: convert standard price currency

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1027,8 +1027,22 @@ class PurchaseOrderLine(models.Model):
         if seller or not self.date_planned:
             self.date_planned = self._get_date_planned(seller).strftime(DEFAULT_SERVER_DATETIME_FORMAT)
 
+        # If not seller, use the standard price. It needs a proper currency conversion.
         if not seller:
-            self.price_unit = self.product_id.standard_price
+            price_unit = self.env['account.tax']._fix_tax_included_price_company(
+                self.product_id.standard_price,
+                self.product_id.supplier_taxes_id,
+                self.taxes_id,
+                self.company_id,
+            )
+            if price_unit and self.order_id.currency_id and self.order_id.company_id.currency_id != self.order_id.currency_id:
+                price_unit = self.order_id.company_id.currency_id._convert(
+                    price_unit,
+                    self.order_id.currency_id,
+                    self.order_id.company_id,
+                    self.date_order or fields.Date.today(),
+                )
+            self.price_unit = price_unit
             return
 
         price_unit = self.env['account.tax']._fix_tax_included_price_company(seller.price, self.product_id.supplier_taxes_id, self.taxes_id, self.company_id) if seller else 0.0


### PR DESCRIPTION
- Activate Multi-Currency, set a rate for a foreign currency
- Create a product with a cost of 10
- Create a PO
- Add the product

The price remains 10: it is not converted in the foreign currency.

Up to 13.0, a price of zero was set if no seller was found. This was
changed in 6b41dbf6831517523d47e to set the standard price instead.
However, no currency conversion is performed.

opw-2394076

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
