### PR TITLE
many2one autocomplete dropdown position in rtl

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -692,6 +692,10 @@ var FieldDateRange = InputField.extend({
         this.dateRangePickerOptions.startDate = startDate || moment();
         this.dateRangePickerOptions.endDate = endDate || moment();
 
+        if (_t.database.parameters.direction === "rtl") {
+            this.$el.addClass("pull-right");
+        }
+
         this.$el.daterangepicker(this.dateRangePickerOptions);
         this.$el.on('apply.daterangepicker', this._applyChanges.bind(this));
         this.$el.on('show.daterangepicker', this._onDateRangePickerShow.bind(this));

--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -321,7 +321,11 @@ var FieldMany2One = AbstractField.extend({
             minLength: 0,
             delay: this.AUTOCOMPLETE_DELAY,
         });
-        this.$input.autocomplete("option", "position", { my : "left top", at: "left bottom" });
+        if (_t.database.parameters.direction === "rtl") {
+            this.$input.autocomplete("option", "position", { my: "right top", at: "right bottom" });
+        } else {
+            this.$input.autocomplete("option", "position", { my : "left top", at: "left bottom" });
+        }
         this.autocomplete_bound = true;
     },
     /**

--- a/addons/web/static/src/js/widgets/date_picker.js
+++ b/addons/web/static/src/js/widgets/date_picker.js
@@ -54,6 +54,12 @@ var DateWidget = Widget.extend({
             keyBinds: null,
         }, options || {});
 
+        if (_t.database.parameters.direction === "rtl") {
+            this.options.widgetPositioning = {
+                horizontal: 'right',
+            };
+        }
+
         this.__libInput = 0;
         // tempusdominus doesn't offer any elegant way to check whether the
         // datepicker is open or not, so we have to listen to hide/show events

--- a/addons/web/static/src/scss/tempusdominus_overridden.scss
+++ b/addons/web/static/src/scss/tempusdominus_overridden.scss
@@ -1,0 +1,11 @@
+.o_rtl .bootstrap-datetimepicker-widget.dropdown-menu.float-right {
+    &:before {
+        left: 6px;
+        right: auto;
+    }
+
+    &:after {
+        left: 7px;
+        right: auto;
+    }
+}

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -3099,6 +3099,39 @@ QUnit.module('basic_fields', {
         form.destroy();
     });
 
+    QUnit.test('Daterange widget in rtl rendered at right side', async function (assert) {
+        assert.expect(4);
+
+        this.data.partner.fields.datetime_end = { string: 'Datetime End', type: 'datetime' };
+        this.data.partner.records[0].datetime_end = '2017-03-13 00:00:00';
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: `
+            <form>
+                <field name="datetime" widget="daterange" options="{'related_end_date': 'datetime_end'}"/>
+                <field name="datetime_end" widget="daterange" options="{'related_start_date': 'datetime'}"/>
+            </form>`,
+            translateParameters: {
+                direction: 'rtl',
+            },
+        });
+
+        // update input for Datetime
+        assert.hasClass(form.$('.o_field_date_range:first'), 'pull-right',
+            "the start date should have pull-right class in RTL");
+        assert.hasClass(form.$('.o_field_date_range:last'), 'pull-right',
+            "the end date should have pull-right class in RTL");
+        assert.hasClass($('.daterangepicker:first'), 'opensleft',
+            "start date should have opensleft class");
+        assert.hasClass($('.daterangepicker:last'), 'opensleft',
+            "end date should have opensleft class");
+
+        form.destroy();
+    });
+
     QUnit.module('FieldDate');
 
     QUnit.test('date field: toggle datepicker [REQUIRE FOCUS]', async function (assert) {

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -3131,6 +3131,32 @@ QUnit.module('basic_fields', {
         form.destroy();
     });
 
+    QUnit.test('date field: datepicker renders at right end in RTL', async function (assert) {
+        assert.expect(3);
+
+        var form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: '<form><field name="date"/></form>',
+            translateParameters: {  // Avoid issues due to localization formats
+                date_format: '%m/%d/%Y',
+                direction: 'rtl',
+            },
+        });
+
+        assert.strictEqual($('.bootstrap-datetimepicker-widget:visible').length, 0,
+            "datepicker should be closed initially");
+
+        await testUtils.dom.openDatepicker(form.$('.o_datepicker'));
+        assert.strictEqual($('.bootstrap-datetimepicker-widget:visible').length, 1,
+            "datepicker should be opened");
+        assert.hasClass($('.bootstrap-datetimepicker-widget:visible'), 'float-right',
+            "datepicker should rendered at right end in RTL");
+
+        form.destroy();
+    });
+
     QUnit.test('date field: toggle datepicker far in the future', async function (assert) {
         assert.expect(3);
 

--- a/addons/web/static/tests/fields/relational_fields/field_many2one_tests.js
+++ b/addons/web/static/tests/fields/relational_fields/field_many2one_tests.js
@@ -208,6 +208,29 @@ QUnit.module('fields', {}, function () {
             form.destroy();
         });
 
+        QUnit.test('many2ones in rtl language', async function (assert) {
+            assert.expect(1);
+
+            const form = await createView({
+                View: FormView,
+                model: 'partner',
+                data: this.data,
+                arch:
+                `<form string="Partners">
+                    <field name="trululu"/>
+                </form>`,
+                translateParameters: {
+                    direction: 'rtl',
+                }
+            });
+
+            const position = form.$('.o_field_many2one input').autocomplete('option', 'position');
+            assert.deepEqual(position, { my: "right top", at: "right bottom" },
+                "should correct position in rtl");
+
+            form.destroy();
+        });
+
         QUnit.test('editing a many2one, but not changing anything', async function (assert) {
             assert.expect(2);
             var form = await createView({

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -80,6 +80,7 @@
         <link rel="stylesheet" type="text/scss" href="/web/static/src/scss/web.zoomodoo.scss"/>
 
         <link rel="stylesheet" type="text/less" href="/web/static/src/scss/fontawesome_overridden.scss"/>
+        <link rel="stylesheet" type="text/less" href="/web/static/src/scss/tempusdominus_overridden.scss"/>
 
         <t t-call="web._assets_common_minimal_js"/>
 


### PR DESCRIPTION
PURPOSE
When many2one is inside group and not inside inner group then opening an autocomplete dropdown inside rtl language shows dropdown at left end instead of right end, autocomplete dropdown should start at right end of input element.

SPEC
When many2one is rendered inside group and not inside inner group then opening an autocomplete dropdown will open from right end in rtl language.

TASK 2418236


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
