### PR TITLE
country_code in request can't match pytz timezone

### DIFF
--- a/odoo/service/db.py
+++ b/odoo/service/db.py
@@ -71,9 +71,9 @@ def _initialize_db(id, db_name, demo, lang, user_password, login='admin', countr
             if country_code:
                 country = env['res.country'].search([('code', 'ilike', country_code)])[0]
                 env['res.company'].browse(1).write({'country_id': country_code and country.id, 'currency_id': country_code and country.currency_id.id})
-                if len(country_timezones.get(country_code, [])) == 1:
+                if len(country_timezones.get(country_code.upper(), [])) >= 1:
                     users = env['res.users'].search([])
-                    users.write({'tz': country_timezones[country_code][0]})
+                    users.write({'tz': country_timezones[country_code.upper()][0]})
             if phone:
                 env['res.company'].browse(1).write({'phone': phone})
             if '@' in login:


### PR DESCRIPTION

Description of the issue/feature this PR addresses:
The country code from request is in lower case and the keys in country_timezones is upper case so the if condition can never meet
and some countries have more than one timezone in country_timezones, so use >= 1 to judge

Current behavior before PR:
the timezone in user profile is always null

Desired behavior after PR is merged:
the timezone in user profile will be set when the country is correctly selected 



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
