### PR TITLE
[FIX] stock : don't reload

### DIFF
--- a/addons/stock/static/src/js/basic_model.js
+++ b/addons/stock/static/src/js/basic_model.js
@@ -8,7 +8,7 @@ BasicModel.include({
 
     _invalidateCache: function (dataPoint) {
         this._super.apply(this, arguments);
-        if (dataPoint.model === 'stock.warehouse' && !localStorage.getItem('running_tour')) {
+        if (dataPoint.model === 'stock.warehouse' && !localStorage.getItem('running_tour')  && dataPoint._changes === null) {
             this.do_action('reload_context');
         }
     }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- go to runbot
- open a warehouse
- edit name (or any other field)
- save
- -> page is reloaded
from this commit https://github.com/odoo/odoo/commit/8414e6b9fde7bfcd0977fbb85464a73ab6f61a05#diff-dd65b906a3e2bfb2a356c591db3fb5755bf5ca120fd02d5992ef12a14bf74e8eR11 : the page is always reload.
It is an issue if you modify warehouse every days (to change opening hour or available product for pick-up, ...).

It is only useful to reload when you Archive or Unarchive : https://github.com/odoo/odoo/blob/14.0/addons/stock/models/stock_warehouse.py#L260

This patch it is a little hack, because during saving (with save button, _changes === {}, but not when you archive with action/archive). (https://github.com/odoo/odoo/blob/14.0/addons/web/static/src/js/views/basic/basic_model.js#L1157)


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
