### PR TITLE
[FIX] stock: do not consider date_deadline when merging moves

### DIFF
--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -300,7 +300,7 @@ class StockRule(models.Model):
             'route_ids': [(4, route.id) for route in values.get('route_ids', [])],
             'warehouse_id': self.propagate_warehouse_id.id or self.warehouse_id.id,
             'date': date_scheduled,
-            'date_deadline': date_deadline,
+            'date_deadline': False if self.group_propagation_option == 'fixed' else date_deadline,
             'propagate_cancel': self.propagate_cancel,
             'description_picking': picking_description,
             'priority': values.get('priority', "0"),


### PR DESCRIPTION
- Set the Delivery in 2 steps in the warehouse
- Create a 'wave' route:
  - Sequence: 5
  - Apply on Product Categories
  - Rules:
    - Action: Pull From
    - Operation Type: San Francisco: Pick
    - Source Location: WH/Stock/Chairs
    - Destination Location: WH/Output
    - Supply Method: Take From Stock
    - Propagation of Procurement Group: Fixed
    - Fixed Procurement Group: Chairs
- Create a 'Chairs' product category, apply the wave route
- Create a 'Chair' product:
  - Category: Chairs
  - Storable
- Make some stock in WH/Stock/Chairs
- Create a SO for 1 Unit of Chair, confirm
  => a picking from WH/Stock/Chairs to WH/Output is created
- Create a SO for 2 Units of Chair, confirm
  => the 2 units are added to the previous picking

However, the 2 stock moves are not merged.

It happens because `date_deadline` prevents the grouping.

opw-2390630

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
