### PR TITLE
[IMP] account: Add country_id information on tax groups

### DIFF
--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -191,6 +191,20 @@
             </field>
         </record>
 
+        <record id="account_tax_group_view_search" model="ir.ui.view">
+            <field name="name">account.tax.group.search.filters</field>
+            <field name="model">account.tax.group</field>
+            <field name="arch" type="xml">
+                <search string="Search Group">
+                    <field name="name"/>
+                    <field name="country_id"/>
+                    <group string="Group By">
+                        <filter string="Country" name="group_by_country" domain="[]" context="{'group_by': 'country_id'}"/>
+                    </group>
+                </search>
+            </field>
+        </record>
+
         <record id="view_tax_group_tree" model="ir.ui.view">
             <field name="name">account.tax.group.tree</field>
             <field name="model">account.tax.group</field>
@@ -198,6 +212,7 @@
                 <tree string="Account Tax Group" editable="bottom" create="false">
                     <field name="sequence" widget="handle"/>
                     <field name="name"/>
+                    <field name="country_id"/>
                     <field name="property_tax_payable_account_id"/>
                     <field name="property_tax_receivable_account_id"/>
                     <field name="property_advance_tax_payment_account_id"/>

--- a/addons/l10n_ae/data/account_data.xml
+++ b/addons/l10n_ae/data/account_data.xml
@@ -4,12 +4,15 @@
         <!-- Account Tax Group -->
         <record id="ae_tax_group_5" model="account.tax.group">
             <field name="name">Tax 5%</field>
+            <field name="country_id" ref="base.ae"/>
         </record>
         <record id="ae_tax_group_0" model="account.tax.group">
             <field name="name">Tax 0%</field>
+            <field name="country_id" ref="base.ae"/>
         </record>
         <record id="ae_tax_group_exempted" model="account.tax.group">
             <field name="name">Tax Exempted</field>
+            <field name="country_id" ref="base.ae"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_ar/data/account_tax_group.xml
+++ b/addons/l10n_ar/data/account_tax_group.xml
@@ -6,46 +6,55 @@
     <record id="tax_group_iva_21" model="account.tax.group">
         <field name="name">VAT 21%</field>
         <field name="l10n_ar_vat_afip_code">5</field>
+        <field name="country_id" ref="base.ar"/>
     </record>
 
     <record id="tax_group_iva_27" model="account.tax.group">
         <field name="name">VAT 27%</field>
         <field name="l10n_ar_vat_afip_code">6</field>
+        <field name="country_id" ref="base.ar"/>
     </record>
 
     <record id="tax_group_iva_105" model="account.tax.group">
         <field name="name">VAT 10.5%</field>
         <field name="l10n_ar_vat_afip_code">4</field>
+        <field name="country_id" ref="base.ar"/>
     </record>
 
     <record id="tax_group_iva_025" model="account.tax.group">
         <field name="name">VAT 2,5%</field>
         <field name="l10n_ar_vat_afip_code">9</field>
+        <field name="country_id" ref="base.ar"/>
     </record>
 
     <record model="account.tax.group" id="tax_group_iva_no_corresponde">
         <field name="name">VAT Not Applicable</field>
         <field name="l10n_ar_vat_afip_code">0</field>
+        <field name="country_id" ref="base.ar"/>
     </record>
 
     <record model="account.tax.group" id="tax_group_iva_no_gravado">
         <field name="name">VAT Untaxed</field>
         <field name="l10n_ar_vat_afip_code">1</field>
+        <field name="country_id" ref="base.ar"/>
     </record>
 
     <record model="account.tax.group" id="tax_group_iva_exento">
         <field name="name">VAT Exempt</field>
         <field name="l10n_ar_vat_afip_code">2</field>
+        <field name="country_id" ref="base.ar"/>
     </record>
 
     <record model="account.tax.group" id="tax_group_iva_0">
         <field name="name">VAT 0%</field>
         <field name="l10n_ar_vat_afip_code">3</field>
+        <field name="country_id" ref="base.ar"/>
     </record>
 
     <record model="account.tax.group" id="tax_group_iva_5">
         <field name="name">VAT 5%</field>
         <field name="l10n_ar_vat_afip_code">8</field>
+        <field name="country_id" ref="base.ar"/>
     </record>
 
     <!-- Others Taxes -->
@@ -54,12 +63,14 @@
         <field name="name">Otros Impuestos</field>
         <field name="sequence">20</field>
         <field name="l10n_ar_tribute_afip_code">99</field>
+        <field name="country_id" ref="base.ar"/>
     </record>
 
     <record model="account.tax.group" id="tax_impuestos_internos">
         <field name="name">Internal Taxes</field>
         <field name="sequence">15</field>
         <field name="l10n_ar_tribute_afip_code">04</field>
+        <field name="country_id" ref="base.ar"/>
     </record>
 
     <!-- Perceptions and Withholding -->
@@ -67,6 +78,7 @@
     <record model="account.tax.group" id="tax_group_percepcion_iva">
         <field name="name">VAT Perception</field>
         <field name="l10n_ar_tribute_afip_code">06</field>
+        <field name="country_id" ref="base.ar"/>
     </record>
 
     <record model="account.tax.group" id="tax_group_percepcion_iibb_caba">
@@ -193,21 +205,25 @@
         <field name="name">IIBB Perceptions</field>
         <field name="sequence">25</field>
         <field name="l10n_ar_tribute_afip_code">07</field>
+        <field name="country_id" ref="base.ar"/>
     </record>
 
     <record model="account.tax.group" id="tax_group_percepcion_municipal">
         <field name="name">Municipal Taxes Perceptions</field>
         <field name="l10n_ar_tribute_afip_code">08</field>
+        <field name="country_id" ref="base.ar"/>
     </record>
 
     <record model="account.tax.group" id="tax_group_percepcion_ganancias">
         <field name="name">Profit Perceptions</field>
         <field name="l10n_ar_tribute_afip_code">09</field>
+        <field name="country_id" ref="base.ar"/>
     </record>
 
     <record model="account.tax.group" id="tax_group_otras_percepciones">
         <field name="name">Other Perceptions</field>
         <field name="l10n_ar_tribute_afip_code">09</field>
+        <field name="country_id" ref="base.ar"/>
     </record>
 
 </odoo>

--- a/addons/l10n_at/data/account_tax_template.xml
+++ b/addons/l10n_at/data/account_tax_template.xml
@@ -4,15 +4,19 @@
         <!-- Account Tax Group -->
         <record id="tax_group_0" model="account.tax.group">
             <field name="name">VAT 0%</field>
+            <field name="country_id" ref="base.at"/>
         </record>
         <record id="tax_group_10" model="account.tax.group">
             <field name="name">VAT 10%</field>
+            <field name="country_id" ref="base.at"/>
         </record>
         <record id="tax_group_13" model="account.tax.group">
             <field name="name">VAT 13%</field>
+            <field name="country_id" ref="base.at"/>
         </record>
         <record id="tax_group_20" model="account.tax.group">
             <field name="name">VAT 20%</field>
+            <field name="country_id" ref="base.at"/>
         </record>
     </data>
     <data>

--- a/addons/l10n_be/data/account_data.xml
+++ b/addons/l10n_be/data/account_data.xml
@@ -6,18 +6,22 @@
 		<!-- Account Tax Group -->
 		<record id="tax_group_tva_21" model="account.tax.group">
 			<field name="name">TVA 21%</field>
+            <field name="country_id" ref="base.be"/>
 		</record>
 
 		<record id="tax_group_tva_12" model="account.tax.group">
 			<field name="name">TVA 12%</field>
+            <field name="country_id" ref="base.be"/>
 		</record>
 
 		<record id="tax_group_tva_6" model="account.tax.group">
 			<field name="name">TVA 6%</field>
+            <field name="country_id" ref="base.be"/>
 		</record>
 
 		<record id="tax_group_tva_0" model="account.tax.group">
 			<field name="name">TVA 0%</field>
+            <field name="country_id" ref="base.be"/>
 		</record>
 
 	</data>

--- a/addons/l10n_bo/data/account_data.xml
+++ b/addons/l10n_bo/data/account_data.xml
@@ -5,10 +5,12 @@
         <!-- Account Tax Group -->
         <record id="tax_group_iva_13" model="account.tax.group">
             <field name="name">IVA 13%</field>
+            <field name="country_id" ref="base.bo"/>
         </record>
 
         <record id="tax_group_it_3" model="account.tax.group">
             <field name="name">IT 3%</field>
+            <field name="country_id" ref="base.bo"/>
         </record>
 
     </data>

--- a/addons/l10n_br/data/account_data.xml
+++ b/addons/l10n_br/data/account_data.xml
@@ -5,139 +5,184 @@
         <!-- Account Tax Group -->
         <record id="tax_group_icms_0" model="account.tax.group">
             <field name="name">ICMS 0%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_icms_7" model="account.tax.group">
             <field name="name">ICMS 7%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_icms_12" model="account.tax.group">
             <field name="name">ICMS 12%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_icms_19" model="account.tax.group">
             <field name="name">ICMS 19%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_icms_26" model="account.tax.group">
             <field name="name">ICMS 26%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
 
         <record id="tax_group_irpj_0" model="account.tax.group">
             <field name="name">IRPJ 0%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_pis_0" model="account.tax.group">
             <field name="name">PIS 0%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_pis_065" model="account.tax.group">
             <field name="name">PIS 0.65%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_cofins_0" model="account.tax.group">
             <field name="name">COFINS 0%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_cofins_3" model="account.tax.group">
             <field name="name">COFINS 3%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ir_0" model="account.tax.group">
             <field name="name">IR 0%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_issqn_0" model="account.tax.group">
             <field name="name">ISSQN 0%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_issqn_1" model="account.tax.group">
             <field name="name">ISSQN 1%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_issqn_2" model="account.tax.group">
             <field name="name">ISSQN 2%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_issqn_3" model="account.tax.group">
             <field name="name">ISSQN 3%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_issqn_4" model="account.tax.group">
             <field name="name">ISSQN 4%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_issqn_5" model="account.tax.group">
             <field name="name">ISSQN 5%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_csll_0" model="account.tax.group">
             <field name="name">CSLL 0%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ipi_0" model="account.tax.group">
             <field name="name">IPI 0%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ipi_2" model="account.tax.group">
             <field name="name">IPI 2%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ipi_3" model="account.tax.group">
             <field name="name">IPI 3%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ipi_4" model="account.tax.group">
             <field name="name">IPI 4%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ipi_5" model="account.tax.group">
             <field name="name">IPI 5%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ipi_7" model="account.tax.group">
             <field name="name">IPI 7%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ipi_8" model="account.tax.group">
             <field name="name">IPI 8%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ipi_10" model="account.tax.group">
             <field name="name">IPI 10%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ipi_12" model="account.tax.group">
             <field name="name">IPI 12%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ipi_13" model="account.tax.group">
             <field name="name">IPI 13%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ipi_15" model="account.tax.group">
             <field name="name">IPI 15%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ipi_16" model="account.tax.group">
             <field name="name">IPI 16%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ipi_18" model="account.tax.group">
             <field name="name">IPI 18%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ipi_20" model="account.tax.group">
             <field name="name">IPI 20%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ipi_22" model="account.tax.group">
             <field name="name">IPI 22%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ipi_24" model="account.tax.group">
             <field name="name">IPI 24%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ipi_25" model="account.tax.group">
             <field name="name">IPI 25%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ipi_27" model="account.tax.group">
             <field name="name">IPI 27%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ipi_30" model="account.tax.group">
             <field name="name">IPI 30%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ipi_35" model="account.tax.group">
             <field name="name">IPI 35%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ipi_40" model="account.tax.group">
             <field name="name">IPI 40%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ipi_42" model="account.tax.group">
             <field name="name">IPI 42%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ipi_45" model="account.tax.group">
             <field name="name">IPI 45%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ipi_50" model="account.tax.group">
             <field name="name">IPI 50%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ipi_60" model="account.tax.group">
             <field name="name">IPI 60%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ipi_300" model="account.tax.group">
             <field name="name">IPI 300%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
         <record id="tax_group_ipi_330" model="account.tax.group">
             <field name="name">IPI 330%</field>
+            <field name="country_id" ref="base.br"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_ca/data/account_data.xml
+++ b/addons/l10n_ca/data/account_data.xml
@@ -5,33 +5,43 @@
         <!-- Account Tax Group -->
         <record id="tax_group_fix" model="account.tax.group">
             <field name="name">Taxes</field>
+            <field name="country_id" ref="base.ca"/>
         </record>
         <record id="tax_group_gst_5" model="account.tax.group">
             <field name="name">GST 5%</field>
+            <field name="country_id" ref="base.ca"/>
         </record>
         <record id="tax_group_pst_5" model="account.tax.group">
             <field name="name">PST 5%</field>
+            <field name="country_id" ref="base.ca"/>
         </record>
         <record id="tax_group_gst_7" model="account.tax.group">
             <field name="name">GST 7%</field>
+            <field name="country_id" ref="base.ca"/>
         </record>
         <record id="tax_group_gst_8" model="account.tax.group">
             <field name="name">GST 8%</field>
+            <field name="country_id" ref="base.ca"/>
         </record>
         <record id="tax_group_pst_8" model="account.tax.group">
             <field name="name">PST 8%</field>
+            <field name="country_id" ref="base.ca"/>
         </record>
         <record id="tax_group_qst_9975" model="account.tax.group">
             <field name="name">QST 9.975%</field>
+            <field name="country_id" ref="base.ca"/>
         </record>
         <record id="tax_group_hst_13" model="account.tax.group">
             <field name="name">HST 13%</field>
+            <field name="country_id" ref="base.ca"/>
         </record>
         <record id="tax_group_hst_14" model="account.tax.group">
             <field name="name">HST 14%</field>
+            <field name="country_id" ref="base.ca"/>
         </record>
         <record id="tax_group_hst_15" model="account.tax.group">
             <field name="name">HST 15%</field>
+            <field name="country_id" ref="base.ca"/>
         </record>
 
     </data>

--- a/addons/l10n_ch/data/account_data.xml
+++ b/addons/l10n_ch/data/account_data.xml
@@ -5,15 +5,19 @@
         <!-- Account Tax Group -->
         <record id="tax_group_tva_0" model="account.tax.group">
             <field name="name">TVA 0%</field>
+            <field name="country_id" ref="base.ch"/>
         </record>
         <record id="tax_group_tva_25" model="account.tax.group">
             <field name="name">TVA 2.5%</field>
+            <field name="country_id" ref="base.ch"/>
         </record>
         <record id="tax_group_tva_37" model="account.tax.group">
             <field name="name">TVA 3.7%</field>
+            <field name="country_id" ref="base.ch"/>
         </record>
         <record id="tax_group_tva_77" model="account.tax.group">
             <field name="name">TVA 7.7%</field>
+            <field name="country_id" ref="base.ch"/>
         </record>
 
     </data>
@@ -21,6 +25,7 @@
     <data>
         <record id="tax_group_tva_100" model="account.tax.group">
             <field name="name">TVA 100%</field>
+            <field name="country_id" ref="base.ch"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_ch/data/account_data.xml
+++ b/addons/l10n_ch/data/account_data.xml
@@ -19,10 +19,6 @@
             <field name="name">TVA 7.7%</field>
             <field name="country_id" ref="base.ch"/>
         </record>
-
-    </data>
-
-    <data>
         <record id="tax_group_tva_100" model="account.tax.group">
             <field name="name">TVA 100%</field>
             <field name="country_id" ref="base.ch"/>

--- a/addons/l10n_cl/data/account_data.xml
+++ b/addons/l10n_cl/data/account_data.xml
@@ -5,6 +5,7 @@
         <!-- Account Tax Group -->
         <record id="tax_group_iva_19" model="account.tax.group">
             <field name="name">IVA 19%</field>
+            <field name="country_id" ref="base.cl"/>
         </record>
 
     </data>

--- a/addons/l10n_cl/data/account_tax_group_data.xml
+++ b/addons/l10n_cl/data/account_tax_group_data.xml
@@ -5,22 +5,27 @@
 
         <record id="tax_group_iva_19" model="account.tax.group">
             <field name="name">IVA 19%</field>
+            <field name="country_id" ref="base.cl"/>
         </record>
 
         <record id="tax_group_impuestos_especificos" model="account.tax.group">
             <field name="name">Impuestos Específicos</field>
+            <field name="country_id" ref="base.cl"/>
         </record>
 
         <record id="tax_group_ila" model="account.tax.group">
             <field name="name">ILA</field>
+            <field name="country_id" ref="base.cl"/>
         </record>
 
         <record id="tax_group_2da_categ" model="account.tax.group">
             <field name="name">Retención de 2da Categoría</field>
+            <field name="country_id" ref="base.cl"/>
         </record>
 
         <record id="tax_group_retenciones" model="account.tax.group">
             <field name="name">Retenciones</field>
+            <field name="country_id" ref="base.cl"/>
         </record>
 
     </data>

--- a/addons/l10n_cn/data/account_tax_group_data.xml
+++ b/addons/l10n_cn/data/account_tax_group_data.xml
@@ -2,11 +2,14 @@
 <odoo noupdate="1">
     <record id="l10n_cn_tax_group_vat_6" model="account.tax.group">
         <field name="name">VAT 6%</field>
+        <field name="country_id" ref="base.cn"/>
     </record>
     <record id="l10n_cn_tax_group_vat_9" model="account.tax.group">
         <field name="name">VAT 9%</field>
+        <field name="country_id" ref="base.cn"/>
     </record>
     <record id="l10n_cn_tax_group_vat_13" model="account.tax.group">
         <field name="name">VAT 13%</field>
+        <field name="country_id" ref="base.cn"/>
     </record>
 </odoo>

--- a/addons/l10n_cr/data/account_data.xml
+++ b/addons/l10n_cr/data/account_data.xml
@@ -5,6 +5,7 @@
         <!-- Account Tax Group -->
         <record id="tax_group_13" model="account.tax.group">
             <field name="name">Tax 13%</field>
+            <field name="country_id" ref="base.cr"/>
         </record>
 
     </data>

--- a/addons/l10n_cz/data/account_data.xml
+++ b/addons/l10n_cz/data/account_data.xml
@@ -5,12 +5,15 @@
         <!-- Account Tax Group -->
         <record id="tax_group_vat_21" model="account.tax.group">
             <field name="name">DPH 21%</field>
+            <field name="country_id" ref="base.cz"/>
         </record>
         <record id="tax_group_vat_15" model="account.tax.group">
             <field name="name">DPH 15%</field>
+            <field name="country_id" ref="base.cz"/>
         </record>
         <record id="tax_group_vat_0" model="account.tax.group">
             <field name="name">DPH 0%</field>
+            <field name="country_id" ref="base.cz"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_de_skr03/data/account_data.xml
+++ b/addons/l10n_de_skr03/data/account_data.xml
@@ -5,21 +5,27 @@
         <!-- Account Tax Group -->
         <record id="tax_group_0" model="account.tax.group">
             <field name="name">USt 0%</field>
+            <field name="country_id" ref="base.de"/>
         </record>
         <record id="tax_group_7" model="account.tax.group">
             <field name="name">USt 7%</field>
+            <field name="country_id" ref="base.de"/>
         </record>
         <record id="tax_group_55" model="account.tax.group">
             <field name="name">USt 5,5%</field>
+            <field name="country_id" ref="base.de"/>
         </record>
         <record id="tax_group_107" model="account.tax.group">
             <field name="name">USt 10,7%</field>
+            <field name="country_id" ref="base.de"/>
         </record>
         <record id="tax_group_x" model="account.tax.group">
             <field name="name">USt x%</field>
+            <field name="country_id" ref="base.de"/>
         </record>
         <record id="tax_group_19" model="account.tax.group">
             <field name="name">USt 19%</field>
+            <field name="country_id" ref="base.de"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_de_skr04/data/account_data.xml
+++ b/addons/l10n_de_skr04/data/account_data.xml
@@ -5,21 +5,27 @@
         <!-- Account Tax Group -->
         <record id="tax_group_0" model="account.tax.group">
             <field name="name">USt 0%</field>
+            <field name="country_id" ref="base.de"/>
         </record>
         <record id="tax_group_7" model="account.tax.group">
             <field name="name">USt 7%</field>
+            <field name="country_id" ref="base.de"/>
         </record>
         <record id="tax_group_55" model="account.tax.group">
             <field name="name">USt 5,5%</field>
+            <field name="country_id" ref="base.de"/>
         </record>
         <record id="tax_group_107" model="account.tax.group">
             <field name="name">USt 10,7%</field>
+            <field name="country_id" ref="base.de"/>
         </record>
         <record id="tax_group_x" model="account.tax.group">
             <field name="name">USt x%</field>
+            <field name="country_id" ref="base.de"/>
         </record>
         <record id="tax_group_19" model="account.tax.group">
             <field name="name">USt 19%</field>
+            <field name="country_id" ref="base.de"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_do/data/account_data.xml
+++ b/addons/l10n_do/data/account_data.xml
@@ -5,45 +5,59 @@
         <!-- Account Tax Group -->
         <record id="group_itbis" model="account.tax.group">
             <field name="name">ITBIS</field>
+            <field name="country_id" ref="base.do"/>
         </record>
         <record id="group_isr" model="account.tax.group">
             <field name="name">ISR</field>
+            <field name="country_id" ref="base.do"/>
         </record>
         <record id="group_ret" model="account.tax.group">
             <field name="name">Retenciones</field>
+            <field name="country_id" ref="base.do"/>
         </record>
         <record id="group_tax" model="account.tax.group">
             <field name="name">Otros Impuestos</field>
+            <field name="country_id" ref="base.do"/>
         </record>
         <record id="tax_group_isc" model="account.tax.group">
             <field name="name">ISC</field>
+            <field name="country_id" ref="base.do"/>
         </record>
         <record id="tax_group_itbis_0" model="account.tax.group">
             <field name="name">Exento</field>
+            <field name="country_id" ref="base.do"/>
         </record>
         <record id="tax_group_tip" model="account.tax.group">
             <field name="name">Propina</field>
+            <field name="country_id" ref="base.do"/>
         </record>
         <record id="tax_group_itbis_18" model="account.tax.group">
             <field name="name">ITBIS 18%</field>
+            <field name="country_id" ref="base.do"/>
         </record>
         <record id="tax_group_itbis_00015" model="account.tax.group">
             <field name="name">ITBIS 0.0015%</field>
+            <field name="country_id" ref="base.do"/>
         </record>
         <record id="tax_group_retencion_2" model="account.tax.group">
             <field name="name">ISR -2%</field>
+            <field name="country_id" ref="base.do"/>
         </record>
         <record id="tax_group_retencion_10" model="account.tax.group">
             <field name="name">ISR -10%</field>
+            <field name="country_id" ref="base.do"/>
         </record>
         <record id="tax_group_retencion_27" model="account.tax.group">
             <field name="name">ISR -27%</field>
+            <field name="country_id" ref="base.do"/>
         </record>
         <record id="tax_group_retencion_54" model="account.tax.group">
             <field name="name">ITBIS -30%</field>
+            <field name="country_id" ref="base.do"/>
         </record>
         <record id="tax_group_retencion_18" model="account.tax.group">
             <field name="name">ITBIS -100%</field>
+            <field name="country_id" ref="base.do"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_ec/data/account_data.xml
+++ b/addons/l10n_ec/data/account_data.xml
@@ -5,18 +5,23 @@
         <!-- Account Tax Group -->
         <record id="tax_group_ret_8" model="account.tax.group">
             <field name="name">Retencion 8%</field>
+            <field name="country_id" ref="base.ec"/>
         </record>
         <record id="tax_group_iva_12" model="account.tax.group">
             <field name="name">IVA 12%</field>
+            <field name="country_id" ref="base.ec"/>
         </record>
         <record id="tax_group_ret_30" model="account.tax.group">
             <field name="name">Retencion 30%</field>
+            <field name="country_id" ref="base.ec"/>
         </record>
         <record id="tax_group_ret_70" model="account.tax.group">
             <field name="name">Retencion 70%</field>
+            <field name="country_id" ref="base.ec"/>
         </record>
         <record id="tax_group_ret_100" model="account.tax.group">
             <field name="name">Retencion 100%</field>
+            <field name="country_id" ref="base.ec"/>
         </record>
 
     </data>

--- a/addons/l10n_es/data/account_data.xml
+++ b/addons/l10n_es/data/account_data.xml
@@ -5,66 +5,87 @@
         <!-- Account Tax Group -->
         <record id="tax_group_iva_0" model="account.tax.group">
             <field name="name">IVA 0%</field>
+            <field name="country_id" ref="base.es"/>
         </record>
         <record id="tax_group_recargo_0-5" model="account.tax.group">
             <field name="name">Recargo de Equivalencia 0.5%</field>
+            <field name="country_id" ref="base.es"/>
         </record>
         <record id="tax_group_retenciones_1" model="account.tax.group">
             <field name="name">Retenciones 1%</field>
+            <field name="country_id" ref="base.es"/>
         </record>
         <record id="tax_group_recargo_1-4" model="account.tax.group">
             <field name="name">Recargo de Equivalencia 1.4%</field>
+            <field name="country_id" ref="base.es"/>
         </record>
         <record id="tax_group_retenciones_2" model="account.tax.group">
             <field name="name">Retenciones 2%</field>
+            <field name="country_id" ref="base.es"/>
         </record>
         <record id="tax_group_iva_4" model="account.tax.group">
             <field name="name">IVA 4%</field>
+            <field name="country_id" ref="base.es"/>
         </record>
         <record id="tax_group_recargo_5-2" model="account.tax.group">
             <field name="name">Recargo de Equivalencia 5.2%</field>
+            <field name="country_id" ref="base.es"/>
         </record>
         <record id="tax_group_retenciones_7" model="account.tax.group">
             <field name="name">Retenciones 7%</field>
+            <field name="country_id" ref="base.es"/>
         </record>
         <record id="tax_group_retenciones_9" model="account.tax.group">
             <field name="name">Retenciones 9%</field>
+            <field name="country_id" ref="base.es"/>
         </record>
         <record id="tax_group_iva_10" model="account.tax.group">
             <field name="name">IVA 10%</field>
+            <field name="country_id" ref="base.es"/>
         </record>
         <record id="tax_group_iva_12" model="account.tax.group">
             <field name="name">IVA 12%</field>
+            <field name="country_id" ref="base.es"/>
         </record>
         <record id="tax_group_retenciones_15" model="account.tax.group">
             <field name="name">Retenciones 15%</field>
+            <field name="country_id" ref="base.es"/>
         </record>
         <record id="tax_group_retenciones_18" model="account.tax.group">
             <field name="name">Retenciones 18%</field>
+            <field name="country_id" ref="base.es"/>
         </record>
         <record id="tax_group_retenciones_19" model="account.tax.group">
             <field name="name">Retenciones 19%</field>
+            <field name="country_id" ref="base.es"/>
         </record>
         <record id="tax_group_retenciones_19-5" model="account.tax.group">
             <field name="name">Retenciones 19.5%</field>
+            <field name="country_id" ref="base.es"/>
         </record>
         <record id="tax_group_retenciones_20" model="account.tax.group">
             <field name="name">Retenciones 20%</field>
+            <field name="country_id" ref="base.es"/>
         </record>
         <record id="tax_group_iva_21" model="account.tax.group">
             <field name="name">IVA 21%</field>
+            <field name="country_id" ref="base.es"/>
         </record>
         <record id="tax_group_retenciones_21" model="account.tax.group">
             <field name="name">Retenciones 21%</field>
+            <field name="country_id" ref="base.es"/>
         </record>
         <record id="tax_group_retenciones_24" model="account.tax.group">
             <field name="name">Retenciones 24%</field>
+            <field name="country_id" ref="base.es"/>
         </record>
         <record id="tax_group_iva_10-5" model="account.tax.group">
             <field name="name">IVA 10,5% REAGYP</field>
+            <field name="country_id" ref="base.es"/>
         </record>
         <record id="tax_group_iva_nd" model="account.tax.group">
             <field name="name">IVA no deducible</field>
+            <field name="country_id" ref="base.es"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_fi/data/account_data.xml
+++ b/addons/l10n_fi/data/account_data.xml
@@ -5,15 +5,19 @@
         <!-- Account Tax Group -->
         <record id="tax_group_24" model="account.tax.group">
             <field name="name">VAT 24%</field>
+            <field name="country_id" ref="base.fi"/>
         </record>
         <record id="tax_group_14" model="account.tax.group">
             <field name="name">VAT 14%</field>
+            <field name="country_id" ref="base.fi"/>
         </record>
         <record id="tax_group_10" model="account.tax.group">
             <field name="name">VAT 10%</field>
+            <field name="country_id" ref="base.fi"/>
         </record>
         <record id="tax_group_0" model="account.tax.group">
             <field name="name">VAT 0%</field>
+            <field name="country_id" ref="base.fi"/>
         </record>
 
     </data>

--- a/addons/l10n_fr/data/account_data.xml
+++ b/addons/l10n_fr/data/account_data.xml
@@ -5,46 +5,57 @@
         <!-- Account Tax Group -->
         <record id="tax_group_tva_0" model="account.tax.group">
             <field name="name">TVA 0%</field>
+            <field name="country_id" ref="base.fr"/>
         </record>
 
         <record id="tax_group_tva_20" model="account.tax.group">
             <field name="name">TVA 20%</field>
+            <field name="country_id" ref="base.fr"/>
         </record>
 
         <record id="tax_group_tva_85" model="account.tax.group">
             <field name="name">TVA 8.5%</field>
+            <field name="country_id" ref="base.fr"/>
         </record>
 
         <record id="tax_group_tva_55" model="account.tax.group">
             <field name="name">TVA 5.5%</field>
+            <field name="country_id" ref="base.fr"/>
         </record>
 
         <record id="tax_group_tva_10" model="account.tax.group">
             <field name="name">TVA 10%</field>
+            <field name="country_id" ref="base.fr"/>
         </record>
 
         <record id="tax_group_tva_21" model="account.tax.group">
             <field name="name">TVA 2.1%</field>
+            <field name="country_id" ref="base.fr"/>
         </record>
 
         <record id="tax_group_intra_20" model="account.tax.group">
             <field name="name">TVA -20.0%</field>
+            <field name="country_id" ref="base.fr"/>
         </record>
 
         <record id="tax_group_intra_85" model="account.tax.group">
             <field name="name">TVA -8.5%</field>
+            <field name="country_id" ref="base.fr"/>
         </record>
 
         <record id="tax_group_intra_55" model="account.tax.group">
             <field name="name">TVA -5.5%</field>
+            <field name="country_id" ref="base.fr"/>
         </record>
 
         <record id="tax_group_intra_10" model="account.tax.group">
             <field name="name">TVA -10.0%</field>
+            <field name="country_id" ref="base.fr"/>
         </record>
 
         <record id="tax_group_intra_21" model="account.tax.group">
             <field name="name">TVA -2.1%</field>
+            <field name="country_id" ref="base.fr"/>
         </record>
 
     </data>

--- a/addons/l10n_generic_coa/data/l10n_generic_coa_post.xml
+++ b/addons/l10n_generic_coa/data/l10n_generic_coa_post.xml
@@ -4,6 +4,7 @@
     <!-- Tax template for sale and purchase -->
     <record id="tax_group_15" model="account.tax.group">
         <field name="name">Tax 15%</field>
+        <field name="country_id" ref="base.us"/>
     </record>
 </data>
 <data>

--- a/addons/l10n_gr/data/account_data.xml
+++ b/addons/l10n_gr/data/account_data.xml
@@ -5,12 +5,15 @@
         <!-- Account Tax Group -->
         <record id="tax_group_19" model="account.tax.group">
             <field name="name">ΦΠΑ 19%</field>
+            <field name="country_id" ref="base.gr"/>
         </record>
         <record id="tax_group_21" model="account.tax.group">
             <field name="name">ΦΠΑ 21%</field>
+            <field name="country_id" ref="base.gr"/>
         </record>
         <record id="tax_group_23" model="account.tax.group">
             <field name="name">ΦΠΑ 23%</field>
+            <field name="country_id" ref="base.gr"/>
         </record>
 
     </data>

--- a/addons/l10n_gt/data/account_data.xml
+++ b/addons/l10n_gt/data/account_data.xml
@@ -5,6 +5,7 @@
         <!-- Account Tax Group -->
         <record id="tax_group_iva_12" model="account.tax.group">
             <field name="name">IVA 12%</field>
+            <field name="country_id" ref="base.gt"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_hn/data/account_data.xml
+++ b/addons/l10n_hn/data/account_data.xml
@@ -5,6 +5,7 @@
         <!-- Account Tax Group -->
         <record id="tax_group_iva_15" model="account.tax.group">
             <field name="name">IVA 15%</field>
+            <field name="country_id" ref="base.hn"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_il/data/account_data.xml
+++ b/addons/l10n_il/data/account_data.xml
@@ -3,17 +3,21 @@
 
     <record id="tax_group_vat_16" model="account.tax.group">
         <field name="name">VAT 16%</field>
+        <field name="country_id" ref="base.il"/>
     </record>
 
     <record id="tax_group_vat_17" model="account.tax.group">
         <field name="name">VAT 17%</field>
+        <field name="country_id" ref="base.il"/>
     </record>
 
     <record id="tax_group_vat_exempt" model="account.tax.group">
         <field name="name">VAT exempt</field>
+        <field name="country_id" ref="base.il"/>
     </record>
 
     <record id="tax_group_retention_purchase" model="account.tax.group">
         <field name="name">Withholding purchase</field>
+        <field name="country_id" ref="base.il"/>
     </record>
 </odoo>

--- a/addons/l10n_in/data/account_data.xml
+++ b/addons/l10n_in/data/account_data.xml
@@ -5,24 +5,31 @@
         <!-- Account Tax Group -->
         <record id="sgst_group" model="account.tax.group">
             <field name="name">SGST</field>
+            <field name="country_id" ref="base.in"/>
         </record>
         <record id="cgst_group" model="account.tax.group">
             <field name="name">CGST</field>
+            <field name="country_id" ref="base.in"/>
         </record>
         <record id="igst_group" model="account.tax.group">
             <field name="name">IGST</field>
+            <field name="country_id" ref="base.in"/>
         </record>
         <record id="cess_group" model="account.tax.group">
             <field name="name">Cess</field>
+            <field name="country_id" ref="base.in"/>
         </record>
         <record id="gst_group" model="account.tax.group">
             <field name="name">GST</field>
+            <field name="country_id" ref="base.in"/>
         </record>
         <record id="exempt_group" model="account.tax.group">
             <field name="name">Exempt</field>
+            <field name="country_id" ref="base.in"/>
         </record>
         <record id="nil_rated_group" model="account.tax.group">
             <field name="name">Nil Rated</field>
+            <field name="country_id" ref="base.in"/>
         </record>
 
     </data>

--- a/addons/l10n_lt/data/account_tax_group_data.xml
+++ b/addons/l10n_lt/data/account_tax_group_data.xml
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo noupdate="1">
     <record id="tax_group_vat_0" model="account.tax.group">
-      <field name="name">VAT 0%</field>
+        <field name="name">VAT 0%</field>
+        <field name="country_id" ref="base.lt"/>
     </record>
     <record id="tax_group_vat_5" model="account.tax.group">
-      <field name="name">VAT 5%</field>
+        <field name="name">VAT 5%</field>
+        <field name="country_id" ref="base.lt"/>
     </record>
     <record id="tax_group_vat_9" model="account.tax.group">
-      <field name="name">VAT 9%</field>
+        <field name="name">VAT 9%</field>
+        <field name="country_id" ref="base.lt"/>
     </record>
     <record id="tax_group_vat_21" model="account.tax.group">
-      <field name="name">VAT 21%</field>
+        <field name="name">VAT 21%</field>
+        <field name="country_id" ref="base.lt"/>
     </record>
 </odoo>

--- a/addons/l10n_ma/data/account_data.xml
+++ b/addons/l10n_ma/data/account_data.xml
@@ -5,18 +5,23 @@
         <!-- Account Tax Group -->
         <record id="tax_group_tva_0" model="account.tax.group">
             <field name="name">TVA 0%</field>
+            <field name="country_id" ref="base.ma"/>
         </record>
         <record id="tax_group_tva_7" model="account.tax.group">
             <field name="name">TVA 7%</field>
+            <field name="country_id" ref="base.ma"/>
         </record>
         <record id="tax_group_tva_10" model="account.tax.group">
             <field name="name">TVA 10%</field>
+            <field name="country_id" ref="base.ma"/>
         </record>
         <record id="tax_group_tva_14" model="account.tax.group">
             <field name="name">TVA 14%</field>
+            <field name="country_id" ref="base.ma"/>
         </record>
         <record id="tax_group_tva_20" model="account.tax.group">
             <field name="name">TVA 20%</field>
+            <field name="country_id" ref="base.ma"/>
         </record>
 
     </data>

--- a/addons/l10n_mx/data/account_data.xml
+++ b/addons/l10n_mx/data/account_data.xml
@@ -5,30 +5,37 @@
         <!-- Account Tax Group -->
         <record id="tax_group_iva_0" model="account.tax.group">
             <field name="name">IVA 0%</field>
+            <field name="country_id" ref="base.mx"/>
         </record>
 
         <record id="tax_group_iva_16" model="account.tax.group">
             <field name="name">IVA 16% </field>
+            <field name="country_id" ref="base.mx"/>
         </record>
 
         <record id="tax_group_iva_8" model="account.tax.group">
             <field name="name">IVA 8%</field>
+            <field name="country_id" ref="base.mx"/>
         </record>
 
         <record id="tax_group_iva_ret_4" model="account.tax.group">
             <field name="name">IVA Retencion 4%</field>
+            <field name="country_id" ref="base.mx"/>
         </record>
 
         <record id="tax_group_iva_ret_10" model="account.tax.group">
             <field name="name">IVA Retencion 10%</field>
+            <field name="country_id" ref="base.mx"/>
         </record>
 
         <record id="tax_group_iva_ret_1067" model="account.tax.group">
             <field name="name">IVA Retencion 10.67%</field>
+            <field name="country_id" ref="base.mx"/>
         </record>
 
         <record id="tax_group_isr_ret_10" model="account.tax.group">
             <field name="name">ISR Retencion 10%</field>
+            <field name="country_id" ref="base.mx"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_nl/data/account_data.xml
+++ b/addons/l10n_nl/data/account_data.xml
@@ -5,39 +5,51 @@
         <!-- Account Tax Group -->
         <record id="tax_group_0" model="account.tax.group">
             <field name="name">BTW 0%</field>
+            <field name="country_id" ref="base.nl"/>
         </record>
         <record id="tax_group_6" model="account.tax.group">
             <field name="name">BTW 6%</field>
+            <field name="country_id" ref="base.nl"/>
         </record>
         <record id="tax_group_9" model="account.tax.group">
             <field name="name">BTW 9%</field>
+            <field name="country_id" ref="base.nl"/>
         </record>
         <record id="tax_group_21" model="account.tax.group">
             <field name="name">BTW 21%</field>
+            <field name="country_id" ref="base.nl"/>
         </record>
         <record id="tax_group_0_eu" model="account.tax.group">
             <field name="name">BTW 0% EU</field>
+            <field name="country_id" ref="base.nl"/>
         </record>
         <record id="tax_group_6_eu" model="account.tax.group">
             <field name="name">BTW 6% EU</field>
+            <field name="country_id" ref="base.nl"/>
         </record>
         <record id="tax_group_9_eu" model="account.tax.group">
             <field name="name">BTW 9% EU</field>
+            <field name="country_id" ref="base.nl"/>
         </record>
         <record id="tax_group_21_eu" model="account.tax.group">
             <field name="name">BTW 21% EU</field>
+            <field name="country_id" ref="base.nl"/>
         </record>
         <record id="tax_group_0_niet_eu" model="account.tax.group">
             <field name="name">BTW 0% Niet EU</field>
+            <field name="country_id" ref="base.nl"/>
         </record>
         <record id="tax_group_6_niet_eu" model="account.tax.group">
             <field name="name">BTW 6% Niet EU</field>
+            <field name="country_id" ref="base.nl"/>
         </record>
         <record id="tax_group_9_niet_eu" model="account.tax.group">
             <field name="name">BTW 9% Niet EU</field>
+            <field name="country_id" ref="base.nl"/>
         </record>
         <record id="tax_group_21_niet_eu" model="account.tax.group">
             <field name="name">BTW 21% Niet EU</field>
+            <field name="country_id" ref="base.nl"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_no/data/account_data.xml
+++ b/addons/l10n_no/data/account_data.xml
@@ -5,18 +5,23 @@
         <!-- Account Tax Group -->
         <record id="tax_group_0" model="account.tax.group">
             <field name="name">MVA 0%</field>
+            <field name="country_id" ref="base.no"/>
         </record>
         <record id="tax_group_10" model="account.tax.group">
             <field name="name">MVA 10%</field>
+            <field name="country_id" ref="base.no"/>
         </record>
         <record id="tax_group_12" model="account.tax.group">
             <field name="name">MVA 12%</field>
+            <field name="country_id" ref="base.no"/>
         </record>
         <record id="tax_group_15" model="account.tax.group">
             <field name="name">MVA 15%</field>
+            <field name="country_id" ref="base.no"/>
         </record>
         <record id="tax_group_25" model="account.tax.group">
             <field name="name">MVA 25%</field>
+            <field name="country_id" ref="base.no"/>
         </record>
 
     </data>

--- a/addons/l10n_pa/data/account_data.xml
+++ b/addons/l10n_pa/data/account_data.xml
@@ -5,6 +5,7 @@
         <!-- Account Tax Group -->
         <record id="tax_group_7" model="account.tax.group">
             <field name="name">ITBMS 7%</field>
+            <field name="country_id" ref="base.pa"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_pe/data/account_tax_data.xml
+++ b/addons/l10n_pe/data/account_tax_data.xml
@@ -7,38 +7,47 @@
     <record id="tax_group_igv" model="account.tax.group">
         <field name="name">IGV</field>
         <field name="sequence">0</field>
+        <field name="country_id" ref="base.pe"/>
     </record>
     <record id="tax_group_ivap" model="account.tax.group">
         <field name="name">IVAP</field>
         <field name="sequence">0</field>
+        <field name="country_id" ref="base.pe"/>
     </record>
     <record id="tax_group_isc" model="account.tax.group">
         <field name="name">ISC</field>
         <field name="sequence">0</field>
+        <field name="country_id" ref="base.pe"/>
     </record>
     <record id="tax_group_exp" model="account.tax.group">
         <field name="name">EXP</field>
         <field name="sequence">0</field>
+        <field name="country_id" ref="base.pe"/>
     </record>
     <record id="tax_group_gra" model="account.tax.group">
         <field name="name">GRA</field>
         <field name="sequence">0</field>
+        <field name="country_id" ref="base.pe"/>
     </record>
     <record id="tax_group_exo" model="account.tax.group">
         <field name="name">EXO</field>
         <field name="sequence">0</field>
+        <field name="country_id" ref="base.pe"/>
     </record>
     <record id="tax_group_ina" model="account.tax.group">
         <field name="name">INA</field>
         <field name="sequence">0</field>
+        <field name="country_id" ref="base.pe"/>
     </record>
     <record id="tax_group_other" model="account.tax.group">
         <field name="name">OTROS</field>
         <field name="sequence">0</field>
+        <field name="country_id" ref="base.pe"/>
     </record>
     <record id="tax_group_det" model="account.tax.group">
         <field name="name">DET</field>
         <field name="sequence">100</field>
+        <field name="country_id" ref="base.pe"/>
     </record>
     
     <!-- VAT for sales -->

--- a/addons/l10n_pl/data/account_data.xml
+++ b/addons/l10n_pl/data/account_data.xml
@@ -5,24 +5,31 @@
         <!-- Account Tax Group -->
         <record id="tax_group_vat_23" model="account.tax.group">
             <field name="name">VAT 23%</field>
+            <field name="country_id" ref="base.pl"/>
         </record>
         <record id="tax_group_vat_22" model="account.tax.group">
             <field name="name">VAT 22%</field>
+            <field name="country_id" ref="base.pl"/>
         </record>
         <record id="tax_group_vat_8" model="account.tax.group">
             <field name="name">VAT 8%</field>
+            <field name="country_id" ref="base.pl"/>
         </record>
         <record id="tax_group_vat_7" model="account.tax.group">
             <field name="name">VAT 7%</field>
+            <field name="country_id" ref="base.pl"/>
         </record>
         <record id="tax_group_vat_5" model="account.tax.group">
             <field name="name">VAT 5%</field>
+            <field name="country_id" ref="base.pl"/>
         </record>
         <record id="tax_group_vat_3" model="account.tax.group">
             <field name="name">VAT 3%</field>
+            <field name="country_id" ref="base.pl"/>
         </record>
         <record id="tax_group_vat_0" model="account.tax.group">
             <field name="name">VAT 0%</field>
+            <field name="country_id" ref="base.pl"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_pt/data/account_data.xml
+++ b/addons/l10n_pt/data/account_data.xml
@@ -5,15 +5,19 @@
         <!-- Account Tax Group -->
         <record id="tax_group_iva_0" model="account.tax.group">
             <field name="name">IVA 0%</field>
+            <field name="country_id" ref="base.pt"/>
         </record>
         <record id="tax_group_iva_6" model="account.tax.group">
             <field name="name">IVA 6%</field>
+            <field name="country_id" ref="base.pt"/>
         </record>
         <record id="tax_group_iva_13" model="account.tax.group">
             <field name="name">IVA 13%</field>
+            <field name="country_id" ref="base.pt"/>
         </record>
         <record id="tax_group_iva_23" model="account.tax.group">
             <field name="name">IVA 23%</field>
+            <field name="country_id" ref="base.pt"/>
         </record>
 
     </data>

--- a/addons/l10n_ro/data/account_data.xml
+++ b/addons/l10n_ro/data/account_data.xml
@@ -5,45 +5,59 @@
         <!-- Account Tax Group -->
         <record id="tax_group_tva_0" model="account.tax.group">
             <field name="name">TVA 0%</field>
+            <field name="country_id" ref="base.ro"/>
         </record>
         <record id="tax_group_tva_5" model="account.tax.group">
             <field name="name">TVA 5%</field>
+            <field name="country_id" ref="base.ro"/>
         </record>
         <record id="tax_group_tva_9" model="account.tax.group">
             <field name="name">TVA 9%</field>
+            <field name="country_id" ref="base.ro"/>
         </record>
         <record id="tax_group_tva_19" model="account.tax.group">
             <field name="name">TVA 19%</field>
+            <field name="country_id" ref="base.ro"/>
         </record>
         <record id="tax_group_tva_20" model="account.tax.group">
             <field name="name">TVA 20%</field>
+            <field name="country_id" ref="base.ro"/>
         </record>
         <record id="tax_group_tva_24" model="account.tax.group">
             <field name="name">TVA 24%</field>
+            <field name="country_id" ref="base.ro"/>
         </record>
         <record id="tax_group_tva_0_eu" model="account.tax.group">
             <field name="name">TVA 0% EU</field>
+            <field name="country_id" ref="base.ro"/>
         </record>
         <record id="tax_group_tva_5_eu" model="account.tax.group">
             <field name="name">TVA 5% EU</field>
+            <field name="country_id" ref="base.ro"/>
         </record>
         <record id="tax_group_tva_9_eu" model="account.tax.group">
             <field name="name">TVA 9% EU</field>
+            <field name="country_id" ref="base.ro"/>
         </record>
         <record id="tax_group_tva_19_eu" model="account.tax.group">
             <field name="name">TVA 19% EU</field>
+            <field name="country_id" ref="base.ro"/>
         </record>
         <record id="tax_group_tva_ned" model="account.tax.group">
             <field name="name">TVA Nedeductibil</field>
+            <field name="country_id" ref="base.ro"/>
         </record>
         <record id="tax_group_tva_ti" model="account.tax.group">
             <field name="name">TVA Taxare Inversa</field>
+            <field name="country_id" ref="base.ro"/>
         </record>
         <record id="tax_group_tva_scutit" model="account.tax.group">
             <field name="name">TVA Scutit</field>
+            <field name="country_id" ref="base.ro"/>
         </record>
         <record id="tax_group_tva_neimp" model="account.tax.group">
             <field name="name">TVA Neimpozabil</field>
+            <field name="country_id" ref="base.ro"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_se/data/account_tax_group.xml
+++ b/addons/l10n_se/data/account_tax_group.xml
@@ -3,15 +3,19 @@
     <data noupdate="1">
         <record id="tax_group_25" model="account.tax.group">
             <field name="name">VAT 25%</field>
+            <field name="country_id" ref="base.se"/>
         </record>
         <record id="tax_group_12" model="account.tax.group">
             <field name="name">VAT 12%</field>
+            <field name="country_id" ref="base.se"/>
         </record>
         <record id="tax_group_6" model="account.tax.group">
             <field name="name">VAT 6%</field>
+            <field name="country_id" ref="base.se"/>
         </record>
         <record id="tax_group_0" model="account.tax.group">
             <field name="name">VAT 0%</field>
+            <field name="country_id" ref="base.se"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_sg/data/account_data.xml
+++ b/addons/l10n_sg/data/account_data.xml
@@ -5,9 +5,11 @@
         <!-- Account Tax Group -->
         <record id="tax_group_0" model="account.tax.group">
             <field name="name">TAX 0%</field>
+            <field name="country_id" ref="base.sg"/>
         </record>
         <record id="tax_group_7" model="account.tax.group">
             <field name="name">TAX 7%</field>
+            <field name="country_id" ref="base.sg"/>
         </record>
 
     </data>

--- a/addons/l10n_sk/data/account_data.xml
+++ b/addons/l10n_sk/data/account_data.xml
@@ -5,12 +5,15 @@
         <!-- Account Tax Group -->
         <record id="tax_group_vat_20" model="account.tax.group">
             <field name="name">DPH 20%</field>
+            <field name="country_id" ref="base.sk"/>
         </record>
         <record id="tax_group_vat_10" model="account.tax.group">
             <field name="name">DPH 10%</field>
+            <field name="country_id" ref="base.sk"/>
         </record>
         <record id="tax_group_vat_0" model="account.tax.group">
             <field name="name">DPH 0%</field>
+            <field name="country_id" ref="base.sk"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_th/data/account_data.xml
+++ b/addons/l10n_th/data/account_data.xml
@@ -5,18 +5,23 @@
         <!-- Account Tax Group -->
         <record id="tax_group_1" model="account.tax.group">
             <field name="name">TAX 1%</field>
+            <field name="country_id" ref="base.th"/>
         </record>
         <record id="tax_group_2" model="account.tax.group">
             <field name="name">TAX 2%</field>
+            <field name="country_id" ref="base.th"/>
         </record>
         <record id="tax_group_3" model="account.tax.group">
             <field name="name">TAX 3%</field>
+            <field name="country_id" ref="base.th"/>
         </record>
         <record id="tax_group_5" model="account.tax.group">
             <field name="name">TAX 5%</field>
+            <field name="country_id" ref="base.th"/>
         </record>
         <record id="tax_group_vat_7" model="account.tax.group">
             <field name="name">VAT 7%</field>
+            <field name="country_id" ref="base.th"/>
         </record>
 
     </data>

--- a/addons/l10n_tr/data/account_data.xml
+++ b/addons/l10n_tr/data/account_data.xml
@@ -5,6 +5,7 @@
         <!-- Account Tax Group -->
         <record id="tax_group_kdv_18" model="account.tax.group">
             <field name="name">KDV %18</field>
+            <field name="country_id" ref="base.tr"/>
         </record>
 
     </data>

--- a/addons/l10n_ua/data/account_tax_group_data.xml
+++ b/addons/l10n_ua/data/account_tax_group_data.xml
@@ -3,21 +3,27 @@
     <data noupdate="1">
         <record id="tax_group_vat20" model="account.tax.group">
             <field name="name">ПДВ 20%</field>
+            <field name="country_id" ref="base.ua"/>
         </record>
         <record id="tax_group_vat14" model="account.tax.group">
             <field name="name">ПДВ 14%</field>
+            <field name="country_id" ref="base.ua"/>
         </record>
         <record id="tax_group_vat7" model="account.tax.group">
             <field name="name">ПДВ 7%</field>
+            <field name="country_id" ref="base.ua"/>
         </record>
         <record id="tax_group_vat0" model="account.tax.group">
             <field name="name">ПДВ 0%</field>
+            <field name="country_id" ref="base.ua"/>
         </record>
         <record id="tax_group_vat_free" model="account.tax.group">
             <field name="name">Звільнено від ПДВ</field>
+            <field name="country_id" ref="base.ua"/>
         </record>
         <record id="tax_group_not_vat" model="account.tax.group">
             <field name="name">Не є ПДВ</field>
+            <field name="country_id" ref="base.ua"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_uy/data/account_data.xml
+++ b/addons/l10n_uy/data/account_data.xml
@@ -5,12 +5,15 @@
         <!-- Account Tax Group -->
         <record id="tax_group_iva_10" model="account.tax.group">
             <field name="name">IVA 10%</field>
+            <field name="country_id" ref="base.uy"/>
         </record>
         <record id="tax_group_iva_22" model="account.tax.group">
             <field name="name">IVA 22%</field>
+            <field name="country_id" ref="base.uy"/>
         </record>
         <record id="tax_group_exenton" model="account.tax.group">
             <field name="name">EXENTOS</field>
+            <field name="country_id" ref="base.uy"/>
         </record>
 
     </data>

--- a/addons/l10n_ve/data/account_data.xml
+++ b/addons/l10n_ve/data/account_data.xml
@@ -5,15 +5,19 @@
         <!-- Account Tax Group -->
         <record id="tax_group_iva_0" model="account.tax.group">
             <field name="name">IVA 0%</field>
+            <field name="country_id" ref="base.ve"/>
         </record>
         <record id="tax_group_iva_8" model="account.tax.group">
             <field name="name">IVA 8%</field>
+            <field name="country_id" ref="base.ve"/>
         </record>
         <record id="tax_group_iva_12" model="account.tax.group">
             <field name="name">IVA 12%</field>
+            <field name="country_id" ref="base.ve"/>
         </record>
         <record id="tax_group_iva_22" model="account.tax.group">
             <field name="name">IVA 22%</field>
+            <field name="country_id" ref="base.ve"/>
         </record>
 
     </data>

--- a/addons/l10n_vn/data/account_data.xml
+++ b/addons/l10n_vn/data/account_data.xml
@@ -5,12 +5,15 @@
         <!-- Account Tax Group -->
         <record id="tax_group_0" model="account.tax.group">
             <field name="name">Thuế GTGT 0%</field>
+            <field name="country_id" ref="base.vn"/>
         </record>
         <record id="tax_group_5" model="account.tax.group">
             <field name="name">Thuế GTGT 5%</field>
+            <field name="country_id" ref="base.vn"/>
         </record>
         <record id="tax_group_10" model="account.tax.group">
             <field name="name">Thuế GTGT 10%</field>
+            <field name="country_id" ref="base.vn"/>
         </record>
 
     </data>


### PR DESCRIPTION
In order to allow proper configuration of new taxes in case of multi
company environment, add a new country_id field on tax groups and
use it to filter the tax group field on taxes.

task id #2206280

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
