### PR TITLE
[FIX] purchase_stock: RFQ update `date_planned` from portal

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -541,8 +541,9 @@ class PurchaseOrderLine(models.Model):
 
     def _update_date_planned(self, updated_date):
         move_to_update = self.move_ids.filtered(lambda m: m.state not in ['done', 'cancel'])
-        if move_to_update:
+        if not self.move_ids or move_to_update:  # Only change the date if there is no move done or none
             super()._update_date_planned(updated_date)
+        if move_to_update:
             self._update_move_date_deadline(updated_date)
 
     @api.model


### PR DESCRIPTION
In case of RFQ with the "Ask confirmation X day(s) before" set,
the email send to the vendor give a link where he (portal user)
can change the date_planned of PO lines. But
the change wasn't done in the server side because the
`_update_date_planned` (of stock_purchase) doesn't call super if
there isn't a linked move (none in case of RFQ).
Move the call of the super.

close #59040
