### PR TITLE
[MERGE] crm: remove global lead alias configuration

### DIFF
--- a/addons/crm/__manifest__.py
+++ b/addons/crm/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'CRM',
-    'version': '1.3',
+    'version': '1.4',
     'category': 'Sales/CRM',
     'sequence': 15,
     'summary': 'Track leads and close opportunities',

--- a/addons/crm/data/mail_data.xml
+++ b/addons/crm/data/mail_data.xml
@@ -1,14 +1,6 @@
 <?xml version="1.0"?>
 <odoo>
     <data noupdate="1">
-        <!--default alias for leads-->
-        <record id="mail_alias_lead_info" model="mail.alias">
-            <field name="alias_name"></field>
-            <field name="alias_model_id" ref="model_crm_lead"/>
-            <field name="alias_user_id" ref="base.user_admin"/>
-            <field name="alias_parent_model_id" ref="model_crm_team"/>
-        </record>
-
         <!-- CRM-related subtypes for messaging / Chatter -->
         <record id="mt_lead_create" model="mail.message.subtype">
             <field name="name">Opportunity Created</field>

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1397,17 +1397,12 @@ class Lead(models.Model):
             through message_process.
             This override updates the document according to the email.
         """
-
-        # remove external users
-        if self.env.user.has_group('base.group_portal'):
-            self = self.with_context(default_user_id=False)
-
         # remove default author when going through the mail gateway. Indeed we
-        # do not want to explicitly set user_id to False; however we do not
-        # want the gateway user to be responsible if no other responsible is
-        # found.
-        if self._uid == self.env.ref('base.user_root').id:
-            self = self.with_context(default_user_id=False)
+        # do not want to explicitly set an user as responsible. We prefer that
+        # assignment is done automatically (scoring) or manually. Otherwise it
+        # would always be either root (gateway user) either alias owner (through
+        # alias_user_id). It also allows to exclude portal / public users.
+        self = self.with_context(default_user_id=False)
 
         if custom_values is None:
             custom_values = {}

--- a/addons/crm/models/res_config_settings.py
+++ b/addons/crm/models/res_config_settings.py
@@ -7,12 +7,6 @@ from odoo import api, fields, models
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
-    crm_alias_prefix = fields.Char(
-        'Default Alias Name for Leads',
-        compute="_compute_crm_alias_prefix" , readonly=False, store=True)
-    generate_lead_from_alias = fields.Boolean(
-        'Manual Assignment of Emails', config_parameter='crm.generate_lead_from_alias',
-        compute="_compute_generate_lead_from_alias", readonly=False, store=True)
     group_use_lead = fields.Boolean(string="Leads", implied_group='crm.group_use_lead')
     group_use_recurring_revenues = fields.Boolean(string="Recurring Revenues", implied_group='crm.group_use_recurring_revenues')
     module_crm_iap_lead = fields.Boolean("Generate new leads based on their country, industries, size, etc.")
@@ -28,18 +22,6 @@ class ResConfigSettings(models.TransientModel):
     predictive_lead_scoring_start_date_str = fields.Char(string='Lead Scoring Starting Date in String', config_parameter='crm.pls_start_date')
     predictive_lead_scoring_fields = fields.Many2many('crm.lead.scoring.frequency.field', string='Lead Scoring Frequency Fields', compute="_compute_pls_fields", inverse="_inverse_pls_fields_str")
     predictive_lead_scoring_fields_str = fields.Char(string='Lead Scoring Frequency Fields in String', config_parameter='crm.pls_fields')
-
-    def _find_default_lead_alias_id(self):
-        alias = self.env.ref('crm.mail_alias_lead_info', False)
-        if not alias:
-            alias = self.env['mail.alias'].search([
-                ('alias_model_id.model', '=', 'crm.lead'),
-                ('alias_force_thread_id', '=', False),
-                ('alias_parent_model_id.model', '=', 'crm.team'),
-                ('alias_parent_thread_id', '=', False),
-                ('alias_defaults', '=', '{}')
-            ], limit=1)
-        return alias
 
     @api.depends('predictive_lead_scoring_fields_str')
     def _compute_pls_fields(self):
@@ -76,37 +58,8 @@ class ResConfigSettings(models.TransientModel):
             if setting.predictive_lead_scoring_start_date:
                 setting.predictive_lead_scoring_start_date_str = fields.Date.to_string(setting.predictive_lead_scoring_start_date)
 
-    @api.depends('group_use_lead')
-    def _compute_generate_lead_from_alias(self):
-        """ Reset alias / leads configuration if leads are not used """
-        for setting in self.filtered(lambda r: not r.group_use_lead):
-            setting.generate_lead_from_alias = False
-
-    @api.depends('generate_lead_from_alias')
-    def _compute_crm_alias_prefix(self):
-        for setting in self:
-            setting.crm_alias_prefix = (setting.crm_alias_prefix or 'contact') if setting.generate_lead_from_alias else False
-
-    @api.model
-    def get_values(self):
-        res = super(ResConfigSettings, self).get_values()
-        alias = self._find_default_lead_alias_id()
-        res.update(
-            crm_alias_prefix=alias.alias_name if alias else False,
-        )
-        return res
-
     def set_values(self):
         super(ResConfigSettings, self).set_values()
-        alias = self._find_default_lead_alias_id()
-        if alias:
-            alias.write({'alias_name': self.crm_alias_prefix})
-        else:
-            self.env['mail.alias'].create({
-                'alias_name': self.crm_alias_prefix,
-                'alias_model_id': self.env['ir.model']._get('crm.lead').id,
-                'alias_parent_model_id': self.env['ir.model']._get('crm.team').id,
-            })
         for team in self.env['crm.team'].search([]):
             team.alias_id.write(team._alias_get_creation_values())
 

--- a/addons/crm/models/res_config_settings.py
+++ b/addons/crm/models/res_config_settings.py
@@ -59,9 +59,14 @@ class ResConfigSettings(models.TransientModel):
                 setting.predictive_lead_scoring_start_date_str = fields.Date.to_string(setting.predictive_lead_scoring_start_date)
 
     def set_values(self):
+        group_lead_before = self.env.ref('crm.group_use_lead') in self.env.user.groups_id
         super(ResConfigSettings, self).set_values()
-        for team in self.env['crm.team'].search([]):
-            team.alias_id.write(team._alias_get_creation_values())
+        group_lead_after = self.env.ref('crm.group_use_lead') in self.env.user.groups_id
+        if group_lead_before != group_lead_after:
+            teams = self.env['crm.team'].search([])
+            teams.filtered('use_opportunities').use_leads = group_lead_after
+            for team in teams:
+                team.alias_id.write(team._alias_get_creation_values())
 
     # ACTIONS
     def action_reset_lead_probabilities(self):

--- a/addons/crm/views/crm_team_views.xml
+++ b/addons/crm/views/crm_team_views.xml
@@ -124,9 +124,10 @@
                     <div class="oe_inline" name="alias_def"
                         attrs="{'invisible': [('use_leads', '=', False),('use_opportunities', '=', False)]}">
                         <field name="alias_id" class="oe_read_only oe_inline"
-                            string="Email Alias" required="0"/>
-                        <div class="oe_edit_only oe_inline" name="edit_alias" style="display: inline;" >
-                            <div attrs="{'invisible': [('alias_domain', '=', False)]}">
+                            string="Email Alias" required="0"
+                            attrs="{'invisible': [('alias_domain', '=', False)]}"/>
+                        <div class="oe_inline" name="edit_alias" style="display: inline;" >
+                            <div class="oe_edit_only" attrs="{'invisible': [('alias_domain', '=', False)]}">
                                 <field name="alias_name" class="oe_inline"/>@<field name="alias_domain" class="oe_inline" readonly="1"/>
                             </div>
                             <button icon="fa-arrow-right" type="action" name="%(base_setup.action_general_configuration)d" string="Configure a custom domain" class="p-0 btn-link" attrs="{'invisible': [('alias_domain', '!=', False)]}"/>

--- a/addons/crm/views/res_config_settings_views.xml
+++ b/addons/crm/views/res_config_settings_views.xml
@@ -66,32 +66,6 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="col-lg-6 o_setting_box" id="crm_lead"
-                                attrs="{'invisible': [('group_use_lead','=',False)]}"
-                                title="Emails received to that address generate new leads not assigned to any Sales Team yet. This can be made when converting them into opportunities. Incoming emails can be automatically assigned to specific Sales Teams. To do so, set an email alias on the Sales Team.">
-                            <div class="o_setting_left_pane">
-                                <field name="generate_lead_from_alias"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="generate_lead_from_alias" string="Incoming Emails"/>
-                                <div class="text-muted">
-                                    Create leads from incoming emails
-                                </div>
-                                <div class="content-group" attrs="{'invisible': [('generate_lead_from_alias','=',False)]}">
-                                    <div class="mt16">
-                                        <field name="crm_alias_prefix" class="oe_inline"
-                                            attrs="{'required': [('generate_lead_from_alias', '=', True)]}"/>
-                                        <label class="mr-0" for="alias_domain" string="@"/>
-                                        <field name="alias_domain" readonly="1" force_save="1" class="oe_inline"/>
-                                    </div>
-                                    <div attrs="{'invisible': [('alias_domain', 'not in', ['localhost', '', False])]}">
-                                        <button type="action"
-                                            name="base_setup.action_general_configuration"
-                                            string="Use an External Email Server" icon="fa-arrow-right" class="oe_link"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
                     </div>
                     <h2>Lead Generation</h2>
                     <div class="row mt16 o_settings_container" name="convert_visitor_setting_container">


### PR DESCRIPTION
PURPOSE

Remove the alias setting option because it is a weird and hackish way to
proceed. We would prefer users to configure their alias through sales teams.
Improve alias configuration on teams.

RATIONALE

"​Incoming Emails" option has many flaws

  * it creates collision when you try to set an alias that is already used
    and it is not easy to find them back;
  * it has no default value (no sales team, no type, ...) and works through the
    'owner' field. This is set with the admin on activation of the feature
    which is not correct.  The admin is potentially not a salesperson. If you
    set the field to blank, you get leads without team and without assigned
    responsible.
  * this alias is not team-bound which thus asks the question: in which team
    should the lead ever go? To the first team? Why?

All this make it seem way healthier to handle this through the Sales Team.
=> By default, we'll already have one working with an alias.

If users really want a global lead alias it can be setup manually through
alias menu in configuration. Shortcut and default alias in crm are removed
but feature is still doable if requested.

SPECIFICATIONS

Remove the s "Incoming emails" setting that allows to setup a global alias for
leads / opportunities with a default value being 'contact'. Also remove related
alias data as it has no use anymore.

When changing "use leads" from CRM settings automatically regenerate apply this
option to all sales teams using opportunities. When de-activating it no team
should have this option activated as menus and options are hidden. When
activating it we consider that all teams should be upgraded by default

LINKS

Task ID-2414079
Sort of follow-up of Task ID-2373095
COM PR #63160
UPG PR odoo/upgrade#2017
