### PR TITLE
[FIX] website_slides: Complete courses with video

### DIFF
--- a/addons/website_slides/static/src/js/slides_course_fullscreen_player.js
+++ b/addons/website_slides/static/src/js/slides_course_fullscreen_player.js
@@ -71,7 +71,6 @@ odoo.define('website_slides.fullscreen', function (require) {
          */
         _setupYoutubePlayer: function (){
             this.player = new YT.Player('youtube-player' + this.slide.id, {
-                host: 'https://www.youtube.com',
                 playerVars: {
                     'autoplay': 1,
                     'origin': window.location.origin


### PR DESCRIPTION
What are the steps to reproduce your issue ?

    1. Install ELearning
    2. Create a course
    3. Add a video from youtube
    4. Attempt to do the course from a user that is invited

What is currently happening ?

    You cannot complete a video (turn the checkmark green) if there is not a quiz. Therefore you cannot complete the course

What are you expecting to happen ?

    Turn the checkmark green to signify that video is completed after watching the video and then have the ability to complete the course

Why is this happening ?

    Because of this commit https://github.com/odoo/odoo/pull/61581/files
    that changes 'youtube.com' to 'youtube-nocookie.com'

How to fix the bug ?

    Change to 'youtube-nocookie.com' at the setup of the youtube video

opw-2418545