### PR TITLE
[MERGE] mail: forward port various leftover fixes and improve tests

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -1563,6 +1563,12 @@ msgid "Customer is required for inbox / email notification"
 msgstr ""
 
 #. module: mail
+#: code:addons/mail/models/mail_notification.py:0
+#, python-format
+msgid "Can not update the message or recipient of a notification."
+msgstr ""
+
+#. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_mail__date
 #: model:ir.model.fields,field_description:mail.field_mail_message__date
 #: model_terms:ir.ui.view,arch_db:mail.view_mail_search

--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -80,7 +80,7 @@ class Channel(models.Model):
         ('chat', 'Chat Discussion'),
         ('channel', 'Channel')],
         'Channel Type', default='channel')
-    is_chat = fields.Boolean(string='Is a chat', compute='_compute_is_chat', default=False)
+    is_chat = fields.Boolean(string='Is a chat', compute='_compute_is_chat')
     description = fields.Text('Description')
     uuid = fields.Char('UUID', size=50, index=True, default=lambda self: str(uuid4()), copy=False)
     email_send = fields.Boolean('Send messages by email', default=False)
@@ -169,12 +169,10 @@ class Channel(models.Model):
         for record in self:
             record.is_member = record in membership_ids
 
+    @api.depends('channel_type')
     def _compute_is_chat(self):
         for record in self:
-            if record.channel_type == 'chat':
-                record.is_chat = True
-            else:
-                record.is_chat = False
+            record.is_chat = record.channel_type == 'chat'
 
     @api.onchange('public')
     def _onchange_public(self):

--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -10,6 +10,7 @@ from odoo import _, api, fields, models, modules, tools, Command
 from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
 from odoo.tools import ormcache, formataddr
+from odoo.exceptions import AccessError
 from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 
 MODERATION_FIELDS = ['moderation', 'moderator_ids', 'moderation_ids', 'moderation_notify', 'moderation_notify_msg', 'moderation_guidelines', 'moderation_guidelines_msg']
@@ -31,6 +32,28 @@ class ChannelPartner(models.Model):
     fold_state = fields.Selection([('open', 'Open'), ('folded', 'Folded'), ('closed', 'Closed')], string='Conversation Fold State', default='open')
     is_minimized = fields.Boolean("Conversation is minimized")
     is_pinned = fields.Boolean("Is pinned on the interface", default=True)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """Similar access rule as the access rule of the mail channel.
+
+        It can not be implemented in XML, because when the record will be created, the
+        partner will be added in the channel and the security rule will always authorize
+        the creation.
+        """
+        if not self.env.is_admin():
+            for vals in vals_list:
+                if 'channel_id' in vals and not self.env.is_admin():
+                    channel_id = self.env['mail.channel'].browse(vals['channel_id'])
+                    if not channel_id._can_invite(vals.get('partner_id')):
+                        raise AccessError(_('This user can not be added in this channel'))
+        return super(ChannelPartner, self).create(vals_list)
+
+    def write(self, vals):
+        if not self.env.is_admin():
+            if {'channel_id', 'partner_id', 'partner_email'} & set(vals):
+                raise AccessError(_('You can not write on this field'))
+        return super(ChannelPartner, self).write(vals)
 
 
 class Moderation(models.Model):
@@ -67,9 +90,6 @@ class Channel(models.Model):
             res['alias_contact'] = 'everyone' if res.get('public', 'private') == 'public' else 'followers'
         return res
 
-    def _default_channel_last_seen_partner_ids(self):
-        return [Command.create({"partner_id": self.env.user.partner_id.id})]
-
     def _get_default_image(self):
         image_path = modules.get_module_resource('mail', 'static/src/img', 'groupdefault.png')
         return base64.b64encode(open(image_path, 'rb').read())
@@ -86,7 +106,7 @@ class Channel(models.Model):
     email_send = fields.Boolean('Send messages by email', default=False)
     # multi users channel
     # depends=['...'] is for `test_mail/tests/common.py`, class Moderation, `setUpClass`
-    channel_last_seen_partner_ids = fields.One2many('mail.channel.partner', 'channel_id', string='Last Seen', depends=['channel_partner_ids'], default=_default_channel_last_seen_partner_ids)
+    channel_last_seen_partner_ids = fields.One2many('mail.channel.partner', 'channel_id', string='Last Seen', depends=['channel_partner_ids'])
     channel_partner_ids = fields.Many2many('res.partner', 'mail_channel_partner', 'channel_id', 'partner_id', string='Listeners', depends=['channel_last_seen_partner_ids'])
     channel_message_ids = fields.Many2many('mail.message', 'mail_message_mail_channel_rel')
     is_member = fields.Boolean('Is a member', compute='_compute_is_member')
@@ -205,15 +225,38 @@ class Channel(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         defaults = self.default_get(['image_128'])
+        current_partner = self.env.user.partner_id.id
+
+        visibilities = []
         for vals in vals_list:
             # ensure image at quick create
             if not vals.get('image_128'):
                 vals['image_128'] = defaults['image_128']
 
+            # always add current user to new channel, go through
+            # channel_last_seen_partner_ids otherwise in v14 the channel is not
+            # visible for the user (because is_pinned is false and taken in account)
+            if 'channel_partner_ids' in vals:
+                vals['channel_partner_ids'] = [
+                    entry
+                    for entry in vals['channel_partner_ids']
+                    if entry[0] != 4 or entry[1] != current_partner
+                ]
+            membership = vals.setdefault('channel_last_seen_partner_ids', [])
+            if all(entry[0] != 0 or entry[2].get('partner_id') != current_partner for entry in membership):
+                membership.append((0, False, {'partner_id': current_partner}))
+
+            visibility_default = self._fields['public'].default(self)
+            visibilities.append(vals.pop('public', visibility_default))
+            vals['public'] = 'public'
         # Create channel and alias
         channels = super(Channel, self.with_context(
             mail_create_nolog=True, mail_create_nosubscribe=True)
         ).create(vals_list)
+
+        for visibility, channel in zip(visibilities, channels):
+            if visibility != 'public':
+                channel.sudo().public = visibility
 
         channels._subscribe_users()
 
@@ -398,7 +441,7 @@ class Channel(models.Model):
         if moderation_status == 'rejected':
             return self.env['mail.message']
 
-        self.filtered(lambda channel: channel.is_chat).mapped('channel_last_seen_partner_ids').write({'is_pinned': True})
+        self.filtered(lambda channel: channel.is_chat).mapped('channel_last_seen_partner_ids').sudo().write({'is_pinned': True})
 
         message = super(Channel, self.with_context(mail_create_nosubscribe=True)).message_post(message_type=message_type, moderation_status=moderation_status, **kwargs)
 
@@ -474,7 +517,7 @@ class Channel(models.Model):
         return True
 
     def _update_moderation_email(self, emails, status):
-        """ This method adds emails into either white or black of the channel list of emails 
+        """ This method adds emails into either white or black of the channel list of emails
             according to status. If an email in emails is already moderated, the method updates the email status.
             :param emails: list of email addresses to put in white or black list of channel.
             :param status: value is 'allow' or 'ban'. Emails are put in white list if 'allow', in black list if 'ban'.
@@ -883,6 +926,26 @@ class Channel(models.Model):
                   ', '.join('%s (channel %s)' % (partner.name, channel.name) for channel, partner in failed)
             )
 
+    def _can_invite(self, partner_id):
+        """Return True if the current user can invite the partner to the channel.
+
+          * public: ok;
+          * private: must be member;
+          * group: both current user and target must have group;
+
+        :return boolean: whether inviting is ok"""
+        partner = self.env['res.partner'].browse(partner_id)
+
+        for channel in self.sudo():
+            if channel.public == 'private' and not channel.is_member:
+                return False
+            if channel.public == 'groups':
+                if not partner.user_ids or channel.group_public_id not in partner.user_ids.groups_id:
+                    return False
+                if channel.group_public_id not in self.env.user.groups_id:
+                    return False
+        return True
+
     @api.model
     def channel_set_custom_name(self, channel_id, name=False):
         domain = [('partner_id', '=', self.env.user.partner_id.id), ('channel_id.id', '=', channel_id)]
@@ -977,7 +1040,6 @@ class Channel(models.Model):
             'name': name,
             'public': privacy,
             'email_send': False,
-            'channel_partner_ids': [Command.link(self.env.user.partner_id.id)]
         })
         notification = _('<div class="o_mail_notification">created <a href="#" class="o_channel_redirect" data-oe-id="%s">#%s</a></div>') % (new_channel.id, new_channel.name,)
         new_channel.message_post(body=notification, message_type="notification", subtype_xmlid="mail.mt_comment")

--- a/addons/mail/security/mail_security.xml
+++ b/addons/mail/security/mail_security.xml
@@ -13,6 +13,20 @@
             <field name="perm_create" eval="False"/>
         </record>
 
+        <record id="ir_rule_mail_channel_partner_group_user" model="ir.rule">
+            <field name="name">mail.channel.partner: write its own entries</field>
+            <field name="model_id" ref="model_mail_channel_partner"/>
+            <field name="groups" eval="[(4, ref('base.group_user')), (4, ref('base.group_portal'))]"/>
+            <field name="domain_force">['|', '|',
+('channel_id.public', '=', 'public'),
+'&amp;', ('channel_id.public', '=', 'private'), ('channel_id.channel_partner_ids', 'in', [user.partner_id.id]),
+'&amp;', ('channel_id.public', '=', 'groups'), ('channel_id.group_public_id', 'in', [g.id for g in user.groups_id])]</field>
+            <field name="perm_read" eval="False"/>
+            <field name="perm_write" eval="True"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_unlink" eval="True"/>
+        </record>
+
         <record id="ir_rule_mail_notifications_group_user" model="ir.rule">
             <field name="name">mail.notifications: group_user: write its own entries</field>
             <field name="model_id" ref="model_mail_notification"/>

--- a/addons/mail/tests/__init__.py
+++ b/addons/mail/tests/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_mail_channel
+from . import test_mail_channel_partner
 from . import test_mail_full_composer
 from . import test_res_partner
 from . import test_update_notification

--- a/addons/mail/tests/__init__.py
+++ b/addons/mail/tests/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import common
+from . import test_mail_channel
 from . import test_mail_full_composer
 from . import test_res_partner
 from . import test_update_notification

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -679,3 +679,24 @@ class MailCommon(common.TransactionCase, MailCase):
             name='Chell Gladys', notification_type='email')
         cls.partner_portal = cls.user_portal.partner_id
         return cls.user_portal
+
+    @classmethod
+    def _activate_multi_company(cls):
+        """ Create another company, add it to admin and create an user that
+        belongs to that new company. It allows to test flows with users from
+        different companies. """
+        cls.company_2 = cls.env['res.company'].create({
+            'name': 'Company 2',
+            'email': 'company_2@test.example.com',
+        })
+        cls.user_admin.write({'company_ids': [(4, cls.company_2.id)]})
+
+        cls.user_employee_c2 = mail_new_test_user(
+            cls.env, login='employee_c2',
+            groups='base.group_user',
+            company_id=cls.company_2.id,
+            name='Enguerrand Employee C2',
+            notification_type='inbox',
+            signature='--\nEnguerrand'
+        )
+        cls.partner_employee_c2 = cls.user_employee_c2.partner_id

--- a/addons/mail/tests/test_mail_channel.py
+++ b/addons/mail/tests/test_mail_channel.py
@@ -3,12 +3,12 @@
 
 from odoo.tests import tagged
 from odoo.addons.mail.tests.common import mail_new_test_user
-from odoo.addons.test_mail.tests.common import TestMailCommon
+from odoo.addons.mail.tests.common import MailCommon
 from odoo.exceptions import AccessError, ValidationError, UserError
 from odoo.tools import mute_logger, formataddr
 
 
-class TestChannelAccessRights(TestMailCommon):
+class TestChannelAccessRights(MailCommon):
 
     @classmethod
     def setUpClass(cls):
@@ -107,7 +107,7 @@ class TestChannelAccessRights(TestMailCommon):
                 trigger_read = partner.with_user(self.user_portal).name
 
 
-class TestChannelFeatures(TestMailCommon):
+class TestChannelFeatures(MailCommon):
 
     @classmethod
     def setUpClass(cls):
@@ -303,7 +303,7 @@ class TestChannelFeatures(TestMailCommon):
 
 
 @tagged('moderation')
-class TestChannelModeration(TestMailCommon):
+class TestChannelModeration(MailCommon):
 
     @classmethod
     def setUpClass(cls):

--- a/addons/mail/tests/test_mail_channel.py
+++ b/addons/mail/tests/test_mail_channel.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests import tagged
 from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.exceptions import AccessError, ValidationError, UserError
+from odoo.tests import tagged
+from odoo.tests.common import users
 from odoo.tools import mute_logger, formataddr
 
 
@@ -15,11 +16,11 @@ class TestChannelAccessRights(MailCommon):
         super(TestChannelAccessRights, cls).setUpClass()
         Channel = cls.env['mail.channel'].with_context(cls._test_context)
 
-        cls.user_public = mail_new_test_user(cls.env, login='bert', groups='base.group_public', name='Bert Tartignole')
-        cls.user_portal = mail_new_test_user(cls.env, login='chell', groups='base.group_portal', name='Chell Gladys')
+        cls.user_public = mail_new_test_user(cls.env, login='user_public', groups='base.group_public', name='Bert Tartignole')
+        cls.user_portal = mail_new_test_user(cls.env, login='user_portal', groups='base.group_portal', name='Chell Gladys')
 
         # Pigs: base group for tests
-        cls.group_pigs = Channel.create({
+        cls.group_groups = Channel.create({
             'name': 'Pigs',
             'public': 'groups',
             'group_public_id': cls.env.ref('base.group_user').id})
@@ -33,71 +34,80 @@ class TestChannelAccessRights(MailCommon):
             'name': 'Private',
             'public': 'private'})
 
-    @mute_logger('odoo.addons.base.models.ir_model', 'odoo.models')
-    def test_access_rights_public(self):
+    @mute_logger('odoo.addons.base.models.ir_rule', 'odoo.addons.base.models.ir_model', 'odoo.models')
+    @users('user_public')
+    def test_access_public(self):
         # Read public group -> ok
-        self.group_public.with_user(self.user_public).read()
+        self.env['mail.channel'].browse(self.group_public.id).read()
 
-        # Read Pigs -> ko, restricted to employees
+        # Read groups -> ko, restricted to employees
         with self.assertRaises(AccessError):
-            self.group_pigs.with_user(self.user_public).read()
+            self.env['mail.channel'].browse(self.group_groups.id).read()
+        # Read private -> ko, restricted to members
+        with self.assertRaises(AccessError):
+            self.env['mail.channel'].browse(self.group_private.id).read()
 
         # Read a private group when being a member: ok
         self.group_private.write({'channel_partner_ids': [(4, self.user_public.partner_id.id)]})
-        self.group_private.with_user(self.user_public).read()
+        self.env['mail.channel'].browse(self.group_private.id).read()
 
         # Create group: ko, no access rights
         with self.assertRaises(AccessError):
-            self.env['mail.channel'].with_user(self.user_public).create({'name': 'Test'})
+            self.env['mail.channel'].create({'name': 'Test'})
 
         # Update group: ko, no access rights
         with self.assertRaises(AccessError):
-            self.group_public.with_user(self.user_public).write({'name': 'Broutouschnouk'})
+            self.env['mail.channel'].browse(self.group_public.id).write({'name': 'Broutouschnouk'})
 
         # Unlink group: ko, no access rights
         with self.assertRaises(AccessError):
-            self.group_public.with_user(self.user_public).unlink()
+            self.env['mail.channel'].browse(self.group_public.id).unlink()
 
-    @mute_logger('odoo.addons.base.models.ir_model', 'odoo.models', 'odoo.models.unlink')
-    def test_access_rights_groups(self):
+    @mute_logger('odoo.addons.base.models.ir_rule', 'odoo.models', 'odoo.models.unlink')
+    @users('employee')
+    def test_access_employee(self):
         # Employee read employee-based group: ok
-        self.group_pigs.with_user(self.user_employee).read()
+        group_groups = self.env['mail.channel'].browse(self.group_groups.id)
+        group_groups.read()
 
         # Employee can create a group
-        self.env['mail.channel'].with_user(self.user_employee).create({'name': 'Test'})
+        new_channel = self.env['mail.channel'].create({'name': 'Test'})
+        self.assertIn(new_channel.channel_partner_ids, self.partner_employee)
 
         # Employee update employee-based group: ok
-        self.group_pigs.with_user(self.user_employee).write({'name': 'modified'})
+        group_groups.write({'name': 'modified'})
 
         # Employee unlink employee-based group: ok
-        self.group_pigs.with_user(self.user_employee).unlink()
+        group_groups.unlink()
 
         # Employee cannot read a private group
         with self.assertRaises(AccessError):
-            self.group_private.with_user(self.user_employee).read()
+            self.env['mail.channel'].browse(self.group_private.id).read()
 
         # Employee cannot write on private
         with self.assertRaises(AccessError):
-            self.group_private.with_user(self.user_employee).write({'name': 're-modified'})
+            self.env['mail.channel'].browse(self.group_private.id).write({'name': 're-modified'})
 
-    @mute_logger('odoo.addons.base.models.ir_model', 'odoo.models')
-    def test_access_rights_followers_ko(self):
-        # self.group_private.name has been put in the cache during the setup as sudo
-        # It must therefore be removed from the cache in other to validate the fact user_portal can't read it.
-        self.group_private.invalidate_cache(['name'])
+        # Employee cannot unlink private
         with self.assertRaises(AccessError):
-            self.group_private.with_user(self.user_portal).name
+            self.env['mail.channel'].browse(self.group_private.id).unlink()
 
-    def test_access_rights_followers_portal(self):
-        # Do: Chell is added into Pigs members and browse it -> ok for messages, ko for partners (no read permission)
+
+    @mute_logger('odoo.addons.base.models.ir_rule', 'odoo.models')
+    @users('user_portal')
+    def test_access_portal(self):
+        with self.assertRaises(AccessError):
+            self.env['mail.channel'].browse(self.group_private.id).name
+
         self.group_private.write({'channel_partner_ids': [(4, self.user_portal.partner_id.id)]})
-        chell_pigs = self.group_private.with_user(self.user_portal)
-        trigger_read = chell_pigs.name
-        for message in chell_pigs.message_ids:
-            trigger_read = message.subject
+        group_private_portal = self.env['mail.channel'].browse(self.group_private.id)
+        group_private_portal.read(['name'])
+        for message in group_private_portal.message_ids:
+            message.read(['subject'])
 
+        # no access to followers (employee only)
         with self.assertRaises(AccessError):
-            chell_pigs.message_partner_ids
+            group_private_portal.message_partner_ids
 
         for partner in self.group_private.message_partner_ids:
             if partner.id == self.user_portal.partner_id.id:
@@ -106,93 +116,114 @@ class TestChannelAccessRights(MailCommon):
             with self.assertRaises(AccessError):
                 trigger_read = partner.with_user(self.user_portal).name
 
+    @mute_logger('odoo.addons.base.models.ir_rule', 'odoo.addons.base.models.ir_model', 'odoo.models')
+    @users('user_portal')
+    def test_members(self):
+        group_public = self.env['mail.channel'].browse(self.group_public.id)
+        group_public.read(['name'])
+        self.assertFalse(group_public.is_member)
 
-class TestChannelFeatures(MailCommon):
+        with self.assertRaises(AccessError):
+            group_public.write({'name': 'Better Name'})
+
+        with self.assertRaises(AccessError):
+            group_public.action_follow()
+
+        group_private = self.env['mail.channel'].browse(self.group_private.id)
+        with self.assertRaises(AccessError):
+            group_private.read(['name'])
+
+        self.env['mail.channel.partner'].create({
+            'partner_id': self.env.user.partner_id.id,
+            'channel_id': group_private.id,
+        })
+        group_private = self.env['mail.channel'].browse(self.group_private.id)
+        self.assertTrue(group_private.is_member)
+        group_private.read(['name', 'channel_last_seen_partner_ids'])
+
+
+class TestChannelInternals(MailCommon):
 
     @classmethod
     def setUpClass(cls):
-        super(TestChannelFeatures, cls).setUpClass()
+        super(TestChannelInternals, cls).setUpClass()
         cls.test_channel = cls.env['mail.channel'].with_context(cls._test_context).create({
             'name': 'Test',
+            'channel_type': 'channel',
+            'email_send': False,
             'description': 'Description',
             'alias_name': 'test',
             'public': 'public',
         })
         cls.test_partner = cls.env['res.partner'].with_context(cls._test_context).create({
             'name': 'Test Partner',
-            'email': 'test@example.com',
+            'email': 'test_customer@example.com',
         })
+        cls.user_employee_nomail = mail_new_test_user(
+            cls.env, login='employee_nomail',
+            email=False,
+            groups='base.group_user',
+            company_id=cls.company_admin.id,
+            name='Evita Employee NoEmail',
+            notification_type='email',
+            signature='--\nEvite'
+        )
+        cls.partner_employee_nomail = cls.user_employee_nomail.partner_id
 
-    def _join_channel(self, channel, partners):
-        for partner in partners:
-            channel.write({'channel_last_seen_partner_ids': [(0, 0, {'partner_id': partner.id})]})
-        channel.invalidate_cache()
-
-    def _leave_channel(self, channel, partners):
-        for partner in partners:
-            channel._action_unfollow(partner)
-
-    def test_channel_listeners(self):
+    def test_channel_members(self):
         self.assertEqual(self.test_channel.message_channel_ids, self.test_channel)
         self.assertEqual(self.test_channel.message_partner_ids, self.env['res.partner'])
         self.assertEqual(self.test_channel.channel_partner_ids, self.env['res.partner'])
 
-        self._join_channel(self.test_channel, self.test_partner)
+        self.test_channel._action_add_members(self.test_partner)
         self.assertEqual(self.test_channel.message_channel_ids, self.test_channel)
         self.assertEqual(self.test_channel.message_partner_ids, self.env['res.partner'])
         self.assertEqual(self.test_channel.channel_partner_ids, self.test_partner)
 
-        self._leave_channel(self.test_channel, self.test_partner)
+        self.test_channel._action_remove_members(self.test_partner)
         self.assertEqual(self.test_channel.message_channel_ids, self.test_channel)
         self.assertEqual(self.test_channel.message_partner_ids, self.env['res.partner'])
         self.assertEqual(self.test_channel.channel_partner_ids, self.env['res.partner'])
 
-    def test_channel_post_nofollow(self):
         self.test_channel.message_post(body='Test', message_type='comment', subtype_xmlid='mail.mt_comment')
         self.assertEqual(self.test_channel.message_channel_ids, self.test_channel)
         self.assertEqual(self.test_channel.message_partner_ids, self.env['res.partner'])
+        self.assertEqual(self.test_channel.channel_partner_ids, self.env['res.partner'])
 
     @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
-    def test_channel_mailing_list_recipients(self):
-        """ Posting a message on a mailing list should send one email to all recipients """
-        self.env['ir.config_parameter'].set_param('mail.catchall.domain', 'schlouby.fr')
-        self.test_channel.write({'email_send': True})
-        self.user_employee.write({'notification_type': 'email'})
-
-        # Subscribe an user without email. We shouldn't try to send email to them.
-        nomail = self.env['res.users'].create({
-            "login": "nomail",
-            "name": "No Mail",
-            "email": False,
-            "notification_type": "email",
-        })
-        self._join_channel(self.test_channel, self.user_employee.partner_id | self.test_partner | nomail.partner_id)
-        with self.mock_mail_gateway():
-            self.test_channel.message_post(body="Test", message_type='comment', subtype_xmlid='mail.mt_comment')
-        self.assertSentEmail(self.test_channel.env.user.partner_id, [self.partner_employee, self.test_partner])
-
-    @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
-    def test_channel_chat_recipients(self):
+    def test_channel_recipients_chat(self):
         """ Posting a message on a chat should not send emails """
         self.env['ir.config_parameter'].set_param('mail.catchall.domain', 'schlouby.fr')
         self.test_channel.write({'email_send': False})
-        self._join_channel(self.test_channel, self.user_employee.partner_id | self.test_partner)
+        self.test_channel._action_add_members(self.user_employee.partner_id | self.test_partner)
         with self.mock_mail_gateway():
             self.test_channel.message_post(body="Test", message_type='comment', subtype_xmlid='mail.mt_comment')
         self.assertNotSentEmail()
         self.assertEqual(len(self._mails), 0)
 
     @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
-    def test_channel_classic_recipients(self):
+    def test_channel_recipients_mailing_list(self):
+        """ Posting a message on a mailing list should send one email to all recipients """
+        self.test_channel.write({'email_send': True})
+        self.user_employee.write({'notification_type': 'email'})
+
+        # Subscribe an user without email. We shouldn't try to send email to them.
+        self.test_channel._action_add_members(self.user_employee.partner_id | self.test_partner | self.partner_employee_nomail)
+        with self.mock_mail_gateway():
+            self.test_channel.message_post(body="Test", message_type='comment', subtype_xmlid='mail.mt_comment')
+        self.assertSentEmail(self.test_channel.env.user.partner_id, [self.partner_employee, self.test_partner])
+
+    @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
+    def test_channel_recipient_noalias(self):
         """ Posting a message on a classic channel should work like classic post """
         self.test_channel.write({'alias_name': False})
-        self.test_channel.message_subscribe([self.user_employee.partner_id.id, self.test_partner.id])
+        self.test_channel.message_subscribe([self.user_employee.partner_id.id, self.test_partner.id, self.partner_employee_nomail.id])
         with self.mock_mail_gateway():
             self.test_channel.message_post(body="Test", message_type='comment', subtype_xmlid='mail.mt_comment')
         self.assertSentEmail(self.test_channel.env.user.partner_id, [self.test_partner])
 
     @mute_logger('odoo.models.unlink')
-    def test_channel_auto_unsubscribe_archived_or_deleted_users(self):
+    def test_channel_user_synchronize(self):
         """Archiving / deleting a user should automatically unsubscribe related partner from private channels"""
         test_channel_private = self.env['mail.channel'].with_context(self._test_context).create({
             'name': 'Winden caves',
@@ -204,102 +235,83 @@ class TestChannelFeatures(MailCommon):
             'public': 'groups',
             'group_public_id': self.env.ref('base.group_user').id})
 
-        test_user = self.env['res.users'].create({
-            "login": "adam",
-            "name": "Jonas",
-        })
-        test_partner = test_user.partner_id
-
-        self._join_channel(self.test_channel, self.user_employee.partner_id | test_partner)
-        self._join_channel(test_channel_private, self.user_employee.partner_id | test_partner)
-        self._join_channel(test_channel_group, self.user_employee.partner_id | test_partner)
+        self.test_channel._action_add_members(self.partner_employee | self.partner_employee_nomail)
+        test_channel_private._action_add_members(self.partner_employee | self.partner_employee_nomail)
+        test_channel_group._action_add_members(self.partner_employee | self.partner_employee_nomail)
 
         # Unsubscribe archived user from the private channels, but not from public channels
         self.user_employee.active = False
-        self.assertEqual(test_channel_private.channel_partner_ids, test_partner)
-        self.assertEqual(test_channel_group.channel_partner_ids, test_partner)
-        self.assertEqual(self.test_channel.channel_partner_ids, self.user_employee.partner_id | test_partner)
+        self.assertEqual(test_channel_private.channel_partner_ids, self.partner_employee_nomail)
+        self.assertEqual(test_channel_group.channel_partner_ids, self.partner_employee_nomail)
+        self.assertEqual(self.test_channel.channel_partner_ids, self.user_employee.partner_id | self.partner_employee_nomail)
 
         # Unsubscribe deleted user from the private channels, but not from public channels
-        test_user.unlink()
+        self.user_employee_nomail.unlink()
         self.assertEqual(test_channel_private.channel_partner_ids, self.env['res.partner'])
         self.assertEqual(test_channel_group.channel_partner_ids, self.env['res.partner'])
-        self.assertEqual(self.test_channel.channel_partner_ids, self.user_employee.partner_id | test_partner)
+        self.assertEqual(self.test_channel.channel_partner_ids, self.user_employee.partner_id | self.partner_employee_nomail)
 
-    def test_channel_get(self):
-        current_user = self.env['res.users'].create({
-            "login": "adam",
-            "name": "Jonas",
-        })
-        current_user = current_user.with_user(current_user)
-        current_partner = current_user.partner_id
-        other_partner = self.test_partner
-
+    @users('employee_nomail')
+    def test_channel_info_get(self):
         # `channel_get` should return a new channel the first time a partner is given
-        initial_channel_info = current_user.env['mail.channel'].channel_get(partners_to=other_partner.ids)
-        self.assertEqual(set(p['id'] for p in initial_channel_info['members']), {current_partner.id, other_partner.id})
+        initial_channel_info = self.env['mail.channel'].channel_get(partners_to=self.test_partner.ids)
+        self.assertEqual(set(p['id'] for p in initial_channel_info['members']), {self.partner_employee_nomail.id, self.test_partner.id})
 
         # `channel_get` should return the existing channel every time the same partner is given
-        same_channel_info = current_user.env['mail.channel'].channel_get(partners_to=other_partner.ids)
+        same_channel_info = self.env['mail.channel'].channel_get(partners_to=self.test_partner.ids)
         self.assertEqual(same_channel_info['id'], initial_channel_info['id'])
 
         # `channel_get` should return the existing channel when the current partner is given together with the other partner
-        together_channel_info = current_user.env['mail.channel'].channel_get(partners_to=(current_partner + other_partner).ids)
+        together_channel_info = self.env['mail.channel'].channel_get(partners_to=(self.partner_employee_nomail + self.test_partner).ids)
         self.assertEqual(together_channel_info['id'], initial_channel_info['id'])
 
         # `channel_get` should return a new channel the first time just the current partner is given,
         # even if a channel containing the current partner together with other partners already exists
-        solo_channel_info = current_user.env['mail.channel'].channel_get(partners_to=current_partner.ids)
+        solo_channel_info = self.env['mail.channel'].channel_get(partners_to=self.partner_employee_nomail.ids)
         self.assertNotEqual(solo_channel_info['id'], initial_channel_info['id'])
-        self.assertEqual(set(p['id'] for p in solo_channel_info['members']), {current_partner.id})
+        self.assertEqual(set(p['id'] for p in solo_channel_info['members']), {self.partner_employee_nomail.id})
 
         # `channel_get` should return the existing channel every time the current partner is given
-        same_solo_channel_info = current_user.env['mail.channel'].channel_get(partners_to=current_partner.ids)
+        same_solo_channel_info = self.env['mail.channel'].channel_get(partners_to=self.partner_employee_nomail.ids)
         self.assertEqual(same_solo_channel_info['id'], solo_channel_info['id'])
 
-    def test_channel_seen(self):
-        """
-        In case of concurrent channel_seen RPC, ensure the oldest call has no effect.
-        """
-        self.test_channel.write({'channel_type': 'chat'})
-        self.test_channel.action_follow()
-        msg_1 = self._add_messages(self.test_channel, 'Body1', author=self.user_employee.partner_id,
+    @users('employee')
+    def test_channel_info_seen(self):
+        """ In case of concurrent channel_seen RPC, ensure the oldest call has no effect. """
+        channel = self.env['mail.channel'].browse(self.test_channel.id)
+        channel.write({'channel_type': 'chat'})
+        channel.action_follow()
+
+        msg_1 = self._add_messages(
+            self.test_channel, 'Body1', author=self.user_employee.partner_id,
             channel_ids=[self.test_channel.id])
-        msg_2 = self._add_messages(self.test_channel, 'Body2', author=self.user_employee.partner_id,
+        msg_2 = self._add_messages(
+            self.test_channel, 'Body2', author=self.user_employee.partner_id,
             channel_ids=[self.test_channel.id])
-        ChannelAsUser = self.test_channel.with_user(self.user_employee).browse(self.test_channel.id)
 
         self.test_channel.channel_seen(msg_2.id)
         self.assertEqual(
-            ChannelAsUser.channel_info()[0]['seen_partners_info'][0]['seen_message_id'],
+            channel.channel_info()[0]['seen_partners_info'][0]['seen_message_id'],
             msg_2.id,
             "Last message id should have been updated"
         )
 
         self.test_channel.channel_seen(msg_1.id)
         self.assertEqual(
-            ChannelAsUser.channel_info()[0]['seen_partners_info'][0]['seen_message_id'],
+            channel.channel_info()[0]['seen_partners_info'][0]['seen_message_id'],
             msg_2.id,
             "Last message id should stay the same after mark channel as seen with an older message"
         )
 
     def test_multi_company_chat(self):
-        company_A = self.env['res.company'].create({'name': 'Company A'})
-        company_B = self.env['res.company'].create({'name': 'Company B'})
-        test_user_1 = self.env['res.users'].create({
-            'login': 'user1',
-            'name': 'My First New User',
-            'company_ids': [(6, 0, company_A.ids)],
-            'company_id': company_A.id
-        })
-        test_user_2 = self.env['res.users'].create({
-            'login': 'user2',
-            'name': 'My Second New User',
-            'company_ids': [(6, 0, company_B.ids)],
-            'company_id': company_B.id
-        })
-        initial_channel_info = self.env['mail.channel'].with_user(test_user_1).with_context(allowed_company_ids=company_A.ids).channel_get(test_user_2.partner_id.ids)
-        self.assertTrue(initial_channel_info, 'should be able to chat with multi company user')
+        self._activate_multi_company()
+        self.assertEqual(self.env.user.company_id, self.company_admin)
+
+        with self.with_user('employee'):
+            initial_channel_info = self.env['mail.channel'].with_context(
+                allowed_company_ids=self.company_admin.ids
+            ).channel_get(self.partner_employee_c2.ids)
+            self.assertTrue(initial_channel_info, 'should be able to chat with multi company user')
 
 
 @tagged('moderation')

--- a/addons/mail/tests/test_mail_channel_partner.py
+++ b/addons/mail/tests/test_mail_channel_partner.py
@@ -1,0 +1,223 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.mail.tests.common import mail_new_test_user
+from odoo.addons.mail.tests.common import MailCommon
+from odoo.exceptions import AccessError, UserError
+
+
+class TestMailChannelMembers(MailCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestMailChannelMembers, cls).setUpClass()
+
+        cls.secret_group = cls.env['res.groups'].create({
+            'name': 'Secret User Group',
+        })
+        cls.env['ir.model.data'].create({
+            'name': 'secret_group',
+            'module': 'mail',
+            'model': cls.secret_group._name,
+            'res_id': cls.secret_group.id,
+        })
+
+        cls.user_1 = mail_new_test_user(
+            cls.env, login='user_1',
+            name='User 1',
+            groups='base.group_user,mail.secret_group')
+        cls.user_2 = mail_new_test_user(
+            cls.env, login='user_2',
+            name='User 2',
+            groups='base.group_user,mail.secret_group')
+        cls.user_portal = mail_new_test_user(
+            cls.env, login='user_portal',
+            name='User Portal',
+            groups='base.group_portal')
+        cls.user_public = mail_new_test_user(
+            cls.env, login='user_ublic',
+            name='User Public',
+            groups='base.group_public')
+
+        cls.private_channel = cls.env['mail.channel'].create({
+            'name': 'Secret channel',
+            'public': 'private',
+            'channel_type': 'channel',
+        })
+        cls.group_channel = cls.env['mail.channel'].create({
+            'name': 'Group channel',
+            'public': 'groups',
+            'channel_type': 'channel',
+            'group_public_id': cls.secret_group.id,
+        })
+        cls.public_channel = cls.env['mail.channel'].create({
+            'name': 'Public channel of user 1',
+            'public': 'public',
+            'channel_type': 'channel',
+        })
+        (cls.private_channel | cls.group_channel | cls.public_channel).channel_last_seen_partner_ids.unlink()
+
+    # ------------------------------------------------------------
+    # PRIVATE CHANNELS
+    # ------------------------------------------------------------
+
+    def test_channel_private_01(self):
+        """Test access on private channel."""
+        res = self.env['mail.channel.partner'].search([('channel_id', '=', self.private_channel.id)])
+        self.assertFalse(res)
+
+        # User 1 can join private channel with SUDO
+        self.private_channel.with_user(self.user_1).sudo().action_follow()
+        res = self.env['mail.channel.partner'].search([('channel_id', '=', self.private_channel.id)])
+        self.assertEqual(res.partner_id, self.user_1.partner_id)
+
+        # User 2 can not join private channel
+        with self.assertRaises(AccessError):
+            self.private_channel.with_user(self.user_2).action_follow()
+
+        # User 2 can not create a `mail.channel.partner` to join the private channel
+        with self.assertRaises(AccessError):
+            self.env['mail.channel.partner'].with_user(self.user_2).create({
+                'partner_id': self.user_2.partner_id.id,
+                'channel_id': self.private_channel.id,
+            })
+
+        # User 2 can not write on `mail.channel.partner` to join the private channel
+        channel_partner = self.env['mail.channel.partner'].with_user(self.user_2).search([('partner_id', '=', self.user_2.partner_id.id)])[0]
+        with self.assertRaises(AccessError):
+            channel_partner.channel_id = self.private_channel.id
+        with self.assertRaises(AccessError):
+            channel_partner.write({'channel_id': self.private_channel.id})
+
+        # But with SUDO, User 2 can
+        channel_partner.sudo().channel_id = self.private_channel.id
+
+        # User 2 can not write on the `partner_id` of `mail.channel.partner`
+        # of an other partner to join a private channel
+        channel_partner_1 = self.env['mail.channel.partner'].search([('channel_id', '=', self.private_channel.id), ('partner_id', '=', self.user_1.partner_id.id)])
+        with self.assertRaises(AccessError):
+            channel_partner_1.with_user(self.user_2).partner_id = self.user_2.partner_id
+        self.assertEqual(channel_partner_1.partner_id, self.user_1.partner_id)
+
+        # but with SUDO he can...
+        channel_partner_1.with_user(self.user_2).sudo().partner_id = self.user_2.partner_id
+        self.assertEqual(channel_partner_1.partner_id, self.user_2.partner_id)
+
+    def test_channel_private_members(self):
+        """Test invitation in private channel part 1 (invite using crud methods)."""
+        self.private_channel.with_user(self.user_1).sudo().action_follow()
+        channel_partners = self.env['mail.channel.partner'].search([('channel_id', '=', self.private_channel.id)])
+        self.assertEqual(len(channel_partners), 1)
+
+        # User 2 is not in the private channel, he can not invite user 3
+        with self.assertRaises(AccessError):
+            self.env['mail.channel.partner'].with_user(self.user_2).create({
+                'partner_id': self.user_portal.partner_id.id,
+                'channel_id': self.private_channel.id,
+            })
+
+        # User 1 is in the private channel, he can invite other users
+        self.env['mail.channel.partner'].with_user(self.user_1).create({
+            'partner_id': self.user_portal.partner_id.id,
+            'channel_id': self.private_channel.id,
+        })
+        channel_partners = self.env['mail.channel.partner'].search([('channel_id', '=', self.private_channel.id)])
+        self.assertEqual(channel_partners.mapped('partner_id'), self.user_1.partner_id | self.user_portal.partner_id)
+
+        # But User 3 can not write on the `mail.channel.partner` of other user
+        channel_partner_1 = self.env['mail.channel.partner'].search([('channel_id', '=', self.private_channel.id), ('partner_id', '=', self.user_1.partner_id.id)])
+        channel_partner_3 = self.env['mail.channel.partner'].search([('channel_id', '=', self.private_channel.id), ('partner_id', '=', self.user_portal.partner_id.id)])
+        channel_partner_3.with_user(self.user_portal).custom_channel_name = 'Test'
+        with self.assertRaises(AccessError):
+            channel_partner_1.with_user(self.user_2).custom_channel_name = 'Blabla'
+        self.assertNotEqual(channel_partner_1.custom_channel_name, 'Blabla')
+
+    def test_channel_private_invite(self):
+        """Test invitation in private channel part 2 (use `invite` action)."""
+        self.private_channel.with_user(self.user_1).sudo().action_follow()
+        channel_partners = self.env['mail.channel.partner'].search([('channel_id', '=', self.private_channel.id)])
+        self.assertEqual(channel_partners.mapped('partner_id'), self.user_1.partner_id)
+
+        # User 2 is not in the channel, he can not invite user_portal
+        with self.assertRaises(AccessError):
+            self.private_channel.with_user(self.user_2).channel_invite([self.user_portal.partner_id.id])
+        channel_partners = self.env['mail.channel.partner'].search([('channel_id', '=', self.private_channel.id)])
+        self.assertEqual(channel_partners.mapped('partner_id'), self.user_1.partner_id)
+
+        # User 1 is in the channel, he can invite user_portal
+        self.private_channel.with_user(self.user_1).channel_invite([self.user_portal.partner_id.id])
+        channel_partners = self.env['mail.channel.partner'].search([('channel_id', '=', self.private_channel.id)])
+        self.assertEqual(channel_partners.mapped('partner_id'), self.user_1.partner_id | self.user_portal.partner_id)
+
+    def test_channel_private_leave(self):
+        """Test kick/leave channel."""
+        self.private_channel.with_user(self.user_1).sudo().action_follow()
+        self.private_channel.with_user(self.user_portal).sudo().action_follow()
+        channel_partners = self.env['mail.channel.partner'].search([('channel_id', '=', self.private_channel.id)])
+        self.assertEqual(len(channel_partners), 2)
+
+        # User 2 is not in the channel, he can not kick user 1
+        with self.assertRaises(AccessError):
+            channel_partners.with_user(self.user_2).unlink()
+
+        # User 3 is in the channel, he can kick user 1
+        channel_partners.with_user(self.user_portal).unlink()
+
+    # ------------------------------------------------------------
+    # GROUP BASED CHANNELS
+    # ------------------------------------------------------------
+
+    def test_channel_group(self):
+        """Test basics on group channel."""
+        channel_partners = self.env['mail.channel.partner'].search([('channel_id', '=', self.group_channel.id)])
+        self.assertFalse(channel_partners)
+
+        # user 1 is in the group, he can join the channel
+        self.group_channel.with_user(self.user_1).action_follow()
+        channel_partners = self.env['mail.channel.partner'].search([('channel_id', '=', self.group_channel.id)])
+        self.assertEqual(channel_partners.mapped('partner_id'), self.user_1.partner_id)
+
+        # user 3 is not in the group, he can not join
+        with self.assertRaises(AccessError):
+            self.group_channel.with_user(self.user_portal).action_follow()
+
+        channel_partners = self.env['mail.channel.partner'].search([('channel_id', '=', self.group_channel.id)])
+        with self.assertRaises(AccessError):
+            channel_partners.with_user(self.user_portal).partner_id = self.user_portal.partner_id
+
+        channel_partners = self.env['mail.channel.partner'].search([('channel_id', '=', self.group_channel.id)])
+        self.assertEqual(channel_partners.mapped('partner_id'), self.user_1.partner_id)
+
+        # user 1 can not invite user 3 because he's not in the group
+        with self.assertRaises(UserError):
+            self.group_channel.with_user(self.user_1).channel_invite([self.user_portal.partner_id.id])
+        channel_partners = self.env['mail.channel.partner'].search([('channel_id', '=', self.group_channel.id)])
+        self.assertEqual(channel_partners.mapped('partner_id'), self.user_1.partner_id)
+
+        # but user 2 is in the group and can be invited by user 1
+        self.group_channel.with_user(self.user_1).channel_invite([self.user_2.partner_id.id])
+        channel_partners = self.env['mail.channel.partner'].search([('channel_id', '=', self.group_channel.id)])
+        self.assertEqual(channel_partners.mapped('partner_id'), self.user_1.partner_id | self.user_2.partner_id)
+
+    # ------------------------------------------------------------
+    # PUBLIC CHANNELS
+    # ------------------------------------------------------------
+
+    def test_channel_public(self):
+        """ Test access on public channels """
+        channel_partners = self.env['mail.channel.partner'].search([('channel_id', '=', self.public_channel.id)])
+        self.assertFalse(channel_partners)
+
+        self.public_channel.with_user(self.user_1).action_follow()
+        channel_partners = self.env['mail.channel.partner'].search([('channel_id', '=', self.public_channel.id)])
+        self.assertEqual(channel_partners.mapped('partner_id'), self.user_1.partner_id)
+
+        self.public_channel.with_user(self.user_2).action_follow()
+        channel_partners = self.env['mail.channel.partner'].search([('channel_id', '=', self.public_channel.id)])
+        self.assertEqual(channel_partners.mapped('partner_id'), self.user_1.partner_id | self.user_2.partner_id)
+
+        # portal/public users still cannot join a public channel, should go through dedicated controllers
+        with self.assertRaises(AccessError):
+            self.public_channel.with_user(self.user_portal).action_follow()
+        with self.assertRaises(AccessError):
+            self.public_channel.with_user(self.user_public).action_follow()

--- a/addons/test_mail/tests/__init__.py
+++ b/addons/test_mail/tests/__init__.py
@@ -7,7 +7,6 @@ from . import test_mail_composer
 from . import test_mail_followers
 from . import test_mail_message
 from . import test_mail_mail
-from . import test_mail_channel
 from . import test_mail_gateway
 from . import test_mail_template
 from . import test_mail_thread_internals

--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -1590,6 +1590,32 @@ msgid ""
 msgstr ""
 
 #. module: base
+#: model:ir.module.module,description:base.module_sale_timesheet_edit
+msgid ""
+"\n"
+"Allow to edit sale order line in the timesheets\n"
+"===============================================\n"
+"\n"
+"This module adds the edition of the sale order line\n"
+"set in the timesheets. This allows adds more flexibility\n"
+"to the user to easily change the sale order line on a\n"
+"timesheet in task form view when it is needed.\n"
+msgstr ""
+
+#. module: base
+#: model:ir.module.module,description:base.module_helpdesk_sale_timesheet_edit
+msgid ""
+"\n"
+"Allow to edit sale order line in the timesheets\n"
+"===============================================\n"
+"\n"
+"This module adds the edition of the sale order line\n"
+"set in the timesheets. This allows adds more flexibility\n"
+"to the user to easily change the sale order line on a\n"
+"timesheet in ticket form view when it is needed.\n"
+msgstr ""
+
+#. module: base
 #: model:ir.module.module,description:base.module_auth_oauth
 msgid ""
 "\n"
@@ -9490,6 +9516,14 @@ msgid "Company"
 msgstr ""
 
 #. module: base
+#: code:addons/base/models/res_users.py:0
+#, python-format
+msgid ""
+"Company %(company_name)s is not in the allowed companies for user "
+"%(user_name)s (%(company_allowed)s)."
+msgstr ""
+
+#. module: base
 #: model_terms:ir.ui.view,arch_db:base.onboarding_company_step
 msgid "Company Data"
 msgstr ""
@@ -11589,6 +11623,12 @@ msgid "Edit Translations"
 msgstr ""
 
 #. module: base
+#: model:ir.module.module,summary:base.module_helpdesk_sale_timesheet_edit
+#: model:ir.module.module,summary:base.module_sale_timesheet_edit
+msgid "Edit the sale order line linked in the timesheets"
+msgstr ""
+
+#. module: base
 #: model:res.partner.industry,name:base.res_partner_industry_P
 msgid "Education"
 msgstr ""
@@ -13520,6 +13560,11 @@ msgstr ""
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_helpdesk_sale_coupon
 msgid "Helpdesk Sale Coupon"
+msgstr ""
+
+#. module: base
+#: model:ir.module.module,shortdesc:base.module_helpdesk_sale_timesheet_edit
+msgid "Helpdesk Sales Timesheet Edit"
 msgstr ""
 
 #. module: base
@@ -21285,6 +21330,11 @@ msgid "Sales Timesheet"
 msgstr ""
 
 #. module: base
+#: model:ir.module.module,shortdesc:base.module_sale_timesheet_edit
+msgid "Sales Timesheet Edit"
+msgstr ""
+
+#. module: base
 #: model:ir.module.module,shortdesc:base.module_sale_timesheet_purchase
 msgid "Sales Timesheet Purchase"
 msgstr ""
@@ -23032,12 +23082,6 @@ msgstr ""
 #. module: base
 #: model:ir.model.fields,help:base.field_res_partner_category__active
 msgid "The active field allows you to hide the category without removing it."
-msgstr ""
-
-#. module: base
-#: code:addons/base/models/res_users.py:0
-#, python-format
-msgid "The chosen company is not in the allowed companies for this user"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -458,8 +458,14 @@ class Users(models.Model):
 
     @api.constrains('company_id', 'company_ids')
     def _check_company(self):
-        if any(user.company_id not in user.company_ids for user in self):
-            raise ValidationError(_('The chosen company is not in the allowed companies for this user'))
+        for user in self:
+            if user.company_id not in user.company_ids:
+                raise ValidationError(
+                    _('Company %(company_name)s is not in the allowed companies for user %(user_name)s (%(company_allowed)s).',
+                      company_name=user.company_id.name,
+                      user_name=user.name,
+                      company_allowed=', '.join(user.mapped('company_ids.name')))
+                )
 
     @api.constrains('action_id')
     def _check_action_id(self):

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -135,13 +135,18 @@ def new_test_user(env, login='', groups='base.group_user', context=None, **kwarg
 
     groups_id = [(6, 0, [env.ref(g.strip()).id for g in groups.split(',')])]
     create_values = dict(kwargs, login=login, groups_id=groups_id)
+    # automatically generate a name as "Login (groups)" to ease user comprehension
     if not create_values.get('name'):
         create_values['name'] = '%s (%s)' % (login, groups)
-    if not create_values.get('email'):
+    # generate email if not given as most test require an email
+    if 'email' not in create_values:
         if single_email_re.match(login):
             create_values['email'] = login
         else:
             create_values['email'] = '%s.%s@example.com' % (login[0], login[0])
+    # ensure company_id + allowed company constraint works if not given at create
+    if 'company_id' in create_values and 'company_ids' not in create_values:
+        create_values['company_ids'] = [(4, create_values['company_id'])]
 
     return env['res.users'].with_context(**context).create(create_values)
 


### PR DESCRIPTION
PURPOSE

All fixes and last improvements are not correctly forward ported in 14.1 and master.
Let us clean and forward everything.

Channel tests are partially cleaned and improved, notably to add test users and
improve code readability.

Manual forward port of odoo/odoo@eda542
Manual forward port of odoo/odoo@340f6ba
Contain some additional fixes.

See sub commits for more details.

LINKS

Task ID-2421795
COM PR odoo/odoo#63677
