### PR TITLE
[12.0][IMP] base: Compute context_timestamp when use widget date with datetime

### DIFF
--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import base64
+import datetime
 import re
 from collections import OrderedDict
 from io import BytesIO
@@ -211,6 +212,8 @@ class DateConverter(models.AbstractModel):
 
     @api.model
     def value_to_html(self, value, options):
+        if isinstance(value, datetime.datetime):
+            value = fields.Datetime.context_timestamp(self, value)
         return format_date(self.env, value, date_format=options.get('format'))
 
 


### PR DESCRIPTION
field to get day correctly.

I know that the problem may be more of a bug in the babel library than an odoo bug, but with this small change we have the problem solved.

This PR can resolve this v13 issue:
https://github.com/odoo/odoo/issues/55827

@Tecnativa

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
