### PR TITLE
[FIX] web_editor: stop suggesting shapes for model-related images

### DIFF
--- a/addons/web_editor/static/src/js/editor/rte.summernote.js
+++ b/addons/web_editor/static/src/js/editor/rte.summernote.js
@@ -1210,11 +1210,15 @@ var SummernoteManager = Class.extend(mixins.EventDispatcherMixin, ServicesMixin,
         }
         data.__alreadyDone = true;
 
+        const model = data.$editable.data('oe-model');
+        const field = data.$editable.data('oe-field');
+        const type = data.$editable.data('oe-type');
         var mediaDialog = new weWidgets.MediaDialog(this,
             _.extend({
-                res_model: data.$editable.data('oe-model'),
+                res_model: model,
                 res_id: data.$editable.data('oe-id'),
                 domain: data.$editable.data('oe-media-domain'),
+                useMediaLibrary: field && (model === 'ir.ui.view' && field === 'arch' || type === 'html'),
             }, data.options),
             data.media
         );

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
@@ -143,6 +143,7 @@ var FileWidget = SearchableMediaWidget.extend({
 
         this.options = _.extend({
             mediaWidth: media && media.parentElement && $(media.parentElement).width(),
+            useMediaLibrary: true,
         }, options || {});
 
         this.attachments = [];
@@ -300,6 +301,9 @@ var FileWidget = SearchableMediaWidget.extend({
         domain = domain.concat(this.options.mimetypeDomain);
         if (needle && needle.length) {
             domain.push(['name', 'ilike', needle]);
+        }
+        if (!this.options.useMediaLibrary) {
+            domain.push('!', ['url', '=ilike', '/web_editor/shape/%']);
         }
         domain.push('!', ['name', '=like', '%.crop']);
         domain.push('|', ['type', '=', 'binary'], '!', ['url', '=like', '/%/static/%']);
@@ -758,7 +762,7 @@ var ImageWidget = FileWidget.extend({
                 attachment.thumbnail_src = newURL.pathname + newURL.search;
             }
         });
-        if (this.needle) {
+        if (this.needle && this.options.useMediaLibrary) {
             try {
                 const response = await this._rpc({
                     route: '/web_editor/media_library_search',

--- a/addons/web_editor/static/src/xml/wysiwyg.xml
+++ b/addons/web_editor/static/src/xml/wysiwyg.xml
@@ -179,7 +179,7 @@
                 <select class="custom-select o_we_search_select">
                     <option value="all">All</option>
                     <option value="database">My Images</option>
-                    <option value="media-library">Illustrations</option>
+                    <option t-if="widget.options.useMediaLibrary" value="media-library">Illustrations</option>
                 </select>
             </div>
         </t>


### PR DESCRIPTION
Those kind of images use a specific route (/web_editor/shape/...) to
be fetched. While waiting for a more complete solution to maybe handle
them for model-related images, this commit only allows their use for
images in views and HTML fields.
