### PR TITLE
[FIX] website_mail: adjust the visibility of the (un)subscribe buttons

### DIFF
--- a/addons/website_mail/static/src/js/follow.js
+++ b/addons/website_mail/static/src/js/follow.js
@@ -85,8 +85,6 @@ publicWidget.registry.follow = publicWidget.Widget.extend({
      * @param {jQuery} $jsFollowEls
      */
     _updateSubscriptionDOM: function (follow, email, $jsFollowEls) {
-        $jsFollowEls.find(".js_follow_btn").toggleClass('d-none', follow);
-        $jsFollowEls.find(".js_unfollow_btn").toggleClass('d-none', !follow);
         $jsFollowEls.find('input.js_follow_email')
             .val(email || "")
             .attr("disabled", email && (follow || this.isUser) ? "disabled" : false);

--- a/addons/website_mail/views/website_mail_templates.xml
+++ b/addons/website_mail/views/website_mail_templates.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="follow">
-        <div class="input-group js_follow" t-att-data-id="object.id"
+        <div t-attf-class="input-group js_follow #{div_class}" t-att-data-id="object.id"
                   t-att-data-object="object._name"
                   t-att-data-follow="object.id and object.message_is_follower and 'on' or 'off'"
                   t-att-data-unsubscribe="'unsubscribe' if 'unsubscribe' in request.params else None">
@@ -22,7 +22,7 @@
                     </div>
                 </button>
             </div>
-            <div t-else="" t-attf-class="#{request.env.user.has_group('base.group_public') and 'input-group-append'} #{div_class}">
+            <div t-else="" t-attf-class="#{request.env.user.has_group('base.group_public') and 'input-group-append'}">
                 <button href="#" t-attf-class="btn btn-secondary js_unfollow_btn">Unsubscribe</button>
                 <button href="#" t-attf-class="btn btn-primary js_follow_btn">Subscribe</button>
             </div>


### PR DESCRIPTION
Before this commit the visibility of the blog (un)subscribe/(un)follow
buttons was behaving inconsistently because of a combination of specific
CSS based on data values and the adding and removal of d-none classes.

After this commit the visibility of the buttons is using only the CSS
mechanism based on data values. Also adjusted the alignment of the email
text input and its attached button (aligned in both blog & forum).

Fixes https://github.com/odoo/odoo/issues/62714

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
