### PR TITLE
[13.0] jsonb translation storage

### DIFF
--- a/addons/product/__manifest__.py
+++ b/addons/product/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'Products & Pricelists',
-    'version': '1.2',
+    'version': '1.3',
     'category': 'Sales/Sales',
     'depends': ['base', 'mail', 'uom'],
     'description': """

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -45,14 +45,14 @@ class ProductTemplate(models.Model):
             category_ids = categories._search([], order=order, access_rights_uid=SUPERUSER_ID)
         return categories.browse(category_ids)
 
-    name = fields.Char('Name', index=True, required=True, translate=True)
+    name = fields.Char('Name', index=True, required=True, translate=True, translation_storage='json')
     sequence = fields.Integer('Sequence', default=1, help='Gives the sequence order when displaying a product list')
     description = fields.Text(
-        'Description', translate=True)
+        'Description', translate=True, translation_storage='json')
     description_purchase = fields.Text(
-        'Purchase Description', translate=True)
+        'Purchase Description', translate=True, translation_storage='json')
     description_sale = fields.Text(
-        'Sales Description', translate=True,
+        'Sales Description', translate=True,  translation_storage='json',
         help="A description of the Product that you want to communicate to your customers. "
              "This description will be copied to every Sales Order, Delivery Order and Customer Invoice/Credit Note")
     type = fields.Selection([

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -366,6 +366,7 @@ class IrModelFields(models.Model):
     readonly = fields.Boolean()
     index = fields.Boolean(string='Indexed')
     translate = fields.Boolean(string='Translatable', help="Whether values for this field can be translated (enables the translation mechanism for that field)")
+    translation_storage = fields.Selection(selection=[("json", "json"), ("ir_translations", "ir_translations")])
     size = fields.Integer()
     state = fields.Selection([('manual', 'Custom Field'), ('base', 'Base Field')], string='Type', default='manual', required=True, readonly=True, index=True)
     on_delete = fields.Selection([('cascade', 'Cascade'), ('set null', 'Set NULL'), ('restrict', 'Restrict')],
@@ -873,6 +874,7 @@ class IrModelFields(models.Model):
             'selectable': bool(field.search or field.store),
             'size': getattr(field, 'size', None),
             'translate': bool(field.translate),
+            'translation_storage': field.translation_storage,
             'relation_field': field.inverse_name if field.type == 'one2many' else None,
             'relation_table': field.relation if field.type == 'many2many' else None,
             'column1': field.column1 if field.type == 'many2many' else None,
@@ -968,6 +970,7 @@ class IrModelFields(models.Model):
         }
         if field_data['ttype'] in ('char', 'text', 'html'):
             attrs['translate'] = bool(field_data['translate'])
+            attrs['translation_storage'] = field_data['translation_storage']
             attrs['size'] = field_data['size'] or None
         elif field_data['ttype'] in ('selection', 'reference'):
             attrs['selection'] = self.env['ir.model.fields.selection']._get_selection_data(field_data['id'])

--- a/odoo/addons/base/models/ir_translation.py
+++ b/odoo/addons/base/models/ir_translation.py
@@ -228,7 +228,7 @@ class IrTranslation(models.Model):
 
         CREATE TRIGGER sync_jsonb_model_tanslation
         AFTER INSERT OR UPDATE OR DELETE ON ir_translation
-        FOR EACH ROW EXECUTE FUNCTION sync_jsonb_model_tanslation()
+        FOR EACH ROW EXECUTE PROCEDURE sync_jsonb_model_tanslation();
         """)
 
         return res

--- a/odoo/addons/base/models/ir_translation.py
+++ b/odoo/addons/base/models/ir_translation.py
@@ -208,7 +208,12 @@ class IrTranslation(models.Model):
             _name varchar;
         BEGIN
             IF (new.type = 'model' or old.type='model') THEN
-                _name := COALESCE(new.name, old.name);
+                
+                IF TG_OP = 'UPDATE' or TG_OP = 'DELETE' THEN 
+                    _name := old.name;
+                ELSE
+                    _name := new.name;
+                END IF;
                 model_table := REPLACE(SPLIT_PART(_name, ',', 1), '.', '_')::varchar;
                 field_col := SPLIT_PART(_name ,',', 2)::varchar || '_translations';
                 PERFORM COLUMN_NAME FROM information_schema.columns where columns.table_name = model_table and columns.column_name = field_col;

--- a/odoo/addons/base/models/ir_translation.py
+++ b/odoo/addons/base/models/ir_translation.py
@@ -206,14 +206,17 @@ class IrTranslation(models.Model):
             model_table varchar;
             field_col varchar;
             _name varchar;
+            _value varchar;
+            _type varchar;
         BEGIN
-            IF (new.type = 'model' or old.type='model') THEN
-                
-                IF TG_OP = 'UPDATE' or TG_OP = 'DELETE' THEN 
-                    _name := old.name;
-                ELSE
-                    _name := new.name;
-                END IF;
+            IF TG_OP = 'UPDATE' or TG_OP = 'DELETE' THEN 
+                _name := old.name;
+                _type := old.type;
+            ELSE
+                _name := new.name;
+                _type := new.type;
+            END IF;
+            IF (_type = 'model') THEN
                 model_table := REPLACE(SPLIT_PART(_name, ',', 1), '.', '_')::varchar;
                 field_col := SPLIT_PART(_name ,',', 2)::varchar || '_translations';
                 PERFORM COLUMN_NAME FROM information_schema.columns where columns.table_name = model_table and columns.column_name = field_col;

--- a/odoo/addons/base/models/res_lang.py
+++ b/odoo/addons/base/models/res_lang.py
@@ -93,9 +93,10 @@ class Lang(models.Model):
         model_fields = self.env["ir.model.fields"].search(
             [("translate", "=", True), ("translation_storage", "=", "json")])
         for model_field in model_fields:
-            model = self.env[model_field.model]
-            field = model._fields[model_field.name]
-            field._update_translation_index(model)
+            if model_field.model in self.env:
+                model = self.env[model_field.model]
+                field = model._fields[model_field.name]
+                field._update_translation_index(model)
 
     @api.model
     def load_lang(self, lang, lang_name=None):

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1419,7 +1419,6 @@ class _String(Field):
                       )
             )
 
-
     @property
     def translation_column(self):
         return "%s_translations" % self.name

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2458,9 +2458,8 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         if necessary:
             _logger.debug("Table '%s': setting default value of new column %s to %r",
                           self._table, column_name, value)
-            column_format = field.column_format
             query = 'UPDATE "%s" SET "%s"=%s WHERE "%s" IS NULL' % (
-                self._table, column_name, column_format, column_name)
+                self._table, column_name, field.column_format, column_name)
             self._cr.execute(query, (value,))
 
     @ormcache()

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4268,14 +4268,12 @@ Fields:
 
         :return: the qualified field name (or expression) to use for ``field``
         """
-        if self._fields[field].translation_storage == 'json':
-            source_value = '"%s"."%s"' % (table_alias, field)
-            if self.env.lang:
+        if self.env.lang:
+            if self._fields[field].translation_storage == 'json':
+                source_value = '"%s"."%s"' % (table_alias, field)
                 translated_value = '"%s"."%s"->>\'%s\'' % (table_alias, self._fields[field].translation_column, self.env.lang)
                 return 'COALESCE(%s, %s)' % (translated_value, source_value)
-            else:
-                return source_value
-        if self.env.lang:
+
             alias, alias_statement = query.add_join(
                 (table_alias, 'ir_translation', 'id', 'res_id', field),
                 implicit=False,

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -649,9 +649,9 @@ class TranslationExtendedLeaf(ExtendedLeaf):
         super().__init__(leaf, model, join_context=join_context, internal=internal)
 
 
-def create_json_translation_leaf(leaf):
+def create_json_translation_leaf(leaf, new_elements=None):
     new_join_context = [tuple(context) for context in leaf.join_context]
-    new_leaf = TranslationExtendedLeaf(leaf.leaf, leaf.model, join_context=new_join_context)
+    new_leaf = TranslationExtendedLeaf(new_elements or leaf.leaf, leaf.model, join_context=new_join_context)
     return new_leaf
 
 
@@ -1129,7 +1129,9 @@ class expression(object):
                         push_result(create_substitution_leaf(leaf, OR_OPERATOR))
                         # search into translation values first
                         push_result(create_json_translation_leaf(leaf))
-                        # fallback on the non translated value
+                        # fallback on the non translated value if  ot value
+                        push_result(create_substitution_leaf(leaf, AND_OPERATOR))
+                        push_result(create_json_translation_leaf(leaf, (leaf.leaf[0], '=', False)))
                         push_result(leaf)
                     else:
                         need_wildcard = operator in ('like', 'ilike', 'not like', 'not ilike')

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -1113,8 +1113,7 @@ class expression(object):
                     else:
                         push_result(leaf)
 
-
-                elif field.translate is True and right:
+                elif field.translate is True and right and not field.translation_storage == "json":
                     need_wildcard = operator in ('like', 'ilike', 'not like', 'not ilike')
                     sql_operator = {'=like': 'like', '=ilike': 'ilike'}.get(operator, operator)
                     if need_wildcard:
@@ -1180,6 +1179,12 @@ class expression(object):
         assert not isinstance(right, BaseModel), \
             "Invalid value %r in domain term %r" % (right, leaf)
 
+        field = left in model._fields and model._fields[left]
+        if leaf not in (TRUE_LEAF, FALSE_LEAF):
+            quoted_left = _quote(left)
+            if field.translation_storage == "json":
+                quoted_left = "%s->>'%s'" % (_quote(field.translation_column), get_lang(model.env).code)
+
         table_alias = '"%s"' % (eleaf.generate_alias())
 
         if leaf == TRUE_LEAF:
@@ -1191,11 +1196,11 @@ class expression(object):
             params = []
 
         elif operator == 'inselect':
-            query = '(%s."%s" in (%s))' % (table_alias, left, right[0])
+            query = '(%s.%s in (%s))' % (table_alias, quoted_left, right[0])
             params = right[1]
 
         elif operator == 'not inselect':
-            query = '(%s."%s" not in (%s))' % (table_alias, left, right[0])
+            query = '(%s.%s not in (%s))' % (table_alias, quoted_left, right[0])
             params = right[1]
 
         elif operator in ['in', 'not in']:
@@ -1204,12 +1209,12 @@ class expression(object):
             if isinstance(right, bool):
                 _logger.warning("The domain term '%s' should use the '=' or '!=' operator." % (leaf,))
                 if (operator == 'in' and right) or (operator == 'not in' and not right):
-                    query = '(%s."%s" IS NOT NULL)' % (table_alias, left)
+                    query = '(%s.%s IS NOT NULL)' % (table_alias, quoted_left)
                 else:
-                    query = '(%s."%s" IS NULL)' % (table_alias, left)
+                    query = '(%s.%s IS NULL)' % (table_alias, quoted_left)
                 params = []
             elif isinstance(right, (list, tuple)):
-                if model._fields[left].type == "boolean":
+                if field.type == "boolean":
                     params = [it for it in (True, False) if it in right]
                     check_null = False in right
                 else:
@@ -1219,34 +1224,33 @@ class expression(object):
                     if left == 'id':
                         instr = ','.join(['%s'] * len(params))
                     else:
-                        field = model._fields[left]
                         instr = ','.join([field.column_format] * len(params))
                         params = [field.convert_to_column(p, model, validate=False) for p in params]
-                    query = '(%s."%s" %s (%s))' % (table_alias, left, operator, instr)
+                    query = '(%s.%s %s (%s))' % (table_alias, quoted_left, operator, instr)
                 else:
                     # The case for (left, 'in', []) or (left, 'not in', []).
                     query = 'FALSE' if operator == 'in' else 'TRUE'
                 if (operator == 'in' and check_null) or (operator == 'not in' and not check_null):
-                    query = '(%s OR %s."%s" IS NULL)' % (query, table_alias, left)
+                    query = '(%s OR %s.%s IS NULL)' % (query, table_alias, quoted_left)
                 elif operator == 'not in' and check_null:
-                    query = '(%s AND %s."%s" IS NOT NULL)' % (query, table_alias, left)  # needed only for TRUE.
+                    query = '(%s AND %s.%s IS NOT NULL)' % (query, table_alias, quoted_left)  # needed only for TRUE.
             else:  # Must not happen
                 raise ValueError("Invalid domain term %r" % (leaf,))
 
-        elif left in model and model._fields[left].type == "boolean" and ((operator == '=' and right is False) or (operator == '!=' and right is True)):
-            query = '(%s."%s" IS NULL or %s."%s" = false )' % (table_alias, left, table_alias, left)
+        elif field and field.type == "boolean" and ((operator == '=' and right is False) or (operator == '!=' and right is True)):
+            query = '(%s.%s IS NULL or %s.%s = false )' % (table_alias, quoted_left, table_alias, quoted_left)
             params = []
 
         elif (right is False or right is None) and (operator == '='):
-            query = '%s."%s" IS NULL ' % (table_alias, left)
+            query = '%s.%s IS NULL ' % (table_alias, quoted_left)
             params = []
 
-        elif left in model and model._fields[left].type == "boolean" and ((operator == '!=' and right is False) or (operator == '==' and right is True)):
-            query = '(%s."%s" IS NOT NULL and %s."%s" != false)' % (table_alias, left, table_alias, left)
+        elif field and field.type == "boolean" and ((operator == '!=' and right is False) or (operator == '==' and right is True)):
+            query = '(%s.%s IS NOT NULL and %s.%s != false)' % (table_alias, quoted_left, table_alias, quoted_left)
             params = []
 
         elif (right is False or right is None) and (operator == '!='):
-            query = '%s."%s" IS NOT NULL' % (table_alias, left)
+            query = '%s.%s IS NOT NULL' % (table_alias, quoted_left)
             params = []
 
         elif operator == '=?':
@@ -1266,18 +1270,17 @@ class expression(object):
 
             if left not in model:
                 raise ValueError("Invalid field %r in domain term %r" % (left, leaf))
-            format = '%s' if need_wildcard else model._fields[left].column_format
+            format = '%s' if need_wildcard else field.column_format
             unaccent = self._unaccent if sql_operator.endswith('like') else lambda x: x
-            column = '%s.%s' % (table_alias, _quote(left))
+            column = '%s.%s' % (table_alias, quoted_left)
             query = '(%s %s %s)' % (unaccent(column + cast), sql_operator, unaccent(format))
 
             if (need_wildcard and not right) or (right and operator in NEGATIVE_TERM_OPERATORS):
-                query = '(%s OR %s."%s" IS NULL)' % (query, table_alias, left)
+                query = '(%s OR %s.%s IS NULL)' % (query, table_alias, quoted_left)
 
             if need_wildcard:
                 params = ['%%%s%%' % pycompat.to_text(right)]
             else:
-                field = model._fields[left]
                 params = [field.convert_to_column(right, model, validate=False)]
 
         return query, params


### PR DESCRIPTION
POC Update performances of translated fields

see also #61618 for comments about the proposed solution.

I took the time to do some performance tests based on the use of a jsonb column to store the translations of translated fields. These tests were done using pg12. 
In order to have a database with a lot of data representative of a real situation, I used a metadata file with more than 500.000 products from amazon available here http://jmcauley.ucsd.edu/data/amazon/links.html. The database has been populated from one of these metadata files into 4 languages (the same labels are used for all the languages since my goal was to have a db with a large amount of data into different languages). As result I've an odoo database with 435276 rows into the product_product table and 3777584 rows into ir_translation.

The script used to do this test simulates 2 requests made when the product tree is used into the Odoo UI:
* The display of the default tree of the products.
* The display of the tree of saleable products containing the word 'fish'.

For each of these situations, the script searches 10 times for different pages and we compute the average time.

The requests are executed in English and French. They are first executed using odoo's native mechanism to access the translations and then using jsonb columns.

Here is the script used

``` python
#!/usr/bin/env python3

import click
import time
from contextlib import contextmanager
import click_odoo


@contextmanager
def native_env_test(env):
    """Native Odoo"""
    ProductTemplate = env["product.template"]
    for fn in [
        "name",
        "description",
        "description_sale",
        "description_purchase",
    ]:
        ProductTemplate._fields[fn].translation_storage = False
    yield


@contextmanager
def json_store_env_test(env):
    """ Use json storage for translations"""
    ProductTemplate = env["product.template"]
    for fn in [
        "name",
        "description",
        "description_sale",
        "description_purchase",
    ]:
        ProductTemplate._fields[fn].translation_storage = "json"
    yield


@contextmanager
def average_time_recorder(display_message, count):
    start_time = time.time()
    yield
    click.echo(
        display_message
        + "--- Average time for %d requests:  %s seconds ---" % (count, (time.time() - start_time) / count)
    )


LANGS = ["en_US", "fr_BE"]
COUNT = 10

TEST_ENV_METHODS = [native_env_test, json_store_env_test]


def product_search_read(env, lang, domain):
    fields = [
        "default_code",
        "barcode",
        "name",
        "product_template_attribute_value_ids",
        "company_id",
        "lst_price",
        "standard_price",
        "categ_id",
        "type",
        "price",
        "uom_id",
        "product_tmpl_id",
        "active",
    ]
    msg = "product.template.search_read() with domain %s" % (domain)
    with average_time_recorder(msg, COUNT):
        limit = 80
        offset = 0
        for i in range(10):
            env["product.product"].with_context(lang=lang).search_read(
                fields=fields, domain=domain, limit=limit, offset=offset
            )
            offset += 80


def do_test(env, warmup=False):
    if warmup:
        click.echo(
            "-------------------------- WARMUP --------------------------"
        )
    else:
        click.echo(
            "-------------------------- TESTS --------------------------"
        )
    for lang in LANGS:
        for env_method in TEST_ENV_METHODS:
            with env_method(env):
                msg = lang + " " + env_method.__doc__
                click.echo("-" * len(msg))
                click.echo(msg)
                click.echo("-" * len(msg))
                product_search_read(
                    env, lang, domain=[["sale_ok", "=", True]]
                )
                product_search_read(
                    env,
                    lang,
                    domain=[
                        "&",
                        ["sale_ok", "=", True],
                        "|",
                        "|",
                        ["default_code", "ilike", "fish"],
                        ["name", "ilike", "fish"],
                        ["barcode", "ilike", "fish"],
                    ],
                )


@click.command()
@click_odoo.env_options(default_log_level="info")
def main(env):
    do_test(env, warmup=True)
    do_test(env, warmup=False)


if __name__ == "__main__":
    main()
``` 

Results:

**Native Odoo**

query | en_US | fr_BE
-|-|-|
Default tree| 0.5519938468933105| 1.5560268402099608
Tree 'fish'| 1.477855658531189 | 3.6364696741104128


**jsonb Odoo**

query | en_US | fr_BE
-|-|-|
Default tree| 0.711717963218689| 0.698885154724121
Tree 'fish'| 1.0866673946380616 | 1.0526456832885742

The performance boost is indisputable and allows Odoo to manage large multi-lingual data catalogues efficiently and without performance degradation.

@mart-e @rco-odoo @odony @fpodoo It would really be a great step forward if we could finally improve this part of the ORM which is causing us a lot of problems on our big projects. My proposal may not be the best, but it has the merit of demonstrating that other, more efficient approaches are possible without compromising the current functionalities.  


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
