### PR TITLE
[FIX] l10n_cl: exclude vendor bills from last sequence domain

### DIFF
--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -114,7 +114,7 @@ class AccountMove(models.Model):
         if self.company_id.country_id.code == "CL" and self.l10n_latam_use_documents:
             where_string = where_string.replace('journal_id = %(journal_id)s AND', '')
             where_string += ' AND l10n_latam_document_type_id = %(l10n_latam_document_type_id)s AND ' \
-                            'company_id = %(company_id)s'
+                            'company_id = %(company_id)s AND move_type IN (\'out_invoice\', \'out_refund\')'
             param['company_id'] = self.company_id.id or False
             param['l10n_latam_document_type_id'] = self.l10n_latam_document_type_id.id or 0
         return where_string, param


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Erroneous next invoice number

Current behavior before PR:
When calculating the last used invoice number, vendor bills are evaluated

Desired behavior after PR is merged:
The query where is modified in order to exclude 'in' move_types

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr