### PR TITLE
[FIX] product_margin: Extra not displayed with variants

### DIFF
--- a/addons/product_margin/views/product_product_views.xml
+++ b/addons/product_margin/views/product_product_views.xml
@@ -32,7 +32,7 @@
 
                             <separator string="Sales" colspan="4"/>
                             <field name="sale_avg_price" string="Avg. Unit Price"/>
-                            <field name="list_price" string="Catalog Price" readonly="1"/>
+                            <field name="lst_price" string="Catalog Price" readonly="1"/>
                             <field name="sale_num_invoiced" />
                             <field name="sales_gap" />
                             <field name="turnover" />


### PR DESCRIPTION
Steps to reproduce:

- Let's consider a product temlpate PT with two variants V1 and V2
- PT has a sals price of 10€
- V1 has an extra of 5€ and V2 has an extra of 6€
- Go to the Product margins report

Bug:

Both V1 and V2 have catalog price of 10€ instead of 15€ and 16€

opw:2416486