### PR TITLE
[FIX] sale: Optional product price

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1635,7 +1635,7 @@ class SaleOrderLine(models.Model):
             )
 
         if self.order_id.pricelist_id.discount_policy == 'with_discount':
-            return product.with_context(pricelist=self.order_id.pricelist_id.id).price
+            return product.with_context(pricelist=self.order_id.pricelist_id.id, uom=self.product_uom.id).price
         product_context = dict(self.env.context, partner_id=self.order_id.partner_id.id, date=self.order_id.date_order, uom=self.product_uom.id)
 
         final_price, rule_id = self.order_id.pricelist_id.with_context(product_context).get_product_price_rule(product or self.product_id, self.product_uom_qty or 1.0, self.order_id.partner_id)


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a product P with sale UOM = Unit and unit price = 10€
- Create a SO and add a sale.order.option SOO with P and Dozen as UOM

Bug:

The unit price was 10€ instead of 120€

opw:2413237