### PR TITLE
[FIX] l10n_vn: Anglo-Saxon is not accepted in Vietnam

### DIFF
--- a/addons/l10n_vn/data/l10n_vn_chart_data.xml
+++ b/addons/l10n_vn/data/l10n_vn_chart_data.xml
@@ -11,7 +11,7 @@
         <field name="bank_account_code_prefix">112</field>
         <field name="cash_account_code_prefix">111</field>
         <field name="transfer_account_code_prefix">113</field>
-        <field name="use_anglo_saxon" eval="True"/>
+        <field name="use_anglo_saxon" eval="False"/>
     </record>
 </data>
 </odoo>


### PR DESCRIPTION
This bug was introduced by https://github.com/odoo/odoo/pull/42577

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
