### PR TITLE
[14.0] Fix: _post() method should return in l10n_cl

### DIFF
--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -96,7 +96,7 @@ class AccountMove(models.Model):
 
     def _post(self, soft=True):
         self._check_document_types_post()
-        super()._post(soft)
+        return super()._post(soft)
 
     def _l10n_cl_get_formatted_sequence(self, number=0):
         return '%s %06d' % (self.l10n_latam_document_type_id.doc_code_prefix, number)


### PR DESCRIPTION
### Steps to reproduce:
1. Set the company with country "Argentina"
2. Install modules `account_accountant`, `l10n_ar`, `l10n_ar_edi` and `l10n_cl`
3. Create a new invoice
4. Confirm the inovice
=> TypeError: Mixing apples and oranges: account.move().concat(None)

### Reason:
`_post()` method in `l10n_cl` module does not return any value, so `None` is returned [1]
The return value is used to be concated in `_post()` method in `l10n_ar_edi` moodule [2]

### Solution:
`_post()` method should return `account.move` object

opw-2409156

[1] https://github.com/odoo/odoo/blob/14.0/addons/l10n_cl/models/account_move.py#L99
[2] https://github.com/odoo/enterprise/blob/c814ab1ad67140c9976860fab5ff37e6c713733d/l10n_ar_edi/models/account_move.py#L150

