### PR TITLE
[FIX] product,sale_management: apply pricelist discount on template price

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -618,6 +618,7 @@ class ProductProduct(models.Model):
             uom = self.env['uom.uom'].browse(self._context['uom'])
         if not currency and self._context.get('currency'):
             currency = self.env['res.currency'].browse(self._context['currency'])
+        template_prices = self._context.get('template_prices', {})
 
         products = self
         if price_type == 'standard_price':
@@ -628,7 +629,11 @@ class ProductProduct(models.Model):
 
         prices = dict.fromkeys(self.ids, 0.0)
         for product in products:
-            prices[product.id] = product[price_type] or 0.0
+            prices[product.id] = (
+                template_prices[product.id]
+                if price_type == 'list_price' and product.id in template_prices
+                else product[price_type] or 0.0
+            )
             if price_type == 'list_price':
                 prices[product.id] += product.price_extra
                 # we need to add the price from the attributes that do not generate variants

--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -141,6 +141,7 @@ class Pricelist(models.Model):
             products_qty_partner = [(products[index], data_struct[1], data_struct[2]) for index, data_struct in enumerate(products_qty_partner)]
         else:
             products = [item[0] for item in products_qty_partner]
+        template_prices = self._context.get('template_prices', {})
 
         if not products:
             return {}
@@ -167,6 +168,8 @@ class Pricelist(models.Model):
 
         results = {}
         for product, qty, partner in products_qty_partner:
+            if product.id in template_prices:
+                product = product.with_context(template_prices={product.id: template_prices[product.id]})
             results[product.id] = 0.0
             suitable_rule = False
 

--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -76,7 +76,8 @@ class SaleOrder(models.Model):
             if line.product_id:
                 discount = 0
                 if self.pricelist_id:
-                    price = self.pricelist_id.with_context(uom=line.product_uom_id.id).get_product_price(line.product_id, 1, False)
+                    template_prices = {line.product_id.id: line.price_unit} if line.price_unit != line.product_id.list_price else {}
+                    price = self.pricelist_id.with_context(uom=line.product_uom_id.id, template_prices=template_prices).get_product_price(line.product_id, 1, False)
                     if self.pricelist_id.discount_policy == 'without_discount' and line.price_unit:
                         discount = (line.price_unit - price) / line.price_unit * 100
                         # negative discounts (= surcharge) are included in the display price
@@ -84,8 +85,6 @@ class SaleOrder(models.Model):
                             discount = 0
                         else:
                             price = line.price_unit
-                    elif line.price_unit:
-                        price = line.price_unit
 
                 else:
                     price = line.price_unit


### PR DESCRIPTION
- Install sale_management
- Go to Sales > Configuration > Settings
- Enable Pricelists with Advanced price rules
- Go to Sales > Products > Pricelists
- Create a Pricelist with the following Price Rule:
  * Apply On: All Products
  * Compute Price: Percentage (discount)
  * Percentage Price: 10%
- Go to Sales > Configuration > Quotation Templates
- Create a Quotation Template with a Product
- Create a Quotation:
  1) Select Customer
  2) Select created Pricelist
  3) Select created Quotation Template
The Unit Price of the Product is exactly the one from Template, without
the discount from Pricelist applied to it.

There are 2 reasons for this behavior:
- When a Quotation Template is selected, prices used for Products are exactly
the ones defined in Template.
- Pricelists only compute prices from Product directly and Unit Prices defined
in a Template are not available during this computation. Therefore, they cannot
be used as base value when applying Price Rules from Pricelist.

To be able to apply Price Rules to prices from Quotation Template, these prices
are set in the context and retrieved in price_compute method of "product.product".

opw-2411978

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
