### PR TITLE
[12.0][FIX] _filter_access_rules fail for empty transient recordset

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3116,7 +3116,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
 
     def _filter_access_rules(self, operation):
         """ Return the subset of ``self`` for which ``operation`` is allowed. """
-        if self._uid == SUPERUSER_ID:
+        if not self.ids or self._uid == SUPERUSER_ID:
             return self
 
         if self.is_transient():


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
As reported in https://github.com/OCA/credit-control/pull/69#issuecomment-743089858, deleting a transient model with an attachment linked to it will fail.

Quoted:
- In `ir.attachment.check(...)` there is call to `self.env[res_model].browse(res_ids).exists()` that returns an empty record so `check_access_rights` and `check_access_rule` are called on an empty recordset that leads to an exception in `_filter_access_rules` called from `check_access_rule`.
```
            records = self.env[res_model].browse(res_ids).exists()
            # For related models, check if we can write to the model, as unlinking
            # and creating attachments can be seen as an update to the model
            access_mode = 'write' if mode in ('create', 'unlink') else mode
            records.check_access_rights(access_mode)
            records.check_access_rule(access_mode)
```

**Current behavior before PR:**
An exception is raised, stopping wizard progress 

**Desired behavior after PR is merged:**
Unlink should be called without errors

The traceback:
```
Traceback (most recent call last):
  File "/media/data/dec/projects/12.0/odoo/odoo/http.py", line 685, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/media/data/dec/projects/12.0/odoo/odoo/http.py", line 343, in _handle_exception
    raise pycompat.reraise(type(exception), exception, sys.exc_info()[2])
  File "/media/data/dec/projects/12.0/odoo/odoo/tools/pycompat.py", line 87, in reraise
    raise value
  File "/media/data/dec/projects/12.0/odoo/odoo/http.py", line 727, in dispatch
    result = self._call_function(**self.params)
  File "/media/data/dec/projects/12.0/odoo/odoo/http.py", line 375, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/media/data/dec/projects/12.0/odoo/odoo/service/model.py", line 98, in wrapper
    return f(dbname, *args, **kwargs)
  File "/media/data/dec/projects/12.0/odoo/odoo/http.py", line 368, in checked_call
    result = self.endpoint(*a, **kw)
  File "/media/data/dec/projects/12.0/odoo/odoo/http.py", line 979, in __call__
    return self.method(*args, **kw)
  File "/media/data/dec/projects/12.0/odoo/odoo/http.py", line 548, in response_wrap
    response = f(*args, **kw)
  File "/media/data/dec/projects/12.0/odoo/addons/web/controllers/main.py", line 966, in call_button
    action = self._call_kw(model, method, args, {})
  File "/media/data/dec/projects/12.0/odoo/addons/web/controllers/main.py", line 954, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/media/data/dec/projects/12.0/odoo/odoo/api.py", line 761, in call_kw
    return _call_kw_multi(method, model, args, kwargs)
  File "/media/data/dec/projects/12.0/odoo/odoo/api.py", line 748, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/media/data/dec/projects/12.0/odoo-addons/oca/credit-control/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py", line 125, in run
    existing_actions.unlink()
  File "/media/data/dec/projects/12.0/odoo/odoo/models.py", line 3199, in unlink
    attachments.unlink()
  File "/media/data/dec/projects/12.0/odoo/odoo/addons/base/models/ir_attachment.py", line 501, in unlink
    self.check('unlink')
  File "/media/data/dec/projects/12.0/odoo/odoo/addons/base/models/ir_attachment.py", line 384, in check
    records.check_access_rule(mode)
  File "/media/data/dec/projects/12.0/odoo/odoo/models.py", line 3073, in check_access_rule
    invalid = self - self._filter_access_rules(operation)
  File "/media/data/dec/projects/12.0/odoo/odoo/models.py", line 3118, in _filter_access_rules
    self._cr.execute(query, (tuple(self.ids), self._uid))
  File "/media/data/dec/projects/12.0/odoo/odoo/sql_db.py", line 154, in wrapper
    return f(self, *args, **kwargs)
  File "/media/data/dec/projects/12.0/odoo/odoo/sql_db.py", line 231, in execute
    res = self._obj.execute(query, params)
psycopg2.errors.SyntaxError: syntax error at or near ")"
LINE 1: SELECT id FROM overdue_reminder_step WHERE id IN () AND crea...
```

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
