### PR TITLE
[FIX] web: Load odoo script after other scripts

### DIFF
--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -421,7 +421,7 @@
                 <title t-esc="title or 'Odoo'"/>
                 <link type="image/x-icon" rel="shortcut icon" t-att-href="x_icon or '/web/static/src/img/favicon.ico'"/>
 
-                <script type="text/javascript">
+                <script id="web.layout.odooscript" type="text/javascript">
                     var odoo = {
                         csrf_token: "<t t-esc="request.csrf_token(None)"/>",
                         debug: "<t t-esc="debug"/>",
@@ -441,7 +441,7 @@
             <t t-call-assets="web.assets_common" t-js="false"/>
             <t t-call-assets="web.assets_frontend" t-js="false"/>
         </xpath>
-        <xpath expr="//head/script" position="after">
+        <xpath expr="//head/script[@id='web.layout.odooscript']" position="after">
             <script type="text/javascript">
                 odoo.session_info = <t t-raw="json.dumps(request.env['ir.http'].get_frontend_session_info())"/>;
             </script>


### PR DESCRIPTION
What are the steps to reproduce your issue ?

    1. Install website
    2. Connect on the website
    3. Choose Customize > HTML/CSS/JS Editor
    4. Choose "Web layout" (in "XML (HTML)" )
    5. Modify the HTML code by adding any <script> before the existing <script> (console.log whatever)
    6. Save
    7. Refresh

What is currently happening ?

    Traceback: TypeError: Cannot read property 'user_context' of undefined

How to fix the bug ?

    Target the odoo script by id in the xpath.

opw-2375490