### PR TITLE
[FIX] website_slides: fix search layout

### DIFF
--- a/addons/website_slides/views/website_slides.xml
+++ b/addons/website_slides/views/website_slides.xml
@@ -315,7 +315,7 @@
                     <div class="alert alert-success mb0" role="status">
                         <b t-esc="len(slides)"/> results found for the given criteria <b><t t-esc="search"/></b>
                     </div>
-                    <div class="row mt0">
+                    <div>
                         <t t-call="website_slides.slides_grid_view"/>
                     </div>
                     <div class="row text-center">


### PR DESCRIPTION
Without this patch, it looked broken.








Current behavior before PR:  Description of the issue/feature this PR addresses: Just go to `/slides/public-channel-1?search=crm` on any v12 runbot and you'll see this: 
![imagen](https://user-images.githubusercontent.com/973709/101358558-ec8d5c80-3892-11eb-9248-1a14c26fcf79.png)

Desired behavior after PR is merged: 
![imagen](https://user-images.githubusercontent.com/973709/101358479-d1bae800-3892-11eb-986b-5e05ba7e86a7.png)





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
@Tecnativa TT26627