### PR TITLE
[IMP] stock: adds price on stock move

### DIFF
--- a/addons/stock/populate/stock.py
+++ b/addons/stock/populate/stock.py
@@ -526,6 +526,7 @@ class StockMove(models.Model):
                 yield values
 
         def _compute_picking_values(iterator, field_name, model_name):
+            random = populate.Random('_compute_picking_values')
             for values in iterator:
                 if values.get('picking_id'):
                     picking = self.env['stock.picking'].browse(values['picking_id'])
@@ -535,6 +536,8 @@ class StockMove(models.Model):
                     values['name'] = picking.name
                     values['date'] = picking.scheduled_date
                     values['company_id'] = picking.company_id.id
+                    if picking.picking_type_id.code == 'incoming':
+                        values['price_unit'] = random.randint(1, 100)
                 yield values
 
         return [


### PR DESCRIPTION
This commit adds some value on incoming stock moves created by the
`populate` generation. This makes transfers more realistic and allow
creating stock valuation if accounting is installed as well.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
