### PR TITLE
[FIX] point_of_sale: discount product with tax

### DIFF
--- a/addons/pos_discount/static/src/js/DiscountButton.js
+++ b/addons/pos_discount/static/src/js/DiscountButton.js
@@ -49,7 +49,7 @@ odoo.define('pos_discount.DiscountButton', function(require) {
             // We add the price as manually set to avoid recomputation when changing customer.
             var base_to_discount = order.get_total_without_tax();
             if (product.taxes_id.length){
-                var first_tax = this.pos.taxes_by_id[product.taxes_id[0]];
+                var first_tax = this.env.pos.taxes_by_id[product.taxes_id[0]];
                 if (first_tax.price_include) {
                     base_to_discount = order.get_total_with_tax();
                 }


### PR DESCRIPTION
When you are using a discount product with a tax, you get a traceback
when trying to add the discount. It is caused by a typo and is fixed
here.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
