### PR TITLE
[IMP] microsoft_account: allow configuration of endpoints

### DIFF
--- a/addons/microsoft_account/models/microsoft_service.py
+++ b/addons/microsoft_account/models/microsoft_service.py
@@ -14,8 +14,8 @@ _logger = logging.getLogger(__name__)
 
 TIMEOUT = 20
 
-MICROSOFT_AUTH_ENDPOINT = 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize'
-MICROSOFT_TOKEN_ENDPOINT = 'https://login.microsoftonline.com/common/oauth2/v2.0/token'
+DEFAULT_MICROSOFT_AUTH_ENDPOINT = 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize'
+DEFAULT_MICROSOFT_TOKEN_ENDPOINT = 'https://login.microsoftonline.com/common/oauth2/v2.0/token'
 
 
 class MicrosoftService(models.AbstractModel):
@@ -24,6 +24,14 @@ class MicrosoftService(models.AbstractModel):
 
     def _get_calendar_scope(self):
         return 'offline_access openid Calendars.ReadWrite'
+
+    @api.model
+    def _get_auth_endpoint(self):
+        return self.env["ir.config_parameter"].sudo().get_param('microsoft_account.auth_endpoint', DEFAULT_MICROSOFT_AUTH_ENDPOINT)
+
+    @api.model
+    def _get_token_endpoint(self):
+        return self.env["ir.config_parameter"].sudo().get_param('microsoft_account.token_endpoint', DEFAULT_MICROSOFT_TOKEN_ENDPOINT)
 
     @api.model
     def generate_refresh_token(self, service, authorization_code):
@@ -49,7 +57,7 @@ class MicrosoftService(models.AbstractModel):
             'grant_type': "refresh_token"
         }
         try:
-            req = requests.post(MICROSOFT_TOKEN_ENDPOINT, data=data, headers=headers, timeout=TIMEOUT)
+            req = requests.post(self._get_token_endpoint(), data=data, headers=headers, timeout=TIMEOUT)
             req.raise_for_status()
             content = req.json()
         except IOError:
@@ -82,7 +90,7 @@ class MicrosoftService(models.AbstractModel):
             'prompt': 'consent',
             'access_type': 'offline'
         })
-        return "%s?%s" % (MICROSOFT_AUTH_ENDPOINT, encoded_params)
+        return "%s?%s" % (self._get_auth_endpoint(), encoded_params)
 
     @api.model
     def _get_microsoft_tokens(self, authorize_code, service):
@@ -105,7 +113,7 @@ class MicrosoftService(models.AbstractModel):
             'redirect_uri': base_url + '/microsoft_account/authentication'
         }
         try:
-            dummy, response, dummy = self._do_request(MICROSOFT_TOKEN_ENDPOINT, params=data, headers=headers, method='POST', preuri='')
+            dummy, response, dummy = self._do_request(self._get_token_endpoint(), params=data, headers=headers, method='POST', preuri='')
             access_token = response.get('access_token')
             refresh_token = response.get('refresh_token')
             ttl = response.get('expires_in')

--- a/addons/microsoft_calendar/models/res_users.py
+++ b/addons/microsoft_calendar/models/res_users.py
@@ -9,7 +9,6 @@ from datetime import timedelta
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.loglevels import exception_to_unicode
-from odoo.addons.microsoft_account.models.microsoft_service import MICROSOFT_TOKEN_ENDPOINT
 from odoo.addons.microsoft_calendar.utils.microsoft_calendar import MicrosoftCalendarService, InvalidSyncToken
 
 _logger = logging.getLogger(__name__)
@@ -50,7 +49,8 @@ class User(models.Model):
         }
 
         try:
-            dummy, response, dummy = self.env['microsoft.service']._do_request(MICROSOFT_TOKEN_ENDPOINT, params=data, headers=headers, method='POST', preuri='')
+            endpoint = self.env['microsoft.service']._get_token_endpoint()
+            dummy, response, dummy = self.env['microsoft.service']._do_request(endpoint, params=data, headers=headers, method='POST', preuri='')
             ttl = response.get('expires_in')
             self.write({
                 'microsoft_calendar_token': response.get('access_token'),


### PR DESCRIPTION
The endpoints were hardcoded in the application code. This commit aims
at making them overridable with system parameters:

 - `microsoft_account.auth_endpoint` defaults to
    https://login.microsoftonline.com/common/oauth2/v2.0/authorize

 - `microsoft_account.token_endpoint` defaults to
    https://login.microsoftonline.com/common/oauth2/v2.0/token

This change allows customers to restrict the tenant the API targets[0].

[0] https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols#endpoints

TaskID: 2413197

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
