### PR TITLE
[FIX] sale_coupon: Filter the taxes by company.

### DIFF
--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -99,7 +99,7 @@ class SaleOrder(models.Model):
 
         reward_qty = min(int(int(max_product_qty / program.rule_min_quantity) * program.reward_product_quantity), reward_product_qty)
         # Take the default taxes on the reward product, mapped with the fiscal position
-        taxes = program.reward_product_id.taxes_id
+        taxes = program.reward_product_id.taxes_id.filtered(lambda t: t.company_id.id == self.company_id.id)
         if self.fiscal_position_id:
             taxes = self.fiscal_position_id.map_tax(taxes)
         return {

--- a/addons/sale_coupon_delivery/models/sale_order.py
+++ b/addons/sale_coupon_delivery/models/sale_order.py
@@ -26,7 +26,7 @@ class SaleOrder(models.Model):
 
     def _get_reward_values_free_shipping(self, program):
         delivery_line = self.order_line.filtered(lambda x: x.is_delivery)
-        taxes = delivery_line.product_id.taxes_id
+        taxes = delivery_line.product_id.taxes_id.filtered(lambda t: t.company_id.id == self.company_id.id)
         if self.fiscal_position_id:
             taxes = self.fiscal_position_id.map_tax(taxes)
         return {


### PR DESCRIPTION
In this case for scenario with multi-company, the new line of the reward product, should be set with the taxes for company of the current sale order.
Before this change the taxes that are selected were for the all companies setted in the product.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
