### PR TITLE
[FIX] mail: set main attachment id also in mass_mail mode

### DIFF
--- a/addons/account/wizard/account_invoice_send.py
+++ b/addons/account/wizard/account_invoice_send.py
@@ -92,6 +92,9 @@ class AccountInvoiceSend(models.TransientModel):
                 #Salesman send posted invoice, without the right to write
                 #but they should have the right to change this flag
                 self.mapped('invoice_ids').sudo().write({'invoice_sent': True})
+            for inv in self.invoice_ids:
+                if inv.attachment_ids:
+                    inv._message_set_main_attachment_id([(False,att) for att in inv.attachment_ids.ids])
 
     def _print_document(self):
         """ to override for each type of models that will use this composer."""


### PR DESCRIPTION
On Invoicing
Select 2+ draft records.
Action > Post entries
Action > Send & print
Send

The `message_main_attachment_id` will not be registered on the records
unless manually opening them in the view. This will have a negative side effect
on the functionalities based on that field such as account_followup
send_email with join_invoices

opw-2391508

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
