### PR TITLE
[IMP] test_lint: adjust ES version for supported browsers

### DIFF
--- a/odoo/addons/test_lint/tests/test_ecmascript.py
+++ b/odoo/addons/test_lint/tests/test_ecmascript.py
@@ -11,7 +11,7 @@ from odoo.modules import get_modules, get_module_path
 
 from . import lint_case
 
-MAX_ES_VERSION = 'es8'
+MAX_ES_VERSION = 'es10'
 
 _logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This reverts commit d431f94c759f9811c640d81a274e90301276d001 and even
upgrade the EcmaScript version further to ES10/2019.

The original commit mainly targeted the support of MS Edge
(pre-Chromium) and earlier versions of iOS 11.

As with the release of Odoo 14, we don't support either of those (MS
Edge only Chromium-based and iOS 12), the original restriction can be
lifted and again target EcmaScript 9/2018.

But furthermore, some features of ES10/2019 are already in use in Odoo
14+ (e.g. `Object.fromEntries()` used in SpreadSheet, PoS, WebEditor,
Website Sale...) and the only browser not supporting them is Safari on
iOS versions < 12.2.

As there is no drop of supported devices between iOS 11 and 12 and they
all have access to - at least - the latest revision of iOS 12 (cf.
12.5), it looks reasonable to target the latest revision only and not
the earlier ones. This policy also matches the "ever-green-browsers"
policy applied on desktop.

Note: please note that the tool (es-check) used for testing the
EcmaScript version targeted has for primary goal to catch unsupported
syntax and reserved keywords only, but not the actual APIs available for
a given EcmaScript version. (e.g. async/await keywords or string
literals are tested *but not* Object.fromEntries() or
Array.prototype.flatMap()).

References:
- https://kangax.github.io/compat-table/es2016plus/
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries
- https://en.wikipedia.org/wiki/IOS_12