### PR TITLE
[IMP] *: simplify onboarding progress API

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -557,7 +557,7 @@ class account_journal(models.Model):
     #####################
     def mark_bank_setup_as_done_action(self):
         """ Marks the 'bank setup' step as done in the setup bar and in the company."""
-        self.company_id.sudo().set_onboarding_step_done('account_setup_bank_data_state')
+        self.company_id._set_onboarding_step_done('account_setup_bank_data_state')
 
     def unmark_bank_setup_as_done_action(self):
         """ Marks the 'bank setup' step as not done in the setup bar and in the company."""

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2540,7 +2540,7 @@ class AccountMove(models.Model):
     @api.model
     def setting_upload_bill_wizard(self):
         """ Called by the 'First Bill' button of the setup bar."""
-        self.env.company.sudo().set_onboarding_step_done('account_setup_bill_state')
+        self.env.company._set_onboarding_step_done('account_setup_bill_state')
 
         new_wizard = self.env['account.tour.upload.bill'].create({})
         view_id = self.env.ref('account.account_tour_upload_bill').id

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -304,7 +304,7 @@ class ResCompany(models.Model):
     def setting_chart_of_accounts_action(self):
         """ Called by the 'Chart of Accounts' button of the setup bar."""
         company = self.env.company
-        company.sudo().set_onboarding_step_done('account_setup_coa_state')
+        company._set_onboarding_step_done('account_setup_coa_state')
 
         # If an opening move has already been posted, we open the tree view showing all the accounts
         if company.opening_move_posted():
@@ -451,11 +451,11 @@ class ResCompany(models.Model):
     def action_save_onboarding_invoice_layout(self):
         """ Set the onboarding step as done """
         if bool(self.external_report_layout_id):
-            self.set_onboarding_step_done('account_onboarding_invoice_layout_state')
+            self._set_onboarding_step_done('account_onboarding_invoice_layout_state')
 
     def action_save_onboarding_sale_tax(self):
         """ Set the onboarding step as done """
-        self.set_onboarding_step_done('account_onboarding_sale_tax_state')
+        self._set_onboarding_step_done('account_onboarding_sale_tax_state')
 
     def get_chart_of_accounts_or_fail(self):
         account = self.env['account.account'].search([('company_id', '=', self.id)], limit=1)

--- a/addons/account/wizard/setup_wizards.py
+++ b/addons/account/wizard/setup_wizards.py
@@ -60,7 +60,7 @@ class FinancialYearOpeningWizard(models.TransientModel):
         return super().write(vals)
 
     def action_save_onboarding_fiscal_year(self):
-        self.env.company.sudo().set_onboarding_step_done('account_setup_fy_data_state')
+        self.env.company._set_onboarding_step_done('account_setup_fy_data_state')
 
 
 class SetupBarBankConfigWizard(models.TransientModel):

--- a/addons/payment/wizards/payment_acquirer_onboarding_wizard.py
+++ b/addons/payment/wizards/payment_acquirer_onboarding_wizard.py
@@ -153,7 +153,7 @@ class PaymentWizard(models.TransientModel):
         return {'type': 'ir.actions.act_window_close'}
 
     def _set_payment_acquirer_onboarding_step_done(self):
-        self.env.company.sudo().set_onboarding_step_done('payment_acquirer_onboarding_state')
+        self.env.company._set_onboarding_step_done('payment_acquirer_onboarding_state')
 
     def action_onboarding_other_payment_acquirer(self):
         self._set_payment_acquirer_onboarding_step_done()

--- a/addons/sale/models/res_company.py
+++ b/addons/sale/models/res_company.py
@@ -96,7 +96,7 @@ class ResCompany(models.Model):
 
         message_composer.send_mail()
 
-        self.set_onboarding_step_done('sale_onboarding_sample_quotation_state')
+        self._set_onboarding_step_done('sale_onboarding_sample_quotation_state')
 
         self.action_close_sale_quotation_onboarding()
 

--- a/addons/sale/wizard/payment_acquirer_onboarding_wizard.py
+++ b/addons/sale/wizard/payment_acquirer_onboarding_wizard.py
@@ -25,7 +25,7 @@ class PaymentWizard(models.TransientModel):
 
     def _set_payment_acquirer_onboarding_step_done(self):
         """ Override. """
-        self.env.company.sudo().set_onboarding_step_done('sale_onboarding_order_confirmation_state')
+        self.env.company._set_onboarding_step_done('sale_onboarding_order_confirmation_state')
 
     def add_payment_methods(self, *args, **kwargs):
         self.env.company.sale_onboarding_payment_method = self.payment_method

--- a/addons/website_sale/wizard/payment_acquirer_onboarding_wizard.py
+++ b/addons/website_sale/wizard/payment_acquirer_onboarding_wizard.py
@@ -11,4 +11,4 @@ class PaymentWizard(models.TransientModel):
 
     def _set_payment_acquirer_onboarding_step_done(self):
         """ Override. """
-        self.env.company.sudo().set_onboarding_step_done('website_sale_onboarding_payment_acquirer_state')
+        self.env.company._set_onboarding_step_done('website_sale_onboarding_payment_acquirer_state')

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -270,7 +270,8 @@ class Company(models.Model):
         action['res_id'] = self.env.company.id
         return action
 
-    def set_onboarding_step_done(self, step_name):
+    def _set_onboarding_step_done(self, step_name):
+        self = self.sudo()
         if self[step_name] == 'not_done':
             self[step_name] = 'just_done'
 
@@ -295,7 +296,7 @@ class Company(models.Model):
 
     def action_save_onboarding_company_step(self):
         if bool(self.street):
-            self.set_onboarding_step_done('base_onboarding_company_state')
+            self._set_onboarding_step_done('base_onboarding_company_state')
 
     @api.model
     def _get_main_company(self):


### PR DESCRIPTION
Currently the onboarding progress API thing is exposed publicly and has to be sudoed almost everywhere because the user currently handling the onboarding may not have write access to the company.

Given the onboarding info is low-stakes, it seems much simpler to make the onboarding progress completely internal (no RPC access), and sudo internally. This removes a bunch of sudoes which makes safety review easier.