### PR TITLE
[IMP] sale_stock: Allow to see the quantity available by warehouse only

### DIFF
--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -280,7 +280,7 @@ class SaleOrderLine(models.Model):
         if self.product_id.type == 'product':
             precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
             product = self.product_id.with_context(
-                warehouse=self.order_id.warehouse_id.id,
+                location=self.order_id.warehouse_id.lot_stock_id.id,
                 lang=self.order_id.partner_id.lang or self.env.user.lang or 'en_US'
             )
             product_qty = self.product_uom._compute_quantity(self.product_uom_qty, self.product_id.uom_id)
@@ -291,10 +291,11 @@ class SaleOrderLine(models.Model):
                             (self.product_uom_qty, self.product_uom.name, self.product_id.name, product.virtual_available, product.uom_id.name, self.order_id.warehouse_id.name)
                     # We check if some products are available in other warehouses.
                     if float_compare(product.virtual_available, self.product_id.virtual_available, precision_digits=precision) == -1:
+                        warehouse_ids = self.env['stock.warehouse'].search([])
                         message += _('\nThere are %s %s available across all warehouses.\n\n') % \
-                                (self.product_id.virtual_available, product.uom_id.name)
-                        for warehouse in self.env['stock.warehouse'].search([]):
-                            quantity = self.product_id.with_context(warehouse=warehouse.id).virtual_available
+                                (self.product_id.with_context(location=warehouse_ids.mapped('lot_stock_id').ids).virtual_available, product.uom_id.name)
+                        for warehouse in warehouse_ids:
+                            quantity = self.product_id.with_context(location=warehouse.lot_stock_id.id).virtual_available
                             if quantity > 0:
                                 message += "%s: %s %s\n" % (warehouse.name, quantity, self.product_id.uom_id.name)
                     warning_mess = {


### PR DESCRIPTION
from the main location of the each warehouse,

Before this commit if you have the setting
WH/stock
WH/other_not_for_the_sales
(it could here a location that I do not want to consider like stock
available by te sale e.g warranty, demos, ... )

Stock avaiable into WH/stock---10 Units
Stock available into WH/other_not_for_the_sales---10 Units

The warning from sales says that you have 20 Units available

After this commit, the warning says, that you have 10 Units, only the
stock available from the main location fo the warehouse of the sale
order

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
