### PR TITLE
[FIX] mail: ensure that thread name is up to date on message

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -6783,6 +6783,7 @@ msgstr ""
 
 #. module: mail
 #: code:addons/mail/models/mail_thread.py:0
+#: code:addons/mail/static/src/components/message/message.xml:0
 #, python-format
 msgid "document"
 msgstr ""
@@ -7006,4 +7007,11 @@ msgstr ""
 #: code:addons/mail/static/src/models/follower/follower.js:0
 #, python-format
 msgid "The subscription preferences were successfully applied."
+msgstr ""
+
+#. module: mail
+#. openerp-web
+#: code:addons/mail/static/src/components/message/message.xml:0
+#, python-format
+msgid "channel"
 msgstr ""

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -949,6 +949,12 @@ class Message(models.Model):
         self.check_access_rule('read')
         vals_list = self._read_format(fnames)
         safari = request and request.httprequest.user_agent.browser == 'safari'
+
+        thread_ids_by_model_name = defaultdict(set)
+        for message in self:
+            if message.model and message.res_id:
+                thread_ids_by_model_name[message.model].add(message.res_id)
+
         for vals in vals_list:
             message_sudo = self.browse(vals['id']).sudo().with_prefetch(self.ids)
 
@@ -988,11 +994,21 @@ class Message(models.Model):
                         'field_type': tracking.field_type,
                     })
 
+            if message_sudo.model and message_sudo.res_id:
+                record_name = self.env[message_sudo.model] \
+                    .browse(message_sudo.res_id) \
+                    .sudo() \
+                    .with_prefetch(thread_ids_by_model_name[message_sudo.model]) \
+                    .display_name
+            else:
+                record_name = False
+
             vals.update({
                 'author_id': author,
                 'notifications': message_sudo.notification_ids._filtered_for_web_client()._notification_format(),
                 'attachment_ids': attachment_ids,
                 'tracking_value_ids': tracking_value_ids,
+                'record_name': record_name,
             })
 
         return vals_list

--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -82,10 +82,10 @@
                             <t t-if="threadView and message.originThread and message.originThread !== threadView.thread">
                                 <div class="o_Message_originThread" t-att-class="{ 'o-message-selected': props.isSelected }">
                                     <t t-if="message.originThread.model === 'mail.channel'">
-                                        (from <a class="o_Message_originThreadLink" t-att-href="message.originThread.url" t-on-click="_onClickOriginThread">#<t t-esc="message.originThread.name"/></a>)
+                                        (from <a class="o_Message_originThreadLink" t-att-href="message.originThread.url" t-on-click="_onClickOriginThread"><t t-if="message.originThread.name">#<t t-esc="message.originThread.name"/></t><t t-else="">channel</t></a>)
                                     </t>
                                     <t t-else="">
-                                        on <a class="o_Message_originThreadLink" t-att-href="message.originThread.url" t-on-click="_onClickOriginThread"><t t-esc="message.originThread.name"/></a>
+                                        on <a class="o_Message_originThreadLink" t-att-href="message.originThread.url" t-on-click="_onClickOriginThread"><t t-if="message.originThread.name"><t t-esc="message.originThread.name"/></t><t t-else="">document</t></a>
                                     </t>
                                 </div>
                             </t>

--- a/addons/test_mail/tests/test_mail_message.py
+++ b/addons/test_mail/tests/test_mail_message.py
@@ -27,6 +27,40 @@ class TestMessageValues(TestMailCommon):
         cls.Message = cls.env['mail.message'].with_user(cls.user_employee)
 
     @mute_logger('odoo.models.unlink')
+    def test_mail_message_format(self):
+        record1 = self.env['mail.test.simple'].create({'name': 'Test1'})
+        message = self.env['mail.message'].create([{
+            'model': 'mail.test.simple',
+            'res_id': record1.id,
+        }])
+        res = message.message_format()
+        self.assertEqual(res[0].get('record_name'), 'Test1')
+
+        record1.write({"name": "Test2"})
+        res = message.message_format()
+        self.assertEqual(res[0].get('record_name'), 'Test2')
+
+    @mute_logger('odoo.models.unlink')
+    def test_mail_message_format_access(self):
+        """
+        User that doesn't have access to a record should still be able to fetch
+        the record_name inside message_format.
+        """
+        company_2 = self.env['res.company'].create({'name': 'Second Test Company'})
+        record1 = self.env['mail.test.multi.company'].create({
+            'name': 'Test1',
+            'company_id': company_2.id,
+        })
+        message = record1.message_post(body='', partner_ids=[self.user_employee.partner_id.id])
+        # We need to flush and invalidate the ORM cache since the record_name
+        # is already cached from the creation. Otherwise it will leak inside
+        # message_format.
+        message.flush()
+        message.invalidate_cache()
+        res = message.with_user(self.user_employee).message_format()
+        self.assertEqual(res[0].get('record_name'), 'Test1')
+
+    @mute_logger('odoo.models.unlink')
     def test_mail_message_values_no_document_values(self):
         msg = self.Message.create({
             'reply_to': 'test.reply@example.com',

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -854,7 +854,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         messages.flush()
         messages.invalidate_cache()
 
-        with self.assertQueryCount(emp=13):
+        with self.assertQueryCount(emp=15):
             res = messages.message_format()
             self.assertEqual(len(res), 6)
 

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -832,6 +832,32 @@ class TestMailComplexPerformance(BaseMailPerformance):
             for message in res:
                 self.assertEqual(len(message['attachment_ids']), 2)
 
+    @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
+    @users('emp')
+    @warmup
+    def test_message_format_group_thread_name_by_model(self):
+        """Ensures the fetch of multiple thread names is grouped by model."""
+        records = []
+        for i in range(5):
+            records.append(self.env['mail.test.simple'].create({'name': 'Test'}))
+        records.append(self.env['mail.test.track'].create({'name': 'Test'}))
+
+        messages = self.env['mail.message'].create([{
+            'model': record._name,
+            'res_id': record.id
+        } for record in records])
+
+        with self.assertQueryCount(emp=5):
+            res = messages.message_format()
+            self.assertEqual(len(res), 6)
+
+        messages.flush()
+        messages.invalidate_cache()
+
+        with self.assertQueryCount(emp=13):
+            res = messages.message_format()
+            self.assertEqual(len(res), 6)
+
 
 @tagged('mail_performance')
 class TestMailHeavyPerformancePost(BaseMailPerformance):


### PR DESCRIPTION
When formatting a message, some record can be with an empty or obsolet
record_name field. It's better to rely on the relation between the message and
the record and fetch the record_name when formatting the message.

task-2411715