### PR TITLE
[FIX] stock: fix typo in domain

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -46,7 +46,7 @@ class StockQuant(models.Model):
             return
         domain = [('type', '=', 'product')]
         if self.env.context.get('product_tmpl_ids') or self.env.context.get('product_tmpl_id'):
-            products = self.env.context.get('product_tmpl_id', []) + [self.env.context.get('product_tmpl_id', 0)]
+            products = self.env.context.get('product_tmpl_ids', []) + [self.env.context.get('product_tmpl_id', 0)]
             domain = expression.AND([domain, [('product_tmpl_id', 'in', products)]])
         return domain
 


### PR DESCRIPTION
Commit 49b965eb1ec6a7ec6c07fa643cc6ae35ee8b5d91 introduced
`product_tmpl_ids` into the context for displaying kit components but
did not use it in the domain due to a missing `s`.

This commit adds the missing `s` in the domain.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
