### PR TITLE
remove custom group field if already there in group dropdown

### DIFF
--- a/addons/web/static/src/js/control_panel/custom_group_by_item.js
+++ b/addons/web/static/src/js/control_panel/custom_group_by_item.js
@@ -3,6 +3,7 @@ odoo.define('web.CustomGroupByItem', function (require) {
 
     const DropdownMenuItem = require('web.DropdownMenuItem');
     const { useModel } = require('web/static/src/js/model.js');
+    const { onPatched } = owl.hooks;
 
     /**
      * Group by generator menu
@@ -21,20 +22,9 @@ odoo.define('web.CustomGroupByItem', function (require) {
             this.state.fieldName = this.props.fields[0].name;
 
             this.model = useModel('searchModel');
-            this.state.fields = this._getGroupByFields();
-        }
 
-        //---------------------------------------------------------------------
-        // Private
-        //---------------------------------------------------------------------
-
-        _getGroupByFields() {
-            const groupBys = this.model.get('filters', f => f.type === 'groupBy');
-            if (!groupBys) {
-                return this.props.fields;
-            }
-            return this.props.fields.filter(field => {
-                return !groupBys.find(group => group.fieldName === field.name);
+            onPatched(() => {
+                this.state.fieldName = this.props.fields[0].name;
             });
         }
 
@@ -48,9 +38,8 @@ odoo.define('web.CustomGroupByItem', function (require) {
         _onApply() {
             const field = this.props.fields.find(f => f.name === this.state.fieldName);
             this.model.dispatch('createNewGroupBy', field);
-            this.state.fields = this._getGroupByFields();
-            this.state.fieldName = this.state.fields.length && this.state.fields[0].name;
             this.state.open = false;
+            this.trigger('custom-group-applied');
         }
     }
 

--- a/addons/web/static/src/js/control_panel/custom_group_by_item.js
+++ b/addons/web/static/src/js/control_panel/custom_group_by_item.js
@@ -21,6 +21,21 @@ odoo.define('web.CustomGroupByItem', function (require) {
             this.state.fieldName = this.props.fields[0].name;
 
             this.model = useModel('searchModel');
+            this.state.fields = this._getGroupByFields();
+        }
+
+        //---------------------------------------------------------------------
+        // Private
+        //---------------------------------------------------------------------
+
+        _getGroupByFields() {
+            const groupBys = this.model.get('filters', f => f.type === 'groupBy');
+            if (!groupBys) {
+                return this.props.fields;
+            }
+            return this.props.fields.filter(field => {
+                return !groupBys.find(group => group.fieldName === field.name);
+            });
         }
 
         //---------------------------------------------------------------------
@@ -33,6 +48,8 @@ odoo.define('web.CustomGroupByItem', function (require) {
         _onApply() {
             const field = this.props.fields.find(f => f.name === this.state.fieldName);
             this.model.dispatch('createNewGroupBy', field);
+            this.state.fields = this._getGroupByFields();
+            this.state.fieldName = this.state.fields.length && this.state.fields[0].name;
             this.state.open = false;
         }
     }

--- a/addons/web/static/src/js/control_panel/custom_group_by_item.js
+++ b/addons/web/static/src/js/control_panel/custom_group_by_item.js
@@ -3,7 +3,7 @@ odoo.define('web.CustomGroupByItem', function (require) {
 
     const DropdownMenuItem = require('web.DropdownMenuItem');
     const { useModel } = require('web/static/src/js/model.js');
-    const { onPatched } = owl.hooks;
+    const { onWillUpdateProps } = owl.hooks;
 
     /**
      * Group by generator menu
@@ -23,8 +23,8 @@ odoo.define('web.CustomGroupByItem', function (require) {
 
             this.model = useModel('searchModel');
 
-            onPatched(() => {
-                this.state.fieldName = this.props.fields[0].name;
+            onWillUpdateProps((nextProps) => {
+                this.state.fieldName = nextProps.fields[0].name;
             });
         }
 

--- a/addons/web/static/src/js/control_panel/groupby_menu.js
+++ b/addons/web/static/src/js/control_panel/groupby_menu.js
@@ -20,11 +20,12 @@ odoo.define('web.GroupByMenu', function (require) {
         constructor() {
             super(...arguments);
 
-            this.fields = Object.values(this.props.fields)
+            this.model = useModel('searchModel');
+
+            const fields = Object.values(this.props.fields)
                 .filter(field => this._validateField(field))
                 .sort(({ string: a }, { string: b }) => a > b ? 1 : a < b ? -1 : 0);
-
-            this.model = useModel('searchModel');
+            this.state.fields = this._getCustomGroupByFields(fields);
         }
 
         //---------------------------------------------------------------------
@@ -58,6 +59,20 @@ odoo.define('web.GroupByMenu', function (require) {
 
         /**
          * @private
+         * @param {Object} fields
+         * @returns {Object}
+         */
+        _getCustomGroupByFields(fields) {
+            const groupBys = this.model.get('filters', f => f.type === 'groupBy');
+            if (!groupBys) {
+                return fields;
+            }
+            return fields.filter(field => {
+                return !groupBys.find(group => group.fieldName === field.name);
+            });
+        }
+        /**
+         * @private
          * @param {Object} field
          * @returns {boolean}
          */
@@ -71,6 +86,14 @@ odoo.define('web.GroupByMenu', function (require) {
         // Handlers
         //---------------------------------------------------------------------
 
+        /**
+         * @private
+         * @param {OwlEvent} ev
+         */
+        _onCustomGroupApplied(ev) {
+            ev.stopPropagation();
+            this.state.fields = this._getCustomGroupByFields(this.state.fields);
+        }
         /**
          * @private
          * @param {OwlEvent} ev

--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -210,10 +210,13 @@
 </t>
 
 <t t-name="web.GroupByMenu" t-inherit="web.DropdownMenu" t-inherit-mode="primary" owl="1">
+    <xpath expr="//div[contains(@class, 'o_dropdown')]" position="attributes">
+        <attribute name="t-on-custom-group-applied">_onCustomGroupApplied</attribute>
+    </xpath>
     <xpath expr="//ul[@role='menu']" position="inside">
-        <t t-if="fields.length">
+        <t t-if="state.fields.length">
             <li t-if="items.length" class="dropdown-divider" role="separator"/>
-            <CustomGroupByItem fields="fields"/>
+            <CustomGroupByItem fields="state.fields"/>
         </t>
     </xpath>
 </t>
@@ -444,7 +447,7 @@
         </button>
         <div t-if="state.open" class="dropdown-item-text">
             <select class="w-auto o_input o_group_by_selector" t-model="state.fieldName">
-                <option t-foreach="state.fields" t-as="field" t-key="field.name"
+                <option t-foreach="props.fields" t-as="field" t-key="field.name"
                     t-att-value="field.name"
                     t-esc="field.string"
                 />

--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -444,7 +444,7 @@
         </button>
         <div t-if="state.open" class="dropdown-item-text">
             <select class="w-auto o_input o_group_by_selector" t-model="state.fieldName">
-                <option t-foreach="props.fields" t-as="field" t-key="field.name"
+                <option t-foreach="state.fields" t-as="field" t-key="field.name"
                     t-att-value="field.name"
                     t-esc="field.string"
                 />


### PR DESCRIPTION
PURPOSE
Remove field from custom groupby if groupby dropdown already have group filter available on that field.

SPEC
Currently custom filter dropdown shows all fields even though group filter is available on that field, if group filter on field is available then custom group should filter those fields.

TASK 2393762


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
