### PR TITLE
[IMP] test_lint: Support ES9/ES2018

### DIFF
--- a/odoo/addons/test_lint/tests/test_ecmascript.py
+++ b/odoo/addons/test_lint/tests/test_ecmascript.py
@@ -11,7 +11,7 @@ from odoo.modules import get_modules, get_module_path
 
 from . import lint_case
 
-MAX_ES_VERSION = 'es8'
+MAX_ES_VERSION = 'es9'
 
 _logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Commit d431f94 fixed the supported ES version to ES8 because Edge did
not support "Spread in destructuring" of higher version.
It's now supported since Edge version 79. Hence we can support the next
version.

We now have several libraries written in Typescript. If we stick to an older ES
version, we would need to compile the Typescript code to this older version.
The source code and compiled code would then be quite different.
The compiled code would also be much less readable and therefore more difficult to
debug in Odoo where we have the compiled code only.

We might support ES10/ES2019 before V15.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
