### PR TITLE
"No results to show" item was not displayed in m2o

### DIFF
--- a/addons/web/static/src/legacy/js/fields/relational_fields.js
+++ b/addons/web/static/src/legacy/js/fields/relational_fields.js
@@ -663,13 +663,10 @@ var FieldMany2One = AbstractField.extend({
         if (this.limit < values.length) {
             values = this._manageSearchMore(values, value, domain, context);
         }
-        if (!this.can_create) {
-            return values;
-        }
 
         // Additional options...
-        const canQuickCreate = !this.nodeOptions.no_quick_create;
-        const canCreateEdit = !this.nodeOptions.no_create_edit;
+        const canQuickCreate = this.can_create && !this.nodeOptions.no_quick_create;
+        const canCreateEdit = this.can_create && !this.nodeOptions.no_create_edit;
         if (value.length) {
             // "Quick create" option
             const nameExists = results.some((result) => result[1] === value);
@@ -699,7 +696,8 @@ var FieldMany2One = AbstractField.extend({
             // "No results" option
             if (!values.length) {
                 values.push({
-                    label: _t("No results to show..."),
+                    label: _t("No records"),
+                    classname: 'o_m2o_no_result',
                 });
             }
         } else if (!this.value && (canQuickCreate || canCreateEdit)) {

--- a/addons/web/static/src/legacy/scss/dropdown.scss
+++ b/addons/web/static/src/legacy/scss/dropdown.scss
@@ -22,11 +22,11 @@
             }
         }
 
-        &.o_m2o_dropdown_option, &.o_m2o_start_typing {
+        &.o_m2o_dropdown_option, &.o_m2o_start_typing, &.o_m2o_no_result {
             text-indent: $o-dropdown-hpadding * .5;
         }
 
-        &.o_m2o_start_typing {
+        &.o_m2o_start_typing, &.o_m2o_no_result {
             font-style: italic;
             cursor: default;
             a.ui-menu-item-wrapper, a.ui-state-active, a.ui-state-active:hover {

--- a/addons/web/static/tests/legacy/fields/relational_fields/field_many2one_tests.js
+++ b/addons/web/static/tests/legacy/fields/relational_fields/field_many2one_tests.js
@@ -2585,6 +2585,33 @@ QUnit.module('fields', {}, function () {
             form.destroy();
         });
 
+        QUnit.test('many2one with can_create=false shows no result item when searched something that doesn\'t exist', async function (assert) {
+            assert.expect(2);
+
+            const form = await createView({
+                View: FormView,
+                model: 'partner',
+                data: this.data,
+                arch:
+                    `<form string="Partners">
+                    <sheet>
+                        <field name="product_id" can_create="false" can_write="false"/>
+                    </sheet>
+                </form>`,
+            });
+
+            await testUtils.dom.click(form.$('.o_field_many2one input'));
+            await testUtils.fields.editAndTrigger(form.$('.o_field_many2one[name="product_id"] input'),
+                'abc', 'keydown');
+            await testUtils.nextTick();
+            assert.strictEqual($('.ui-autocomplete .o_m2o_dropdown_option:contains(Create)').length, 0,
+                "there shouldn't be any option to search and create");
+            assert.strictEqual($('.ui-autocomplete .ui-menu-item a:contains(No records)').length, 1,
+                "there should be option for 'No records'");
+
+            form.destroy();
+        });
+
         QUnit.test('pressing enter in a m2o in an editable list', async function (assert) {
             assert.expect(8);
             var M2O_DELAY = relationalFields.FieldMany2One.prototype.AUTOCOMPLETE_DELAY;


### PR DESCRIPTION
PURPOSE
When m2o has can_create=false and user try to search something that doesn't exist then it should show 'No results to show' in m2o autocomplete.

SPEC
If user can not create m2o record and if user searches in m2o that doesn't exist in m2o model then it should display 'No results to show' item in m2o autocomplete.

TASK 2376435


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
