### PR TITLE
[IMP] mail: correctly support hidden textarea with emojis mixin

### DIFF
--- a/addons/mail/static/src/scss/emojis.scss
+++ b/addons/mail/static/src/scss/emojis.scss
@@ -21,7 +21,7 @@ $o-mail-emoji-height: 2rem;
     // Emojis widgets should hide the emoji dropdown button when the field is invisible.
     // This is necessary because the button is added *after* the main element (and not inside)
     // (see '_attachEmojisDropdown' for more details)
-    .o_invisible_modifier + .o_mail_add_emoji{
+    .o_invisible_modifier + .o_mail_add_emoji, .o_invisible_modifier + textarea + .o_mail_add_emoji{
         display: none !important;
     }
 }


### PR DESCRIPTION
This commit fixes the scss file to correctly hide emojis button if they are
linked to a Text-type field that is also hidden (using attributes, attrs, ...).

Task 2209729

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
