### PR TITLE
[FIX] mail: keep changes of form while schedule the activity

### DIFF
--- a/addons/mail/static/src/js/activity.js
+++ b/addons/mail/static/src/js/activity.js
@@ -176,7 +176,7 @@ var BasicActivity = AbstractField.extend({
                 if (rslt_action) {
                     self.do_action(rslt_action, {
                         on_close: function () {
-                            self.trigger_up('reload');
+                            self.trigger_up('reload', { keepChanges: true });
                         },
                     });
                 } else {


### PR DESCRIPTION
**Before this commit:**

The changes in the form which are done in an edit mode are erased while the user
marks activity as done and schedule a new one in chatter.

**After this commit:**

The changes done in an edit mode will remain the same while the user marks
activity as done and schedule a new one in chatter.

**LINKS**

PR https://github.com/odoo/odoo/pull/63158
Task-2160474