### PR TITLE
[FIX] web: don't update the list view if not needed

### DIFF
--- a/addons/web/static/src/js/views/list/list_renderer.js
+++ b/addons/web/static/src/js/views/list/list_renderer.js
@@ -1168,6 +1168,7 @@ var ListRenderer = BasicRenderer.extend({
      * @private
      */
     _updateSelection: function () {
+        const previousSelection = JSON.stringify(this.selection);
         this.selection = [];
         var self = this;
         var $inputs = this.$('tbody .o_list_record_selector input:visible:not(:disabled)');
@@ -1180,7 +1181,9 @@ var ListRenderer = BasicRenderer.extend({
             }
         });
         this.$('thead .o_list_record_selector input').prop('checked', allChecked);
-        this.trigger_up('selection_changed', { allChecked, selection: this.selection });
+        if (JSON.stringify(this.selection) !== previousSelection) {
+            this.trigger_up('selection_changed', { allChecked, selection: this.selection });
+        }
         this._updateFooter();
     },
 


### PR DESCRIPTION
Before this commit, an event was triggered even when no change occurred.

Steps to reproduces:
* Go to Document
* Change to list view
* Go to app switcher
* Select another app that has enough content to be able to scroll
* Scroll the view => Bug

Task ID: 2347584

Co-authored-by: Michaël Mattiello <mcm@odoo.com>
