### PR TITLE
Fix several access rights related warnings / behavior

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -528,7 +528,8 @@ class Channel(models.Model):
         notifications = []
         for partner in self.env['res.partner'].browse(partner_ids):
             user_id = partner.user_ids and partner.user_ids[0] or False
-            if user_id:
+            # Send notifications to internal users
+            if user_id and user_id.has_group('base.group_user'):
                 for channel_info in self.sudo(user_id).channel_info():
                     notifications.append([(self._cr.dbname, 'res.partner', partner.id), channel_info])
         return notifications

--- a/addons/mail/views/mail_channel_views.xml
+++ b/addons/mail/views/mail_channel_views.xml
@@ -84,8 +84,17 @@
             <field name="priority" eval="10"/>
             <field name="arch" type="xml">
                 <form string="Mail Channel Form">
+                    <field name="is_member" invisible="1"/>
+                    <field name="is_channel_admin" invisible="1"/>
                     <header>
                         <button name="send_guidelines" type="object" string="Send guidelines" confirm="You are going to send the guidelines to all the subscribers. Do you confirm the action?" attrs="{'invisible':['|',('moderation_guidelines','=',False), ('is_moderator', '=', False)]}"/>
+                        <button name="action_unfollow_reload" string="Leave channel"
+                            type="object" class="oe_read_only"
+                            confirm="You are the administrator of this channel. Are you sure you want to unsubscribe?"
+                            attrs="{'invisible': ['|', ('is_member', '=', False), '&amp;', ('is_member', '=', True), ('is_channel_admin', '=', False)]}"/>
+                        <button name="action_unfollow_reload" string="Leave channel"
+                            type="object" class="oe_read_only"
+                            attrs="{'invisible': ['|', ('is_member', '=', False), '&amp;', ('is_member', '=', True), ('is_channel_admin', '=', True)]}"/>
                     </header>
                     <sheet>
                         <div class="oe_button_box" name="button_box">


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
There are several access rights related warnings that prevent user from performing actions which they should be allowed to do.

**Current behavior before PR:**
1. When user removes himself from the 'Members' of mail channel form view (for the private channel), access right warning is raised.
2. When user having no access rights is invited to a channel, access right warning is raised.

**Desired behavior after PR is merged:**
1. Add a button leave channel on the private channel's form view which will unsubscribe user from the channel and redirect back to 'Discuss' app.
2. Allow to invite user who don't belong to any user groups (internal, portal, public..)

TaskID - 2411038



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
