### PR TITLE
[FIX] sale,sale_coupon: not suggest to create invoice without invoiceable …

### DIFF
--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -439,6 +439,33 @@ class SaleOrder(models.Model):
         """
         return self.code_promo_program_id + self.no_code_promo_program_ids + self.applied_coupon_ids.mapped('program_id')
 
+    def _get_invoice_status(self):
+        # Handling of a specific situation: an order contains
+        # a product invoiced on delivery and a promo line invoiced
+        # on order. We would avoid having the invoice status 'to_invoice'
+        # if the created invoice will only contain the promotion line
+        super()._get_invoice_status()
+        for order in self.filtered(lambda order: order.invoice_status == 'to invoice'):
+            paid_lines = order._get_paid_order_lines()
+            if not any(line.invoice_status == 'to invoice' for line in paid_lines):
+                order.invoice_status = 'no'
+
+    def _get_invoiceable_lines(self, final=False):
+        """ Ensures we cannot invoice only reward lines.
+
+        Since promotion lines are specified with service products,
+        those lines are directly invoiceable when the order is confirmed
+        which can result in invoices containing only promotion lines.
+
+        To avoid those cases, we allow the invoicing of promotion lines
+        iff at least another 'basic' lines is also invoiceable.
+        """
+        invoiceable_lines = super()._get_invoiceable_lines(final)
+        reward_lines = self._get_reward_lines()
+        if invoiceable_lines <= reward_lines:
+            return self.env['sale.order.line'].browse()
+        return invoiceable_lines
+
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"

--- a/addons/sale_coupon/tests/__init__.py
+++ b/addons/sale_coupon/tests/__init__.py
@@ -6,3 +6,4 @@ from . import test_program_with_code_operations
 from . import test_program_rules
 from . import test_program_numbers
 from . import test_program_multi_company
+from . import test_sale_invoicing

--- a/addons/sale_coupon/tests/test_sale_invoicing.py
+++ b/addons/sale_coupon/tests/test_sale_invoicing.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.addons.sale_coupon.tests.common import TestSaleCouponCommon
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install')
+class TestSaleInvoicing(TestSaleCouponCommon):
+
+    def test_invoicing_order_with_promotions(self):
+        discount_coupon_program = self.env['sale.coupon.program'].create({
+            'name': '10% Discount', # Default behavior
+            'program_type': 'coupon_program',
+            'reward_type': 'discount',
+            'discount_apply_on': 'on_order',
+            'promo_code_usage': 'no_code_needed',
+        })
+        product = self.env['product.product'].create({
+            'invoice_policy': 'delivery',
+            'name': 'Product invoiced on delivery',
+            'lst_price': 500,
+        })
+
+        order = self.empty_order
+        order.write({
+            'order_line': [
+                (0, 0, {
+                    'product_id': product.id,
+                })
+            ]
+        })
+
+        order.recompute_coupon_lines()
+        # Order is not confirmed, there shouldn't be any invoiceable line
+        invoiceable_lines = order._get_invoiceable_lines()
+        self.assertEqual(len(invoiceable_lines), 0)
+
+        order.action_confirm()
+        invoiceable_lines = order._get_invoiceable_lines()
+        # Product was not delivered, we cannot invoice
+        # the product line nor the promotion line
+        self.assertEqual(len(invoiceable_lines), 0)
+        with self.assertRaises(UserError):
+            order._create_invoices()
+
+        order.order_line[0].qty_delivered = 1
+        # Product is delivered, the two lines can be invoiced.
+        invoiceable_lines = order._get_invoiceable_lines()
+        self.assertEqual(order.order_line, invoiceable_lines)
+        account_move = order._create_invoices()
+        self.assertEqual(len(account_move.invoice_line_ids), 2)


### PR DESCRIPTION
…paid lines

Create a promotion auto applied with 0 minimum amount on any product in
catalog.
Have a DEMO product invoiced on delivery
Create a sale order with DEMO, apply the promotion. Confirm.
Click on 'Create Invoice'.

The invoice will only contain the promotion because the line for
DEMO is to be invoiced only after delivery, while by default the
promotion product has the invoice policy 'on order'

opw-2414630

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
