### PR TITLE
[FIX] sale: search on invoice_ids

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -137,6 +137,9 @@ class SaleOrder(models.Model):
         self.ensure_one()
         return 'form'
 
+    def _search_invoice_ids(self, operator, value):
+        return ['&', ('order_line.invoice_lines.invoice_id.type', 'in', ('out_invoice', 'out_refund')), ('order_line.invoice_lines.invoice_id', operator, value)]
+
     name = fields.Char(string='Order Reference', required=True, copy=False, readonly=True, states={'draft': [('readonly', False)]}, index=True, default=lambda self: _('New'))
     origin = fields.Char(string='Source Document', help="Reference of the document that generated this sales order request.")
     client_order_ref = fields.Char(string='Customer Reference', copy=False)
@@ -174,7 +177,7 @@ class SaleOrder(models.Model):
     order_line = fields.One2many('sale.order.line', 'order_id', string='Order Lines', states={'cancel': [('readonly', True)], 'done': [('readonly', True)]}, copy=True, auto_join=True)
 
     invoice_count = fields.Integer(string='Invoice Count', compute='_get_invoiced', readonly=True)
-    invoice_ids = fields.Many2many("account.invoice", string='Invoices', compute="_get_invoiced", readonly=True, copy=False)
+    invoice_ids = fields.Many2many("account.invoice", string='Invoices', compute="_get_invoiced", readonly=True, copy=False, search="_search_invoice_ids")
     invoice_status = fields.Selection([
         ('upselling', 'Upselling Opportunity'),
         ('invoiced', 'Fully Invoiced'),


### PR DESCRIPTION
Some fields may depend on invoice_ids, which lead to a perf issue when
field is not searchable.

BACKPORT of afb927076ea22f80c62fe4ea4165e18c7f946fe1 and 25cc70245951f876db626ca018825790003b83bb

Must be merged up to 13.0, 13.0 excluded.

Description of the issue/feature this PR addresses:
Searching SO fails (error in the logs) and query ignores domain and retrieves all SO rather than the required one, leading to slowness.
Error message:
```
2020-12-18 10:22:15,417 11012 ERROR oe_support_customer odoo.osv.expression: Non-stored field sale.order.invoice_ids cannot be searched. 
``` 

Current behavior before PR:
Creating / Duplicating invoice is slow

Desired behavior after PR is merged:
Creating / Duplicating invoice is fast

opw-2390604



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
