### PR TITLE
[FIX] website_forum: hide posts by access rules for multiwebsite

### DIFF
--- a/addons/website_forum/controllers/main.py
+++ b/addons/website_forum/controllers/main.py
@@ -212,8 +212,9 @@ class WebsiteForum(WebsiteProfile):
         if not forum.active:
             return request.render("website_forum.header", {'forum': forum})
 
+        # Hide posts by access rules for multiwebsite
         # Hide posts from abusers (negative karma), except for moderators
-        if not question.can_view:
+        if not forum.can_access_from_current_website() or not question.can_view:
             raise werkzeug.exceptions.NotFound()
 
         # Hide pending posts from non-moderators and non-creator


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

**Current behavior before PR:**

eg: post 1 on website 1, post 2 on website 2
    access blog 1 from website 1 => can access -> normal
    access blog 1 from website 2 => can access -> normal

**Desired behavior after PR is merged:**

eg: post 1 on website 1, post 2 on website 2
    access blog 1 from website 1 => can access -> normal
    access blog 1 from website 2 => can access -> should crash because (ir rule)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
