### PR TITLE
[FIX] website_sale_digital: error if no records in check on attachment

### DIFF
--- a/addons/website_sale_digital/models/ir_attachment.py
+++ b/addons/website_sale_digital/models/ir_attachment.py
@@ -14,7 +14,7 @@ class Attachment(models.Model):
     @api.model
     def check(self, mode, values=None):
         super().check(mode, values=values)
-        if mode == 'read' and not self.env.user.has_group('base.group_user'):
+        if mode == 'read' and self and not self.env.user.has_group('base.group_user'):
             self._cr.execute('SELECT 1 FROM ir_attachment WHERE product_downloadable AND id IN %s', [tuple(self.ids)])
             if self._cr.rowcount:
                 raise AccessError(_("Sorry, you are not allowed to access this document."))


### PR DESCRIPTION
Since f9c00ced9, the code might throw an error if self is an empty recordset,
as `id IN ()` will crash in psql.
