### PR TITLE
[IMP] purchase: avoid generating vendor bill with zero qty lines

### DIFF
--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
+from odoo.tools.float_utils import float_is_zero
 
 
 class AccountMove(models.Model):
@@ -52,7 +53,7 @@ class AccountMove(models.Model):
         # Copy purchase lines.
         po_lines = self.purchase_id.order_line - self.line_ids.mapped('purchase_line_id')
         new_lines = self.env['account.move.line']
-        for line in po_lines.filtered(lambda l: not l.display_type):
+        for line in po_lines.filtered(lambda l: not l.display_type and not float_is_zero(l._get_to_bill_quantity(), precision_rounding=l.product_uom.rounding)):
             new_line = new_lines.new(line._prepare_account_move_line(self))
             new_line.account_id = new_line._get_computed_account()
             new_line._onchange_price_subtotal()

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -753,7 +753,7 @@ class PurchaseOrderLine(models.Model):
 
         return name
 
-    def _prepare_account_move_line(self, move):
+    def _get_to_bill_quantity(self):
         self.ensure_one()
         if self.product_id.purchase_method == 'purchase':
             qty = self.product_qty - self.qty_invoiced
@@ -761,6 +761,11 @@ class PurchaseOrderLine(models.Model):
             qty = self.qty_received - self.qty_invoiced
         if float_compare(qty, 0.0, precision_rounding=self.product_uom.rounding) <= 0:
             qty = 0.0
+        return qty
+
+    def _prepare_account_move_line(self, move):
+        self.ensure_one()
+        qty = self._get_to_bill_quantity()
 
         if self.currency_id == move.company_id.currency_id:
             currency = False


### PR DESCRIPTION
### Steps to reproduce
1. Create some products with `On received quantities` specified for vendor bill policy
2. Create a PO for these products
3. Receive some of them (in Inventory)
4. Create a bill from PO

### Current Behaviour
Each PO line will generate a bill line no mater the to-bill quantity is. For example, we have 100 lines on PO and we just receive a part of the first PO line, Odoo will still generate a bill with 100 lines 99 of which come with zero quantity.
Then, accountant should have to remove these 99 lines manually as they don't want it as it does not make sense.

### Expected behaviour
A new vendor bill is genrated with lines of non-zero quatity. Products that we have not received should not create a bill line


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
