### PR TITLE
[FIX] account: if the base_tags are empty, it won't be updated

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -612,7 +612,7 @@ class AccountMove(models.Model):
             compute_all_vals = _compute_base_line_taxes(line)
 
             # Assign tags on base line
-            line.tag_ids = compute_all_vals['base_tags']
+            line.tag_ids = compute_all_vals['base_tags'] or [(5, 0, 0)]
 
             tax_exigible = True
             for tax_vals in compute_all_vals['taxes']:


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
If you have a move line which was having tag_ids before and you apply a new tax which has no values defined and result in an empty list, the assignment does not work on a x2m field, so we do offer the proper notation for such a use case.



**Current behavior before PR:**
The already set `tag_ids` are not changed if the other tax_id does not have tags at all.

**Desired behavior after PR is merged:**
The `tag_ids` are removed if the the new retrieved tags based on valid `tax_ids`

Info: @wt-io-it

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
