### PR TITLE
[IMP] hr: Hide menu_hr_employee for group_hr_user

### DIFF
--- a/addons/hr/data/hr_data.xml
+++ b/addons/hr/data/hr_data.xml
@@ -20,6 +20,7 @@
 
         <record id="employee_admin" model="hr.employee">
             <field name="name" eval="obj(ref('base.partner_admin')).name" model="res.partner"/>
+            <field name="department_id" ref="dep_administration"/>
             <field name="user_id" ref="base.user_admin"/>
             <field name="address_id" ref="base.partner_admin"/>
             <field name="address_home_id" ref="res_partner_admin_private_address"/>

--- a/addons/hr/models/__init__.py
+++ b/addons/hr/models/__init__.py
@@ -16,3 +16,4 @@ from . import res_partner
 from . import res_users
 from . import res_company
 from . import resource
+from . import ir_ui_menu

--- a/addons/hr/models/ir_ui_menu.py
+++ b/addons/hr/models/ir_ui_menu.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, api, tools
+
+
+class IrUiMenu(models.Model):
+    _inherit = 'ir.ui.menu'
+
+    def _load_menus_blacklist(self):
+        res = super()._load_menus_blacklist()
+        if self.env.user.has_group('hr.group_hr_user'):
+            res.append(self.env.ref('hr.menu_hr_employee').id)
+        return res

--- a/addons/hr/views/hr_views.xml
+++ b/addons/hr/views/hr_views.xml
@@ -31,7 +31,7 @@
 
         <menuitem
             id="menu_hr_employee"
-            name="Employee Directory"
+            name="Directory"
             action="hr_employee_public_action"
             parent="menu_hr_root"
             sequence="4"/>


### PR DESCRIPTION
Reason: In Employees app, it is confusing for the first time users to see
both 'Employees' and 'Employee Directory' folder. Also, first user
is not assigned to any departments.

Solution: If the user can see the folder 'Employees', don't show
the folder 'Employee Directory'. Assign the first user to the
'Administration' department.

Task - 2377506

