### PR TITLE
[FIX] sale_timesheet: Error when creating analytical accounts

### DIFF
--- a/addons/sale_timesheet/__init__.py
+++ b/addons/sale_timesheet/__init__.py
@@ -4,3 +4,10 @@ from . import controllers
 from . import models
 from . import wizard
 from . import report
+
+from odoo import api, SUPERUSER_ID
+
+def uninstall_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    env.ref("account.account_analytic_line_rule_billing_user").write({'domain_force': "[(1, '=', 1)]"})

--- a/addons/sale_timesheet/__manifest__.py
+++ b/addons/sale_timesheet/__manifest__.py
@@ -41,4 +41,5 @@ have real delivered quantities in sales orders.
         'data/sale_service_demo.xml',
     ],
     'auto_install': True,
+    'uninstall_hook': 'uninstall_hook',
 }


### PR DESCRIPTION
Steps to reproduce the bug:

- Install Accounting, Sales, Project and Timesheet apps
- Enable Analytic accounting in Accounting settings
- Uninstall Timesheet app
- Try to create an analytic account

Bug:

An error was raised because the field project_id didn't exist on model
account.analytic.line

opw:2420177