### PR TITLE
[IMP] l10n_ch: add company name to qr_report

### DIFF
--- a/addons/l10n_ch/report/swissqr_report.xml
+++ b/addons/l10n_ch/report/swissqr_report.xml
@@ -51,6 +51,9 @@
                             </t>
 
                             <span class="swissqr_text title">Payable by</span><br/>
+                            <t t-if="o.partner_id.parent_id">
+                                <span class="swissqr_text content" t-field="o.partner_id.parent_id.name" /><br/>
+                            </t>
                             <span class="swissqr_text content" t-field="o.partner_id.name"/><br/>
                             <span class="swissqr_text content" t-field="o.partner_id.country_id.code"/>
                             <span class="swissqr_text content" t-field="o.partner_id.zip"/>
@@ -101,6 +104,9 @@
                             <br/>
 
                             <span class="swissqr_text title">Payable by</span><br/>
+                            <t t-if="o.partner_id.parent_id">
+                                <span class="swissqr_text content" t-field="o.partner_id.parent_id.name" /><br/>
+                            </t>
                             <span class="swissqr_text content" t-field="o.partner_id.name"/><br/>
                             <span class="swissqr_text content" t-field="o.partner_id.street"> </span>
                             <span class="swissqr_text content" t-field="o.partner_id.street2"/><br/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
the company name is not printed on qr_invoice as on usual invoice, PR is making invoice address same on both reports

Current behavior before PR:
the company name is not  printed in qr_invoice

Desired behavior after PR is merged:
the company name is not  printed on qr_invoice





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
