### PR TITLE
[REF] tests: delete duplicated arg for headless browser

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -813,7 +813,6 @@ class ChromeBrowser():
             '--remote-debugging-address': HOST,
             '--remote-debugging-port': str(self.devtools_port),
             '--no-sandbox': '',
-            '--disable-crash-reporter': '',
             '--disable-gpu': '',
         }
         cmd = [self.executable]


### PR DESCRIPTION
It was added here: https://github.com/odoo/odoo/commit/253d5341a4e2d19d2cb9bad6bb1b1986f52dd66f

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
