### PR TITLE
[FIX] mail: pass res_id and model to link generator when notifying

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2225,7 +2225,7 @@ class MailThread(models.AbstractModel):
 
         model = msg_vals.get('model') if msg_vals else message.model
         model_name = model_description or (self.with_lang().env['ir.model']._get(model).display_name if model else False) # one query for display name
-        recipients_groups_data = self._notify_classify_recipients(partners_data, model_name)
+        recipients_groups_data = self._notify_classify_recipients(partners_data, model_name, msg_vals=msg_vals)
 
         if not recipients_groups_data:
             return True
@@ -2562,7 +2562,7 @@ class MailThread(models.AbstractModel):
             )
         ]
 
-    def _notify_classify_recipients(self, recipient_data, model_name):
+    def _notify_classify_recipients(self, recipient_data, model_name, **kwargs):
         """ Classify recipients to be notified of a message in groups to have
         specific rendering depending on their group. For example users could
         have access to buttons customers should not have in their emails.
@@ -2596,7 +2596,13 @@ class MailThread(models.AbstractModel):
 
         groups = self._notify_get_groups()
 
-        access_link = self._notify_get_action_link('view')
+        link_args = {}
+        msg_vals = kwargs.get('msg_vals')
+        if msg_vals and 'model' in msg_vals and 'res_id' in msg_vals:
+            link_args['model'] = msg_vals.get('model')
+            link_args['res_id'] = msg_vals.get('res_id')
+
+        access_link = self._notify_get_action_link('view', **link_args)
 
         if model_name:
             view_title = _('View %s') % model_name


### PR DESCRIPTION
Steps:
- Install Approvals
- Log in as demo user
- Create an approval request with admin as Request Owner
- Submit it
- Log in as admin
- Go to Settings > Technical > Email/Emails
- Open the last email

Bug:
The "View Approval Request" button leads to an error 500.

Explanation:
The button leads to "/mail/view?model=mail.thread&res_id=False" instead of "/mail/view?model=approval.request&res_id=2".
This is due to the fact that we leave the `approval.request` environment by directly calling `MailThread` instead of `self`. `self._name` is going to be `mail.thread` and `self.ids` has not been initialized. This results in an unusable link.
https://github.com/odoo/odoo/blob/4fe7f48e0443eef4a4e5d9807e0ffaef2ebbbc83/addons/mail/models/mail_thread.py#L2496-L2499
Since directly calling `MailThread` is needed in order to avoid posting the message in the chatter, this fix is passing `model` and `res_id` through the stack.

opw:2416552