### PR TITLE
[FIX] website_slides: Fix missing api.model on create

### DIFF
--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -32,6 +32,7 @@ class SlidePartnerRelation(models.Model):
     completed = fields.Boolean('Completed')
     quiz_attempts_count = fields.Integer('Quiz attempts count', default=0)
 
+    @api.model
     def create(self, values):
         res = super(SlidePartnerRelation, self).create(values)
         completed = res.filtered('completed')


### PR DESCRIPTION

Description of the issue/feature this PR addresses:

api.model is not defined in create , will result error in rpc call


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
