### PR TITLE
[FIX][13.0] http_routing: error should occur the path was not "latin1" string

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -6,6 +6,7 @@ import re
 import traceback
 import unicodedata
 import werkzeug
+from werkzeug._compat import wsgi_encoding_dance
 
 # optional python-slugify import (https://github.com/un33k/python-slugify)
 try:
@@ -526,6 +527,7 @@ class IrHttp(models.AbstractModel):
 
     @classmethod
     def reroute(cls, path):
+        path = wsgi_encoding_dance(path)
         if not hasattr(request, 'rerouting'):
             request.rerouting = [request.httprequest.path]
         if path in request.rerouting:


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

**Current behavior before PR:**
For multi language website, when request `http:/localhost/en/something`, Odoo reroutes from the requested path `/en/something` to the new path `/something` with `lang=en_US` in context.

If the new path is a unicode string like `http:/localhost/vi/xin-chào`, `http:/localhost/ru/привет`, a error should occur at `werkzeug._compat.wsgi_decoding_dance()` because the path was not `latin1` string.

**Desired behavior after PR is merged:**
This PR fixes the issue by converting the path to `latin1` using corresponding `wsgi_encoding_dance()` before it is passed to `wsgi_decoding_dance()`.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
