### PR TITLE
[FIX] point_of_sale: barcode and decimal notation

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1772,7 +1772,7 @@ exports.Orderline = Backbone.Model.extend({
             this.order.remove_orderline(this);
             return;
         }else{
-            var quant = field_utils.parse.float('' + quantity) || 0;
+            var quant = typeof(quantity) === 'number' ? quantity : (field_utils.parse.float('' + quantity) || 0);
             var unit = this.get_unit();
             if(unit){
                 if (unit.rounding) {


### PR DESCRIPTION
In some languages, if the thousands/decimals separators are different
from ','/'.' , when scanning a barcode that contains a decimal quantity,
the conversion won't be correct.

To reproduce the error:
1. Go to Settings > Inventory
2. Enable "Units of Measure"
3. Go to Point of Sale > Products > Products
4. Create a Product P
	- Set a barcode, e.g. 2112345000008
	- Set UoM to 'kg'
5. Go to Settings > Translations > Languages
6. Add and switch to French (BE)
7. Run one POS
8. Use the debugging window to simulate a scan
	- Enter the code, e.g. 2112345087550
		(It means 8.755kg of product P)
	- Click on "Scan EAN-13"

=> Here is the error: it actually adds 8755kg of P-product. This comes
from the quantity conversion. The barcode provides the qty as a number with
basic decimal notation (.) but later, it is converted using the user's
language configuration.

OPW-2412561