### PR TITLE
[IMP] iap: mock IAP jsonrpc to avoid errors/spam of the real servers

### DIFF
--- a/addons/iap/tools/iap_tools.py
+++ b/addons/iap/tools/iap_tools.py
@@ -6,13 +6,33 @@ import logging
 import json
 import requests
 import uuid
+from unittest.mock import patch
 
 from odoo import exceptions, _
+from odoo.tests.common import BaseCase
 from odoo.tools import pycompat
 
 _logger = logging.getLogger(__name__)
 
 DEFAULT_ENDPOINT = 'https://iap.odoo.com'
+
+
+# We need to mock iap_jsonrpc during tests as we don't want to perform real calls to RPC endpoints
+def iap_jsonrpc_mocked(*args, **kwargs):
+    raise exceptions.AccessError("Unavailable during tests.")
+
+
+iap_patch = patch('odoo.addons.iap.tools.iap_tools.iap_jsonrpc', iap_jsonrpc_mocked)
+
+
+def setUp(self):
+    old_setup_func(self)
+    iap_patch.start()
+    self.addCleanup(iap_patch.stop)
+
+
+old_setup_func = BaseCase.setUp
+BaseCase.setUp = setUp
 
 #----------------------------------------------------------
 # Helpers for both clients and proxy


### PR DESCRIPTION
Before this commit, some requests could be sent to the actual IAP
servers during testing. These calls weren't always mocked as many
of these requests are sent in background while performing usual
tasks such as creating a bill.

Now, any call to the function iap_jsonrpc during testing will result
in an AccessError.