### PR TITLE
[FIX] mail: prevent Safari from indefinitely focusing composer

### DIFF
--- a/addons/mail/static/src/components/composer_text_input/composer_text_input.js
+++ b/addons/mail/static/src/components/composer_text_input/composer_text_input.js
@@ -165,11 +165,13 @@ class ComposerTextInput extends Component {
         }
         this._textareaRef.el.value = this.composer.textInputContent;
         this._mirroredTextareaRef.el.value = this.composer.textInputContent;
-        this._textareaRef.el.setSelectionRange(
-            this.composer.textInputCursorStart,
-            this.composer.textInputCursorEnd,
-            this.composer.textInputSelectionDirection,
-        );
+        if (this.composer.hasFocus) {
+            this._textareaRef.el.setSelectionRange(
+                this.composer.textInputCursorStart,
+                this.composer.textInputCursorEnd,
+                this.composer.textInputSelectionDirection,
+            );
+        }
         this._updateHeight();
     }
 


### PR DESCRIPTION
`setSelectionRange()` on Safari has side-effect to focusing the
input element, which is not the case in Chrome and Firefox.

Task-2410311