### PR TITLE
[FIX] sale: Traceback on update price (price list) and price = 0

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -464,7 +464,7 @@ class SaleOrder(models.Model):
             )
             price_unit = self.env['account.tax']._fix_tax_included_price_company(
                 line._get_display_price(product), line.product_id.taxes_id, line.tax_id, line.company_id)
-            if self.pricelist_id.discount_policy == 'without_discount':
+            if self.pricelist_id.discount_policy == 'without_discount' and price_unit:
                 discount = max(0, (price_unit - product.price) * 100 / price_unit)
             else:
                 discount = 0


### PR DESCRIPTION
Issue

	- Create a Price list and set 'Discount Policy' as
	  "Show public price & discount to the customer "
	- Create an SO
	- Add a multiple product with at least one with price unit = 0
	- Change the pricelist and update prices

Cause

	Division by zero when calculating discount.

Solution

	Calculate discount only if there is a price_unit.

opw-2393790