### PR TITLE
do not display notebook ul element if all pages hidden

### DIFF
--- a/addons/web/static/src/legacy/js/views/form/form_renderer.js
+++ b/addons/web/static/src/legacy/js/views/form/form_renderer.js
@@ -1007,6 +1007,8 @@ var FormRenderer = BasicRenderer.extend({
                             self.inactiveNotebooks.push(renderedTabs);
                         }
                     }
+                    // if all pages are invisible then hide notebooks header's ul as well
+                    $headers.toggleClass('o_invisible_modifier', !$headers.find('li:not(.o_invisible_modifier)').length);
                 },
             });
         });

--- a/addons/web/static/tests/legacy/views/form_tests.js
+++ b/addons/web/static/tests/legacy/views/form_tests.js
@@ -947,6 +947,39 @@ QUnit.module('Views', {
         form.destroy();
     });
 
+    QUnit.test('hide notebook element if all pages hidden', async function (assert) {
+        assert.expect(4);
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: `<form string="Partners">
+                    <sheet>
+                        <field name="bar"/>
+                        <notebook class="new_class">
+                            <page string="Foo" attrs="{'invisible': [['bar', '=', true]]}">
+                                <field name="foo"/>
+                            </page>
+                        </notebook>
+                    </sheet>
+                </form>`,
+        });
+
+        assert.ok(form.$('.o_notebook .nav li:not(.o_invisible_modifier)').length,
+            "there should be visible page");
+        assert.notOk(form.$('.o_notebook .nav').hasClass('o_invisible_modifier'),
+            'the notebook headers should not be hidden if one of the page is visible');
+
+        await testUtils.dom.click(form.$('.o_field_boolean input'));
+        assert.notOk(form.$('.o_notebook .nav li:not(.o_invisible_modifier)').length,
+            "there should not be any visible page");
+        assert.ok(form.$('.o_notebook .nav').hasClass('o_invisible_modifier'),
+            'the notebook headers should be hidden if none of the page is visible');
+
+        form.destroy();
+    });
+
     QUnit.test('autofocus on second notebook page', async function (assert) {
         assert.expect(2);
 


### PR DESCRIPTION
PURPOSE
Do not display empty notebook element

SPEC
If all pages are hidden then hide the notebook ul element as well.

TASK 2411651


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
