### PR TITLE
[FIX] sale_stock : widget wrong value

### DIFF
--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -342,11 +342,13 @@ class SaleOrderLine(models.Model):
                 line.free_qty_today = free_qty_today - qty_processed_per_product[line.product_id.id]
                 line.virtual_available_at_date = virtual_available_at_date - qty_processed_per_product[line.product_id.id]
                 line.forecast_expected_date = False
+                product_qty = line.product_uom_qty
                 if line.product_uom and line.product_id.uom_id and line.product_uom != line.product_id.uom_id:
                     line.qty_available_today = line.product_id.uom_id._compute_quantity(line.qty_available_today, line.product_uom)
                     line.free_qty_today = line.product_id.uom_id._compute_quantity(line.free_qty_today, line.product_uom)
                     line.virtual_available_at_date = line.product_id.uom_id._compute_quantity(line.virtual_available_at_date, line.product_uom)
-                qty_processed_per_product[line.product_id.id] += line.product_uom_qty
+                    product_qty = line.product_uom._compute_quantity(product_qty, line.product_id.uom_id)
+                qty_processed_per_product[line.product_id.id] += product_qty
             treated |= lines
         remaining = (self - treated)
         remaining.virtual_available_at_date = False


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
`qty_processed_per_product` should be in uom of product.

Go to runbot :
- create a product A, put 13 in stock
- create SO
- add a line with product A and unit `dozen`
- add a line with product A and unit `dozen`

you see that all are in stock (it is wrong because you have 13 in stock)
![image](https://user-images.githubusercontent.com/16716992/102813535-4466b000-43c9-11eb-9a46-81e490900eaf.png)


@nim-odoo



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
