### PR TITLE
[FIX] web: editable list: do not discard row on m2o blur

### DIFF
--- a/addons/web/static/src/js/views/list/list_editable_renderer.js
+++ b/addons/web/static/src/js/views/list/list_editable_renderer.js
@@ -1815,12 +1815,12 @@ ListRenderer.include({
             return;
         }
 
-        // ignore clicks in modals, except if the list is in a modal, and the
-        // click is performed in that modal
-        var $clickModal = $(event.target).closest('.modal');
-        if ($clickModal.length) {
+        // ignore clicks if there is a modal, except if the list is in the last
+        // (active) modal
+        var $modal = $('.modal:last');
+        if ($modal.length) {
             var $listModal = this.$el.closest('.modal');
-            if ($clickModal.prop('id') !== $listModal.prop('id')) {
+            if ($modal.prop('id') !== $listModal.prop('id')) {
                 return;
             }
         }

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -8175,6 +8175,52 @@ QUnit.module('Views', {
         list.destroy();
     });
 
+    QUnit.test('editable list with many2one: click out does not discard the row', async function (assert) {
+        // In this test, we simulate a long click by manually triggering a mousedown and later on
+        // mouseup and click events
+        assert.expect(5);
+
+        this.data.bar.fields.m2o = {string: "M2O field", type: "many2one", relation: "foo"};
+
+        const form = await createView({
+            View: FormView,
+            model: 'foo',
+            data: this.data,
+            arch: `
+                <form>
+                    <field name="display_name"/>
+                    <field name="o2m">
+                        <tree editable="bottom">
+                            <field name="m2o" required="1"/>
+                        </tree>
+                    </field>
+                </form>`,
+        });
+
+        assert.containsNone(form, '.o_data_row');
+
+        await testUtils.dom.click(form.$('.o_field_x2many_list_row_add > a'));
+        assert.containsOnce(form, '.o_data_row');
+
+        // focus and write something in the m2o
+        form.$('.o_field_many2one input').focus().val('abcdef').trigger('keyup');
+        await testUtils.nextTick();
+
+        // then simulate a mousedown outside
+        form.$('.o_field_widget[name="display_name"]').focus().trigger('mousedown');
+        await testUtils.nextTick();
+        assert.containsOnce(document.body, '.modal', "should ask confirmation to create a record");
+
+        // trigger the mouseup and the click
+        form.$('.o_field_widget[name="display_name"]').trigger('mouseup').trigger('click');
+        await testUtils.nextTick();
+
+        assert.containsOnce(document.body, '.modal', "modal should still be displayed");
+        assert.containsOnce(form, '.o_data_row', "the row should still be there");
+
+        form.destroy();
+    });
+
     QUnit.test('list grouped by date:month', async function (assert) {
         assert.expect(1);
 


### PR DESCRIPTION
Let's assume an editable list with a many2one field. The user types
something in the many2one and then clicks outside (mousedown, not
mouseup, and thus click, yet). A dialog opens to ask the user if he
wants to quickcreate a record.

Before this commit, the dialog and the row disappeared as soon as
he released the click, because the click was considered by the
list renderer as an "external click", and the row was discarded
(alongside the many2one it contained).

Task 2411029

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
