### PR TITLE
[IMP] crm, hr_payroll, *:  base no create/open on country_id.

### DIFF
--- a/addons/account/views/account_account_tag_views.xml
+++ b/addons/account/views/account_account_tag_views.xml
@@ -14,7 +14,7 @@
                             <field name="name"/>
                             <field name="applicability"/>
                             <field name="tax_negate" attrs="{'invisible': [('applicability', '!=', 'taxes')]}"/>
-                            <field name="country_id" attrs="{'invisible': [('applicability', '!=', 'taxes')]}"/>
+                            <field name="country_id" options="{'no_open': True, 'no_create': True}" attrs="{'invisible': [('applicability', '!=', 'taxes')]}"/>
                             <field name="tax_report_line_ids" attrs="{'invisible': [('applicability', '!=', 'taxes')]}"/>
                         </group>
                     </sheet>

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -20,7 +20,7 @@
                             <field name="states_count" invisible="1"/>
                             <field name="vat_required" attrs="{'invisible': [('auto_apply', '!=', True)]}"/>
                             <field name="country_group_id" attrs="{'invisible': [('auto_apply', '!=', True)]}"/>
-                            <field name="country_id" attrs="{'invisible': [('auto_apply', '!=', True)]}"/>
+                            <field name="country_id" attrs="{'invisible': [('auto_apply', '!=', True)]}" options="{'no_open': True, 'no_create': True}"/>
                             <field name="state_ids" widget="many2many_tags" domain="[('country_id', '=', country_id)]"
                                 attrs="{'invisible': ['|', '|', ('auto_apply', '!=', True), ('country_id', '=', False), ('states_count', '=', 0)]}"/>
                             <label for="zip_from" string="Zip Range"

--- a/addons/base_address_city/views/res_city_view.xml
+++ b/addons/base_address_city/views/res_city_view.xml
@@ -7,7 +7,7 @@
                 <tree string="City" editable="top">
                     <field name="name"/>
                     <field name="zipcode"/>
-                    <field name="country_id"/>
+                    <field name="country_id" options="{'no_open': True, 'no_create': True}"/>
                     <field name="state_id" context="{'default_country_id': country_id}"/>
                 </tree>
             </field>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -336,7 +336,7 @@
                     <field name="company_id" groups="base.group_multi_company" optional="show"/>
                     <field name="city" optional="show"/>
                     <field name="state_id" optional="hide"/>
-                    <field name="country_id" optional="show"/>
+                    <field name="country_id" optional="show" options="{'no_open': True, 'no_create': True}"/>
                     <field name="partner_id" invisible="1"/>
                     <field name="user_id" optional="show"  widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
                     <field name="team_id" optional="show"/>
@@ -652,7 +652,7 @@
                     <field name="company_id" groups="base.group_multi_company" optional="show"/>
                     <field name="city" optional="hide"/>
                     <field name="state_id" optional="hide"/>
-                    <field name="country_id" optional="hide"/>
+                    <field name="country_id" optional="hide" options="{'no_open': True, 'no_create': True}"/>
                     <field name="user_id" widget="many2one_avatar_user" optional="show" domain="[('share', '=', False)]"/>
                     <field name="team_id" optional="show"/>
                     <field name="priority" optional="hide"/>

--- a/addons/crm/wizard/crm_lead_to_opportunity_mass_views.xml
+++ b/addons/crm/wizard/crm_lead_to_opportunity_mass_views.xml
@@ -24,7 +24,7 @@
                             <field name="name"/>
                             <field name="type"/>
                             <field name="contact_name"/>
-                            <field name="country_id" invisible="context.get('invisible_country', True)"/>
+                            <field name="country_id" invisible="context.get('invisible_country', True)" options="{'no_open': True, 'no_create': True}"/>
                             <field name="email_from"/>
                             <field name="stage_id"/>
                             <field name="user_id"/>

--- a/addons/crm/wizard/crm_lead_to_opportunity_views.xml
+++ b/addons/crm/wizard/crm_lead_to_opportunity_views.xml
@@ -19,7 +19,7 @@
                             <field name="name"/>
                             <field name="type"/>
                             <field name="contact_name"/>
-                            <field name="country_id" invisible="context.get('invisible_country', True)"/>
+                            <field name="country_id" invisible="context.get('invisible_country', True)" options="{'no_open': True, 'no_create': True}"/>
                             <field name="email_from"/>
                             <field name="stage_id"/>
                             <field name="user_id"/>

--- a/addons/crm_iap_lead_website/views/crm_reveal_views.xml
+++ b/addons/crm_iap_lead_website/views/crm_reveal_views.xml
@@ -33,7 +33,7 @@
                                 <field name="active" widget="boolean_toggle"/>
                             </group>
                             <group string="Website Traffic Conditions">
-                                <field name="country_ids" widget="many2many_tags"/>
+                                <field name="country_ids" widget="many2many_tags" options="{'no_open': True, 'no_create': True}"/>
                                 <field name="website_id" options="{'no_open': True, 'no_create_edit': True}" groups="website.group_multi_website"/>
                                 <field name="state_ids" widget="many2many_tags" attrs="{'invisible': [('country_ids', '=', [])]}" domain="[('country_id', 'in', country_ids)]"/>
                                 <field name="regex_url" widget="website_urls" placeholder="e.g. /page"/>

--- a/addons/delivery/views/delivery_view.xml
+++ b/addons/delivery/views/delivery_view.xml
@@ -136,7 +136,7 @@
                                 </group>
                                 <group>
                                     <group name="country_details">
-                                        <field name="country_ids" widget="many2many_tags"/>
+                                        <field name="country_ids" widget="many2many_tags" options="{'no_open': True, 'no_create': True}"/>
                                         <field name="state_ids" widget="many2many_tags"/>
                                     </group>
                                     <group></group>

--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -239,7 +239,7 @@
                             <div class="oe_inline" attrs="{'invisible': [('action', '!=', 'auto_popup')]}">
                                 <field name="auto_popup_timer" class="oe_inline"/> seconds
                             </div>
-                            <field name="country_ids" widget="many2many_tags"/>
+                            <field name="country_ids" widget="many2many_tags" options="{'no_open': True, 'no_create': True}"/>
                         </group>
                     </sheet>
                 </form>

--- a/addons/link_tracker/views/link_tracker_views.xml
+++ b/addons/link_tracker/views/link_tracker_views.xml
@@ -120,7 +120,7 @@
                         <group>
                             <field name="link_id"/>
                             <field name="ip"/>
-                            <field name="country_id"/>
+                            <field name="country_id" options="{'no_open': True, 'no_create': True}"/>
                         </group>
                     </sheet>
                 </form>

--- a/addons/mass_mailing/views/mailing_contact_views.xml
+++ b/addons/mass_mailing/views/mailing_contact_views.xml
@@ -177,7 +177,7 @@
                             </div>
                             <field name="title_id"/>
                             <field name="company_name"/>
-                            <field name="country_id"/>
+                            <field name="country_id" options="{'no_open': True, 'no_create': True}"/>
                         </group>
                         <group>
                             <field name="create_date" readonly="1"/>

--- a/addons/payment/views/payment_views.xml
+++ b/addons/payment/views/payment_views.xml
@@ -56,7 +56,7 @@
                                         <field name="qr_code" attrs="{'invisible': [('provider', '!=', 'transfer')]}"/>
                                     </group>
                                     <group string="Availability" name="availability">
-                                        <field name="country_ids" widget="many2many_tags" placeholder="Select countries. Leave empty to use everywhere."/>
+                                        <field name="country_ids" widget="many2many_tags" placeholder="Select countries. Leave empty to use everywhere." options="{'no_open': True, 'no_create': True}"/>
                                     </group>
                                     <group string="Payment Followup" name="payment_followup">
                                         <field name="journal_id" context="{'default_type': 'bank'}"

--- a/odoo/addons/base/views/res_company_views.xml
+++ b/odoo/addons/base/views/res_company_views.xml
@@ -26,7 +26,7 @@
                                         <field name="city" placeholder="City" class="o_address_city"/>
                                         <field name="state_id" class="o_address_state" placeholder="State" options='{"no_open": True}'/>
                                         <field name="zip" placeholder="ZIP" class="o_address_zip"/>
-                                        <field name="country_id" placeholder="Country" class="o_address_country" options='{"no_open": True}'/>
+                                        <field name="country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'/>
                                     </div>
                                     <field name="vat"/>
                                     <field name="company_registry"/>

--- a/odoo/addons/base/views/res_country_views.xml
+++ b/odoo/addons/base/views/res_country_views.xml
@@ -84,7 +84,7 @@
                             <h1><field name="name"/></h1>
                         </div>
                         <group name="country_group">
-                            <field name="country_ids" widget="many2many_tags"/>
+                            <field name="country_ids" widget="many2many_tags" options="{'no_open': True, 'no_create': True}"/>
                         </group>
                     </sheet>
                 </form>
@@ -106,7 +106,7 @@
                 <tree string="State" editable="bottom">
                     <field name="name"/>
                     <field name="code"/>
-                    <field name="country_id" options="{'no_create': True}"/>
+                    <field name="country_id" options="{'no_create': True, 'no_open': True}"/>
                 </tree>
             </field>
         </record>


### PR DESCRIPTION
Purpose of the task, is to prevent users from inadvertently creation/opening
countries from country_id fields.
Countries should be managed from their dedicated menu item.

In this commit, we have set both no_open and no_create to True.

Task-Id:- 2241677
PR:- 63773