### PR TITLE
[FIX] im_livechat: move chat window over navbar in mobile ui

### DIFF
--- a/addons/im_livechat/static/src/scss/im_livechat.scss
+++ b/addons/im_livechat/static/src/scss/im_livechat.scss
@@ -20,7 +20,7 @@
 }
 
 .o_thread_window {
-    z-index: 1002; // to go over the navbar
+    z-index: ($zindex-fixed + $zindex-modal-backdrop) / 2;
     .o_thread_date_separator {
         display: none;
     }


### PR DESCRIPTION
This is a z-index fight with 702f2b9

STEPS:
* install im_livechat, website
* start chat in mobile UI

BEFORE: no way to quit from chat, because main header is always on top of chat
header

AFTER: you can quit from chat, though you cannot open menu and you don't
see website logo before you quit from the chat.

In Odoo 12 you can open menu without
leaving a chat, though it's a buggy feature.

---

opw-2412932