### PR TITLE
[FIX] website_forum: ensure media modal opens on click button

### DIFF
--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -181,7 +181,7 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
                     </div>`,
             };
 
-            await wysiwygLoader.loadFromTextarea(this, $textarea, options);
+            await wysiwygLoader.loadFromTextarea(self, $textarea, options);
         });
 
         _.each(this.$('.o_wforum_bio_popover'), authorBox => {


### PR DESCRIPTION
Clicking the media button failed to open the media modal. The reason was that initializing the media modal involved triggering an RPC to fetch attachments but that resulted in a never-resolving promise because `trigger_up('call_service')` was never caught. That is because `website_forum` failed to pass itself as parent of `wysiwyg` when instantiating the editor, thus breaking the chain that should have led to `public_root`, which listens to `'call_service'` custom events.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
