### PR TITLE
[FIX] sale_project: `is_fsm` for recurrent tasks should be checked before use

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -148,6 +148,8 @@ class ProjectTaskRecurrence(models.Model):
     def _new_task_values(self, task):
         values = super(ProjectTaskRecurrence, self)._new_task_values(task)
         task = self.sudo().task_ids[0]
-        if not task.is_fsm:
-            values['sale_line_id'] = task.sale_line_id.id
+        values['sale_line_id'] = self._get_sale_line_id(task)
         return values
+
+    def _get_sale_line_id(self, task):
+        return task.sale_line_id.id


### PR DESCRIPTION
### Step to reproduce:
1. Install module "sale_project"
2. In Project > Configuration > Settings, turn on "Recurring Tasks"
3. Create a recurrent task
4. Set the "next_recurrence_date" for the recurrence ahead of today
5. Run scheduled action " Project: Create Recurring Tasks"
=> error: 'project.task' object has no attribute 'is_fsm'

### Reason:
`is_fsm` is defined in the module `industry_fsm` and the module `sale_project` does not depend on that module.
`is_fsm` should be checked before the usage

opw-2412370

