### PR TITLE
[FIX] point_of_sale: print bill should not destroy order

### DIFF
--- a/addons/pos_restaurant/static/src/js/printbill.js
+++ b/addons/pos_restaurant/static/src/js/printbill.js
@@ -28,6 +28,10 @@ var BillScreenWidget = screens.ReceiptScreenWidget.extend({
         this._super();
         this.pos.get_order()._printed = false;
     },
+    print_html: function(){
+        this._super();
+        this.pos.get_order()._printed = false;
+    },
 });
 
 gui.define_screen({name:'bill', widget: BillScreenWidget});


### PR DESCRIPTION
When the bill is printed without iot box, and the function 'print_html'
is called, the value of the order is set to printed. That lead to the
destruction of the order when another product is added.

To avoid this behavior, we override it in the Bill screen like for
function 'print_web'.

OPW-2417455

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
