### PR TITLE
[FIX] calendar: make ics exportable again for recurring events

### DIFF
--- a/addons/calendar/models/calendar.py
+++ b/addons/calendar/models/calendar.py
@@ -984,8 +984,9 @@ class Meeting(models.Model):
         def ics_datetime(idate, allday=False):
             if idate:
                 if allday:
-                    return idate
+                    return fields.Date.to_date(idate)
                 else:
+                    idate = fields.Datetime.to_datetime(idate)
                     return idate.replace(tzinfo=pytz.timezone('UTC'))
             return False
 


### PR DESCRIPTION
STEPS:

* install website_calendar
* create recurring event, add Azure Interior as participant
* open mail.mail with the invitation
* open Accept link in new incognito window
* click "-> Add to iCal/Outlook"

BEFORE:
```
  File "/opt/odoo/auto/addons/calendar/models/calendar.py", line 1007, in _get_ics_file
    event.add('dtstart').value = ics_datetime(meeting.start, meeting.allday)
  File "/opt/odoo/auto/addons/calendar/models/calendar.py", line 990, in ics_datetime
    return idate.replace(tzinfo=pytz.timezone('UTC'))
TypeError: replace() takes no keyword arguments
```

AFTER: now error, both recurring and usual events can be exported as ics file,
because to_date/to_datetime checks for value type and return as is, if it's
already date/datetime

https://github.com/odoo/odoo/blob/fa3e3851f3e486f8c99d714d1b0c8f50e923ee37/odoo/fields.py#L1711-L1714

https://github.com/odoo/odoo/blob/fa3e3851f3e486f8c99d714d1b0c8f50e923ee37/odoo/fields.py#L1813-L1818

---

opw-2415703

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
