### PR TITLE
[FIX] stock_picking_batch: processing batch picking with tracking

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -75,7 +75,7 @@ class StockPickingBatch(models.Model):
                 picking_type = picking.picking_type_id
                 if (picking_type.use_create_lots or picking_type.use_existing_lots):
                     for ml in picking.move_line_ids:
-                        if ml.product_id.tracking != 'none':
+                        if ml.product_id.tracking != 'none' and not ml.lot_id and not ml.lot_name:
                             raise UserError(_('Some products require lots/serial numbers.'))
                 # Check if we need to set some qty done.
                 picking_without_qty_done |= picking


### PR DESCRIPTION
Behavior prior to the commit:

- if there is a batch transfer for a product that is tracked by lot or
serial number, it always fails to validate with an error prompt saying
that a serial/lot number is required, even if a product with a serial
number has already been reserved on the transfer.  In that case it is
expected that processing the batch transfer would work without user
intervention, just like it does when you process the individual
transfers.

Behavior after the commit:

- the batch transfer can be processed, as long as there is a serial
number assigned to the product

opw-2413897
