### PR TITLE
[FIX] hr_holidays_calendar: hide archived employee

### DIFF
--- a/addons/hr_holidays_calendar/report/hr_leave_report_calendar_views.xml
+++ b/addons/hr_holidays_calendar/report/hr_leave_report_calendar_views.xml
@@ -7,7 +7,7 @@
                    a stable release. -->
         <field name="view_id"/>
         <field name="search_view_id"/>
-        <field name="domain"/>
+        <field name="domain">[('employee_id.active','=',True)]</field>
         <field name="context"/>
     </record>
 


### PR DESCRIPTION
When going on Leaves dashboard, if an employee is archived, his leaves
are still displayed.

To reproduce the error:
1. Add time-off to an employee E
2. Archive E
3. Go back to Time Off module > Everyone

=> The E's leaves are still shown

They should be hidden.

Notes:
- Manual forward-port.
- In previous versions, the fix concerned the `hr_holidays` module
- Replace #62795
- Initial PR #62726

OPW-2406702