### PR TITLE
[FIX] website_sale: compare id with id instead of record

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -261,7 +261,7 @@ class Website(models.Model):
                 self.env['account.fiscal.position'].sudo()
                 .with_context(force_company=sale_order.company_id.id)
                 .get_fiscal_position(sale_order.partner_id.id, delivery_id=sale_order.partner_shipping_id.id)
-            )
+            ).id
             if sale_order.fiscal_position_id.id != fpos_id:
                 sale_order = None
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:  compare ID with an ID, not a record.

Current behavior before PR: Before this commit Odoo tries to compare an 'account.fiscal.position' id with an 'account.fiscal.position' record.
This causes a 'Comparing apples and oranges' warning in the logs and is not the right way to do this.
This is a fix for d89fa970e8e5b07f1b9a396e6ee02db7fdd136e4 where this issue was introduced coming back from https://github.com/odoo/odoo/pull/60269

Desired behavior after PR is merged: Comparison of ID with an ID, not a record.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
