### PR TITLE
[FIX] website: gallery img inside anchor is too large

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -885,6 +885,11 @@ table.table_desc tr td {
                 align-items: center;
                 height: 100%;
                 padding-bottom: 64px;
+                > a {
+                    display: flex;
+                    height: 100%;
+                    width: 100%;
+                }
             }
             img {
                 max-height: 100%;


### PR DESCRIPTION
Steps:
- Go to "Website" > "Go to Website"
- Click Edit
- Add an image gallery
- Add an image to the gallery
- Click the image
- Click on the Link button in the top panel
- Add a link and save

Bug:
The image is too large.

Explanation:
The flex layout is not carried over to `img` when it's nested into an `a` tag. Redefining the flex layout on the `a` tag fixes the issue.

This fixes portrait images:
```css
height: 100%;
width: 100%;
```

And adding this also fixes landscape and smaller images:
```css
display: flex;
```

Backport of #63364

opw:2416010