### PR TITLE
[FIX] account: set main attachment id also in mass_mail mode

### DIFF
--- a/addons/account/models/ir_actions_report.py
+++ b/addons/account/models/ir_actions_report.py
@@ -27,4 +27,8 @@ class IrActionsReport(models.Model):
         # don't save the 'account.report_original_vendor_bill' report as it's just a mean to print existing attachments
         if self.report_name == 'account.report_original_vendor_bill':
             return None
-        return super(IrActionsReport, self).postprocess_pdf_report(record, buffer)
+        res = super(IrActionsReport, self).postprocess_pdf_report(record, buffer)
+        if self.report_name == 'account.report_invoice_with_payments':
+            att = self.retrieve_attachment(record)
+            att.register_as_main_attachment()
+        return res

--- a/addons/account/wizard/account_invoice_send.py
+++ b/addons/account/wizard/account_invoice_send.py
@@ -92,9 +92,6 @@ class AccountInvoiceSend(models.TransientModel):
                 #Salesman send posted invoice, without the right to write
                 #but they should have the right to change this flag
                 self.mapped('invoice_ids').sudo().write({'invoice_sent': True})
-            for inv in self.invoice_ids:
-                if hasattr(inv, 'attachment_ids') and inv.attachment_ids:
-                    inv._message_set_main_attachment_id([(False,att) for att in inv.attachment_ids.ids])
 
     def _print_document(self):
         """ to override for each type of models that will use this composer."""


### PR DESCRIPTION
In commit 2243e063e22f515abfffa649ccba15ebadf8f3c8 was used the
wrong field `attachment_ids`

opw-2391508

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
