### PR TITLE
[FIX] account: Fix payment consistency with edited journal configuration

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -158,7 +158,11 @@ class AccountPayment(models.Model):
         writeoff_lines = self.env['account.move.line']
 
         for line in self.move_id.line_ids:
-            if line.account_id in (self.journal_id.payment_debit_account_id, self.journal_id.payment_credit_account_id):
+            if line.account_id in (
+                    self.journal_id.default_account_id,
+                    self.journal_id.payment_debit_account_id,
+                    self.journal_id.payment_credit_account_id,
+            ):
                 liquidity_lines += line
             elif line.account_id.internal_type in ('receivable', 'payable') or line.partner_id == line.company_id.partner_id:
                 counterpart_lines += line


### PR DESCRIPTION
After a migration, if the payment is using the bank account instead of the oustanding one, we shouldn't block the user in any case when checking the payment consistency.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
