### PR TITLE
[FIX] mail: turn tagged name with special characters into links

### DIFF
--- a/addons/mail/static/src/js/utils.js
+++ b/addons/mail/static/src/js/utils.js
@@ -146,7 +146,7 @@ function parseEmail(text) {
  */
 function escapeAndCompactTextContent(content) {
     //Removing unwanted extra spaces from message
-    let value = _.escape(content).trim();
+    let value = owl.utils.escape(content).trim();
     value = value.replace(/(\r|\n){2,}/g, '<br/><br/>');
     value = value.replace(/(\r|\n)/g, '<br/>');
 


### PR DESCRIPTION
STEPS:
* Created partner with following name: Putin's spokesman
* Tag the partner in a message: @Putin's spokesman

BEFORE: tag is not converted into a link
AFTER: the link is created

WHY: body is additionally escaped which breaks replacing text to link:

https://github.com/odoo/odoo/blob/329b00365e7b7702eb4923443c99ddac13340ae8/addons/mail/static/src/js/utils.js#L149

---

opw-2408863

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
