### PR TITLE
[FIX] mrp: update date on move when editing date after planning WO

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -716,6 +716,8 @@ class MrpProduction(models.Model):
                     raise UserError(_('You cannot move a manufacturing order once it is cancelled or done.'))
                 if production.is_planned:
                     production.button_unplan()
+                    move_vals = self._get_move_finished_values(self.product_id, self.product_uom_qty, self.product_uom_id)
+                    production.move_finished_ids.write({'date': move_vals['date']})
             if vals.get('date_planned_start'):
                 production.move_raw_ids.write({'date': production.date_planned_start, 'date_deadline': production.date_planned_start})
             if vals.get('date_planned_finished'):

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -316,6 +316,22 @@ class TestMrpOrder(TestMrpCommon):
         production = mo_form.save()
         self.assertEqual(production.workorder_ids.duration_expected, 90)
 
+    def test_update_plan_date(self):
+        """Editing the scheduled date after planning the MO should unplan the MO, and adjust the date on the stock moves"""
+        planned_date = datetime(2023, 5, 15, 9, 0)
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.product_id = self.product_4
+        mo_form.bom_id = self.bom_1
+        mo_form.product_qty = 1
+        mo_form.date_planned_start = planned_date
+        mo = mo_form.save()
+        self.assertEqual(mo.move_finished_ids[0].date, datetime(2023, 5, 15, 10, 0))
+        mo.action_confirm()
+        mo.button_plan()
+        with Form(mo) as frm:
+            frm.date_planned_start = datetime(2024, 5, 15, 9, 0)
+        self.assertEqual(mo.move_finished_ids[0].date, datetime(2024, 5, 15, 10, 0))
+
     def test_rounding(self):
         """ Checks we round up when bringing goods to produce and round half-up when producing.
         This implementation allows to implement an efficiency notion (see rev 347f140fe63612ee05e).


### PR DESCRIPTION
Behavior prior to this commit:

 - normally when editing the Scheduled Date on a MO, the date on the
 related stock moves is updated.  However this does not happen once the
 MO is planned
 - if the date is edited and the MO is planned, the MO is automatically
 unplanned, but the date on the stock moves is not automatically updated

Behavior after this commit:

 - the dates on the stock moves will automatically update, whether the
 MO is planned or not (since the MO will be unplan once it saves anyway
 if you update the date, there is no point in restricting those writes)

opw-2417108
