### PR TITLE
[FIX] sale: don't recompute tax id when it is read only

### DIFF
--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -354,8 +354,9 @@
                                             <field name="sequence" invisible="1"/>
                                         </group>
                                         <group attrs="{'invisible': [('display_type', '!=', False)]}">
+                                            <field name="is_tax_readonly" invisible="1"/>
                                             <field name="tax_id" widget="many2many_tags" options="{'no_create': True}" context="{'search_view_ref': 'account.account_tax_view_search'}" domain="[('type_tax_use','=','sale'),('company_id','=',parent.company_id)]"
-                                                attrs="{'readonly': [('qty_invoiced', '&gt;', 0)]}"/>
+                                                attrs="{'readonly': [('is_tax_readonly', '=', True)]}"/>
                                             <label for="customer_lead"/>
                                             <div>
                                                 <field name="customer_lead" class="oe_inline"/> days


### PR DESCRIPTION
Behavior prior to this commit:

- when a SO line has been invoiced, the tax on it becomes readonly.  But it
is still possible to modify the fiscal position on the SO (since
other lines on the SO might not have been invoiced yet).  Doing so may
change the tax on the view, even though the change does not actually
post when saving the view (it is silently discarded)

Behavior after the commit:

- the tax id is not modified when changing the fiscal position, for
lines that have already been invoiced.

opw-2411692
