### PR TITLE
[FIX] portal: show default lang in selector when lang is not found

### DIFF
--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -45,6 +45,9 @@
     </template>
 
     <template id="language_selector" name="Language Selector">
+        <t t-if="lang not in (lg[0] for lg in languages)">
+            <t t-set="lang" t-value="website.default_lang_id.code"/>
+        </t>
         <t t-set="active_lang" t-value="list(filter(lambda lg : lg[0] == lang, languages))[0]"/>
         <t t-set="language_selector_visible" t-value="len(languages) &gt; 1"/>
         <div t-attf-class="js_language_selector #{_div_classes}" t-if="language_selector_visible">


### PR DESCRIPTION
STEPS:
* install project, website
* install translation, but don't apply to website
* create a task with Customer that has that language
* close the task
* open rating request message in ``Settings >> Technical >> Messages``
* click any of the smiles

BEFORE:

Error to render compiling AST
IndexError: list index out of range
Template: portal.language_selector
Path: /t/t[1]
Node: <t t-set="active_lang" t-value="list(filter(lambda lg : lg[0] == lang,
languages))[0]"/>

AFTER:
no errors, page is translated to customer's language, though language selector
shows default website's language

---

opw-2416586

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
