### PR TITLE
[FIX] core: accounting groups field dropped from users' form view

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1440,25 +1440,46 @@ class UsersView(models.Model):
     def fields_get(self, allfields=None, attributes=None):
         res = super(UsersView, self).fields_get(allfields, attributes=attributes)
         # add reified groups fields
-        for app, kind, gs, category_name in self.env['res.groups'].sudo().get_groups_by_application():
+        Group = self.env['res.groups'].sudo()
+        for app, kind, gs, category_name in Group.get_groups_by_application():
             if kind == 'selection':
                 # 'User Type' should not be 'False'. A user is either 'employee', 'portal' or 'public' (required).
                 selection_vals = [(False, '')]
                 if app.xml_id == 'base.module_category_user_type':
                     selection_vals = []
-                field_name = name_selection_groups(gs.ids)
-                if allfields and field_name not in allfields:
-                    continue
-                # selection group field
-                tips = ['%s: %s' % (g.name, g.comment) for g in gs if g.comment]
-                res[field_name] = {
-                    'type': 'selection',
-                    'string': app.name or _('Other'),
-                    'selection': selection_vals + [(g.id, g.name) for g in gs],
-                    'help': '\n'.join(tips),
-                    'exportable': False,
-                    'selectable': False,
-                }
+
+                # FIXME: in Accounting, the groups in the selection are not
+                # totally ordered, and their order therefore partially depends
+                # on their name, which is translated!  So we generate all the
+                # possible field names according to the partial order.
+                gs_list = [gs]
+                if app.xml_id == 'base.module_category_accounting_accounting':
+                    # ranks = {0: [A, B], 2: [C], 3: [D]}
+                    ranks = defaultdict(list)
+                    for g in gs:
+                        ranks[len(g.trans_implied_ids & gs)].append(g)
+                    # perms = [[AB, BA], [C], [D]]
+                    perms = [
+                        [Group.concat(*perm) for perm in itertools.permutations(rank)]
+                        for k, rank in sorted(ranks.items())
+                    ]
+                    # gs_list = [ABCD, BACD]
+                    gs_list = [Group.concat(*perm) for perm in itertools.product(*perms)]
+
+                for gs in gs_list:
+                    field_name = name_selection_groups(gs.ids)
+                    if allfields and field_name not in allfields:
+                        continue
+                    # selection group field
+                    tips = ['%s: %s' % (g.name, g.comment) for g in gs if g.comment]
+                    res[field_name] = {
+                        'type': 'selection',
+                        'string': app.name or _('Other'),
+                        'selection': selection_vals + [(g.id, g.name) for g in gs],
+                        'help': '\n'.join(tips),
+                        'exportable': False,
+                        'selectable': False,
+                    }
             else:
                 # boolean group fields
                 for g in gs:


### PR DESCRIPTION
To reproduce this issue, install the module "Accounting" in English,
then switch language to Dutch, and go to a user's form.  The selection
field for accounting groups is missing from the users' form view.

The source of the bug is the special case introduced for accounting
groups in d8c5cc1335806d379134866262840fcafb05b643.  The groups in that
selection field are not totally ordered, and the non-ordered elements
are de facto ordered by name, which is a translated field!  In the
example above, the English version uses the field name
`sel_groups_22_23_24_25` while the Dutch version uses the field name
`sel_groups_23_22_24_25`.  Because the first one is used in the form
view, and it is not found in the model's documented fields (which uses
the second one), the field is discarded from the view.

The patch modifies the override of method `fields_get()` to consider all
the possible names for that selection field, and returns them all.

OPW-2394209