### PR TITLE
[FIX] packaging: create rpm repo from container

### DIFF
--- a/setup/package.dffedora
+++ b/setup/package.dffedora
@@ -7,6 +7,7 @@ MAINTAINER Odoo S.A. <info@odoo.com>
 RUN dnf update -d 0 -e 0 -y && \
 	dnf install -d 0 -e 0 -y \
 		babel \
+		createrepo \
 		pychart \
 		pyparsing \
 		python3-babel \

--- a/setup/package.py
+++ b/setup/package.py
@@ -146,27 +146,13 @@ def gen_deb_package(args, published_files):
 # ---------------------------------------------------------
 # Generates an RPM repo
 # ---------------------------------------------------------
-def gen_rpm_repo(args, file_name):
+def rpm_sign(args, file_name):
     """Genereate a rpm repo in publish directory"""
     # Sign the RPM
     rpmsign = pexpect.spawn('/bin/bash', ['-c', 'rpm --resign %s' % file_name], cwd=os.path.join(args.pub, 'rpm'))
-    rpmsign.expect_exact('Enter pass phrase: ')
+    rpmsign.expect_exact('Enter passphrase: ')
     rpmsign.send(GPGPASSPHRASE + '\r\n')
     rpmsign.expect(pexpect.EOF)
-
-    # Removes the old repodata
-    shutil.rmtree(os.path.join(args.pub, 'rpm', 'repodata'))
-
-    # Copy files to a temp directory (required because the working directory must contain only the
-    # files of the last release)
-    temp_path = tempfile.mkdtemp(suffix='rpmPackages')
-    shutil.copy(file_name, temp_path)
-
-    run_cmd(['createrepo', temp_path]).check_returncode()  # creates a repodata folder in temp_path
-    shutil.copytree(os.path.join(temp_path, "repodata"), os.path.join(args.pub, 'rpm', 'repodata'))
-
-    # Remove temp directory
-    shutil.rmtree(temp_path)
 
 
 def _prepare_build_dir(args, win32=False):
@@ -184,7 +170,7 @@ def _prepare_build_dir(args, win32=False):
             except shutil.Error as e:
                 logging.warning("Warning '%s' while moving addon '%s", e, addon_path)
                 if addon_path.startswith(args.build_dir) and os.path.isdir(addon_path):
-                    logging.info("Removing ''".format(addon_path))
+                    logging.info("Removing '{}'".format(addon_path))
                     try:
                         shutil.rmtree(addon_path)
                     except shutil.Error as rm_error:
@@ -372,6 +358,21 @@ class DockerRpm(Docker):
         self.test_odoo()
         logging.info('Finished testing rpm package')
 
+    def gen_rpm_repo(self, args, rpm_filepath):
+        # Removes the old repodata
+        shutil.rmtree(os.path.join(args.pub, 'rpm', 'repodata'))
+
+        # Copy files to a temp directory (required because the working directory must contain only the
+        # files of the last release)
+        temp_path = tempfile.mkdtemp(suffix='rpmPackages')
+        shutil.copy(rpm_filepath, temp_path)
+
+        logging.info('Start creating rpm repo')
+        self.run('createrepo /data/src/', temp_path, 'odoo-rpm-createrepo-%s' % TSTAMP)
+        shutil.copytree(os.path.join(temp_path, "repodata"), os.path.join(args.pub, 'rpm', 'repodata'))
+
+        # Remove temp directory
+        shutil.rmtree(temp_path)
 
 # KVM stuffs
 class KVM(object):
@@ -528,7 +529,10 @@ def main(args):
                 docker_rpm.start_test()
                 published_files = publish(args, 'rpm', ['rpm'])
                 if args.sign:
-                    gen_rpm_repo(args, published_files[0])
+                    logging.info('Signing rpm package')
+                    rpm_sign(args, published_files[0])
+                    logging.info('Generate rpm repo')
+                    docker_rpm.gen_rpm_repo(args, published_files[0])
             except Exception as e:
                 logging.error("Won't publish the rpm release.\n Exception: %s" % str(e))
         if args.build_deb:


### PR DESCRIPTION
The `createrepo` Debian package is not available in Ubuntu Focal anymore, this
can cause problems on Ubuntu based build systems.

In order to solve that once and for all, with this commit the rpm repo is
generated from a Docker container.

Fixes #63419
