### PR TITLE
[FIX] website: keep same access for portal users

### DIFF
--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -195,13 +195,16 @@ class Http(models.AbstractModel):
 
         request.website = request.env['website'].get_current_website()  # can use `request.env` since auth methods are called
         context['website_id'] = request.website.id
-        # This is mainly to avoid access errors in website controllers where there is no
-        # context (eg: /shop), and it's not going to propagate to the global context of the tab
-        # If the company of the website is not in the allowed companies of the user, set the main
-        # company of the user.
-        if request.website.company_id in request.env.user.company_ids:
+        is_portal_user = request.env.user != request.website.user_id and request.env.user.share
+        if is_portal_user:
+            context['allowed_company_ids'] = request.env.user.company_ids.ids
+        elif request.website.company_id in request.env.user.company_ids:
+            # This is mainly to avoid access errors in website controllers where there is no
+            # context (eg: /shop), and it's not going to propagate to the global context of the tab
             context['allowed_company_ids'] = request.website.company_id.ids
         else:
+            # If the company of the website is not in the allowed companies of the user, set the main
+            # company of the user.
             context['allowed_company_ids'] = request.env.user.company_id.ids
 
         # modify bound context


### PR DESCRIPTION
STEPS:

1. Install Purchase & website
2. Settings > User & Companies > Companies
3. Create a new company
4. Go on Marc Demo user and add the new added company into it's allowed companies
4.A Go on Marc Demo partner and add remove empty Company field
5. Refresh the page (to have the selector of the companies near your profile)
6. Check on the second company
7. Go in Purchase
8. Create a new Request for Quotation with:
- Vendor: Marc Demo
- Company: <the second company>
9. Confirm Order
10. Connect youself as Marc Demo
11. Go on "<website name>/my/purchase"

BEFORE: The PO created on 9. is missing
AFTER: all records for user's allowed companies are visible (only if you have
one website)

WHY:
* This allows to keep same logic as when website module is not installed.
* The one_website_only check is a workaround for stable version. More
flexible solution could be done in new versions

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
