### PR TITLE
[FIX] website_crm_partner_assign: fix opportunities portal page witho…

### DIFF
--- a/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
+++ b/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
@@ -320,7 +320,10 @@
                         </td>
                         <td><span t-field="opp.contact_name" /></td>
                         <td>
-                            <span class="text-nowrap" t-esc="opp.planned_revenue" t-options="{'widget': 'monetary', 'display_currency': opp.company_currency}"/> at <span t-field="opp.probability" />%
+                            <span t-if="opp.company_currency" class="text-nowrap" t-esc="opp.planned_revenue" t-options="{'widget': 'monetary', 'display_currency': opp.company_currency}"/>
+                            <span t-else="" class="text-nowrap" t-esc="opp.planned_revenue"/>
+                            <span> at </span>
+                            <span t-field="opp.probability" />%
                         </td>
                         <td>
                             <span class="badge badge-info badge-pill" title="Current stage of the opportunity" t-esc="opp.stage_id.name" />


### PR DESCRIPTION
…ut currency

When you remove the 'company_id' on a crm.lead, you also remove the computed
'company_currency'.
When trying to view this kind of leads in the website_crm_partner_assign portal
page, it would raise an error while trying to display the planned_revenue in
the missing currency.

Now, we display the number without any currency sign, which is a "best effort"
solution, just the same as on the crm.lead form view.
So it will look like "9000 at 47%" instead of "$9000 at 47%".

Task 2416841

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
