### PR TITLE
[FIX] hr_holidays: Responsible couldn't read leave description

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -282,7 +282,7 @@ class HolidaysRequest(models.Model):
         is_officer = self.user_has_groups('hr_holidays.group_hr_holidays_user')
 
         for leave in self:
-            if is_officer or leave.user_id == self.env.user or leave.manager_id == self.env.user:
+            if is_officer or leave.user_id == self.env.user or leave.employee_id.leave_manager_id == self.env.user:
                 leave.name = leave.sudo().private_name
             else:
                 leave.name = '*****'
@@ -291,7 +291,7 @@ class HolidaysRequest(models.Model):
         is_officer = self.user_has_groups('hr_holidays.group_hr_holidays_user')
 
         for leave in self:
-            if is_officer or leave.user_id == self.env.user or leave.manager_id == self.env.user:
+            if is_officer or leave.user_id == self.env.user or leave.employee_id.leave_manager_id == self.env.user:
                 leave.sudo().private_name = leave.name
 
     def _search_description(self, operator, value):


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider two users U1 and U2
- U1 is linked to employee E1 and U2 to E2
- E1 is the manager of E2
- U1 has the access rights Responsible for Time Off
- Create a leave request LR for E2 with a description D
- Log with U1 and open LR

Bug:

The description appeared like **** instead of displaying D

opw:2414759