### PR TITLE
[FIX] account: error in caba entry with stock valuation account

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1731,10 +1731,10 @@ class AccountPartialReconcile(models.Model):
                 for line in move.line_ids:
                     if not line.tax_exigible:
                         #amount is the current cash_basis amount minus the one before the reconciliation
-                        if percentage_after == 1.0 and line.amount_residual:
+                        amount = line.balance * percentage_after - line.balance * percentage_before
+                        if percentage_after == 1.0 and percentage_before > 0.0 and line.amount_residual < 0 and amount < 0 and float_compare(line.amount_residual, amount, precision_rounding=line.company_id.currency_id.rounding) < 0:
+                            # when registering the final payment we use directly the amount_residual to correct rounding issues
                             amount = line.amount_residual
-                        else:
-                            amount = line.balance * percentage_after - line.balance * percentage_before
                         rounded_amt = self._get_amount_tax_cash_basis(amount, line)
                         if float_is_zero(rounded_amt, precision_rounding=line.company_id.currency_id.rounding):
                             continue


### PR DESCRIPTION
- Install Accounting, Purchases and Inventory;
- Configure cash basis accounting;
- Configure purchases taxes as 'Based on Payment' with 16% of amount;
- Create a new product and configure it as a Storable Product.
- Configure the product category with costing method of the to FIFO and
    the Inventory Valuation to Automated;
- Create a Purchase Order for a stock product with quantity 1,262.84 and
    price unit of 10.37;
- Confirm the Purchase Order;
- Receive product for 1,262.835 (0.005 less than ordered);
- Create the vendor bill from the purchase order for the original
    quantity (1,262.84) and price unit of 10.37;
- Validate the vendor bill and pay it.

Before this commit, the cash basis journal entry was created with an
incorrect amount of 0.05 of Base Tax Received Account.

Now, the cash basis journal entry is created with the amount paid of
13095.65 of Base Tax Received Account

fine-tuning of e25f857e672a645bfc46a9bac9b871c107b0a8db

opw-2411516
