### PR TITLE
[FIX] web_editor: fix crash on chrome (cannot read editable of null)

### DIFF
--- a/addons/web_editor/static/src/js/editor/summernote.js
+++ b/addons/web_editor/static/src/js/editor/summernote.js
@@ -2033,8 +2033,9 @@ eventHandler.modules.editor.currentStyle = function (target) {
     if (!styleInfo.image || !dom.isEditable(styleInfo.image)) {
         styleInfo.image = undefined;
         var r = range.create();
-        if (r)
+        if (r && r.isOnEditable()) {
             styleInfo.image = r.isOnImg();
+        }
     }
     // Fix when the target is a link: the text-align buttons state should
     // indicate the alignment of the link in the parent, not the text inside


### PR DESCRIPTION
This crash is caused by some of our integration code with summernote.
When clicking on a button of the toolbar, we attempt to create a range
from the current selection so that we can show the image toolbar if the
selection contains an image, but there was no check to see whether the
current selection was actually inside of the editable part of the page.
This causes issues later when we attempt to generate layoutInfo for the
image, as it will look for the editable area that contains the image and
fail.

This commit fixes that by making sure that the current selection is
inside of the editable area before adding it to the styleInfo.

opw-2376794
