### PR TITLE
[FIX] stock: action should be a dict

### DIFF
--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -524,7 +524,8 @@
             <field name="code">
             if records:
                 res = records.button_validate()
-                action = res
+                if isinstance(res, dict):
+                    action = res
             </field>
         </record>
 


### PR DESCRIPTION
Steps:
- Install Inventory
- Go to Inventory > Configuration > Settings
- Enable Warehouse > Storage Locations
- Go to Inventory > Internal Transfers
- Create a transfer with a product and add done quantity to the product
- Come back to the list
- Select the Ready transfers
- Click Actions > Validate

Bug:
Traceback here: https://github.com/odoo/odoo/blob/7e9d052beabe15d932e5d403f8ca2f4837c7d24f/addons/web/controllers/main.py#L328
AttributeError: 'bool' object has no attribute 'setdefault'

Explanation:
`button_validate()` can return `True`. https://github.com/odoo/odoo/blob/7e9d052beabe15d932e5d403f8ca2f4837c7d24f/addons/stock/models/stock_picking.py#L861-L931
Therefore, a `True` action can be propagated up to the traceback point.
Another solution could be to only accept dict actions when calling `clean_action()`