### PR TITLE
[FIX] web_editor: Qunit test properly wait for editor stop

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -42,6 +42,7 @@ var Wysiwyg = Widget.extend({
         this.value = options.value || '';
         this.options = options;
         this.colorPickers = [];
+        this.isEditorStoppedPromise = new Promise(resolve => this._editorStoppedResolve = resolve);
         this.JWEditorLib = JWEditorLib;
         if (this.options.enableTranslation) {
             this._modeConfig = {
@@ -453,7 +454,7 @@ var Wysiwyg = Widget.extend({
         // Saving the content of the editor is not possible after destroy,
         // so there's no need to keep the pop-up warning in this case.
         window.onbeforeunload = null;
-        this.editor.stop();
+        this.editor.stop().then(this._editorStoppedResolve);
         this._super();
     },
 

--- a/addons/web_editor/static/tests/field_html_tests.js
+++ b/addons/web_editor/static/tests/field_html_tests.js
@@ -255,6 +255,7 @@ QUnit.module('web_editor', {}, function () {
 
             odoo.__DEBUG__.services['root.widget'] = rootWidget;
             form.destroy();
+            await wysiwyg.isEditorStoppedPromise;
         });
 
         QUnit.test('media dialog: image', async function (assert) {
@@ -320,6 +321,7 @@ QUnit.module('web_editor', {}, function () {
             testUtils.mock.unpatch(MediaDialog);
 
             form.destroy();
+            await wysiwyg.isEditorStoppedPromise;
         });
 
         QUnit.test('media dialog: icon', async function (assert) {
@@ -378,6 +380,7 @@ QUnit.module('web_editor', {}, function () {
             testUtils.mock.unpatch(MediaDialog);
 
             form.destroy();
+            await wysiwyg.isEditorStoppedPromise;
         });
 
         QUnit.test('save', async function (assert) {
@@ -419,13 +422,17 @@ QUnit.module('web_editor', {}, function () {
             await testUtils.nextTick();
             await new Promise((resolve) => wysiwyg.editor.execCommand(resolve));
             await openColorpicker();
-            await testUtils.nextTick();
 
+            await testUtils.nextTick();
             await new Promise((resolve) => wysiwyg.editor.execCommand(resolve));
             await testUtils.dom.click($('jw-toolbar .o_we_color_btn[style="background-color:#00FFFF;"]'));
+
+            await testUtils.nextTick();
+            await new Promise((resolve) => wysiwyg.editor.execCommand(resolve));
             await testUtils.form.clickSave(form);
 
-            await form.destroy();
+            await wysiwyg.isEditorStoppedPromise;
+            form.destroy();
         });
 
         QUnit.module('cssReadonly');


### PR DESCRIPTION
Fix an error in the QUnit tests that would sometimes pop up when the `editor.stop()` is a bit slow and the QUnit test case is over before the editor html is properly cleaned.

**Bug report :** 

[XDO] Undeterministic runbot error: https://runbot.odoo.com/runbot/build/5082722 Body still contains undesirable elements: jw-follow-range
    ╰─[DMO] This was already reported and already marked as fixed. However, it seems this bug still appears as this build is from master today (Nov 19). If I remember correctly, the fix was to add an await in the test for the closing of the editor. However, I was surprised that this await wasn't needed in the other editor tests. Maybe this is why the bug is till there ? That it is another test that exhibits the same shortcoming ?





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
