### PR TITLE
[FIX] microsoft_calendar: fix recurrence event creation

### DIFF
--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -320,13 +320,13 @@ class Meeting(models.Model):
                 pattern['firstDayOfWeek'] = 'sunday'
 
             if recurrence.rrule_type == 'monthly' and recurrence.month_by == 'day':
-                byday_selection = [
-                    ('1', 'first'),
-                    ('2', 'second'),
-                    ('3', 'third'),
-                    ('4', 'fourth'),
-                    ('-1', 'last')
-                ]
+                byday_selection = {
+                    '1': 'first',
+                    '2': 'second',
+                    '3': 'third',
+                    '4': 'fourth',
+                    '-1': 'last',
+                }
                 pattern['index'] = byday_selection[recurrence.byday]
 
             rule_range = {


### PR DESCRIPTION
Create an event as follows:

- Recurrent
- Repeat every 1 Months
- Until End date <far in future>
- Day of Month Day of Month First Monday

An exception will raise

opw-2412598

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
