### PR TITLE
[FIX] mail: inconsistency of new message style

### DIFF
--- a/addons/mail/static/src/components/chat_window/chat_window.xml
+++ b/addons/mail/static/src/components/chat_window/chat_window.xml
@@ -40,7 +40,6 @@
                         </span>
                         <AutocompleteInput
                             class="o_ChatWindow_newMessageFormInput"
-                            isHtml="true"
                             placeholder="newMessageFormInputPlaceholder"
                             select="_onAutocompleteSelect"
                             source="_onAutocompleteSource"


### PR DESCRIPTION
The style of discuss new message (+) and chat window new message
should be consistent, as they both cover the exact same feature.