### PR TITLE
[FIX] mrp: cancel WO from backorder when no quantity to produce.

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1420,6 +1420,8 @@ class MrpProduction(models.Model):
                     wo.qty_producing = 1
                 else:
                     wo.qty_producing = wo.qty_remaining
+                if wo.qty_producing == 0:
+                    wo.action_cancel()
 
             production.name = self._get_name_backorder(production.name, production.backorder_sequence)
 


### PR DESCRIPTION
- Have a finished Product FP (quantity 1) processed in
2 workcenters: A and B
- Create manufacturing order for FP1, raise the quantity to produce to
10
- process first workorder with lower quantity (i.e. 5)
- process second workorder with even lower quantity (i.e. 4)
- Mark MO as completed, creating a backorder
- There will be 2 backorders for the original MO.
- Process the workorder A of the last MO (record 0 quantity).
Now check the work orders report

Work orders report is showing incorrect qty for A (i.e. 6 and not 5)
The last workorder processed display Quantity 1.
This occur because the report display the quantity handled by the
workorder (1), not the actual produced quantity (0), but this is a
technical limitation of the pivot view.

A solution is to cancel the workorder when we detect a quantity to
produce equal to 0. This will also avoid users starting by accident the
workorder timer when there is no work to do.

opw-2411203

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
