### PR TITLE
[FIX] mail: Receive EML file in attachment

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1721,6 +1721,8 @@ class MailThread(models.AbstractModel):
                     continue
                 if isinstance(content, str):
                     content = content.encode('utf-8')
+                elif isinstance(content, EmailMessage):
+                    content = content.as_bytes()
                 elif content is None:
                     continue
                 attachement_values= {


### PR DESCRIPTION
Configure the incomming mail server, use another mail client to send a
message to Odoo with an EML file as attachment. The fetchmail server
fails.

Since the introduction of the new EmailMessage python API to
encode/decode email messages, every EML attachment is automatically
parsed into a EmailMessage.

Task: 2329606
