### PR TITLE
[FIX] web: fix pdfjs bug with annotation position

### DIFF
--- a/addons/web/static/lib/pdfjs/src/display/canvas.js
+++ b/addons/web/static/lib/pdfjs/src/display/canvas.js
@@ -1776,6 +1776,11 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     beginAnnotations: function CanvasGraphics_beginAnnotations() {
       this.save();
       this.current = new CanvasExtraState();
+
+      // Odoo: fix issue with annotation position https://github.com/mozilla/pdf.js/pull/6814
+      if (this.baseTransform) {
+        this.ctx.setTransform.apply(this.ctx, this.baseTransform);
+      }
     },
 
     endAnnotations: function CanvasGraphics_endAnnotations() {


### PR DESCRIPTION
This applies fix from https://github.com/mozilla/pdf.js/pull/6814

STEPS:
* install documents app
* upload this pdf:
https://github.com/mozilla/pdf.js/blob/edf8ccc1d8b2202aef5832a85a7352ee07c69ad9/test/pdfs/issue5946.pdf
* click on pdf icon to preview

BEFORE: text is disappeared

AFTER: text is rendered correctly

---

opw-2392099

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
