### PR TITLE
[FIX] odoo_referral: fix Error systray_odoo_referral.gift_icon not found

### DIFF
--- a/addons/odoo_referral/__manifest__.py
+++ b/addons/odoo_referral/__manifest__.py
@@ -9,5 +9,8 @@
     'data': [
         'views/templates.xml',
     ],
-    'auto_install': True,
+    'qweb': [
+        "static/src/xml/systray.xml",
+    ],
+    'auto_install': False,
 }

--- a/addons/odoo_referral/static/src/xml/systray.xml
+++ b/addons/odoo_referral/static/src/xml/systray.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates>
+   <t t-name="systray_odoo_referral.gift_icon">
+   </t>
+</templates>


### PR DESCRIPTION
Problem
-------
Before the commit 6304c6d0c430f3e02ee84587f18ed5dde5241ecd, odoo
had a JS file that was loading odoo_referral/static/src/xml/systray.xml
When the source are updated after this commit but odoo server is not
restarted, an error is raised when the user reach /web.

This make the database unusable

Solution
--------
Keep the file with an empty template.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
