### PR TITLE
[FIX] stock: fix performance of forecasted when lot of locations

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -436,8 +436,8 @@ class StockMove(models.Model):
                 [('id', 'child_of', warehouse.view_location_id.id)],
                 ['id'],
             )]
-            forecast_lines = self.env['report.stock.report_product_product_replenishment']\
-                ._get_report_lines(None, product_variant_ids, wh_location_ids)
+            ForecastedReport = self.env['report.stock.report_product_product_replenishment']
+            forecast_lines = ForecastedReport.with_context(warehouse=warehouse.id)._get_report_lines(None, product_variant_ids, wh_location_ids)
             for move in moves:
                 lines = [l for l in forecast_lines if l["move_out"] == move._origin and l["replenishment_filled"] is True]
                 if lines:

--- a/addons/stock/report/report_stock_forecasted.py
+++ b/addons/stock/report/report_stock_forecasted.py
@@ -143,7 +143,7 @@ class ReplenishmentReport(models.AbstractModel):
         ins_per_product = defaultdict(lambda: [])
         for in_ in ins:
             ins_per_product[in_.product_id.id].append([in_.product_qty, in_])
-        currents = {c['id']: c['qty_available'] for c in outs.product_id.with_context(location=wh_location_ids).read(['qty_available'])}
+        currents = {c['id']: c['qty_available'] for c in outs.product_id.read(['qty_available'])}
 
         lines = []
         for product in (ins | outs).product_id:


### PR DESCRIPTION
In the DB with a warehouse with a lot of stock location.
The forecasted widget return a traceback due to a memory error due
to the `_get_domain_locations_new`
(`_get_report_lines`->`read(['qty_available'])`->`_compute_quantities`
->`_compute_quantities_dict`->`_get_domain_locations`)
how returns a extremely long domain (one expression
by location in the context) to compute child location.
But the locations (put in the context) contain already
children locations because of
`('id', 'child_of', warehouse.view_location_id.id)`.

TO SOLVE
Instead of adding location in the context
(for fix 1aa6a32),
add the warehouse in the context before
calling the `_get_report_lines` in the `_compute_forecast_information`.

closes #61666