### PR TITLE
[IMP] base: export translation terms in po/pot format by default

### DIFF
--- a/odoo/addons/base/wizard/base_export_language.py
+++ b/odoo/addons/base/wizard/base_export_language.py
@@ -22,7 +22,7 @@ class BaseLanguageExport(models.TransientModel):
     name = fields.Char('File Name', readonly=True)
     lang = fields.Selection(_get_languages, string='Language', required=True, default=NEW_LANG_KEY)
     format = fields.Selection([('csv','CSV File'), ('po','PO File'), ('tgz', 'TGZ Archive')],
-                              string='File Format', required=True, default='csv')
+                              string='File Format', required=True, default='po')
     modules = fields.Many2many('ir.module.module', 'rel_modules_langexport', 'wiz_id', 'module_id',
                                string='Apps To Export', domain=[('state','=','installed')])
     data = fields.Binary('File', readonly=True, attachment=False)


### PR DESCRIPTION
WHY: I'm tired to switch it every time I update pot file in my pull requests

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
