### PR TITLE
[FIX] website: support GA 4 (latest GA version)

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -243,15 +243,16 @@
             </t>
         </t>
     </xpath>
+    <xpath expr="//script[last()]" position="after">
+        <script t-if="website and website.google_analytics_key and not editable" defer="defer" type="text/javascript" t-attf-src="https://www.googletagmanager.com/gtag/js?id={{ website.google_analytics_key.strip() }}" />
+    </xpath>
     <xpath expr="//div[@id='wrapwrap']" position="after">
         <script id='tracking_code' t-if="website and website.google_analytics_key and not editable">
-            (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-            })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
 
-            ga('create', _.str.trim('<t t-esc="website.google_analytics_key"/>'), 'auto');
-            ga('send','pageview');
+            gtag('config', '<t t-esc="website.google_analytics_key"/>'.trim());
         </script>
     </xpath>
 

--- a/doc/cla/individual/mamiu.md
+++ b/doc/cla/individual/mamiu.md
@@ -1,0 +1,11 @@
+Australia, 2020-12-05
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Manuel Miunske miu.manu@gmx.de https://github.com/mamiu


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

The current Google Analytics script doesn't support GA4 which is the default for new google analytics accounts. Read more about it here:
https://support.google.com/analytics/answer/9164320?hl=en

This change supports the old Universal Analytics (UA) as well as the new Google Analytics 4 (GA4) properties at the same time as described on this page:
https://developers.google.com/analytics/devguides/collection/ga4/basic-tag?technology=gtagjs

This pull request can and should be forwarded to branch `13.0` and `14.0`.

### Current behavior before PR:

Google Analytics doesn't collect user data from website interactions with a GA4 tracking code.

### Desired behavior after PR is merged:

Google Analytics collects user data from website interactions with the old Universal Analytics (UA) as well as the new GA4 tracking codes.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
