### PR TITLE
[FIX] website: gallery cover img inside anchor is not well placed

### DIFF
--- a/addons/website/static/src/snippets/s_image_gallery/001.scss
+++ b/addons/website/static/src/snippets/s_image_gallery/001.scss
@@ -115,10 +115,17 @@
         > .container, > .container-fluid, > .o_container_small {
             height: 100%;
         }
-        &.s_image_gallery_cover .carousel-item > img {
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
+        &.s_image_gallery_cover .carousel-item {
+            > a {
+                width: 100%;
+                height: 100%;
+            }
+            > a > img,
+            > img {
+                width: 100%;
+                height: 100%;
+                object-fit: cover;
+            }
         }
         &:not(.s_image_gallery_show_indicators) .carousel {
             ul.carousel-indicators {


### PR DESCRIPTION
Steps:
- Go to "Website" > "Go to Website"
- Click Edit
- Add an image gallery
- Add an image to the gallery
- Add the same image to the gallery
- Click the first image
- Click "Image Cover" in the side panel
- Click on the Link button in the bottom-right of the side panel
- Add a link and save

Bug:
The first image is not displayed in the same way as the second one.

Explanation:
The layout is not carried over to `img` when it's nested into an `a` tag. Redefining the layout on the `a` tag fixes the issue.

opw:2394953