### PR TITLE
[IMP] website_sale: add optional cart redirect behaviour

### DIFF
--- a/addons/test_website_slides_full/tests/tours/slides_certification_member.js
+++ b/addons/test_website_slides_full/tests/tours/slides_certification_member.js
@@ -2,6 +2,7 @@ odoo.define('test_website_slides_full.tour.slide.certification.member', function
 "use strict";
 
 var tour = require('web_tour.tour');
+const tourUtils = require('website_sale.tour_utils');
 
 /**
  * The purpose of this tour is to check the whole certification flow:
@@ -40,7 +41,9 @@ var initTourSteps = [{
 var buyCertificationSteps = [{
     content: 'eLearning: try to buy course',
     trigger: 'a:contains("Add to Cart")'
-}, {
+}, 
+    tourUtils.goToCart(),
+{
     content: 'eCommerce: Process Checkout',
     trigger: 'a:contains("Process Checkout")'
 }, {

--- a/addons/website_sale/models/res_config_settings.py
+++ b/addons/website_sale/models/res_config_settings.py
@@ -34,6 +34,7 @@ class ResConfigSettings(models.TransientModel):
                                                   related='website_id.cart_recovery_mail_template_id', readonly=False)
     cart_abandoned_delay = fields.Float("Abandoned Delay", help="Number of hours after which the cart is considered abandoned.",
                                         related='website_id.cart_abandoned_delay', readonly=False)
+    cart_add_on_page = fields.Boolean("Stay on page after adding to cart", related='website_id.cart_add_on_page', readonly=False)
 
     @api.model
     def get_values(self):

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -50,6 +50,8 @@ class Website(models.Model):
 
     shop_extra_field_ids = fields.One2many('website.sale.extra.field', 'website_id', string='E-Commerce Extra Fields')
 
+    cart_add_on_page = fields.Boolean("Stay on page after adding to cart", default=True)
+
     @api.depends('all_pricelist_ids')
     def _compute_pricelist_ids(self):
         Pricelist = self.env['product.pricelist']

--- a/addons/website_sale/static/src/js/tours/tour_utils.js
+++ b/addons/website_sale/static/src/js/tours/tour_utils.js
@@ -1,0 +1,20 @@
+odoo.define("website_sale.tour_utils", function (require) {
+    "use strict";
+    
+    const core = require("web.core");
+    const _t = core._t;
+
+
+    function goToCart(quantity = 1, position = "bottom") {
+        return {
+            content: _t("Go to cart"),
+            trigger: `a:has(.my_cart_quantity:containsExact(${quantity}))`,
+            position: position,
+            run: "click",
+        };
+    }
+
+    return {
+        goToCart,
+    };
+});

--- a/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
+++ b/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
@@ -3,6 +3,7 @@ odoo.define('website_sale_tour.tour', function (require) {
 
     var tour = require("web_tour.tour");
     var rpc = require("web.rpc");
+    const tourUtils = require('website_sale.tour_utils');
 
     tour.register('website_sale_tour', {
         test: true,
@@ -26,6 +27,7 @@ odoo.define('website_sale_tour.tour', function (require) {
         content: "Click on add to cart",
         trigger: '#add_to_cart',
     },
+        tourUtils.goToCart(2),
     {
         content: "Check for 2 products in cart and proceed to checkout",
         extra_trigger: '#cart_products tr:contains("Storage Box Test") input.js_quantity:propValue(2)',
@@ -220,6 +222,7 @@ odoo.define('website_sale_tour.tour', function (require) {
         content: "Click on add to cart",
         trigger: '#add_to_cart',
     },
+        tourUtils.goToCart(2),
     {
         content: "Check for 2 products in cart and proceed to checkout",
         extra_trigger: '#cart_products tr:contains("Storage Box Test") input.js_quantity:propValue(2)',
@@ -359,6 +362,7 @@ odoo.define('website_sale_tour.tour', function (require) {
         content: "Click on add to cart",
         trigger: '#add_to_cart',
     },
+        tourUtils.goToCart(),
     {
         content: "Proceed to checkout",
         trigger: 'a[href*="/shop/checkout"]',

--- a/addons/website_sale/static/tests/tours/website_sale_shop_cart_recovery.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_cart_recovery.js
@@ -4,6 +4,7 @@ odoo.define('website_sale.tour_shop_cart_recovery', function (require) {
 var localStorage = require('web.local_storage');
 var rpc = require('web.rpc');
 var tour = require('web_tour.tour');
+const tourUtils = require('website_sale.tour_utils');
 require('web.dom_ready');
 
 var orderIdKey = 'website_sale.tour_shop_cart_recovery.orderId';
@@ -22,6 +23,7 @@ tour.register('shop_cart_recovery', {
         content: "click add to cart",
         trigger: '#product_details #add_to_cart',
     },
+        tourUtils.goToCart(),
     {
         content: "check product is in cart, get cart id, logout, go to login",
         trigger: 'td.td-product_name:contains("Acoustic Bloc Screens")',

--- a/addons/website_sale/static/tests/tours/website_sale_shop_custom_attribute_value.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_custom_attribute_value.js
@@ -2,6 +2,7 @@ odoo.define("website_sale.tour_shop_custom_attribute_value", function (require) 
     "use strict";
 
     var tour = require("web_tour.tour");
+    const tourUtils = require('website_sale.tour_utils');
 
     tour.register("shop_custom_attribute_value", {
         url: "/shop?search=Customizable Desk",
@@ -20,7 +21,9 @@ odoo.define("website_sale.tour_shop_custom_attribute_value", function (require) 
         id: 'add_cart_step',
         trigger: 'a:contains(Add to Cart)',
         run: 'click',
-    }, {
+    },
+        tourUtils.goToCart(), 
+    {
         trigger: 'span:contains(Custom TEST: Wood)',
         extra_trigger: '#cart_products',
         run: function (){}, // check

--- a/addons/website_sale/static/tests/tours/website_sale_shop_customize.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_customize.js
@@ -2,6 +2,7 @@ odoo.define('website_sale.tour_shop_customize', function (require) {
     'use strict';
 
     var tour = require("web_tour.tour");
+    const tourUtils = require('website_sale.tour_utils');
 
     tour.register('shop_customize', {
         test: true,
@@ -119,6 +120,7 @@ odoo.define('website_sale.tour_shop_customize', function (require) {
                 trigger: '.my_cart_quantity:containsExact(1),.o_extra_menu_items .fa-plus',
                 run: function () {}, // it's a check
             },
+                tourUtils.goToCart(),
             {
                 content: "click on shop",
                 trigger: "a:contains(Continue Shopping)",

--- a/addons/website_sale/static/tests/tours/website_sale_shop_dynamic_variants.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_dynamic_variants.js
@@ -2,6 +2,7 @@ odoo.define('website_sale.tour_shop_dynamic_variants', function (require) {
 'use strict';
 
 var tour = require('web_tour.tour');
+const tourUtils = require('website_sale.tour_utils');
 
 // This tour relies on a data created from the python test.
 tour.register('tour_shop_dynamic_variants', {
@@ -27,6 +28,7 @@ tour.register('tour_shop_dynamic_variants', {
         extra_trigger: 'body:has(input[type="hidden"][name="product_id"][value=0])',
         trigger: '#add_to_cart',
     },
+        tourUtils.goToCart(),
     {
         content: "check the variant is in the cart",
         trigger: 'td.td-product_name:contains(Dynamic Product (Dynamic Value 2))',

--- a/addons/website_sale/static/tests/tours/website_sale_shop_list_view_b2c.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_list_view_b2c.js
@@ -2,6 +2,7 @@ odoo.define('website_sale.tour_shop_list_view_b2c', function (require) {
 'use strict';
 
 var tour = require('web_tour.tour');
+const tourUtils = require('website_sale.tour_utils');
 
 tour.register('shop_list_view_b2c', {
     test: true,
@@ -60,6 +61,7 @@ tour.register('shop_list_view_b2c', {
             content: "click on 'Add to Cart' button",
             trigger: 'a:contains(Add to Cart)',
         },
+            tourUtils.goToCart(),
         {
             content: "check price on /cart",
             trigger: '#cart_products .oe_currency_value:containsExact("880.44")',

--- a/addons/website_sale/static/tests/tours/website_sale_shop_mail.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_mail.js
@@ -3,6 +3,7 @@ odoo.define('website_sale.tour_shop_mail', function (require) {
 
 var rpc = require('web.rpc');
 var tour = require('web_tour.tour');
+const tourUtils = require('website_sale.tour_utils');
 
 require('web.dom_ready');
 
@@ -47,6 +48,7 @@ tour.register('shop_mail', {
         content: "click add to cart",
         trigger: '#product_details #add_to_cart',
     },
+        tourUtils.goToCart(),
     {
         content: "check product is in cart, get cart id, go to backend",
         trigger: 'td.td-product_name:contains("Acoustic Bloc Screens")',

--- a/addons/website_sale/static/tests/tours/website_sale_shop_no_variant_attribute.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_no_variant_attribute.js
@@ -2,6 +2,7 @@ odoo.define('website_sale.tour_shop_no_variant_attribute', function (require) {
 'use strict';
 
 var tour = require('web_tour.tour');
+const tourUtils = require('website_sale.tour_utils');
 
 // This tour relies on a data created from the python test.
 tour.register('tour_shop_no_variant_attribute', {
@@ -22,6 +23,7 @@ tour.register('tour_shop_no_variant_attribute', {
         content: "add to cart",
         trigger: 'a:contains(Add to Cart)',
     },
+        tourUtils.goToCart(),
     {
         content: "check no_variant value is present",
         trigger: '.td-product_name:contains(No Variant Attribute: No Variant Value)',

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -59,6 +59,20 @@
                             </div>
                         </div>
                     </div>
+
+                    <div class="col-12 col-lg-6 o_setting_box" id="cart_redirect_setting">
+                        <div class="o_setting_left_pane">
+                            <field name="cart_add_on_page"/>
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="cart_add_on_page"/>
+                            <span class="fa fa-lg fa-globe" title="Values set here are website-specific." groups="website.group_multi_website"/>
+                            <div class="text-muted">
+                                No redirect when the user adds a product to cart.
+                            </div>
+                        </div>
+                    </div>
+
                     <div class="col-12 col-lg-6 o_setting_box" id="comparator_option_setting">
                         <div class="o_setting_left_pane">
                             <field name="module_website_sale_comparison"/>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -53,6 +53,7 @@
 
     <template id="assets_common" name="tour" inherit_id="web.assets_common">
         <xpath expr="." position="inside">
+            <script type="text/javascript" src="/website_sale/static/src/js/tours/tour_utils.js"></script>
             <script type="text/javascript" src="/website_sale/static/src/js/tours/website_sale_shop.js"></script>
         </xpath>
     </template>
@@ -771,7 +772,7 @@
 
     <template id="product_buy_now" inherit_id="website_sale.product" active="False" customize_show="True" name="Buy Now Button">
         <xpath expr="//a[@id='add_to_cart']" position="after">
-            <a role="button" id="buy_now" class="btn btn-outline-primary btn-lg mt16 d-block d-sm-inline-block" href="#"><i class="fa fa-bolt"/> Buy Now</a>
+            <a role="button" class="btn btn-outline-primary btn-lg mt16 d-block d-sm-inline-block o_we_buy_now" href="#"><i class="fa fa-bolt"/> Buy Now</a>
         </xpath>
     </template>
 
@@ -1932,4 +1933,9 @@
         </xpath>
     </template>
 
+    <template id="add_to_cart_redirect" inherit_id="website.layout" name="Cart Redirection" priority="1">
+        <xpath expr="//html" position="before">
+            <t t-set="html_data" t-value="dict(html_data, **{'data-add2cart-redirect': website.cart_add_on_page and '1' or '0'})"/>
+        </xpath>
+    </template>
 </odoo>

--- a/addons/website_sale_comparison/static/tests/tours/website_sale_comparison.js
+++ b/addons/website_sale_comparison/static/tests/tours/website_sale_comparison.js
@@ -3,6 +3,7 @@ odoo.define('website_sale_comparison.tour_comparison', function (require) {
 
     var tour = require('web_tour.tour');
     var rpc = require('web.rpc');
+    const tourUtils = require('website_sale.tour_utils');
 
     tour.register('product_comparison', {
         test: true,
@@ -159,6 +160,7 @@ odoo.define('website_sale_comparison.tour_comparison', function (require) {
         content: "add product 'Conference Chair' to cart",
         trigger: '.product_summary:contains("Conference Chair") .a-submit:contains("Add to Cart")',
     },
+        tourUtils.goToCart(),
     {
         content: "check product correctly added to cart",
         trigger: '#cart_products:contains("Conference Chair") .js_quantity[value="1"]',

--- a/addons/website_sale_coupon/static/tests/tours/website_sale_coupon.js
+++ b/addons/website_sale_coupon/static/tests/tours/website_sale_coupon.js
@@ -4,6 +4,7 @@ odoo.define('website_sale_coupon.test', function (require) {
 require("website_sale.tour");
 var tour = require("web_tour.tour");
 var ajax = require('web.ajax');
+const tourUtils = require('website_sale.tour_utils');
 
 tour.register('shop_sale_coupon', {
     test: true,
@@ -39,6 +40,7 @@ tour.register('shop_sale_coupon', {
             content: "click on 'Add to Cart' button",
             trigger: "a:contains(Add to Cart)",
         },
+            tourUtils.goToCart(2),
         {
             content: "open customize menu",
             extra_trigger: '.oe_website_sale .oe_cart',
@@ -119,6 +121,7 @@ tour.register('shop_sale_coupon', {
             content: "click on 'Add to Cart' button",
             trigger: "a:contains(Add to Cart)",
         },
+            tourUtils.goToCart(3),
         {
             content: "check reduction amount got recomputed and merged both discount lines into one only",
             extra_trigger: '.oe_currency_value:contains("-﻿75.50"):not(#cart_total .oe_currency_value:contains("-﻿75.50"))',

--- a/addons/website_sale_delivery/static/tests/tours/website_free_delivery.js
+++ b/addons/website_sale_delivery/static/tests/tours/website_free_delivery.js
@@ -2,6 +2,7 @@ odoo.define('website_sale_delivery.tour', function (require) {
 'use strict';
 
 var tour = require("web_tour.tour");
+const tourUtils = require('website_sale.tour_utils');
 
 tour.register('check_free_delivery', {
         test: true,
@@ -17,6 +18,7 @@ tour.register('check_free_delivery', {
             content: "click on add to cart",
             trigger: '#product_details #add_to_cart',
         },
+            tourUtils.goToCart(),
         {
             content: "go to checkout",
             extra_trigger: '#cart_products input.js_quantity:propValue(1)',

--- a/addons/website_sale_product_configurator/static/src/js/website_sale_options.js
+++ b/addons/website_sale_product_configurator/static/src/js/website_sale_options.js
@@ -35,7 +35,18 @@ publicWidget.registry.WebsiteSale.include({
 
         return this.optionalProductsModal.opened();
     },
-
+    /**
+     * Overridden to resolve _opened promise on modal
+     * when stayOnPageOption is activated.
+     *
+     * @override
+     */
+    _submitForm() {
+        if (this.optionalProductsModal && this.stayOnPageOption) {
+            this.optionalProductsModal._openedResolver();
+        }
+        return this._super(...arguments);
+    },
     /**
      * Update web shop base form quantity
      * when quantity is updated in the optional products window

--- a/addons/website_sale_slides/views/website_slides_templates.xml
+++ b/addons/website_sale_slides/views/website_slides_templates.xml
@@ -111,7 +111,9 @@
                     <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()" />
                     <input type="hidden" class="product_id" name="product_id" t-att-value="channel.product_id.id"/>
                     <input type="hidden" class="product_template_id" name="product_template_id" t-att-value="channel.product_id.id"/>
-                    <a id="add_to_cart" role="button" class="btn btn-primary btn-block js_check_product o_js_add_to_cart a-submit" href="#">
+                    <a id="add_to_cart" role="button" href="#"
+                       class="btn btn-primary btn-block js_check_product o_js_add_to_cart a-submit"
+                       data-animation-selector=".o_wslides_course_pict">
                         <i class="fa fa-shopping-cart"></i> Add to Cart
                     </a>
                     <div id="product_option_block"/>

--- a/addons/website_sale_stock/static/src/js/variant_mixin.js
+++ b/addons/website_sale_stock/static/src/js/variant_mixin.js
@@ -10,6 +10,7 @@ var xml_load = ajax.loadXML(
     '/website_sale_stock/static/src/xml/website_sale_stock_product_availability.xml',
     QWeb
 );
+require('website_sale.website_sale');
 
 /**
  * Addition to the variant_mixin._onChangeCombination
@@ -45,7 +46,7 @@ VariantMixin._onChangeCombinationStock = function (ev, $parent, combination) {
     var qty = $parent.find('input[name="add_qty"]').val();
 
     $parent.find('#add_to_cart').removeClass('out_of_stock');
-    $parent.find('#buy_now').removeClass('out_of_stock');
+    $parent.find('.o_we_buy_now').removeClass('out_of_stock');
     if (combination.product_type === 'product' && _.contains(['always', 'threshold'], combination.inventory_availability)) {
         combination.virtual_available -= parseInt(combination.cart_qty);
         if (combination.virtual_available < 0) {
@@ -60,7 +61,7 @@ VariantMixin._onChangeCombinationStock = function (ev, $parent, combination) {
         if (qty > combination.virtual_available
             || combination.virtual_available < 1 || qty < 1) {
             $parent.find('#add_to_cart').addClass('disabled out_of_stock');
-            $parent.find('#buy_now').addClass('disabled out_of_stock');
+            $parent.find('.o_we_buy_now').addClass('disabled out_of_stock');
         }
     }
 


### PR DESCRIPTION
CURRENT BEHAVIOUR:

On basic install withtout option, on add to cart, it is a controller
that redirect user checkout after.

The goal of this PR is to configure a new option within the settings
to add products to cart in the same page and tweak the current code
to make it suitable for this option.

task-2411759

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
