### PR TITLE
[FIX] crm: fix rainbowman message display conditions

### DIFF
--- a/addons/crm/static/tests/crm_rainbowman_tests.js
+++ b/addons/crm/static/tests/crm_rainbowman_tests.js
@@ -114,6 +114,30 @@ odoo.define('crm.form_rainbowman_tests', function (require) {
             form.destroy();
         });
 
+        QUnit.test("first lead won, click on statusbar in edit mode then save", async function (assert) {
+            assert.expect(3);
+
+            const form = await createView(_.extend(this.testFormView, {
+                res_id: 6,
+                mockRPC: async function (route, args) {
+                    const result = await this._super(...arguments);
+                    if (args.model === 'crm.lead' && args.method === 'get_rainbowman_message') {
+                        assert.step(result || "no rainbowman");
+                    }
+                    return result;
+                },
+                viewOptions: {mode: 'edit'}
+            }));
+
+            await testUtils.dom.click(form.$(".o_statusbar_status button[data-value='3']"));
+            assert.verifySteps([]); // no message displayed yet
+
+            await testUtils.form.clickSave(form);
+            assert.verifySteps(['Go, go, go! Congrats for your first deal.']);
+
+            form.destroy();
+        });
+
         QUnit.test("team record 30 days, click on statusbar", async function (assert) {
             assert.expect(2);
 


### PR DESCRIPTION
This commit fixes the display of the rainbowman message when leads go through
the "won" stage.

Currently, some flows don't show the message when they are supposed to or show
the message when they are NOT supposed to.
This is because the case when the form is saved through the regular "Save"
button is not handled at all.

The CRM form controller extension was completed with the missing use case and
fixed.
An additional QUnit test ensures the correct behavior.

Task-2418294

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
