### PR TITLE
[FIX] account: make AccountInvoiceReport available in single company env

### DIFF
--- a/addons/account/report/account_invoice_report.py
+++ b/addons/account/report/account_invoice_report.py
@@ -105,6 +105,9 @@ class AccountInvoiceReport(models.Model):
 
     @api.model
     def _from(self):
+        # In normal report options, multi_company contains lists the available companies
+        # but here the list is obtained by ResCurrency._get_query_currency_table()
+        is_multi_company = len(self.env.companies) > 1
         return '''
             FROM account_move_line line
                 LEFT JOIN res_partner partner ON partner.id = line.partner_id
@@ -118,7 +121,7 @@ class AccountInvoiceReport(models.Model):
                 LEFT JOIN res_partner commercial_partner ON commercial_partner.id = move.commercial_partner_id
                 JOIN {currency_table} ON currency_table.company_id = line.company_id
         '''.format(
-            currency_table=self.env['res.currency']._get_query_currency_table({'multi_company': True, 'date': {'date_to': fields.Date.today()}}),
+            currency_table=self.env['res.currency']._get_query_currency_table({'multi_company': is_multi_company, 'date': {'date_to': fields.Date.today()}}),
         )
 
     @api.model


### PR DESCRIPTION
Before this commit an invalid SQL query was generated in single company
environment when obtaining the table query for AccountInvoiceReport.

After this commit the companies-related information used in the table
query are obtained according to whether the environment contains more
than one company.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
