### PR TITLE
[FIX] stock(_account): performance _action_done stock move

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -5,6 +5,7 @@ from collections import Counter
 
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import UserError, ValidationError
+from odoo.tools import OrderedSet
 from odoo.tools.float_utils import float_round, float_compare, float_is_zero
 
 
@@ -416,7 +417,7 @@ class StockMoveLine(models.Model):
         # adjustment, enforce some rules on the `lot_id` field. If `qty_done` is null, we unlink
         # the line. It is mandatory in order to free the reservation and correctly apply
         # `action_done` on the next move lines.
-        ml_to_delete = self.env['stock.move.line']
+        ml_ids_to_delete = OrderedSet()
         lot_vals_to_create = []  # lot values for batching the creation
         associate_line_lot = []  # move_line to associate to the lot
         for ml in self:
@@ -457,18 +458,22 @@ class StockMoveLine(models.Model):
             elif qty_done_float_compared < 0:
                 raise UserError(_('No negative quantities allowed'))
             else:
-                ml_to_delete |= ml
-        ml_to_delete.unlink()
+                ml_ids_to_delete.add(ml.id)
+
+        mls_to_delete = self.env['stock.move.line'].browse(ml_ids_to_delete)
+        mls_to_delete.unlink()
 
         # Batching the creation of lots and associated each to the right ML (order is preserve in the create)
         lots = self.env['stock.production.lot'].create(lot_vals_to_create)
         for ml, lot in zip(associate_line_lot, lots):
             ml.write({'lot_id': lot.id})
 
-        (self - ml_to_delete)._check_company()
+        mls_todo = (self - mls_to_delete)
+        mls_todo._check_company()
+
         # Now, we can actually move the quant.
-        done_ml = self.env['stock.move.line']
-        for ml in self - ml_to_delete:
+        ml_ids_to_ignore = OrderedSet()
+        for ml in mls_todo:
             if ml.product_id.type == 'product':
                 rounding = ml.product_uom_id.rounding
 
@@ -476,7 +481,8 @@ class StockMoveLine(models.Model):
                 if not ml._should_bypass_reservation(ml.location_id) and float_compare(ml.qty_done, ml.product_uom_qty, precision_rounding=rounding) > 0:
                     qty_done_product_uom = ml.product_uom_id._compute_quantity(ml.qty_done, ml.product_id.uom_id, rounding_method='HALF-UP')
                     extra_qty = qty_done_product_uom - ml.product_qty
-                    ml._free_reservation(ml.product_id, ml.location_id, extra_qty, lot_id=ml.lot_id, package_id=ml.package_id, owner_id=ml.owner_id, ml_to_ignore=done_ml)
+                    ml_to_ignore = self.env['stock.move.line'].browse(ml_ids_to_ignore)
+                    ml._free_reservation(ml.product_id, ml.location_id, extra_qty, lot_id=ml.lot_id, package_id=ml.package_id, owner_id=ml.owner_id, ml_to_ignore=ml_to_ignore)
                 # unreserve what's been reserved
                 if not ml._should_bypass_reservation(ml.location_id) and ml.product_id.type == 'product' and ml.product_qty:
                     try:
@@ -495,9 +501,9 @@ class StockMoveLine(models.Model):
                         Quant._update_available_quantity(ml.product_id, ml.location_id, -taken_from_untracked_qty, lot_id=False, package_id=ml.package_id, owner_id=ml.owner_id)
                         Quant._update_available_quantity(ml.product_id, ml.location_id, taken_from_untracked_qty, lot_id=ml.lot_id, package_id=ml.package_id, owner_id=ml.owner_id)
                 Quant._update_available_quantity(ml.product_id, ml.location_dest_id, quantity, lot_id=ml.lot_id, package_id=ml.result_package_id, owner_id=ml.owner_id, in_date=in_date)
-            done_ml |= ml
+            ml_ids_to_ignore.add(ml.id)
         # Reset the reserved quantity as we just moved it to the destination location.
-        (self - ml_to_delete).with_context(bypass_reservation_update=True).write({
+        mls_todo.with_context(bypass_reservation_update=True).write({
             'product_uom_qty': 0.00,
             'date': fields.Datetime.now(),
         })

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -472,8 +472,11 @@ class Picking(models.Model):
             picking.move_line_exist = bool(picking.move_line_ids)
 
     def _compute_has_packages(self):
+        domain = [('picking_id', 'in', self.ids), ('result_package_id', '!=', False)]
+        cnt_by_picking = self.env['stock.move.line'].read_group(domain, ['picking_id'], ['picking_id'])
+        cnt_by_picking = {d['picking_id'][0]: d['picking_id_count'] for d in cnt_by_picking}
         for picking in self:
-            picking.has_packages = picking.move_line_ids.filtered(lambda ml: ml.result_package_id)
+            picking.has_packages = bool(cnt_by_picking.get(picking.id, False))
 
     def _compute_show_check_availability(self):
         """ According to `picking.show_check_availability`, the "check availability" button will be

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -66,7 +66,7 @@ class StockQuant(models.Model):
         domain=lambda self: self._domain_location_id(),
         auto_join=True, ondelete='restrict', readonly=True, required=True, index=True, check_company=True)
     lot_id = fields.Many2one(
-        'stock.production.lot', 'Lot/Serial Number',
+        'stock.production.lot', 'Lot/Serial Number', index=True,
         ondelete='restrict', readonly=True, check_company=True,
         domain=lambda self: self._domain_lot_id())
     package_id = fields.Many2one(

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-from odoo.tools import float_compare, float_round, float_is_zero
+from odoo.tools import float_compare, float_round, float_is_zero, OrderedSet
 
 import logging
 _logger = logging.getLogger(__name__)
@@ -57,13 +57,13 @@ class StockMove(models.Model):
         :rtype: recordset
         """
         self.ensure_one()
-        res = self.env['stock.move.line']
+        res = OrderedSet()
         for move_line in self.move_line_ids:
             if move_line.owner_id and move_line.owner_id != move_line.company_id.partner_id:
                 continue
             if not move_line.location_id._should_be_valued() and move_line.location_dest_id._should_be_valued():
-                res |= move_line
-        return res
+                res.add(move_line.id)
+        return self.env['stock.move.line'].browse(res)
 
     def _is_in(self):
         """Check if the move should be considered as entering the company so that the cost method


### PR DESCRIPTION
Bounch of fixes to improve the performance of `_action_validate`.

[FIX] stock: improve perf of `_compute_has_packages` of `stock.picking`

When a picking contains a lot (> 10000) of stock move line, the time
to open the picking become a issue (for 50000 sml, +- 6.5 sec) because of the
`_compute_has_packages`. Use a search with a limit=1 to avoid fetching
all `stock.move.line` with `result_package_id`
(for 50000 sml, +- 2.5 sec).

backport of 8551836af8935f8f2badb0322c7032be7bff37ea

[FIX] stock: avoid flush all env in quants update

Issue:
The `_update_available_quantity` will flush the all environment due to
the savepoint (at each call). When we working with the package,
it becomes bottleneck due to the `_compute_package_info`. Indeed,
it computes two compute store field (`location_id` and `company_id`) and
depends of multiple field of related quants `quants_ids.xxx`. It means
that each time we enter/exit in the savepoint to update quants, this
compute will be execute (because of flush + compute_store).

Solution:
Avoid flushing when enter in the savepoint of
`_update_available_quantity` (`flush=False`)

backport of 8e7c0e544a8d3d18c57634750ee7ea03052c84b1

[FIX] stock: add index on `lot_id` of `stock.quant`

For validate 5K stock move line with SN:
Without index: 200 sec of SQL execution
With index: 15 of SQL execution

[FIX] stock: `_action_done` with OrderedSet for scalability

Make more scalable the `_action_done` by replacing
recordset/union by OrderedSet/add.

[FIX] stock: batch create of lots in `_action_done`

[FIX] stock_account: fix performance of `_get_in_move_lines`

stock.move can contain thousands of move_line. Then to covers that case
change the orderset union by a OrderedSet.

opw-2347525
