### PR TITLE
[FIX] sale_timesheet: restore ir.rule on uninstalling

### DIFF
--- a/addons/sale_timesheet/__init__.py
+++ b/addons/sale_timesheet/__init__.py
@@ -1,6 +1,17 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import api, SUPERUSER_ID
+
 from . import controllers
 from . import models
 from . import wizard
 from . import report
+
+
+def uninstall_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    module_domain = "('project_id', '=', False)"
+    original_domain = "(1, '=', 1)"
+    rule = env.ref('account.account_analytic_line_rule_billing_user', raise_if_not_found=False)
+    if rule and rule.domain_force:
+        rule.domain_force = rule.domain_force.replace(module_domain, original_domain)

--- a/addons/sale_timesheet/__manifest__.py
+++ b/addons/sale_timesheet/__manifest__.py
@@ -40,4 +40,5 @@ have real delivered quantities in sales orders.
         'data/sale_service_demo.xml',
     ],
     'auto_install': True,
+    'uninstall_hook': 'uninstall_hook',
 }


### PR DESCRIPTION
STEPS:
* install sale_timesheet
* uninstalling sale_timesheet

BEFORE: error on reading account.analytic.line:

    ValueError: Invalid field account.analytic.line.project_id in
    leaf ('project_id', '=', False)

AFTER: rule domain is restored to original value

---

opw-2418498

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
