### PR TITLE
[FIX] website_slides: show fullscreen mode buttons

### DIFF
--- a/addons/website_slides/static/src/scss/slides_slide_fullscreen.scss
+++ b/addons/website_slides/static/src/scss/slides_slide_fullscreen.scss
@@ -1,7 +1,7 @@
 
 .o_wslides_fs_main {
     @include o-position-absolute(0,0,0,0);
-    z-index: $zindex-dropdown;
+    z-index: $zindex-fixed;
     background-image: linear-gradient(120deg, $o-wslides-color-dark2, $o-wslides-color-dark3);
 
     .o_wslides_slide_fs_header {


### PR DESCRIPTION
When a user is watching a video course in full-screen mode, the video course
options are hidden by the website top bar.

To reproduce the error:
1. Go to eLearning
2. Select/Create a course
3. Add Content
	- Must be a video
4. Go to the public page of the course
5. Click on the video

=> Above the video, the main top bar is displayed (with website's name,
tabs, your name, etc). This bar should be hidden. Moreover, it overlays
the options of the video course ("Write a review", "Share", "Exit
Fullscreen", "Back to course")

OPW-2411534