### PR TITLE
[FIX] account: disable partial payments in auto reconciliation

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -715,6 +715,11 @@ class AccountReconcileModel(models.Model):
 
                             new_aml_dicts = reconciliation_results['new_aml_dicts']
                             if reconciliation_results['open_balance_dict']:
+                                open_balance_debit = reconciliation_results['open_balance_dict']['debit']
+                                open_balance_credit = reconciliation_results['open_balance_dict']['credit']
+                                if open_balance_debit or open_balance_credit:
+                                    # TODO: add partial payment support
+                                    break
                                 new_aml_dicts.append(reconciliation_results['open_balance_dict'])
                             if not line.partner_id and partner:
                                 line.partner_id = partner


### PR DESCRIPTION
STEPS:

* install Accounting
* open ``Accounting >> Configuration >> Accounting >> Reconciliation Models``
* open *Invoices Matching Rule* and set  ``[x] Auto-Validate``
* create customer invoice
* create bank statement with partial payment for the invoice
* click `[Reconcile]`

BEFORE:
* customer invoice is marked as paid
* "Open Balance" line is created

AFTER: Reconciliation page is open with warning sign /!\ near to the partial
payment

---

opw-2344257
opw-2409622

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
