### PR TITLE
[IMP] scafold: replace coding: utf-8 by licence

### DIFF
--- a/odoo/cli/templates/default/__init__.py.template
+++ b/odoo/cli/templates/default/__init__.py.template
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import controllers
 from . import models

--- a/odoo/cli/templates/default/__manifest__.py.template
+++ b/odoo/cli/templates/default/__manifest__.py.template
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 {
     'name': "{{ name }}",
 

--- a/odoo/cli/templates/default/controllers/__init__.py.template
+++ b/odoo/cli/templates/default/controllers/__init__.py.template
@@ -1,3 +1,3 @@
-# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import controllers

--- a/odoo/cli/templates/default/controllers/controllers.py.template
+++ b/odoo/cli/templates/default/controllers/controllers.py.template
@@ -1,7 +1,8 @@
 {%- set mod = name|snake -%}
 {%- set model = "%s.%s"|format(mod, mod) -%}
 {%- set root = "/%s/%s"|format(mod, mod) -%}
-# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 # from odoo import http
 
 

--- a/odoo/cli/templates/default/models/__init__.py.template
+++ b/odoo/cli/templates/default/models/__init__.py.template
@@ -1,3 +1,3 @@
-# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import models

--- a/odoo/cli/templates/default/models/models.py.template
+++ b/odoo/cli/templates/default/models/models.py.template
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 # from odoo import models, fields, api
 


### PR DESCRIPTION
Since Python 3, the default file encoding used by the interpreter is
utf-8 by default, most of our source code is ascii friendly (could
decode('ascii') 97% of our python files) and most text editors/IDE (even
the Windows notepad !) do open and save files in utf-8 by default.