### PR TITLE
[IMP] mass_mailing: update admin email with data

### DIFF
--- a/addons/mass_mailing/models/res_users.py
+++ b/addons/mass_mailing/models/res_users.py
@@ -19,3 +19,10 @@ class Users(models.Model):
                 activity['name'] = _('Email Marketing')
                 break
         return activities
+
+    def write(self, values):
+        if values.get('email') and self == self.env.ref('base.user_admin'):
+            contact_data = self.env.ref('mass_mailing.mass_mailing_contact_0', raise_if_not_found=False)
+            if contact_data:
+                contact_data.email = values['email']
+        return super(Users, self).write(values)


### PR DESCRIPTION
SPECIFICATIONS

We create a mailing.contact for the admin but the email address should be his and not @example.com
=> This is important as we want him to receive the email.

LIMITATIONS

It will work only
  * if user is admin;
  * he still uses its default contact data;

It will not work if
  * another user tries mass mailing and changes its email;
  * admin removes default contact data and creates a new one for him;
  * admin udpates its partner data as only user is supported to limit cost
    of such an unnecessary feature;

LINKS

Task ID-2327564
