### PR TITLE
[FIX] account: remove transifex duplicate narration transaltion

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -5595,11 +5595,6 @@ msgid "Internal Group"
 msgstr ""
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr ""
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr ""

--- a/addons/account/i18n/ar.po
+++ b/addons/account/i18n/ar.po
@@ -5890,11 +5890,6 @@ msgid "Internal Group"
 msgstr "مجموعة داخلية"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "ملاحظة داخلية"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "ملاحظات داخلية"

--- a/addons/account/i18n/az.po
+++ b/addons/account/i18n/az.po
@@ -5693,11 +5693,6 @@ msgid "Internal Group"
 msgstr ""
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr ""
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr ""

--- a/addons/account/i18n/bg.po
+++ b/addons/account/i18n/bg.po
@@ -5816,11 +5816,6 @@ msgid "Internal Group"
 msgstr ""
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Вътрешна бележка"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Вътрешни бележки"

--- a/addons/account/i18n/bn.po
+++ b/addons/account/i18n/bn.po
@@ -5636,10 +5636,6 @@ msgstr ""
 msgid "Internal Group"
 msgstr ""
 
-#. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr ""
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note

--- a/addons/account/i18n/bs.po
+++ b/addons/account/i18n/bs.po
@@ -5636,11 +5636,6 @@ msgid "Internal Group"
 msgstr ""
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Interna bilješka"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Interne zabilješke"

--- a/addons/account/i18n/ca.po
+++ b/addons/account/i18n/ca.po
@@ -5763,11 +5763,6 @@ msgid "Internal Group"
 msgstr ""
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Nota interna"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Notes internes"

--- a/addons/account/i18n/cs.po
+++ b/addons/account/i18n/cs.po
@@ -5838,11 +5838,6 @@ msgid "Internal Group"
 msgstr "Interní skupina"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Interní poznámka"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Interní poznámky"

--- a/addons/account/i18n/da.po
+++ b/addons/account/i18n/da.po
@@ -5956,11 +5956,6 @@ msgid "Internal Group"
 msgstr "Intern gruppe"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Intern note"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Interne notater"

--- a/addons/account/i18n/de.po
+++ b/addons/account/i18n/de.po
@@ -6010,10 +6010,6 @@ msgstr ""
 msgid "Internal Group"
 msgstr "Interne Gruppe"
 
-#. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Interne Mitteilung"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note

--- a/addons/account/i18n/el.po
+++ b/addons/account/i18n/el.po
@@ -5782,11 +5782,6 @@ msgid "Internal Group"
 msgstr ""
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Εσωτερική Σημείωση"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Εσωτερικά Σημειώματα"

--- a/addons/account/i18n/es.po
+++ b/addons/account/i18n/es.po
@@ -6027,11 +6027,6 @@ msgid "Internal Group"
 msgstr "Grupo interno"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Nota interna"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Notas internas"

--- a/addons/account/i18n/et.po
+++ b/addons/account/i18n/et.po
@@ -5737,11 +5737,6 @@ msgid "Internal Group"
 msgstr ""
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Sisemised märkused"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Ettevõttesisesed märkmed"

--- a/addons/account/i18n/eu.po
+++ b/addons/account/i18n/eu.po
@@ -5671,11 +5671,6 @@ msgid "Internal Group"
 msgstr ""
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Barne oharra"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Barne oharrak"

--- a/addons/account/i18n/fa.po
+++ b/addons/account/i18n/fa.po
@@ -5802,10 +5802,6 @@ msgstr ""
 msgid "Internal Group"
 msgstr "گروه داخلی"
 
-#. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "یادداشت داخلی"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note

--- a/addons/account/i18n/fi.po
+++ b/addons/account/i18n/fi.po
@@ -5855,11 +5855,6 @@ msgid "Internal Group"
 msgstr "Sisäinen ryhmä"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Sisäinen muistiinpano"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Sisäiset kommentit"

--- a/addons/account/i18n/fr.po
+++ b/addons/account/i18n/fr.po
@@ -6042,11 +6042,6 @@ msgid "Internal Group"
 msgstr "Groupe interne"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Note interne"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Notes internes"

--- a/addons/account/i18n/gu.po
+++ b/addons/account/i18n/gu.po
@@ -5599,11 +5599,6 @@ msgid "Internal Group"
 msgstr ""
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr ""
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr ""

--- a/addons/account/i18n/he.po
+++ b/addons/account/i18n/he.po
@@ -5755,11 +5755,6 @@ msgid "Internal Group"
 msgstr "קבוצה פנימית"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "הערה פנימית"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "הערות פנימיות"

--- a/addons/account/i18n/hr.po
+++ b/addons/account/i18n/hr.po
@@ -5736,11 +5736,6 @@ msgid "Internal Group"
 msgstr "Interna grupa"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Interna bilješka"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Interne bilješke"

--- a/addons/account/i18n/hu.po
+++ b/addons/account/i18n/hu.po
@@ -5726,11 +5726,6 @@ msgid "Internal Group"
 msgstr "Belső csoport"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Belső jegyzet"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Belső jegyzetek"

--- a/addons/account/i18n/id.po
+++ b/addons/account/i18n/id.po
@@ -5962,11 +5962,6 @@ msgid "Internal Group"
 msgstr "Internal Group"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Catatan Internal"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Catatan Internal"

--- a/addons/account/i18n/it.po
+++ b/addons/account/i18n/it.po
@@ -5975,11 +5975,6 @@ msgid "Internal Group"
 msgstr "Gruppo interno"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Nota interna"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Note interne"

--- a/addons/account/i18n/ja.po
+++ b/addons/account/i18n/ja.po
@@ -5720,11 +5720,6 @@ msgid "Internal Group"
 msgstr "内部グループ"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "内部注釈"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "内部注記"

--- a/addons/account/i18n/ko.po
+++ b/addons/account/i18n/ko.po
@@ -5779,11 +5779,6 @@ msgid "Internal Group"
 msgstr "내부 그룹"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "내부 노트"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "내부 노트"

--- a/addons/account/i18n/lb.po
+++ b/addons/account/i18n/lb.po
@@ -5599,11 +5599,6 @@ msgid "Internal Group"
 msgstr ""
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr ""
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr ""

--- a/addons/account/i18n/lo.po
+++ b/addons/account/i18n/lo.po
@@ -5605,11 +5605,6 @@ msgid "Internal Group"
 msgstr ""
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr ""
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "ບັນທຶກພາຍໃນ"

--- a/addons/account/i18n/lt.po
+++ b/addons/account/i18n/lt.po
@@ -5929,11 +5929,6 @@ msgid "Internal Group"
 msgstr "Vidinė grupė"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Vidinė pastaba"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Vidinės pastabos"

--- a/addons/account/i18n/lv.po
+++ b/addons/account/i18n/lv.po
@@ -5648,11 +5648,6 @@ msgid "Internal Group"
 msgstr "Iekšējā grupa"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Iekšējā piezīme"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Iekšējās piezīmes"

--- a/addons/account/i18n/ml.po
+++ b/addons/account/i18n/ml.po
@@ -5954,11 +5954,6 @@ msgid "Internal Group"
 msgstr "ആന്തരിക ഗ്രൂപ്പ്"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "ആന്തരിക കുറിപ്പ്"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "ആന്തരിക കുറിപ്പുകൾ"

--- a/addons/account/i18n/mn.po
+++ b/addons/account/i18n/mn.po
@@ -5902,11 +5902,6 @@ msgid "Internal Group"
 msgstr "Дотоод бүлэг"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Дотоод тэмдэглэл"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Дотоод тэмдэглэл"

--- a/addons/account/i18n/my.po
+++ b/addons/account/i18n/my.po
@@ -5605,11 +5605,6 @@ msgid "Internal Group"
 msgstr ""
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "မှတ်စု"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr ""

--- a/addons/account/i18n/nb.po
+++ b/addons/account/i18n/nb.po
@@ -5683,11 +5683,6 @@ msgid "Internal Group"
 msgstr ""
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Internt notat"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Interne notater"

--- a/addons/account/i18n/nl.po
+++ b/addons/account/i18n/nl.po
@@ -5964,11 +5964,6 @@ msgid "Internal Group"
 msgstr "Interne groep"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Interne notitie"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Interne notities"

--- a/addons/account/i18n/pl.po
+++ b/addons/account/i18n/pl.po
@@ -5776,11 +5776,6 @@ msgid "Internal Group"
 msgstr ""
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Notatka wewnętrzna"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Uwagi wewnętrzne"

--- a/addons/account/i18n/pt.po
+++ b/addons/account/i18n/pt.po
@@ -5835,11 +5835,6 @@ msgid "Internal Group"
 msgstr "Grupo Interno"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Nota Interna"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Notas internas"

--- a/addons/account/i18n/pt_BR.po
+++ b/addons/account/i18n/pt_BR.po
@@ -5967,11 +5967,6 @@ msgid "Internal Group"
 msgstr "Grupo Interno"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Anotação Interna"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Anotações Internas"

--- a/addons/account/i18n/ro.po
+++ b/addons/account/i18n/ro.po
@@ -5936,11 +5936,6 @@ msgid "Internal Group"
 msgstr "Grup intern"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Nota interna"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Note Interne"

--- a/addons/account/i18n/ru.po
+++ b/addons/account/i18n/ru.po
@@ -5889,11 +5889,6 @@ msgid "Internal Group"
 msgstr "Внутренняя группа"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Внутреннее примечание"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Внутренние заметки"

--- a/addons/account/i18n/sk.po
+++ b/addons/account/i18n/sk.po
@@ -5945,11 +5945,6 @@ msgid "Internal Group"
 msgstr "Interná skupina"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Interná poznámka"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Interné poznámky"

--- a/addons/account/i18n/sl.po
+++ b/addons/account/i18n/sl.po
@@ -5734,11 +5734,6 @@ msgid "Internal Group"
 msgstr "Interna skupina"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Interni Zaznamek"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Interne opombe"

--- a/addons/account/i18n/sr.po
+++ b/addons/account/i18n/sr.po
@@ -5637,11 +5637,6 @@ msgid "Internal Group"
 msgstr ""
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr ""
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Interne Beleske"

--- a/addons/account/i18n/sv.po
+++ b/addons/account/i18n/sv.po
@@ -5677,11 +5677,6 @@ msgid "Internal Group"
 msgstr ""
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Intern notering"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Interna anteckningar"

--- a/addons/account/i18n/th.po
+++ b/addons/account/i18n/th.po
@@ -5887,11 +5887,6 @@ msgid "Internal Group"
 msgstr "จัดกลุ่มตาม..."
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "บันทึกภายใน"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "บันทึกภายใน"

--- a/addons/account/i18n/tr.po
+++ b/addons/account/i18n/tr.po
@@ -5939,11 +5939,6 @@ msgid "Internal Group"
 msgstr "İç Grup"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "İç Not"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "İç Notlar"

--- a/addons/account/i18n/ug.po
+++ b/addons/account/i18n/ug.po
@@ -5599,11 +5599,6 @@ msgid "Internal Group"
 msgstr ""
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr ""
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr ""

--- a/addons/account/i18n/uk.po
+++ b/addons/account/i18n/uk.po
@@ -5946,11 +5946,6 @@ msgid "Internal Group"
 msgstr "Внутрішня група"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Внутрішня примітка"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Внутрішні примітки"

--- a/addons/account/i18n/uz.po
+++ b/addons/account/i18n/uz.po
@@ -5595,11 +5595,6 @@ msgid "Internal Group"
 msgstr ""
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr ""
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr ""

--- a/addons/account/i18n/vi.po
+++ b/addons/account/i18n/vi.po
@@ -5847,11 +5847,6 @@ msgid "Internal Group"
 msgstr "Nhóm nội bộ"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "Ghi chú nội bộ"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "Ghi chú nội bộ"

--- a/addons/account/i18n/zh_CN.po
+++ b/addons/account/i18n/zh_CN.po
@@ -5779,11 +5779,6 @@ msgid "Internal Group"
 msgstr "内部群组"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "内部备注"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "内部备注"

--- a/addons/account/i18n/zh_TW.po
+++ b/addons/account/i18n/zh_TW.po
@@ -5754,11 +5754,6 @@ msgid "Internal Group"
 msgstr "內部群組"
 
 #. module: account
-#: model:ir.model.fields,field_description:account.field_account_move__narration
-msgid "Internal Note"
-msgstr "內部備註"
-
-#. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__note
 msgid "Internal Notes"
 msgstr "內部備註"


### PR DESCRIPTION
Since #53725, a new entry was added to the pot for account.field_account_move__narration
without removint the previous one. The Transifex translation based on this pot created
a duplicate entry for this xmlid leading to an error when trying to install a new lang.
