### PR TITLE
fix optional dropdown in rtl language

### DIFF
--- a/addons/web/static/src/js/views/list/list_renderer.js
+++ b/addons/web/static/src/js/views/list/list_renderer.js
@@ -882,10 +882,8 @@ var ListRenderer = BasicRenderer.extend({
         // The button is located at the end of the list headers
         // We want the dropdown to expand towards the list rather than away from it
         // https://getbootstrap.com/docs/4.0/components/dropdowns/#menu-alignment
-        var direction = _t.database.parameters.direction;
-        var dropdownMenuClass = direction === 'rtl' ? 'dropdown-menu-left' : 'dropdown-menu-right';
         var $dropdown = $("<div>", {
-            class: 'dropdown-menu o_optional_columns_dropdown ' + dropdownMenuClass,
+            class: 'dropdown-menu o_optional_columns_dropdown dropdown-menu-right',
             role: 'menu',
         });
         this.optionalColumns.forEach(function (col) {

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -8605,8 +8605,8 @@ QUnit.module('Views', {
         assert.ok(optionalFieldsDropdown.classList.contains('o_optional_columns'),
             'The optional fields is the last element');
 
-        assert.ok(list.$('.o_optional_columns .dropdown-menu').hasClass('dropdown-menu-left'),
-            'In RTL, the dropdown should be anchored to the left and expand to the right');
+        assert.ok(list.$('.o_optional_columns .dropdown-menu').hasClass('dropdown-menu-right'),
+            'In RTL, the dropdown should dropdown-menu-right class as rtlcss will reverse css');
 
         list.destroy();
     });


### PR DESCRIPTION
PURPOSE
when optional dropdown is opened in RTL language dropdown is opened right aligned while in RTL language dropdown should be opened left aligned.

SPEC
Always keep dropdown-menu-right class on optional dropdown, rtlcss will change 'right' to 'left' and 'left' to 'right' in while converting css.

TASK 2411219



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
