### PR TITLE
[Fix] google_calendar: fix owner attendee being deleted

### DIFF
--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -88,6 +88,12 @@ class Meeting(models.Model):
         attendee_commands = []
         partner_commands = []
         google_attendees = google_event.attendees or []
+        if google_event.organizer and google_event.organizer.get('self', False):
+            user = google_event.owner(self.env)
+            google_attendees += [{
+                'email': user.partner_id.email,
+                'status': {'response': 'accepted'},
+            }]
         emails = [a.get('email') for a in google_attendees]
         existing_attendees = self.env['calendar.attendee']
         if google_event.exists(self.env):
@@ -167,6 +173,7 @@ class Meeting(models.Model):
             'method': "email" if alarm.alarm_type == "email" else "popup",
             'minutes': alarm.duration_minutes
         } for alarm in self.alarm_ids]
+        attendee_ids = self.attendee_ids.filtered(lambda a: a.partner_id not in self.user_id.partner_id)
         values = {
             'id': self.google_id,
             'start': start,

--- a/addons/google_calendar/tests/test_sync_google2odoo.py
+++ b/addons/google_calendar/tests/test_sync_google2odoo.py
@@ -48,10 +48,11 @@ class TestSyncGoogle2Odoo(SavepointCase):
         self.assertEqual(event.description, values.get('description'))
         self.assertEqual(event.start, datetime(2020, 1, 13, 15, 55))
         self.assertEqual(event.stop, datetime(2020, 1, 13, 18, 55))
-        self.assertEqual('admin@yourcompany.example.com', event.attendee_ids.email)
-        self.assertEqual('Mitchell Admin', event.attendee_ids.partner_id.name)
+        admin_attendee = event.attendee_ids.filtered(lambda e: e.email == 'admin@yourcompany.example.com')
+        self.assertEqual('admin@yourcompany.example.com', admin_attendee.email)
+        self.assertEqual('Mitchell Admin', admin_attendee.partner_id.name)
         self.assertEqual(event.partner_ids, event.attendee_ids.partner_id)
-        self.assertEqual('needsAction', event.attendee_ids.state)
+        self.assertEqual('needsAction', admin_attendee.state)
 
     def test_cancelled(self):
         google_id = 'oj44nep1ldf8a3ll02uip0c9aa'
@@ -122,8 +123,9 @@ class TestSyncGoogle2Odoo(SavepointCase):
         self.assertEqual(event.partner_ids, user.partner_id)
         self.assertEqual(event.attendee_ids.partner_id, user.partner_id)
         self.sync(gevent)
-        self.assertFalse(event.attendee_ids, "The attendee should have been removed")
-        self.assertFalse(event.partner_ids, "The partner should have been removed")
+        # User attendee removed but gevent owner might be added after synch.
+        self.assertNotEqual(event.attendee_ids.partner_id, user.partner_id)
+        self.assertNotEqual(event.partner_ids, user.partner_id)
 
     def test_recurrence(self):
         recurrence_id = 'oj44nep1ldf8a3ll02uip0c9aa'


### PR DESCRIPTION
Currently when creating a calendar.event with google sync switched
on and without adding another attendee, the event is immediatly
removed from the calendar view. This is because the user_id is filtered out
of the attendee_ids before sending the values to google calendar. Then, at
the next sync, google response attendees list does not contain the user_id
so Odoo turns that into a [(3, id)] command. Thus, the corresponding event
disappear from the current calendar view even though it is still in the DB.

This fix is essentially the same as the one implemented in the
microsoft_calendar addons available from 14.0 onwards. It adds the
calendar owner if the event organizer is not null. This way, even
though the owner is not sent as an attendee, it is not removed
after google's response.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
