### PR TITLE
[12.0][FIX] Do not override start or stop when allday is not active

### DIFF
--- a/addons/calendar/models/calendar.py
+++ b/addons/calendar/models/calendar.py
@@ -979,12 +979,12 @@ class Meeting(models.Model):
 
     @api.onchange('start_date')
     def _onchange_start_date(self):
-        if self.start_date:
+        if self.start_date and self.allday:
             self.start = datetime.datetime.combine(self.start_date, datetime.time.min)
 
     @api.onchange('stop_date')
     def _onchange_stop_date(self):
-        if self.stop_date:
+        if self.stop_date and self.allday:
             self.stop = datetime.datetime.combine(self.stop_date, datetime.time.max)
 
     ####################################################


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
odoo/odoo#63569

**Current behavior before PR:**
OnChange on start_date or stop_date can reset start/stop hours to 0

**Desired behavior after PR is merged:**
Do not override start or stop when allday is not active 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
