### PR TITLE
[FIX] account: Register payment

### DIFF
--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -140,7 +140,7 @@ class AccountPaymentRegister(models.TransientModel):
         '''
         self.ensure_one()
 
-        lines = self.line_ids
+        lines = self.line_ids._origin
 
         if len(lines.company_id) > 1:
             raise UserError(_("You can't create payments for entries belonging to different companies."))


### PR DESCRIPTION
Steps to reproduce:

- Create a customer invoice I for a total of 1000€
- Confirm I
- Register a payment

Bug:

The default amout in the wizard was 0€ instead of 1000€

The default amount is computed by _get_wizard_values_from_batch with the sum of
amount_residual of all the lines. But in function _compute_amount_residual, it
checked line.id and this case, all the lines were in cache with NewId

opw:2413064