### PR TITLE
update RAM Calculation

### DIFF
--- a/doc/setup/deploy.rst
+++ b/doc/setup/deploy.rst
@@ -242,7 +242,7 @@ Configuration sample
 * 60 users / 6 = 10 <- theorical number of worker needed
 * (4 * 2) + 1 = 9 <- theorical maximal number of worker
 * We'll use 8 workers + 1 for cron. We'll also use a monitoring system to measure cpu load, and check if it's between 7 and 7.5 .
-* RAM = 9 * ((0.8*150) + (0.2*1024)) ~= 3Go RAM for Odoo
+* RAM = 9 * ((0.8*150) + (0.2*1024)) = 2923,2MB RAM ~= 3GB RAM for Odoo
 
 in ``/etc/odoo.conf``:
 


### PR DESCRIPTION
RAM advice could be further simplified by 9 * ((0.8*150) + (0.2*1024)) = 9 * 324,8
So by providing the rule of thumb: 325MB RAM for each desired worker. It is nice to know how this magic factor (325MB) comprises but many user would probably rather have an even simpler RAM advice. Hence the magic factor 325MB

Description of the issue/feature this PR addresses: Fix typo Go ->GB
 
Current behavior before PR: unclear what `Go` is

Desired behavior after PR is merged: Go to GB and advice about magic factor.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
