### PR TITLE
[FIX] core: filtered_domain() should return its result in order

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -763,6 +763,16 @@ class TestExpression(TransactionCase):
         expr = expression.AND([expression.OR([false]), normal])
         self.assertEqual(expr, false)
 
+    def test_filtered_domain_order(self):
+        domain = [('name', 'ilike', 'a')]
+        countries = self.env['res.country'].search(domain)
+        self.assertGreater(len(countries), 1)
+        # same ids, same order
+        self.assertEqual(countries.filtered_domain(domain)._ids, countries._ids)
+        # again, trying the other way around
+        countries = countries.browse(reversed(countries._ids))
+        self.assertEqual(countries.filtered_domain(domain)._ids, countries._ids)
+
 
 class TestAutoJoin(TransactionCase):
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5350,7 +5350,7 @@ Fields:
                         model = model[fname]
                 if comparator in ('like', 'ilike', '=like', '=ilike', 'not ilike', 'not like'):
                     value_esc = value.replace('_', '?').replace('%', '*').replace('[', '?')
-                records_ids = set()
+                records_ids = OrderedSet()
                 for rec in self:
                     data = rec.mapped(key)
                     if comparator in ('child_of', 'parent_of'):


### PR DESCRIPTION
Use an `OrderedSet` instead of a `set` to collect ids.