### PR TITLE
Master website event handle better what is not published shr

### DIFF
--- a/addons/website_event/static/src/scss/event_templates_list.scss
+++ b/addons/website_event/static/src/scss/event_templates_list.scss
@@ -12,7 +12,9 @@
         background-color: gray('300');
     }
 }
-
+.unpublished-div > *:not(.o_wevent_unpublished){
+    opacity: 0.5!important;
+}
 // Index
 .o_wevent_index {
     // Events List

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -161,17 +161,16 @@
         </div>
     </t>
     <!-- List -->
-    <div t-foreach="event_ids" t-as="event" t-attf-class=" #{opt_event_size} mb-4">
+    <div t-foreach="event_ids" t-as="event" t-attf-class="#{opt_event_size} mb-4">
         <a t-attf-href="/event/#{ slug(event) }/#{(not event.menu_id) and 'register'}" class="text-decoration-none">
             <article t-attf-class="h-100 #{opt_events_list_cards and 'card border-0 shadow-sm'}" itemscope="itemscope" itemtype="http://schema.org/Event">
-                <div class="h-100 row no-gutters">
+                    <div t-attf-class="h-100 row no-gutters">
                     <!-- Header -->
                     <header t-attf-class="overflow-hidden bg-secondary #{opt_events_list_columns and 'col-12 rounded-top' or 'col-sm-4 col-lg-3 rounded-left'} #{(not opt_events_list_cards) and 'rounded shadow'} #{(not opt_events_list_cards and not opt_events_list_columns) and 'rounded-top'}">
                         <!-- Image + Link -->
-                        <div class="d-block h-100 w-100">
+                        <div t-attf-class="#{'%s' % ('unpublished-div' if not event.website_published else '')} d-block h-100 w-100">
                             <t t-call="website.record_cover">
                                 <t t-set="_record" t-value="event"/>
-
                                 <!-- Short Date -->
                                 <div class="o_wevent_event_date position-absolute bg-white shadow-sm text-dark">
                                     <span t-field="event.with_context(tz=event.date_tz).date_begin" t-options="{'format': 'LLL'}" class="o_wevent_event_month"/>
@@ -181,14 +180,14 @@
                                 <small t-if="event.is_participating" class="o_wevent_participating bg-success">
                                     <i class="fa fa-check mr-2"/>Registered
                                 </small>
-                                <!-- Unpublished -->
-                                <small t-if="not event.website_published" class="o_wevent_unpublished bg-danger">
-                                    <i class="fa fa-ban mr-2"/>Unpublished
-                                </small>
                             </t>
                         </div>
+                        <!-- Unpublished -->
+                        <small t-if="not event.website_published" class="o_wevent_unpublished bg-danger">
+                            <i class="fa fa-ban mr-2"/>Unpublished
+                        </small>
                     </header>
-                    <div t-att-class="'%s %s' % (
+                    <div t-attf-class="#{'%s' % ('unpublished-div' if not event.website_published else '')} '%s %s' % (
                         opt_events_list_columns and 'col-12' or 'col',
                         opt_events_list_columns and event.event_registrations_open and not event.event_registrations_sold_out and 'h-100' or '')">
                         <!-- Body -->
@@ -216,7 +215,8 @@
                     </div>
                     <!-- Footer -->
                     <footer t-if="not event.event_registrations_open or event.event_registrations_sold_out"
-                        t-att-class="'small align-self-end w-100 %s %s' % (
+                        t-att-class="'%s small align-self-end w-100 %s %s' % (
+                            'unpublished-div' if not event.website_published else '',
                             opt_events_list_cards and 'card-footer' or (not opt_events_list_columns and 'mx-4 mt-auto pt-2') or 'py-2',
                             opt_events_list_cards and 'border-top' or '',
                         )">
@@ -327,5 +327,4 @@
         </div>
     </xpath>
 </template>
-
 </odoo>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
    In event section, there was no difference between published
    and non-published events view(UI). Both published and un-published events looks similar, except
    that there is extra tag"Unpublished" with red background, shows that event
    is unpublished.

Current behavior before PR: 
    both publish and non-publish events has same look.

Desired behavior after PR is merged:
    Improve the management of non-published things for internal users.
    To make different look between that events,
    **opacity will apply for each un-published events**. Opacity is applied to
    whole unpublished event' UI **except for the tag "Unpublished".**


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
