### PR TITLE
[FIX] base: key error during uninstall of unavailable module

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1885,8 +1885,11 @@ class IrModelData(models.Model):
         # methods is not in cache it will be fetched, and fields that exist in the registry but not
         # in the database will be prefetched, this will of course fail and prevent the uninstall.
         for ir_field in self.env['ir.model.fields'].browse(field_ids):
-            field = self.pool[ir_field.model]._fields[ir_field.name]
-            field.prefetch = False
+            model = self.pool.get(ir_field.model)
+            if model is not None:
+                field = model._fields.get(ir_field.name)
+                if field is not None:
+                    field.prefetch = False
 
         # to collect external ids of records that cannot be deleted
         undeletable_ids = []


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
In order to disable prefetch based on information from the database it is needed that the module and models of the unavailable module is initialized which is not the case if code is for example not available anymore, though we do check if the field is initialized on the related module.

**Current behavior before PR:**
KeyError on uninstall while the code of the installed module is not available anymore

**Desired behavior after PR is merged:**
Uninstall is working as expected

Info: @wt-io-it



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
