### PR TITLE
[FIX] mass_mailing: show attachments composer mailings

### DIFF
--- a/addons/mass_mailing/wizard/mail_compose_message.py
+++ b/addons/mass_mailing/wizard/mail_compose_message.py
@@ -38,6 +38,7 @@ class MailComposeMessage(models.TransientModel):
                         'body_html': self.body,
                         'mailing_model_id': self.env['ir.model']._get(self.model).id,
                         'mailing_domain': self.active_domain,
+                        'attachment_ids': [(4, attach.id) for attach in self.attachment_ids],
                 })
 
             # Preprocess res.partners to batch-fetch from db


### PR DESCRIPTION
STEPS:
* Install mass_mailing
* Open Contacts menu
* Select any number of records
* Click `Action > Send email`
* Set **Mass Mailing Name**
* Attach a file
* Send
* Open ``Email Marketing`` app
* Open the created mailing
* Check ``[Settings]`` tab

BEFORE: Attachments field is empty
AFTER: You can see the attachments sent to the partners

WHY: In 2014 attachments were added to mailing.mailing, but not to composer
https://github.com/odoo/odoo/commit/7e1e475d89694d09e62c33d2529fa061c7983dff

---

opw-2410938

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
