### PR TITLE
[FIX] point_of_sale: list 5 payment methods

### DIFF
--- a/addons/point_of_sale/static/src/css/pos.css
+++ b/addons/point_of_sale/static/src/css/pos.css
@@ -1349,6 +1349,12 @@ td {
     flex-direction: column;
 }
 
+@media screen and (min-width: 768px) {
+    .screen .left-content {
+        max-width: 34%
+    }
+}
+
 .pos .btn-switch-payment {
     background-color: #6ec89b;
     border-radius: 0px;


### PR DESCRIPTION
If a POS has more than 5 payment methods, the display is not correct:
the list is full width when it should be on left (as long as the screen
is large enough).

This fix ensures the display is the same as the previous version, 
see (from v13):
https://github.com/odoo/odoo/blob/732ba5ca51e628b9d9a7427acd30d01d83e85068/addons/point_of_sale/static/src/css/pos.css#L1213-L1215

So, if the screen is larger than 768px, the width of the list will be
limited to 34% of the display area.

OPW-2400629