### PR TITLE
add support of 'create' attribute on list groupby tag

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -697,6 +697,7 @@
                     <button name="action_snooze" class="text-warning" type="object" string="Snooze 7d" icon="fa-bell-slash"
                         attrs="{'invisible': [('activity_date_deadline_my', '=', False)]}"/>
                     <button name="%(crm.action_lead_mail_compose)d" type="action" string="Email" icon="fa-envelope"/>
+                    <groupby name="stage_id" create="1"></groupby>
                 </tree>
             </field>
         </record>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -950,6 +950,7 @@
                     <field name="kanban_state" widget="state_selection" optional="hide" readonly="1"/>
                     <field name="stage_id" invisible="context.get('set_visible',False)" optional="show" readonly="1"/>
                     <field name="recurrence_id" invisible="1" />
+                    <groupby name="stage_id" create="context.get('group_create', True)"></groupby>
                 </tree>
             </field>
         </record>
@@ -1048,7 +1049,7 @@
             <field name="name">Tasks</field>
             <field name="res_model">project.task</field>
             <field name="view_mode">tree,kanban,form,calendar,pivot,graph,activity</field>
-            <field name="context">{'search_default_my_tasks': 1, 'all_task': 0}</field>
+            <field name="context">{'search_default_my_tasks': 1, 'all_task': 0, 'group_create': False}</field>
             <field name="search_view_id" ref="view_task_search_form"/>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">

--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -697,6 +697,10 @@ var BasicModel = AbstractModel.extend({
         });
         return Promise.all(proms);
     },
+    getDefaultContext(listID) {
+        const list = this.localData[listID];
+        return this._getDefaultContext(list);
+    },
     /**
      * Returns the current display_name for the record.
      *

--- a/addons/web/static/src/js/views/list/list_controller.js
+++ b/addons/web/static/src/js/views/list/list_controller.js
@@ -31,6 +31,7 @@ var ListController = BasicController.extend({
     custom_events: _.extend({}, BasicController.prototype.custom_events, {
         activate_next_widget: '_onActivateNextWidget',
         add_record: '_onAddRecord',
+        add_group_record: '_onAddGroupRecord',
         button_clicked: '_onButtonClicked',
         group_edit_button_clicked: '_onEditGroupClicked',
         edit_line: '_onEditLine',
@@ -671,6 +672,22 @@ var ListController = BasicController.extend({
     _onActivateNextWidget: function (ev) {
         ev.stopPropagation();
         this.renderer.editFirstRecord(ev);
+    },
+    /**
+     *
+     * @param {OdooEvent} ev
+     */
+    async _onAddGroupRecord(ev) {
+        const state = this.model.get(this.handle);
+        const recordContext = state.getContext();
+        const defaultContext = this.model.getDefaultContext(ev.data.groupId);
+        Object.assign(recordContext, defaultContext);
+        this.do_action({
+            context: recordContext,
+            type: 'ir.actions.act_window',
+            views: [[false, 'form']],
+            res_model: this.modelName,
+        });
     },
     /**
      * Add a record to the list

--- a/addons/web/static/src/js/views/list/list_editable_renderer.js
+++ b/addons/web/static/src/js/views/list/list_editable_renderer.js
@@ -1056,9 +1056,11 @@ ListRenderer.include({
      * @override
      * @private
      */
-    _renderGroup: function (group) {
+    _renderGroup: function (group, groupLevel) {
         var result = this._super.apply(this, arguments);
-        if (!group.groupedBy.length && this.addCreateLineInGroups) {
+        const groupBy = this.state.groupedBy[groupLevel];
+        if (!group.groupedBy.length && this.addCreateLineInGroups &&
+            !(this.groupbys[groupBy] && this.groupbys[groupBy].create && this.addPlusIconInGroups)) {
             var $groupBody = result[0];
             var $a = $('<a href="#" role="button">')
                 .text(_t("Add a line"))
@@ -1428,6 +1430,24 @@ ListRenderer.include({
                 groupId: groupId,
             });
         });
+    },
+    /**
+     *
+     * @param {Object} list
+     * @param {jQueryEvent} ev
+     * @override
+     */
+    _onGroupPlusClick(list, ev) {
+        if (this.editable) {
+            ev.stopPropagation();
+            this.unselectRow().then(() => {
+                this.trigger_up('add_record', {
+                    groupId: list.id,
+                });
+            });
+        } else {
+            this._super(...arguments);
+        }
     },
     /**
      * This method is called when we click on the 'Add a line' button in a sub

--- a/addons/web/static/src/js/views/list/list_renderer.js
+++ b/addons/web/static/src/js/views/list/list_renderer.js
@@ -65,6 +65,10 @@ var ListRenderer = BasicRenderer.extend({
     init: function (parent, state, params) {
         this._super.apply(this, arguments);
         this._preprocessColumns();
+
+        // if addPlusIconInGroups is true, the renderer will add a '+' icon
+        // at the header of each group
+        this.addPlusIconInGroups = params.addPlusIconInGroups;
         this.columnInvisibleFields = params.columnInvisibleFields || {};
         this.rowDecorations = this._extractDecorationAttrs(this.arch);
         this.fieldDecorations = {};
@@ -765,6 +769,17 @@ var ListRenderer = BasicRenderer.extend({
             this._renderGroupPager(group, lastCell);
         }
         if (group.isOpen && this.groupbys[groupBy]) {
+            if (this.groupbys[groupBy].create && this.addPlusIconInGroups) {
+                const $createButton = dom.renderButton({
+                    icon: 'fa-plus',
+                    attrs: {
+                        class: 'o_list_group_create',
+                        title: _t('Create')
+                    }
+                });
+                $createButton.on("click", this._onGroupPlusClick.bind(this, group));
+                $th.append($createButton);
+            }
             var $buttons = this._renderGroupButtons(group, this.groupbys[groupBy]);
             if ($buttons.length) {
                 var $buttonSection = $('<div>', {
@@ -1239,6 +1254,17 @@ var ListRenderer = BasicRenderer.extend({
         if (ev.keyCode === $.ui.keyCode.ENTER) {
             ev.stopPropagation();
         }
+    },
+    /**
+     *
+     * @param {Object} list
+     * @param {jQueryEvent} ev
+     */
+    _onGroupPlusClick(list, ev) {
+        ev.stopPropagation();
+        this.trigger_up('add_group_record', {
+            groupId: list.id,
+        });
     },
     /**
      * When the user clicks on the checkbox in optional fields dropdown the

--- a/addons/web/static/src/js/views/list/list_view.js
+++ b/addons/web/static/src/js/views/list/list_view.js
@@ -47,7 +47,7 @@ var ListView = BasicView.extend({
         this.headerButtons = [];
         this.arch.children.forEach(function (child) {
             if (child.tag === 'groupby') {
-                self._extractGroup(child);
+                self._extractGroup(child, pyevalContext);
             }
             if (child.tag === 'header') {
                 self._extractHeaderButtons(child);
@@ -75,6 +75,7 @@ var ListView = BasicView.extend({
         this.rendererParams.selectedRecords = selectedRecords;
         this.rendererParams.addCreateLine = false;
         this.rendererParams.addCreateLineInGroups = editable && this.controllerParams.activeActions.create;
+        this.rendererParams.addPlusIconInGroups = !params.readonly && this.controllerParams.activeActions.create;
         this.rendererParams.isMultiEditable = this.arch.attrs.multi_edit && !!JSON.parse(this.arch.attrs.multi_edit);
 
         this.modelParams.groupbys = this.groupbys;
@@ -94,9 +95,10 @@ var ListView = BasicView.extend({
      * @private
      * @param {Object} node
      */
-    _extractGroup: function (node) {
+    _extractGroup: function (node, pyevalContext) {
         var innerView = this.fields[node.attrs.name].views.groupby;
         this.groupbys[node.attrs.name] = this._processFieldsView(innerView, 'groupby');
+        this.groupbys[node.attrs.name]['create'] = !!JSON.parse(pyUtils.py_eval(node.attrs.create || "0", { 'context': pyevalContext }));
     },
     /**
      * Extracts action buttons definitions from the <header> node of the list

--- a/addons/web/static/src/scss/list_view.scss
+++ b/addons/web/static/src/scss/list_view.scss
@@ -180,6 +180,10 @@
                     }
                 }
             }
+            .o_list_group_create {
+                padding: 0 0.2rem;
+                border: none;
+            }
         }
         tbody + tbody {
             border-top: none;  // Override bootstrap for grouped list views

--- a/doc/reference/views.rst
+++ b/doc/reference/views.rst
@@ -1833,10 +1833,14 @@ Possible children elements of the list view are:
   ``name``
       the name of a many2one field (on the current model). Custom header will be
       displayed when grouping the view on this field name.
+  ``create``
+      if set to "1", each group header will display ``+`` icon to add record, if
+      listview is editable then clicking ``+`` icon will add new record in group
+      top/bottom based on editable attribute else will open form view.
 
   .. code-block:: xml
 
-    <groupby name="partner_id">
+    <groupby name="partner_id" create="1">
       <field name="name"/> <!-- name of partner_id -->
         <button type="edit" name"edit" string="Edit/>
         <button type="object" name="my_method" string="Button1"

--- a/odoo/addons/base/rng/tree_view.rng
+++ b/odoo/addons/base/rng/tree_view.rng
@@ -11,6 +11,7 @@
         <rng:element name="groupby">
             <rng:attribute name="name"/>
             <rng:optional><rng:attribute name="expand"/></rng:optional>
+            <rng:optional><rng:attribute name="create"/></rng:optional>
             <rng:zeroOrMore>
                 <rng:ref name="field"/>
             </rng:zeroOrMore>


### PR DESCRIPTION
PURPOSE
This task introduces a new 'create' boolean option on the <groupby> listview tag.

The goal is to provide the user with a way to create records directly from a group.
Example: create a project task directly from a stage
NB: this option makes the most sense when used on a field with a group_expand method

SPEC
Add a new 'create' boolean option on the <groupby> tag of the listview
    when 'create'=true, add a fa-plus icon after the group header, with title='Create' 
    when clicking on the 'plus' icon
        if editable='top', create a new record as first line of the group
        if editable='bottom', create a new record as last line of the group
        else, open the formview of a new record

TASK 2414138



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
