### PR TITLE
[FIX] requirements.txt: make Odoo installable for Python >= 3.8

### DIFF
--- a/doc/cla/corporate/opensourceintegrators.md
+++ b/doc/cla/corporate/opensourceintegrators.md
@@ -16,6 +16,7 @@ Greg Mader gmader@opensourceintegrators.com https://github.com/gmader
 Antonio Yamuta ayamuta@opensourceintegrators.com https://github.com/agyamuta
 Balaji Kannan bkannan@opensourceintegrators.com https://github.com/b-kannan
 Bhavesh Odedra bodedra@opensourceintegrators.com https://github.com/bodedra
+Daniel Reis dreis@opensourceintegrators.com https://github.com/dreispt
 Mayank Gosai mgosai@opensourceintegrators.com https://github.com/mgosai
 Maxime Chambreuil mchambreuil@opensourceintegrators.com https://github.com/max3903
 Michael Allen mallen@opensourceintegrators.com https://github.com/osimallen

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,10 +19,10 @@ num2words==0.5.6
 ofxparse==0.16
 passlib==1.6.5
 Pillow==4.0.0 ; python_version < '3.7'
-Pillow==6.1.0 ; python_version >= '3.7'
+Pillow==8.0 ; python_version >= '3.7'
 psutil==4.3.1; sys_platform != 'win32'
 psutil==5.6.3; sys_platform == 'win32'
-psycopg2==2.7.3.1; sys_platform != 'win32'
+psycopg2==2.8.6; sys_platform != 'win32'
 psycopg2==2.8.3; sys_platform == 'win32'
 pydot==1.2.3
 pyldap==2.4.28; sys_platform != 'win32'


### PR DESCRIPTION
# Description of the issue/feature this PR addresses:

Odoo installation in a Python >= 3.8 environment

# Current behavior before PR:

Odoo `pip install -r requirements.txt` errors

# Desired behavior after PR is merged:

Odoo `pip install -r requirements.txt` is successful



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
