### PR TITLE
[FIX] mail: fix display of chatter topbar in multiline

### DIFF
--- a/addons/mail/static/src/components/chatter_topbar/chatter_topbar.scss
+++ b/addons/mail/static/src/components/chatter_topbar/chatter_topbar.scss
@@ -18,7 +18,7 @@
     display: flex;
     flex: 1;
     flex-direction: row;
-    flex-wrap: wrap;
+    flex-wrap: wrap-reverse; // reverse to ensure send buttons are directly above composer
 }
 
 .o_ChatterTopbar_button {


### PR DESCRIPTION
When the topbar goes to multiple line due to too much text content to fit its
currently available space (depending for example on length of text after
translations), it will look bad before this commit because the "send message"
and "log note" have a visual effect when they are open that requires them to be
directly above the composer to look good.

Part of task-2413814