### PR TITLE
[FIX] mail: use correct badge color for messaging and activity menu

### DIFF
--- a/addons/mail/static/src/components/messaging_menu/messaging_menu.scss
+++ b/addons/mail/static/src/components/messaging_menu/messaging_menu.scss
@@ -105,7 +105,7 @@
 }
 
 .o_MessagingMenu_counter {
-    background-color: $o-brand-primary;
+    background-color: $o-enterprise-primary-color;
 }
 
 .o_MessagingMenu_dropdownMenu.o-mobile {

--- a/addons/mail/static/src/scss/systray.scss
+++ b/addons/mail/static/src/scss/systray.scss
@@ -20,7 +20,7 @@
         margin-top: -0.8rem;
         margin-right: 0;
         margin-left: -0.6rem;
-        background: #00A09D;
+        background: $o-enterprise-primary-color;
         color: white;
         vertical-align: super;
         font-size: 0.7em;


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

![image](https://user-images.githubusercontent.com/4851083/101706416-4ce5ef00-3a89-11eb-9ade-0347e6d460b4.png)

Desired behavior after PR is merged:

![image](https://user-images.githubusercontent.com/4851083/101758366-885bda00-3ad8-11eb-94db-58a24f8b85d3.png)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
