### PR TITLE
[FIX] stock: no backorder if added on delivery page

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -187,7 +187,7 @@ class StockMoveLine(models.Model):
             new_move = self.env['stock.move'].create({
                 'name': _('New Move:') + move_line.product_id.display_name,
                 'product_id': move_line.product_id.id,
-                'product_uom_qty': move_line.qty_done,
+                'product_uom_qty': 0 if move_line.picking_id and move_line.picking_id.state != 'done' else move_line.qty_done,
                 'product_uom': move_line.product_uom_id.id,
                 'description_picking': move_line.description_picking,
                 'location_id': move_line.picking_id.location_id.id,


### PR DESCRIPTION
In the Barcode app, if the user is on a delivery order, adds a product
and then decreases the product's quantity, when validating the order,
the backorder window is displayed.

To reproduce the error:
(Need sale_management,stock_barcode)
1. Go to Sales
2. Create a SO
	- Add one Product P
3. Save, Confirm
4. Check the generated delivery reference R
4. Go to Barcode > Operations > Delivery Orders > R
5. Complete the P's quantity
6. Add Product
	- Select a Product P_extra
	- Set a quantity (e.g., 1)
7. Confirm
8. Edit the P_extra's line
	- Decrease the quantity (e.g., 0)
9. Confirm
10. Validate

=> A window is displayed so the user can create a backorder for the
missing P_extra. Since the SO does not contains any P_extra, proposing
to create a backorder does not make sense.

When adding an extra product to the delivery, it creates a stock move
line with the `product_uom_qty` set to 0. Since there isn't any stock
move associated, it also creates a new one. Here is the issue: the
`product_uom_qty` of the stock move is defined thanks to the `qty_done`
of the extra product. Later, when validating the delivery, the server
uses the `product_uom_qty` of the stock move to check if a backorder is
needed. This the reason why, if the user decreased the quantity, the
backorder proposition is displayed: the `qty_done` is less than the
`product_uom_qty`.

OPW-2411461