### PR TITLE
[FIX] web_editor, website: fix modified images keeping theme information

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -476,18 +476,21 @@ class Web_Editor(http.Controller):
             View = View.sudo()
         return View._render_template(xmlid, {k: values[k] for k in values if k in trusted_value_keys})
 
+    def get_modified_image_fields(self, original, data, res_model):
+        return {
+            'original_id': original.id,
+            'datas': data,
+            'type': 'binary',
+            'res_model': res_model or 'ir.ui.view',
+        }
+
     @http.route('/web_editor/modify_image/<model("ir.attachment"):attachment>', type="json", auth="user", website=True)
     def modify_image(self, attachment, res_model=None, res_id=None, name=None, data=None, original_id=None):
         """
         Creates a modified copy of an attachment and returns its image_src to be
         inserted into the DOM.
         """
-        fields = {
-            'original_id': attachment.id,
-            'datas': data,
-            'type': 'binary',
-            'res_model': res_model or 'ir.ui.view',
-        }
+        fields = self.get_modified_image_fields(attachment, data, res_model)
         if fields['res_model'] == 'ir.ui.view':
             fields['res_id'] = 0
         elif res_id:

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -23,6 +23,7 @@ from odoo.addons.http_routing.models.ir_http import slug, slugify, _guess_mimety
 from odoo.addons.web.controllers.main import Binary
 from odoo.addons.portal.controllers.portal import pager as portal_pager
 from odoo.addons.portal.controllers.web import Home
+from odoo.addons.web_editor.controllers.main import Web_Editor
 
 logger = logging.getLogger(__name__)
 
@@ -578,3 +579,10 @@ class WebsiteBinary(http.Controller):
         response = request.redirect(website.image_url(website, 'favicon'), code=301)
         response.headers['Cache-Control'] = 'public, max-age=%s' % http.STATIC_CACHE_LONG
         return response
+
+class WebsiteWeb_editor(Web_Editor):
+    def get_modified_image_fields(self, original, data, res_model):
+        fields = super().get_modified_image_fields(original, data, res_model)
+        # Prevent theme update/change from updating modified images
+        fields.update({'theme_template_id': None, 'key': None})
+        return fields


### PR DESCRIPTION
Previously, when modifying an image in the website editor, the original
attachment would be copied and its binary data would be replaced by the
new ones. However, theme data associated with that attachment (key and
theme_template_id) was also copied but it should not be, because the key
will be used to find the default images of a theme, so this will cause
modified images to "shadow" default theme images, and the
theme_template_id is used when updating the theme or changing it to
remove default theme attachments and replace them with the one from the
new or updated theme, which would cause a crash because the record is
expected to be a singleton.

closes #62933