### PR TITLE
select2 input in rtl shows glitches

### DIFF
--- a/addons/web/static/src/scss/select2_overridden.scss
+++ b/addons/web/static/src/scss/select2_overridden.scss
@@ -1,0 +1,21 @@
+.o_rtl {
+    .select2-container {
+        .select2-choice {
+            abbr {
+                background: url('../../lib/select2/select2.png') right top no-repeat#{"/*rtl:ignore*/"};
+            }
+            b {
+                background: url('../../lib/select2/select2.png') no-repeat 0 1px#{"/*rtl:ignore*/"};
+            }
+        }
+    }
+    .select2-search input {
+        /*rtl:begin:ignore*/
+        background: #fff url('../../lib/select2/select2.png') no-repeat -37px -22px;
+        background: url('../../lib/select2/select2.png') no-repeat -37px -22px, -webkit-gradient(linear, left bottom, left top, color-stop(0.85, #fff), color-stop(0.99, #eee));
+        background: url('../../lib/select2/select2.png') no-repeat -37px -22px, -webkit-linear-gradient(center bottom, #fff 85%, #eee 99%);
+        background: url('../../lib/select2/select2.png') no-repeat -37px -22px, -moz-linear-gradient(center bottom, #fff 85%, #eee 99%);
+        background: url('../../lib/select2/select2.png') no-repeat -37px -22px, linear-gradient(to bottom, #fff 85%, #eee 99%) 0 0;
+        /*rtl:end:ignore*/
+    }
+}

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -66,6 +66,7 @@
         <link rel="stylesheet" type="text/scss" href="/web/static/src/scss/keyboard.scss"/>
 
         <link rel="stylesheet" type="text/less" href="/web/static/src/scss/fontawesome_overriden.scss"/>
+        <link rel="stylesheet" type="text/less" href="/web/static/src/scss/select2_overridden.scss"/>
 
         <script type="text/javascript" src="/web/static/lib/es5-shim/es5-shim.min.js"></script>
         <script type="text/javascript" src="/web/static/lib/underscore/underscore.js"></script>


### PR DESCRIPTION
PURPOSE
select2 input box in rtl shows UI glitches, say for example import view, there we have select2 boxes, icons of select2 box are not showing properly.

SPEC
select2 input box should display proper icons at the proper place.

TASK 2417476


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
