### PR TITLE
[IMP] website_slides: open rating composer in fullscreen mode

### DIFF
--- a/addons/portal_rating/static/src/js/portal_rating_composer.js
+++ b/addons/portal_rating/static/src/js/portal_rating_composer.js
@@ -1,11 +1,12 @@
 odoo.define('portal.rating.composer', function (require) {
 'use strict';
 
-var publicWidget = require('web.public.widget');
-var session = require('web.session');
-var portalComposer = require('portal.composer');
+const publicWidget = require('web.public.widget');
+const session = require('web.session');
+const portalComposer = require('portal.composer');
+const {_t, qweb} = require('web.core');
 
-var PortalComposer = portalComposer.PortalComposer;
+const PortalComposer = portalComposer.PortalComposer;
 
 /**
  * RatingPopupComposer
@@ -13,8 +14,11 @@ var PortalComposer = portalComposer.PortalComposer;
  * Display the rating average with a static star widget, and open
  * a popup with the portal composer when clicking on it.
  **/
-var RatingPopupComposer = publicWidget.Widget.extend({
-    template: 'portal_rating.PopupComposer',
+const RatingPopupComposer = publicWidget.Widget.extend({
+    selector: '.o_rating_popup_composer',
+    custom_events: {
+        reload_rating_popup_composer: '_onReloadRatingPopupComposer',
+    },
     xmlDependencies: [
         '/portal/static/src/xml/portal_chatter.xml',
         '/portal_rating/static/src/xml/portal_chatter.xml',
@@ -22,8 +26,10 @@ var RatingPopupComposer = publicWidget.Widget.extend({
         '/portal_rating/static/src/xml/portal_rating_composer.xml',
     ],
 
-    init: function (parent, options) {
-        this._super.apply(this, arguments);
+    willStart: function (parent) {
+        const def = this._super.apply(this, arguments);
+
+        const options = this.$el.data();
         this.rating_avg = Math.round(options['rating_avg'] * 100) / 100 || 0.0;
         this.rating_count = options['rating_count'] || 0.0;
 
@@ -32,49 +38,23 @@ var RatingPopupComposer = publicWidget.Widget.extend({
             'res_model': false,
             'res_id': false,
             'pid': 0,
-            'display_composer': options['disable_composer'] ? false : !session.is_website_user,
             'display_rating': true,
             'csrf_token': odoo.csrf_token,
             'user_id': session.user_id,
         });
-    },
-    /**
-     * @override
-     */
-    start: function () {
-        var defs = [];
-        defs.push(this._super.apply(this, arguments));
 
-        // instanciate and insert composer widget
-        this._composer = new PortalComposer(this, this.options);
-        defs.push(this._composer.replace(this.$('.o_portal_chatter_composer')));
-
-        return Promise.all(defs);
-    },
-});
-
-publicWidget.registry.RatingPopupComposer = publicWidget.Widget.extend({
-    selector: '.o_rating_popup_composer',
-    custom_events: {
-        reload_rating_popup_composer: '_onReloadRatingPopupComposer',
+        return def;
     },
 
     /**
      * @override
      */
     start: function () {
-        this.ratingPopupData = this.$el.data();
-        this.ratingPopupData.display_composer = !this.ratingPopupData.disable_composer && !session.is_website_user;
-        this.ratingPopup = new RatingPopupComposer(this, this.ratingPopupData);
         return Promise.all([
             this._super.apply(this, arguments),
-            this.ratingPopup.appendTo(this.$el)
+            this._reloadRatingPopupComposer(),
         ]);
     },
-
-    //--------------------------------------------------------------------------
-    // Private
-    //--------------------------------------------------------------------------
 
     /**
      * Destroy existing ratingPopup and insert new ratingPopup widget
@@ -82,14 +62,41 @@ publicWidget.registry.RatingPopupComposer = publicWidget.Widget.extend({
      * @private
      * @param {Object} data
      */
-    _reloadRatingPopupComposer: function (data) {
-        if (this.ratingPopup) {
-            this.ratingPopup.destroy();
+    _reloadRatingPopupComposer: function () {
+        if (this.options.hide_rating_avg) {
+            this.$('.o_rating_popup_composer_stars').empty();
+        } else {
+            const ratingAverage = qweb.render(
+                'portal_rating.rating_stars_static', {
+                inline_mode: true,
+                widget: this,
+                val: this.rating_avg,
+            });
+            this.$('.o_rating_popup_composer_stars').empty().html(ratingAverage);
         }
-        if (this.ratingPopupData.display_composer) {
-            this.ratingPopup = new RatingPopupComposer(this, Object.assign(this.ratingPopupData, data));
-            this.ratingPopup.appendTo(this.$el);
+
+        // Append the modal
+        const modal = qweb.render(
+            'portal_rating.PopupComposer', {
+            inline_mode: true,
+            widget: this,
+            val: this.rating_avg,
+        });
+        this.$('.o_rating_popup_composer_modal').html(modal);
+
+        if (this._composer) {
+            this._composer.destroy();
         }
+
+        // Instantiate the "Portal Composer" widget and insert it into the modal
+        this._composer = new PortalComposer(this, this.options);
+        return this._composer.appendTo(this.$('.o_rating_popup_composer_modal .o_portal_chatter_composer')).then(() => {
+            // Change the text of the button
+            this.$('.o_rating_popup_composer_text').text(
+                this.options.default_message_id ?
+                _t('Modify your review') : _t('Add a review')
+            );
+        });
     },
 
     //--------------------------------------------------------------------------
@@ -98,12 +105,28 @@ publicWidget.registry.RatingPopupComposer = publicWidget.Widget.extend({
 
     /**
      * @private
-     * @param {OdooEvent} ev
+     * @param {OdooEvent} event
      */
-    _onReloadRatingPopupComposer: function (ev) {
-        this._reloadRatingPopupComposer(ev.data);
+    _onReloadRatingPopupComposer: function (event) {
+        const data = event.data;
+
+        // Refresh the internal state of the widget
+        this.rating_avg = data.rating_avg;
+        this.rating_count = data.rating_count;
+        this.rating_value = data.rating_value;
+
+        // Clean the dictionary
+        delete data.rating_avg;
+        delete data.rating_count;
+        delete data.rating_value;
+
+        this.options = _.extend(this.options, data);
+
+        this._reloadRatingPopupComposer();
     }
 });
+
+publicWidget.registry.RatingPopupComposer = RatingPopupComposer;
 
 return RatingPopupComposer;
 

--- a/addons/portal_rating/static/src/js/portal_rating_composer.js
+++ b/addons/portal_rating/static/src/js/portal_rating_composer.js
@@ -17,6 +17,7 @@ var RatingPopupComposer = publicWidget.Widget.extend({
     template: 'portal_rating.PopupComposer',
     xmlDependencies: [
         '/portal/static/src/xml/portal_chatter.xml',
+        '/portal_rating/static/src/xml/portal_chatter.xml',
         '/portal_rating/static/src/xml/portal_tools.xml',
         '/portal_rating/static/src/xml/portal_rating_composer.xml',
     ],

--- a/addons/portal_rating/static/src/xml/portal_rating_composer.xml
+++ b/addons/portal_rating/static/src/xml/portal_rating_composer.xml
@@ -7,22 +7,25 @@
     <t t-name="portal_rating.PopupComposer">
         <div class="d-flex flex-wrap align-items-center">
             <div class="text-nowrap">
-                <t t-call="portal_rating.rating_stars_static">
+                <t t-call="portal_rating.rating_stars_static" t-if="!widget.options['hide_rating_avg']">
                     <t t-set="val" t-value="widget.rating_avg || 0"/>
                     <t t-set="inline_mode" t-value="true"/>
                 </t>
             </div>
             <button t-if="widget.options['display_composer']" type="button"
-                t-att-class="'btn btn-sm mx-3 ' + widget.options['link_btn_classes'] or 'btn-primary'"
+                t-att-class="'btn ' + widget.options['link_btn_classes'] or 'btn-primary'"
                 data-toggle="modal" data-target="#ratingpopupcomposer">
-                <t t-if="widget.options['display_composer']">
-                    <t t-if="widget.options['default_message_id']">
-                        Modify your review
+                <i t-if="widget.options['icon']" t-att-class="widget.options['icon']"/>
+                <span t-att-class="widget.options['_text_classes']">
+                    <t t-if="widget.options['display_composer']">
+                        <t t-if="widget.options['default_message_id']">
+                            Modify your review
+                        </t>
+                        <t t-else="">
+                            Write a review
+                        </t>
                     </t>
-                    <t t-else="">
-                        Write a review
-                    </t>
-                </t>
+                </span>
             </button>
         </div>
 

--- a/addons/portal_rating/static/src/xml/portal_rating_composer.xml
+++ b/addons/portal_rating/static/src/xml/portal_rating_composer.xml
@@ -5,30 +5,6 @@
         It can also be used to modify a message
     -->
     <t t-name="portal_rating.PopupComposer">
-        <div class="d-flex flex-wrap align-items-center">
-            <div class="text-nowrap">
-                <t t-call="portal_rating.rating_stars_static" t-if="!widget.options['hide_rating_avg']">
-                    <t t-set="val" t-value="widget.rating_avg || 0"/>
-                    <t t-set="inline_mode" t-value="true"/>
-                </t>
-            </div>
-            <button t-if="widget.options['display_composer']" type="button"
-                t-att-class="'btn ' + widget.options['link_btn_classes'] or 'btn-primary'"
-                data-toggle="modal" data-target="#ratingpopupcomposer">
-                <i t-if="widget.options['icon']" t-att-class="widget.options['icon']"/>
-                <span t-att-class="widget.options['_text_classes']">
-                    <t t-if="widget.options['display_composer']">
-                        <t t-if="widget.options['default_message_id']">
-                            Modify your review
-                        </t>
-                        <t t-else="">
-                            Write a review
-                        </t>
-                    </t>
-                </span>
-            </button>
-        </div>
-
         <div t-if="widget.options['display_composer']" class="modal fade" id="ratingpopupcomposer" tabindex="-1" role="dialog" aria-labelledby="ratingpopupcomposerlabel" aria-hidden="true">
             <div class="modal-dialog" role="document">
                 <div class="modal-content">

--- a/addons/portal_rating/views/rating_templates.xml
+++ b/addons/portal_rating/views/rating_templates.xml
@@ -50,7 +50,10 @@
             t-att-data-default_attachment_ids="default_attachment_ids"
             t-att-data-force_submit_url="force_submit_url"
             t-att-data-disable_composer="disable_composer"
-            t-att-data-link_btn_classes="_link_btn_classes">
+            t-att-data-link_btn_classes="_link_btn_classes"
+            t-att-data-icon="icon"
+            t-att-data-text_classes="_text_classes"
+            t-att-data-hide_rating_avg="hide_rating_avg">
         </div>
     </template>
 </odoo>

--- a/addons/portal_rating/views/rating_templates.xml
+++ b/addons/portal_rating/views/rating_templates.xml
@@ -35,6 +35,8 @@
                      the message will be posted with the identity of the partner_id of the object
     -->
     <template id="rating_stars_static_popup_composer" name="Rating: rating composer in popup">
+        <t t-set="display_composer" t-value="not disable_composer and not request.session.is_website_user"/>
+
         <div class="d-print-none o_rating_popup_composer o_not_editable p-0"
             t-att-data-rating_avg="rating_avg or 0.0"
             t-att-data-rating_count="rating_count or 0.0"
@@ -50,10 +52,24 @@
             t-att-data-default_attachment_ids="default_attachment_ids"
             t-att-data-force_submit_url="force_submit_url"
             t-att-data-disable_composer="disable_composer"
+            t-att-data-display_composer="display_composer"
             t-att-data-link_btn_classes="_link_btn_classes"
             t-att-data-icon="icon"
             t-att-data-text_classes="_text_classes"
             t-att-data-hide_rating_avg="hide_rating_avg">
+            <div class="d-flex flex-wrap align-items-center">
+                <div class="o_rating_popup_composer_stars text-nowrap"/>
+                <button t-if="display_composer" type="button"
+                    t-att-class="'btn ' + _link_btn_classes or 'btn-primary'"
+                    data-toggle="modal" data-target="#ratingpopupcomposer">
+                    <i t-if="icon" t-att-class="icon"/>
+                    <span t-attf-class="#{_text_classes} o_rating_popup_composer_text">
+                        <t t-if="default_message_id">Modify your review</t>
+                        <t t-else="">Write a review</t>
+                    </span>
+                </button>
+                <div class="o_rating_popup_composer_modal"/>
+            </div>
         </div>
     </template>
 </odoo>

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -513,49 +513,14 @@ class WebsiteSlides(WebsiteProfile):
             'slide_types': slide_types,
             'sorting': actual_sorting,
             'search': search,
-            # chatter
-            'rating_avg': channel.rating_avg,
-            'rating_count': channel.rating_count,
             # display data
             'user': request.env.user,
             'pager': pager,
             'is_public_user': request.website.is_public_user(),
             # display upload modal
             'enable_slide_upload': 'enable_slide_upload' in kw,
+            ** self._slide_channel_prepare_review_values(channel),
         }
-        if not request.env.user._is_public():
-            last_message = request.env['mail.message'].search([
-                ('model', '=', channel._name),
-                ('res_id', '=', channel.id),
-                ('author_id', '=', request.env.user.partner_id.id),
-                ('message_type', '=', 'comment'),
-                ('is_internal', '=', False)
-            ], order='write_date DESC', limit=1)
-            if last_message:
-                last_message_values = last_message.read(['body', 'rating_value', 'attachment_ids'])[0]
-                last_message_attachment_ids = last_message_values.pop('attachment_ids', [])
-                if last_message_attachment_ids:
-                    # use sudo as portal user cannot read access_token, necessary for updating attachments
-                    # through frontend chatter -> access is already granted and limited to current user message
-                    last_message_attachment_ids = json.dumps(
-                        request.env['ir.attachment'].sudo().browse(last_message_attachment_ids).read(
-                            ['id', 'name', 'mimetype', 'file_size', 'access_token']
-                        )
-                    )
-            else:
-                last_message_values = {}
-                last_message_attachment_ids = []
-            values.update({
-                'last_message_id': last_message_values.get('id'),
-                'last_message': tools.html2plaintext(last_message_values.get('body', '')),
-                'last_rating_value': last_message_values.get('rating_value'),
-                'last_message_attachment_ids': last_message_attachment_ids,
-            })
-            if channel.can_review:
-                values.update({
-                    'message_post_hash': channel._sign_token(request.env.user.partner_id.id),
-                    'message_post_pid': request.env.user.partner_id.id,
-                })
 
         # fetch slides and handle uncategorized slides; done as sudo because we want to display all
         # of them but unreachable ones won't be clickable (+ slide controller will crash anyway)
@@ -617,6 +582,50 @@ class WebsiteSlides(WebsiteProfile):
             'tag_ids': [(6, 0, tag_ids)],
             'allow_comment': bool(kw.get('allow_comment')),
         }
+
+    def _slide_channel_prepare_review_values(self, channel):
+        values = {
+            'rating_avg': channel.rating_avg,
+            'rating_count': channel.rating_count,
+        }
+
+        if not request.env.user._is_public():
+            last_message = request.env['mail.message'].search([
+                ('model', '=', channel._name),
+                ('res_id', '=', channel.id),
+                ('author_id', '=', request.env.user.partner_id.id),
+                ('message_type', '=', 'comment'),
+                ('is_internal', '=', False)
+            ], order='write_date DESC', limit=1)
+
+            if last_message:
+                last_message_values = last_message.read(['body', 'rating_value', 'attachment_ids'])[0]
+                last_message_attachment_ids = last_message_values.pop('attachment_ids', [])
+                if last_message_attachment_ids:
+                    # use sudo as portal user cannot read access_token, necessary for updating attachments
+                    # through frontend chatter -> access is already granted and limited to current user message
+                    last_message_attachment_ids = json.dumps(
+                        request.env['ir.attachment'].sudo().browse(last_message_attachment_ids).read(
+                            ['id', 'name', 'mimetype', 'file_size', 'access_token']
+                        )
+                    )
+            else:
+                last_message_values = {}
+                last_message_attachment_ids = []
+
+            values.update({
+                'last_message_id': last_message_values.get('id'),
+                'last_message': tools.html2plaintext(last_message_values.get('body', '')),
+                'last_rating_value': last_message_values.get('rating_value'),
+                'last_message_attachment_ids': last_message_attachment_ids,
+            })
+            if channel.can_review:
+                values.update({
+                    'message_post_hash': channel._sign_token(request.env.user.partner_id.id),
+                    'message_post_pid': request.env.user.partner_id.id,
+                })
+
+        return values
 
     @http.route('/slides/channel/enroll', type='http', auth='public', website=True)
     def slide_channel_join_http(self, channel_id):
@@ -730,12 +739,13 @@ class WebsiteSlides(WebsiteProfile):
 
         values['channel'] = slide.channel_id
         values = self._prepare_additional_channel_values(values, **kwargs)
-        values.pop('channel', None)
-
         values['signup_allowed'] = request.env['res.users'].sudo()._get_signup_invitation_scope() == 'b2c'
 
         if kwargs.get('fullscreen') == '1':
+            values.update(self._slide_channel_prepare_review_values(slide.channel_id))
             return request.render("website_slides.slide_fullscreen", values)
+
+        values.pop('channel', None)
         return request.render("website_slides.slide_main", values)
 
     @http.route('''/slides/slide/<model("slide.slide"):slide>/pdf_content''',

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -154,7 +154,7 @@
                                     <t t-set="default_attachment_ids" t-value="last_message_attachment_ids"/>
                                     <t t-set="force_submit_url" t-value="'/slides/mail/update_comment' if last_message_id else False"/>
                                     <t t-set="disable_composer" t-value="not channel.can_review"/>
-                                    <t t-set="_link_btn_classes" t-value="'btn-link text-white'"/>
+                                    <t t-set="_link_btn_classes" t-value="'btn-sm btn-link text-white mx-3'"/>
                                 </t>
                             </div>
                         </div>

--- a/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
@@ -18,8 +18,25 @@
                     <a class="o_wslides_fs_toggle_sidebar d-flex align-items-center px-3" href="#" title="Lessons">
                         <i class="fa fa-bars"/><span class="d-none d-md-inline-block ml-1">Lessons</span>
                     </a>
-                    <a class="o_wslides_fs_review d-flex align-items-center px-3" t-att-href="slide.channel_id.website_url + '?active_tab=review'" title="Reviews" t-if="slide.channel_id.allow_comment">
-                        <i class="fa fa-pencil"/><span class="d-none d-md-inline-block ml-1">Write a review</span>
+                    <a class="o_wslides_fs_review d-flex align-items-center" title="Reviews" t-if="slide.channel_id.allow_comment">
+                        <t t-call="portal_rating.rating_stars_static_popup_composer">
+                            <t t-set="rating_avg" t-value="rating_avg"/>
+                            <t t-set="rating_total" t-value="rating_count"/>
+                            <t t-set="object" t-value="channel"/>
+                            <t t-set="token" t-value="channel.access_token"/>
+                            <t t-set="hash" t-value="message_post_hash"/>
+                            <t t-set="pid" t-value="message_post_pid"/>
+                            <t t-set="default_message" t-value="last_message"/>
+                            <t t-set="default_message_id" t-value="last_message_id"/>
+                            <t t-set="default_rating_value" t-value="last_rating_value"/>
+                            <t t-set="default_attachment_ids" t-value="last_message_attachment_ids"/>
+                            <t t-set="force_submit_url" t-value="'/slides/mail/update_comment' if last_message_id else False"/>
+                            <t t-set="disable_composer" t-value="not channel.can_review"/>
+                            <t t-set="_link_btn_classes" t-value="'d-inline-block text-white font-weight-light shadow-none'"/>
+                            <t t-set="icon" t-value="'fa fa-pencil'"/>
+                            <t t-set="_text_classes" t-value="'d-none d-md-inline-block'"/>
+                            <t t-set="hide_rating_avg" t-value="True"/>
+                        </t>
                     </a>
                     <a class="o_wslides_fs_share d-flex align-items-center px-3" href="#" title="Share">
                         <i class="fa fa-share-alt"/><span class="d-none d-md-inline-block ml-1">Share</span>


### PR DESCRIPTION
Purpose
=======
Currently we can write a review in the slide fullscreen view.
But if we click on the button "review", we are redirected to the reviews
page. Instead, we want to open the rating composer and to stay in the
page.

Technical
=========
Add the dependency "portal_chatter.xml" from portal rating on the portal
composer Widget. It already has the dependency "portal_chatter.xml"
from the simple portal module, but because the second file was not in
the dependency, the view was not inherited and we were not able to rate
the review.

Add a new option on the portal rating composer, "hide_rating_avg" in
order to hide the global rating on the button and allow to fully
customize the button to have the same look as other buttons in the same
view.

Task-2322583