### PR TITLE
change handle icon from fa-arrows to fa-sort

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -1498,7 +1498,7 @@ var ListFieldText = FieldText.extend({
 var HandleWidget = AbstractField.extend({
     description: _lt("Handle"),
     noLabel: true,
-    className: 'o_row_handle fa fa-arrows ui-sortable-handle',
+    className: 'o_row_handle fa fa-sort ui-sortable-handle',
     widthInList: '33px',
     tagName: 'span',
     supportedFieldTypes: ['integer'],

--- a/addons/web/static/src/js/views/list/list_editable_renderer.js
+++ b/addons/web/static/src/js/views/list/list_editable_renderer.js
@@ -1092,6 +1092,7 @@ ListRenderer.include({
                 items: '> tr.o_data_row',
                 helper: 'clone',
                 handle: '.o_row_handle',
+                cursor: "grabbing",
                 stop: function (event, ui) {
                     // update currentID taking moved line into account
                     if (self.currentRow !== null) {

--- a/addons/web/static/src/js/widgets/data_export.js
+++ b/addons/web/static/src/js/widgets/data_export.js
@@ -84,6 +84,7 @@ var DataExport = Dialog.extend({
         this.opened().then(function () {
             self.$('.o_fields_list').sortable({
                 axis: 'y',
+                cursor: 'grabbing',
                 handle: '.o_short_field',
                 forcePlaceholderSize: true,
                 placeholder: 'o-field-placeholder',
@@ -140,7 +141,7 @@ var DataExport = Dialog.extend({
         if (!$fieldList.find(".o_export_field[data-field_id='" + fieldID + "']").length) {
             $fieldList.append(
                 $('<li>', {'class': 'o_export_field', 'data-field_id': fieldID}).append(
-                    $('<span>', {'class': "fa fa-arrows o_short_field mx-1"}),
+                    $('<span>', {'class': "fa fa-sort o_short_field mx-1"}),
                     label.trim(),
                     $('<span>', {'class': 'fa fa-trash m-1 pull-right o_remove_field', 'title': _t("Remove field")})
                 )

--- a/addons/web/static/src/scss/data_export.scss
+++ b/addons/web/static/src/scss/data_export.scss
@@ -37,7 +37,7 @@
             flex: 1;
             overflow: auto;
             .o_short_field {
-                cursor: ns-resize;
+                cursor: grab;
             }
             .o-field-placeholder {
                 border: 1px dashed $o-brand-primary;

--- a/addons/web/static/src/scss/fields.scss
+++ b/addons/web/static/src/scss/fields.scss
@@ -278,7 +278,13 @@
 
     // Handle widget
     &.o_row_handle {
-        cursor: ns-resize;
+        cursor: grab;
+        color: #adb5bd;
+        text-align: center;
+        width: 100%;
+        &:hover {
+            color: #666666;
+        }
     }
 
     &.o_field_selection_badge {

--- a/addons/web/static/src/scss/form_view.scss
+++ b/addons/web/static/src/scss/form_view.scss
@@ -132,6 +132,10 @@
             max-width: map-get($container-max-widths, md) - (2 * $o-horizontal-padding);
         }
 
+        .o_field_x2many .o_list_table .o_handle_cell .o_row_handle {
+            padding: 0.3rem;
+        }
+
         @include media-breakpoint-up(vsm, $o-extra-grid-breakpoints) {
             .o_row {
                 > .o_field_widget, > div {


### PR DESCRIPTION
PURPOSE
Our current drag handle icon (fa-arrows) would be more adapted for moving items in a two-dimensional space (left/right and up/down). The purpose of this task is to improve the icon of the 'handle' widget

SPEC
    change the fa-arrows icon to fa-sort
    when hover set cursor: grab
    when dragging the row set cursor: grabbing

TASK 2413274



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
