### PR TITLE
add unfold attribute on list groupby tag

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -171,7 +171,7 @@
             <field name="model">account.move.line</field>
             <field eval="1" name="priority"/>
             <field name="arch" type="xml">
-                <tree string="Journal Items" create="false" expand="context.get('expand', False)" multi_edit="1">
+                <tree string="Journal Items" create="false" multi_edit="1">
                     <field name="date" optional="show" readonly="1"/>
                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" optional="show"/>
                     <field name="move_id" optional="show"/>
@@ -199,7 +199,7 @@
                     <field name="tax_tag_ids" widget="many2many_tags" width="0.5" optional="hide" string="Tax Grids"
                            options="{'no_open': True, 'no_create': True}"
                            domain="[('applicability', '=', 'taxes')]"/>
-                    <groupby name="move_id">
+                    <groupby name="move_id" unfold="context.get('expand', False)">
                         <field name="state" invisible="1"/>
                         <button name="edit" type="edit" icon="fa-edit" title="Edit"/>
                         <button name="action_post" states="draft" icon="fa-check" title="Post" type="object" groups="account.group_account_invoice"/>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -658,6 +658,7 @@
                     <field name="tag_ids" optional="hide" widget="many2many_tags" options="{'color_field': 'color'}"/>
                     <field name="referred" invisible="1"/>
                     <field name="message_needaction" invisible="1"/>
+                    <groupby name="stage_id" unfold="1"/>
                 </tree>
             </field>
         </record>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -924,6 +924,7 @@
                     <field name="kanban_state" widget="state_selection" optional="hide" readonly="1"/>
                     <field name="stage_id" invisible="context.get('set_visible',False)" optional="show" readonly="1"/>
                     <field name="recurrence_id" invisible="1" />
+                    <groupby name="stage_id" unfold="context.get('unfold',True)"/>
                 </tree>
             </field>
         </record>
@@ -1022,7 +1023,7 @@
             <field name="name">Tasks</field>
             <field name="res_model">project.task</field>
             <field name="view_mode">tree,kanban,form,calendar,pivot,graph,activity</field>
-            <field name="context">{'search_default_my_tasks': 1, 'all_task': 0}</field>
+            <field name="context">{'search_default_my_tasks': 1, 'all_task': 0, 'unfold': False}</field>
             <field name="search_view_id" ref="view_task_search_form"/>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">

--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -4632,7 +4632,7 @@ var BasicModel = AbstractModel.extend({
             return order.name === rawGroupBy || list.fields[order.name].group_operator !== undefined;
         });
         var openGroupsLimit = list.groupsLimit || self.OPEN_GROUP_LIMIT;
-        var expand = list.openGroupByDefault && options.fetchRecordsWithGroups;
+        var expand = list.openGroupByDefault && options.fetchRecordsWithGroups || options.unfoldGroups;
         return this._rpc({
                 model: list.model,
                 method: 'web_read_group',
@@ -4710,7 +4710,7 @@ var BasicModel = AbstractModel.extend({
                         // form view) are reloaded
                         newGroup.limit = oldGroup.limit + oldGroup.loadMoreOffset;
                         self.localData[newGroup.id] = newGroup;
-                    } else if (!newGroup.openGroupByDefault || openGroupCount >= openGroupsLimit) {
+                    } else if ((!newGroup.openGroupByDefault && !options.unfoldGroups) || openGroupCount >= openGroupsLimit) {
                         newGroup.isOpen = false;
                     } else if ('__fold' in group) {
                         newGroup.isOpen = !group.__fold;

--- a/addons/web/static/src/js/views/list/list_model.js
+++ b/addons/web/static/src/js/views/list/list_model.js
@@ -102,6 +102,13 @@ odoo.define('web.ListModel', function (require) {
             var self = this;
             options = options || {};
             options.fetchRecordsWithGroups = true;
+            const unfoldGroups = Object.keys(this.groupbys).filter(key => {
+                return !!this.groupbys[key].unfold;
+            });
+            const groupByField = list.groupedBy[0].split(':')[0];
+            if (unfoldGroups.includes(groupByField)) {
+                options.unfoldGroups = true;
+            }
             return this._super(list, options).then(function (result) {
                 return self._readGroupExtraFields(list).then(_.constant(result));
             });

--- a/addons/web/static/src/js/views/list/list_view.js
+++ b/addons/web/static/src/js/views/list/list_view.js
@@ -48,7 +48,7 @@ var ListView = BasicView.extend({
         this.headerButtons = [];
         this.arch.children.forEach(function (child) {
             if (child.tag === 'groupby') {
-                self._extractGroup(child);
+                self._extractGroup(child, pyevalContext);
             }
             if (child.tag === 'header') {
                 self._extractHeaderButtons(child);
@@ -95,9 +95,10 @@ var ListView = BasicView.extend({
      * @private
      * @param {Object} node
      */
-    _extractGroup: function (node) {
+    _extractGroup: function (node, pyevalContext) {
         var innerView = this.fields[node.attrs.name].views.groupby;
         this.groupbys[node.attrs.name] = this._processFieldsView(innerView, 'groupby');
+        this.groupbys[node.attrs.name]['unfold'] = !!JSON.parse(pyUtils.py_eval(node.attrs.unfold || "0", { 'context': pyevalContext }));
     },
     /**
      * Extracts action buttons definitions from the <header> node of the list

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -4842,6 +4842,61 @@ QUnit.module('Views', {
         list.destroy();
     });
 
+    QUnit.test('groupby node with a unfold attribute', async function (assert) {
+        assert.expect(4);
+
+        const list = await createView({
+            View: ListView,
+            model: 'foo',
+            data: this.data,
+            arch: `<tree>
+                    <field name="foo"/>
+                    <field name="m2o"/>
+                    <groupby name="currency_id" unfold="1"/>
+                </tree>`,
+            groupBy: ['m2o'],
+        });
+
+        assert.containsN(list, '.o_group_header', 2, "there should be 2 group headers");
+        assert.containsNone(list, '.o_data_row', "groups should not be expaned");
+
+        await list.update({ groupBy: ['currency_id'] });
+        assert.containsN(list, '.o_group_header', 2,
+            "there should be 2 group headers");
+        assert.containsN(list, '.o_data_row', 4, "groups should be expaned");
+
+        list.destroy();
+    });
+
+    QUnit.test('groupby node with a unfold attribute based on context', async function (assert) {
+        assert.expect(4);
+
+        const list = await createView({
+            View: ListView,
+            model: 'foo',
+            data: this.data,
+            arch: `<tree>
+                <field name="foo"/>
+                <groupby name="m2o" unfold="1"/>
+                <groupby name="currency_id" unfold="context.get('unfold', True)"/>
+            </tree>`,
+            groupBy: ['m2o'],
+            viewOptions: {
+                context: { unfold: false },
+            },
+        });
+
+        assert.containsN(list, '.o_group_header', 2, "there should be 2 group headers");
+        assert.containsN(list, '.o_data_row', 4, "groups should not be expaned");
+
+        await list.update({ groupBy: ['currency_id'] });
+        assert.containsN(list, '.o_group_header', 2,
+            "there should be 2 group headers");
+        assert.containsNone(list, '.o_data_row', "groups should not be expaned");
+
+        list.destroy();
+    });
+
     QUnit.test('list view, editable, without data', async function (assert) {
         assert.expect(12);
 

--- a/doc/reference/views.rst
+++ b/doc/reference/views.rst
@@ -1573,10 +1573,13 @@ Possible children elements of the list view are:
   ``name``
       the name of a many2one field (on the current model). Custom header will be
       displayed when grouping the view on this field name.
+  ``unfold``
+      if set to "1", group will unfolded by default, group can be unfolded based context
+      for e.g. unfold="context.get('unfold',True)"
 
   .. code-block:: xml
 
-    <groupby name="partner_id">
+    <groupby name="partner_id" unfold="1">
       <field name="name"/> <!-- name of partner_id -->
         <button type="edit" name"edit" string="Edit/>
         <button type="object" name="my_method" string="Button1"

--- a/odoo/addons/base/rng/tree_view.rng
+++ b/odoo/addons/base/rng/tree_view.rng
@@ -10,7 +10,7 @@
     <rng:define name="groupby">
         <rng:element name="groupby">
             <rng:attribute name="name"/>
-            <rng:optional><rng:attribute name="expand"/></rng:optional>
+            <rng:optional><rng:attribute name="unfold"/></rng:optional>
             <rng:zeroOrMore>
                 <rng:ref name="field"/>
             </rng:zeroOrMore>


### PR DESCRIPTION
PURPOSE

This task introduces a new 'unfold' boolean option on the <groupby> listview tag.

The goal is to allow grouped listview to have their groups unfolded by default.
This is especially useful on models where records progress through the stages of a pipeline.
Example: lead/opportunities or project tasks

we also need to depreciate the existing 'expand' option on <tree>
We want to be able to choose which grouping we want to unfold by default.
The current 'expand' will unfold any grouping of the treeview.

SPECIFICATION

Add a new 'unfold' boolean option on <groupby>
    if 'unfold'=True, groups are unfolded by default
    False by default

task-2391255


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
