### PR TITLE
[FIX] web: Hide dateRangePicker when scrolling

### DIFF
--- a/addons/web/static/lib/tempusdominus/tempusdominus.js
+++ b/addons/web/static/lib/tempusdominus/tempusdominus.js
@@ -2726,6 +2726,19 @@ var TempusDominusBootstrap4 = function ($) {
             });
         };
 
+        TempusDominusBootstrap4._onScroll = function _onScroll(event){
+            var $target = getSelectorFromElement($(this)),
+            config = $target.data(DateTimePicker.DATA_KEY);
+            if ($target.length === 0) {
+                return;
+            }
+            // /!\ ODOO FIX: check on 'config' existence added by odoo
+            if (config && config._options.debug || window.debug) {
+                return;
+            }
+            TempusDominusBootstrap4._jQueryInterface.call($target, 'hide', event);
+        }
+
         return TempusDominusBootstrap4;
     }(DateTimePicker);
 
@@ -2758,6 +2771,7 @@ var TempusDominusBootstrap4 = function ($) {
         if (config && config._options.debug || window.debug) {
             return;
         }
+        window.removeEventListener('scroll', TempusDominusBootstrap4._onScroll, true);
         TempusDominusBootstrap4._jQueryInterface.call($target, 'hide', event);
     }).on(DateTimePicker.Event.KEYDOWN, '.' + DateTimePicker.ClassName.INPUT, function (event) {
         var $target = getSelectorFromElement($(this));
@@ -2781,6 +2795,7 @@ var TempusDominusBootstrap4 = function ($) {
         if (!(config && config._options.allowInputToggle)) {
             return;
         }
+        window.addEventListener('scroll', TempusDominusBootstrap4._onScroll.bind(this), true);
         TempusDominusBootstrap4._jQueryInterface.call($target, 'show', event);
     });
 


### PR DESCRIPTION
What are the steps to reproduce your issue ?

    1. Install events
    2. Create new event
    3. Click on date and scroll to the top or bottom

What is currently happening ?

    You should have the calendar chooser follow you when scrolling through the page.

How to fix the bug ?

    Hide the calendar when scrolling

opw-2415229