### PR TITLE
[IMP] project: generic improvements

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -164,7 +164,6 @@
                     <field name="fold" optional="show"/>
                     <field name="mail_template_id" optional="show"/>
                     <field name="rating_template_id" optional="show"/>
-                    <field name="auto_validation_kanban_state" optional="hide" />
                     <field name="description" optional="hide"/>
                     <field name="project_ids" optional="show" widget="many2many_tags" options="{'color_field': 'color'}" />
                 </tree>


### PR DESCRIPTION
Before this commit, the Automatic Kanban Status field present without
any meaning in view of stages of a project.

In this commit, we remove the auto_validation_kanban_state field from
the stages of a project.

Task-Id: 2378811
PR: #63727

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
