### PR TITLE
[IMP] mrp,stock: allow quants for consu in packages

### DIFF
--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -288,7 +288,7 @@ class MrpUnbuild(models.Model):
         precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
         available_qty = self.env['stock.quant']._get_available_quantity(self.product_id, self.location_id, self.lot_id, strict=True)
         unbuild_qty = self.product_uom_id._compute_quantity(self.product_qty, self.product_id.uom_id)
-        if float_compare(available_qty, unbuild_qty, precision_digits=precision) >= 0:
+        if self.product_id.type == 'consu' or float_compare(available_qty, unbuild_qty, precision_digits=precision) >= 0:
             return self.action_unbuild()
         else:
             return {

--- a/addons/stock/models/stock_inventory.py
+++ b/addons/stock/models/stock_inventory.py
@@ -244,7 +244,8 @@ class Inventory(models.Model):
         locations_ids = [l['id'] for l in self.env['stock.location'].search_read(domain_loc, ['id'])]
 
         domain = [('company_id', '=', self.company_id.id),
-                  ('location_id', 'in', locations_ids)]
+                  ('location_id', 'in', locations_ids),
+                  ('product_id.type', '=', 'product')]
         if self.prefill_counted_quantity == 'zero':
             domain.append(('product_id.active', '=', True))
         if self.lot_ids:
@@ -397,7 +398,8 @@ class Inventory(models.Model):
         neg_quants = self.env['stock.quant'].search(expression.AND([
             [
                 ('quantity', '<', 0.0),
-                ('location_id.usage', 'in', ['internal', 'transit'])
+                ('location_id.usage', 'in', ['internal', 'transit']),
+                ('product_id.type', '=', 'product')
             ], company_domain]))
         company_ids = neg_quants.mapped('company_id')
         warehouse_ids = self.env['stock.warehouse'].search([('company_id', 'in', company_ids.ids)])

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1293,7 +1293,7 @@ class StockMove(models.Model):
             rounding = roundings[move]
             missing_reserved_uom_quantity = move.product_uom_qty - reserved_availability[move]
             missing_reserved_quantity = move.product_uom._compute_quantity(missing_reserved_uom_quantity, move.product_id.uom_id, rounding_method='HALF-UP')
-            if move._should_bypass_reservation():
+            if move._should_bypass_reservation() and not (move.product_id.type == 'consu' and move.move_orig_ids.filtered(lambda m: m.state == 'done').mapped('move_line_ids.result_package_id')):
                 # create the move line(s) but do not impact quants
                 if move.product_id.tracking == 'serial' and (move.picking_type_id.use_create_lots or move.picking_type_id.use_existing_lots):
                     for i in range(0, int(missing_reserved_quantity)):

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -321,7 +321,7 @@ class StockMoveLine(models.Model):
         # When editing a done move line, the reserved availability of a potential chained move is impacted. Take care of running again `_action_assign` on the concerned moves.
         if updates or 'qty_done' in vals:
             next_moves = self.env['stock.move']
-            mls = self.filtered(lambda ml: ml.move_id.state == 'done' and ml.product_id.type == 'product')
+            mls = self.filtered(lambda ml: ml.move_id.state == 'done' and ml.product_id.type in ['product', 'consu'])
             if not updates:  # we can skip those where qty_done is already good up to UoM rounding
                 mls = mls.filtered(lambda ml: not float_is_zero(ml.qty_done - vals['qty_done'], precision_rounding=ml.product_uom_id.rounding))
             for ml in mls:
@@ -398,7 +398,7 @@ class StockMoveLine(models.Model):
         precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
         for ml in self:
             # Unlinking a move line should unreserve.
-            if ml.product_id.type == 'product' and not ml._should_bypass_reservation(ml.location_id) and not float_is_zero(ml.product_qty, precision_digits=precision):
+            if not ml._should_bypass_reservation(ml.location_id) and not float_is_zero(ml.product_qty, precision_digits=precision):
                 try:
                     self.env['stock.quant']._update_reserved_quantity(ml.product_id, ml.location_id, -ml.product_qty, lot_id=ml.lot_id, package_id=ml.package_id, owner_id=ml.owner_id, strict=True)
                 except UserError:
@@ -492,7 +492,7 @@ class StockMoveLine(models.Model):
         # Now, we can actually move the quant.
         done_ml = self.env['stock.move.line']
         for ml in self - ml_to_delete:
-            if ml.product_id.type == 'product':
+            if ml.product_id.type in ['product', 'consu']:
                 rounding = ml.product_uom_id.rounding
 
                 # if this move line is force assigned, unreserve elsewhere if needed
@@ -501,7 +501,7 @@ class StockMoveLine(models.Model):
                     extra_qty = qty_done_product_uom - ml.product_qty
                     ml._free_reservation(ml.product_id, ml.location_id, extra_qty, lot_id=ml.lot_id, package_id=ml.package_id, owner_id=ml.owner_id, ml_to_ignore=done_ml)
                 # unreserve what's been reserved
-                if not ml._should_bypass_reservation(ml.location_id) and ml.product_id.type == 'product' and ml.product_qty:
+                if not ml._should_bypass_reservation(ml.location_id) and ml.product_qty:
                     try:
                         Quant._update_reserved_quantity(ml.product_id, ml.location_id, -ml.product_qty, lot_id=ml.lot_id, package_id=ml.package_id, owner_id=ml.owner_id, strict=True)
                     except UserError:
@@ -644,7 +644,8 @@ class StockMoveLine(models.Model):
 
     def _should_bypass_reservation(self, location):
         self.ensure_one()
-        return location.should_bypass_reservation() or self.product_id.type != 'product'
+        # consumables within a package have quants that need to be reserved/unreserved
+        return location.should_bypass_reservation() or (self.product_id.type != 'product' and not self.package_id)
 
     def _get_aggregated_product_quantities(self, **kwargs):
         """ Returns a dictionary of products (key = id+name+description+uom) and corresponding values of interest.

--- a/addons/stock/report/report_stock_quantity.py
+++ b/addons/stock/report/report_stock_quantity.py
@@ -73,7 +73,10 @@ WITH forecast_qty AS (
         stock_quant q
     LEFT JOIN stock_location l on (l.id=q.location_id)
     LEFT JOIN stock_warehouse wh ON l.parent_path like concat('%/', wh.view_location_id, '/%')
+    LEFT JOIN product_product pp on pp.id=q.product_id
+    LEFT JOIN product_template pt on pt.id=pp.product_tmpl_id
     WHERE
+        pt.type = 'product' AND
         (l.usage = 'internal' AND wh.id IS NOT NULL) OR
         l.usage = 'transit'
     UNION

--- a/addons/stock/tests/test_quant.py
+++ b/addons/stock/tests/test_quant.py
@@ -163,8 +163,13 @@ class StockQuant(TransactionCase):
         """
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product_consu, self.stock_location), 0.0)
         self.assertEqual(len(self.gather_relevant(self.product_consu, self.stock_location)), 0)
-        with self.assertRaises(ValidationError):
-            self.env['stock.quant']._update_available_quantity(self.product_consu, self.stock_location, 1.0)
+        # consumable without package shouldn't have quants
+        self.env['stock.quant']._update_available_quantity(self.product_consu, self.stock_location, 1.0)
+        self.assertEqual(len(self.gather_relevant(self.product_consu, self.stock_location)), 0)
+        # consumable with package should have quants
+        package = self.env['stock.quant.package'].create({'name': 'consumable_pack'})
+        self.env['stock.quant']._update_available_quantity(self.product_consu, self.stock_location, 1.0, package_id=package)
+        self.assertEqual(len(self.gather_relevant(self.product_consu, self.stock_location)), 1)
 
     def test_get_available_quantity_9(self):
         """ Quantity availability by a demo user with access rights/rules.

--- a/addons/stock_account/models/stock_quant.py
+++ b/addons/stock_account/models/stock_quant.py
@@ -28,7 +28,8 @@ class StockQuant(models.Model):
                 return
 
             if not quant.location_id._should_be_valued() or\
-                    (quant.owner_id and quant.owner_id != quant.company_id.partner_id):
+                    (quant.owner_id and quant.owner_id != quant.company_id.partner_id) or\
+                    quant.product_id.type != 'product':
                 quant.value = 0
                 continue
             if quant.product_id.cost_method == 'fifo':

--- a/addons/stock_account/wizard/stock_quantity_history.py
+++ b/addons/stock_account/wizard/stock_quantity_history.py
@@ -10,7 +10,7 @@ class StockQuantityHistory(models.TransientModel):
         active_model = self.env.context.get('active_model')
         if active_model == 'stock.valuation.layer':
             action = self.env["ir.actions.actions"]._for_xml_id("stock_account.stock_valuation_layer_action")
-            action['domain'] = [('create_date', '<=', self.inventory_datetime)]
+            action['domain'] = [('create_date', '<=', self.inventory_datetime), ('product_id.type', '=', 'product')]
             action['display_name'] = str(self.inventory_datetime)
             return action
 


### PR DESCRIPTION
The main implementation of product type consumable not having a stock to
manage is for it to never have quants. Unfortunately this made it so when
consumables are placed in packages then they aren't tracked in the
package at all.

In order to show consumables in packages (and take their package weight
into account), this commit makes it so consumables within packages are
tracked with a quant. In order to ensure that consumables are not
confused with stock managed products, views/reports have been updated
accordingly (including unbuild). Tests and pick-pack-ship logic have
also been updated accordingly.

Task: 2033341

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
