### PR TITLE
Copy necessary filestore to new db when using db template

### DIFF
--- a/odoo/service/db.py
+++ b/odoo/service/db.py
@@ -110,6 +110,10 @@ def _create_empty_database(name):
                 """CREATE DATABASE "%s" ENCODING 'unicode' %s TEMPLATE "%s" """ %
                 (name, collate, chosen_template)
             )
+        from_fs = odoo.tools.config.filestore(chosen_template)
+        to_fs = odoo.tools.config.filestore(name)
+        if os.path.exists(from_fs) and not os.path.exists(to_fs):
+            shutil.copytree(from_fs, to_fs)
 
 @check_db_management_enabled
 def exp_create_database(db_name, demo, lang, user_password='admin', login='admin', country_code=None, phone=None):


### PR DESCRIPTION
Copy necessary filestore to new db when using db template

Description of the issue/feature this PR addresses:
The filestore will not be created when use db template to create new database

Current behavior before PR:
static files like css in filestore will lost

Desired behavior after PR is merged:
copy template's filestore to new database




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
