### PR TITLE
[FIX] website_sale_digital: adapt forward port with sudo changes

### DIFF
--- a/addons/website_sale_digital/models/ir_attachment.py
+++ b/addons/website_sale_digital/models/ir_attachment.py
@@ -14,7 +14,7 @@ class Attachment(models.Model):
     @api.model
     def check(self, mode, values=None):
         super().check(mode, values=values)
-        if mode == 'read' and self and not self.env.user.has_group('base.group_user'):
+        if mode == 'read' and self and not (self.env.user.has_group('base.group_user') or self.env.su):
             self._cr.execute('SELECT 1 FROM ir_attachment WHERE product_downloadable AND id IN %s', [tuple(self.ids)])
             if self._cr.rowcount:
                 raise AccessError(_("Sorry, you are not allowed to access this document."))


### PR DESCRIPTION
In 13.0, sudo() has changed and does not change the env user, see 1e6c3bec2c5c

f9c00ced9 fixed in 12.0 incorrect digital produt access, but the condition is
not letting sudo() go through in 13.0.
