### PR TITLE
[FIX] web_editor: fix background layers buttons

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -3315,7 +3315,9 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
         $weight.find('b').text(`${(weight / 1024).toFixed(1)} kb`);
         $weight.removeClass('d-none');
         img.classList.add('o_modified_image_to_save');
-        return loadImage(dataURL, img);
+        const loadedImg = await loadImage(dataURL, img);
+        this._applyImage(loadedImg);
+        return loadedImg;
     },
     /**
      * Loads the image's attachment info.
@@ -3361,6 +3363,14 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
      * @returns {Int} the maximum width at which the image can be displayed
      */
     _computeMaxDisplayWidth() {},
+    /**
+     * Use the processed image when it's needed in the DOM.
+     *
+     * @private
+     * @abstract
+     * @param {HTMLImageElement} img
+     */
+    _applyImage(img) {},
 });
 
 /**
@@ -3492,13 +3502,6 @@ registry.BackgroundOptimize = ImageHandlerOption.extend({
         return 1920;
     },
     /**
-     * @override
-     */
-    async _applyOptions() {
-        await this._super(...arguments);
-        this.$target.css('background-image', `url('${this._getImg().getAttribute('src')}')`);
-    },
-    /**
      * Initializes this.img to an image with the background image url as src.
      *
      * @override
@@ -3512,6 +3515,12 @@ registry.BackgroundOptimize = ImageHandlerOption.extend({
         // Don't set the src if not relative (ie, not local image: cannot be modified)
         this.img.src = src.startsWith('/') ? src : '';
         return await this._super(...arguments);
+    },
+    /**
+     * @override
+     */
+    _applyImage(img) {
+        this.$target.css('background-image', `url('${img.getAttribute('src')}')`);
     },
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
Example to reproduce:

ISSUE 1- Drop the "Cover" snippet and try to remove the background image. Clicking
on image button has to be done 3 times to land on the correct result:

- First click removes image, but not filter and leaves both buttons checked
- Second click removes the filter and unchecks its button.
- Third click unchecks the image button.

It should be one click to remove image, filter and uncheck both buttons.

ISSUE 2- Add background image to "Cover" snippet by setting image url
in 'Add URL' input => background removed.

1- When trying to enable the option 'bg_filter_toggle_opt' after a click
on image button, the 'getBgImageURL()' returns '/' as a valid background
url since converting to relative url [fullURL.href.slice(fullURL.origin.length)]
returns '/[search][hash]' as result;

2- The override for '_applyOptions()' method in 'BackgroundOptimize' will always
change the background url even if the chosen image is not optimizable.

The goal of this PR is to prevent _applyOptions() from setting background-image
values if image is not optimizable. This filter will solve the first issue since
empty values (badly parsed by getBgImageURL()) won't be added as background urls.

task-2312878
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
