### PR TITLE
[FIX] hr: Edit private address fields directly instead of M2O

### DIFF
--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -25,6 +25,14 @@ class User(models.Model):
     employee_parent_id = fields.Many2one(related='employee_id.parent_id', readonly=False, related_sudo=False)
     coach_id = fields.Many2one(related='employee_id.coach_id', readonly=False, related_sudo=False)
     address_home_id = fields.Many2one(related='employee_id.address_home_id', readonly=False, related_sudo=False)
+    private_street = fields.Char(related='address_home_id.street', string="Private Street", readonly=False, related_sudo=False)
+    private_street2 = fields.Char(related='address_home_id.street2', string="Private Street2", readonly=False, related_sudo=False)
+    private_city = fields.Char(related='address_home_id.city', string="Private City", readonly=False, related_sudo=False)
+    private_state_id = fields.Many2one(
+        related='address_home_id.state_id', string="Private State", readonly=False, related_sudo=False,
+        domain="[('country_id', '=?', private_country_id)]")
+    private_zip = fields.Char(related='address_home_id.zip', readonly=False, string="Private Zip", related_sudo=False)
+    private_country_id = fields.Many2one(related='address_home_id.country_id', string="Private Country", readonly=False, related_sudo=False)
     is_address_home_a_company = fields.Boolean(related='employee_id.is_address_home_a_company', readonly=False, related_sudo=False)
     private_email = fields.Char(related='address_home_id.email', string="Private Email", readonly=False)
     km_home_work = fields.Integer(related='employee_id.km_home_work', readonly=False, related_sudo=False)
@@ -78,6 +86,7 @@ class User(models.Model):
             'active',
             'child_ids',
             'employee_id',
+            'address_home_id',
             'employee_ids',
             'employee_parent_id',
             'hr_presence_state',
@@ -88,7 +97,12 @@ class User(models.Model):
 
         hr_writable_fields = [
             'additional_note',
-            'address_home_id',
+            'private_street',
+            'private_street2',
+            'private_city',
+            'private_state_id',
+            'private_zip',
+            'private_country_id',
             'address_id',
             'barcode',
             'birthday',

--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -124,14 +124,17 @@
                         <group>
                             <group string="Contact Information">
                                 <field name="employee_ids" invisible="1"/>
-                                <field name="address_home_id"
-                                    context="{
-                                        'show_address': 1,
-                                        'default_employee_ids': employee_ids,
-                                        'default_type': 'private',
-                                        'form_view_ref': 'base.res_partner_view_form_private'}"
-                                    options='{"always_reload": True, "highlight_first_line": True}'
-                                    attrs="{'readonly': [('can_edit', '=', False)]}"/>
+                                <field name="address_home_id" invisible="1"/>
+                                <label for="private_street" string="Private Address"/>
+                                <div class="o_address_format">
+                                    <field name="private_street" placeholder="Street..." class="o_address_street"/>
+                                    <field name="private_street2" placeholder="Street 2..." class="o_address_street"/>
+                                    <field name="private_city" placeholder="City" class="o_address_city"/>
+                                    <field name="private_state_id" class="o_address_state" placeholder="State" options="{'no_open': True, 'no_quick_create': True}" context="{'default_country_id': private_country_id}"/>
+                                    <field name="private_zip" placeholder="ZIP" class="o_address_zip"/>
+                                    <field name="private_country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'/>
+                                </div>
+
                                 <field name="private_email" string="Email" attrs="{'readonly': [('can_edit', '=', False)], 'invisible': [('address_home_id', '=', False)]}"/>
                                 <field name="employee_phone" string="Phone" class="o_force_ltr" attrs="{'readonly': [('can_edit', '=', False)], 'invisible': [('address_home_id', '=', False)]}" options="{'enable_sms': false}"/>
                                 <field name="employee_bank_account_id" attrs="{'readonly': [('can_edit', '=', False)]}"/>


### PR DESCRIPTION
Purpose
=======

The goal of this commit if double:
- Prevent employees to change the m2o address_home_id, that could lead
  to future inconsistencies on future HR processes
- Allow the employee to modify it own private address, even if the
  access is restricted to administrators for private addresses

TaskID: 2412387

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
