### PR TITLE
[FIX] account: allow all accounts when creating bank/cash journal

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -212,7 +212,9 @@ class AccountJournal(models.Model):
         }
 
         for journal in self:
-            if journal.type in default_account_id_types:
+            if journal.type in ('bank', 'cash'):
+                journal.default_account_type = True
+            elif journal.type in default_account_id_types:
                 journal.default_account_type = self.env.ref(default_account_id_types[journal.type]).id
             else:
                 journal.default_account_type = False


### PR DESCRIPTION
An account with the type "Credit Card" can not be chosen for the creation
of a journal with the type "Bank" as the domain for bank account filter
only for accounts with the type "Bank and Cash"

As the filter on the `user_type_id` is too restrictive we remove it in
case the journal is bank or cash

opw-2394959

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
