### PR TITLE
[FIX] event: make ticket sale start date inclusive

### DIFF
--- a/addons/event/models/event_ticket.py
+++ b/addons/event/models/event_ticket.py
@@ -145,6 +145,6 @@ class EventTicket(models.Model):
         if self.start_sale_date:
             ticket = self._set_tz_context()
             current_date = fields.Date.context_today(ticket)
-            return ticket.start_sale_date < current_date
+            return ticket.start_sale_date <= current_date
         else:
             return True

--- a/addons/event/tests/test_event_internals.py
+++ b/addons/event/tests/test_event_internals.py
@@ -348,6 +348,14 @@ class TestEventTicketData(TestEventCommon):
         })
         self.assertFalse(second_ticket.sale_available)
         self.assertFalse(second_ticket.is_expired)
+        # sale started today
+        second_ticket.write({
+            'start_sale_date': date(2020, 1, 31),
+            'end_sale_date': date(2020, 2, 20),
+        })
+        self.assertTrue(second_ticket.sale_available)
+        self.assertTrue(second_ticket.is_launched())
+        self.assertFalse(second_ticket.is_expired)
         # incoherent dates are invalid
         with self.assertRaises(exceptions.UserError):
             second_ticket.write({'end_sale_date': date(2020, 1, 20)})


### PR DESCRIPTION
This commit fixes the ticket sale start date to be considered inclusive.

Indeed, before this commit, if the sales of a ticket starts on the 1st of
December, people arriving on the website at that exact date will NOT be able to
buy tickets although they should be. They will have to wait for the next day to
be able to buy tickets.

A small test was added to ensure this behavior.

Task 2415917

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
