### PR TITLE
[FIX] stock: fix update quantity action on Product Variant

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -509,7 +509,7 @@ class Product(models.Model):
         return self.env['stock.quant'].with_context(ctx)._get_quants_action(domain)
 
     def action_update_quantity_on_hand(self):
-        return self.product_tmpl_id.with_context(default_product_id=self.id).action_update_quantity_on_hand()
+        return self.product_tmpl_id.with_context(default_product_id=self.id, create=True).action_update_quantity_on_hand()
 
     def action_product_forecast_report(self):
         action = self.env.ref('stock.report_stock_quantity_action_product').read()[0]


### PR DESCRIPTION
- Install stock
- Create a Storable Product
- Add an Attribute with Variant Creation Mode set to Instantly (i.e. Color)
- On Product form, click on Variant smart button and open a Product Variant
- Click on "Update Quantity"
The Create button to edit Quantity on Hand is not present.

This comes from the Variant smart button (id: product_variant_action) that adds
'create': False in the context to prevent creation of Variant.
But when navigating to Update Quantity page, it is still in the context and hides
the Create button.

opw-2412380

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
