### PR TITLE
[FIX] account,sale: restrict access rights

### DIFF
--- a/addons/account/security/account_security.xml
+++ b/addons/account/security/account_security.xml
@@ -200,6 +200,28 @@
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>
 
+    <!-- Billing: invoice, invoice lines, jounnal items -->
+    <record id="account_invoice_rule_billing" model="ir.rule">
+        <field name="name">Billing: All Invoices</field>
+        <field name="model_id" ref="account.model_account_invoice"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('account.group_account_invoice'))]"/>
+    </record>
+
+    <record id="account_invoice_line_rule_billing" model="ir.rule">
+        <field name="name">Billing: All Invoice Lines</field>
+        <field name="model_id" ref="account.model_account_invoice_line"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('account.group_account_invoice'))]"/>
+    </record>
+
+    <record id="account_move_line_rule_billing" model="ir.rule">
+        <field name="name">Billing: All Journal Items</field>
+        <field name="model_id" ref="account.model_account_move_line"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('account.group_account_invoice'))]"/>
+    </record>
+
     <!-- Enable products on bills by default at installation -->
     <record id="base.group_user" model="res.groups">
         <field name="implied_ids" eval="[(4, ref('account.group_products_in_bills'))]"/>

--- a/addons/sale/security/sale_security.xml
+++ b/addons/sale/security/sale_security.xml
@@ -93,6 +93,47 @@
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>
 
+    <!-- Accounting rules: invoice, invoice lines, jounal items -->
+
+    <record id="account_invoice_personal_rule" model="ir.rule">
+        <field name="name">Personal Invoices</field>
+        <field name="model_id" ref="account.model_account_invoice"/>
+        <field name="domain_force">['|',('user_id','=',user.id),('user_id','=',False)]</field>
+        <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
+    </record>
+    <record id="account_invoice_see_all" model="ir.rule">
+        <field name="name">All Invoices</field>
+        <field name="model_id" ref="account.model_account_invoice"/>
+        <field name="domain_force">[(1,'=',1)]</field>
+        <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
+    </record>
+
+    <record id="account_invoice_line_personal_rule" model="ir.rule">
+        <field name="name">Personal Invoice Lines</field>
+        <field name="model_id" ref="account.model_account_invoice_line"/>
+        <field name="domain_force">['|',('invoice_id.user_id','=',user.id),('invoice_id.user_id','=',False)]</field>
+        <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
+    </record>
+    <record id="account_invoice_line_see_all" model="ir.rule">
+        <field name="name">All Invoice Lines</field>
+        <field name="model_id" ref="account.model_account_invoice_line"/>
+        <field name="domain_force">[(1,'=',1)]</field>
+        <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
+    </record>
+
+    <record id="account_move_line_personal_rule" model="ir.rule">
+        <field name="name">Personal Move Lines</field>
+        <field name="model_id" ref="account.model_account_move_line"/>
+        <field name="domain_force">['|',('invoice_id.user_id','=',user.id),('invoice_id.user_id','=',False)]</field>
+        <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
+    </record>
+    <record id="account_move_line_see_all" model="ir.rule">
+        <field name="name">All Move Lines</field>
+        <field name="model_id" ref="account.model_account_move_line"/>
+        <field name="domain_force">[('invoice_id','!=',False)]</field>
+        <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
+    </record>
+
     <!-- Multi - Salesmen sales order assignation rules -->
 
     <record id="sale_order_personal_rule" model="ir.rule">


### PR DESCRIPTION
STEPS:
* create a user with with Sales access ("User: Own Documents only" or higher),
but without Accounting access
* log in as that user and open directly (via link you get when logged in as
admin) one of the following pages:

  - Invoices menu/record
  - Journal Item menu/record

BEFORE: not restrictions are applied for invoices/journal item

AFTER:
* Invoices:
  - "User: Own Documents only": only his records
  - "User: All Documents": all records
* Journal Items:
  - "User: Own Documents only": only his records
  - "User: All Documents": all records from invoices

WHY:
* This is something similar to what was done in Odoo 13+: https://github.com/odoo/odoo/commit/3abe78087a0426ad2783942baa01e1d5fbdff2d9
* This can be further improved to make separation for sales/purchase, but this
seems too dangerous for stable branch

---

opw-2379023

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
