### PR TITLE
editable row unselected when m2oDialog is opened in popup

### DIFF
--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -159,6 +159,15 @@ var FieldMany2One = AbstractField.extend({
         this.$external_button = this.$('.o_external_button');
         return this._super.apply(this, arguments);
     },
+    destroy: function () {
+        if (this._onWindowMousedown) {
+            window.removeEventListener('scroll', this._onWindowMousedown, true);
+        }
+        if (this._onWindowClick) {
+            window.removeEventListener('scroll', this._onWindowClick, true);
+        }
+        this._super.apply(this, arguments);
+    },
 
     //--------------------------------------------------------------------------
     // Public
@@ -275,7 +284,7 @@ var FieldMany2One = AbstractField.extend({
                         return;
                     }
                     if (self.floating && self.$input.hasClass('ui-autocomplete-input')) {
-                        const $dropdown = self.$input.autocomplete("widget");
+                        var $dropdown = self.$input.autocomplete("widget");
                         if ($dropdown.is(":visible")) {
                             preventWindowClick = true;
                         }
@@ -313,6 +322,12 @@ var FieldMany2One = AbstractField.extend({
                 // root, to prevent unwanted discard operations.
                 if (event.which === $.ui.keyCode.ESCAPE) {
                     event.stopPropagation();
+                }
+                if (self._onWindowMousedown) {
+                    window.removeEventListener('scroll', self._onWindowMousedown, true);
+                }
+                if (self._onWindowClick) {
+                    window.removeEventListener('scroll', self._onWindowClick, true);
                 }
             },
             autoFocus: true,

--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -266,6 +266,30 @@ var FieldMany2One = AbstractField.extend({
                     }
                 });
             },
+            open: function (event, ui) {
+                // maybe bind mousedown and set flag like preventWindowClick and on window click stopPropagation of flag is set
+                var preventWindowClick = false;
+                self._onWindowMousedown = function (ev) {
+                    if (self.el.contains(ev.target) || this.el === ev.target
+                        || $(ev.target).parents('.ui-autocomplete').length) {
+                        return;
+                    }
+                    if (self.floating && self.$input.hasClass('ui-autocomplete-input')) {
+                        const $dropdown = self.$input.autocomplete("widget");
+                        if ($dropdown.is(":visible")) {
+                            preventWindowClick = true;
+                        }
+                    }
+                };
+                self._onWindowClick = function (ev) {
+                    if (preventWindowClick) {
+                        ev.stopPropagation();
+                        preventWindowClick = false;
+                    }
+                };
+                window.addEventListener('mousedown', self._onWindowMousedown, true);
+                window.addEventListener('click', self._onWindowClick, true);
+            },
             select: function (event, ui) {
                 // we do not want the select event to trigger any additional
                 // effect, such as navigating to another field.


### PR DESCRIPTION
PURPOSE
Scenario: Open editable listview and write a text in m2o value which asks you to create record -> click Create and Edit -> Modal will open -> open any many2one field in modal -> write some value in modal many2one which is not available and click anywhere in modal which will open M2ODialog, as soon as M2ODialog is opened it will close editable row and that's why modal will also get closed.
This is happening because Window Click is propagated to editable listview and due to which editable row is unselected and all child elements of row also get destroyed.
This should not happen, when M2ODialog should be opened inside Modal.

SPEC
Do not propagate window click event to editable listview if click is done inside modal.

TASK 2411029




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
