### PR TITLE
fix control panel delete filter inconsistency

### DIFF
--- a/addons/web/static/tests/chrome/action_manager_tests.js
+++ b/addons/web/static/tests/chrome/action_manager_tests.js
@@ -3576,6 +3576,7 @@ QUnit.module('ActionManager', {
                         };
                         assert.deepEqual(filter.context, expectedContext,
                             "should save the correct context");
+                        return Promise.resolve();
                     },
                 }
             },

--- a/addons/web/static/tests/views/view_dialogs_tests.js
+++ b/addons/web/static/tests/views/view_dialogs_tests.js
@@ -470,6 +470,7 @@ QUnit.module('Views', {
                         };
                         assert.deepEqual(filter.context, expectedContext,
                             "should save the correct context");
+                        return Promise.resolve();
                     },
                 }
             },


### PR DESCRIPTION
PURPOSE
Deleting filter sometimes do not remove filter from favourite dropdown and sometimes removes and update favourite dropdown, there is inconcistency in this behaviour.

SPEC
Deleting filter from favourite menu will always remove item from dropdown and remove facet from searchbar.

TASK 2393756


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
