### PR TITLE
[13.0][FIX] Fix use expense account in manual stock valuation

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -227,6 +227,7 @@ class AccountMoveLine(models.Model):
         self.ensure_one()
         if self.product_id.type == 'product' \
             and self.move_id.company_id.anglo_saxon_accounting \
+            and self.product_id.categ_id.property_valuation == 'real_time' \
             and self.move_id.is_purchase_document():
             fiscal_position = self.move_id.fiscal_position_id
             accounts = self.product_id.product_tmpl_id.get_product_accounts(fiscal_pos=fiscal_position)

--- a/doc/cla/corporate/360erp.md
+++ b/doc/cla/corporate/360erp.md
@@ -1,0 +1,15 @@
+The Netherlands, 2020-12-07
+
+360 ERP B.V. agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Cas Vissers cas.vissers@360erp.nl https://github.com/CasVissers-360ERP
+
+List of contributors:
+
+Cas Vissers cas.vissers@360erp.nl https://github.com/CasVissers-360ERP


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In Anglo Saxon accounting the expense account should be used for supplier invoices if valuation is set to manual.

Current behavior before PR:
https://drive.google.com/file/d/1MoN5rSKXMhcqhckBygVteUH72A0YaOtG/view
COGS account is loaded with manual valuation.

Desired behavior after PR is merged:
Expense account is loaded with manual valuation


OPW #2413320

@nim-odoo @Yenthe666 
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
