### PR TITLE
[FIX] base_data.sql: remove obsolete field size

### DIFF
--- a/odoo/addons/base/data/base_data.sql
+++ b/odoo/addons/base/data/base_data.sql
@@ -38,7 +38,7 @@ CREATE TABLE ir_module_category (
     write_date timestamp without time zone,
     write_uid integer, -- references res_users on delete set null,
     parent_id integer REFERENCES ir_module_category ON DELETE SET NULL,
-    name character varying(128) NOT NULL,
+    name character varying NOT NULL,
     primary key(id)
 );
 
@@ -48,14 +48,14 @@ CREATE TABLE ir_module_module (
     create_date timestamp without time zone,
     write_date timestamp without time zone,
     write_uid integer, -- references res_users on delete set null,
-    website character varying(256),
-    summary character varying(256),
-    name character varying(128) NOT NULL,
+    website character varying,
+    summary character varying,
+    name character varying NOT NULL,
     author character varying,
     icon varchar,
     state character varying(16),
-    latest_version character varying(64),
-    shortdesc character varying(256),
+    latest_version character varying,
+    shortdesc character varying,
     category_id integer REFERENCES ir_module_category ON DELETE SET NULL,
     description text,
     application boolean default False,
@@ -75,7 +75,7 @@ CREATE TABLE ir_module_module_dependency (
     create_date timestamp without time zone,
     write_date timestamp without time zone,
     write_uid integer, -- references res_users on delete set null,
-    name character varying(128),
+    name character varying,
     module_id integer REFERENCES ir_module_module ON DELETE cascade,
     primary key(id)
 );


### PR DESCRIPTION
those field sizes were deleted from orm definition in 2014 https://github.com/odoo/odoo/commit/026e38b48f3963aed08bba4e76a0a796d662f6a4

STEPS:
* set manifest's summary attribute to a long string
* create empty database

BEFORE: error

```
2020-12-28 10:44:51,325 1 ERROR ? odoo.sql_db: bad query: UPDATE ir_module_module SET state='installed' WHERE state IN ('to remove', 'to upgrade')
ERROR: relation "ir_module_module" does not exist
LINE 1: UPDATE ir_module_module SET state='installed' WHERE state IN...
               ^

2020-12-28 10:44:51,325 1 ERROR ? odoo.modules.registry: Failed to load registry
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/modules/registry.py", line 86, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 338, in load_modules
    odoo.modules.db.initialize(cr)
  File "/opt/odoo/custom/src/odoo/odoo/modules/db.py", line 63, in initialize
    info['sequence'], info['summary']))
  File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 173, in wrapper
    return f(self, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 250, in execute
    res = self._obj.execute(query, params)
psycopg2.DataError: value too long for type character varying(256)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/modules/registry.py", line 88, in new
    odoo.modules.reset_modules_state(db_name)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 558, in reset_modules_state
    "UPDATE ir_module_module SET state='installed' WHERE state IN ('to remove', 'to upgrade')"
  File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 173, in wrapper
    return f(self, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 250, in execute
    res = self._obj.execute(query, params)
psycopg2.ProgrammingError: relation "ir_module_module" does not exist
LINE 1: UPDATE ir_module_module SET state='installed' WHERE state IN...
```

AFTER: database successfully created

---

opw-2415057

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
