### PR TITLE
[FIX] web_editor: make the color picker available as a public asset

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -471,10 +471,11 @@ class Web_Editor(http.Controller):
         values = len_args > 1 and args[1] or {}
 
         View = request.env['ir.ui.view']
-        if request.env.user._is_public() \
-                and xmlid in request.env['web_editor.assets']._get_public_asset_xmlids():
-            View = View.sudo()
-        return View._render_template(xmlid, {k: values[k] for k in values if k in trusted_value_keys})
+        if xmlid in request.env['web_editor.assets']._get_public_asset_xmlids():
+            # for white listed assets, bypass access verification
+            return View.sudo()._render_template(xmlid, {k: values[k] for k in values if k in trusted_value_keys})
+        # otherwise use normal flow
+        return View.render_public_asset(xmlid, {k: values[k] for k in values if k in trusted_value_keys})
 
     @http.route('/web_editor/modify_image/<model("ir.attachment"):attachment>', type="json", auth="user", website=True)
     def modify_image(self, attachment, res_model=None, res_id=None, name=None, data=None, original_id=None):

--- a/addons/web_editor/models/assets.py
+++ b/addons/web_editor/models/assets.py
@@ -275,4 +275,4 @@ class Assets(models.AbstractModel):
         return {}
 
     def _get_public_asset_xmlids(self):
-        return ["web_editor.compiled_assets_wysiwyg"]
+        return ["web_editor.compiled_assets_wysiwyg", "web_editor.colorpicker"]

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
@@ -373,11 +373,12 @@ ColorPaletteWidget.loadDependencies = async function (rpcCapableObj) {
         // We can call the colorPalette multiple times but only need 1 rpc
         if (!colorpickerTemplateProm && !qweb.has_template('web_editor.colorpicker')) {
             colorpickerTemplateProm = rpcCapableObj._rpc({
-                model: 'ir.ui.view',
-                method: 'read_template',
-                args: ['web_editor.colorpicker'],
+	            route: '/web_editor/public_render_template',
+                params: {
+                    args: ['web_editor.colorpicker'],
+                },
             }).then(template => {
-                return qweb.add_template('<templates>' + template + '</templates>');
+                return qweb.add_template('<templates><t name="Color-Picker" t-name="web_editor.colorpicker">' + template + '</t></templates>');
             });
         }
         proms.push(colorpickerTemplateProm);

--- a/addons/web_editor/static/tests/test_utils.js
+++ b/addons/web_editor/static/tests/test_utils.js
@@ -9,7 +9,6 @@ var Wysiwyg = require('web_editor.wysiwyg');
 var options = require('web_editor.snippets.options');
 
 const COLOR_PICKER_TEMPLATE = `
-    <t t-name="web_editor.colorpicker">
         <colorpicker>
             <div class="o_colorpicker_section" data-name="theme" data-display="Theme Colors" data-icon-class="fa fa-flask">
                 <button data-color="o-color-1"/>
@@ -28,8 +27,7 @@ const COLOR_PICKER_TEMPLATE = `
                 <button data-color="white-75"/>
             </div>
             <div class="o_colorpicker_section" data-name="common" data-display="Common Colors" data-icon-class="fa fa-paint-brush"/>
-        </colorpicker>
-    </t>`;
+        </colorpicker>`;
 const SNIPPETS_TEMPLATE = `
     <h2 id="snippets_menu">Add blocks</h2>
     <div id="o_scroll">
@@ -92,11 +90,12 @@ MockServer.include({
      * @returns {Promise}
      */
     async _performRpc(route, args) {
-        if (args.model === "ir.ui.view") {
-            if (args.method === 'read_template' && args.args[0] === "web_editor.colorpicker") {
+        if ((args.model === "ir.ui.view" && args.method === 'render_public_asset') ||
+                route === '/web_editor/public_render_template') {
+            if (args.args[0] === "web_editor.colorpicker") {
                 return COLOR_PICKER_TEMPLATE;
             }
-            if (args.method === 'render_public_asset' && args.args[0] === "web_editor.snippets") {
+            if (args.args[0] === "web_editor.snippets") {
                 return SNIPPETS_TEMPLATE;
             }
         }
@@ -192,14 +191,11 @@ function wysiwygData(data) {
                 },
             },
             records: [],
-            read_template(args) {
-                if (args[0] === 'web_editor.colorpicker') {
-                    return COLOR_PICKER_TEMPLATE;
-                }
-            },
             render_template(args) {
                 if (args[0] === 'web_editor.snippets') {
                     return SNIPPETS_TEMPLATE;
+                } else if (args[0] === 'web_editor.colorpicker') {
+                    return COLOR_PICKER_TEMPLATE;
                 }
             },
         },

--- a/addons/web_editor/views/editor.xml
+++ b/addons/web_editor/views/editor.xml
@@ -230,7 +230,7 @@
     If a color is no longer used you need to add the d-none class to it and not remove it from this file !!
     Else you will no longer be able to use them.
 -->
-<template id="web_editor.colorpicker" name="Color-Picker" groups="base.group_user">
+<template id="web_editor.colorpicker" name="Color-Picker" groups="base.group_user,base.group_portal">
     <colorpicker>
         <div class="o_colorpicker_section" data-name="theme">
             <button t-foreach="5" t-as="i" t-attf-data-color="o-color-#{i + 1}"></button>


### PR DESCRIPTION
Before this commit the color picker could only be accessed by users
belonging to the Administration/Settings group.

After this commit the color picker is available to all users and portal
users. Also uniformized public_render_template by using the public asset
rendering.

task-2412545

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
