### PR TITLE
Run odoo 14.0 on python 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ idna==2.6
 Jinja2==2.10.1; python_version < '3.8'
 # bullseye version, focal patched 2.10
 Jinja2==2.11.2; python_version >= '3.8'
-libsass==0.17.0
+libsass==0.20.1
 lxml==3.7.1 ; sys_platform != 'win32' and python_version < '3.7'
 lxml==4.3.2 ; sys_platform != 'win32' and python_version == '3.7'
 lxml==4.6.1 ; sys_platform != 'win32' and python_version > '3.7'
@@ -26,7 +26,7 @@ Mako==1.0.7
 MarkupSafe==1.1.0
 num2words==0.5.6
 ofxparse==0.19
-passlib==1.7.1
+passlib==1.7.4
 Pillow==5.4.1 ; python_version <= '3.7' and sys_platform != 'win32'
 Pillow==6.1.0 ; python_version <= '3.7' and sys_platform == 'win32'
 Pillow==8.0.1 ; python_version > '3.7'
@@ -47,7 +47,7 @@ reportlab==3.5.13; python_version < '3.8'
 reportlab==3.5.55; python_version >= '3.8'
 requests==2.21.0
 zeep==3.2.0
-python-stdnum==1.8
+python-stdnum==1.14
 vobject==0.9.6.1
 Werkzeug==0.16.1
 XlsxWriter==1.1.2


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Run odoo 14.0 on python 3.8

Current behavior before PR: it generates build errors

Desired behavior after PR is merged: build completes without issues, below are environment details 
- odoo 14.0
- python 3.8
- windows 10
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
