### PR TITLE
l10n_fr: remove vat_required on fiscal position 'Domestique - France'

### DIFF
--- a/addons/l10n_fr/data/account_fiscal_position_template_data.xml
+++ b/addons/l10n_fr/data/account_fiscal_position_template_data.xml
@@ -16,7 +16,6 @@
             <field name="name">Domestique - France</field>
             <field name="chart_template_id" ref="l10n_fr_pcg_chart_template"/>
             <field name="auto_apply" eval="True" />
-            <field name="vat_required" eval="True" />
             <field name="country_id" ref="base.fr"></field>
         </record>
         <record id="fiscal_position_template_intraeub2c" model="account.fiscal.position.template">


### PR DESCRIPTION
VAT should only be required on fiscal position "Intra-EU B2B", not on "Domestique - France"