### PR TITLE
[IMP] doc: add link to tutorial in client actions reference doc

### DIFF
--- a/doc/howtos/web.rst
+++ b/doc/howtos/web.rst
@@ -1753,6 +1753,8 @@ attributes are:
                 </div>
             </t>
 
+.. _howtos/web/client_actions:
+
 Client Actions
 --------------
 

--- a/doc/reference/actions.rst
+++ b/doc/reference/actions.rst
@@ -403,6 +403,9 @@ Triggers an action implemented entirely in the client.
 tells the client to start the Point of Sale interface, the server has no idea
 how the POS interface works.
 
+.. seealso::
+   - :ref:`Tutorial: Client Actions <howtos/web/client_actions>`
+
 .. _reference/actions/cron:
 
 Automated Actions (``ir.cron``)


### PR DESCRIPTION
The doc for client actions is currently too minimalistic to be of much
use. This commit adds a seealso linking to the related tutorial.

task-2423824

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
