### PR TITLE
[FIX] sale_timesheet: Non billable timesheets

### DIFF
--- a/addons/sale_timesheet/views/hr_timesheet_views.xml
+++ b/addons/sale_timesheet/views/hr_timesheet_views.xml
@@ -10,8 +10,8 @@
                     <field name="timesheet_invoice_type"/>
                 </xpath>
                 <xpath expr="//filter[@name='month']" position="before">
-                    <filter name="billable_timesheet" string="Billable" domain="[('non_allow_billable', '=', False)]"/>
-                    <filter name="non_billable_timesheet" string="Non Billable" domain="[('non_allow_billable', '=', True)]"/>
+                    <filter name="billable_timesheet" string="Billable" domain="[('so_line', '!=', False), ('non_allow_billable', '=', False)]"/>
+                    <filter name="non_billable_timesheet" string="Non Billable" domain="['|', ('so_line', '=', False), ('non_allow_billable', '=', True)]"/>
                     <separator/>
                     <filter name="billable_time" string="Billed on Timesheets" domain="[('timesheet_invoice_type', '=', 'billable_time')]"/>
                     <filter name="billable_fixed" string="Billed at a Fixed Price" domain="[('timesheet_invoice_type', '=', 'billable_fixed')]"/>


### PR DESCRIPTION
Steps to reproduce the bug:

- Create new project P with "Billable" unchecked
- Create a new task T in P and log hours on the timesheet TS
- Go to Timesheets > All Timesheets and filter for "Billable"

Bug:

TS was displayed even if P was not billable

opw:2394624