### PR TITLE
calendar popover in rtl language

### DIFF
--- a/addons/web/static/src/js/views/calendar/calendar_renderer.js
+++ b/addons/web/static/src/js/views/calendar/calendar_renderer.js
@@ -746,7 +746,8 @@ return AbstractRenderer.extend({
             title: eventData.record.display_name,
             template: qweb.render('CalendarView.event.popover.placeholder', {color: this.getColor(eventData.color_index)}),
             container: eventData.allDay ? '.fc-view' : '.fc-scroller',
-        }
+            placement: _t.database.parameters.direction === "rtl" ? 'top' : 'right', // FIXME: remove fix placement 'top' once popper.js handles rtl
+        };
     },
     /**
      * Render event popover

--- a/addons/web/static/src/scss/web_calendar.scss
+++ b/addons/web/static/src/scss/web_calendar.scss
@@ -532,6 +532,7 @@ $o-cw-filter-avatar-size: 20px;
     min-width: 256px;
     max-width: 328px;
     font-size: $font-size-base;
+    direction: ltr;
 
     .card-header, .card-header .popover-header {
         font-size: 1.05em;
@@ -572,7 +573,7 @@ $o-cw-filter-avatar-size: 20px;
     }
 
     .fc-rtl & {
-        text-align: right;
+        text-align: right#{"/*rtl:ignore*/"};
         .o_calendar_avatars {
             > div {
                 justify-content: flex-end;

--- a/addons/web/static/tests/views/calendar_tests.js
+++ b/addons/web/static/tests/views/calendar_tests.js
@@ -799,6 +799,36 @@ QUnit.module('Views', {
         calendar.destroy();
     });
 
+    QUnit.test('render popover in RTL language', async function (assert) {
+        assert.expect(2);
+
+        const calendar = await createCalendarView({
+            View: CalendarView,
+            model: 'event',
+            data: this.data,
+            arch:
+            `<calendar
+                date_start="start"
+                date_stop="stop">
+                <field name="name" string="Custom Name"/>
+            '</calendar>`,
+            viewOptions: {
+                initialDate: initialDate,
+            },
+            translateParameters: {
+                direction: 'rtl',
+            },
+        });
+
+        await testUtils.dom.click($('.fc-event:contains(event 4)'));
+
+        assert.containsOnce(calendar, '.o_cw_popover', "should open a popover clicking on event");
+        const popoverPlacement = calendar.$(".o_cw_popover").attr("x-placement");
+        assert.ok(['top', 'bottom'].includes(popoverPlacement));
+
+        calendar.destroy();
+    });
+
     QUnit.test('render popover with modifiers', async function (assert) {
         assert.expect(3);
 


### PR DESCRIPTION
PURPOSE
Calendar popover when opened in RTL language it shows content left aligned, it should be respect RTL direction.

SPEC
Show content of the popover right to left.

TASK 2411193


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
