### PR TITLE
[FIX] account: multicurrency reconciliation

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3320,7 +3320,7 @@ class AccountMoveLine(models.Model):
                         else:
                             date = partial_line.credit_move_id.date if partial_line.debit_move_id == line else partial_line.debit_move_id.date
                             rate = line.currency_id.with_context(date=date).rate
-                        amount_residual_currency += sign_partial_line * line.currency_id.round(partial_line.amount * rate)
+                        amount_residual_currency += sign_partial_line * partial_line.amount * rate
 
             #computing the `reconciled` field.
             reconciled = False


### PR DESCRIPTION
[This commit](https://github.com/odoo/odoo/commit/a20b84d05a3f76040a4ca9477b7719537e9c987d#diff-dd671a54296b170ea1393dca1a5f7798) reverts [this one](https://github.com/odoo/odoo/commit/0164c9dfcb8f94dd09ffc5a0ce056e4e23308abe) that was working properly for us.

We where not able yet to reproduce the error on odoo standard. The issue is linked to a change on the reconciliation process done by us [here](https://github.com/ingadhoc/account-financial-tools/blob/13.0/account_ux/models/account_move_line.py#L39).

