### PR TITLE
[FIX] hr_holidays: float representation issues with 38 hours schedule

### DIFF
--- a/addons/hr_holidays/i18n/hr_holidays.pot
+++ b/addons/hr_holidays/i18n/hr_holidays.pot
@@ -1583,6 +1583,7 @@ msgstr ""
 
 #. module: hr_holidays
 #. openerp-web
+#: code:addons/hr_holidays/models/hr_leave.py:0
 #: code:addons/hr_holidays/static/src/xml/time_off_calendar.xml:0
 #: code:addons/hr_holidays/static/src/xml/time_off_calendar.xml:0
 #: model:ir.model.fields.selection,name:hr_holidays.selection__hr_leave_allocation__unit_per_interval__hours

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -521,7 +521,7 @@ class HolidaysRequest(models.Model):
     def _compute_number_of_hours_text(self):
         # YTI Note: All this because a readonly field takes all the width on edit mode...
         for leave in self:
-            leave.number_of_hours_text = '%s%s Hours%s' % (
+            leave.number_of_hours_text = '%s%g Hours%s' % (
                 '' if leave.request_unit_half or leave.request_unit_hours else '(',
                 float_round(leave.number_of_hours_display, precision_digits=2),
                 '' if leave.request_unit_half or leave.request_unit_hours else ')')

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -521,9 +521,10 @@ class HolidaysRequest(models.Model):
     def _compute_number_of_hours_text(self):
         # YTI Note: All this because a readonly field takes all the width on edit mode...
         for leave in self:
-            leave.number_of_hours_text = '%s%g Hours%s' % (
+            leave.number_of_hours_text = '%s%g %s%s' % (
                 '' if leave.request_unit_half or leave.request_unit_hours else '(',
                 float_round(leave.number_of_hours_display, precision_digits=2),
+                _('Hours'),
                 '' if leave.request_unit_half or leave.request_unit_hours else ')')
 
     @api.depends('state', 'employee_id', 'department_id')

--- a/addons/hr_holidays/tests/test_automatic_leave_dates.py
+++ b/addons/hr_holidays/tests/test_automatic_leave_dates.py
@@ -34,7 +34,7 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
             leave_form.request_date_from_period = 'am'
 
             self.assertEqual(leave_form.number_of_days_display, 0)
-            self.assertEqual(leave_form.number_of_hours_text, '0.0 Hours')
+            self.assertEqual(leave_form.number_of_hours_text, '0 Hours')
 
     def test_single_attendance_on_morning_and_afternoon(self):
         calendar = self.env['resource.calendar'].create({
@@ -67,12 +67,12 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
             leave_form.request_date_from_period = 'am'
 
             self.assertEqual(leave_form.number_of_days_display, .5)
-            self.assertEqual(leave_form.number_of_hours_text, '4.0 Hours')
+            self.assertEqual(leave_form.number_of_hours_text, '4 Hours')
 
             leave_form.request_date_from_period = 'pm'
 
             self.assertEqual(leave_form.number_of_days_display, .5)
-            self.assertEqual(leave_form.number_of_hours_text, '4.0 Hours')
+            self.assertEqual(leave_form.number_of_hours_text, '4 Hours')
 
     def test_multiple_attendance_on_morning(self):
         calendar = self.env['resource.calendar'].create({
@@ -111,12 +111,12 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
             leave_form.request_date_from_period = 'am'
 
             self.assertEqual(leave_form.number_of_days_display, .5)
-            self.assertEqual(leave_form.number_of_hours_text, '4.0 Hours')
+            self.assertEqual(leave_form.number_of_hours_text, '4 Hours')
 
             leave_form.request_date_from_period = 'pm'
 
             self.assertEqual(leave_form.number_of_days_display, .5)
-            self.assertEqual(leave_form.number_of_hours_text, '4.0 Hours')
+            self.assertEqual(leave_form.number_of_hours_text, '4 Hours')
 
     def test_attendance_on_morning(self):
         calendar = self.env['resource.calendar'].create({
@@ -141,13 +141,13 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
             leave_form.request_date_from_period = 'am'
 
             self.assertEqual(leave_form.number_of_days_display, 1)
-            self.assertEqual(leave_form.number_of_hours_text, '8.0 Hours')
+            self.assertEqual(leave_form.number_of_hours_text, '8 Hours')
 
             # Ask for afternoon
             leave_form.request_date_from_period = 'pm'
 
             self.assertEqual(leave_form.number_of_days_display, 1)
-            self.assertEqual(leave_form.number_of_hours_text, '8.0 Hours')
+            self.assertEqual(leave_form.number_of_hours_text, '8 Hours')
 
     def test_attendance_next_day(self):
         self.env.user.tz = 'Europe/Brussels'
@@ -174,7 +174,7 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
 
 
             self.assertEqual(leave_form.number_of_days_display, 0)
-            self.assertEqual(leave_form.number_of_hours_text, '0.0 Hours')
+            self.assertEqual(leave_form.number_of_hours_text, '0 Hours')
             self.assertEqual(leave_form.date_from, datetime(2019, 9, 2, 6, 0, 0))
             self.assertEqual(leave_form.date_to, datetime(2019, 9, 2, 10, 0, 0))
 
@@ -203,7 +203,7 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
 
 
             self.assertEqual(leave_form.number_of_days_display, 0)
-            self.assertEqual(leave_form.number_of_hours_text, '0.0 Hours')
+            self.assertEqual(leave_form.number_of_hours_text, '0 Hours')
             self.assertEqual(leave_form.date_from, datetime(2019, 9, 3, 6, 0, 0))
             self.assertEqual(leave_form.date_to, datetime(2019, 9, 3, 10, 0, 0))
 
@@ -242,7 +242,7 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
             leave_form.request_date_from_period = 'am'
 
             self.assertEqual(leave_form.number_of_days_display, 1)
-            self.assertEqual(leave_form.number_of_hours_text, '2.0 Hours')
+            self.assertEqual(leave_form.number_of_hours_text, '2 Hours')
             self.assertEqual(leave_form.date_from, datetime(2019, 9, 2, 8, 0, 0))
             self.assertEqual(leave_form.date_to, datetime(2019, 9, 2, 10, 0, 0))
 
@@ -255,7 +255,7 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
             leave_form.request_date_from_period = 'am'
 
             self.assertEqual(leave_form.number_of_days_display, 1)
-            self.assertEqual(leave_form.number_of_hours_text, '4.0 Hours')
+            self.assertEqual(leave_form.number_of_hours_text, '4 Hours')
             self.assertEqual(leave_form.date_from, datetime(2019, 9, 9, 6, 0, 0))
             self.assertEqual(leave_form.date_to, datetime(2019, 9, 9, 10, 0, 0))
 
@@ -286,6 +286,6 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
             leave_form.request_date_from_period = 'am'
 
             self.assertEqual(leave_form.number_of_days_display, 0)
-            self.assertEqual(leave_form.number_of_hours_text, '0.0 Hours')
+            self.assertEqual(leave_form.number_of_hours_text, '0 Hours')
             self.assertEqual(leave_form.date_from, datetime(2019, 9, 2, 6, 0, 0))
             self.assertEqual(leave_form.date_to, datetime(2019, 9, 2, 10, 0, 0))


### PR DESCRIPTION
Steps:
- Install Time Off
- Go to Employees
- Click an employee (A)
- Change Work Information > Schedule > Working Hours to "Standard 38 hours/week"
- Go to Time Off > Managers > Time Off
- Click Create
- Select employee (A)
- In the title, select Unpaid
- From 2020-12-20 to 2020-12-24

Bug:
Float representation issue: 4.00 Days (30.400000000000002 Hours)

opw:2418740