### PR TITLE
[MERGE] event: improve state, display and performance of event mail schedulers

### DIFF
--- a/addons/event/__manifest__.py
+++ b/addons/event/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'Events Organization',
-    'version': '1.4',
+    'version': '1.5',
     'website': 'https://www.odoo.com/page/events',
     'category': 'Marketing/Events',
     'summary': 'Trainings, Conferences, Meetings, Exhibitions, Registrations',
@@ -44,4 +44,7 @@ Key Features
     ],
     'installable': True,
     'auto_install': False,
+    'qweb': [
+        'static/src/xml/field_icon_selection.xml',
+    ],
 }

--- a/addons/event/__manifest__.py
+++ b/addons/event/__manifest__.py
@@ -27,6 +27,7 @@ Key Features
         'views/event_stage_views.xml',
         'report/event_event_templates.xml',
         'report/event_event_reports.xml',
+        'data/ir_cron_data.xml',
         'data/mail_template_data.xml',
         'data/event_data.xml',
         'views/res_config_settings_views.xml',

--- a/addons/event/data/event_data.xml
+++ b/addons/event/data/event_data.xml
@@ -1,19 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data noupdate="1">
-        <!-- Event Mail Scheduler-->
-        <record model="ir.cron" forcecreate="True" id="event_mail_scheduler">
-            <field name="name">Event: Mail Scheduler</field>
-            <field name="model_id" ref="model_event_mail"/>
-            <field name="state">code</field>
-            <field name="code">model.run(True)</field>
-            <field name="user_id" ref="base.user_root"/>
-            <field name="interval_number">1</field>
-            <field name="interval_type">hours</field>
-            <field name="numbercall">-1</field>
-            <field name="doall" eval="False" />
-        </record>
-
         <!-- Event Categories -->
         <record id="event_type_data_ticket" model="event.type">
             <field name="name">Ticketing</field>

--- a/addons/event/data/ir_cron_data.xml
+++ b/addons/event/data/ir_cron_data.xml
@@ -5,7 +5,7 @@
         <field name="name">Event: Mail Scheduler</field>
         <field name="model_id" ref="model_event_mail"/>
         <field name="state">code</field>
-        <field name="code">model.run(True)</field>
+        <field name="code">model.schedule_communications(autocommit=True)</field>
         <field name="user_id" ref="base.user_root"/>
         <field name="interval_number">1</field>
         <field name="interval_type">hours</field>

--- a/addons/event/data/ir_cron_data.xml
+++ b/addons/event/data/ir_cron_data.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo><data noupdate="1">
+    <!-- Event Mail Scheduler-->
+    <record model="ir.cron" forcecreate="True" id="event_mail_scheduler">
+        <field name="name">Event: Mail Scheduler</field>
+        <field name="model_id" ref="model_event_mail"/>
+        <field name="state">code</field>
+        <field name="code">model.run(True)</field>
+        <field name="user_id" ref="base.user_root"/>
+        <field name="interval_number">1</field>
+        <field name="interval_type">hours</field>
+        <field name="numbercall">-1</field>
+        <field name="doall" eval="False" />
+    </record>
+</data></odoo>

--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -398,7 +398,7 @@ class EventEvent(models.Model):
 
             # lines to keep: those with already sent emails or registrations
             mails_to_remove = event.event_mail_ids.filtered(
-                lambda mail: not(mail._origin.mail_sent or mail._origin.mail_registration_ids)
+                lambda mail: not(mail._origin.mail_done) and not(mail._origin.mail_registration_ids)
             )
             command = [Command.unlink(mail.id) for mail in mails_to_remove]
             if event.event_type_id.use_mail_schedule:

--- a/addons/event/models/event_mail.py
+++ b/addons/event/models/event_mail.py
@@ -95,17 +95,17 @@ class EventMailScheduler(models.Model):
             else:
                 mail.done = len(mail.mail_registration_ids) == len(mail.event_id.registration_ids) and all(mail.mail_sent for mail in mail.mail_registration_ids)
 
-    @api.depends('event_id.date_begin', 'interval_type', 'interval_unit', 'interval_nbr')
+    @api.depends('event_id.date_begin', 'event_id.date_end', 'interval_type', 'interval_unit', 'interval_nbr')
     def _compute_scheduled_date(self):
-        for mail in self:
-            if mail.interval_type == 'after_sub':
-                date, sign = mail.event_id.create_date, 1
-            elif mail.interval_type == 'before_event':
-                date, sign = mail.event_id.date_begin, -1
+        for scheduler in self:
+            if scheduler.interval_type == 'after_sub':
+                date, sign = scheduler.event_id.create_date, 1
+            elif scheduler.interval_type == 'before_event':
+                date, sign = scheduler.event_id.date_begin, -1
             else:
-                date, sign = mail.event_id.date_end, 1
+                date, sign = scheduler.event_id.date_end, 1
 
-            mail.scheduled_date = date + _INTERVALS[mail.interval_unit](sign * mail.interval_nbr) if date else False
+            scheduler.scheduled_date = date + _INTERVALS[scheduler.interval_unit](sign * scheduler.interval_nbr) if date else False
 
     def execute(self):
         for mail in self:

--- a/addons/event/models/event_mail.py
+++ b/addons/event/models/event_mail.py
@@ -85,9 +85,9 @@ class EventMailScheduler(models.Model):
     scheduled_date = fields.Datetime('Scheduled Sent Mail', compute='_compute_scheduled_date', store=True)
     mail_registration_ids = fields.One2many('event.mail.registration', 'scheduler_id')
     mail_sent = fields.Boolean('Mail Sent on Event', copy=False)
-    done = fields.Boolean('Sent', compute='_compute_done', store=True)
+    done = fields.Boolean('Sent', compute='_compute_done', store=True, copy=False)
 
-    @api.depends('mail_sent', 'interval_type', 'event_id.registration_ids', 'mail_registration_ids')
+    @api.depends('mail_sent', 'interval_type', 'event_id.registration_ids', 'mail_registration_ids.mail_sent')
     def _compute_done(self):
         for mail in self:
             if mail.interval_type in ['before_event', 'after_event']:

--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -208,6 +208,36 @@ class EventRegistration(models.Model):
     def action_cancel(self):
         self.write({'state': 'cancel'})
 
+    def action_send_badge_email(self):
+        """ Open a window to compose an email, with the template - 'event_badge'
+            message loaded by default
+        """
+        self.ensure_one()
+        template = self.env.ref('event.event_registration_mail_template_badge')
+        compose_form = self.env.ref('mail.email_compose_message_wizard_form')
+        ctx = dict(
+            default_model='event.registration',
+            default_res_id=self.id,
+            default_use_template=bool(template),
+            default_template_id=template.id,
+            default_composition_mode='comment',
+            custom_layout="mail.mail_notification_light",
+        )
+        return {
+            'name': _('Compose Email'),
+            'type': 'ir.actions.act_window',
+            'view_mode': 'form',
+            'res_model': 'mail.compose.message',
+            'views': [(compose_form.id, 'form')],
+            'view_id': compose_form.id,
+            'target': 'new',
+            'context': ctx,
+        }
+
+    # ------------------------------------------------------------
+    # MAILING / GATEWAY
+    # ------------------------------------------------------------
+
     def _message_get_suggested_recipients(self):
         recipients = super(EventRegistration, self)._message_get_suggested_recipients()
         public_users = self.env['res.users'].sudo()
@@ -248,31 +278,9 @@ class EventRegistration(models.Model):
                 ]).write({'partner_id': new_partner.id})
         return super(EventRegistration, self)._message_post_after_hook(message, msg_vals)
 
-    def action_send_badge_email(self):
-        """ Open a window to compose an email, with the template - 'event_badge'
-            message loaded by default
-        """
-        self.ensure_one()
-        template = self.env.ref('event.event_registration_mail_template_badge')
-        compose_form = self.env.ref('mail.email_compose_message_wizard_form')
-        ctx = dict(
-            default_model='event.registration',
-            default_res_id=self.id,
-            default_use_template=bool(template),
-            default_template_id=template.id,
-            default_composition_mode='comment',
-            custom_layout="mail.mail_notification_light",
-        )
-        return {
-            'name': _('Compose Email'),
-            'type': 'ir.actions.act_window',
-            'view_mode': 'form',
-            'res_model': 'mail.compose.message',
-            'views': [(compose_form.id, 'form')],
-            'view_id': compose_form.id,
-            'target': 'new',
-            'context': ctx,
-        }
+    # ------------------------------------------------------------
+    # TOOLS
+    # ------------------------------------------------------------
 
     def get_date_range_str(self):
         self.ensure_one()

--- a/addons/event/static/src/js/field_icon_selection.js
+++ b/addons/event/static/src/js/field_icon_selection.js
@@ -1,0 +1,29 @@
+odoo.define('event.field_icon_selection', function (require) {
+"use strict";
+
+var core = require('web.core');
+var registry = require('web.field_registry');
+var AbstractField = require('web.AbstractField');
+var QWeb = core.qweb;
+
+var IconSelection = AbstractField.extend({
+    supportedFieldTypes: ['char', 'text', 'selection'],
+
+    /**
+    * @override
+    * @private
+    */
+    _render: function () {
+        this._super.apply(this, arguments);
+        this.icon = this.nodeOptions[this.value];
+        this.title = this.value.charAt(0).toUpperCase() + this.value.slice(1);
+        this.$el.empty().append(QWeb.render('event.IconSelection', {'widget': this}));
+    },
+
+});
+
+registry.add('icon_selection', IconSelection);
+
+return IconSelection;
+
+});

--- a/addons/event/static/src/xml/field_icon_selection.xml
+++ b/addons/event/static/src/xml/field_icon_selection.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates xml:space="preserve">
+    <t t-name="event.IconSelection">
+        <i t-att-class="widget.icon" t-att-title="widget.title"/>
+    </t>
+</templates>

--- a/addons/event/tests/test_event_mail_schedule.py
+++ b/addons/event/tests/test_event_mail_schedule.py
@@ -27,8 +27,11 @@ class TestMailSchedule(TestEventCommon, MockEmail):
         event_date_end = datetime(2021, 3, 24, 18, 0, 0)
 
         with freeze_time(now):
-            test_event = self.env['event.event'].with_user(self.user_eventmanager).create({
+            # create with admin to force create_date
+            test_event = self.env['event.event'].create({
                 'name': 'TestEventMail',
+                'create_date': now,
+                'user_id': self.user_eventmanager.id,
                 'auto_confirm': True,
                 'date_begin': event_date_begin,
                 'date_end': event_date_end,
@@ -54,26 +57,35 @@ class TestMailSchedule(TestEventCommon, MockEmail):
                         'template_id': self.env['ir.model.data'].xmlid_to_res_id('event.event_reminder')}),
                 ]
             })
+            self.assertEqual(test_event.create_date, now)
 
         # check subscription scheduler
         after_sub_scheduler = self.env['event.mail'].search([('event_id', '=', test_event.id), ('interval_type', '=', 'after_sub'), ('interval_unit', '=', 'now')])
         self.assertEqual(len(after_sub_scheduler), 1, 'event: wrong scheduler creation')
         self.assertEqual(after_sub_scheduler.scheduled_date, test_event.create_date)
-        self.assertTrue(after_sub_scheduler.done)
+        self.assertFalse(after_sub_scheduler.mail_done)
+        self.assertEqual(after_sub_scheduler.mail_state, 'running')
+        self.assertEqual(after_sub_scheduler.mail_count_done, 0)
         after_sub_scheduler_2 = self.env['event.mail'].search([('event_id', '=', test_event.id), ('interval_type', '=', 'after_sub'), ('interval_unit', '=', 'hours')])
         self.assertEqual(len(after_sub_scheduler_2), 1, 'event: wrong scheduler creation')
         self.assertEqual(after_sub_scheduler_2.scheduled_date, test_event.create_date + relativedelta(hours=1))
-        self.assertTrue(after_sub_scheduler_2.done)
+        self.assertFalse(after_sub_scheduler_2.mail_done)
+        self.assertEqual(after_sub_scheduler_2.mail_state, 'running')
+        self.assertEqual(after_sub_scheduler_2.mail_count_done, 0)
         # check before event scheduler
         event_prev_scheduler = self.env['event.mail'].search([('event_id', '=', test_event.id), ('interval_type', '=', 'before_event')])
         self.assertEqual(len(event_prev_scheduler), 1, 'event: wrong scheduler creation')
         self.assertEqual(event_prev_scheduler.scheduled_date, event_date_begin + relativedelta(days=-1))
-        self.assertFalse(event_prev_scheduler.done)
+        self.assertFalse(event_prev_scheduler.mail_done)
+        self.assertEqual(event_prev_scheduler.mail_state, 'scheduled')
+        self.assertEqual(event_prev_scheduler.mail_count_done, 0)
         # check after event scheduler
         event_next_scheduler = self.env['event.mail'].search([('event_id', '=', test_event.id), ('interval_type', '=', 'after_event')])
         self.assertEqual(len(event_next_scheduler), 1, 'event: wrong scheduler creation')
         self.assertEqual(event_next_scheduler.scheduled_date, event_date_end + relativedelta(hours=1))
-        self.assertFalse(event_next_scheduler.done)
+        self.assertFalse(event_next_scheduler.mail_done)
+        self.assertEqual(event_next_scheduler.mail_state, 'scheduled')
+        self.assertEqual(event_next_scheduler.mail_count_done, 0)
 
         # create some registrations
         with freeze_time(now), self.mock_mail_gateway():
@@ -100,7 +112,9 @@ class TestMailSchedule(TestEventCommon, MockEmail):
         for mail_registration in after_sub_scheduler.mail_registration_ids:
             self.assertEqual(mail_registration.scheduled_date, now)
             self.assertTrue(mail_registration.mail_sent, 'event: registration mail should be sent at registration creation')
-        self.assertTrue(after_sub_scheduler.done, 'event: all subscription mails should have been sent')
+        self.assertTrue(after_sub_scheduler.mail_done, 'event: all subscription mails should have been sent')
+        self.assertEqual(after_sub_scheduler.mail_state, 'running')
+        self.assertEqual(after_sub_scheduler.mail_count_done, 2)
 
         # check emails effectively sent
         self.assertEqual(len(self._new_mails), 2, 'event: should have 2 scheduled emails (1 / registration)')
@@ -116,13 +130,15 @@ class TestMailSchedule(TestEventCommon, MockEmail):
         for mail_registration in after_sub_scheduler_2.mail_registration_ids:
             self.assertEqual(mail_registration.scheduled_date, now + relativedelta(hours=1))
             self.assertFalse(mail_registration.mail_sent, 'event: registration mail should be scheduled, not sent')
-        self.assertFalse(after_sub_scheduler_2.done, 'event: all subscription mails should be scheduled, not sent')
+        self.assertFalse(after_sub_scheduler_2.mail_done, 'event: all subscription mails should be scheduled, not sent')
+        self.assertEqual(after_sub_scheduler_2.mail_count_done, 0)
 
         # execute event reminder scheduler explicitly, before scheduled date -> should not do anything
         with freeze_time(now), self.mock_mail_gateway():
             after_sub_scheduler_2.execute()
         self.assertFalse(any(mail_reg.mail_sent for mail_reg in after_sub_scheduler_2.mail_registration_ids))
-        self.assertFalse(after_sub_scheduler_2.done)
+        self.assertFalse(after_sub_scheduler_2.mail_done)
+        self.assertEqual(after_sub_scheduler_2.mail_count_done, 0)
         self.assertEqual(len(self._new_mails), 0, 'event: should not send mails before scheduled date')
 
         # execute event reminder scheduler explicitly, right at scheduled date -> should sent mails
@@ -133,7 +149,9 @@ class TestMailSchedule(TestEventCommon, MockEmail):
         # verify that subscription scheduler was auto-executed after each registration
         self.assertEqual(len(after_sub_scheduler_2.mail_registration_ids), 2, 'event: should have 2 scheduled communication (1 / registration)')
         self.assertTrue(all(mail_reg.mail_sent for mail_reg in after_sub_scheduler_2.mail_registration_ids))
-        self.assertTrue(after_sub_scheduler_2.done, 'event: all subscription mails should have been sent')
+        self.assertTrue(after_sub_scheduler_2.mail_done, 'event: all subscription mails should have been sent')
+        self.assertEqual(after_sub_scheduler_2.mail_state, 'running')
+        self.assertEqual(after_sub_scheduler_2.mail_count_done, 2)
 
         # check emails effectively sent
         self.assertEqual(len(self._new_mails), 2, 'event: should have 2 scheduled emails (1 / registration)')
@@ -147,26 +165,27 @@ class TestMailSchedule(TestEventCommon, MockEmail):
         # PRE SCHEDULERS (MOVE FORWARD IN TIME)
         # --------------------------------------------------
 
-        self.assertFalse(event_prev_scheduler.mail_sent)
-        self.assertFalse(event_prev_scheduler.done)
+        self.assertFalse(event_prev_scheduler.mail_done)
+        self.assertEqual(event_prev_scheduler.mail_state, 'scheduled')
 
-        # execute event reminder scheduler explicitly, before scheduled date -> should not do anything
+        # simulate cron running before scheduled date -> should not do anything
         now_start = event_date_begin + relativedelta(hours=-25)
         with freeze_time(now_start), self.mock_mail_gateway():
-            event_prev_scheduler.execute()
+            event_cron_id.method_direct_trigger()
 
-        self.assertFalse(event_prev_scheduler.mail_sent)
-        self.assertFalse(event_prev_scheduler.done)
+        self.assertFalse(event_prev_scheduler.mail_done)
+        self.assertEqual(event_prev_scheduler.mail_state, 'scheduled')
+        self.assertEqual(event_prev_scheduler.mail_count_done, 0)
         self.assertEqual(len(self._new_mails), 0)
 
-        # execute cron to run schedulers
+        # execute cron to run schedulers after scheduled date
         now_start = event_date_begin + relativedelta(hours=-23)
         with freeze_time(now_start), self.mock_mail_gateway():
             event_cron_id.method_direct_trigger()
 
         # check that scheduler is finished
-        self.assertTrue(event_prev_scheduler.mail_sent, 'event: reminder scheduler should have run')
-        self.assertTrue(event_prev_scheduler.done, 'event: reminder scheduler should have run')
+        self.assertTrue(event_prev_scheduler.mail_done, 'event: reminder scheduler should have run')
+        self.assertEqual(event_prev_scheduler.mail_state, 'sent', 'event: reminder scheduler should have run')
 
         # check emails effectively sent
         self.assertEqual(len(self._new_mails), 2, 'event: should have scheduled 2 mails (1 / registration)')
@@ -192,12 +211,10 @@ class TestMailSchedule(TestEventCommon, MockEmail):
         self.assertEqual(reg3.state, 'draft')
 
         # schedulers state untouched
-        self.assertTrue(event_prev_scheduler.mail_sent)
-        self.assertTrue(event_prev_scheduler.mail_sent)
-        self.assertFalse(event_next_scheduler.mail_sent)
-        self.assertFalse(event_next_scheduler.done)
-        self.assertFalse(after_sub_scheduler.done, 'event: scheduler registrations should be lower than effective registrations')
-        self.assertFalse(after_sub_scheduler_2.done, 'event: scheduler registrations should be lower than effective registrations')
+        self.assertTrue(event_prev_scheduler.mail_done)
+        self.assertFalse(event_next_scheduler.mail_done)
+        self.assertTrue(after_sub_scheduler.mail_done, 'event: scheduler on registration not updated next to draft registration')
+        self.assertTrue(after_sub_scheduler_2.mail_done, 'event: scheduler on registration not updated next to draft registration')
 
         # confirm registration -> should trigger registration schedulers
         # NOTE: currently all schedulers are based on date_open which equals create_date
@@ -205,19 +222,20 @@ class TestMailSchedule(TestEventCommon, MockEmail):
         with freeze_time(now_start + relativedelta(hours=1)), self.mock_mail_gateway():
             reg3.action_confirm()
 
-       # verify that subscription scheduler was auto-executed after new registration confirmed
+        # verify that subscription scheduler was auto-executed after new registration confirmed
         self.assertEqual(len(after_sub_scheduler.mail_registration_ids), 3, 'event: should have 3 scheduled communication (1 / registration)')
         new_mail_reg = after_sub_scheduler.mail_registration_ids.filtered(lambda mail_reg: mail_reg.registration_id == reg3)
         self.assertEqual(new_mail_reg.scheduled_date, now_start)
         self.assertTrue(new_mail_reg.mail_sent, 'event: registration mail should be sent at registration creation')
-        self.assertTrue(after_sub_scheduler.done, 'event: all subscription mails should have been sent')
-
-       # verify that subscription scheduler was auto-executed after new registration confirmed
+        self.assertTrue(after_sub_scheduler.mail_done, 'event: all subscription mails should have been sent')
+        self.assertEqual(after_sub_scheduler.mail_count_done, 3)
+        # verify that subscription scheduler was auto-executed after new registration confirmed
         self.assertEqual(len(after_sub_scheduler_2.mail_registration_ids), 3, 'event: should have 3 scheduled communication (1 / registration)')
         new_mail_reg = after_sub_scheduler_2.mail_registration_ids.filtered(lambda mail_reg: mail_reg.registration_id == reg3)
         self.assertEqual(new_mail_reg.scheduled_date, now_start + relativedelta(hours=1))
         self.assertTrue(new_mail_reg.mail_sent, 'event: registration mail should be sent at registration creation')
-        self.assertTrue(after_sub_scheduler_2.done, 'event: all subscription mails should have been sent')
+        self.assertTrue(after_sub_scheduler_2.mail_done, 'event: all subscription mails should have been sent')
+        self.assertEqual(after_sub_scheduler_2.mail_count_done, 3)
 
         # check emails effectively sent
         self.assertEqual(len(self._new_mails), 2, 'event: should have 1 scheduled emails (new registration only)')
@@ -231,8 +249,7 @@ class TestMailSchedule(TestEventCommon, MockEmail):
         # POST SCHEDULERS (MOVE FORWARD IN TIME)
         # --------------------------------------------------
 
-        self.assertFalse(event_next_scheduler.mail_sent)
-        self.assertFalse(event_next_scheduler.done)
+        self.assertFalse(event_next_scheduler.mail_done)
 
         # execute event reminder scheduler explicitly after its schedule date
         new_end = event_date_end + relativedelta(hours=2)
@@ -240,8 +257,9 @@ class TestMailSchedule(TestEventCommon, MockEmail):
             event_cron_id.method_direct_trigger()
 
         # check that scheduler is finished
-        self.assertTrue(event_next_scheduler.mail_sent, 'event: reminder scheduler should should have run')
-        self.assertTrue(event_next_scheduler.done, 'event: reminder scheduler should have run')
+        self.assertTrue(event_next_scheduler.mail_done, 'event: reminder scheduler should should have run')
+        self.assertEqual(event_next_scheduler.mail_state, 'sent', 'event: reminder scheduler should have run')
+        self.assertEqual(event_next_scheduler.mail_count_done, 3)
 
         # check emails effectively sent
         self.assertEqual(len(self._new_mails), 3, 'event: should have scheduled 3 mails, one for each registration')

--- a/addons/event/tests/test_event_mail_schedule.py
+++ b/addons/event/tests/test_event_mail_schedule.py
@@ -133,8 +133,7 @@ class TestMailSchedule(TestEventCommon, MockEmail):
         # verify that subscription scheduler was auto-executed after each registration
         self.assertEqual(len(after_sub_scheduler_2.mail_registration_ids), 2, 'event: should have 2 scheduled communication (1 / registration)')
         self.assertTrue(all(mail_reg.mail_sent for mail_reg in after_sub_scheduler_2.mail_registration_ids))
-        # FIXME: field not updated
-        # self.assertTrue(after_sub_scheduler_2.done, 'event: all subscription mails should have been sent')
+        self.assertTrue(after_sub_scheduler_2.done, 'event: all subscription mails should have been sent')
 
         # check emails effectively sent
         self.assertEqual(len(self._new_mails), 2, 'event: should have 2 scheduled emails (1 / registration)')

--- a/addons/event/views/event_templates.xml
+++ b/addons/event/views/event_templates.xml
@@ -4,6 +4,7 @@
         <template id="assets_backend" name="event assets" inherit_id="web.assets_backend">
             <xpath expr="." position="inside">
                 <link rel="stylesheet" type="text/scss" href="/event/static/src/scss/event.scss"/>
+                <script type="text/javascript" src="/event/static/src/js/field_icon_selection.js"></script>
             </xpath>
         </template>
 

--- a/addons/event/views/event_views.xml
+++ b/addons/event/views/event_views.xml
@@ -266,7 +266,7 @@
                                         <field name="interval_nbr" attrs="{'readonly':[('interval_unit','=','now')]}"/>
                                         <field name="interval_unit"/>
                                         <field name="interval_type"/>
-                                        <field name="scheduled_date" groups="base.group_no_one" string="Schedule date"/>
+                                        <field name="scheduled_date" groups="base.group_no_one"/>
                                         <field name="mail_count_done"/>
                                         <field name="mail_state" widget="icon_selection" string=" "
                                             options="{'sent': 'fa fa-check', 'scheduled': 'fa fa-hourglass-half', 'running': 'fa fa-cogs'}"/>

--- a/addons/event/views/event_views.xml
+++ b/addons/event/views/event_views.xml
@@ -266,7 +266,10 @@
                                         <field name="interval_nbr" attrs="{'readonly':[('interval_unit','=','now')]}"/>
                                         <field name="interval_unit"/>
                                         <field name="interval_type"/>
-                                        <field name="done"/>
+                                        <field name="scheduled_date" groups="base.group_no_one" string="Schedule date"/>
+                                        <field name="mail_count_done"/>
+                                        <field name="mail_state" widget="icon_selection" string=" "
+                                            options="{'sent': 'fa fa-check', 'scheduled': 'fa fa-hourglass-half', 'running': 'fa fa-cogs'}"/>
                                     </tree>
                                 </field>
                             </page>
@@ -750,7 +753,7 @@
                                 <field name="event_id"/>
                                 <field name="notification_type" invisible="1"/>
                                 <field name="template_id" attrs="{'required': [('notification_type', '=', 'mail')]}"/>
-                                <field name="mail_sent"/>
+                                <field name="mail_state"/>
                             </group>
                             <group>
                                 <label for="interval_nbr"/>
@@ -787,8 +790,9 @@
                     <field name="notification_type" invisible="1"/>
                     <field name="template_id" attrs="{'required': [('notification_type', '=', 'mail')]}"/>
                     <field name="scheduled_date"/>
-                    <field name="mail_sent" string="Sent"/>
-                    <field name="done"/>
+                    <field name="mail_count_done"/>
+                    <field name="mail_state" widget="icon_selection" string=" "
+                        options="{'sent': 'fa fa-check', 'scheduled': 'fa fa-hourglass-half', 'running': 'fa fa-cogs'}"/>
                 </tree>
             </field>
         </record>

--- a/addons/event_sms/models/event_mail.py
+++ b/addons/event_sms/models/event_mail.py
@@ -45,6 +45,9 @@ class EventMailScheduler(models.Model):
                         mass_keep_log=True
                     )
                     mail.write({'mail_sent': True})
+
+                    mail.mail_count_done = len(mail.event_id.registration_ids.filtered(lambda reg: reg.state != 'cancel'))
+
         return super(EventMailScheduler, self).execute()
 
 

--- a/odoo/addons/base/__manifest__.py
+++ b/odoo/addons/base/__manifest__.py
@@ -30,6 +30,7 @@ The kernel of Odoo, needed for all installation.
         'views/ir_actions_views.xml',
         'views/ir_config_parameter_views.xml',
         'views/ir_cron_views.xml',
+        'views/ir_cron_trigger_views.xml',
         'views/ir_filters_views.xml',
         'views/ir_mail_server_views.xml',
         'views/ir_model_views.xml',

--- a/odoo/addons/base/views/ir_cron_trigger_views.xml
+++ b/odoo/addons/base/views/ir_cron_trigger_views.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="ir_cron_trigger_view_form" model="ir.ui.view">
+        <field name="name">ir.cron.trigger.view.form</field>
+        <field name="model">ir.cron.trigger</field>
+        <field name="arch" type="xml">
+            <form string="Cron Trigger">
+                <sheet>
+                    <group>
+                        <field name="cron_id"/>
+                        <field name="call_at"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="ir_cron_trigger_view_tree" model="ir.ui.view">
+        <field name="name">ir.cron.trigger.view.tree</field>
+        <field name="model">ir.cron.trigger</field>
+        <field name="arch" type="xml">
+            <tree string="Cron Triggers">
+                <field name="cron_id"/>
+                <field name="call_at"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="ir_cron_trigger_view_search" model="ir.ui.view">
+        <field name="name">ir.cron.trigger.view.search</field>
+        <field name="model">ir.cron.trigger</field>
+        <field name="arch" type="xml">
+            <search string="Cron Triggers">
+                <field name="cron_id"/>
+                <field name="call_at"/>
+            </search>
+        </field>
+    </record>
+
+    <record id="ir_cron_trigger_action" model="ir.actions.act_window">
+        <field name="name">Scheduled Actions Triggers</field>
+        <field name="res_model">ir.cron.trigger</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem id="ir_cron_trigger_menu"
+        action="ir_cron_trigger_action"
+        parent="base.menu_automation"
+        sequence="3"/>
+
+</odoo>

--- a/odoo/addons/base/views/ir_cron_views.xml
+++ b/odoo/addons/base/views/ir_cron_views.xml
@@ -91,6 +91,9 @@
             <field name="view_id" ref="ir_cron_view_tree"/>
         </record>
 
-        <menuitem id="menu_ir_cron_act" action="ir_cron_act" parent="base.menu_automation"/>
+        <menuitem id="menu_ir_cron_act"
+            parent="base.menu_automation"
+            action="ir_cron_act"
+            sequence="2"/>
 
 </odoo>


### PR DESCRIPTION
PURPOSE

Improve event mail scheduled communications: add a state and a contacted
count. Improve performances and code readability.

SPECIFICATIONS: STATE

Instead of the checkbox "sent", an event mail can have 3 values

  1. Sent, if all the mails has been sent;
  2. Scheduled, if scheduled but no attendee have been contacted;
  3. Running, if not all attendees have been contacted;

Note that communication targeting "after registration" are always considered
as being "running" as any new registration triggers a new communication.
A new widget is added that displays an icon depending on the state.
A new field holding contact count is added. When scheduler send emails it is
updated to keep a count of sent communications.

SPECIFICATIONS: MAIL COMPUTATION IMPROVEMENT

Purpose of this merge is to remove the "done" field computation. Indeed
it is based on either

  * mail_sent field if scheduler is global to the event (before or after
    event). This computation is light as this field changes only once
    when emails are scheduled and sent;
  * status of event registrations compared to all sent communication on
    those registrations. This is costly as adding a new registration changes

In this merge we therefore

  * rename ``done`` to ``mail_done`` to ease grep and understanding;
  * remove ``mail_sent`` as it is integrated within ``done``;
  * manually update ``mail_done`` when updating schedulers instead of doing
    it through a compute method;

Some code cleaning is performed to make it clearer and easier to understand.

LINKS

Task ID-2414658
COM PR odoo/odoo#63093
UPG PR odoo/upgrade#2014