### PR TITLE
[FIX] point_of_sale: Failed electronic payment cancel

### DIFF
--- a/addons/point_of_sale/static/src/js/screens.js
+++ b/addons/point_of_sale/static/src/js/screens.js
@@ -2036,7 +2036,7 @@ var PaymentScreenWidget = ScreenWidget.extend({
             line.set_payment_status('waitingCancel');
             self.render_paymentlines();
 
-            payment_terminal.send_payment_cancel(self.pos.get_order(), cid).finally(function () {
+            payment_terminal.send_payment_cancel(self.pos.get_order(), cid).then(function () {
                 line.set_payment_status('retry');
                 self.render_paymentlines();
             });


### PR DESCRIPTION
Canceling an electronic payment could fail, so we shouldn't set the
status to 'retry' in every case.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
