### PR TITLE
[FIX] calendar_sms: do not clear the cache

### DIFF
--- a/addons/calendar_sms/models/calendar.py
+++ b/addons/calendar_sms/models/calendar.py
@@ -42,9 +42,14 @@ class AlarmManager(models.AbstractModel):
         """ Cron method, overridden here to send SMS reminders as well
         """
         result = super(AlarmManager, self).get_next_mail()
+
+        cron = self.env.ref('calendar.ir_cron_scheduler_alarm', raise_if_not_found=False)
+        if not cron:
+            # Like the super method, do nothing if cron doesn't exist anymore
+            return result
+
         now = fields.Datetime.to_string(fields.Datetime.now())
-        last_sms_cron = self.env['ir.config_parameter'].get_param('calendar_sms.last_sms_cron', default=now)
-        cron = self.env['ir.model.data'].get_object('calendar', 'ir_cron_scheduler_alarm')
+        last_sms_cron = cron.lastcall
 
         interval_to_second = {
             "weeks": 7 * 24 * 60 * 60,
@@ -74,5 +79,4 @@ class AlarmManager(models.AbstractModel):
                 event_start = fields.Datetime.from_string(event.start)
                 for alert in self.do_check_alarm_for_one_date(event_start, event, max_delta, 0, 'sms', after=last_sms_cron, missing=True):
                     event.browse(alert['event_id'])._do_sms_reminder()
-        self.env['ir.config_parameter'].set_param('calendar_sms.last_sms_cron', now)
         return result


### PR DESCRIPTION
in a cron run frequently.

The cron "calendar.ir_cron_scheduler_alarm", when `calendar_sms` is installed, stores its last run datetime
 in an `ir.config.parameter`.  Since modifying config parameters cleans the cache,
the cron clears the cache every 30 minutes, unless modified...

As the cache is used to improve global system performance, clearing it
frequently should be avoided as much as possible.

Since v13, ir.cron records now store their lastcall datetime, there
is no need to keep the information in a config parameter anymore.

This commit uses this lastcall information instead, as it was done for
the calendar module:
See https://github.com/odoo/odoo/commit/52645a7b43be157be0782674a0f6b38359293f21

Fixes #63354 for 13+ versions.

For earlier versions (12.0), it cannot be "fixed" since the lastcall
information isn't available (note that the cache clear also happens in the
base calendar method in 12.0).



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
