### PR TITLE
[FIX] web: prevent crash on image resize/crop

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1098,7 +1098,10 @@ class Binary(http.Controller):
                     content = getattr(odoo.tools, 'image_resize_image_%s' % suffix)(content)
 
         if crop and (width or height):
-            content = crop_image(content, type='center', size=(width, height), ratio=(1, 1))
+            try:
+                content = crop_image(content, type='center', size=(width, height), ratio=(1, 1))
+            except Exception:
+                return request.not_found()
         elif (width or height):
             if not upper_limit:
                 # resize maximum 500*500
@@ -1106,9 +1109,12 @@ class Binary(http.Controller):
                     width = 500
                 if height > 500:
                     height = 500
-            content = odoo.tools.image_resize_image(base64_source=content, size=(width or None, height or None),
+            try:
+                content = odoo.tools.image_resize_image(base64_source=content, size=(width or None, height or None),
                                                     encoding='base64', upper_limit=upper_limit,
                                                     avoid_if_small=avoid_if_small)
+            except Exception:
+                return request.not_found()
 
         image_base64 = base64.b64decode(content)
         headers.append(('Content-Length', len(image_base64)))


### PR DESCRIPTION
When attempting to resize or crop an attachment through the '/web/image'
route, if the attachment isn't actually an image (even if the record's
mimetype says so) or doesn't match one of the format supported by PIL
(Python Imaging Library) - like Apple's HEIF -  the request crashes with
a "500 Internal Error".

Although it makes sense to return a response with an HTTP error code, a
more sensible approach would be to return a "404 Not Found" response
instead.

The point by handling the Exception thrown by PIL and returning a 404
status code is to more closely match the semantic of this HTTP status
code. Getting a resized version of a non-image doesn't really make sense
as this resource doesn't exist at all ; hence the "404 Not Found"
response. On the other hand returning a "500 Internal Error" would
denote that a legitimate request failed on the server side, which is not
the case here.

Note: this difference of semantic, even if only visible in a regular
browser, has its importance in the mobile apps because we use it to
given a meaningful feedback to the user in case if failed HTTP requests.

Note: the mimetype detection could be improved to ease the handling of
this kind of errors but would require too much changes to be done in
stable branch.

Steps to reproduce in Documents:
- rename an HEIF file with a ".jpeg" extension
- upload it in documents
- select the document in kanban view
=> the thumbnail in the document inspector (right panel) throws an HTTP
error 500

Steps to reproduce in Discuss:
- rename an HEIF file with a ".jpeg" extension
- upload it in a chat window
=> the thumbnail in the chat window throws an HTTP error 500

opw-2417172