### PR TITLE
[FIX] stock: duplicated stock picking's state

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -365,7 +365,7 @@ class Picking(models.Model):
     show_reserved = fields.Boolean(related='picking_type_id.show_reserved')
     show_lots_text = fields.Boolean(compute='_compute_show_lots_text')
     has_tracking = fields.Boolean(compute='_compute_has_tracking')
-    immediate_transfer = fields.Boolean(default=False)
+    immediate_transfer = fields.Boolean(default=False, copy=False)
     package_level_ids = fields.One2many('stock.package_level', 'picking_id')
     package_level_ids_details = fields.One2many('stock.package_level', 'picking_id')
 
@@ -586,6 +586,12 @@ class Picking(models.Model):
                 picking.message_subscribe([vals.get('partner_id')])
 
         return res
+
+    def copy(self, default=None):
+        ctx = dict(self.env.context)
+        ctx.pop('default_immediate_transfer', None)
+        self = self.with_context(ctx)
+        return super().copy(default)
 
     def write(self, vals):
         if vals.get('picking_type_id') and self.state != 'draft':


### PR DESCRIPTION
When duplicating a stock picking, its state is "Ready". This prevents
the user from editing the duplicated object.

To reproduce the error:
1. Go to Settings > Inventory > Warehouse
2. Enable "Multi-Step Routes"
3. Go to Inventory > Internal Transfers
4. Create a new one
	- Add a product P
	- Set the quantity done of P
5. Save, Validate
	- Note: the state is 'Done'
6. Action > Duplicate

=> The duplicated stock picking's state is "Ready". The user is then not
able to edit several fields.

When creating a new stock picking, a variable (`immediate_transfer`) is
automatically set to True. This speeds up the process when the user
clicks on "Validate" (see step 5, the state changes from 'Draft' to
'Done' and skips the intermediate status). Problem is that the default
value is set in the context:
https://github.com/odoo/odoo/blob/472fc28255ad29bcaaa7bd2f68a64018361b2665/addons/stock/models/stock_picking.py#L205-L214
This is the reason why the `copy_data` method is needed: it forces the
`immediate_transfer` value to False.

OPW-2417693