### PR TITLE
[FIX] stock: create back-orders from Operations tab in new wh

### DIFF
--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -926,6 +926,7 @@ class Warehouse(models.Model):
                 'default_location_src_id': False,
                 'sequence': max_sequence + 1,
                 'show_reserved': False,
+                'show_operations': False,
                 'sequence_code': 'IN',
                 'company_id': self.company_id.id,
             }, 'out_type_id': {

--- a/addons/stock/tests/test_warehouse.py
+++ b/addons/stock/tests/test_warehouse.py
@@ -508,6 +508,7 @@ class TestWarehouse(TestStockCommon):
 
         # Picking Type
         self.assertFalse(warehouse.in_type_id.active)
+        self.assertFalse(warehouse.in_type_id.show_operations)
         self.assertFalse(warehouse.out_type_id.active)
         self.assertFalse(warehouse.int_type_id.active)
         self.assertFalse(warehouse.pick_type_id.active)
@@ -532,6 +533,7 @@ class TestWarehouse(TestStockCommon):
 
         # Picking Type
         self.assertTrue(warehouse.in_type_id.active)
+        self.assertFalse(warehouse.in_type_id.show_operations)
         self.assertTrue(warehouse.out_type_id.active)
         self.assertTrue(warehouse.int_type_id.active)
         self.assertFalse(warehouse.pick_type_id.active)


### PR DESCRIPTION
When a new warehouse is created, the receipts of the purchase orders done in this new warehouse have different behavior than the ones from the inital warehouse. With the new warehouse the 'Detailed Operations' tab of the receipt is visible but not the button next to 'Done' in the 'Operations' tab. Since no elements are inside the 'Detailed Operations', it requires a manual entry of all elements for every receipt with back-order. This aligns the behavior of new warehouses with the initial one, not showing the 'Detailed Operations' tab in the receipts but allowing to use the button of the 'Operations' tab.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
