### PR TITLE
[FIX] web_editor: allow edition of branded nodes only

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -97,6 +97,21 @@ var Wysiwyg = Widget.extend({
                     {
                         selector: [
                             (node) => {
+                                return !node.closest(ancestor => {
+                                    return (
+                                        ancestor instanceof this.JWEditorLib.OdooStructureNode ||
+                                        ancestor instanceof this.JWEditorLib.OdooFieldNode
+                                    );
+                                });
+                            },
+                        ],
+                        properties: {
+                            editable: { value: false },
+                        },
+                    },
+                    {
+                        selector: [
+                            (node) => {
                                 const attributes = node.modifiers.find(this.JWEditorLib.Attributes);
                                 const isWrapper = attributes && attributes.classList.has('oe_structure') ;
                                 return isWrapper;


### PR DESCRIPTION
To be able to be saved, nodes have to provide information on where to save them. This is done through the use of data attributes. Nodes that do not have these data attributes or are not contained within nodes that do, should therefore not be editable.
Recent changes in Jabberwock ensure that the nodes with these data attributes are saved either as `OdooStructureNode` or as `OdooFieldNode` so we can simply check for these.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
