### PR TITLE
[FIX] l10n_multilang: COA translations overwritten with new company

### DIFF
--- a/addons/l10n_multilang/models/l10n_multilang.py
+++ b/addons/l10n_multilang/models/l10n_multilang.py
@@ -22,7 +22,9 @@ class AccountChartTemplate(models.Model):
             ], order='id', limit=1)
             module = external_id and self.env.ref('base.module_' + external_id.module)
             if module and module.state == 'installed':
-                chart_template.process_coa_translations()
+                langs = chart_template._get_langs()
+                if langs:
+                    chart_template._process_single_company_coa_translations(company.id, langs)
         return res
 
     def process_translations(self, langs, in_field, in_ids, out_ids):
@@ -59,29 +61,38 @@ class AccountChartTemplate(models.Model):
         return True
 
     def process_coa_translations(self):
-        installed_langs = dict(self.env['res.lang'].get_installed())
         company_obj = self.env['res.company']
         for chart_template_id in self:
-            langs = []
-            if chart_template_id.spoken_languages:
-                for lang in chart_template_id.spoken_languages.split(';'):
-                    if lang not in installed_langs:
-                        # the language is not installed, so we don't need to load its translations
-                        continue
-                    else:
-                        langs.append(lang)
-                if langs:
-                    company_ids = company_obj.search([('chart_template_id', '=', chart_template_id.id)])
-                    for company in company_ids:
-                        # write account.account translations in the real COA
-                        chart_template_id._process_accounts_translations(company.id, langs, 'name')
-                        # copy account.tax name translations
-                        chart_template_id._process_taxes_translations(company.id, langs, 'name')
-                        # copy account.tax description translations
-                        chart_template_id._process_taxes_translations(company.id, langs, 'description')
-                        # copy account.fiscal.position translations
-                        chart_template_id._process_fiscal_pos_translations(company.id, langs, 'name')
+            langs = chart_template_id._get_langs()
+            if langs:
+                company_ids = company_obj.search([('chart_template_id', '=', chart_template_id.id)])
+                for company in company_ids:
+                    chart_template_id._process_single_company_coa_translations(company.id, langs)
         return True
+
+    def _process_single_company_coa_translations(self, company_id, langs):
+        # write account.account translations in the real COA
+        self._process_accounts_translations(company_id, langs, 'name')
+        # copy account.tax name translations
+        self._process_taxes_translations(company_id, langs, 'name')
+        # copy account.tax description translations
+        self._process_taxes_translations(company_id, langs, 'description')
+        # copy account.fiscal.position translations
+        self._process_fiscal_pos_translations(company_id, langs, 'name')
+
+    def _get_langs(self):
+        if not self.spoken_languages:
+            return []
+
+        installed_langs = dict(self.env['res.lang'].get_installed())
+        langs = []
+        for lang in self.spoken_languages.split(';'):
+            if lang not in installed_langs:
+                # the language is not installed, so we don't need to load its translations
+                continue
+            else:
+                langs.append(lang)
+        return langs
 
     def _process_accounts_translations(self, company_id, langs, field):
         in_ids, out_ids = self._get_template_from_model(company_id, 'account.account')


### PR DESCRIPTION
Steps:
- Install "Belgium - Accounting" and "Accounting"
- Add the Dutch language in settings
- Select a Belgian company
- Go to Accounting > Configuration > Chart of Account
- Select an account like "755000 Financial income - Foreign currency translation differences"
- Change the translation of the account name in English and Dutch
- Create a new company in Settings > Companies
- Select this new company
- Go to Accounting > Configuration > Settings, set the Fiscal Localization to Belgian PCMN and save
- Return in the first company
- Go to Accounting > Configuration > Chart of Account and check the translations you previously set

Bug:
The Dutch translation has been reset and the English one remains the same.

Explanation:
`process_coa_translations()` uses `spoken_languages` as seen here:
https://github.com/odoo/odoo/blob/bb31ce3bc6c0c7e1e101d93924eccea995206733/addons/l10n_multilang/models/l10n_multilang.py#L67
The spoken languages are defined here: https://github.com/odoo/odoo/blob/f4e7e06a1ff9756471d55138575c758f456b5905/addons/l10n_be/data/account_chart_template_data.xml#L10
This is why English is not affected.

The bug appeared with https://github.com/odoo/odoo/commit/c346e7af3314ce504fe3add9e9f6a4839bcad64a
It was meant to apply Chart of Account translations on the current company but applied it on all the companies. This reset edited translations on the other companies.

This commit refactors `process_coa_translations()` so that we can use the same logic on a single company while keeping the definition of the original function intact.

opw:2376334