### PR TITLE
[FIX] website_sale_delivery: use RPC data for fixed_price

### DIFF
--- a/addons/website_sale_delivery/i18n/website_sale_delivery.pot
+++ b/addons/website_sale_delivery/i18n/website_sale_delivery.pot
@@ -131,6 +131,11 @@ msgid "Last Modified on"
 msgstr ""
 
 #. module: website_sale_delivery
+#: model_terms:ir.ui.view,arch_db:website_sale_delivery.payment_delivery_methods
+msgid "Loading..."
+msgstr ""
+
+#. module: website_sale_delivery
 #: code:addons/website_sale_delivery/controllers/main.py:0
 #, python-format
 msgid ""
@@ -151,11 +156,6 @@ msgstr ""
 #. module: website_sale_delivery
 #: model:ir.model,name:website_sale_delivery.model_sale_order
 msgid "Sales Order"
-msgstr ""
-
-#. module: website_sale_delivery
-#: model_terms:ir.ui.view,arch_db:website_sale_delivery.payment_delivery_methods
-msgid "Select to compute delivery rate"
 msgstr ""
 
 #. module: website_sale_delivery

--- a/addons/website_sale_delivery/views/website_sale_delivery_templates.xml
+++ b/addons/website_sale_delivery/views/website_sale_delivery_templates.xml
@@ -32,18 +32,7 @@
         <input t-att-value="delivery.id" t-att-id="'delivery_%i' % delivery.id" type="radio" name="delivery_type" t-att-checked="order.carrier_id and order.carrier_id.id == delivery.id and 'checked' or False" t-att-class="'d-none' if delivery_nb == 1 else ''"/>
         <label class="label-optional" t-field="delivery.name"/>
         <t t-set='badge_class' t-value="(delivery_nb != 1 and 'float-right ' or '') + 'badge badge-secondary'" />
-        <t t-if="delivery.delivery_type == 'fixed'">
-          <span t-if="delivery.fixed_price > 0.0" t-att-class="badge_class">
-            <t t-esc="delivery.rate_shipment(website_sale_order)['price'] if delivery.free_over else delivery.fixed_price"
-               t-options='{"widget": "monetary",
-                           "from_currency": website_sale_order.currency_id if delivery.free_over else delivery.product_id.company_id.currency_id or website_sale_order.company_id.currency_id,
-                           "display_currency": website_sale_order.currency_id}'/>
-          </span>
-          <span t-else="" t-att-class="badge_class">Free</span>
-        </t>
-        <t t-else="">
-            <span t-attf-class="#{badge_class} o_wsale_delivery_badge_price">Select to compute delivery rate</span>
-        </t>
+        <span t-attf-class="#{badge_class} o_wsale_delivery_badge_price">Loading...</span>
         <t t-if="delivery.website_description">
             <div t-field="delivery.website_description" class="text-muted mt8"/>
         </t>


### PR DESCRIPTION
Steps:
- Install eCommerce
- Go to Website > Configuration > Settings
- Select Pricing > Product Prices > Tax-Included
- Check Shipping > Shipping Costs
- Go to Configuration > eCommerce/Shipping Methods
- Publish Normal Delivery Charges
- Go to the eCommerce
- Add a product to the cart (here, Customizable Desk)
- Click My Cart > Process Checkout
- Select Normal Delivery Charges

Bug:
The delivery price of the Normal Delivery Charges line isn't tax-included.

Explanation:
When we arrive on the delivery selection, prices are computed with an RPC. But delivery methods with a fixed price don't use the RPC results and display the fixed price straight away.
This is a relic of 12.0 where you would have to click on a delivery to see its price. At that time, we tried to display as much info as early as possible (the fixed price was already known).