### PR TITLE
[FIX] web: Don't duplicate line in signatures

### DIFF
--- a/addons/web/static/src/js/widgets/name_and_signature.js
+++ b/addons/web/static/src/js/widgets/name_and_signature.js
@@ -246,8 +246,8 @@ var NameAndSignature = Widget.extend({
         this.$signatureField
             .empty()
             .jSignature({
-                'decor-color': '#D1D0CE',
-                'background-color': '#FFF',
+                'decor-color': this.defaultSignature ? null : '#D1D0CE',
+                'background-color': this.defaultSignature ? 'transparent' :'#FFF',
                 'color': '#000',
                 'lineWidth': 2,
                 'width': width,
@@ -566,7 +566,8 @@ var NameAndSignature = Widget.extend({
      */
     _onClickSignDrawClear: function (ev) {
         ev.preventDefault();
-        this.$signatureField.jSignature('reset');
+        delete this.defaultSignature
+        this.resetSignature();
     },
     /**
      * Handles click on the Load button: activates @see mode 'load'.
@@ -579,6 +580,7 @@ var NameAndSignature = Widget.extend({
         // open file upload automatically (saves 1 click)
         this.$loadFile.find('input').click();
         this.setMode('load');
+        this.resetSignature();
     },
     /**
      * Triggers up the signature change event.


### PR DESCRIPTION
# What are the steps to reproduce your issue ?

    1. Install eSign
    2. Go to user and uner the preference, add a signature (load image)
    3. On the sign app, sign a document

# What is currently happening ?

There will be a line on the signature and every time you sign a documentan additionnal line appears in signature

# What are you expecting to happen ?

  Sign documents without added lines

# Why is this happening ?

  Each time a signature is made a line is by default inserted in the signature area.
  But for each document signed the signature is saved in the user signature which adds a line to the original signature.
  So on each time a new line will be added to the original signature.

# How to fix the bug ?
  Do not display the line when one of these conditions is true:
      - The signature is an imported image
      - The signature has been previously saved in the user (no matter whether it is imported or drawn, it is not necessary to redraw over it and keep it as it is)

opw-2342050