### PR TITLE
[FIX] web: increase timeout for js tests

### DIFF
--- a/addons/web/tests/test_js.py
+++ b/addons/web/tests/test_js.py
@@ -12,7 +12,7 @@ class WebSuite(odoo.tests.HttpCase):
 
     def test_js(self):
         # webclient desktop test suite
-        self.browser_js('/web/tests?mod=web', "", "", login='admin', timeout=1800)
+        self.browser_js('/web/tests?mod=web', "", "", login='admin', timeout=3600)
 
     def test_check_suite(self):
         # verify no js test is using `QUnit.only` as it forbid any other test to be executed


### PR DESCRIPTION
last increasing was in 2018 https://github.com/odoo/odoo/commit/473edda86edd367a070084573d8b8cb46a7be2d4

STEPS: in odoo.sh run two dev branches that install and test following modules:
sale,purchase,account_accountant

BEFORE:
```
2020-12-10 10:16:09,861 6 ERROR yelizariev-odoo-sh-dev-account-2-1803664 odoo.addons.web.tests.test_js: FAIL: WebSuite.test_js
Traceback (most recent call last):
  File "/home/odoo/src/odoo/addons/web/tests/test_js.py", line 15, in test_js
    self.browser_js('/web/tests?mod=web', "", "", login='admin', timeout=1800)
  File "/home/odoo/src/odoo/odoo/tests/common.py", line 1418, in browser_js
    self.fail('%s\n%s' % (message, error))
AssertionError: Some js test failed
Script timeout exceeded : 1800.019751548767
```

AFTER: more time to try all the tests

---

opw-2378464

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
