### PR TITLE
[FIX] sale: don't recompute tax id when it is read only

### DIFF
--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -408,8 +408,9 @@
                                                 <field name="qty_invoiced" attrs="{'invisible': [('parent.state', 'not in', ['sale', 'done'])]}"/>
                                             </div>
                                             <field name="price_unit"/>
+                                            <field name="is_tax_readonly" invisible="1"/>
                                             <field name="tax_id" widget="many2many_tags" options="{'no_create': True}" context="{'search_view_ref': 'account.account_tax_view_search'}" domain="[('type_tax_use','=','sale'),('company_id','=',parent.company_id)]"
-                                                attrs="{'readonly': [('qty_invoiced', '&gt;', 0)]}"/>
+                                                attrs="{'readonly': [('is_tax_readonly', '=', True)]}"/>
                                             <label for="discount" groups="product.group_discount_per_so_line"/>
                                             <div name="discount" groups="product.group_discount_per_so_line">
                                                 <field name="discount" class="oe_inline"/> %%


### PR DESCRIPTION
Behavior prior to this commit:

- when a SO line has been invoiced, the tax on it becomes readonly.  But it
is still possible to modify the fiscal position on the SO (since
other lines on the SO might not have been invoiced yet).  Doing so may
change the tax on the view, even though the change does not actually
post when saving the view (it is silently discarded)

Behavior after the commit:

- the tax id is not modified when changing the fiscal position, for
lines that have already been invoiced.

Note:

- PR targets master, not 14.0, since it is a potentially breaking change of behavior (in case somebody was relying on getting the tax recalculated on change of fiscal position even when it was read-only - e.g with a 3rd party module)

opw-2411692
