### PR TITLE
[FIX] stock: make package level package consistent

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -235,6 +235,16 @@ class StockMoveLine(models.Model):
             if key in vals:
                 updates[key] = self.env[model].browse(vals[key])
 
+        if 'result_package_id' in updates:
+            for ml in self.filtered(lambda ml: ml.package_level_id):
+                if updates.get('result_package_id'):
+                    ml.package_level_id.package_id = updates.get('result_package_id')
+                else:
+                    # TODO: make package levels less of a pain and fix this
+                    package_level = ml.package_level_id
+                    ml.package_level_id = False
+                    package_level.unlink()
+
         # When we try to write on a reserved move line any fields from `triggers` or directly
         # `product_uom_qty` (the actual reserved quantity), we need to make sure the associated
         # quants are correctly updated in order to not make them out of sync (i.e. the sum of the


### PR DESCRIPTION
Currently a package level is created and has the newly created package
assigned to it when "Put In Pack" is used. Unfortunately if a move line
has its result_package_id changed after having a package assigned via
the Put In Pack, then the package level's package_id isn't correctly
updated. This leads to incorrect data in the db. This incorrect data
doesn't affect much since result_package_id from an entire package move
cannot be changed in any views, but it does mean that the created
package associated with the package level can never be deleted even if
it's never used.

Steps to reproduce:
1. active (delivery) packages in settings
2. create a picking and create some done values
3. use "Put In Pack" to put done move lines into a package
4. change the newly created Destination Package to another package
5. Go to Packages and try to delete the package created by Put In Pack

Expected result: able to delete the package
Actual result: Server error that package is still required by Stock
Package Level.

Task ID: 2418907

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
