### PR TITLE
[FIX] account: new journal name sequence on old journal

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -375,6 +375,8 @@ class AccountMove(models.Model):
             if new_currency != self.currency_id:
                 self.currency_id = new_currency
                 self._onchange_currency()
+        if self.state == 'draft' and self._get_last_sequence() and self.name and self.name != '/':
+            self.name = '/'
 
     @api.onchange('partner_id')
     def _onchange_partner_id(self):

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -380,6 +380,11 @@ class TestAccountMove(AccountTestInvoicingCommon):
         self.assertEqual(copy2.name, 'MISC2/2016/01/0001')
         with Form(copy2) as move_form:  # It is editable in the form
             move_form.name = 'MyMISC/2016/0001'
+            move_form.journal_id = self.test_move.journal_id
+            self.assertEqual(move_form.name, '/')
+            move_form.journal_id = new_journal
+            self.assertEqual(move_form.name, 'MISC2/2016/01/0001')
+            move_form.name = 'MyMISC/2016/0001'
         copy2.action_post()
         self.assertEqual(copy2.name, 'MyMISC/2016/0001')
 


### PR DESCRIPTION
- Create a new sales journal;
- Start creating a new invoice using the new journal (the name/sequence
    will be editable) and before saving, change the journal to the
    old one;

Before this commit, the invoice will be on the old journal and will have
the new journal name/sequence and after validate the invoice all the new
invoices on the old journal will have the new journal name/sequence.

Now, when you change to the old journal the name of the invoice came
back to 'Draft'.

opw-2415975
