### PR TITLE
Master logistic remove index ryv

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -432,7 +432,7 @@ class MrpByProduct(models.Model):
         'Quantity',
         default=1.0, digits='Product Unit of Measure', required=True)
     product_uom_id = fields.Many2one('uom.uom', 'Unit of Measure', required=True)
-    bom_id = fields.Many2one('mrp.bom', 'BoM', ondelete='cascade')
+    bom_id = fields.Many2one('mrp.bom', 'BoM', ondelete='cascade', index=True)
     allowed_operation_ids = fields.Many2many('mrp.routing.workcenter', compute='_compute_allowed_operation_ids')
     operation_id = fields.Many2one(
         'mrp.routing.workcenter', 'Produced in Operation', check_company=True,

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -136,8 +136,8 @@ class MrpProduction(models.Model):
     date_deadline = fields.Datetime(
         'Deadline', copy=False, store=True, readonly=True, compute='_compute_date_deadline', inverse='_set_date_deadline',
         help="Informative date allowing to define when the manufacturing order should be processed at the latest to fulfill delivery on time.")
-    date_start = fields.Datetime('Start Date', copy=False, index=True, readonly=True)
-    date_finished = fields.Datetime('End Date', copy=False, index=True, readonly=True)
+    date_start = fields.Datetime('Start Date', copy=False, readonly=True, help="Date of the WO")
+    date_finished = fields.Datetime('End Date', copy=False, readonly=True, help="Date when the MO has been close")
     bom_id = fields.Many2one(
         'mrp.bom', 'Bill of Material',
         readonly=True, states={'draft': [('readonly', False)]},

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -74,7 +74,7 @@ class MrpProduction(models.Model):
     name = fields.Char(
         'Reference', copy=False, readonly=True, default=lambda x: _('New'))
     priority = fields.Selection(
-        PROCUREMENT_PRIORITIES, string='Priority', default='0', index=True,
+        PROCUREMENT_PRIORITIES, string='Priority', default='0',
         help="Components will be reserved first for the MO with the highest priorities.")
     backorder_sequence = fields.Integer("Backorder Sequence", default=0, copy=False, help="Backorder sequence, if equals to 0 means there is not related backorder")
     origin = fields.Char(

--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -70,7 +70,7 @@ class MrpUnbuild(models.Model):
         string='Processed Disassembly Lines')
     state = fields.Selection([
         ('draft', 'Draft'),
-        ('done', 'Done')], string='Status', default='draft', index=True)
+        ('done', 'Done')], string='Status', default='draft')
     allowed_mo_ids = fields.One2many('mrp.production', compute='_compute_allowed_mo_ids')
 
     @api.depends('company_id', 'product_id')

--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -308,12 +308,12 @@ class MrpWorkcenterProductivity(models.Model):
             company_id = self.env.company
         return company_id
 
-    production_id = fields.Many2one('mrp.production', string='Manufacturing Order', related='workorder_id.production_id', readonly='True')
-    workcenter_id = fields.Many2one('mrp.workcenter', "Work Center", required=True, check_company=True)
+    production_id = fields.Many2one('mrp.production', string='Manufacturing Order', related='workorder_id.production_id', readonly=True)
+    workcenter_id = fields.Many2one('mrp.workcenter', "Work Center", required=True, check_company=True, index=True)
     company_id = fields.Many2one(
         'res.company', required=True, index=True,
         default=lambda self: self._get_default_company_id())
-    workorder_id = fields.Many2one('mrp.workorder', 'Work Order', check_company=True)
+    workorder_id = fields.Many2one('mrp.workorder', 'Work Order', check_company=True, index=True)
     user_id = fields.Many2one(
         'res.users', "User",
         default=lambda self: self.env.uid)

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -425,15 +425,6 @@
             </field>
         </record>
 
-        <record id="view_production_gantt" model="ir.ui.view">
-            <field name="name">mrp.production.gantt</field>
-            <field name="model">mrp.production</field>
-            <field name="arch" type="xml">
-                <gantt date_stop="date_finished" date_start="date_start" string="Productions" create="0">
-                </gantt>
-            </field>
-        </record>
-
         <record id="view_production_pivot" model="ir.ui.view">
             <field name="name">mrp.production.pivot</field>
             <field name="model">mrp.production</field>

--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -500,7 +500,6 @@
         <field name="arch" type="xml">
             <search string="Operations">
                 <field name="workcenter_id"/>
-                <field name="workcenter_id"/>
                 <field name="loss_id"/>
                 <separator/>
                 <filter name="availability" string="Availability Losses" domain="[('loss_type','=','availability')]"/>

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -33,7 +33,6 @@ class StockMove(models.Model):
     priority = fields.Selection(
         PROCUREMENT_PRIORITIES, 'Priority', default='0',
         compute="_compute_priority", store=True, index=True)
-    create_date = fields.Datetime('Creation Date', index=True, readonly=True)
     date = fields.Datetime(
         'Date Scheduled', default=fields.Datetime.now, index=True, required=True,
         help="Scheduled date until move is done, then date of actual move processing")

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -32,7 +32,7 @@ class StockMove(models.Model):
     sequence = fields.Integer('Sequence', default=10)
     priority = fields.Selection(
         PROCUREMENT_PRIORITIES, 'Priority', default='0',
-        compute="_compute_priority", store=True, index=True)
+        compute="_compute_priority", store=True)
     date = fields.Datetime(
         'Date Scheduled', default=fields.Datetime.now, index=True, required=True,
         help="Scheduled date until move is done, then date of actual move processing")

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -28,7 +28,7 @@ class StockMove(models.Model):
             return self.env['stock.picking'].browse(self.env.context['default_picking_id']).group_id.id
         return False
 
-    name = fields.Char('Description', index=True, required=True)
+    name = fields.Char('Description', required=True)
     sequence = fields.Integer('Sequence', default=10)
     priority = fields.Selection(
         PROCUREMENT_PRIORITIES, 'Priority', default='0',
@@ -112,7 +112,7 @@ class StockMove(models.Model):
     price_unit = fields.Float(
         'Unit Price', help="Technical field used to record the product cost set by the user during a picking confirmation (when costing "
                            "method used is 'average price' or 'real'). Value given in company currency and in product uom.", copy=False)  # as it's a technical field, we intentionally don't provide the digits attribute
-    backorder_id = fields.Many2one('stock.picking', 'Back Order of', related='picking_id.backorder_id', index=True, readonly=False)
+    backorder_id = fields.Many2one('stock.picking', 'Back Order of', related='picking_id.backorder_id', readonly=False)
     origin = fields.Char("Source Document")
     procure_method = fields.Selection([
         ('make_to_stock', 'Default: Take From Stock'),

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -279,7 +279,7 @@ class Picking(models.Model):
         'procurement.group', 'Procurement Group',
         readonly=True, related='move_lines.group_id', store=True)
     priority = fields.Selection(
-        PROCUREMENT_PRIORITIES, string='Priority', default='0', index=True,
+        PROCUREMENT_PRIORITIES, string='Priority', default='0',
         help="Products will be reserved first for the transfers with the highest priorities.")
     scheduled_date = fields.Datetime(
         'Scheduled Date', compute='_compute_scheduled_date', inverse='_set_scheduled_date', store=True,

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -294,7 +294,7 @@ class Picking(models.Model):
         help="Is late or will be late depending on the deadline and scheduled date")
     date = fields.Datetime(
         'Creation Date',
-        default=fields.Datetime.now, index=True, tracking=True,
+        default=fields.Datetime.now, tracking=True,
         states={'done': [('readonly', True)], 'cancel': [('readonly', True)]},
         help="Creation Date, usually the time of the order")
     date_done = fields.Datetime('Date of Transfer', copy=False, readonly=True, help="Date at which the transfer has been processed or cancelled.")

--- a/addons/stock/models/stock_production_lot.py
+++ b/addons/stock/models/stock_production_lot.py
@@ -16,7 +16,7 @@ class ProductionLot(models.Model):
         required=True, help="Unique Lot/Serial Number")
     ref = fields.Char('Internal Reference', help="Internal reference number in case it differs from the manufacturer's lot/serial number")
     product_id = fields.Many2one(
-        'product.product', 'Product',
+        'product.product', 'Product', index=True,
         domain=lambda self: self._domain_product_id(), required=True, check_company=True)
     product_uom_id = fields.Many2one(
         'uom.uom', 'Unit of Measure',

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -85,7 +85,7 @@ class StockRule(models.Model):
     auto = fields.Selection([
         ('manual', 'Manual Operation'),
         ('transparent', 'Automatic No Step Added')], string='Automatic Move',
-        default='manual', index=True, required=True,
+        default='manual', required=True,
         help="The 'Manual Operation' value will create a stock move after the current one. "
              "With 'Automatic No Step Added', the location is replaced in the original move.")
     rule_message = fields.Html(compute='_compute_action_message')

--- a/addons/stock/populate/stock.py
+++ b/addons/stock/populate/stock.py
@@ -90,11 +90,11 @@ class Location(models.Model):
                     depth = 1
                 else:
                     # Scenario 3 : one company with high depth location tree
-                    depth = 20
+                    depth = 10
 
                 nb_by_level = int(math.log(nb_loc_to_take, depth)) + 1 if depth > 1 else nb_loc_to_take  # number of loc to put by level
 
-                _logger.info("Create locations (%d) tree for one warehouse - depth : %d, width : %d" % (nb_loc_to_take, depth, nb_by_level))
+                _logger.info("Create locations (%d) tree for a warehouse (%s) - depth : %d, width : %d" % (nb_loc_to_take, warehouse.code, depth, nb_by_level))
 
                 # Root is the lot_stock_id of warehouse
                 root = warehouse.lot_stock_id
@@ -109,7 +109,7 @@ class Location(models.Model):
                             children.append(loc_ids_by_company[company_id].pop())
 
                         child_locations = self.env['stock.location'].concat(*children)
-                        child_locations.location_id = parent
+                        child_locations.location_id = parent  # Quite slow, because the ORM flush each time
                         for child in child_locations:
                             link_next_locations(child, level + 1)
 
@@ -119,7 +119,7 @@ class Location(models.Model):
         # Change 20 % the usage of some no-leaf location into 'view' (instead of 'internal')
         to_views = locations_sample.filtered_domain([('child_ids', '!=', [])]).ids
         random = populate.Random('stock_location_views')
-        self.browse(random.sample(to_views, int(len(to_views) * 0.2))).usage = 'view'
+        self.browse(random.sample(to_views, int(len(to_views) * 0.1))).usage = 'view'
 
         return locations
 

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -34,7 +34,6 @@
                     <field name="date" groups="base.group_no_one" decoration-danger="(state not in ('cancel','done')) and date > current_date" />
                     <field name="reference"/>
                     <field name="picking_type_id" invisible="1"/>
-                    <field name="create_date" invisible="1" groups="base.group_no_one"/>
                     <field name="product_id"/>
                     <field name="location_id" options="{'no_create': True}" string="From"/>
                     <field name="location_dest_id" options="{'no_create': True}" string="To"/>
@@ -435,7 +434,6 @@
                     <field name="product_uom" options="{'no_open': True, 'no_create': True}" string="Unit of Measure" groups="uom.group_uom"/>
                     <field name="location_id" options="{'no_create': True}" invisible="1"/>
                     <field name="location_dest_id" invisible="1"/>
-                    <field name="create_date" invisible="1"/>
                     <field name="state" optional="show"/>
                     <field name="company_id" invisible="1"/>
                 </tree>


### PR DESCRIPTION
Review all indexes of main logistics modules:
- Remove useless ones (10) to gain insert/update performance and save some space disk
- Add few indexes (4) on some fields to gain in scalability (performance).

Improve a bit the populate script. 

odoo/upgrade#2042