### PR TITLE
[FIX] website_forum, website_profile: disable editor toolbar options

### DIFF
--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -117,6 +117,8 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
             var editorKarma = $textarea.data('karma') || 0; // default value for backward compatibility
             var $form = $textarea.closest('form');
             var hasFullEdit = parseInt($("#karma").val()) >= editorKarma;
+            // Warning: Do not activate any option that adds inline style.
+            // Because the style is deleted after save.
             var toolbar = [
                 ['style', ['style']],
                 ['font', ['bold', 'italic', 'underline', 'clear']],
@@ -139,6 +141,7 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
                     res_model: 'forum.post',
                     res_id: +window.location.pathname.split('-').pop(),
                 },
+                disableResizeImage: true,
             };
             if (!hasFullEdit) {
                 options.plugins = {

--- a/addons/website_profile/static/src/js/website_profile.js
+++ b/addons/website_profile/static/src/js/website_profile.js
@@ -60,13 +60,26 @@ publicWidget.registry.websiteProfileEditor = publicWidget.Widget.extend({
             return def;
         }
 
+        // Warning: Do not activate any option that adds inline style.
+        // Because the style is deleted after save.
+        var toolbar = [
+            ['style', ['style']],
+            ['font', ['bold', 'italic', 'underline', 'clear']],
+            ['para', ['ul', 'ol', 'paragraph']],
+            ['table', ['table']],
+            ['insert', ['link', 'picture']],
+            ['history', ['undo', 'redo']],
+        ];
+
         var $textarea = this.$('textarea.o_wysiwyg_loader');
         var loadProm = wysiwygLoader.load(this, $textarea[0], {
+            toolbar: toolbar,
             recordInfo: {
                 context: this._getContext(),
                 res_model: 'res.users',
                 res_id: parseInt(this.$('input[name=user_id]').val()),
             },
+            disableResizeImage: true,
         }).then(wysiwyg => {
             this._wysiwyg = wysiwyg;
         });


### PR DESCRIPTION
Before this commit, the inline style added with some options of the
editor toolbar when editing a textarea was removed due to the
strip_style of the content field.

Since we cannot remove this strip_style for security reasons, we can
only disable options that add inline style.

This commit closes #34288

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
