### PR TITLE
[FIX] hr_expense: expense reconciliation

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -74,6 +74,7 @@ class HrExpense(models.Model):
         domain="[('company_id', '=', company_id), ('type_tax_use', '=', 'purchase')]", string='Taxes')
     untaxed_amount = fields.Float("Subtotal", store=True, compute='_compute_amount', digits='Account')
     total_amount = fields.Monetary("Total", compute='_compute_amount', store=True, currency_field='currency_id', tracking=True)
+    amount_residual = fields.Monetary(string='Amount Due', compute='_compute_amount_residual')
     company_currency_id = fields.Many2one('res.currency', string="Report Company Currency", related='sheet_id.currency_id', store=True, readonly=False)
     total_amount_company = fields.Monetary("Total (Company Currency)", compute='_compute_total_amount_company', store=True, currency_field='company_currency_id')
     company_id = fields.Many2one('res.company', string='Company', required=True, readonly=True, states={'draft': [('readonly', False)], 'refused': [('readonly', False)]}, default=lambda self: self.env.company)
@@ -125,6 +126,20 @@ class HrExpense(models.Model):
             expense.untaxed_amount = expense.unit_amount * expense.quantity
             taxes = expense.tax_ids.compute_all(expense.unit_amount, expense.currency_id, expense.quantity, expense.product_id, expense.employee_id.user_id.partner_id)
             expense.total_amount = taxes.get('total_included')
+
+    @api.depends("sheet_id.account_move_id.line_ids")
+    def _compute_amount_residual(self):
+        for expense in self:
+            if not expense.sheet_id:
+                expense.amount_residual = expense.total_amount
+                continue
+            if not expense.currency_id or expense.currency_id == expense.company_id.currency_id:
+                residual_field = 'amount_residual'
+            else:
+                residual_field = 'amount_residual_currency'
+            payment_term_lines = expense.sheet_id.account_move_id.line_ids \
+                .filtered(lambda line: line.expense_id == self and line.account_internal_type in ('receivable', 'payable'))
+            expense.amount_residual = -sum(payment_term_lines.mapped(residual_field))
 
     @api.depends('date', 'total_amount', 'company_currency_id')
     def _compute_total_amount_company(self):

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -145,6 +145,7 @@
                             </div>
                             <field name="tax_ids" widget="many2many_tags" groups="account.group_account_readonly" attrs="{'readonly': [('is_editable', '=', False)]}" context="{'default_company_id': company_id}"/>
                             <field name="total_amount" widget='monetary' options="{'currency_field': 'currency_id'}"/>
+                            <field name="amount_residual" widget='monetary' options="{'currency_field': 'currency_id'}"/>
                         </group><group>
                             <field name="reference" attrs="{'readonly': [('is_ref_editable', '=', False)]}"/>
                             <field name="date"/>


### PR DESCRIPTION
The reconciliatin between an expense and a bank statement does not
update the expense and its sheet.

To reproduce the error:
(Need account_accountant)
1. Go to Expenses
2. Create one (e.g. an expense of $20)
3. Save, Create Report, Approve, Post Journal Entries
4. Go to Accounting > Bank
5. Create a bank statement (e.g. $-20)
6. Save, Post, Reconcile
7. Select the expense, Validate
8. Go to Expense > The created expense

=> The expense's state is still 'Approved'. It should be 'Paid'.
Moreover, if you click on the associated report ("View Report"), the
same error appears: the sheet's state is 'Posted' instead of 'Paid'.

The problem was that the method 'action_invoice_paid' (deleted in this
commit) was never reached. Moreover, there was no way to get the
expense's residual amount.

Notes:
	- Manual backporting of 79fc263
	- Initial PR #63486

OPW-2389414