### PR TITLE
[FIX] sale_stock_margin: compute purchase_price from correct company

### DIFF
--- a/addons/sale_stock_margin/models/sale_order_line.py
+++ b/addons/sale_stock_margin/models/sale_order_line.py
@@ -14,5 +14,5 @@ class SaleOrderLine(models.Model):
             if not line.move_ids:
                 lines_without_moves |= line
             else:
-                line.purchase_price = line.product_id._compute_average_price(0, line.product_uom_qty, line.move_ids)
+                line.purchase_price = line.product_id.with_company(line.company_id)._compute_average_price(0, line.product_uom_qty, line.move_ids)
         return super(SaleOrderLine, lines_without_moves)._compute_purchase_price()


### PR DESCRIPTION
- Install sale_stock_margin
- In a multi-company environment, create a Product (i.e. Product X)
with a different Cost in each Company
- Switch to Company that is not the main one
- Create a SO with Product X
- Make sure Cost (purchase_price) field is diplayed in Order Lines tab
- Confirm SO
After confirmation, the purchase_price of Product X switches from Cost configured
for current Company to Cost configured for the main Company.

opw-2389741

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
