### PR TITLE
[FIX] For Python 3.8 you need xlrd==1.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,5 +45,6 @@ Werkzeug==0.14.1 ; sys_platform != 'win32'
 Werkzeug==0.16.0 ; sys_platform == 'win32'
 XlsxWriter==1.1.2
 xlwt==1.3.*
-xlrd==1.1.0
+xlrd==1.1.0; python_version < '3.8'
+xlrd==1.2.0; python_version >= '3.8'
 pypiwin32 ; sys_platform == 'win32'


### PR DESCRIPTION
For Python 3.8 you must use the xlrd >= 1.2 version.
In Odoo 14.0 this fix is included, but for Odoo 13.0 no.

Without this fix if you install Odoo 13 with Python 3.8 you are not able to import Excel files.
The error is: https://stackoverflow.com/questions/58569361/attributeerror-module-time-has-no-attribute-clock-in-python-3-8

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
