### PR TITLE
[FIX] mrp: make done unbuild form readonly

### DIFF
--- a/addons/mrp/views/mrp_unbuild_views.xml
+++ b/addons/mrp/views/mrp_unbuild_views.xml
@@ -102,13 +102,13 @@
                         </div>
                         <group>
                             <group>
-                                <field name="product_id" attrs="{'readonly':[('mo_id','!=',False)]}" force_save="1"/>
+                                <field name="product_id" attrs="{'readonly':['|', ('mo_id','!=',False), ('state', '=', 'done')]}" force_save="1"/>
                                 <field name="mo_bom_id" invisible="1"/>
-                                <field name="bom_id" attrs="{'required': [('mo_id', '=', False)], 'readonly':[('mo_id','!=',False)], 'invisible': [('mo_id', '!=', False), ('mo_bom_id', '=', False)]}" force_save="1"/>
+                                <field name="bom_id" attrs="{'required': [('mo_id', '=', False)], 'readonly':['|', ('mo_id','!=',False), ('state', '=', 'done')], 'invisible': [('mo_id', '!=', False), ('mo_bom_id', '=', False)]}" force_save="1"/>
                                 <label for="product_qty"/>
                                 <div class="o_row">
-                                    <field name="product_qty" attrs="{'readonly': [('has_tracking', '=', 'serial')]}"/>
-                                    <field name="product_uom_id" options="{'no_open': True, 'no_create': True}" groups="uom.group_uom" attrs="{'readonly': [('mo_id', '!=', False)]}" force_save="1"/>
+                                    <field name="product_qty" attrs="{'readonly': ['|', ('has_tracking', '=', 'serial'), ('state', '=', 'done')]}"/>
+                                    <field name="product_uom_id" options="{'no_open': True, 'no_create': True}" groups="uom.group_uom" attrs="{'readonly': ['|', ('mo_id', '!=', False), ('state', '=', 'done')]}" force_save="1"/>
                                 </div>
                             </group>
                             <group>


### PR DESCRIPTION
Some added readonly attributes in the unbuild form view were overriding
the `states={'done': [('readonly', True)]}` attributes in the models'
fields. So we add the readonly when state='done' to the view as well.

Note that same issue exists in saas-12.3 and 13.0, but only for 2 of the
4 fields fixed in this commit (i.e. it probably isn't a big deal for
these older versions.)

Discovered during task: 2033341

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
