### PR TITLE
[IMP] website: add buttons with svg for the page layout options

### DIFF
--- a/addons/website/static/src/img/snippets_options/page_layout_boxed.svg
+++ b/addons/website/static/src/img/snippets_options/page_layout_boxed.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="18" height="14" viewBox="0 0 18 14">
+  <g fill="none" fill-rule="evenodd" class="symbols">
+    <g>
+      <rect fill="#D8D8D8" width="1" height="14" class="o_subdle"/>
+      <rect fill="#FFF" x="4" width="10" height="14" class="o_graphic"/>
+      <rect fill="#D8D8D8" x="17" width="1" height="14" class="o_subdle"/>
+    </g>
+  </g>
+</svg>

--- a/addons/website/static/src/img/snippets_options/page_layout_framed.svg
+++ b/addons/website/static/src/img/snippets_options/page_layout_framed.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="18" height="16" viewBox="0 0 18 16">
+  <g fill="none" fill-rule="evenodd" class="symbols">
+    <g>
+      <rect fill="#D8D8D8" y="1" width="1" height="14" class="o_subdle"/>
+      <rect fill="#D8D8D8" width="18" height="1" class="o_subdle"/>
+      <rect fill="#FFF" x="3" y="3" width="12" height="10" class="o_graphic"/>
+      <rect fill="#D8D8D8" x="17" y="1" width="1" height="14" class="o_subdle"/>
+      <rect fill="#D8D8D8" y="15" width="18" height="1" class="o_subdle"/>
+    </g>
+  </g>
+</svg>

--- a/addons/website/static/src/img/snippets_options/page_layout_full.svg
+++ b/addons/website/static/src/img/snippets_options/page_layout_full.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14">
+  <g fill="none" fill-rule="evenodd" class="symbols">
+    <g fill="#FFF">
+      <g>
+        <rect width="14" height="14" class="o_graphic"/>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/addons/website/static/src/img/snippets_options/page_layout_postcard.svg
+++ b/addons/website/static/src/img/snippets_options/page_layout_postcard.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="18" height="16" viewBox="0 0 18 16">
+  <g fill="none" fill-rule="evenodd" class="symbols">
+    <g>
+      <rect fill="#D8D8D8" y="1" width="1" height="14" class="o_subdle"/>
+      <rect fill="#FFF" x="3" y="1" width="12" height="2" class="o_graphic"/>
+      <rect fill="#FFF" x="3" y="4" width="12" height="6" class="o_graphic"/>
+      <rect fill="#FFF" x="3" y="11" width="12" height="2" class="o_graphic"/>
+      <rect fill="#D8D8D8" x="17" y="1" width="1" height="14" class="o_subdle"/>
+      <rect fill="#D8D8D8" y="15" width="18" height="1" class="o_subdle"/>
+    </g>
+  </g>
+</svg>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -1094,12 +1094,21 @@
         <we-checkbox string="Show Header"
                      data-customize-website-views="website.option_layout_hide_header|"
                      data-reload="/"/>
-        <we-select string="Page Layout" data-variable="layout">
-            <we-button data-customize-website-variable="'full'" data-name="layout_full_opt">Full</we-button>
-            <we-button data-customize-website-variable="'boxed'">Boxed</we-button>
-            <we-button data-customize-website-variable="'framed'">Framed</we-button>
-            <we-button data-customize-website-variable="'postcard'">Postcard</we-button>
-        </we-select>
+        <we-button-group string="Page Layout" data-variable="layout">
+            <we-button data-customize-website-variable="'full'"
+                       data-img="/website/static/src/img/snippets_options/page_layout_full.svg"
+                       data-name="layout_full_opt"
+                       title="Full"/>
+            <we-button data-customize-website-variable="'boxed'"
+                       data-img="/website/static/src/img/snippets_options/page_layout_boxed.svg"
+                       title="Boxed"/>
+            <we-button data-customize-website-variable="'framed'"
+                       data-img="/website/static/src/img/snippets_options/page_layout_framed.svg"
+                       title="Framed"/>
+            <we-button data-customize-website-variable="'postcard'"
+                       data-img="/website/static/src/img/snippets_options/page_layout_postcard.svg"
+                       title="Postcard"/>
+        </we-button-group>
         <we-row string="⌙ Background" data-no-preview="true">
             <we-colorpicker data-dependencies="!layout_full_opt"
                             data-customize-website-color=""


### PR DESCRIPTION
Before this commit, the page layout options was in a basic select.
After this commit, the page layout options are buttons with svg images.

task-2359250

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
