### PR TITLE
Improve graph measure label

### DIFF
--- a/addons/web/static/src/js/views/graph/graph_renderer.js
+++ b/addons/web/static/src/js/views/graph/graph_renderer.js
@@ -104,6 +104,15 @@ odoo.define("web/static/src/js/views/graph/graph_renderer", function (require) {
         }
 
         //---------------------------------------------------------------------
+        // Getters
+        //---------------------------------------------------------------------
+
+        get measureDescription() {
+            const measure = this.props.measures.find(m => m.fieldName === this.props.measure);
+            return measure ? measure.description : this.props.fields[this.props.measure].string;
+        }
+
+        //---------------------------------------------------------------------
         // Private
         //---------------------------------------------------------------------
 
@@ -312,7 +321,7 @@ odoo.define("web/static/src/js/views/graph/graph_renderer", function (require) {
 
             const innerHTML = this.env.qweb.renderToString("web.GraphRenderer.CustomTooltip", {
                 maxWidth: getMaxWidth(this.chart.chartArea),
-                measure: this.props.fields[this.props.measure].string,
+                measure: this.measureDescription,
                 tooltipItems: this._getTooltipItems(tooltipModel),
             });
             const template = Object.assign(document.createElement("template"), { innerHTML });
@@ -460,8 +469,7 @@ odoo.define("web/static/src/js/views/graph/graph_renderer", function (require) {
                     datasetLabel ? ("/" + datasetLabel) : ""
                 );
             }
-            datasetLabel = datasetLabel || this.props.fields[this.props.measure].string;
-            return datasetLabel;
+            return datasetLabel || this.measureDescription;
         }
 
         /**
@@ -640,7 +648,7 @@ odoo.define("web/static/src/js/views/graph/graph_renderer", function (require) {
                 type: "linear",
                 scaleLabel: {
                     display: !this.props.isEmbedded,
-                    labelString: this.props.fields[this.props.measure].string,
+                    labelString: this.measureDescription,
                 },
                 ticks: {
                     callback: value => this._formatValue(value),
@@ -1028,6 +1036,7 @@ odoo.define("web/static/src/js/views/graph/graph_renderer", function (require) {
         isEmbedded: Boolean,
         isSample: { type: Boolean, optional: 1 },
         measure: String,
+        measures: { type: Array, element: Object },
         mode: { validate: m => ["bar", "line", "pie"].includes(m) },
         origins: { type: Array, element: String },
         processedGroupBy: { type: Array, element: String },

--- a/addons/web/static/src/js/views/graph/graph_view.js
+++ b/addons/web/static/src/js/views/graph/graph_view.js
@@ -145,6 +145,7 @@ var GraphView = AbstractView.extend({
         ];
 
         this.rendererParams.fields = this.fields;
+        this.rendererParams.measures = this.controllerParams.measures;
         this.rendererParams.title = this.arch.attrs.title; // TODO: use attrs.string instead
         this.rendererParams.disableLinking = !!JSON.parse(this.arch.attrs.disable_linking || '0');
 

--- a/addons/web/static/tests/views/graph_tests.js
+++ b/addons/web/static/tests/views/graph_tests.js
@@ -872,6 +872,59 @@ QUnit.module('Views', {
         graph.destroy();
     });
 
+    QUnit.test('graph view with string attribute on view architecture fields', async function (assert) {
+        assert.expect(4);
+
+        const graph = await createView({
+            View: GraphView,
+            model: "foo",
+            data: this.data,
+            arch: `
+            <graph string="Partners">
+                <field name="product_id" type="measure" string="Jethalal"/>
+                <field name="foo" type="measure"/>
+            </graph>`,
+        });
+
+        checkLegend(assert, graph, 'Foo');
+        let chart = graph.renderer.componentRef.comp.chart;
+        let yAxisLabel = chart.config.options.scales.yAxes[0].scaleLabel.labelString;
+        assert.strictEqual(yAxisLabel, "Foo");
+
+        await cpHelpers.toggleMenu(graph, "Measures");
+        await cpHelpers.toggleMenuItem(graph, "Jethalal");
+        checkLegend(assert, graph, 'Jethalal');
+
+        chart = graph.renderer.componentRef.comp.chart;
+        yAxisLabel = chart.config.options.scales.yAxes[0].scaleLabel.labelString;
+        assert.strictEqual(yAxisLabel, "Jethalal");
+
+        graph.destroy();
+    });
+
+    QUnit.test('graph view "graph_measure" field in context not in measures', async function (assert) {
+        assert.expect(2);
+
+        const graph = await createView({
+            View: GraphView,
+            model: "foo",
+            data: this.data,
+            arch: '<graph><field name="product_id"/></graph>',
+            viewOptions: {
+                context: {
+                    graph_measure: 'product_id',
+                },
+            },
+        });
+
+        checkLegend(assert, graph, 'Product');
+        let chart = graph.renderer.componentRef.comp.chart;
+        let yAxisLabel = chart.config.options.scales.yAxes[0].scaleLabel.labelString;
+        assert.strictEqual(yAxisLabel, "Product");
+
+        graph.destroy();
+    });
+
     QUnit.test('Undefined should appear in bar, pie graph but not in line graph', async function (assert) {
         assert.expect(3);
 


### PR DESCRIPTION
PURPOSE
The graph view fields can have the "string" attribute. Unfortunately, it is not used by in the chart.js instance to update the labels and popover.

SPEC
When we define a graph view, the string attribute is ignored in the label and popover, use field strings given in view definition on more priority then field definition.

TASK 2264636



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
