### PR TITLE
[FIX] l10n_fr: use correct account type for "chèques à encaisser"

### DIFF
--- a/addons/l10n_fr/data/account.account.template.csv
+++ b/addons/l10n_fr/data/account.account.template.csv
@@ -419,7 +419,7 @@
 "pcg_5088","Intérêts courus sur obligations, bons et valeurs assimilées","508800","account.data_account_type_liquidity","l10n_fr.l10n_fr_pcg_chart_template","False"
 "pcg_509","Versements restant à effectuer sur valeurs mobilières de placement non libérées","509000","account.data_account_type_liquidity","l10n_fr.l10n_fr_pcg_chart_template","False"
 "pcg_5111","Coupons échus à l'encaissement","511100","account.data_account_type_liquidity","l10n_fr.l10n_fr_pcg_chart_template","True"
-"pcg_5112","Chèques à encaisser","511200","account.data_account_type_liquidity","l10n_fr.l10n_fr_pcg_chart_template","True"
+"pcg_5112","Chèques à encaisser","511200","account.data_account_type_current_assets","l10n_fr.l10n_fr_pcg_chart_template","True"
 "pcg_5113","Effets à l'encaissement","511300","account.data_account_type_liquidity","l10n_fr.l10n_fr_pcg_chart_template","True"
 "pcg_5114","Effets à l'escompte","511400","account.data_account_type_liquidity","l10n_fr.l10n_fr_pcg_chart_template","True"
 "pcg_5121"," Comptes en monnaie nationale","512100","account.data_account_type_liquidity","l10n_fr.l10n_fr_pcg_chart_template","False"


### PR DESCRIPTION
This account is intended to be used on a bank journal instead of the bank account. Making it reconcilable is required so that it can be reconciled with a statement made in another bank journal (representing the actual bank account).

https://github.com/odoo/odoo/commit/7df9704845f99ad985607940386bacf691ef28db changed this account's type to liquidity, but that breaks the above use case, as a liquidity account is not supposed to be reconcilable at all (and so, instead of creating a writeoff, only statement_line_id is set on the check's line, and the statement balances of each journals don't match the general ledger).

OPW 2356956
