### PR TITLE
[FIX] web_editor: properly crop an image

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2455,7 +2455,7 @@ var SnippetsMenu = Widget.extend({
      * @private
      */
     _onDeactivateSnippet: function (ev) {
-        this._enableLastEditor(ev.data.previewMode);
+        this._enableLastEditor(ev && ev.data.previewMode);
     },
 
     /**

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop_widget.js
@@ -98,7 +98,6 @@ const ImageCropWidget = Widget.extend({
             this.$cropperImage.cropper('destroy');
             this.document.removeEventListener('mousedown', this._onDocumentMousedown, {capture: true});
         }
-        this.media.setAttribute('src', this.initialSrc);
         return this._super(...arguments);
     },
 
@@ -125,9 +124,18 @@ const ImageCropWidget = Widget.extend({
             }
         });
         delete this.media.dataset.resizeWidth;
-        this.initialSrc = await applyModifications(this.media);
+        this.media.setAttribute('src', await applyModifications(this.media));
         this.$media.trigger('image_cropped');
-        this.destroy();
+        return this.destroy();
+    },
+    /**
+     * Discards the current cropping session and restores the original image.
+     *
+     * @private
+     */
+    _discard() {
+        this.media.setAttribute('src', this.initialSrc);
+        return this.destroy();
     },
     /**
      * Returns an attribute's value for saving.
@@ -183,7 +191,7 @@ const ImageCropWidget = Widget.extend({
             case 'apply':
                 return this._save();
             case 'discard':
-                return this.destroy();
+                return this._discard();
         }
     },
     /**


### PR DESCRIPTION
This fixes two bugs:
1. Opening the image crop dialog caused a traceback
2. Cropping was not applied in jabberwock, causing it to rerender the image as it was before cropping.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
