### PR TITLE
Phone warning displayed twice

### DIFF
--- a/addons/web/static/src/js/model.js
+++ b/addons/web/static/src/js/model.js
@@ -430,6 +430,9 @@ odoo.define("web/static/src/js/model.js", function (require) {
         async _notifyComponents() {
             const rev = ++this.rev;
             const subscriptions = this.subscriptions.update;
+            if (!subscriptions) {
+                return;
+            }
             const groups = partitionBy(subscriptions, (s) =>
                 s.owner ? s.owner.__owl__.depth : -1
             );

--- a/addons/web/static/src/js/views/abstract_controller.js
+++ b/addons/web/static/src/js/views/abstract_controller.js
@@ -588,8 +588,23 @@ var AbstractController = mvc.Controller.extend(ActionMixin, {
      * @private
      * @param {Object} searchQuery
      */
-    _onSearch: function (searchQuery) {
-        this.reload(_.extend({ offset: 0, groupsOffset: 0 }, searchQuery));
+    async _onSearch(searchQuery) {
+        try {
+            await this.reload(_.extend({ offset: 0, groupsOffset: 0 }, searchQuery));
+        } catch (err) {
+            if (
+                err &&
+                err.message &&
+                err.message.data &&
+                err.message.data.name === "odoo.exceptions.UserError"
+            ) {
+                // The new search params are considered the issue of the error
+                // so we revert the last action on the search query (note that
+                // this will trigger another reload).
+                this.searchModel.dispatch("undoLastQueryAction");
+            }
+            throw err;
+        }
     },
     /**
      * Intercepts the 'switch_view' event to add the controllerID into the data,

--- a/addons/web/static/src/js/views/action_model.js
+++ b/addons/web/static/src/js/views/action_model.js
@@ -101,9 +101,10 @@ odoo.define("web/static/src/js/views/action_model.js", function (require) {
          */
         __get(excluded, property) {
             const results = super.__get(...arguments);
+            const { domain, context } = this.config;
             switch (property) {
-                case "domain": return [this.config.domain, ...results];
-                case "context": return [this.config.context, ...results];
+                case "domain": return domain ? [domain, ...results] : results;
+                case "context": return context ? [context, ...results] : results;
             }
             return results;
         }


### PR DESCRIPTION
PURPOSE
When searching on phone with less than 3 digits and CRM Pipeline it shows warning twice, warning should come only once, if it fails.

SPEC
Phone search warning should come only once, if search is failed then only one warning dialog should appear.

TASK 2375667




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
