### PR TITLE
[FIX] stock: click on forecast widget

### DIFF
--- a/addons/stock/static/src/js/forecast_widget.js
+++ b/addons/stock/static/src/js/forecast_widget.js
@@ -34,7 +34,7 @@ const ForecastWidgetField = AbstractField.extend({
         data.will_be_fulfilled = utils.round_decimals(data.forecast_availability, this.record.fields.forecast_availability.digits[1]) >= utils.round_decimals(data.product_qty, this.record.fields.product_qty.digits[1]);
 
         this.$el.html(QWeb.render('stock.forecastWidget', data));
-        this.$el.on('click', this._onOpenReport.bind(this));
+        this.$('.o_forecast_report_button').on('click', this._onOpenReport.bind(this));
     },
 
     isSet: function () {


### PR DESCRIPTION
Before this commit, once a field has the 'forecast_widget', the user is redirect to the forecast report also when they clicks on the field.

How to reproduce:
  - Creates/Opens a delivery;
  - In Operations list, clicks on the reserved qty. field of one of the line -> It opens the forecast report.

The wanted behaviour is the user is redirected to the report only if they
clicks on the widget's button, not on the field itself.

task-2415918