### PR TITLE
[FIX] mass_mailing: correctly fill default mailing lists

### DIFF
--- a/addons/mass_mailing/wizard/mailing_list_merge.py
+++ b/addons/mass_mailing/wizard/mailing_list_merge.py
@@ -22,7 +22,7 @@ class MassMailingListMerge(models.TransientModel):
         res = super(MassMailingListMerge, self).default_get(fields)
         src_list_ids = self.env.context.get('active_ids')
         res.update({
-            'src_list_ids': src_list_ids,
+            'src_list_ids': [(6, 0, src_list_ids)],
             'dest_list_id': src_list_ids and src_list_ids[0] or False,
         })
         return res


### PR DESCRIPTION
Steps to reproduce the bug:

- Email Marketing--> Mailing List
- Select Records --> Action --> Merge Selected Mailing Lists

Bug:

It will raise Traceback
`TypeError: 'int' object is not subscriptable`



With this Commit:

We will correctly add default mailing lists

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
