### PR TITLE
[FIX] web_editor: fix background position on shapes

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4005,6 +4005,7 @@ registry.BackgroundShape = SnippetOptionWidget.extend({
         } else {
             // Remove custom bg image and let the shape class set the bg shape
             $(shapeContainer).css('background-image', '');
+            $(shapeContainer).css('background-position', '');
         }
         if (previewMode === false) {
             this.prevShapeContainer = shapeContainer.cloneNode(true);


### PR DESCRIPTION
Before this commit, the background-position was not removed from a
shape when it was re-flipped to its original orientation.

introduced in #61114

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
