### PR TITLE
[FIX] point_of_sale: having negative value with decrease quantity

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
@@ -252,13 +252,12 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
                 startingValue: 0,
                 title: this.env._t('Set the new quantity'),
             });
-            let newQuantity = inputNumber !== ""? Math.abs(inputNumber): null;
+            let newQuantity = inputNumber !== ""? inputNumber: null;
             if (confirmed && newQuantity !== null) {
                 let order = this.env.pos.get_order();
                 let selectedLine = this.env.pos.get_order().get_selected_orderline();
                 let currentQuantity = selectedLine.get_quantity()
-
-                if(currentQuantity === 1 && newQuantity > 0)
+                if(selectedLine.is_last_line() && currentQuantity === 1 && newQuantity < currentQuantity)
                     selectedLine.set_quantity(newQuantity);
                 else if(newQuantity >= currentQuantity)
                     selectedLine.set_quantity(newQuantity);

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -2339,6 +2339,13 @@ exports.Orderline = Backbone.Model.extend({
       this.product.lst_price = round_di(parseFloat(price) || 0, this.pos.dp['Product Price']);
       this.trigger('change',this);
     },
+    is_last_line: function() {
+        var order = this.pos.get_order();
+        var last_id = Object.keys(order.orderlines._byId)[Object.keys(order.orderlines._byId).length-1];
+        var selectedLine = order? order.selected_orderline: null;
+
+        return !selectedLine ? false : last_id === selectedLine.cid;
+    },
 });
 
 var OrderlineCollection = Backbone.Collection.extend({

--- a/addons/point_of_sale/static/src/xml/Popups/NumberPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/NumberPopup.xml
@@ -35,12 +35,7 @@
                         <button class="input-button number-char" t-on-mousedown.prevent="sendInput('7')">7</button>
                         <button class="input-button number-char" t-on-mousedown.prevent="sendInput('8')">8</button>
                         <button class="input-button number-char" t-on-mousedown.prevent="sendInput('9')">9</button>
-                        <t t-if="props.cheap">
-                            <button class="mode-button add" t-on-mousedown.prevent="sendInput('+5')">+5</button>
-                        </t>
-                        <t t-if="!props.cheap">
-                            <button class="mode-button add" t-on-mousedown.prevent="sendInput('+50')">+50</button>
-                        </t>
+                        <button class="input-button number-char" t-on-mousedown.prevent="sendInput('-')">-</button>
                         <br />
                         <button class="input-button numpad-char" t-on-mousedown.prevent="sendInput('Delete')">C</button>
                         <button class="input-button number-char" t-on-mousedown.prevent="sendInput('0')">0</button>


### PR DESCRIPTION
When you have a localisation like the french one that does not allow
you to decrease the value of a line, you cannot make returns because the
popup that shows you new value to encode, does not let you enter
negative numbers.

To allow those negative values, we let the modification of the line if
we are on the last line, and the quantity is equal to 1 which is the
default value of the line. It is the same behavior as in 13.0.

OPW-2411356

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
