### PR TITLE
[FIX] website_jitsi: participant count after last leave

### DIFF
--- a/addons/website_jitsi/static/src/js/chat_room.js
+++ b/addons/website_jitsi/static/src/js/chat_room.js
@@ -189,6 +189,15 @@ publicWidget.registry.ChatRoom = publicWidget.Widget.extend({
             }
         });
 
+        // update the participant count when using the "Leave" button
+        jitsiRoom.addEventListener('videoConferenceLeft', async (event) => {
+            this.allParticipantIds = Object.keys(jitsiRoom._participants)
+            if (!this.allParticipantIds.length) {
+                // bypass the checks and timer of updateParticipantCount
+                this._updateParticipantCount(this.allParticipantIds.length, false);
+            }
+        });
+
         return jitsiRoom;
     },
 


### PR DESCRIPTION
When leaving the Jitsi meeting, if the participant is the last one, the
meeting participant count will still be 1.

To reproduce the error:
1. Go to Events
2. Create and Save an event
3. Go to associated Rooms
4. Create and Save room R
5. "Go to Website" (on R's form)
6. Join the meeting
7. Leave the meeting
	- Use the "Leave" icon
8. Go back to R's form

=> "Participant count" is still set to 1.

This fix ensures the participant count will be 0 when nobody is in the
room. However, it will only work if the participant uses the "Leave"
button. So, for instance, if the last participant directly closes the window
to leave the meeting, the participant count will be incorrect. This is a
consequence of Jitsi which does not provide a way to get the number of
participants in a meeting (see file for more details, L119-142).

OPW-2416995