### PR TITLE
[FIX] stock: company for stock.rule should be required

### DIFF
--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -38,7 +38,7 @@ class StockRule(models.Model):
         selection=[('pull', 'Pull From'), ('push', 'Push To'), ('pull_push', 'Pull & Push')], string='Action',
         required=True)
     sequence = fields.Integer('Sequence', default=20)
-    company_id = fields.Many2one('res.company', 'Company',
+    company_id = fields.Many2one('res.company', 'Company', required=True,
         default=lambda self: self.env.company)
     location_id = fields.Many2one('stock.location', 'Destination Location', required=True, check_company=True)
     location_src_id = fields.Many2one('stock.location', 'Source Location', check_company=True)


### PR DESCRIPTION
If it's not required, and you have a stock rule without company, then it will break multicompany constraint (saying that its location or warehouse has a company).

If you don't want to require a company for stock rules, and let existing rules without company, then you should relax a bit the multicompany constrain (as done here https://github.com/odoo/odoo/pull/46043).

So please choose one way or the other.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr