### PR TITLE
[FIX] website_theme_install: env/cache inconsistencies

### DIFF
--- a/addons/website_theme_install/models/ir_module_module.py
+++ b/addons/website_theme_install/models/ir_module_module.py
@@ -209,9 +209,6 @@ class IrModuleModule(models.Model):
             for model_name in self._theme_model_names:
                 module._update_records(model_name, website)
 
-            # reload registry to check if 'theme.utils'._<theme_name>_post_copy exists
-            self.env.reset()
-            self = self.env()[self._name].browse(self.id)
             self.env['theme.utils']._post_copy(module, website)
 
     @api.multi


### PR DESCRIPTION
In the `_theme_load` method, a call to `self.env.reset()` in the
for loop leaded to an inconsistency between the new `self.env` and
the `module.env` that was still refering to the old `self.env`.

This inconsistency leaded to cache invalidation issues.

After discussion with the website team, this `reset` patch is not
useful anymore (see PR #63253).

Upgrade request: 48631 and 49373

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
