### PR TITLE
[FIX] account: list all credit note methods

### DIFF
--- a/addons/account/wizard/account_move_reversal.py
+++ b/addons/account/wizard/account_move_reversal.py
@@ -52,7 +52,7 @@ class AccountMoveReversal(models.TransientModel):
     @api.depends('move_ids')
     def _compute_from_moves(self):
         for record in self:
-            move_ids = record.move_ids
+            move_ids = record.move_ids._origin
             record.residual = len(move_ids) == 1 and move_ids.amount_residual or 0
             record.currency_id = len(move_ids.currency_id) == 1 and move_ids.currency_id or False
             record.move_type = move_ids.move_type if len(move_ids) == 1 else (any(move.move_type in ('in_invoice', 'out_invoice') for move in move_ids) and 'some_invoice' or False)


### PR DESCRIPTION
When adding a credit note, the user can only select the "Partial
Refund" credit method.

To reproduce the error:
1. Go to Invoicing
2. Create a new one
	- Add at least one invoice line
3. Save, Confirm
4. Click on "Add Credit Note"

=> You can not change the credit method.

The method field is editable only when the residual amount is different
from 0. Here is the issue: when clicking on "Add Credit Note", it
actually triggers some `onchange` methods. The latter uses a new record
to compute the values:
https://github.com/odoo/odoo/blob/45422d56bce413b8577f1784e10dd22ede93c751/odoo/models.py#L6147-L6148
Then, some `_compute` methods are also triggered. Among them, the amount
residual computation of the associated `account_move_line`. However,
`_compute_amount_residual` will skip the not-yet-created objects and set
the amount residual to 0. This is the reason why the residual amount of
the account move is zero and therefore, the user can't change the credit
method.

OPW-2418582