### PR TITLE
[FIX] web: Select subfields without removing filter text on export

### DIFF
--- a/addons/web/static/src/js/widgets/data_export.js
+++ b/addons/web/static/src/js/widgets/data_export.js
@@ -264,7 +264,6 @@ var DataExport = Dialog.extend({
             var $el = $(el);
             $el.find('.o_tree_column').first().toggleClass('o_required', !!self.records[$el.data('id')].required);
         });
-        this.$('#o-export-search-filter').val('');
     },
     /**
      * @private
@@ -318,7 +317,6 @@ var DataExport = Dialog.extend({
                 $child.show();
             }
         }
-        this.$('#o-export-search-filter').val('');
     },
     /**
      * Fetches the saved export list for the current model


### PR DESCRIPTION
What are the steps to reproduce your issue ?

    1. Install "contacts"
    2. Select list view and select one or more contacts
    3. Select "Export" actions

What is currently happening ?

    When filtering fields with text, the system only displays the corresponding
    fields, but when clicking on sub-field the text written just before
    is deleted, which prevents us to return to all fields without filter

What are you expecting to happen ?

    Filter fields and select sub-field without deleting the filter text

opw-2411928