### PR TITLE
[FIX] fleet : duplication in filter

### DIFF
--- a/addons/fleet/views/fleet_vehicle_cost_views.xml
+++ b/addons/fleet/views/fleet_vehicle_cost_views.xml
@@ -139,7 +139,6 @@
                 <field name="vehicle_id" string="Vehicle" filter_domain="[('vehicle_id.name','ilike', self)]"/>
                 <field name="purchaser_id" string="Driver" filter_domain="[('purchaser_id','child_of', self)]"/>
                 <field name="insurer_id" string="Vendor" filter_domain="[('insurer_id','child_of', self)]"/>
-                <filter string="Archived" name="inactive" domain="[('active','=',False)]"/>
                 <filter string="In Progress" name="open" domain="[('state', '=', 'open')]"/>
                 <filter string="Expired" name="expired" domain="[('state', '=', 'expired')]"/>
                 <separator/>


### PR DESCRIPTION
Observed Behavior:

Open Vehicles > Contracts and going to use the filter,
there are two filters with the same name 'Archived'

This commit solves this issue and we have only one filter named 'Archived'

task - 2413755


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
