### PR TITLE
[FIX] sale_coupon: allow salespeople to use coupons

### DIFF
--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -238,7 +238,7 @@ class SaleOrder(models.Model):
         if coupon:
             coupon.write({'state': 'reserved'})
         else:
-            coupon = self.env['sale.coupon'].create({
+            coupon = self.env['sale.coupon'].sudo().create({
                 'program_id': program.id,
                 'state': 'reserved',
                 'partner_id': self.partner_id.id,

--- a/addons/sale_coupon/security/ir.model.access.csv
+++ b/addons/sale_coupon/security/ir.model.access.csv
@@ -3,7 +3,7 @@ access_program_salesman,salesman,model_sale_coupon_program,sales_team.group_sale
 access_program_manager,program manager,model_sale_coupon_program,sales_team.group_sale_manager,1,1,1,1
 access_applicability_salesman,salesman,model_sale_coupon_rule,sales_team.group_sale_salesman,1,0,0,0
 access_applicability_manager,program manager,model_sale_coupon_rule,sales_team.group_sale_manager,1,1,1,0
-access_coupon_salesman,salesman,model_sale_coupon,sales_team.group_sale_salesman,1,0,0,0
+access_coupon_salesman,salesman,model_sale_coupon,sales_team.group_sale_salesman,1,1,0,0
 access_coupon_manager,program manager,model_sale_coupon,sales_team.group_sale_manager,1,1,1,0
 access_reward_salesman,salesman,model_sale_coupon_reward,sales_team.group_sale_salesman,1,0,0,0
 access_reward_manager,program manager,model_sale_coupon_reward,sales_team.group_sale_manager,1,1,1,0


### PR DESCRIPTION
Steps:
- Have a demo user with "User: Own Documents Only" rights on Sales.
- Connect as admin
- Go to Sales > Products > Coupon Program
- Click one of the programs
- Generate a Coupon
- Reconnect as demo user
- Create a Sales Order
- Apply the generated coupon

Bug:
Access rights restriction on the coupon.


Sorry, you are not allowed to modify documents of type 'Sales Coupon' (sale.coupon). This operation is allowed for the groups:
	- Sales/Administrator - (Operation: write, User: 6)


Explanation:
When applying a coupon to the sales order, it tries to update the coupon's state and link it to the order. This needs to update the coupon record.
This commit also fixes confirming quotations and cancelling sales orders with coupons for salespeople.

opw:2409858