### PR TITLE
[FIX] hr_recruitment: sync alias defaults

### DIFF
--- a/addons/hr_recruitment/models/hr_department.py
+++ b/addons/hr_recruitment/models/hr_department.py
@@ -32,3 +32,9 @@ class HrDepartment(models.Model):
         for department in self:
             department.new_hired_employee = new_emp.get(department.id, 0)
             department.expected_employee = expected_emp.get(department.id, 0)
+
+    def unlink(self):
+        related_jobs = self.env['hr.job'].search([('department_id', 'in', self.ids)])
+        result = super().unlink()
+        related_jobs._sync_alias_values()
+        return result


### PR DESCRIPTION
Before this patch, incoming mails to the job alias would fail always when a department was deleted.

To reproduce:

1. Create the `hr.job` for department A, with an alias.
2. Delete department A.
3. Send an email to the alias.

Expected result: new applicant created without department.

Result before the patch: mail lost.

@Tecnativa TT27368


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
