### PR TITLE
[IMP] website_event, event: filter by tag category in website in event

### DIFF
--- a/addons/event/views/event_menu_views.xml
+++ b/addons/event/views/event_menu_views.xml
@@ -43,7 +43,7 @@
         groups="base.group_no_one"/>
     <menuitem name="Event Tags Categories"
         id="menu_event_category"
-        sequence="20"
+        sequence="3"
         parent="menu_event_configuration"/>
 
 </data></odoo>

--- a/addons/website_event/__manifest__.py
+++ b/addons/website_event/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'Events',
-    'version': '1.2',
+    'version': '1.3',
     'category': 'Marketing/Events',
     'sequence': 140,
     'summary': 'Publish events, sell tickets',
@@ -28,6 +28,7 @@
         'views/website_templates.xml',
         'views/event_event_views.xml',
         'views/event_registration_views.xml',
+        'views/event_tag_category_views.xml',
         'views/event_type_views.xml',
         'views/website_event_menu_views.xml',
         'views/website_visitor_views.xml',

--- a/addons/website_event/models/__init__.py
+++ b/addons/website_event/models/__init__.py
@@ -3,6 +3,7 @@
 
 from . import event_event
 from . import event_registration
+from . import event_tag_category
 from . import event_type
 from . import website
 from . import website_event_menu

--- a/addons/website_event/models/event_tag_category.py
+++ b/addons/website_event/models/event_tag_category.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class EventTagCategory(models.Model):
+    _name = 'event.tag.category'
+    _inherit = ['event.tag.category', 'website.published.mixin']
+
+    def _default_is_published(self):
+        return True

--- a/addons/website_event/security/event_security.xml
+++ b/addons/website_event/security/event_security.xml
@@ -13,9 +13,9 @@
     </record>
 
     <record id="ir_rule_event_tag_public" model="ir.rule">
-        <field name="name">Event Tag: public/portal: color = published</field>
+        <field name="name">Event Tag: public/portal: color = published and category = published</field>
         <field name="model_id" ref="event.model_event_tag"/>
-        <field name="domain_force">['&amp;', ('color', '!=', False), ('color', '!=', 0)]</field>
+        <field name="domain_force">[('category_id.website_published', '=', True), ('color', '!=', False), ('color', '!=', 0)]</field>
         <field name="groups" eval="[(4, ref('base.group_public')), (4, ref('base.group_portal'))]"/>
         <field name="perm_read" eval="True"/>
         <field name="perm_write" eval="False"/>

--- a/addons/website_event/views/event_tag_category_views.xml
+++ b/addons/website_event/views/event_tag_category_views.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="event_tag_category_view_form" model="ir.ui.view">
+        <field name="name">event.tag.category.view.form.inherit.website</field>
+        <field name="model">event.tag.category</field>
+        <field name="inherit_id" ref="event.event_tag_category_view_form"/>
+        <field name="arch" type="xml">
+            <field name="tag_ids" position="before">
+                <field name="is_published" string="Show on Website" widget="boolean_toggle"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="event_tag_category_view_tree" model="ir.ui.view">
+        <field name="name">event.tag.category.view.tree.inherit.website</field>
+        <field name="model">event.tag.category</field>
+        <field name="inherit_id" ref="event.event_tag_category_view_tree"/>
+        <field name="arch" type="xml">
+            <field name="tag_ids" position="before">
+                <field name="is_published" string="Show on Website"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -97,7 +97,7 @@
 <template id="event_category_tag" inherit_id="website_event.index_topbar" active="False" customize_show="True" name="Filter by Tags">
     <xpath expr="//ul[hasclass('o_wevent_index_topbar_filters')]" position="inside">
         <t t-foreach="categories" t-as="category">
-            <li t-if="category.tag_ids and any(tag.color for tag in category.tag_ids)" class="nav-item dropdown mr-2 my-1">
+            <li t-if="category.is_published and category.tag_ids and any(tag.color for tag in category.tag_ids)" class="nav-item dropdown mr-2 my-1">
                 <a href="#" role="button" class="btn dropdown-toggle" data-toggle="dropdown">
                     <i class="fa fa-folder-open"/>
                     <t t-esc="category.name"/>
@@ -205,7 +205,7 @@
                             <!-- Location -->
                             <div itemprop="location" t-field="event.address_id" t-options="{'widget': 'contact', 'fields': ['city'], 'no_marker': 'true'}"/>
                             <div class="mt8 d-flex align-items-center">
-                                <t t-foreach="event.tag_ids" t-as="tag">
+                                <t t-foreach="event.tag_ids.filtered(lambda tag: tag.category_id.is_published)" t-as="tag">
                                     <span t-if="tag.color"
                                         t-attf-class="badge mr8 #{'badge-primary' if tag in search_tags else 'badge-light'} #{'o_tag_color_%s' % tag.color if tag.color else ''}">
                                         <span t-esc="tag.name"/>


### PR DESCRIPTION
PURPOSE
Allow users to use event tags both externally (filter on the /event page) as well as internally [NDLR: which is considered the "advanced mode"] (reports, filters, o-spreadsheets, ...).

SPECIFICATIONS

Current
User cannot decide the filter by tag category on website should be shown.

To be
Add a boolean field on event tag categories.
Default value is TRUE.
If true, the category is shown on event page in header in website
If false... Well, hide it!


LINKS

PR
Task: 2300230
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr