### PR TITLE
[FIX] l10n_ch_qriban: Impossible to create a vendor bill

### DIFF
--- a/addons/l10n_ch_qriban/models/res_bank.py
+++ b/addons/l10n_ch_qriban/models/res_bank.py
@@ -37,7 +37,7 @@ class ResPartnerBank(models.Model):
         return super().write(vals)
 
     def _is_qr_iban(self):
-        return super()._is_qr_iban() or self.l10n_ch_qr_iban
+        return self and super(ResPartnerBank, self)._is_qr_iban() or self.l10n_ch_qr_iban
 
     def _prepare_swiss_code_url_vals(self, amount, currency_name, debtor_partner, reference_type, reference, comment):
         qr_code_vals = super()._prepare_swiss_code_url_vals(amount, currency_name, debtor_partner, reference_type, reference, comment)


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a company C with l10n_ch installed
- Try to create a vendor bill

Bug:

A traceback was raised.

PS: Function _is_qr_iban has an ensure_one and when creating a vendor bill
the function _is_qr_iban by _compute_l10n_ch_isr_needs_fixing was called with no partner_bank

opw:2416809