### PR TITLE
[FIX] hr: search on employee_id field raise bad query

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -7,6 +7,7 @@ from string import digits
 from werkzeug.urls import url_encode
 
 from odoo import api, fields, models, _
+from odoo.osv.query import Query
 from odoo.exceptions import ValidationError, AccessError
 from odoo.modules.module import get_module_resource
 
@@ -162,7 +163,11 @@ class HrEmployeePrivate(models.Model):
         """
         if self.check_access_rights('read', raise_exception=False):
             return super(HrEmployeePrivate, self)._search(args, offset=offset, limit=limit, order=order, count=count, access_rights_uid=access_rights_uid)
-        return self.env['hr.employee.public']._search(args, offset=offset, limit=limit, order=order, count=count, access_rights_uid=access_rights_uid)
+        ids = self.env['hr.employee.public']._search(args, offset=offset, limit=limit, order=order, count=count, access_rights_uid=access_rights_uid)
+        if not count and isinstance(ids, Query):
+            # the result is expected from this table, so we should link tables
+            ids = super(HrEmployeePrivate, self.sudo())._search([('id', 'in', ids)])
+        return ids
 
     def get_formview_id(self, access_uid=None):
         """ Override this method in order to redirect many2one towards the right model depending on access_uid """

--- a/addons/hr/tests/test_self_user_access.py
+++ b/addons/hr/tests/test_self_user_access.py
@@ -185,3 +185,7 @@ class TestSelfAccessRights(TestHrCommon):
         for f in self.self_protected_fields_user:
             with self.assertRaises(AccessError):
                 self.hubert.with_user(self.richard).write({f: 'dummy'})
+
+    def testSearchUserEMployee(self):
+        # Searching user based on employee_id field should not raise bad query error
+        self.env['res.users'].with_user(self.richard).search([('employee_id', 'ilike', 'Hubert')])


### PR DESCRIPTION
Problem
-------
A user with no read access on private employee (hr.employee) model
will get a bad query error if he search on employee_id on res.users

The new domain evaluation system generate query like this
SELECT "hr_employee"."user_id" FROM "hr_employee_public"
because the _search of hr.employee was not returning the search result
from the right table

Solution
--------
Return a search result from the right table


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
