### PR TITLE
[FIX] account: display account.journal's currency_id field at the right place in form view

### DIFF
--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -68,6 +68,7 @@
                                                groups="account.group_account_readonly"/>
                                         <field name="refund_sequence" attrs="{'invisible': [('type', 'not in', ['sale', 'purchase'])]}"/>
                                         <field name="code"/>
+                                        <field name="currency_id" options="{'no_create': True}" groups="base.group_multi_currency"/>
                                     </group>
                                     <group string="Bank Account Number" attrs="{'invisible': [('type', '!=', 'bank')]}">
                                         <field name="company_partner_id" invisible="1"/>
@@ -90,7 +91,6 @@
                                         <field name="payment_credit_account_id"
                                                attrs="{'required': [('id', '!=', False), ('type', 'in', ('bank', 'cash'))], 'invisible': [('type', 'not in', ('bank', 'cash'))]}"
                                                groups="account.group_account_readonly"/>
-                                        <field name="currency_id" options="{'no_create': True}" groups="base.group_multi_currency"/>
                                         <field name="outbound_payment_method_ids" string="Methods" widget="many2many_checkboxes" attrs="{'invisible': [('type', 'not in', ['bank', 'cash'])]}"/>
                                     </group>
                                     <group name="outgoing_payment" />


### PR DESCRIPTION
Before that, that field was located under "Outgoing payment", which made no sense.
