### PR TITLE
[IMP] res.partner: improve error message when changing company

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -533,7 +533,9 @@ class Partner(models.Model):
                 if company_id and partner.user_ids:
                     company = self.env['res.company'].browse(company_id)
                     companies = set(user.company_id for user in partner.user_ids)
-                    if len(companies) > 1 or company not in companies:
+                    if len(companies) > 1:
+                        raise UserError(_("You can not change the company as the partner/user has multiple user linked with different companies."))
+                    elif company not in companies:
                         raise UserError(
                             ("The selected company is not compatible with the companies of the related user(s)"))
                 if partner.child_ids:


### PR DESCRIPTION
this improves previous change made in https://github.com/odoo/odoo/commit/6c9176652fa74ad622c89c3f97902bd23d720905

STEPS:

* create 2 users so 2 related partners will created automatically
* now go to  merge functionality for above 2 partner which created from above 2 users and merge it.
* now come to users form and try to change the compay it will give error/warning

BEFORE: error message "The selected company is not compatible with the companies of the related user(s)"
AFTER: error message "You can not change the company as the partner/user has multiple user linked with different companies."

---

opw-2372226

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
