### PR TITLE
add separate task_with_hours widget for list

### DIFF
--- a/addons/hr_timesheet/static/src/js/task_with_hours.js
+++ b/addons/hr_timesheet/static/src/js/task_with_hours.js
@@ -4,8 +4,9 @@ odoo.define('hr_timesheet.task_with_hours', function (require) {
 var field_registry = require('web.field_registry');
 var relational_fields = require('web.relational_fields');
 var FieldMany2One = relational_fields.FieldMany2One;
+const ListFieldMany2One = relational_fields.ListFieldMany2One;
 
-var TaskWithHours = FieldMany2One.extend({
+const TaskWithHoursMixin = {
     /**
      * @override
      */
@@ -23,14 +24,19 @@ var TaskWithHours = FieldMany2One.extend({
      * @override
      * @private
      */
-    _renderEdit: function (){
+    _renderEdit: function () {
         this.m2o_value = this._getDisplayNameWithoutHours(this.m2o_value);
         this._super.apply(this, arguments);
     },
-});
+};
+
+const TaskWithHours = FieldMany2One.extend(TaskWithHoursMixin, {});
+
+const ListTaskWithHours = ListFieldMany2One.extend(TaskWithHoursMixin, {});
 
 field_registry.add('task_with_hours', TaskWithHours);
+field_registry.add('list.task_with_hours', ListTaskWithHours);
 
-return TaskWithHours;
+return { TaskWithHours, ListTaskWithHours };
 
 });


### PR DESCRIPTION
PURPOSE
Task many2one field inside timesheet listview, writing something which is not available in task many2one and clicking outside shows M2ODialog for second and then it hides and record is also unselected.

SPEC
When user click outside of task many2one in timesheet listview it should keep M2ODialog open and editable row should not be unselected.

TASK 2411029



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
