### PR TITLE
[DOC] Add a note about CSRF token validation for JSON routes

### DIFF
--- a/doc/cla/individual/ryanc-me.md
+++ b/doc/cla/individual/ryanc-me.md
@@ -1,0 +1,11 @@
+New Zealand, 2020-12-17
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Ryan Cole admin@ryanc.me https://github.com/ryanc-me

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -503,6 +503,9 @@ def route(route=None, **kw):
           to implement other methods of request validation (to ensure
           it is not called by an unrelated third-party).
 
+          Note that CSRF tokens are *not* validated for JSON routes.
+          If `csrf_token` is passed in a JSON request, even if it is
+          a `POST` request, the value will be ignored.
     """
     routing = kw.copy()
     assert 'type' not in routing or routing['type'] in ("http", "json")


### PR DESCRIPTION
The [documentation on CSRF tokens](https://www.odoo.com/documentation/14.0/reference/http.html#routing) is not explicitly clear that tokens are not validated for JSON routes. The docs do mention "UNSAFE HTTP routes", but this is open to interpretation (does this mean `HTTP/1.1`, or `type='http'`?).

If `csrf_token` is passed to a JSON route, it is ignored ([see here](https://github.com/odoo/odoo/blob/14.0/odoo/http.py#L552)). This may lead developers to assume the tokens are being checked, and could lead to a situation where routes are exposed without CSRF checks.

Some reference:

- https://www.odoo.com/forum/help-1/how-to-set-csrf-verification-for-http-route-type-json-162706
- https://github.com/odoo/odoo/issues/43151


As a semi-unrelated question: Is this behavior intentional? It seems like adding CSRF validation to JSON routes would be fairly easy. Even if CSRF was opt-in for JSON routes (to prevent breaking older modules), it would be a nice security boost.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
