### PR TITLE
[IMP]event_sale: change default invoicing policy

### DIFF
--- a/addons/event_sale/data/event_sale_data.xml
+++ b/addons/event_sale/data/event_sale_data.xml
@@ -14,6 +14,7 @@
             <field name="uom_po_id" ref="uom.product_uom_unit"/>
             <field name="name">Event Registration</field>
             <field name="description_sale" eval="False"/>
+            <field name="invoice_policy">order</field>
             <field name="categ_id" ref="event_sale.product_category_events"/>
             <field name="type">service</field>
         </record>

--- a/addons/event_sale/models/product.py
+++ b/addons/event_sale/models/product.py
@@ -13,6 +13,7 @@ class ProductTemplate(models.Model):
     def _onchange_event_ok(self):
         if self.event_ok:
             self.type = 'service'
+            self.invoice_policy = 'order'
 
 
 class Product(models.Model):
@@ -25,3 +26,4 @@ class Product(models.Model):
         """ Redirection, inheritance mechanism hides the method on the model """
         if self.event_ok:
             self.type = 'service'
+            self.invoice_policy = 'order'


### PR DESCRIPTION
purpose
In most cases, you don't really handle the "delivery" of the ticket. It's most likely to be sent by email automatically.
So this makes it easier to invoice the SO.

specification
In this module event have default value is delivery but there is issue if is an event ticket, checkbox is checked then we have to convert default value delivery to order. so if user create new event and is an event ticket checkbox is true by default radio button order is selected.

to Be
we improve this issue by changing the default value of radio button is order quantities.

**Task Id** - 2243915
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
