### PR TITLE
[FIX] account: fix fiscal position mapping in pos

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -53,7 +53,7 @@ class AccountFiscalPosition(models.Model):
         for tax in taxes:
             tax_count = 0
             for t in self.tax_ids:
-                if t.tax_src_id == tax:
+                if t.tax_src_id.id == (tax._origin or tax).id:
                     tax_count += 1
                     if t.tax_dest_id:
                         result |= t.tax_dest_id


### PR DESCRIPTION
Have a Fiscal position FPOS which map tax A to tax B
Have a storable product DEMO and DEMO2
Allow FPOS in POS, Open a session, sell DEMO and DEMO2
close POS
Go to Orders, select the last one, hit return, edit, delete a line

Tax will be set to 0
This occcur because the fiscal position mapping fail an equivalence
check with a virtual record

opw-2409553

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
