### PR TITLE
[IMP] various: generic improvements of the various module

### DIFF
--- a/addons/crm_iap_lead/data/crm.iap.lead.role.csv
+++ b/addons/crm_iap_lead/data/crm.iap.lead.role.csv
@@ -1,5 +1,5 @@
 "id",name,reveal_id
-"crm_iap_lead_role_1","ceo","ceo"
+"crm_iap_lead_role_1","CEO","CEO"
 "crm_iap_lead_role_2","communications","communications"
 "crm_iap_lead_role_3","consulting","consulting"
 "crm_iap_lead_role_4","customer_service","customer_service"

--- a/addons/crm_iap_lead/models/crm_iap_lead.py
+++ b/addons/crm_iap_lead/models/crm_iap_lead.py
@@ -6,7 +6,7 @@ class IndustryTag(models.Model):
     _name = 'crm.iap.lead.industry'
     _description = 'Industry Tag'
 
-    name = fields.Char(string='Tag Name', required=True, translate=True)
+    name = fields.Char(string='Industry', required=True, translate=True)
     reveal_id = fields.Char(required=True)
     color = fields.Integer(string='Color Index')
 

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -291,7 +291,7 @@
                                    <li t-if="record.work_email.raw_value" class="o_text_overflow"><field name="work_email" /></li>
                                    <li t-if="record.work_phone.raw_value" class="o_force_ltr"><field name="work_phone" /></li>
                                </ul>
-                                <div class="oe_kanban_content">
+                                <div class="oe_kanban_content position-absolute fixed-bottom mr-2">
                                     <div class="o_kanban_record_bottom">
                                         <div class="oe_kanban_bottom_left"/>
                                         <div class="oe_kanban_bottom_right">

--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -24,7 +24,7 @@
                 <tree editable="top" string="Timesheet Activities" sample="1">
                     <field name="date"/>
                     <field name="employee_id" invisible="1"/>
-                    <field name="project_id" required="1" options="{'no_create_edit': True}" context="{'form_view_ref': 'project.project_project_view_form_simplified',}"/>
+                    <field name="project_id" required="1" options="{'no_create_edit': True}"/>
                     <field name="task_id" optional="show" options="{'no_create_edit': True, 'no_open': True}" widget="task_with_hours" context="{'default_project_id': project_id}" domain="[('project_id', '=', project_id)]"/>
                     <field name="name" optional="show" required="0"/>
                     <field name="unit_amount" optional="show" widget="timesheet_uom" sum="Total" decoration-danger="unit_amount &gt; 24"/>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -45,12 +45,12 @@
                                     <field name="categ_id" string="Product Category"/>
                                 </group>
                                 <group name="group_standard_price">
-                                    <label for="list_price"/>
+                                    <label for="list_price" class="mt-1"/>
                                     <div name="pricing">
                                       <field name="list_price" class="oe_inline" widget='monetary'
                                         options="{'currency_field': 'currency_id', 'field_digits': True}"/>
                                       <button name="open_pricelist_rules" icon="fa-arrow-right" type="object"
-                                        groups="product.group_product_pricelist" class="oe_inline">
+                                        groups="product.group_product_pricelist" class="oe_inline btn-link pt-1">
                                         <field name="pricelist_item_count" attrs="{'invisible': [('pricelist_item_count', '=', 0)]}"/>
                                         <span attrs="{'invisible': [('pricelist_item_count', '=', 1)]}">
                                           Extra Prices

--- a/addons/project/static/src/js/tours/project.js
+++ b/addons/project/static/src/js/tours/project.js
@@ -39,17 +39,23 @@ tour.register('project_tour', {
         actions.auto('.modal:visible .btn.btn-primary');
     },
 }, {
-    trigger: ".o_kanban_project_tasks .o_column_quick_create input",
+    trigger: ".o_kanban_project_tasks .o_column_quick_create .input-group",
     content: _t("Add columns to organize your tasks into <b>stages</b> <i>e.g. New - In Progress - Done</i>."),
-    position: 'bottom',
+    position: 'right',
+    run: function (actions) {
+        actions.text("Test", this.$anchor.find("input"));
+    },
 }, {
     trigger: ".o_kanban_project_tasks .o_column_quick_create .o_kanban_add",
     auto: true,
 }, {
-    trigger: ".o_kanban_project_tasks .o_column_quick_create input",
+    trigger: ".o_kanban_project_tasks .o_column_quick_create .input-group",
     extra_trigger: '.o_kanban_group',
     content: _t("Add columns to organize your tasks into <b>stages</b> <i>e.g. New - In Progress - Done</i>."),
-    position: 'bottom',
+    position: 'right',
+    run: function (actions) {
+        actions.text("Test", this.$anchor.find("input"));
+    },
 }, {
     trigger: ".o_kanban_project_tasks .o_column_quick_create .o_kanban_add",
     auto: true,

--- a/addons/project/static/src/scss/project_dashboard.scss
+++ b/addons/project/static/src/scss/project_dashboard.scss
@@ -40,6 +40,12 @@
             }
         }
     }
+
+    @include media-breakpoint-down(sm) {
+        .o_view_nocontent {
+            top: 15%;
+        }
+    }
 }
 
 .o_dow_widget {

--- a/addons/web/static/src/js/chrome/action_manager.js
+++ b/addons/web/static/src/js/chrome/action_manager.js
@@ -536,7 +536,7 @@ var ActionManager = Widget.extend({
                 var message = _t('A popup window has been blocked. You ' +
                              'may need to change your browser settings to allow ' +
                              'popup windows for this page.');
-                this.do_warn(false, message, true);
+                this.do_warn(false, message, false);
             }
         }
 


### PR DESCRIPTION
Purpose of this task is to improve the various modules like crm_iap_lead, hr,
hr_timesheet, product, project, web.

So in this commit done the below changes:
- timesheet: project is open in the form view insted of the quick view
- earlier the popup window notification is sticky so after this commit it will
  disappear automatically after a few seconds
- product form view: 'extra prices'  display as a link
- project sample data: move the helper a bit higher in mobile view
- CRM > Generate leads > industries > search more: rename 'tag name' into
 'Industry'
- preferred_role_id: 'ceo' written in all caps
- employees kanban view: the chat icon  aligned to the bottom of the card

LINKS
PR: #63693
Task-Id: 2374726

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
