### PR TITLE
[FIX] sale_coupon: cannot set coupons to 'expired' state when archiving coupon programs

### DIFF
--- a/addons/sale_coupon/views/sale_coupon_program_views.xml
+++ b/addons/sale_coupon/views/sale_coupon_program_views.xml
@@ -176,7 +176,7 @@
         <field name="domain">[('program_type','=', 'coupon_program')]</field>
         <field name="context">{
             'default_program_type': 'coupon_program',
-            'promo_code_usage': 'code_needed',
+            'default_promo_code_usage': 'code_needed',
             'search_default_opened': 1
             }</field>
         <field name="help" type="html">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
close #63061
Current behavior before PR:
when archiving coupon programs, the state of generated coupons still is 'valid'
Desired behavior after PR is merged:
when archiving coupon programs, the state of generated coupons will be set to 'expired'



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
