### PR TITLE
[FIX] account: fix regexp when partner name contains +

### DIFF
--- a/addons/account/tests/test_reconciliation_matching_rules.py
+++ b/addons/account/tests/test_reconciliation_matching_rules.py
@@ -678,6 +678,18 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
             self.bank_line_2.id: {'aml_ids': []},
         }, self.bank_st)
 
+    def test_partner_name_with_regexp_chars(self):
+        self.invoice_line_1.partner_id.write({'name': "Archibald + Haddock"})
+        self.bank_line_1.write({'partner_id': None, 'payment_ref': '1234//HADDOCK+Archibald'})
+        self.bank_line_2.write({'partner_id': None})
+        self.rule_1.write({'match_partner': False})
+
+        # The query should still work
+        self._check_statement_matching(self.rule_1, {
+            self.bank_line_1.id: {'aml_ids': [self.invoice_line_1.id], 'model': self.rule_1, 'partner': self.bank_line_1.partner_id},
+            self.bank_line_2.id: {'aml_ids': []},
+        }, self.bank_st)
+
     def test_match_multi_currencies(self):
         ''' Ensure the matching of candidates is made using the right statement line currency.
 


### PR DESCRIPTION
When the name of a partner contains a regular expression operator, such as grouping parenthesis, `+`, `*`, brackets... the resulting regexp may match wrong names or worse be invalid and lead to an exception.

With this commit, we create a regular expression from only the words formed from at least 3 of ~`[a-zA-Z0-9]`~ `\w`, ignoring all other characters, including those who may have a meaning in a regular expression.

This avoids these issues:
- regexp injection (security issue)
- punctuation resulting in erroneous regular expression (`"ABC + SPRL"` resulted in `"(?=.*ABC.*)(?=.*+.*)(?=.*SPRL.*)"` which is invalid at the `".*+"` part)
- false positives due to words that are too small (~`\b`~`\y` were added, and the minimal matching word size is 3)
- accentuation mismatch (both sides are filtered through `unaccent`)
- special cases in unicode that have a special behavior with `lower()`.

See the discussion on #63145 for a detailled explaination about
these issues.

[OPW-2360687](https://www.odoo.com/web#id=2360687&model=project.task)