### PR TITLE
[FIX] sale_coupon: public user cannot use promo code with edited rule

### DIFF
--- a/addons/sale_coupon/models/sale_coupon_program.py
+++ b/addons/sale_coupon/models/sale_coupon_program.py
@@ -310,7 +310,7 @@ class SaleCouponProgram(models.Model):
         return programs
 
     def _is_valid_partner(self, partner):
-        if self.rule_partners_domain:
+        if self.rule_partners_domain and self.rule_partners_domain != '[]':
             domain = safe_eval(self.rule_partners_domain) + [('id', '=', partner.id)]
             return bool(self.env['res.partner'].search_count(domain))
         else:


### PR DESCRIPTION
Steps:
- Install eCommerce
- Go to Website > Products > Promotion Programs
- Create a promotion program with a filter Based on Customers and a promotion code
- Save
- Edit the new program and clear the filter Based on Customers
- Save again
- Log out and go to the shop
- Add an article to your cart and click "View Cart"
- Click "I have a promo code"
- Apply the promo code you created earlier

Bug:
The promo code is not accepted.

Explanation:
When the filter Based on Customers is cleared, `[]` is written on the program rule. This makes the app search for a partner with id = 4 (Public User). Since this user is not active, the search returns no results and, therefore, forbids the user from using the promo code.
This works flawlessly when you create a promotion program with no filters as they are initialized with `NULL` and a `NULL` filter always returns `True`.

opw:2419796