### PR TITLE
many2many search and focusout throws access error

### DIFF
--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -770,7 +770,7 @@ var FieldMany2One = AbstractField.extend({
         }
         const firstValue = this.suggestions.find(s => s.id);
         if (firstValue) {
-            this.reinitialize(firstValue.id);
+            this.reinitialize({ id: firstValue.id, name: firstValue.name });
         } else if (this.can_create) {
             new M2ODialog(this, this.string, this.$input.val()).open();
         }

--- a/addons/web/static/tests/fields/relational_fields/field_many2many_tests.js
+++ b/addons/web/static/tests/fields/relational_fields/field_many2many_tests.js
@@ -1554,6 +1554,30 @@ QUnit.module('fields', {}, function () {
 
             form.destroy();
         });
+
+        QUnit.test('many2one select value on focus out in a many2many_tags', async function (assert) {
+            assert.expect(4);
+
+            const form = await createView({
+                View: FormView,
+                model: 'partner',
+                data: this.data,
+                arch: '<form><field name="timmy" widget="many2many_tags"/></form>',
+            });
+
+            assert.containsNone(form, '.o_field_many2manytags .badge');
+
+            await testUtils.fields.editAndTrigger(form.$('.o_field_many2manytags input'),
+                'gol', ['input', 'keyup']);
+            form.$('.o_field_many2manytags input').trigger('focusout');
+            await testUtils.nextTick();
+
+            assert.containsNone(document.body, '.modal');
+            assert.strictEqual(form.$('.o_field_many2manytags .o_badge_text').text(), 'gold');
+            assert.containsOnce(form, '.o_field_many2manytags .badge');
+
+            form.destroy();
+        });
     });
 });
 });


### PR DESCRIPTION
PURPOSE
Many2many throws access error when search on existing term and click outside.

SPEC
Fix access error thrown on many2many search existing term and clicking outside.

TASK 2415302


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
