### PR TITLE
[FIX] fix on POS Ui for editing customers always asking to change name

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientDetailsEdit.js
+++ b/addons/point_of_sale/static/src/js/Screens/ClientListScreen/ClientDetailsEdit.js
@@ -44,7 +44,8 @@ odoo.define('point_of_sale.ClientDetailsEdit', function(require) {
                     processedChanges[key] = value;
                 }
             }
-            if (!processedChanges.name) {
+            if ((!this.props.partner.name && !processedChanges.name) ||
+                processedChanges.name === '' ){
                 return this.showPopup('ErrorPopup', {
                   title: _('A Customer Name Is Required'),
                 });

--- a/doc/cla/individual/fedegobea.md
+++ b/doc/cla/individual/fedegobea.md
@@ -1,0 +1,11 @@
+Argentina, 12/12/2020
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Federico Gobea 65693362+fedegobea@users.noreply.github.com https://github.com/fedegobea


### PR DESCRIPTION

Best regards

Description of the issue/feature this PR addresses:
Hi i detected an issue on POS, to reproduce just get into a customer on the POS UI, change something else than the name, then try to save changes, this trigger the if in line 47 of ClientDetailsEdit, making the user to mandatory edit the name field then save again and it works.

Current behavior before PR:
Name is asked when user edits something else when name ios available

Desired behavior after PR is merged:
If name is present it doesnt ask for it, if it isnt presents it asks for it

The only change on the file is on line 47 where I check if the name is already on the prop so that it works as intended.

Its a mild UX issue with a very easy fix. hope you can upload it soon to the repo so that users on Odoo SaaS or users with no code skills dont have this Issue anymore-


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
