### PR TITLE
selecting image in customer form throw traceback

### DIFF
--- a/addons/point_of_sale/static/src/js/screens.js
+++ b/addons/point_of_sale/static/src/js/screens.js
@@ -1538,14 +1538,16 @@ var ClientListScreenWidget = ScreenWidget.extend({
             });
 
             contents.find('.image-uploader').on('change',function(event){
-                self.load_image_file(event.target.files[0],function(res){
-                    if (res) {
-                        contents.find('.client-picture img, .client-picture .fa').remove();
-                        contents.find('.client-picture').append("<img src='"+res+"'>");
-                        contents.find('.detail.picture').remove();
-                        self.uploaded_picture = res;
-                    }
-                });
+                if (event.target.files.length) {
+                    self.load_image_file(event.target.files[0],function(res){
+                        if (res) {
+                            contents.find('.client-picture img, .client-picture .fa').remove();
+                            contents.find('.client-picture').append("<img src='"+res+"'>");
+                            contents.find('.detail.picture').remove();
+                            self.uploaded_picture = res;
+                        }
+                    });
+                }
             });
         } else if (visibility === 'hide') {
             contents.empty();


### PR DESCRIPTION
PURPOSE
scenario: open customer form by clicking new customer button and select image and again click on image which will open file explore, now click cancel button in file explorer, will throw traceback.
Fix this traceback, if the image is not selected then do nothing.

SPEC
traceback should not be thrown if image is not selected from file explorer.

TASK 2412485



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
