### PR TITLE
[Fix] mail: incorrect activity creation date

### DIFF
--- a/addons/mail/static/src/models/activity/activity.js
+++ b/addons/mail/static/src/models/activity/activity.js
@@ -43,7 +43,7 @@ function factory(dependencies) {
             if ('can_write' in data) {
                 data2.canWrite = data.can_write;
             }
-            if ('create_data' in data) {
+            if ('create_date' in data) {
                 data2.dateCreate = data.create_date;
             }
             if ('date_deadline' in data) {


### PR DESCRIPTION
After an activity creation, if a user checks the activity's information,
the creation date will be the current date.

To reproduce the error:
1. Add an activity (e.g. a TODO activity)
2. In log notes, click on the activity's information icon

=> The "Created" field is actually the current date and not the
activity's creation date.

OPW-2412967