### PR TITLE
[FIX] mail: Receive EML file in attachment

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1763,6 +1763,8 @@ class MailThread(models.AbstractModel):
                     content = content.encode('utf-8')
                 elif content is None:
                     continue
+                elif isinstance(content, EmailMessage):
+                    content = content.as_bytes()
                 attachement_values= {
                     'name': name,
                     'datas': base64.b64encode(content),


### PR DESCRIPTION
Configure the incomming mail server, use another mail client to send a
message to Odoo with an EML file as attachment. The fetchmail server
fails.

Since the introduction of the new EmailMessage python API to
encode/decode email messages, every EML attachment is automatically
parsed into a EmailMessage.

Task: 2329606
