### PR TITLE
[FIX] project: Fix wrong recipient display based on email_from

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1173,7 +1173,7 @@ class Task(models.Model):
     @api.depends('partner_id.email', 'parent_id.email_from')
     def _compute_email_from(self):
         for task in self:
-            task.email_from = task.partner_id.email or task.email_from or task.parent_id.email_from
+            task.email_from = task.partner_id.email or ((task.partner_id or task.parent_id) and task.email_from) or task.parent_id.email_from
 
     @api.depends('parent_id.project_id.subtask_project_id')
     def _compute_project_id(self):


### PR DESCRIPTION
Currently, The customer that is not selected anymore is suggested
as a recipient

steps to reproduce:
1. create a project task without a customer set
2. select a customer, then remove it, then save
3. send a message in the chatter
--> the customer that is not selected anymore is still suggested as
a recipient.
The issue is due to invalid value of partner's email in the field
email_from on task.

So in this commit, when the customer is not defined or is not a child
task then keep the email_From of the task.
(Here we are checking the task.parent_id because when someone update
the email_from on parent it should be updated in child task's
email_from and when we remove the email_From in parent it should not
be removed from child task)

TaskID: 2339894

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
