### PR TITLE
[FIX] website_form: prevent adding lang prefix to form action url

### DIFF
--- a/addons/website_form/controllers/main.py
+++ b/addons/website_form/controllers/main.py
@@ -19,6 +19,11 @@ from odoo.addons.base.models.ir_qweb_fields import nl2br
 
 class WebsiteForm(http.Controller):
 
+    @http.route('/website_form/', type='http', auth="public", methods=['POST'], multilang=False)
+    def website_form_empty(self, **kwargs):
+        # This is a workaround to don't add language prefix to <form action="/website_form/" ...>
+        return ""
+
     # Check and insert values from the form on the model <model>
     @http.route('/website_form/<string:model_name>', type='http', auth="public", methods=['POST'], website=True, csrf=False)
     def website_form(self, model_name, **kwargs):


### PR DESCRIPTION
STEPS:
* create fresh db with default lang fr_CH
* install website
* activate additional language, e.g. en_GB
* set for website only one available language: fr_CH
* for admin user set lang en_GB
* open website and add form

BEFORE: the form doesn't work, because action url is "/en_GB/website_form/"

AFTER: action url is not changed

WHY:

1.

``is_multilang_url`` returns ``True``, because there is no route ``/website_form/``

https://github.com/odoo/odoo/blob/0adcb9a09fe5714fe8479df9450ddcefa7ba0688/addons/http_routing/models/ir_http.py#L233-L244

2.

Model name in action is added after rendering only, this is why ``is_multilang_url`` is
called with ``/website_form/`` and not real url

https://github.com/odoo/odoo/blob/0adcb9a09fe5714fe8479df9450ddcefa7ba0688/addons/website_form/static/src/js/website_form.js#L144

3.

As result we get error on trying to make request ``/en_GB/website_form/mail.mail``

---

opw-2413960