### PR TITLE
[FIX] core: imports with one2many lines with dangling external ids

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -2008,7 +2008,9 @@ class IrModelData(models.Model):
             INSERT INTO ir_model_data (module, name, model, res_id, noupdate)
             VALUES {rows}
             ON CONFLICT (module, name)
-            DO UPDATE SET write_date=(now() at time zone 'UTC') {where}
+            DO UPDATE SET (model, res_id, write_date) =
+                (EXCLUDED.model, EXCLUDED.res_id, now() at time zone 'UTC')
+                {where}
         """.format(
             rows=", ".join([rowf] * len(sub_rows)),
             where="WHERE NOT ir_model_data.noupdate" if update else "",

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -62,6 +62,7 @@ from .tools.misc import CountingStream, clean_context, DEFAULT_SERVER_DATETIME_F
 from .tools.translate import _
 from .tools import date_utils
 from .tools import populate
+from .tools.lru import LRU
 
 _logger = logging.getLogger(__name__)
 _schema = logging.getLogger(__name__ + '.schema')
@@ -1077,7 +1078,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
 
         # make 'flush' available to the methods below, in the case where XMLID
         # resolution fails, for instance
-        flush_self = self.with_context(import_flush=flush)
+        flush_self = self.with_context(import_flush=flush, import_cache=LRU(1024))
 
         # TODO: break load's API instead of smuggling via context?
         limit = self._context.get('_import_limit')


### PR DESCRIPTION
Consider a model M with a one2many field with comodel L, such that
deleting records in M cascade-deletes records in L.  Import a bunch of
records in M with one2many lines having specific external ids.  Delete
the imported records: the database cascade-deletes the corresponding
lines, but the lines' external ids are not deleted.  Now re-import the
same records: this crashes, because the import process finds the lines'
external ids and tries to update the deleted lines!

The fix consists in checking that an external id's record actually
exists.  The existence check was removed for performance reasons by
https://github.com/odoo/odoo/pull/26496.  We reintroduce it by resolving
the external id with a join on the model's name, which checks the
record's existence faster than an extra query.  This patch allows to
re-create the imported records' lines.

Another patch is necessary to actually update the external ids that
refer to deleted records, otherwise they remain dangling, and importing
the same records again duplicates the lines, because their external ids
do not match any existing record.

OPW 2409649