### PR TITLE
[FIX] hr_expense : supplier_taxes_id is not visible

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -466,6 +466,9 @@
                         <label for="can_be_expensed"/>
                     </div>
                 </div>
+                <xpath expr="//page[@name='general_information']//field[@name='taxes_id']" position="after">
+                    <field name="supplier_taxes_id" widget="many2many_tags" attrs="{'invisible':['|',('can_be_expensed','=',False),('purchase_ok','=',True)]}" context="{'default_type_tax_use':'purchase', 'search_default_purchase': 1, 'search_default_service': type == 'service', 'search_default_goods': type == 'consu'}"/>
+                </xpath>
             </field>
         </record>
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
- install `hr_expense`
- create a product with `can_be_expensed = True` and `purchase_ok = False`

Issue the field `supplier_taxes_id` is not visible (because inside Purchase page, this page is invisible when `purchase_ok = False`).

With this PR the field `supplier_taxes_id` is visible in the `general_information` only if can_be_expensed = True` and `purchase_ok = False`

@oco-odoo 


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
