### PR TITLE
[FIX] web_editor: fix color-customize dynamic svgs on snippet drop

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2067,7 +2067,7 @@ var SnippetsMenu = Widget.extend({
                     // Color-customize dynamic SVGs in dropped snippets with current theme colors.
                     [...$snippetToInsert.find('img[src^="/web_editor/shape/"]')].forEach(dynamicSvg => {
                         const colorCustomizedURL = new URL(dynamicSvg.getAttribute('src'), window.location.origin);
-                        colorCustomizedURL.searchParams.forEach((key, value) => {
+                        colorCustomizedURL.searchParams.forEach((value, key) => {
                             const match = key.match(/^c([1-5])$/);
                             if (match) {
                                 colorCustomizedURL.searchParams.set(key, getCSSVariableValue(`o-color-${match[1]}`))


### PR DESCRIPTION
Before this commit, the theme colors did not update dynamic svg images
due to an inversion between key and value in the code.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
