### PR TITLE
[FIX] pos_cache: make it compatible with onboarding tool

### DIFF
--- a/addons/pos_cache/controllers/__init__.py
+++ b/addons/pos_cache/controllers/__init__.py
@@ -1,4 +1,2 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from . import models
-from . import controllers
+from . import main

--- a/addons/pos_cache/controllers/main.py
+++ b/addons/pos_cache/controllers/main.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.addons.point_of_sale.controllers.main import PosController
+from odoo import http
+from odoo.http import request
+
+
+class PosCache(PosController):
+
+    @http.route()
+    def load_onboarding_data(self):
+        super().load_onboarding_data()
+        request.env["pos.cache"].refresh_all_caches()

--- a/addons/pos_cache/static/src/js/pos_cache.js
+++ b/addons/pos_cache/static/src/js/pos_cache.js
@@ -21,6 +21,7 @@ models.PosModel = models.PosModel.extend({
         // uncached way, so get rid of it.
         if (product_index !== -1) {
             this.models.splice(product_index, 1);
+            this.product_model = product_model;
         }
         return posmodel_super.load_server_data.apply(this, arguments).then(function () {
           // Give both the fields and domain to pos_cache in the
@@ -28,8 +29,8 @@ models.PosModel = models.PosModel.extend({
           // values in the backend and they automatically stay in
           // sync with whatever is defined (and maybe extended by
           // other modules) in js.
-          var product_fields =  typeof product_model.fields === 'function'  ? product_model.fields(self)  : product_model.fields;
-          var product_domain =  typeof product_model.domain === 'function'  ? product_model.domain(self)  : product_model.domain;
+          var product_fields =  typeof self.product_model.fields === 'function'  ? self.product_model.fields(self)  : self.product_model.fields;
+          var product_domain =  typeof self.product_model.domain === 'function'  ? self.product_model.domain(self)  : self.product_model.domain;
             var records = rpc.query({
                     model: 'pos.config',
                     method: 'get_products_from_cache',


### PR DESCRIPTION
STEPS:
* install pos_cache in clean database without demo
* open pos
* click OK on popup "Would you like to load demo data"

BEFORE: error, products are not loaded even after refreshing

AFTER: no errors, products are loaded

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
