### PR TITLE
[FIX] account_edi: hide alert when there are no web services

### DIFF
--- a/addons/account_edi/models/account_move.py
+++ b/addons/account_edi/models/account_move.py
@@ -55,7 +55,7 @@ class AccountMove(models.Model):
         for move in self:
             to_process = move.edi_document_ids.filtered(lambda d: d.state in ['to_send', 'to_cancel'])
             format_web_services = to_process.edi_format_id.filtered(lambda f: f._needs_web_services())
-            move.edi_web_services_to_process = ', '.join(f.name for f in format_web_services) or False
+            move.edi_web_services_to_process = ', '.join(f.name for f in format_web_services)
 
     @api.depends('restrict_mode_hash_table', 'state')
     def _compute_show_reset_to_draft_button(self):

--- a/addons/account_edi/views/account_move_views.xml
+++ b/addons/account_edi/views/account_move_views.xml
@@ -24,7 +24,7 @@
                 </xpath>
                 <xpath expr="//header" position="after">
                     <div class="alert alert-info" role="alert" style="margin-bottom:0px;"
-                        attrs="{'invisible': [('edi_web_services_to_process', '=', False)]}">
+                        attrs="{'invisible': [('edi_web_services_to_process', 'in', ['', False])]}">
                          <div>The invoice will be sent asynchronously to :
                             <field name="edi_web_services_to_process" class="oe_inline"/>
                          </div>

--- a/addons/account_edi/views/account_payment_views.xml
+++ b/addons/account_edi/views/account_payment_views.xml
@@ -16,7 +16,7 @@
             <field name="arch" type="xml">
                 <xpath expr="//header" position="after">
                     <div class="alert alert-info" role="alert" style="margin-bottom:0px;"
-                         attrs="{'invisible': ['|', ('edi_web_services_to_process', '=', ''), ('state', '=', 'draft')]}">
+                         attrs="{'invisible': ['|', ('edi_web_services_to_process', 'in', ['', False]), ('state', '=', 'draft')]}">
                          <div>The payment will be sent asynchronously to :
                             <field name="edi_web_services_to_process" class="oe_inline"/>
                          </div>


### PR DESCRIPTION
this is more safe way than previously applied in
#62939

because it doesn't require updating account_edi module in cases when it worked
correctly, i.e. when _compute_edi_web_services_to_process is called, but
computes empty string value

---

opw-2414500

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
