### PR TITLE
popover opened in rtl takes full space

### DIFF
--- a/addons/web/static/src/scss/popover.scss
+++ b/addons/web/static/src/scss/popover.scss
@@ -55,8 +55,6 @@
     max-width: 100vw;
 
     position: fixed;
-    top: 0; // will be updated in js
-    left: 0; // but let's set it in the viewport in case of test/debug
     z-index: 1060;
     border: 1px solid $border-color;
     background-color: #fff;


### PR DESCRIPTION
PURPOSE
Smiley box popover in rtl langauge takes full space, it should be displayed with max-width: 200px;

SPEC
Smiley box popover should be displayed with expected width i.e. max width 200px

TASK 2418264


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
