### PR TITLE
[FIX] event: fix the event tour when we go outside of Event

### DIFF
--- a/addons/event/static/src/js/tours/event_tour.js
+++ b/addons/event/static/src/js/tours/event_tour.js
@@ -38,41 +38,43 @@ tour.register('event_tour', {
     edition: 'community',
 }, {
     trigger: '.o-kanban-button-new',
+    extra_trigger: '.o_event_kanban_view',
     content: _t("Let's create your first <b>event</b>."),
     position: 'bottom',
     width: 175,
 }, {
-    trigger: 'input[name="name"]',
+    trigger: '.o_event_form_view input[name="name"]',
     content: _t("This is the <b>name</b> your guests will see when registering."),
     run: 'text Odoo Experience 2020',
 }, {
-    trigger: 'input[name="date_end"]',
+    trigger: '.o_event_form_view input[name="date_end"]',
     content: _t("When will your event take place? <b>Select</b> the start and end dates <b>and click Apply</b>."),
     run: function () {
         $('input[name="date_begin"]').val('09/30/2020 08:00:00').change();
         $('input[name="date_end"]').val('10/02/2020 23:00:00').change();
     },
 }, {
-    trigger: 'div[name="event_ticket_ids"] .o_field_x2many_list_row_add a',
+    trigger: '.o_event_form_view div[name="event_ticket_ids"] .o_field_x2many_list_row_add a',
     content: _t("Ticket types allow you to distinguish your attendees. Let's <b>create</b> a new one."),
 }, {
     trigger: '.o_form_button_save',
+    extra_trigger: '.o_event_form_view',
     content: _t("Awesome! Now, let's <b>save</b> your changes."),
     position: 'bottom',
     width: 250,
 }, ...new EventAdditionalTourSteps()._get_website_event_steps(), {
-    trigger: 'div[name="stage_id"] button:contains("Booked")',
+    trigger: '.o_event_form_view div[name="stage_id"] button:contains("Booked")',
     extra_trigger: 'div.o_form_buttons_view:not(.o_hidden)',
     content: _t("Now that your event is ready, click here to move it to another stage."),
     position: 'bottom',
 }, {
     trigger: 'ol.breadcrumb li.breadcrumb-item:first',
-    extra_trigger: 'div[name="stage_id"] button.disabled:contains("Booked")',
+    extra_trigger: '.o_event_form_view div[name="stage_id"] button.disabled:contains("Booked")',
     content: _t("Use the <b>breadcrumbs</b> to go back to your kanban overview."),
     position: 'bottom',
     run: 'click',
 }, {
-    trigger: 'div.o_quick_create_folded',
+    trigger: '.o_event_kanban_view div.o_quick_create_folded',
     content: _t("This pipeline can be customized on the fly to fit your organizational needs. For example, let's create a new stage."),
     position: 'bottom',
     run: function (actions) {
@@ -80,7 +82,7 @@ tour.register('event_tour', {
         $('div.o_kanban_header input[type="text"]').val('New Stage');
     },
 }, {
-    trigger: 'button.o_kanban_add',
+    trigger: '.o_event_kanban_view button.o_kanban_add',
     content: _t("Click <b>add</b> to create a new stage."),
     position: 'bottom',
     width: 200,

--- a/addons/event/views/event_views.xml
+++ b/addons/event/views/event_views.xml
@@ -197,7 +197,7 @@
             <field name="name">event.event.form</field>
             <field name="model">event.event</field>
             <field name="arch" type="xml">
-                <form string="Events">
+                <form string="Events" class="o_event_form_view">
                     <header>
                         <field name="stage_id" widget="statusbar" options="{'clickable': '1'}"/>
                     </header>

--- a/addons/website_event/static/src/js/tours/event_tour.js
+++ b/addons/website_event/static/src/js/tours/event_tour.js
@@ -15,30 +15,34 @@ EventAdditionalTourSteps.include({
     _get_website_event_steps: function () {
         this._super.apply(this, arguments);
         return [{
-                trigger: 'button[name="is_published"]',
+                trigger: '.o_event_form_view button[name="is_published"]',
                 extra_trigger: 'div.o_form_buttons_view:not(.o_hidden)',
                 content: _t("Use this <b>shortcut</b> to easily access your event web page."),
                 position: 'bottom',
             }, {
                 trigger: 'li#edit-page-menu a',
+                extra_trigger: '.o_wevent_event',
                 content: _t("With the Edit button, you can <b>customize</b> the web page visitors will see when registrating."),
                 position: 'bottom',
             }, {
                 trigger: 'div[name="Image - Text"] .oe_snippet_thumbnail',
+                extra_trigger: '.o_wevent_event',
                 content: _t("<b>Drag and Drop</b> this snippet below the event title."),
                 position: 'bottom',
                 run: 'drag_and_drop #o_wevent_event_main_col',
             }, {
                 trigger: 'button[data-action="save"]',
+                extra_trigger: '.o_wevent_event',
                 content: _t("Don't forget to click <b>save</b> when you're done."),
                 position: 'bottom',
             }, {
                 trigger: 'label.js_publish_btn',
+                extra_trigger: '.o_wevent_event',
                 content: _t("Looking great! Let's now <b>publish</b> this page so that it becomes <b>visible</b> on your website!"),
                 position: 'bottom',
             }, {
                 trigger: 'a.css_edit_dynamic',
-                extra_trigger: 'div.o_notification_manager:empty',
+                extra_trigger: '.js_publish_management[data-object="event.event"] .js_publish_btn .css_unpublish:visible',
                 content: _t("Want to change your event configuration? Let's go back to the event form."),
                 position: 'bottom',
                 run: function (actions) {
@@ -46,6 +50,7 @@ EventAdditionalTourSteps.include({
                 },
             }, {
                 trigger: 'a#edit-in-backend',
+                extra_trigger: '.o_wevent_event',
                 content: _t("This shortcut will bring you right back to the event form."),
                 position: 'bottom'
             }];


### PR DESCRIPTION
Bug
===
When we start the Event tour, if we go outside of Event during the tour
we might see the tour bubble in the other application.

It should be visible only in Event.

Task 2381898
