### PR TITLE
[11.0] Fix dashboard action domain evaluation

### DIFF
--- a/addons/board/static/src/js/dashboard.js
+++ b/addons/board/static/src/js/dashboard.js
@@ -336,11 +336,12 @@ FormRenderer.include({
 
         // render each view
         _.each(this.actionsDescr, function (action) {
-            self.defs.push(self._createController({
+            var eval_context = self._getActionEvalContext(action);
+            var domain =  pyUtils.eval('domain', action.domain || '[]', eval_context);            self.defs.push(self._createController({
                 $node: $html.find('.oe_action[data-id=' + action.id + '] .oe_content'),
                 actionID: _.str.toNumber(action.name),
-                context: new Context(action.context),
-                domain: Domain.prototype.stringToArray(action.domain, {}),
+                context: eval_context,
+                domain: domain,
                 viewType: action.view_mode,
             }));
         });
@@ -353,6 +354,16 @@ FormRenderer.include({
         });
 
         return $html;
+    },
+    /**
+     * @private
+     * @param {Object} action
+     * @returns {Object}
+     */
+    _getActionEvalContext: function (action) {
+        var rawContext = new Context(action.context, {lang: session.user_context.lang});
+        var context = pyUtils.eval('context', rawContext);
+        return _.extend(context, session.user_context);
     },
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Dashboard actions' domain must be evaluated w/ current context
otherwise is impossible to define dynamic filter.
Without this change you cannot even use uid in the domain.

It used to work before version 11.

Current behavior before PR:

Dashboard broken if you use uid in action domain because domain evaluation is static.

Desired behavior after PR is merged:

Make it work as it used to.
Replaces https://github.com/odoo/odoo/pull/33055 that creates conflicts when trying to merge (too old)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr