### PR TITLE
[FIX] account: read invoice of archived partner

### DIFF
--- a/addons/payment/models/account_invoice.py
+++ b/addons/payment/models/account_invoice.py
@@ -20,7 +20,7 @@ class AccountMove(models.Model):
 
     def get_portal_last_transaction(self):
         self.ensure_one()
-        return self.transaction_ids.get_last_transaction()
+        return self.with_context(active_test=False).transaction_ids.get_last_transaction()
 
     def _create_payment_transaction(self, vals):
         '''Similar to self.env['payment.transaction'].create(vals) but the values are filled with the


### PR DESCRIPTION
If a user has the portal access, when going to his documents, if one of
them belongs to an archived partner, it will raise a 403 error.

To reproduce the error:
1. Go to Settings > Invoicing > Customer Payments
2. Enable "Invoice Online Payment"
3. Create a customer C
	- Set a name
	- In Contacts & Addresses, add two contacts C_01 and C_02
		- Both are "Invoice Address"
		- Add a valid email for C_01
4. Go to Customers > C_01, Action, Grand portal acess
	- Check "In Portal", Apply
5. Go to Settings > Users & Companies > Users
6. Remove the search filter, Select C_01, Add a password
7. Create an invoice INV
	- Customer: C_02
8. Connect to C_01's account
9. Click on "Invoices & Bills"
	- The invoice INV is listed
10. Connect to admin's account
11. Go to Customers, Archive C_02
12. Repeat steps 8-9

=> A 403-Forbidden page is displayed with a traceback. 

For a user to have access to the "Invoices & Bills", one of the
followers of each invoice must be part of the same commercial partner:
`('message_partner_ids','child_of',[user.commercial_partner_id.id])`.
Here is the issue: if archived, the partner will not be in the
`message_partner_ids` list. This is the reason why, in our case, C_01
can no longer access the documents.

This commit allows the archived partners to be listed when getting the
portal transactions.

OPW-2417275