### PR TITLE
[FIX] sale_quotation_builder: change website_description when the tem…

### DIFF
--- a/addons/sale_quotation_builder/views/sale_order_views.xml
+++ b/addons/sale_quotation_builder/views/sale_order_views.xml
@@ -8,10 +8,10 @@
         <field name="arch" type="xml">
 
             <xpath expr="//page/field[@name='order_line']/tree/field[@name='name']" position="after">
-                <field name="website_description" invisible="1" readonly="1"/>
+                <field name="website_description" invisible="1"/>
             </xpath>
             <xpath expr="//page/field[@name='order_line']/form/field[@name='name']" position="after">
-                <field name="website_description" invisible="1" readonly="1"/>
+                <field name="website_description" invisible="1"/>
             </xpath>
 
             <xpath expr="//button[@name='button_add_to_order']" position="after">


### PR DESCRIPTION
…plate id changes

Fine-tuning of 0106fcd59c8c97b1a1e39a263f305650978c0606

Have a SO with a partner in another language
Apply a quote template to a SO
Customize the portal view to show website_description of a product on the template
Translate it
Show the SO on the portal

Before this commit, the description of the product was not translated
This was because the field was not included in the onchange of template_id
causing that field to never have changed, that is, it kept the description
done injected with the first write

After this commit, the description is changed according to the partner's lang

opw-2366738