### PR TITLE
[FIX]: point_of_sale: this is undefined in a non-arrow function

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -3238,7 +3238,7 @@ exports.Order = Backbone.Model.extend({
             tax_set[tax_id[i]] = true;
         }
 
-        this.orderlines.each(function(line){
+        this.orderlines.each(line => {
             var taxes_ids = this.tax_ids || line.get_product().taxes_id;
             for (var i = 0; i < taxes_ids.length; i++) {
                 if (tax_set[taxes_ids[i]]) {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fix the undefined error caused by a 'this' in a non-arrow function
Current behavior before PR:
Error when calling the function get_total_for_taxes(tax_id) from the Order class
Desired behavior after PR is merged:
No more error

