### PR TITLE
[MERGE] website_event_*: better manage what is not published

### DIFF
--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -162,8 +162,8 @@
     </t>
     <!-- List -->
     <div t-foreach="event_ids" t-as="event" t-attf-class=" #{opt_event_size} mb-4">
-        <a t-attf-href="/event/#{ slug(event) }/#{(not event.menu_id) and 'register'}" class="text-decoration-none">
-            <article t-attf-class="h-100 #{opt_events_list_cards and 'card rounded-0 border-0 shadow-sm'}" itemscope="itemscope" itemtype="http://schema.org/Event">
+        <a t-attf-href="/event/#{ slug(event) }/#{(not event.menu_id) and 'register'}" class="text-decoration-none" t-att-data-publish="event.website_published and 'on' or 'off'">
+            <article t-attf-class="h-100 #{opt_events_list_cards and 'card border-0 shadow-sm'}" itemscope="itemscope" itemtype="http://schema.org/Event">
                 <div class="h-100 row no-gutters">
                     <!-- Header -->
                     <header t-attf-class="overflow-hidden bg-secondary #{opt_events_list_columns and 'col-12' or 'col-sm-4 col-lg-3'} #{(not opt_events_list_cards) and 'shadow'}">

--- a/addons/website_event_exhibitor/static/src/js/event_exhibitor_connect.js
+++ b/addons/website_event_exhibitor/static/src/js/event_exhibitor_connect.js
@@ -61,7 +61,7 @@ var ExhibitorConnectClosedDialog = Dialog.extend({
 
 
 publicWidget.registry.eventExhibitorConnect = publicWidget.Widget.extend({
-    selector: '.o_wesponsor_js_connect',
+    selector: '.o_wesponsor_connect_button',
     xmlDependencies: ['/website_event_exhibitor/static/src/xml/event_exhibitor_connect.xml'],
 
     /**

--- a/addons/website_event_exhibitor/static/src/scss/event_exhibitor_templates.scss
+++ b/addons/website_event_exhibitor/static/src/scss/event_exhibitor_templates.scss
@@ -61,19 +61,19 @@
             a {
                 display: none;
             }
-        }
+            @include media-breakpoint-up(md) {
+                &:hover {
+                    cursor: pointer;
+                    transition: background-color .2s linear;
+                    background-color: rgba(0,0,0,.1);
 
-        @include media-breakpoint-up(md) {
-            :hover .o_wesponsor_connect_button {
-                cursor: pointer;
-                transition: background-color .2s linear;
-                background-color: rgba(0,0,0,.1);
-
-                a {
-                    display: inline-block;
+                    a {
+                        display: inline-block;
+                    }
                 }
             }
         }
+
     }
 
     /*

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
@@ -156,52 +156,28 @@
 <!-- ============================================================ -->
 
 <template id="exhibitor_card" name="Exhibitor Card">
-    <article t-att-class="'h-100 card rounded-0 border-0 shadow-sm o_wesponsor_card %s' % ('o_wesponsor_card_unpublished' if not sponsor.is_published else '')"
+    <article class="h-100 card border-0 shadow-sm o_wesponsor_card"
         itemscope="itemscope" itemtype="http://schema.org/Event">
-        <div class="h-100 row no-gutters">
+        <div class="h-100 row no-gutters" t-att-data-publish="sponsor.website_published and 'on' or 'off'">
             <t t-set="sponsor_image_url" t-value="sponsor.website_image_url"/>
             <header t-att-class="'overflow-hidden col-12 %s' % ('bg-secondary' if not sponsor_image_url else '')">
-                <div class="d-block h-100 w-100 o_wesponsor_js_connect"
-                     t-att-data-sponsor-url="sponsor.website_url"
-                     t-attf-data-register-url="/event/#{slug(event)}/register?from_sponsor_id=#{sponsor.id}"
-                     t-att-data-is-participating="event.is_participating"
-                     t-att-data-sponsor-id="sponsor.id"
-                     t-att-data-event-is-ongoing="sponsor.event_id.is_ongoing"
-                     t-att-data-sponsor-is-ongoing="sponsor.is_in_opening_hours"
-                     t-att-data-user-event-manager="is_event_user">
+                <div class="d-block h-100 w-100">
                     <div t-if="sponsor_image_url" class="card-img-top position-static o_wesponsor_bg_image"
                         t-attf-style="padding-top: 50%; background-image: url(#{sponsor_image_url});">
                         <small t-if="not sponsor.is_published" class="o_wesponsor_card_header_badge bg-danger">
                             <i class="fa fa-ban mr-2"/>Unpublished
                         </small>
-                        <div class="o_wesponsor_connect_button">
-                            <a href="#" class="btn btn-primary h3">
-                                <t t-if="not is_event_user and not sponsor.event_id.is_ongoing and not event.is_participating">
-                                    Register
-                                </t>
-                                <t t-elif="sponsor.exhibitor_type == 'online'">Connect</t>
-                                <t t-else="">More info</t>
-                            </a>
-                        </div>
                         <img class="position-absolute mr-2 mt-2"
                             style="right: 0; top: 0; max-height: 20px;"
                             t-if="sponsor.partner_id.country_id"
                             t-att-src="sponsor.partner_id.country_id.image_url"
                             t-att-alt="sponsor.partner_id.country_id.name"/>
                     </div>
-                    <div t-else="" class="o_wesponsor_gradient card-img-top position-relative"
+                    <div t-else="" class="o_wesponsor_gradient card-img-top"
                         style="padding-top: 50%">
                         <small t-if="not sponsor.is_published" class="o_wesponsor_card_header_badge bg-danger">
                             <i class="fa fa-ban mr-2"/>Unpublished
                         </small>
-                        <div class="o_wesponsor_connect_button">
-                            <a href="#" class="btn btn-primary h3">
-                                <t t-if="not is_event_user and not sponsor.event_id.is_ongoing and not event.is_participating">
-                                    Register
-                                </t>
-                                <t t-else="">Connect</t>
-                            </a>
-                        </div>
                     </div>
                 </div>
             </header>
@@ -218,6 +194,22 @@
                     <span class="text-muted" t-esc="sponsor.subtitle"/>
                 </main>
             </div>
+        </div>
+        <div class="o_wesponsor_connect_button"
+            t-att-data-sponsor-url="sponsor.website_url"
+            t-attf-data-register-url="/event/#{slug(event)}/register?from_sponsor_id=#{sponsor.id}"
+            t-att-data-is-participating="event.is_participating"
+            t-att-data-sponsor-id="sponsor.id"
+            t-att-data-event-is-ongoing="sponsor.event_id.is_ongoing"
+            t-att-data-sponsor-is-ongoing="sponsor.is_in_opening_hours"
+            t-att-data-user-event-manager="is_event_user">
+            <a href="#" class="btn btn-primary h3">
+                <t t-if="not is_event_user and not sponsor.event_id.is_ongoing and not event.is_participating">
+                    Register
+                </t>
+                <t t-elif="sponsor.exhibitor_type == 'online'">Connect</t>
+                <t t-else="">More info</t>
+            </a>
         </div>
     </article>
 </template>

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
@@ -161,7 +161,8 @@
             <ul id="collapse_exhibitor_aside" class="list-unstyled collapse d-lg-block mb-0">
                 <li t-foreach="sponsors_other" t-as="sponsor_other">
                     <a class="row no-gutters px-2 pt-2 pb-1 text-decoration-none"
-                        t-att-href="sponsor_other.website_url">
+                        t-att-href="sponsor_other.website_url"
+                        t-att-data-publish="sponsor_other.website_published and 'on' or 'off'">
                         <div class="col-3 d-flex flex-column align-items-center">
                             <img t-if="sponsor_other.partner_id.country_id"
                             class="mr-2 mb-1 o_wesponsor_aside_logo"
@@ -179,6 +180,9 @@
 
                             </span>
                             <small class="text-muted" t-esc="sponsor_other.subtitle"/>
+                            <div class="d-inline-block float-right" t-if="not sponsor_other.website_published">
+                                <small class="badge badge-danger">Unpublished</small>
+                            </div>
                         </div>
                     </a>
                 </li>

--- a/addons/website_event_exhibitor/views/event_templates_sponsor.xml
+++ b/addons/website_event_exhibitor/views/event_templates_sponsor.xml
@@ -3,34 +3,36 @@
 
 <template name="Sponsors" id="event_sponsor" customize_show="True" inherit_id="website_event.layout">
     <xpath expr="//div[@id='wrap']" position="inside">
-        <t t-set="sponsors" t-value="event.sponsor_ids.filtered(lambda sponsor: sponsor.website_published)"/>
-        <div class="container mt32 mb16 d-none d-md-block d-print-none" t-if="sponsors">
-            <div t-attf-class="d-flex flex-wrap mb-5 #{'' if (len(sponsors) > 10) else 'justify-content-md-center'}">
-                <t t-foreach="sponsors" t-as="sponsor">
+        <div class="container mt32 mb16 d-none d-md-block d-print-none" t-if="event.sponsor_ids">
+            <div t-attf-class="d-flex flex-wrap mb-5 #{'' if (len(event.sponsor_ids) > 10) else 'justify-content-md-center'}">
+                <t t-foreach="event.sponsor_ids.sorted(lambda sponsor: not sponsor.website_published)" t-as="sponsor">
                     <t t-if="sponsor.url">
-                        <a class="o_wevent_sponsor o_wevent_sponsor_card" target="_blank" t-att-href="sponsor.url">
-                            <div class="h-100 shadow-sm p-2">
-                                <span t-field="sponsor.image_128"
-                                    t-options='{"widget": "image", "class": "img img-fluid"}'/>
-                                <span t-if="sponsor.sponsor_type_id.display_ribbon_style and sponsor.sponsor_type_id.display_ribbon_style != 'no_ribbon'"
-                                      t-field="sponsor.sponsor_type_id" t-attf-class="o_ribbon o_ribbon_right ribbon_#{sponsor.sponsor_type_id.display_ribbon_style}"/>
-                            </div>
+                        <a class="o_wevent_sponsor o_wevent_sponsor_card h-100 text-decoration-none" target="_blank" t-att-href="sponsor.url"
+                            t-att-data-publish="'on' if sponsor.website_published else 'off'">
+                            <t t-call="website_event_exhibitor.event_sponsor_thumb_details"/>
                         </a>
                     </t>
                     <t t-if="not sponsor.url">
-                        <div class="o_wevent_sponsor o_wevent_sponsor_card">
-                            <div class="h-100 shadow-sm p-2">
-                                <span t-field="sponsor.image_128"
-                                    t-options='{"widget": "image", "class": "img img-fluid"}'/>
-                                <span t-if="sponsor.sponsor_type_id.display_ribbon_style and sponsor.sponsor_type_id.display_ribbon_style != 'no_ribbon'"
-                                      t-field="sponsor.sponsor_type_id" t-attf-class="o_ribbon o_ribbon_right ribbon_#{sponsor.sponsor_type_id.display_ribbon_style}"/>
-                            </div>
+                        <div class="o_wevent_sponsor o_wevent_sponsor_card h-100" t-att-data-publish="'on' if sponsor.website_published else 'off'">
+                            <t t-call="website_event_exhibitor.event_sponsor_thumb_details"/>
                         </div>
                     </t>
                 </t>
             </div>
         </div>
     </xpath>
+</template>
+
+<!-- Common template for sponsor images and 'Unpublished' badge -->
+<template id="event_sponsor_thumb_details">
+    <div class="h-100 shadow-sm p-2">
+        <span t-field="sponsor.image_128"
+            t-options='{"widget": "image", "class": "img img-fluid"}'/>
+        <span t-if="sponsor.sponsor_type_id.display_ribbon_style and sponsor.sponsor_type_id.display_ribbon_style != 'no_ribbon'"
+            t-field="sponsor.sponsor_type_id" t-attf-class="o_ribbon o_ribbon_right ribbon_#{sponsor.sponsor_type_id.display_ribbon_style}"/>
+    </div>
+    <span t-if="not sponsor.website_published"
+        class="d-flex justify-content-center badge badge-danger o_wevent_online_badge_unpublished">Unpublished</span>
 </template>
 
 </odoo>

--- a/addons/website_event_meet/controllers/community.py
+++ b/addons/website_event_meet/controllers/community.py
@@ -61,7 +61,7 @@ class WebsiteEventMeetController(EventCommunityController):
 
         return {
             # event information
-            "event": event.sudo(),
+            "event": event,
             'main_object': event,
             # rooms
             "meeting_rooms": meeting_rooms,

--- a/addons/website_event_meet/controllers/community.py
+++ b/addons/website_event_meet/controllers/community.py
@@ -23,7 +23,7 @@ class WebsiteEventMeetController(EventCommunityController):
         return search_domain_base
 
     def _sort_event_rooms(self, room):
-        return (room.is_pinned, room.room_last_activity, room.id)
+        return (room.website_published, room.is_pinned, room.room_last_activity, room.id)
 
     # ------------------------------------------------------------
     # MAIN PAGE

--- a/addons/website_event_meet/static/src/scss/event_meet_templates.scss
+++ b/addons/website_event_meet/static/src/scss/event_meet_templates.scss
@@ -57,3 +57,8 @@
     position: absolute;
     opacity: 0.6;
 }
+
+.o_wevent_meeting_room_manager_menu {
+    top:  $spacer / 2;
+    right: $spacer;
+}

--- a/addons/website_event_meet/views/event_meet_templates_list.xml
+++ b/addons/website_event_meet/views/event_meet_templates_list.xml
@@ -122,26 +122,13 @@
         t-att-href="meeting_room_href"
         t-att-data-toggle="meeting_room_data_toggle"
         t-att-data-target="meeting_room_data_target">
-        <div class="text-decoration-none w-100 h-100 p-3">
+        <div class="text-decoration-none w-100 h-100 p-3" t-att-data-publish="meeting_room.website_published and 'on' or 'off'">
             <div class="o_wevent_meeting_room_corner_ribbon" t-if="meeting_room.room_is_full">Full</div>
             <div class="d-flex flex-column">
-                <div class="d-flex flex-row justify-content-between">
-                    <h4 class="text-break mw-75 text-uppercase" t-esc="meeting_room.name"/>
-                    <div t-if="not meeting_room.is_published">
+                <div class="d-flex flex-row">
+                    <h4 t-att-class="'text-break text-uppercase %s' % ('w-75' if meeting_room.website_published else 'w-50')" t-esc="meeting_room.name"/>
+                    <div t-if="not meeting_room.is_published" class="w-25">
                         <span class="badge badge-danger">Unpublished</span>
-                    </div>
-                    <div t-if="is_event_user" class="w-25">
-                        <div class="dropdown float-right dropleft">
-                            <button class="btn py-0" data-toggle="dropdown"><h3 class="m-0">&#8942;</h3></button>
-                            <div class="dropdown-menu">
-                                <div class="dropdown-item font-weight-bold disabled">Room Manager</div>
-                                <button class="dropdown-item btn btn-danger o_wevent_meeting_room_duplicate" type="button">Duplicate</button>
-                                <button class="dropdown-item btn btn-danger o_wevent_meeting_room_delete" type="button">Close</button>
-                            </div>
-                        </div>
-                        <button t-attf-class="o_wevent_meeting_room_is_pinned float-right btn #{'o_wevent_meeting_room_pinned' if meeting_room.is_pinned else ''}">
-                            <i class="fa fa-thumb-tack"/>
-                        </button>
                     </div>
                 </div>
                 <span class="text-muted" t-field="meeting_room.summary"/>
@@ -152,6 +139,18 @@
                         <span t-else="" class="text-uppercase">participant(s)</span>
                     </span>
                     <div class="d-inline border py-1 px-2 bg-secondary" t-esc="meeting_room.room_lang_id.name"/>
+                </div>
+            </div>
+        </div>
+        <div t-if="is_event_user" class="position-absolute o_wevent_meeting_room_manager_menu d-flex justify-content-end flex-column flex-md-row">
+            <button t-attf-class="o_wevent_meeting_room_is_pinned btn #{'o_wevent_meeting_room_pinned' if meeting_room.is_pinned else ''}">
+                <i class="fa fa-thumb-tack"/>
+            </button>
+            <div class="dropdown dropleft">
+                <button class="btn" data-toggle="dropdown"><i class="fa fa-ellipsis-v px-1"/></button>
+                <div class="dropdown-menu">
+                    <button class="dropdown-item btn o_wevent_meeting_room_duplicate" type="button">Duplicate</button>
+                    <button class="dropdown-item btn o_wevent_meeting_room_delete" type="button">Close</button>
                 </div>
             </div>
         </div>

--- a/addons/website_event_track/controllers/event_track.py
+++ b/addons/website_event_track/controllers/event_track.py
@@ -96,7 +96,7 @@ class EventTrackController(http.Controller):
         now_tz = utc.localize(fields.Datetime.now().replace(microsecond=0), is_dst=False).astimezone(timezone(event.date_tz))
         today_tz = now_tz.date()
         event = event.with_context(tz=event.date_tz or 'UTC')
-        tracks_sudo = event.env['event.track'].sudo().search(search_domain, order='date asc')
+        tracks_sudo = event.env['event.track'].sudo().search(search_domain, order='is_published desc, date asc')
         tag_categories = request.env['event.track.tag.category'].sudo().search([])
 
         # filter on wishlist (as post processing due to costly search on is_reminder_on)

--- a/addons/website_event_track/static/src/scss/event_track_templates.scss
+++ b/addons/website_event_track/static/src/scss/event_track_templates.scss
@@ -134,6 +134,11 @@
                 > div {
                     padding: 0.3em;
                 }
+                // For unpublished tracks, opacity is already reduced
+                [data-publish='off'] .o_weagenda_track_badges > .o_wevent_online_badge_unpublished {
+                    opacity: unset;
+                }
+
 
             }
             // Remove me in master

--- a/addons/website_event_track/views/event_track_templates_agenda.xml
+++ b/addons/website_event_track/views/event_track_templates_agenda.xml
@@ -156,16 +156,16 @@
 </template>
 
 <template id="agenda_main_track" name="Track Agenda: Track">
-    <div class="d-flex flex-column h-100">
+    <div class="d-flex flex-column h-100" t-att-data-publish="track.website_published and 'on' or 'off'">
         <div class="d-flex justify-content-end flex-wrap-reverse align-items-center o_weagenda_track_badges">
             <small t-if="track.is_track_live and not track.is_track_done and track.website_published"
                 class="mx-1 badge badge-danger rounded-sm">Live
             </small>
-            <small t-if="not track.website_published and is_event_user and track.stage_id.is_accepted"
+            <small t-if="not track.website_published and is_event_user"
                    title="Unpublished"
-                   class="ml-1 badge badge-danger o_wevent_online_badge_unpublished rounded-sm">Unpublished</small>
+                   class="ml-1 mt-1 mt-md-0 badge badge-danger o_wevent_online_badge_unpublished">Unpublished</small>
             <small t-if="not track.stage_id.is_accepted" title="Not Accepted"
-                   class="ml-1 badge badge-danger o_wevent_online_badge_unpublished rounded-sm">Not Accepted</small>
+                   class="ml-1 mt-1 mt-md-0 badge badge-danger o_wevent_online_badge_unpublished">Not Accepted</small>
             <span t-if="option_track_wishlist">
                 <t t-call="website_event_track.track_widget_reminder">
                     <t t-set="reminder_light" t-value="True"/>

--- a/addons/website_event_track/views/event_track_templates_page.xml
+++ b/addons/website_event_track/views/event_track_templates_page.xml
@@ -174,12 +174,15 @@
                     <ul class="list-unstyled mb-0">
                         <li t-foreach="tracks_other" t-as="track_other" class="w-100">
                             <a t-if="is_event_user or track_other.is_published"
+                                t-att-data-publish="track_other.website_published and 'on' or 'off'"
                                 class="d-block w-100 h-100 px-2 pt-2 pb-1 text-decoration-none"
                                 t-att-href="track_other.website_url">
                                 <t t-call="website_event_track.event_track_aside_other_track"/>
                             </a>
                             <div t-else="" class="text-muted px-2 pt-2 pb-1">
-                                <t t-call="website_event_track.event_track_aside_other_track"/>
+                                <div t-att-data-publish="track_other.website_published and 'on' or 'off'">
+                                    <t t-call="website_event_track.event_track_aside_other_track"/>
+                                </div>
                             </div>
                         </li>
                     </ul>
@@ -194,6 +197,8 @@
     <div class="d-flex align-items-center">
         <small class="text-muted" t-esc="track_other.partner_name"/>
         <div class="d-inline-block ml-auto o_wesession_track_aside_info text-truncate">
+            <small t-if="not track_other.website_published and user_event_manager"
+                class="badge badge-danger">Unpublished</small>
             <small t-if="track_other.is_track_live and not track_other.is_track_done"
                 class="badge badge-danger">Live</small>
             <small t-elif="track_other.is_track_done"


### PR DESCRIPTION
PURPOSE

Improve the management of non-published event subrecords for internal users.

SPECIFICATIONS

In this task we did 3 changes

1) In Community section of any event non-publish room is not available. Here
    we add unpublished rooms with tag, just like shop with opacity.

2) Before this commit unpublished exhibitors are mixed with the published ones
    with random position. After our merge all unpublished exhibitors are shown at
    the end of list and not mixed with published ones. Moreover display of exhibitors
    is improved to better find unpublished one.

3) In agenda section only unpublished tags have blurry effect and except that
    whole section is same as published ones. We add blurry effect for whole
    unpublished agenda. Moreover this we added this blurry effect for main event
    section, which looks more systematic..

LINKS

Task ID-2346612
