### PR TITLE
[FIX] purchase: x2m tree purchase.order subfield ok


### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -529,7 +529,7 @@
                     <field name="amount_total" sum="Total amount" widget="monetary" optional="show"/>
                     <field name="currency_id" invisible="1"/>
                     <field name="state" optional="show"/>
-                    <field name="invoice_status" attrs="{'column_invisible': [('parent.state', 'not in', ('purchase', 'done'))]}"/>
+                    <field name="invoice_status" optional="hide"/>
                     <field name="activity_exception_decoration" widget="activity_exception"/>
                 </tree>
             </field>


### PR DESCRIPTION

In 376891294 the default purchase.order view tree was changed to have
different view with dashboard.

But the current view referenced:

    ('parent.state', 'not in', ('purchase', 'done'))

which seems incorrect because an x2many view towards purchase.order
could currently only be used for purchase.requisition (doesn't have
purchase/done as state value) and stock.production.lot (doesn't have
state field) or a customization that might not have state field.

With this change, we copy what there was originally on this field.

opw-2381767
