### PR TITLE
[FIX] mail: clean subqueries when searching error message

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -233,7 +233,8 @@ class MailThread(models.AbstractModel):
 
     @api.model
     def _search_message_has_error(self, operator, operand):
-        return ['&', ('message_ids.has_error', operator, operand), ('message_ids.author_id', '=', self.env.user.partner_id.id)]
+        message_ids = self.env['mail.message']._search([('has_error', operator, operand), ('author_id', '=', self.env.user.partner_id.id)])
+        return [('message_ids', 'in', message_ids)]
 
     def _compute_message_attachment_count(self):
         read_group_var = self.env['ir.attachment'].read_group([('res_id', 'in', self.ids), ('res_model', '=', self._name)],


### PR DESCRIPTION
Thread search with `message_has_error` should only return threads containing
messages with failure of which the current user is author.

Follow up on https://github.com/odoo/odoo/pull/52403 that changed how
sub-queries were built. The current fix using `_search` is a non-ideal solution
until task-2366651 brings a new domain operator for this use case.

task-2409543