### PR TITLE
[IMP] account: Allow locking the period with cancelled statement lines

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -223,6 +223,7 @@ class ResCompany(models.Model):
                 ('company_id', 'in', self.ids),
                 ('is_reconciled', '=', False),
                 ('date', '<=', values['fiscalyear_lock_date']),
+                ('move_id.state', 'in', ('draft', 'posted')),
             ])
             if unreconciled_statement_lines:
                 error_msg = _("There are still unreconciled bank statement lines in the period you want to lock."


### PR DESCRIPTION
This case shouldn't appear in a normal usage of the statement lines because there is no way to cancel them.
However, this case should be supported in 14.0 due to a choice we made for the migration.
Indeed, we don't want to create draft journal entries in a locked period during the migration but the statement lines that are not reconciled in a locked period shouldn't be deleted in order to keep the statement starting/ending balance consistency.
So, the journal entries created in a locked period for not reconciled statement lines are cancelled and then, we don't want to block the locking of any period because of that.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
