### PR TITLE
[FIX] account_edi: fix 'send now' visibility in account.move form view

### DIFF
--- a/addons/account_edi/models/account_move.py
+++ b/addons/account_edi/models/account_move.py
@@ -55,7 +55,7 @@ class AccountMove(models.Model):
         for move in self:
             to_process = move.edi_document_ids.filtered(lambda d: d.state in ['to_send', 'to_cancel'])
             format_web_services = to_process.edi_format_id.filtered(lambda f: f._needs_web_services())
-            move.edi_web_services_to_process = ', '.join(f.name for f in format_web_services)
+            move.edi_web_services_to_process = ', '.join(f.name for f in format_web_services) or False
 
     @api.depends('restrict_mode_hash_table', 'state')
     def _compute_show_reset_to_draft_button(self):

--- a/addons/account_edi/views/account_move_views.xml
+++ b/addons/account_edi/views/account_move_views.xml
@@ -24,7 +24,7 @@
                 </xpath>
                 <xpath expr="//header" position="after">
                     <div class="alert alert-info" role="alert" style="margin-bottom:0px;"
-                        attrs="{'invisible': [('edi_web_services_to_process', '=', '')]}">
+                        attrs="{'invisible': [('edi_web_services_to_process', '=', False)]}">
                          <div>The invoice will be sent asynchronously to :
                             <field name="edi_web_services_to_process" class="oe_inline"/>
                          </div>


### PR DESCRIPTION
- Before the fix, the banner with the button would show when the move is posted or in creation mode even though no async edi is associated to this move.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
