### PR TITLE
[FIX] point_of_sale: missing search bar when no pos category

### DIFF
--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ProductsWidget.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ProductsWidget.xml
@@ -3,9 +3,7 @@
 
     <t t-name="ProductsWidget" owl="1">
       <div class="products-widget">
-            <t t-if="!hasNoCategories">
-                <ProductsWidgetControlPanel breadcrumbs="breadcrumbs" subcategories="subcategories" />
-            </t>
+            <ProductsWidgetControlPanel breadcrumbs="breadcrumbs" subcategories="subcategories" hasNoCategories="hasNoCategories" />
             <ProductList products="productsToDisplay" searchWord="searchWord" />
         </div>
     </t>

--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ProductsWidgetControlPanel.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/ProductsWidgetControlPanel.xml
@@ -3,36 +3,38 @@
 
     <t t-name="ProductsWidgetControlPanel" owl="1">
         <div class="products-widget-control">
-            <div class="rightpane-header" t-att-class="{
-                'green-border-bottom': !env.pos.config.iface_display_categ_images,
-                'grey-border-bottom': env.pos.config.iface_display_categ_images,
-            }">
-                <!-- Breadcrumbs -->
-                <div class="breadcrumbs">
-                    <HomeCategoryBreadcrumb subcategories="props.subcategories" currentCat="props.breadcrumbs[props.breadcrumbs.length - 1]"/>
-                    <t t-if="!env.isMobile">
-                        <t t-foreach="props.breadcrumbs" t-as="category" t-key="category.id">
-                            <CategoryBreadcrumb category="category" />
+            <t t-if="!props.hasNoCategories">
+                <div class="rightpane-header" t-att-class="{
+                    'green-border-bottom': !env.pos.config.iface_display_categ_images,
+                    'grey-border-bottom': env.pos.config.iface_display_categ_images,
+                }">
+                    <!-- Breadcrumbs -->
+                    <div class="breadcrumbs">
+                        <HomeCategoryBreadcrumb subcategories="props.subcategories" currentCat="props.breadcrumbs[props.breadcrumbs.length - 1]"/>
+                        <t t-if="!env.isMobile">
+                            <t t-foreach="props.breadcrumbs" t-as="category" t-key="category.id">
+                                <CategoryBreadcrumb category="category" />
+                            </t>
+                        </t>
+                    </div>
+                    <!-- Subcategories -->
+                    <t t-if="props.subcategories.length > 0 and !env.pos.config.iface_display_categ_images and !env.isMobile">
+                        <t t-foreach="props.subcategories" t-as="category" t-key="category.id">
+                            <CategorySimpleButton category="category" />
                         </t>
                     </t>
                 </div>
-                <!-- Subcategories -->
-                <t t-if="props.subcategories.length > 0 and !env.pos.config.iface_display_categ_images and !env.isMobile">
-                    <t t-foreach="props.subcategories" t-as="category" t-key="category.id">
-                        <CategorySimpleButton category="category" />
-                    </t>
-                </t>
-            </div>
-            <t t-if="props.subcategories.length > 0 and env.pos.config.iface_display_categ_images and !env.isMobile">
-                <div class="categories">
-                    <div class="category-list-scroller">
-                        <div class="category-list">
-                            <t t-foreach="props.subcategories" t-as="category" t-key="category.id">
-                                <CategoryButton category="category" />
-                            </t>
+                <t t-if="props.subcategories.length > 0 and env.pos.config.iface_display_categ_images and !env.isMobile">
+                    <div class="categories">
+                        <div class="category-list-scroller">
+                            <div class="category-list">
+                                <t t-foreach="props.subcategories" t-as="category" t-key="category.id">
+                                    <CategoryButton category="category" />
+                                </t>
+                            </div>
                         </div>
                     </div>
-                </div>
+                </t>
             </t>
             <Portal target="'.pos .search-bar-portal'">
                 <div class="search-box">


### PR DESCRIPTION
To reproduce:
1. Start an odoo instance without demo with point_of_sale module.
2. Install a generic fiscal local if not automatically installed.
3. Create a product.
4. Open a pos session.
5. BUG: no search bar

This is because the search bar is rendered inside ProductsWidgetControlPanel
which is only rendered when there are categories. Instead, we render it
always but we pass the hasNoCategory information to selectively render
it's part. This now always show the search bar.

OPW: 2418858

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
