### PR TITLE
[FIX] sale_stock: log exception activity only once

### DIFF
--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -213,7 +213,7 @@ class SaleOrder(models.Model):
                 sale_order_lines_quantities = {order_line: (order_line.product_uom_qty, 0) for order_line in sale_order.order_line}
                 documents = self.env['stock.picking']._log_activity_get_documents(sale_order_lines_quantities, 'move_ids', 'UP')
         self.picking_ids.filtered(lambda p: p.state != 'done').action_cancel()
-        if documents:
+        if documents and self._context.get('disable_cancel_warning'):
             filtered_documents = {}
             for (parent, responsible), rendering_context in documents.items():
                 if parent._name == 'stock.picking':


### PR DESCRIPTION
Steps to reproduce the bug:

- Create SO --> Process Picking
- Cancel SO

Bug:

There are duplicate activities `exception_on_so` added on Picking.


With this Commit:

Log activity only once on Cancelling Sale order.


Fixes: #63796

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
