### PR TITLE
[FIX] mrp: hide operations for archived BOM

### DIFF
--- a/addons/mrp/views/mrp_routing_views.xml
+++ b/addons/mrp/views/mrp_routing_views.xml
@@ -73,6 +73,7 @@
                 Each operation is done at a specific Work Center and has a specific duration.
               </p>
             </field>
+            <field name="domain">['|', ('bom_id', '=', False), ('bom_id.active', '=', True)]</field>
         </record>
 
         <menuitem id="menu_mrp_routing_action"


### PR DESCRIPTION
Before this commit, the operations for archived bills of materials are still displayed in the operations list view. This commit adds a domain on the action to hide them.

task-2417937