### PR TITLE
[FIX] account: cascade delete of reconcile lines

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -31,7 +31,7 @@ class AccountReconcileModelLine(models.Model):
     _order = 'sequence, id'
     _check_company_auto = True
 
-    model_id = fields.Many2one('account.reconcile.model', readonly=True)
+    model_id = fields.Many2one('account.reconcile.model', readonly=True, ondelete='cascade')
     match_total_amount = fields.Boolean(related='model_id.match_total_amount')
     match_total_amount_param = fields.Float(related='model_id.match_total_amount_param')
     rule_type = fields.Selection(related='model_id.rule_type')


### PR DESCRIPTION
When deleting an `account_reconcile_model`, it does not delete the
corresponding `account_reconcile_model_line`. Moreover, this may prevent
the user from using the l10n_de_skr04 module.

To reproduce the error:
(Use demo data)
1. Go to Apps
2. Install "Germany SKR04 - Accounting"
3. Change the company
	- Select "DE03 Company"
4. Go to Settings > Invoicing > Fiscal Localization
5. Change the package
	- Select "Deutscher Kontenplan SKR04"
6. Save

=> A validation error is displayed: "The operation cannot be completed:
another model requires the record being deleted[...]".

When changing for SKR04, the module's installation first deletes some
models, among them: `account_reconcile_model` and later `account_tax`. The
validation error appears on `account_tax` deletion. Since version 14, an
`account_reconcile_model` is composed of `account_reconcile_model_line`
and the latter is linked to `account_tax` (with `ondelete='restrict'`).
Here is the issue: when deleting the `account_reconcile_model` model,
the corresponding lines are not deleted. As a result: later, when trying
to delete all the `account_tax`, since some `account_reconcile_model_line`
are still present in database, it triggers the `ondelete='restrict'`
constraint.

OPW-2416066