### PR TITLE
[FIX] website: fix usability of the popup snippet

### DIFF
--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -682,6 +682,18 @@ registry.backgroundVideo = publicWidget.Widget.extend({
 
         $(window).on('resize.' + this.iframeID, throttledUpdate);
 
+        const $modal = this.$target.closest('.modal');
+        if ($modal.length) {
+            $modal.on('show.bs.modal', () => {
+                const videoContainerEl = this.$target[0].querySelector('.o_bg_video_container');
+                videoContainerEl.classList.add('d-none');
+            });
+            $modal.on('shown.bs.modal', () => {
+                this._adjustIframe();
+                const videoContainerEl = this.$target[0].querySelector('.o_bg_video_container');
+                videoContainerEl.classList.remove('d-none');
+            });
+        }
         return Promise.all(proms).then(() => this._appendBgVideo());
     },
     /**

--- a/addons/website/static/src/snippets/s_popup/000.js
+++ b/addons/website/static/src/snippets/s_popup/000.js
@@ -10,6 +10,7 @@ const PopupWidget = publicWidget.Widget.extend({
     events: {
         'click .js_close_popup': '_onCloseClick',
         'hide.bs.modal': '_onHideModal',
+        'show.bs.modal': '_onShowModal',
     },
 
     /**
@@ -92,6 +93,19 @@ const PopupWidget = publicWidget.Widget.extend({
         const nbDays = this.$el.find('.modal').data('consentsDuration');
         utils.set_cookie(this.$el.attr('id'), true, nbDays * 24 * 60 * 60);
         this._popupAlreadyShown = true;
+
+        this.$target.find('.media_iframe_video iframe').each((i, iframe) => {
+            iframe.src = '';
+        });
+    },
+    /**
+     * @private
+     */
+    _onShowModal() {
+        this.el.querySelectorAll('.media_iframe_video').forEach(media => {
+            const iframe = media.querySelector('iframe');
+            iframe.src = media.dataset.oeExpression || media.dataset.src; // TODO still oeExpression to remove someday
+        });
     },
 });
 

--- a/addons/website/static/src/snippets/s_popup/options.js
+++ b/addons/website/static/src/snippets/s_popup/options.js
@@ -17,10 +17,21 @@ options.registry.SnippetPopup = options.Class.extend({
         });
         this.$target.on('shown.bs.modal.SnippetPopup', () => {
             this.trigger_up('snippet_option_visibility_update', {show: true});
+            // TODO duplicated code from the popup public widget, this should
+            // be moved to a *video* public widget and be reviewed in master
+            this.$target[0].querySelectorAll('.media_iframe_video').forEach(media => {
+                const iframe = media.querySelector('iframe');
+                iframe.src = media.dataset.oeExpression || media.dataset.src; // TODO still oeExpression to remove someday
+            });
         });
         this.$target.on('hidden.bs.modal.SnippetPopup', () => {
             this.trigger_up('snippet_option_visibility_update', {show: false});
+            this._removeIframeSrc();
         });
+        // The video might be playing before entering edit mode (possibly with
+        // sound). Stop the video, as the user can't do it (no button on video
+        // in edit mode).
+        this._removeIframeSrc();
         return this._super(...arguments);
     },
     /**
@@ -28,6 +39,9 @@ options.registry.SnippetPopup = options.Class.extend({
      */
     destroy: function () {
         this._super(...arguments);
+        // The video should not start before the modal opens, remove it from the
+        // DOM. It will be added back on modal open to start the video.
+        this._removeIframeSrc();
         this.$target.off('.SnippetPopup');
     },
     /**
@@ -109,6 +123,17 @@ options.registry.SnippetPopup = options.Class.extend({
                 return this.$target.closest('footer').length ? 'moveToFooter' : 'moveToBody';
         }
         return this._super(...arguments);
+    },
+    /**
+     * Removes the iframe `src` attribute (a copy of the src is already on the
+     * parent `oe-expression` attribute).
+     *
+     * @private
+     */
+    _removeIframeSrc() {
+        this.$target.find('.media_iframe_video iframe').each((i, iframe) => {
+            iframe.src = '';
+        });
     },
 });
 });


### PR DESCRIPTION
**SPECIFICATION**
> If you add a video inside the popal. It should stop on close
> Add a video as background for a popup, save the page, return to edit mode, open the popup
issue -> the video is not correctly displayed https://i.imgur.com/xhqpobc.jpg

task-2251203

**[RDE]: Things that have to be respected:**
1. The src attribute should only be set on modal show, so the video starts on show, otherwise the user is missing the start of the video (which correspond to the set delay, which could be 20 seconds.. which is terrible if the video is 23 seconds long..)
   Put otherwise, the video should never start playing if in background (modal closed or not yet opened).
   Note that another issue is that the user will ear the video sound without seeing it (probably always prevented by browser tho)
2. (Admin/Editor) When the modal is shown, if the user click on "Edit", the video should stop playing, as the options.js is closing it (invisible element). Otherwise, the video keep playing, which is annoying if sound is enabled as the admin can't stop it.
3. If the admin/editor close the modal (not in edit mode), then click on "Edit", we should ensure:
   - The video is shown when the modal is shown (click on show invisible element) -> so src need to be set back
   - When saving, that the video is still correctly shown to later user (or himself if he deletes his cookies) -> or feature broken, blank video as no src
4. If the admin/Editor is in edit mode, on invisible element click, the video should not keep playing when the modal is hidden.
5. If the admin/editor click on "Edit" before the modal is shown (eg 15 seconds) -> ensure everything is fine (no sound when hidden, ok when click on invisible element show/close)