### PR TITLE
[i18n] Fix translation for NL

### DIFF
--- a/addons/purchase/i18n/nl.po
+++ b/addons/purchase/i18n/nl.po
@@ -35,7 +35,7 @@ msgid ""
 "                'Purchase Order - %s' % (object.name))"
 msgstr ""
 "\n"
-"                    (object.state in ('concept', 'verzonden') en 'Offerte aanvraag - %s'% (object.name) of\n"
+"                    (object.state in ('concept', 'verzonden') and 'Offerte aanvraag - %s'% (object.name) or\n"
 "                    'Inkooporder - %s'% (object.name))"
 
 #. module: purchase


### PR DESCRIPTION
operators `and` and `or` should not be translated




