### PR TITLE
[FIX] base: translated group name hides Accounting Access rights

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1188,7 +1188,7 @@ class GroupsView(models.Model):
                 # group of res.groups without implied groups (with each other).
                 if app.xml_id == 'base.module_category_user_type':
                     # application name with a selection field
-                    field_name = name_selection_groups(gs.ids)
+                    field_name = name_selection_groups(sorted(gs.ids))
                     user_type_field_name = field_name
                     user_type_readonly = str({'readonly': [(user_type_field_name, '!=', group_employee.id)]})
                     attrs['widget'] = 'radio'
@@ -1198,7 +1198,7 @@ class GroupsView(models.Model):
 
                 elif kind == 'selection':
                     # application name with a selection field
-                    field_name = name_selection_groups(gs.ids)
+                    field_name = name_selection_groups(sorted(gs.ids))
                     attrs['attrs'] = user_type_readonly
                     if category_name not in xml_by_category:
                         xml_by_category[category_name] = []
@@ -1446,7 +1446,7 @@ class UsersView(models.Model):
                 selection_vals = [(False, '')]
                 if app.xml_id == 'base.module_category_user_type':
                     selection_vals = []
-                field_name = name_selection_groups(gs.ids)
+                field_name = name_selection_groups(sorted(gs.ids))
                 if allfields and field_name not in allfields:
                     continue
                 # selection group field


### PR DESCRIPTION
Issue

	- Install 'Accounting' module
	- Set user language as "Dutch"
	- Go Settings -> Users -> Mitchel Admin

	Selection groups field not visible under "Boekhouding" group access right.
Cause

	The groups are ordered by there implied ids (a group appears in
	the selection after its implied groups):
	https://github.com/odoo/odoo/blob/ee2625a9311f308b9df3fc160dc5c9fe4cc5a497/odoo%2Faddons%2Fbase%2Fmodels%2Fres_users.py#L1266
	If the sequence is the same for multiple groups, the groups
	concerned will be order by there name, and since it can be
	translated, the order may vary depending the language.
	ex :    EN => sel_groups_22_23_24_25
		NL => sel_groups_23_22_24_25

Solution

	Order groups by ids (only for the field_name, not for selection choice order).

opw-2394209
