### PR TITLE
[FIX] account: onchange of product and uom should not use currency ro…

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3067,7 +3067,7 @@ class AccountMoveLine(models.Model):
 
             # Convert the unit price to the invoice's currency.
             company = line.move_id.company_id
-            line.price_unit = company.currency_id._convert(line.price_unit, line.move_id.currency_id, company, line.move_id.date)
+            line.price_unit = company.currency_id._convert(line.price_unit, line.move_id.currency_id, company, line.move_id.date, round=False)
 
         if len(self) == 1:
             return {'domain': {'product_uom_id': [('category_id', '=', self.product_uom_id.category_id.id)]}}
@@ -3087,7 +3087,7 @@ class AccountMoveLine(models.Model):
 
         # Convert the unit price to the invoice's currency.
         company = self.move_id.company_id
-        self.price_unit = company.currency_id._convert(price_unit, self.move_id.currency_id, company, self.move_id.date)
+        self.price_unit = company.currency_id._convert(price_unit, self.move_id.currency_id, company, self.move_id.date, round=False)
 
     @api.onchange('account_id')
     def _onchange_account_id(self):


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
As the price_unit and the uom rounding can be more detailed than the currency/accounting rounding (2 decimals as a standard) to cut the number before subtotal is wrong.

**Current behavior before PR:**
Invoice Line Price Unit of 5 digits is cut to 2 digits on change of a product or the UoM.

**Desired behavior after PR is merged:**
Keep the non-rounded and limited by the field `price_unit` number to calculate the correct subtotal which is rounding correctly based on the currency rounding.


Info: @wt-io-it

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
