### PR TITLE
[PATCH] account: type on docstring

### DIFF
--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -123,7 +123,7 @@ class SequenceMixin(models.AbstractModel):
     def _get_last_sequence_domain(self, relaxed=False):
         """Get the sql domain to retreive the previous sequence number.
 
-        This function should be overriden by models heriting from this mixin.
+        This function should be overriden by models inheriting from this mixin.
 
         :param relaxed: see _get_last_sequence.
 

--- a/doc/cla/individual/advalaki.md
+++ b/doc/cla/individual/advalaki.md
@@ -1,0 +1,9 @@
+India, 2020-12-21
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Alpesh Valaki alpeshvalaki@gmail.com https://github.com/ADVALAKI


### PR DESCRIPTION
Description of the issue/feature this PR addresses: fix typo on docstring of _get_last_sequence method

Current behavior before PR: Typo on docstring

Desired behavior after PR is merged: fixed typo on docstring

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
