### PR TITLE
remove inactive calendar sidebar filter

### DIFF
--- a/addons/web/static/src/js/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/js/views/calendar/calendar_controller.js
@@ -191,12 +191,14 @@ var CalendarController = AbstractController.extend({
         this.reload();
     },
     /**
+     * When filter is changed reloads whole calendar view
+     *
      * @private
      * @param {OdooEvent} event
      */
     _onChangeFilter: function (event) {
-        if (this.model.changeFilter(event.data) && !event.data.no_reload) {
-            this.reload();
+        if (this.model.changeFilter(event.data)) {
+            this.update({}, { reload: 'reload' in event.data ? event.data.reload : true });
         }
     },
     /**

--- a/addons/web/static/src/js/views/calendar/calendar_model.js
+++ b/addons/web/static/src/js/views/calendar/calendar_model.js
@@ -148,6 +148,8 @@ return AbstractModel.extend({
         if (f) {
             if (f.active !== filter.active) {
                 f.active = filter.active;
+            } else if (filter.toRemove) {
+                Filter.filters.splice(Filter.filters.indexOf(f), 1);
             } else {
                 return false;
             }

--- a/addons/web/static/src/js/views/calendar/calendar_renderer.js
+++ b/addons/web/static/src/js/views/calendar/calendar_renderer.js
@@ -155,11 +155,15 @@ var SidebarFilter = Widget.extend(FieldManagerMixin, {
                         args: [[$filter.data('id')]],
                     })
                     .then(function () {
+                        // if filter is already inactive then there is no need to reload model,
+                        // just re-render calendar renderer so sidebar filters are updated.
                         self.trigger_up('changeFilter', {
                             'fieldName': self.fieldName,
                             'id': $filter.data('id'),
                             'active': false,
                             'value': $filter.data('value'),
+                            toRemove: true,
+                            reload: $filter.find('input').is(":checked"),
                         });
                     });
             },


### PR DESCRIPTION
PURPOSE
Inactive calendar sidebar filter not removed when click on X icon, it should be removed when X is clicked and user confirm deletion of filter.

SPEC
Inactive filters from calendar sidebar should be deleted.

TASK 2412488


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
