### PR TITLE
[FIX] website: gallery img inside anchor is too large

### DIFF
--- a/addons/website/static/src/snippets/s_image_gallery/001.scss
+++ b/addons/website/static/src/snippets/s_image_gallery/001.scss
@@ -238,10 +238,18 @@
 }
 
 %image-gallery-slideshow-styles {
-    &:not(.s_image_gallery_cover) .carousel-item > img {
-        max-height: 100%;
-        max-width: 100%;
-        margin: auto;
+    &:not(.s_image_gallery_cover) .carousel-item {
+        > a {
+            display: flex;
+            height: 100%;
+            width: 100%;
+        }
+        > a > img,
+        > img {
+            max-height: 100%;
+            max-width: 100%;
+            margin: auto;
+        }
     }
     .carousel {
         height: 100%;


### PR DESCRIPTION
Steps:
- Go to "Website" > "Go to Website"
- Click Edit
- Add an image gallery
- Add an image to the gallery
- Click the image
- Click on the Link button in the bottom-right of the side panel
- Add a link and save

Bug:
The image is too large.

Explanation:
The flex layout is not carried over to `img` when it's nested into an `a` tag. Redefining the flex layout on the `a` tag fixes the issue.

This fixes portrait images:
```css
height: 100%;
width: 100%;
```

And adding this also fixes landscape and smaller images:
```css
display: flex;
```

opw:2394953