### PR TITLE
[FIX] pos_cache: fix error on opening POS

### DIFF
--- a/addons/pos_cache/models/pos_cache.py
+++ b/addons/pos_cache/models/pos_cache.py
@@ -5,6 +5,7 @@ import json
 from ast import literal_eval
 
 from odoo import models, fields, api
+from odoo.tools import date_utils
 
 
 class pos_cache(models.Model):
@@ -30,7 +31,7 @@ class pos_cache(models.Model):
                 display_default_code=False, lang=cache.compute_user_id.lang)
             res = prod_ctx.read(cache.get_product_fields())
             cache.write({
-                'cache': base64.encodebytes(json.dumps(res).encode('utf-8')),
+                'cache': base64.encodebytes(json.dumps(res, default=date_utils.json_default).encode('utf-8')),
             })
 
     @api.model


### PR DESCRIPTION
STEP:
* install pos_cache
* create some products (this step is not needed in demo database)
* open POS

BEFORE: error "TypeError: Object of type 'datetime' is not JSON serializable"

AFTER: no errors

WHY:
* Since Odoo 12 date fields are not strings: https://github.com/odoo/odoo/commit/960360afe478a8f7b9c456721b5591154952a37d
* Since Odoo 14 fields lists to read contains write_date:
https://github.com/odoo/odoo/commit/c6397ab3b3654da336a4269a81d5d91016baf520 --
see models.js

---

opw-2410334

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
