### PR TITLE
[FIX] website_form: verify that both input and textarea select form

### DIFF
--- a/addons/website_form/static/tests/tours/website_form_editor.js
+++ b/addons/website_form/static/tests/tours/website_form_editor.js
@@ -91,7 +91,37 @@ odoo.define('website_form_editor.tour', function (require) {
             trigger: '#oe_snippets .oe_snippet:has(.s_website_form) .oe_snippet_thumbnail',
             run: 'drag_and_drop #wrap',
         }, {
-            content: "Check dropped snippet and select it",
+            content: "Select form by clicking on an input field",
+            extra_trigger: '.s_website_form_field',
+            trigger: 'section.s_website_form input',
+        }, {
+            content: "Verify that the form editor appeared",
+            trigger: '.o_we_customize_panel .snippet-option-WebsiteFormEditor',
+            run: () => null,
+        }, {
+            content: "Go back to blocks to unselect form",
+            trigger: '.o_we_add_snippet_btn',
+        }, {
+            content: "Select form by clicking on a text area",
+            extra_trigger: '.s_website_form_field',
+            trigger: 'section.s_website_form textarea',
+        }, {
+            content: "Verify that the form editor appeared",
+            trigger: '.o_we_customize_panel .snippet-option-WebsiteFormEditor',
+            run: () => null,
+        }, {
+            content: "Rename the field label",
+            trigger: 'we-input[data-set-label-text] input',
+            run: "text Renamed",
+        }, {
+            content: "Leave the rename options",
+            trigger: 'we-input[data-set-label-text] input',
+            run: "text_blur",
+        }, {
+            content: "Go back to blocks to unselect form",
+            trigger: '.o_we_add_snippet_btn',
+        }, {
+            content: "Select form itself (not a specific field)",
             extra_trigger: '.s_website_form_field',
             trigger: 'section.s_website_form',
         },


### PR DESCRIPTION
When Jabberwock was introduced in [1], forms were not selected anymore
by clicking on the form fields.
That behavior got fixed when Jabberwock was removed in [2] but this
commit introducing a test about it was not attached to a task - and did
not get merged at the time.

Before this commit there was no test to verify if the form became
selected when clicking on one of its input field or textarea.

After this commit there is a test that makes sure that the form is
selected when the user clicks on either an input field or a textarea.
Also added the renaming of a field label followed by a blur to ensure
it triggers all UI events.

[1] https://github.com/odoo/odoo/commit/347f4413d1b1a2b1a6a9ecd6d9c20cf7f3ec5ff3 
[2] https://github.com/odoo/odoo/commit/e5572c317a7775a58675ed73efc89b5c9f6c0c39 

task-2729643


Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
