### PR TITLE
[IMP] delivery, stock: allow to print labels in PICK+PACK+SHIP

### DIFF
--- a/addons/delivery/models/stock_move.py
+++ b/addons/delivery/models/stock_move.py
@@ -19,7 +19,8 @@ class StockMove(models.Model):
 
     def _get_new_picking_values(self):
         vals = super(StockMove, self)._get_new_picking_values()
-        vals['carrier_id'] = self.mapped('sale_line_id.order_id.carrier_id').id
+        carrier_id = self.group_id.sale_id.carrier_id.id
+        vals['carrier_id'] = self.rule_id.propagate_carrier and carrier_id
         return vals
 
     def _key_assign_picking(self):

--- a/addons/delivery/views/delivery_view.xml
+++ b/addons/delivery/views/delivery_view.xml
@@ -385,9 +385,11 @@
                 <xpath expr="//field[@name='backorder_id']" position="after">
                     <field name="carrier_tracking_ref" optional="hide"/>
                     <field name="carrier_id" optional="hide"/>
+                    <field name="destination_country_code" optional="hide" string="Destination"/>
                     <field name="weight" optional="hide"/>
                     <field name="shipping_weight" optional="hide"/>
                 </xpath>
             </field>
         </record>
+
 </odoo>

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -58,6 +58,9 @@ class PickingType(models.Model):
     use_existing_lots = fields.Boolean(
         'Use Existing Lots/Serial Numbers', default=True,
         help="If this is checked, you will be able to choose the Lots/Serial Numbers. You can also decide to not put lots in this operation type.  This means it will create stock with no lot or not put a restriction on the lot taken. ")
+    print_label = fields.Boolean(
+        'Print Label',
+        help="If this checkbox is ticked, label will be print in this operation.")
     show_operations = fields.Boolean(
         'Show Detailed Operations', default=_default_show_operations,
         help="If this checkbox is ticked, the pickings lines will represent detailed stock operations. If not, the picking lines will represent an aggregate of detailed stock operations.")
@@ -175,15 +178,19 @@ class PickingType(models.Model):
         if self.code == 'incoming':
             self.default_location_src_id = self.env.ref('stock.stock_location_suppliers').id
             self.default_location_dest_id = stock_location.id
+            self.print_label = False
         elif self.code == 'outgoing':
             self.default_location_src_id = stock_location.id
             self.default_location_dest_id = self.env.ref('stock.stock_location_customers').id
-        elif self.code == 'internal' and not self.user_has_groups('stock.group_stock_multi_locations'):
-            return {
-                'warning': {
-                    'message': _('You need to activate storage locations to be able to do internal operation types.')
+            self.print_label = True
+        elif self.code == 'internal':
+            self.print_label = False
+            if not self.user_has_groups('stock.group_stock_multi_locations'):
+                return {
+                    'warning': {
+                        'message': _('You need to activate storage locations to be able to do internal operation types.')
+                    }
                 }
-            }
 
     @api.onchange('company_id')
     def _onchange_company_id(self):

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -78,6 +78,9 @@ class StockRule(models.Model):
     propagate_cancel = fields.Boolean(
         'Cancel Next Move', default=False,
         help="When ticked, if the move created by this rule is cancelled, the next move will be cancelled too.")
+    propagate_carrier = fields.Boolean(
+        'Propagation of carrier', default=False,
+        help="When ticked, carrier of shipment will be propgated.")
     warehouse_id = fields.Many2one('stock.warehouse', 'Warehouse', check_company=True)
     propagate_warehouse_id = fields.Many2one(
         'stock.warehouse', 'Warehouse to Propagate',

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -491,6 +491,7 @@ class Warehouse(models.Model):
                 },
                 'rules_values': {
                     'active': True,
+                    'propagate_carrier': True
                 }
             },
             'crossdock_route_id': {
@@ -929,6 +930,7 @@ class Warehouse(models.Model):
                 'default_location_dest_id': False,
                 'sequence': max_sequence + 5,
                 'sequence_code': 'OUT',
+                'print_label': True,
                 'company_id': self.company_id.id,
             }, 'pack_type_id': {
                 'name': _('Pack'),

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -43,6 +43,7 @@
                                 <field name="sequence_id" groups="base.group_no_one"/>
                                 <field name="sequence_code"/>
                                 <field name="warehouse_id" groups="stock.group_stock_multi_warehouses" force_save="1"/>
+                                <field name="print_label" attrs="{'invisible': [('code', '!=', 'internal')]}"/>
                                 <label for="reservation_method" attrs="{'invisible': [('code', '=', 'incoming')]}"/>
                                 <div class="o_row" attrs="{'invisible': [('code', '=', 'incoming')]}">
                                     <field name="reservation_method" widget="radio"/>

--- a/addons/stock/views/stock_rule_views.xml
+++ b/addons/stock/views/stock_rule_views.xml
@@ -98,6 +98,7 @@
                                 <field name="group_propagation_option"/>
                                 <field name="group_id" attrs="{'invisible': [('group_propagation_option', '!=', 'fixed')], 'required': [('group_propagation_option', '=', 'fixed')]}"/>
                                 <field name="propagate_cancel"/>
+                                <field name="propagate_carrier" groups="base.group_no_one"/>
                                 <field name="propagate_warehouse_id"/>
                             </group>
                             <group string="Options" attrs="{'invisible': [('action', 'not in', ['pull', 'push', 'pull_push'])]}">


### PR DESCRIPTION
In this commit -
1) Added new field propagate_carrier_id in stock.rule and propgate
carrier in PICK PACK and SHIP if it is ticked.
2) Allow to print Label at any stage of PICK PACK and SHIP

Task-2363484

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
