### PR TITLE
[FIX] hr_expense: wrong company account when creating from mail

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -444,6 +444,9 @@ class HrExpense(models.Model):
             ('work_email', 'ilike', email_address),
             ('user_id.email', 'ilike', email_address)
         ], limit=1)
+        # The expenses alias is the same for all companies, we need to set the proper context
+        company = employee.company_id or self.env.user.company_id
+        self = self.with_context(force_company=company.id)
 
         expense_description = msg_dict.get('subject', '')
 


### PR DESCRIPTION
In a multicompany environment, when a expense is created from the
expense email alias, the expense account is computed with SUPERUSER
context, so depending on the SUPERUSER set company, we could get
a mismatch of expense and employee's company and the account one, wich
causes a subsequent error when trying to post the expense.

Steps to reproduce:

- You should have at least two companies.

- The admin will be in company 1

- And the employee will be in company 2

- It should be possible to create expenses from email.

What are the steps to reproduce your issue?

- The employee send the expense to the expenses alias.

- The expense is created with the employee's company and the expense product (it doesn't matter if it's the default one).

- Add it to an expense report and try to post it.

What is the current behavior that you observe?

- When we try to post the expense an error raises as the account in the expense is from another company.

- The expense account was created with the context of the company the SUPERUSER was in.

What would be your expected behavior in this case?

- The expense account and taxes should be created with the employee's company context

opw-2412436

cc @Tecnativa TT27015
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
