### PR TITLE
[IMP] mail: activity form view improvements

### DIFF
--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -149,6 +149,20 @@
         </field>
     </record>
 
+    <record id="mail_activity_view_form" model="ir.ui.view">
+        <field name="name">mail.activity.view.form</field>
+        <field name="model">mail.activity</field>
+        <field name="priority">21</field>
+        <field name="mode">primary</field>
+        <field name="inherit_id" ref="mail.mail_activity_view_form_popup"/>
+        <field name="arch" type="xml">
+            <field name="activity_type_id" position="before">
+                <field name="res_name" readonly="1" string="Document"/>
+            </field>
+            <footer position="replace"/>
+        </field>
+    </record>
+
     <record id="mail_activity_view_search" model="ir.ui.view">
         <field name="name">mail.activity.view.search</field>
         <field name="model">mail.activity</field>
@@ -188,6 +202,18 @@
                 <field name="date_deadline"/>
             </tree>
         </field>
+    </record>
+
+    <record id="mail_activity_action_view_tree" model="ir.actions.act_window.view">
+        <field name="sequence" eval="1"/>
+        <field name="view_mode">tree</field>
+        <field name="act_window_id" ref="mail.mail_activity_action"/>
+    </record>
+    <record id="mail_activity_action_view_form" model="ir.actions.act_window.view">
+        <field name="sequence" eval="2"/>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="mail.mail_activity_view_form"/>
+        <field name="act_window_id" ref="mail.mail_activity_action"/>
     </record>
 
     <record id="mail_activity_view_calendar" model="ir.ui.view">


### PR DESCRIPTION
**PURPOSE**

The current form view of Activities(from the technical settings) is not very
useful. There is no indication of which document the activity is linked and the
buttons like save/discard etc. looks weird within the form view.

**SPECIFICATION**

-Adding field 'res_name' for indication of document at the top of the form which
 is read-only.
-Removing 'save', 'discard', 'mark as done' and 'done & schedule next' buttons
 within the form and simply make a form view without buttons.

**LINKS**

PR https://github.com/odoo/odoo/pull/63121
Task-2371023