### PR TITLE
[FIX] base: Add support of widget tag in list view

### DIFF
--- a/odoo/addons/base/rng/tree_view.rng
+++ b/odoo/addons/base/rng/tree_view.rng
@@ -83,6 +83,11 @@
                     <rng:element name="newline"><rng:empty/></rng:element>
                 </rng:choice>
             </rng:zeroOrMore>
+            <rng:zeroOrMore>
+                <rng:element name="widget">
+                    <rng:attribute name="name"/>
+                </rng:element>
+            </rng:zeroOrMore>
         </rng:element>
     </rng:define>
     <rng:start>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
Throw validation error when we declare `<widget>` tag in list view.

Desired behavior after PR is merged:
This allows to declare `<widget>` tag in list view.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
