### PR TITLE
[FIX] account: fix inexistent attachment_ids when sending invoice

### DIFF
--- a/addons/account/wizard/account_invoice_send.py
+++ b/addons/account/wizard/account_invoice_send.py
@@ -93,7 +93,7 @@ class AccountInvoiceSend(models.TransientModel):
                 #but they should have the right to change this flag
                 self.mapped('invoice_ids').sudo().write({'invoice_sent': True})
             for inv in self.invoice_ids:
-                if inv.attachment_ids:
+                if hasattr(inv, 'attachment_ids') and inv.attachment_ids:
                     inv._message_set_main_attachment_id([(False,att) for att in inv.attachment_ids.ids])
 
     def _print_document(self):


### PR DESCRIPTION
- Install Invoicing
- Create an invoice
- Post invoice and send it
An AttributeError is raised:
"AttributeError: 'account.move' object has no attribute 'attachment_ids'"

"attachment_ids" field is not available on "account.move" in Invoicing.
It is declared in Accounting.

opw-2413574
opw-2413310

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
