### PR TITLE
[IMP] website use nolabel on visitor country_flag.

### DIFF
--- a/addons/website/views/website_visitor_views.xml
+++ b/addons/website/views/website_visitor_views.xml
@@ -230,8 +230,7 @@
         <field name="model">website.visitor</field>
         <field name="arch" type="xml">
             <tree string="Web Visitors" decoration-success="is_connected" decoration-danger="not is_connected" sample="1">
-                <!--TODO DBE : Handle no_label in treeview-->
-                <field name="country_flag" widget="image_url" options='{"size": [20, 20]}' string=" "/>
+                <field name="country_flag" widget="image_url" options='{"size": [20, 20]}' nolabel="1"/>
                 <field name="display_name"/>
                 <field name="create_date"/>
                 <field name="last_connection_datetime"/>


### PR DESCRIPTION
Before this commit, their was no support of nolabel in tree view.

In this commit, because now we support nolabel in tree view replace
string to nolabel.

task-id:- 2414124
PR: 63519