### PR TITLE
[FIX] bus: get im_status of deleted ID

### DIFF
--- a/addons/bus/controllers/main.py
+++ b/addons/bus/controllers/main.py
@@ -41,4 +41,4 @@ class BusController(Controller):
 
     @route('/longpolling/im_status', type="json", auth="user")
     def im_status(self, partner_ids):
-        return request.env['res.partner'].browse(partner_ids).read(['im_status'])
+        return request.env['res.partner'].with_context(active_test=False).search([('id', 'in', partner_ids)]).read(['im_status'])


### PR DESCRIPTION
When trying to get the im_status of several partners, if one of them
does not exist, it will return an error.

To reproduce the error:
1. Go to Contacts
2. Open a contact
3. Action > Delete
4. Wait max 50 seconds

=> A Missing Record message is displayed. The im_status RPC includes the
deleted partner's identifier and the server looks for it.

Now, the server skips the missing identifiers.

OPW-2390719