### PR TITLE
[IMP] website_forum: simplify vote and delete comment

### DIFF
--- a/addons/website_forum/controllers/main.py
+++ b/addons/website_forum/controllers/main.py
@@ -703,6 +703,4 @@ class WebsiteForum(WebsiteProfile):
 
     @http.route('/forum/<model("forum.forum"):forum>/post/<model("forum.post"):post>/comment/<model("mail.message"):comment>/delete', type='json', auth="user", website=True)
     def delete_comment(self, forum, post, comment, **kwarg):
-        if not request.session.uid:
-            return {'error': 'anonymous_user'}
-        return post.unlink_comment(comment.id)[0]
+        return post.unlink_comment(comment.id)


### PR DESCRIPTION
`unlink_comment` was converted from @api.one to a multimethod but the
conversion doesn't really make sense: it takes a single comment as
input, and a comment can only belong to a single post, and the
relevant controller only ever calls it with a single post as subject,
so it should just work on a single post, and return a single True /
False / error.

`vote` was just weird, though I assume it really is only ever called
on a single post which hides the issues:

* it would first update existing votes... corrupting the `new_vote`
  value in the process
* then it would create a new vote for each input post... for each new
  vote

This would work fine if only ever called on a single post, as it would
either take the `vote_ids` loop *or* the `post_id` loop but never
both (and would only iterate once on both `post_id` loops). It would
even work fine if called on multiple posts as long as they all exist.

Didn't batch the vote creation because Vote.create does not support
batched creation.
