### PR TITLE
[FIX] website: fix trigger of website_url_chosen

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.frontend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.frontend.scss
@@ -22,12 +22,10 @@
 
     .ui-menu-item {
         padding: 0;
-        > a {
-            &.ui-state-active {
-                border: none;
-                font-weight: normal;
-                margin: 0;
-            }
+        > .ui-state-active {
+            border: none;
+            font-weight: normal;
+            margin: 0;
         }
     }
 }

--- a/addons/website/static/src/js/utils.js
+++ b/addons/website/static/src/js/utils.js
@@ -88,8 +88,10 @@ function autocompleteWithPages(self, $input) {
                 });
             }
         },
-        close: function () {
+        select: function (ev, ui) {
+            ev.target.value = ui.item.value;
             self.trigger_up('website_url_chosen');
+            ev.preventDefault();
         },
     });
 }


### PR DESCRIPTION
Before this commit, website_url_chosen was triggered when the dropdown
of the input closed instead of when an item was selected in the
list. This caused the following issue: you lost focus in the input
every time the list closed while typing.

After this commit, website_url_chosen is only triggered when an item
is selected in the results list of a urlpicker input.

task-2312878

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
