### PR TITLE
[FIX] mrp: avoid blocking MO after post inventory

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -511,6 +511,12 @@ class MrpWorkorder(models.Model):
             elif float_compare(quantity_remaining, final_lot_quantity, precision_rounding=rounding) < 0:
                 final_lot_quantity = quantity_remaining
 
+        if not final_lot_quantity and self.production_id.workorder_ids and not self.production_id.workorder_ids.finished_workorder_line_ids and self.production_id.move_finished_ids.filtered(lambda m: m.state == 'done'):
+            # Posted Inventory before workorders completion
+            # this may result in missing workorder lines and blocked MO because
+            # final_lot_quantity is set to 0 while there are still workorders left to finish
+            final_lot_quantity = self.qty_remaining
+
         # final lot line for this lot on this workorder.
         current_lot_lines = self.finished_workorder_line_ids.filtered(lambda line: line.lot_id == self.finished_lot_id)
 


### PR DESCRIPTION
- Install mrp_workorder
- Create a product P, route Manufacture, tracking by SN
- Create 3 components
C1 cons.
C2 storable with SN tracking (update qty on hand)
C3 cons.
- Create a routing R with 5 operations (WO1, WO2...WO5).
In all operation set
"Start Next Operation Once some products are processed"
- Create a BOM for P, routing R, with C1 C2 C3
C1 consumed in operation WO1
C2 consumed in operation WO2
C3 consumed in operation WO5

- Create a MO for P, quantity 2
Finish WO1 and WO2 (process 2 units).
Process 1 quantity for WO3, WO4, WO5
Post Inventory (DEBUG mode)

Process WO3: Error is raised
"You have produced 0.0 Units of lot LOT1 in the previous
workorder. You are trying to produce 1.0 in this one"
Then the user is blocked.

This occur because the code only looks at workorder lines
However, they are transformed into move lines, after "POST INVENTORY".

This commit takes into account this possibility, raising the
`final_lot_quantity` to the `qty_remaining` when we detect that a Post
inventory has occurred and the `final_lot_quantity` would be 0.

opw-2415073

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
