### PR TITLE
[FIX] odoo_tools/mail.py: Crash at html2plaintext if no tree

### DIFF
--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -294,7 +294,7 @@ def html2plaintext(html, body_id=None, encoding='utf-8'):
 
     html = ustr(html)
 
-    if not html:
+    if not html.strip():
         return ''
 
     tree = etree.fromstring(html, parser=etree.HTMLParser())


### PR DESCRIPTION
What are the steps to reproduce your issue ?

    1. Install website_blog
    2. Go to website and add a new blog post
    3. Remove the block content
    4. Save and go to Blog page

What is currently happening ?

    Crash:
    Template fallback
    An error occured while rendering the template website_blog.post_teaser

opw-241937