### PR TITLE
[FIX] stock: restrict unpack access

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -399,6 +399,11 @@ class QuantPackage(models.Model):
             return [('id', '=', False)]
 
     def unpack(self):
+        # All users can read a package but only stock users should be able to write on it.
+        # Without this explicit check, a non-stock user could unpack a pack as the write
+        # on quants is done in sudo mode.
+        self.check_access_rights('write')
+
         for package in self:
             move_line_to_modify = self.env['stock.move.line'].search([
                 ('package_id', '=', package.id),


### PR DESCRIPTION
Any internal user has read access on stock.quant.package but only stock
users have write access to it.
As the unpack method write directly `{'package_id': False}` on the
quants. It has to be done in sudo (quant don't have access rights).
Which means an internal user can see a package AND unpack it.

This commit adds an explicit write access check on packages before
unpacking.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
