### PR TITLE
[FIX] sale_coupon: select correct minimum amount with/without tax rule

### DIFF
--- a/addons/sale_coupon/models/sale_coupon_program.py
+++ b/addons/sale_coupon/models/sale_coupon_program.py
@@ -217,7 +217,7 @@ class SaleCouponProgram(models.Model):
             untaxed_amount = order_amount['amount_untaxed'] - sum(line.price_subtotal for line in lines)
             tax_amount = order_amount['amount_tax'] - sum(line.price_tax for line in lines)
             program_amount = program._compute_program_amount('rule_minimum_amount', order.currency_id)
-            if program.rule_minimum_amount_tax_inclusion == 'tax_included' and program_amount <= (untaxed_amount + tax_amount) or program.rule_minimum_amount_tax_inclusion == 'tax_excluded' and program_amount <= untaxed_amount:
+            if program.rule_minimum_amount_tax_inclusion == 'tax_included' and program_amount <= (untaxed_amount + tax_amount) or program_amount <= untaxed_amount:
                 program_ids.append(program.id)
 
         return self.env['sale.coupon.program'].browse(program_ids)

--- a/addons/sale_coupon/views/sale_coupon_program_views.xml
+++ b/addons/sale_coupon/views/sale_coupon_program_views.xml
@@ -30,7 +30,7 @@
                             <div name="rule_minimum_amount" class="o_row">
                                 <field name="currency_id" invisible="1"/>
                                 <field name="rule_minimum_amount" widget='monetary' options="{'currency_field': 'currency_id'}"/>
-                                <field name="rule_minimum_amount_tax_inclusion"/>
+                                <field name="rule_minimum_amount_tax_inclusion" required="1"/>
                             </div>
                             <field name="company_id" placeholder="Select company" groups="base.group_multi_company"></field>
                         </group>


### PR DESCRIPTION
Create a promotion program with the "Minimum Purchase Of" right field
left as blank
It won't be taken into account in SO when clicking on 'Promotions'

When the field is left as blank `rule_minimum_amount_tax_inclusion`
value is `False` and thus break the check.

opw-2392546

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
