### PR TITLE
[FIX] website: don't add top on bottom popup to prevent offscreen

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -88,7 +88,7 @@ $-seen-urls: ();
 
 #wrapwrap {
     // When the modal is in #wrapwrap, position top should be size of the navbar
-    .modal {
+    .modal:not(.s_popup_bottom) {
         top: $o-navbar-height;
     }
 


### PR DESCRIPTION
Since 6ef622772f7, all modal have top property set. But since modals can be
set as bottom modal, that top margin will make those go offscreen.

Before
![image](https://user-images.githubusercontent.com/30048408/102229350-fabf2680-3eeb-11eb-9eb2-b16f19a6e544.png)

After
![image](https://user-images.githubusercontent.com/30048408/102229292-e67b2980-3eeb-11eb-9b28-6e2390fcb297.png)
