### PR TITLE
[MERGE] *: reduce shift in form view when switching mode

### DIFF
--- a/addons/sale_product_configurator/static/tests/tours/product_configurator_advanced_ui.js
+++ b/addons/sale_product_configurator/static/tests/tours/product_configurator_advanced_ui.js
@@ -25,7 +25,7 @@ tour.register('sale_product_configurator_advanced_tour', {
     auto: true,
 }, {
     trigger: "a:contains('Add a product')",
-    extra_trigger: ".o_field_widget[name=partner_shipping_id] > .o_external_button", // Wait for onchange_partner_id
+    extra_trigger: ".o_field_widget[name=partner_shipping_id] .o_external_button", // Wait for onchange_partner_id
 }, {
     trigger: 'div[name="product_template_id"] input',
     run: function (){

--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -501,6 +501,8 @@ var FieldMany2One = AbstractField.extend({
     _renderEdit: function () {
         var value = this.m2o_value;
 
+        this.$('.o_field_many2one_extra').html(this._renderValueLines(false));
+
         // this is a stupid hack necessary to support the always_reload flag.
         // the field value has been reread by the basic model.  We use it to
         // display the full address of a partner, separated by \n.  This is
@@ -518,13 +520,22 @@ var FieldMany2One = AbstractField.extend({
     },
     /**
      * @private
+     * @param {boolean} needFirstLine
+     * @returns {string} escaped html of value lines
+     */
+    _renderValueLines: function (needFirstLine) {
+        const escapedValue = _.escape((this.m2o_value || "").trim());
+        const lines = escapedValue.split('\n');
+        if (!needFirstLine) {
+            lines.shift();
+        }
+        return lines.map((line) => `<span>${line}</span>`).join('<br/>');
+    },
+    /**
+     * @private
      */
     _renderReadonly: function () {
-        var escapedValue = _.escape((this.m2o_value || "").trim());
-        var value = escapedValue.split('\n').map(function (line) {
-            return '<span>' + line + '</span>';
-        }).join('<br/>');
-        this.$el.html(value);
+        this.$el.html(this._renderValueLines(true));
         if (!this.noOpen && this.value) {
             this.$el.attr('href', _.str.sprintf('#id=%s&model=%s', this.value.res_id, this.field.relation));
             this.$el.addClass('o_form_uri');
@@ -2922,7 +2933,7 @@ var FieldSelection = AbstractField.extend({
         this._super.apply(this, arguments);
         if (!this.attrs.modifiersValue.invisible && this.mode !== 'readonly') {
             this._setValues();
-            this._renderEdit();
+            this._render();
         }
     },
 
@@ -3016,7 +3027,7 @@ var FieldRadio = FieldSelection.extend({
     description: _lt("Radio"),
     template: null,
     className: 'o_field_radio',
-    tagName: 'span',
+    tagName: 'div',
     specialData: "_fetchSpecialMany2ones",
     supportedFieldTypes: ['selection', 'many2one'],
     events: _.extend({}, AbstractField.prototype.events, {
@@ -3027,10 +3038,7 @@ var FieldRadio = FieldSelection.extend({
      */
     init: function () {
         this._super.apply(this, arguments);
-        if (this.mode === 'edit') {
-            this.tagName = 'div';
-            this.className += this.nodeOptions.horizontal ? ' o_horizontal' : ' o_vertical';
-        }
+        this.className += this.nodeOptions.horizontal ? ' o_horizontal' : ' o_vertical';
         this.unique_id = _.uniqueId("radio");
         this._setValues();
     },
@@ -3084,7 +3092,7 @@ var FieldRadio = FieldSelection.extend({
      * @private
      * @override
      */
-    _renderEdit: function () {
+    _render: function () {
         var self = this;
         var currentValue;
         if (this.field.type === 'many2one') {
@@ -3102,6 +3110,7 @@ var FieldRadio = FieldSelection.extend({
                 index: index,
                 name: self.unique_id,
                 value: value,
+                disabled: self.mode !== 'edit',
             }));
         });
     },

--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -1618,16 +1618,21 @@ var BasicModel = AbstractModel.extend({
         }
         var rel_data = _.pick(data, 'id', 'display_name');
 
+        const context = this._getContext(record, {
+            fieldName: fieldName,
+            viewType: options.viewType,
+        });
+
         // the reference field doesn't store its co-model in its field metadata
         // but directly in the data (as the co-model isn't fixed)
         var def;
-        if (rel_data.display_name === undefined) {
+        if (rel_data.display_name === undefined || context.show_address || context.show_vat) {
             // TODO: refactor this to use _fetchNameGet
             def = this._rpc({
                     model: coModel,
                     method: 'name_get',
                     args: [data.id],
-                    context: record.context,
+                    context: context,
                 })
                 .then(function (result) {
                     rel_data.display_name = result[0][1];

--- a/addons/web/static/src/scss/fields.scss
+++ b/addons/web/static/src/scss/fields.scss
@@ -12,8 +12,8 @@
 }
 
 // Empty
-.o_field_empty {
-    display: none!important;
+.o_field_empty:empty {
+    min-height: $font-size-base * $line-height-base;
 }
 
 // Numbers
@@ -84,6 +84,21 @@
                 width: 100px;
                 flex: 1 0 auto;
             }
+        }
+    }
+
+    // Many2One
+    &.o_field_many2one {
+        flex-direction: column;
+
+        .o_field_many2one_selection {
+            display: flex;
+            width: 100%;
+        }
+
+        .o_external_button {
+            padding-top: 0;
+            padding-bottom: 0;
         }
     }
 

--- a/addons/web/static/src/scss/fields_extra.scss
+++ b/addons/web/static/src/scss/fields_extra.scss
@@ -22,6 +22,7 @@
 
     // Many2one
     &.o_field_many2one .o_external_button {
+        flex: 0 0 auto;
         padding: 0;
         margin-left: 2px;
         font-size: 19px;

--- a/addons/web/static/src/scss/form_view.scss
+++ b/addons/web/static/src/scss/form_view.scss
@@ -486,6 +486,12 @@
         .o_priority > .o_priority_star {
             font-size: inherit;
         }
+        > h1 {
+            min-height: 55px;
+        }
+        > h2 {
+            min-height: 43px;
+        }
     }
 
     // Avatar
@@ -506,6 +512,10 @@
         display: inline-block;
         width: 100%;
         margin: 10px 0;
+
+        .o_group {
+            margin: 0;
+        }
 
         // o_group contains nested groups
         @for $i from 1 through $o-form-group-cols {
@@ -554,7 +564,7 @@
                                               // it does not really matter
             // Makes extra buttons (e.g. m2o external button) overflow on the
             // right padding of the parent element
-            > .o_input_dropdown {
+            .o_input_dropdown {
                 flex: 1 0 auto;
             }
         }
@@ -604,6 +614,14 @@
         .o_field_widget {
             margin-bottom: 0px;
         }
+    }
+    td.o_td_label .o_form_label {
+        min-height: 33px;
+    }
+    td:not(.o_field_cell) .o_form_uri > span:first-child {
+        display: inline-block;
+        padding: 1px 0;
+        margin-bottom: 1px;
     }
 
     // Translate icon

--- a/addons/web/static/src/scss/list_view.scss
+++ b/addons/web/static/src/scss/list_view.scss
@@ -275,7 +275,7 @@
             }
             > .o_field_widget {
                 width: 100%;
-                > .o_external_button {
+                .o_external_button {
                     padding: 0;
                     border: none;
                     background-color: inherit;

--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -1235,7 +1235,7 @@
 </t>
 <t t-name="FieldRadio.button">
     <div class="custom-control custom-radio o_radio_item" aria-atomic="true">
-        <input type="radio" class="custom-control-input o_radio_input" t-att-checked="checked ? true : undefined"
+        <input type="radio" class="custom-control-input o_radio_input" t-att-checked="checked ? true : undefined" t-att-disabled="disabled ? true : undefined"
             t-att-name="name" t-att-data-value="value[0]" t-att-data-index="index" t-att-id="id"/>
         <label class="custom-control-label o_form_label" t-att-for="id"><t t-esc="value[1]"/></label>
     </div>
@@ -1253,16 +1253,19 @@
         <span t-if="widget.noOpen"/>
     </t>
     <div t-if="widget.mode === 'edit'" class="o_field_widget o_field_many2one" aria-atomic="true">
-        <div class="o_input_dropdown">
-            <input type="text" class="o_input"
-                t-att-barcode_events="widget.nodeOptions.barcode_events"
-                t-att-tabindex="widget.attrs.tabindex"
-                t-att-autofocus="widget.attrs.autofocus"
-                t-att-placeholder="widget.attrs.placeholder"
-                t-att-id="widget.idForLabel"/>
-            <a role="button" class="o_dropdown_button" draggable="false"/>
+        <div class="o_field_many2one_selection">
+            <div class="o_input_dropdown">
+                <input type="text" class="o_input"
+                    t-att-barcode_events="widget.nodeOptions.barcode_events"
+                    t-att-tabindex="widget.attrs.tabindex"
+                    t-att-autofocus="widget.attrs.autofocus"
+                    t-att-placeholder="widget.attrs.placeholder"
+                    t-att-id="widget.idForLabel"/>
+                <a role="button" class="o_dropdown_button" draggable="false"/>
+            </div>
+            <button type="button" t-if="!widget.noOpen" class="fa fa-external-link btn btn-secondary o_external_button" tabindex="-1" draggable="false" aria-label="External link" title="External link"/>
         </div>
-        <button type="button" t-if="!widget.noOpen" class="fa fa-external-link btn btn-secondary o_external_button" tabindex="-1" draggable="false" aria-label="External link" title="External link"/>
+        <div class="o_field_many2one_extra"/>
     </div>
 </t>
 

--- a/addons/web/static/tests/fields/relational_fields/field_many2one_tests.js
+++ b/addons/web/static/tests/fields/relational_fields/field_many2one_tests.js
@@ -328,7 +328,7 @@ QUnit.module('fields', {}, function () {
         });
 
         QUnit.test('many2ones in form views with show_address', async function (assert) {
-            assert.expect(4);
+            assert.expect(6);
             var form = await createView({
                 View: FormView,
                 model: 'partner',
@@ -360,6 +360,11 @@ QUnit.module('fields', {}, function () {
             assert.strictEqual(form.$('a.o_form_uri').html(), '<span>aaa</span><br><span>Street</span><br><span>City ZIP</span>',
                 "input should have a multi-line content in readonly due to show_address");
             await testUtils.form.clickEdit(form);
+
+            assert.strictEqual(form.$('input.o_input').val(), 'aaa');
+            assert.strictEqual(form.$('.o_field_many2one_extra').html(),
+                '<span>Street</span><br><span>City ZIP</span>');
+
             assert.containsOnce(form, 'button.o_external_button:visible',
                 "should have an open record button");
 

--- a/addons/web/static/tests/fields/relational_fields_tests.js
+++ b/addons/web/static/tests/fields/relational_fields_tests.js
@@ -2148,7 +2148,7 @@ QUnit.module('relational_fields', {
     });
 
     QUnit.test('fieldradio widget with numerical keys encoded as strings', async function (assert) {
-        assert.expect(5);
+        assert.expect(7);
 
         this.data.partner.fields.selection = {
             type: 'selection',
@@ -2173,8 +2173,8 @@ QUnit.module('relational_fields', {
         });
 
 
-        assert.strictEqual(form.$('.o_field_widget').text(), '',
-            "field should be unset");
+        assert.strictEqual(form.$('.o_field_widget').text().trim().split(/\s+/g).join(','), 'Red,Black');
+        assert.containsNone(form, '.o_radio_input:checked', "no value should be checked");
 
         await testUtils.form.clickEdit(form);
 
@@ -2185,8 +2185,9 @@ QUnit.module('relational_fields', {
 
         await testUtils.form.clickSave(form);
 
-        assert.strictEqual(form.$('.o_field_widget').text(), 'Black',
-            "value should be 'Black'");
+        assert.strictEqual(form.$('.o_field_widget').text().trim().split(/\s+/g).join(','), 'Red,Black');
+        assert.containsOnce(form, '.o_radio_input[data-index=1]:checked',
+            "'Black' should be checked");
 
         await testUtils.form.clickEdit(form);
 

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -202,12 +202,12 @@ tour.stepUtils.autoExpandMoreButtons('.o_form_readonly'),
 }, {
     mobile: true,
     trigger: '.o_field_widget[name=code]',
-    extra_trigger: ".o_field_widget[name=product_id] > .o_external_button", // Wait name_create
+    extra_trigger: ".o_field_widget[name=product_id] .o_external_button", // Wait name_create
     // click somewhere else to exit cell focus
 }, {
     mobile: false,
     trigger: 'label:contains("Vendor Taxes")',
-    extra_trigger: ".o_field_widget[name=name] > .o_external_button", // Wait name_create
+    extra_trigger: ".o_field_widget[name=name] .o_external_button", // Wait name_create
     // click somewhere else to exit cell focus
 }, {
     mobile: false,
@@ -315,7 +315,7 @@ tour.stepUtils.autoExpandMoreButtons('.o_form_readonly'),
 }, {
     mobile: true,
     trigger: '.o_field_widget[name=code]',
-    extra_trigger: ".o_field_widget[name=product_id] > .o_external_button", // Wait name_create
+    extra_trigger: ".o_field_widget[name=product_id] .o_external_button", // Wait name_create
     // click somewhere else to exit cell focus
 }, {
     mobile: false,
@@ -422,7 +422,7 @@ tour.stepUtils.autoExpandMoreButtons('.o_form_readonly'),
     position: 'right',
 }, {
     trigger: '.o_form_button_save',
-    extra_trigger: '.o_field_widget[name=project_id] > .o_external_button', // Wait name_create
+    extra_trigger: '.o_field_widget[name=project_id] .o_external_button', // Wait name_create
     content: _t("Save this product and the modifications you've made to it."),
     position: 'bottom',
 }, {
@@ -479,7 +479,7 @@ tour.stepUtils.autoExpandMoreButtons('.o_form_readonly'),
     position: 'right',
 }, {
     trigger: ".o_kanban_quick_create .o_kanban_add",
-    extra_trigger: ".o_kanban_quick_create .o_field_widget[name=partner_id] > .o_external_button", // Wait name_create
+    extra_trigger: ".o_kanban_quick_create .o_field_widget[name=partner_id] .o_external_button", // Wait name_create
     content: _t("Click here to <b>add your opportunity</b>."),
     position: "right",
 }, {


### PR DESCRIPTION
Reduce shift in form view when switching mode
---

This PR reduces the shift between edit and readonly mode in the form view.
Reducing the shift means that both modes should be identical:
* Fields should be at the same place
* Fields have the same render in both modes
* Labels shouldn't show only in one mode, whether they appear in both or they does not

Task 2330101
Enterprise PR: https://github.com/odoo/enterprise/pull/15191