### PR TITLE
[FIX] mrp(_subcontracting): require boms to have bom lines

### DIFF
--- a/addons/mrp/data/mrp_demo.xml
+++ b/addons/mrp/data/mrp_demo.xml
@@ -37,6 +37,10 @@
             <field name="product_tmpl_id" ref="product.product_product_3_product_template"/>
             <field name="product_uom_id" ref="uom.product_uom_unit"/>
             <field name="sequence">1</field>
+            <field name="bom_line_ids" model="mrp.bom.line"
+                eval="[(0, 0, {'product_id': ref('product.product_product_12'),
+                               'product_uom_id': ref('uom.product_uom_unit'),
+                               'product_qty': 1,})]"/>
         </record>
         <record id="mrp_routing_workcenter_0" model="mrp.routing.workcenter">
             <field name="bom_id" ref="mrp_bom_manufacture"/>
@@ -45,14 +49,6 @@
             <field name="time_cycle">60</field>
             <field name="sequence">5</field>
             <field name="worksheet" type="base64" file="mrp/static/img/assebly-worksheet.pdf"/>
-        </record>
-
-        <record id="mrp_bom_manufacture_line_1" model="mrp.bom.line">
-            <field name="product_id" ref="product.product_product_12"/>
-            <field name="product_qty">1</field>
-            <field name="product_uom_id" ref="uom.product_uom_unit"/>
-            <field name="sequence">5</field>
-            <field name="bom_id" ref="mrp_bom_manufacture"/>
         </record>
 
         <record id="mrp_bom_manufacture_line_2" model="mrp.bom.line">
@@ -238,6 +234,11 @@
             <field name="product_uom_id" ref="uom.product_uom_unit"/>
             <field name="sequence">3</field>
             <field name="consumption">flexible</field>
+            <field name="bom_line_ids" model="mrp.bom.line"
+                eval="[(0, 0, {'product_id': ref('product_product_computer_desk_head'),
+                               'product_uom_id': ref('uom.product_uom_unit'),
+                               'product_qty': 1,
+                               'sequence': 1})]"/>
         </record>
         <record id="mrp_routing_workcenter_5" model="mrp.routing.workcenter">
             <field name="bom_id" ref="mrp_bom_desk"/>
@@ -248,22 +249,12 @@
             <field name="worksheet" type="base64" file="mrp/static/img/cutting-worksheet.pdf"/>
         </record>
 
-        <record id="mrp_bom_desk_line_1" model="mrp.bom.line">
-            <field name="product_id" ref="product_product_computer_desk_head"/>
-            <field name="product_qty">1</field>
-            <field name="product_uom_id" ref="uom.product_uom_unit"/>
-            <field name="sequence">1</field>
-            <field name="bom_id" ref="mrp_bom_desk"/>
-            <field name="operation_id" ref="mrp.mrp_routing_workcenter_5"/>
-        </record>
-
         <record id="mrp_bom_desk_line_2" model="mrp.bom.line">
             <field name="product_id" ref="product_product_computer_desk_leg"/>
             <field name="product_qty">4</field>
             <field name="product_uom_id" ref="uom.product_uom_unit"/>
             <field name="sequence">2</field>
             <field name="bom_id" ref="mrp_bom_desk"/>
-            <field name="operation_id" ref="mrp.mrp_routing_workcenter_5"/>
         </record>
 
         <record id="mrp_bom_desk_line_3" model="mrp.bom.line">
@@ -272,7 +263,6 @@
             <field name="product_uom_id" ref="uom.product_uom_unit"/>
             <field name="sequence">3</field>
             <field name="bom_id" ref="mrp_bom_desk"/>
-            <field name="operation_id" ref="mrp.mrp_routing_workcenter_5"/>
         </record>
 
         <record id="mrp_bom_desk_line_4" model="mrp.bom.line">
@@ -281,8 +271,13 @@
             <field name="product_uom_id" ref="uom.product_uom_unit"/>
             <field name="sequence">4</field>
             <field name="bom_id" ref="mrp_bom_desk"/>
-            <field name="operation_id" ref="mrp.mrp_routing_workcenter_5"/>
         </record>
+
+        <!-- Assign workcenters -->
+        <function model="mrp.bom.line" name="write">
+            <value model="mrp.bom.line" eval="obj().env['mrp.bom.line'].search([('bom_id', '=', obj().env.ref('mrp.mrp_bom_desk').id)]).ids"/>
+            <value eval="{'operation_id': ref('mrp.mrp_routing_workcenter_5')}"/>
+        </function>
 
         <!-- Table MO -->
         <record id="mrp_production_3" model="mrp.production">
@@ -303,6 +298,11 @@
             <field name="product_tmpl_id" ref="product_product_computer_desk_head_product_template"/>
             <field name="product_uom_id" ref="uom.product_uom_unit"/>
             <field name="sequence">1</field>
+            <field name="bom_line_ids" model="mrp.bom.line"
+                eval="[(0, 0, {'product_id': ref('product_product_wood_panel'),
+                               'product_uom_id': ref('uom.product_uom_unit'),
+                               'product_qty': 2,
+                               'sequence': 1})]"/>
         </record>
         <record id="mrp_routing_workcenter_0" model="mrp.routing.workcenter">
             <field name="bom_id" ref="mrp_bom_table_top"/>
@@ -313,13 +313,6 @@
             <field name="worksheet" type="base64" file="mrp/static/img/assebly-worksheet.pdf"/>
         </record>
 
-        <record id="mrp_bom_line_wood_panel" model="mrp.bom.line">
-            <field name="product_id" ref="product_product_wood_panel"/>
-            <field name="product_qty">2</field>
-            <field name="product_uom_id" ref="uom.product_uom_unit"/>
-            <field name="sequence">1</field>
-            <field name="bom_id" ref="mrp_bom_table_top"/>
-        </record>
         <record id="mrp_bom_line_plastic_laminate" model="mrp.bom.line">
             <field name="product_id" ref="product_product_plastic_laminate"/>
             <field name="product_qty">4</field>
@@ -332,6 +325,11 @@
             <field name="product_tmpl_id" ref="product_product_plastic_laminate_product_template"/>
             <field name="product_uom_id" ref="uom.product_uom_unit"/>
             <field name="sequence">1</field>
+            <field name="bom_line_ids" model="mrp.bom.line"
+                eval="[(0, 0, {'product_id': ref('product_product_ply_veneer'),
+                               'product_uom_id': ref('uom.product_uom_unit'),
+                               'product_qty': 1,
+                               'sequence': 1})]"/>
         </record>
         <record id="mrp_routing_workcenter_1" model="mrp.routing.workcenter">
             <field name="bom_id" ref="mrp_bom_plastic_laminate"/>
@@ -359,25 +357,16 @@
             <field name="sequence">5</field>
             <field name="worksheet" type="base64" file="mrp/static/img/cutting-worksheet.pdf"/>
         </record>
-        <record id="mrp_bom_line_plastic_laminate" model="mrp.bom.line">
-            <field name="product_id" ref="product_product_ply_veneer"/>
-            <field name="product_qty">1</field>
-            <field name="product_uom_id" ref="uom.product_uom_unit"/>
-            <field name="sequence">1</field>
-            <field name="bom_id" ref="mrp_bom_plastic_laminate"/>
-        </record>
 
         <record id="mrp_bom_wood_panel" model="mrp.bom">
             <field name="product_tmpl_id" ref="product_product_wood_panel_product_template"/>
             <field name="product_uom_id" ref="uom.product_uom_unit"/>
             <field name="sequence">1</field>
-        </record>
-        <record id="mrp_bom_line_wood_panel_ply" model="mrp.bom.line">
-            <field name="product_id" ref="product_product_wood_ply"/>
-            <field name="product_qty">3</field>
-            <field name="product_uom_id" ref="uom.product_uom_unit"/>
-            <field name="sequence">1</field>
-            <field name="bom_id" ref="mrp_bom_wood_panel"/>
+            <field name="bom_line_ids" model="mrp.bom.line"
+                eval="[(0, 0, {'product_id': ref('product_product_wood_ply'),
+                               'product_uom_id': ref('uom.product_uom_unit'),
+                               'product_qty': 3,
+                               'sequence': 1})]"/>
         </record>
         <record id="mrp_bom_line_wood_panel_wear" model="mrp.bom.line">
             <field name="product_id" ref="product_product_wood_wear"/>
@@ -429,13 +418,11 @@
             <field name="product_uom_id" ref="uom.product_uom_unit"/>
             <field name="sequence">2</field>
             <field name="type">phantom</field>
-        </record>
-
-        <record id="mrp_bom_kit_line_1" model="mrp.bom.line">
-            <field name="product_id" ref="product_product_wood_panel"/>
-            <field name="product_qty">1</field>
-            <field name="product_uom_id" ref="uom.product_uom_unit"/>
-            <field name="bom_id" ref="mrp_bom_kit"/>
+            <field name="bom_line_ids" model="mrp.bom.line"
+                eval="[(0, 0, {'product_id': ref('product_product_wood_panel'),
+                               'product_uom_id': ref('uom.product_uom_unit'),
+                               'product_qty': 1,
+                               'sequence': 1})]"/>
         </record>
 
         <record id="mrp_bom_kit_line_2" model="mrp.bom.line">
@@ -579,13 +566,11 @@
             <field name="product_uom_id" ref="uom.product_uom_unit"/>
             <field name="sequence">1</field>
             <field name="code">PRIM-ASSEM</field>
-        </record>
-        <record id="mrp_bom_laptop_cust_line_1" model="mrp.bom.line">
-            <field name="product_id" ref="product_product_drawer_drawer"/>
-            <field name="product_qty">1</field>
-            <field name="product_uom_id" ref="uom.product_uom_unit"/>
-            <field name="sequence">1</field>
-            <field name="bom_id" ref="mrp_bom_laptop_cust"/>
+            <field name="bom_line_ids" model="mrp.bom.line"
+                eval="[(0, 0, {'product_id': ref('product_product_drawer_drawer'),
+                               'product_uom_id': ref('uom.product_uom_unit'),
+                               'product_qty': 1,
+                               'sequence': 1})]"/>
         </record>
         <record id="mrp_bom_laptop_cust_line_2" model="mrp.bom.line">
             <field name="product_id" ref="product_product_drawer_case"/>
@@ -600,6 +585,11 @@
             <field name="product_uom_id" ref="uom.product_uom_unit"/>
             <field name="sequence">2</field>
             <field name="code">SEC-ASSEM</field>
+            <field name="bom_line_ids" model="mrp.bom.line"
+                eval="[(0, 0, {'product_id': ref('product_product_drawer_drawer'),
+                               'product_uom_id': ref('uom.product_uom_unit'),
+                               'product_qty': 1,
+                               'sequence': 1})]"/>
         </record>
         <record id="mrp_routing_workcenter_1" model="mrp.routing.workcenter">
             <field name="bom_id" ref="mrp_bom_laptop_cust_rout"/>
@@ -626,13 +616,6 @@
             <field name="time_cycle">30</field>
             <field name="sequence">5</field>
             <field name="worksheet" type="base64" file="mrp/static/img/cutting-worksheet.pdf"/>
-        </record>
-        <record id="mrp_bom_laptop_cust_rout_line_1" model="mrp.bom.line">
-            <field name="product_id" ref="product_product_drawer_drawer"/>
-            <field name="product_qty">1</field>
-            <field name="product_uom_id" ref="uom.product_uom_unit"/>
-            <field name="sequence">1</field>
-            <field name="bom_id" ref="mrp_bom_laptop_cust_rout"/>
         </record>
         <record id="mrp_bom_laptop_cust_rout_line_2" model="mrp.bom.line">
             <field name="product_id" ref="product_product_drawer_case"/>

--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -88,6 +88,7 @@ class MrpBom(models.Model):
     @api.constrains('product_id', 'product_tmpl_id', 'bom_line_ids')
     def _check_bom_lines(self):
         for bom in self:
+            has_non_service_bom_line = False
             for bom_line in bom.bom_line_ids:
                 if bom.product_id:
                     same_product = bom.product_id == bom_line.product_id
@@ -106,6 +107,10 @@ class MrpBom(models.Model):
                             product=ptav.product_tmpl_id.display_name,
                             bom_product=bom_line.parent_product_tmpl_id.display_name
                         ))
+                if not has_non_service_bom_line and bom_line.product_id.product_tmpl_id.type != 'service':
+                    has_non_service_bom_line = True
+            if not has_non_service_bom_line:
+                raise ValidationError(_("BoM requires at least one (non-service) BoM line product."))
 
     @api.onchange('product_uom_id')
     def onchange_product_uom_id(self):

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -27,6 +27,7 @@ class TestBoM(TestMrpCommon):
             'product_uom_id': self.uom_unit.id,
             'product_qty': 4.0,
             'type': 'normal',
+            'bom_line_ids': [(0, 0, {'product_id': self.product_2.id, 'product_qty': 2,})],
         })
         test_bom.write({
             'operation_ids': [
@@ -34,11 +35,7 @@ class TestBoM(TestMrpCommon):
                 (0, 0, {'name': 'Weld Machine', 'workcenter_id': self.workcenter_1.id, 'time_cycle': 18, 'sequence': 2}),
             ],
         })
-        test_bom_l1 = self.env['mrp.bom.line'].create({
-            'bom_id': test_bom.id,
-            'product_id': self.product_2.id,
-            'product_qty': 2,
-        })
+        test_bom_l1 = test_bom.bom_line_ids[0]
         test_bom_l2 = self.env['mrp.bom.line'].create({
             'bom_id': test_bom.id,
             'product_id': self.product_3.id,
@@ -83,17 +80,13 @@ class TestBoM(TestMrpCommon):
             'product_tmpl_id': self.product_5.product_tmpl_id.id,
             'product_uom_id': self.product_5.uom_id.id,
             'product_qty': 1.0,
-            'type': 'phantom'
+            'type': 'phantom',
+            'bom_line_ids': [(0, 0, {'product_id': self.product_3.id, 'product_qty': 3,})],
         })
         test_bom_1.write({
             'operation_ids': [
                 (0, 0, {'name': 'Gift Wrap Maching', 'workcenter_id': self.workcenter_1.id, 'time_cycle': 15, 'sequence': 1}),
             ],
-        })
-        test_bom_1_l1 = self.env['mrp.bom.line'].create({
-            'bom_id': test_bom_1.id,
-            'product_id': self.product_3.id,
-            'product_qty': 3,
         })
 
         test_bom_2 = self.env['mrp.bom'].create({
@@ -102,6 +95,7 @@ class TestBoM(TestMrpCommon):
             'product_uom_id': self.uom_unit.id,
             'product_qty': 4.0,
             'type': 'normal',
+            'bom_line_ids': [(0, 0, {'product_id': self.product_2.id, 'product_qty': 2,})],
         })
         test_bom_2.write({
             'operation_ids': [
@@ -109,11 +103,7 @@ class TestBoM(TestMrpCommon):
                 (0, 0, {'name': 'Weld Machine', 'workcenter_id': self.workcenter_1.id, 'time_cycle': 18, 'sequence': 2}),
             ]
         })
-        test_bom_2_l1 = self.env['mrp.bom.line'].create({
-            'bom_id': test_bom_2.id,
-            'product_id': self.product_2.id,
-            'product_qty': 2,
-        })
+        test_bom_2_l1 = test_bom_2.bom_line_ids[0]
         test_bom_2_l2 = self.env['mrp.bom.line'].create({
             'bom_id': test_bom_2.id,
             'product_id': self.product_5.id,
@@ -158,7 +148,8 @@ class TestBoM(TestMrpCommon):
             'product_uom_id': self.product_9.uom_id.id,
             'product_qty': 1.0,
             'consumption': 'flexible',
-            'type': 'normal'
+            'type': 'normal',
+            'bom_line_ids': [(0, 0, {'product_id': self.product_10.id, 'product_qty': 1.0,})],
         })
         test_bom_4 = self.env['mrp.bom'].create({
             'product_id': self.product_10.id,
@@ -166,17 +157,8 @@ class TestBoM(TestMrpCommon):
             'product_uom_id': self.product_10.uom_id.id,
             'product_qty': 1.0,
             'consumption': 'flexible',
-            'type': 'phantom'
-        })
-        test_bom_3_l1 = self.env['mrp.bom.line'].create({
-            'bom_id': test_bom_3.id,
-            'product_id': self.product_10.id,
-            'product_qty': 1.0,
-        })
-        test_bom_4_l1 = self.env['mrp.bom.line'].create({
-            'bom_id': test_bom_4.id,
-            'product_id': self.product_9.id,
-            'product_qty': 1.0,
+            'type': 'phantom',
+            'bom_line_ids': [(0, 0, {'product_id': self.product_9.id, 'product_qty': 1.0,})],
         })
         with self.assertRaises(exceptions.UserError):
             test_bom_3.explode(self.product_9, 1)
@@ -292,6 +274,14 @@ class TestBoM(TestMrpCommon):
         bom_form_crumble.product_tmpl_id = crumble.product_tmpl_id
         bom_form_crumble.product_qty = 11
         bom_form_crumble.product_uom_id = uom_kg
+        with bom_form_crumble.bom_line_ids.new() as line:
+            line.product_id = butter
+            line.product_uom_id = uom_kg
+            line.product_qty = 5
+        with bom_form_crumble.bom_line_ids.new() as line:
+            line.product_id = biscuit
+            line.product_uom_id = uom_kg
+            line.product_qty = 6
         bom_crumble = bom_form_crumble.save()
 
         workcenter = self.env['mrp.workcenter'].create({
@@ -300,14 +290,6 @@ class TestBoM(TestMrpCommon):
         })
 
         with Form(bom_crumble) as bom:
-            with bom.bom_line_ids.new() as line:
-                line.product_id = butter
-                line.product_uom_id = uom_kg
-                line.product_qty = 5
-            with bom.bom_line_ids.new() as line:
-                line.product_id = biscuit
-                line.product_uom_id = uom_kg
-                line.product_qty = 6
             with bom.operation_ids.new() as operation:
                 operation.workcenter_id = workcenter
                 operation.name = 'Prepare biscuits'
@@ -387,6 +369,14 @@ class TestBoM(TestMrpCommon):
         bom_form_cheese_cake.product_tmpl_id = cheese_cake.product_tmpl_id
         bom_form_cheese_cake.product_qty = 60
         bom_form_cheese_cake.product_uom_id = self.uom_unit
+        with bom_form_cheese_cake.bom_line_ids.new() as line:
+            line.product_id = cream
+            line.product_uom_id = uom_litre
+            line.product_qty = 3
+        with bom_form_cheese_cake.bom_line_ids.new() as line:
+            line.product_id = crumble
+            line.product_uom_id = uom_kg
+            line.product_qty = 5.4
         bom_cheese_cake = bom_form_cheese_cake.save()
 
         workcenter_2 = self.env['mrp.workcenter'].create({
@@ -397,14 +387,6 @@ class TestBoM(TestMrpCommon):
         })
 
         with Form(bom_cheese_cake) as bom:
-            with bom.bom_line_ids.new() as line:
-                line.product_id = cream
-                line.product_uom_id = uom_litre
-                line.product_qty = 3
-            with bom.bom_line_ids.new() as line:
-                line.product_id = crumble
-                line.product_uom_id = uom_kg
-                line.product_qty = 5.4
             with bom.operation_ids.new() as operation:
                 operation.workcenter_id = workcenter
                 operation.name = 'Mix cheese and crumble'

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -1219,9 +1219,15 @@ class TestMrpOrder(TestMrpCommon):
         })
 
         # Create service type product
-        product_raw = self.env['product.product'].create({
+        product_service = self.env['product.product'].create({
             'name': 'raw Geyser',
             'type': 'service',
+        })
+
+        # Create non-service type product for BOM
+        product_consu = self.env['product.product'].create({
+            'name': 'water',
+            'type': 'consu',
         })
 
         # Create bom for finish product
@@ -1231,7 +1237,7 @@ class TestMrpOrder(TestMrpCommon):
             'product_uom_id': self.env.ref('uom.product_uom_unit').id,
             'product_qty': 1.0,
             'type': 'normal',
-            'bom_line_ids': [(5, 0), (0, 0, {'product_id': product_raw.id})]
+            'bom_line_ids': [(5, 0), (0, 0, {'product_id': product_service.id}), (0, 0, {'product_id': product_consu.id})]
         })
 
         mo_form = Form(self.env['mrp.production'])

--- a/addons/mrp/tests/test_procurement.py
+++ b/addons/mrp/tests/test_procurement.py
@@ -298,54 +298,54 @@ class TestProcurement(TestMrpCommon):
         self.assertEqual(mo.move_finished_ids[0].state, 'cancel', 'Finished move should be cancelled if mo is cancelled.')
         self.assertEqual(mo.move_dest_ids[0].state, 'waiting', 'Destination move should not be cancelled if prapogation cancel is False on manufacturing rule.')
 
-    def test_procurement_with_empty_bom(self):
-        """Ensure that a procurement request using a product with an empty BoM
-        will create a MO in draft state that could be completed afterwards.
-        """
-        self.warehouse = self.env.ref('stock.warehouse0')
-        route_manufacture = self.warehouse.manufacture_pull_id.route_id.id
-        route_mto = self.warehouse.mto_pull_id.route_id.id
-        product = self.env['product.product'].create({
-            'name': 'Clafoutis',
-            'route_ids': [(6, 0, [route_manufacture, route_mto])]
-        })
-        self.env['mrp.bom'].create({
-            'product_id': product.id,
-            'product_tmpl_id': product.product_tmpl_id.id,
-            'product_uom_id': self.uom_unit.id,
-            'product_qty': 1.0,
-            'type': 'normal',
-        })
-        move_dest = self.env['stock.move'].create({
-            'name': 'Customer MTO Move',
-            'product_id': product.id,
-            'product_uom': self.ref('uom.product_uom_unit'),
-            'location_id': self.ref('stock.stock_location_stock'),
-            'location_dest_id': self.ref('stock.stock_location_output'),
-            'product_uom_qty': 10,
-            'procure_method': 'make_to_order',
-        })
-        move_dest._action_confirm()
+    # def test_procurement_with_empty_bom(self):
+    #     """Ensure that a procurement request using a product with an empty BoM
+    #     will create a MO in draft state that could be completed afterwards.
+    #     """
+    #     self.warehouse = self.env.ref('stock.warehouse0')
+    #     route_manufacture = self.warehouse.manufacture_pull_id.route_id.id
+    #     route_mto = self.warehouse.mto_pull_id.route_id.id
+    #     product = self.env['product.product'].create({
+    #         'name': 'Clafoutis',
+    #         'route_ids': [(6, 0, [route_manufacture, route_mto])]
+    #     })
+    #     self.env['mrp.bom'].create({
+    #         'product_id': product.id,
+    #         'product_tmpl_id': product.product_tmpl_id.id,
+    #         'product_uom_id': self.uom_unit.id,
+    #         'product_qty': 1.0,
+    #         'type': 'normal',
+    #     })
+    #     move_dest = self.env['stock.move'].create({
+    #         'name': 'Customer MTO Move',
+    #         'product_id': product.id,
+    #         'product_uom': self.ref('uom.product_uom_unit'),
+    #         'location_id': self.ref('stock.stock_location_stock'),
+    #         'location_dest_id': self.ref('stock.stock_location_output'),
+    #         'product_uom_qty': 10,
+    #         'procure_method': 'make_to_order',
+    #     })
+    #     move_dest._action_confirm()
 
-        production = self.env['mrp.production'].search([('product_id', '=', product.id)])
-        self.assertTrue(production)
-        self.assertFalse(production.move_raw_ids)
-        self.assertEqual(production.state, 'draft')
+    #     production = self.env['mrp.production'].search([('product_id', '=', product.id)])
+    #     self.assertTrue(production)
+    #     self.assertFalse(production.move_raw_ids)
+    #     self.assertEqual(production.state, 'draft')
 
-        comp1 = self.env['product.product'].create({
-            'name': 'egg',
-        })
-        move_values = production._get_move_raw_values(comp1, 40.0, self.env.ref('uom.product_uom_unit'))
-        self.env['stock.move'].create(move_values)
+    #     comp1 = self.env['product.product'].create({
+    #         'name': 'egg',
+    #     })
+    #     move_values = production._get_move_raw_values(comp1, 40.0, self.env.ref('uom.product_uom_unit'))
+    #     self.env['stock.move'].create(move_values)
 
-        production.action_confirm()
-        produce_form = Form(production)
-        produce_form.qty_producing = production.product_qty
-        production = produce_form.save()
-        production.button_mark_done()
+    #     production.action_confirm()
+    #     produce_form = Form(production)
+    #     produce_form.qty_producing = production.product_qty
+    #     production = produce_form.save()
+    #     production.button_mark_done()
 
-        move_dest._action_assign()
-        self.assertEqual(move_dest.reserved_availability, 10.0)
+    #     move_dest._action_assign()
+    #     self.assertEqual(move_dest.reserved_availability, 10.0)
 
     def test_auto_assign(self):
         """ When auto reordering rule exists, check for when:

--- a/addons/mrp/tests/test_stock.py
+++ b/addons/mrp/tests/test_stock.py
@@ -218,57 +218,41 @@ class TestKitPicking(common.TestMrpCommon):
         bom_kit_1 = self.env['mrp.bom'].create({
             'product_tmpl_id': kit_1.product_tmpl_id.id,
             'product_qty': 1.0,
-            'type': 'phantom'})
-        BomLine = self.env['mrp.bom.line']
-        BomLine.create({
-            'product_id': component_a.id,
-            'product_qty': 2.0,
-            'bom_id': bom_kit_1.id})
-        BomLine.create({
-            'product_id': component_b.id,
-            'product_qty': 1.0,
-            'bom_id': bom_kit_1.id})
-        BomLine.create({
-            'product_id': component_c.id,
-            'product_qty': 3.0,
-            'bom_id': bom_kit_1.id})
+            'type': 'phantom',
+            'bom_line_ids': [
+                (0, 0, {'product_id': component_a.id, 'product_qty': 2.0,}),
+                (0, 0, {'product_id': component_b.id, 'product_qty': 1.0,}),
+                (0, 0, {'product_id': component_c.id, 'product_qty': 3.0,}),
+            ]
+        })
         bom_kit_2 = self.env['mrp.bom'].create({
             'product_tmpl_id': kit_2.product_tmpl_id.id,
             'product_qty': 1.0,
-            'type': 'phantom'})
-        BomLine.create({
-            'product_id': component_d.id,
-            'product_qty': 1.0,
-            'bom_id': bom_kit_2.id})
-        BomLine.create({
-            'product_id': kit_1.id,
-            'product_qty': 2.0,
-            'bom_id': bom_kit_2.id})
+            'type': 'phantom',
+            'bom_line_ids': [
+                (0, 0, {'product_id': component_d.id, 'product_qty': 1.0,}),
+                (0, 0, {'product_id': kit_1.id, 'product_qty': 2.0,}),
+            ]
+        })
         bom_kit_parent = self.env['mrp.bom'].create({
             'product_tmpl_id': self.kit_parent.product_tmpl_id.id,
             'product_qty': 1.0,
-            'type': 'phantom'})
-        BomLine.create({
-            'product_id': component_e.id,
-            'product_qty': 1.0,
-            'bom_id': bom_kit_parent.id})
-        BomLine.create({
-            'product_id': kit_2.id,
-            'product_qty': 2.0,
-            'bom_id': bom_kit_parent.id})
+            'type': 'phantom',
+            'bom_line_ids': [
+                (0, 0, {'product_id': component_e.id, 'product_qty': 1.0,}),
+                (0, 0, {'product_id': kit_2.id, 'product_qty': 2.0,})
+            ]
+        })
         bom_kit_3 = self.env['mrp.bom'].create({
             'product_tmpl_id': kit_3.product_tmpl_id.id,
             'product_qty': 1.0,
-            'type': 'phantom'})
-        BomLine.create({
-            'product_id': component_f.id,
-            'product_qty': 1.0,
-            'bom_id': bom_kit_3.id})
-        BomLine.create({
-            'product_id': component_g.id,
-            'product_qty': 2.0,
-            'bom_id': bom_kit_3.id})
-        BomLine.create({
+            'type': 'phantom',
+            'bom_line_ids': [
+                (0, 0, {'product_id': component_f.id, 'product_qty': 1.0,}),
+                (0, 0, {'product_id': component_g.id, 'product_qty': 2.0,}),
+            ]
+        })
+        self.env['mrp.bom.line'].create({
             'product_id': kit_3.id,
             'product_qty': 1.0,
             'bom_id': bom_kit_parent.id})

--- a/addons/mrp_account/tests/test_mrp_account.py
+++ b/addons/mrp_account/tests/test_mrp_account.py
@@ -40,7 +40,7 @@ class TestMrpAccount(TestMrpCommon):
             'type': 'normal',
             'bom_line_ids': [
                 (0, 0, {'product_id': cls.product_2.id, 'product_qty': 2}),
-                (0, 0, {'product_id': cls.product_1.id, 'product_qty': 4})
+                (0, 0, {'product_id': cls.product_1.id, 'product_qty': 4}),
             ]})
         cls.dining_table = cls.env['product.product'].create({
             'name': 'Table (MTO)',
@@ -78,34 +78,31 @@ class TestMrpAccount(TestMrpCommon):
             'operation_ids': [
                 (0, 0, {'workcenter_id': cls.mrp_workcenter.id, 'name': 'Manual Assembly'}),
             ],
-        })
-        cls.mrp_bom_desk.write({
             'bom_line_ids': [
                 (0, 0, {
                     'product_id': cls.product_table_sheet.id,
                     'product_qty': 1,
                     'product_uom_id': cls.env.ref('uom.product_uom_unit').id,
-                    'sequence': 1,
-                    'operation_id': cls.mrp_bom_desk.operation_ids.id}),
+                    'sequence': 1}),
                 (0, 0, {
                     'product_id': cls.product_table_leg.id,
                     'product_qty': 4,
                     'product_uom_id': cls.env.ref('uom.product_uom_unit').id,
-                    'sequence': 2,
-                    'operation_id': cls.mrp_bom_desk.operation_ids.id}),
+                    'sequence': 2}),
                 (0, 0, {
                     'product_id': cls.product_bolt.id,
                     'product_qty': 4,
                     'product_uom_id': cls.env.ref('uom.product_uom_unit').id,
-                    'sequence': 3,
-                    'operation_id': cls.mrp_bom_desk.operation_ids.id}),
+                    'sequence': 3}),
                 (0, 0, {
                     'product_id': cls.product_screw.id,
                     'product_qty': 10,
                     'product_uom_id': cls.env.ref('uom.product_uom_unit').id,
-                    'sequence': 4,
-                    'operation_id': cls.mrp_bom_desk.operation_ids.id}),
+                    'sequence': 4}),
             ]
+        })
+        cls.mrp_bom_desk.bom_line_ids.write({
+            'operation_id': cls.mrp_bom_desk.operation_ids.id
         })
         cls.mrp_workcenter_1 = cls.env['mrp.workcenter'].create({
             'name': 'Drill Station 1',

--- a/addons/mrp_landed_costs/tests/test_stock_landed_costs_mrp.py
+++ b/addons/mrp_landed_costs/tests/test_stock_landed_costs_mrp.py
@@ -44,12 +44,11 @@ class TestStockLandedCostsMrp(ValuationReconciliationTestCommon):
             'product_uom_id': cls.uom_unit.id,
             'product_qty': 1.0,
             'type': 'normal',
+            'bom_line_ids': [
+                (0, 0, {'product_id': cls.product_component1.id, 'product_qty': 3}),
+            ]
         })
-        cls.bom_refri_line1 = cls.env['mrp.bom.line'].create({
-            'bom_id': cls.bom_refri.id,
-            'product_id': cls.product_component1.id,
-            'product_qty': 3,
-        })
+        cls.bom_refri_line1 = cls.bom_refri.bom_line_ids[0]
         cls.bom_refri_line2 = cls.env['mrp.bom.line'].create({
             'bom_id': cls.bom_refri.id,
             'product_id': cls.product_component2.id,

--- a/addons/mrp_subcontracting/data/mrp_subcontracting_demo.xml
+++ b/addons/mrp_subcontracting/data/mrp_subcontracting_demo.xml
@@ -6,13 +6,10 @@
             <field name="product_uom_id" ref="uom.product_uom_unit"/>
             <field name="type">subcontract</field>
             <field name="subcontractor_ids" eval="[(4, ref('base.res_partner_12'))]"/>
-        </record>
-
-        <record id="mrp_bom_line_subcontract" model="mrp.bom.line">
-            <field name="product_id" ref="mrp.product_product_computer_desk_screw"/>
-            <field name="product_qty">1</field>
-            <field name="product_uom_id" ref="uom.product_uom_unit"/>
-            <field name="bom_id" ref="mrp_bom_subcontract"/>
+            <field name="bom_line_ids" model="mrp.bom.line" eval="[(0, 0, {
+                'product_id': ref('mrp.product_product_computer_desk_screw'),
+                'product_uom_id': ref('uom.product_uom_unit'),
+                'product_qty': 1,})]"/>
         </record>
 
         <record id="product_supplierinfo_subcontracting" model="product.supplierinfo">

--- a/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
+++ b/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
@@ -60,22 +60,13 @@ class TestSaleMrpFlow(TransactionCase):
         self.bom_kit_1 = self.env['mrp.bom'].create({
             'product_tmpl_id': self.kit_1.product_tmpl_id.id,
             'product_qty': 1.0,
-            'type': 'phantom'})
-
-        BomLine = self.env['mrp.bom.line']
-        BomLine.create({
-            'product_id': self.component_a.id,
-            'product_qty': 2.0,
-            'bom_id': self.bom_kit_1.id})
-        BomLine.create({
-            'product_id': self.component_b.id,
-            'product_qty': 1.0,
-            'bom_id': self.bom_kit_1.id})
-        BomLine.create({
-            'product_id': self.component_c.id,
-            'product_qty': 3.0,
-            'bom_id': self.bom_kit_1.id})
-
+            'type': 'phantom',
+            'bom_line_ids': [
+                (0, 0, {'product_id': self.component_a.id, 'product_qty': 2.0,}),
+                (0, 0, {'product_id': self.component_b.id, 'product_qty': 1.0,}),
+                (0, 0, {'product_id': self.component_c.id, 'product_qty': 3.0,}),
+            ]
+        })
         # Create a kit 'kit_parent' :
         # ---------------------------
         #
@@ -98,46 +89,31 @@ class TestSaleMrpFlow(TransactionCase):
         bom_kit_2 = self.env['mrp.bom'].create({
             'product_tmpl_id': self.kit_2.product_tmpl_id.id,
             'product_qty': 1.0,
-            'type': 'phantom'})
-
-        BomLine.create({
-            'product_id': self.component_d.id,
-            'product_qty': 1.0,
-            'bom_id': bom_kit_2.id})
-        BomLine.create({
-            'product_id': self.kit_1.id,
-            'product_qty': 2.0,
-            'bom_id': bom_kit_2.id})
-
+            'type': 'phantom',
+            'bom_line_ids': [
+                (0, 0, {'product_id': self.component_d.id, 'product_qty': 1.0,}),
+                (0, 0, {'product_id': self.kit_1.id, 'product_qty': 2.0,}),
+            ]
+        })
         bom_kit_parent = self.env['mrp.bom'].create({
             'product_tmpl_id': self.kit_parent.product_tmpl_id.id,
             'product_qty': 1.0,
-            'type': 'phantom'})
-
-        BomLine.create({
-            'product_id': self.component_e.id,
-            'product_qty': 1.0,
-            'bom_id': bom_kit_parent.id})
-        BomLine.create({
-            'product_id': self.kit_2.id,
-            'product_qty': 2.0,
-            'bom_id': bom_kit_parent.id})
-
+            'type': 'phantom',
+            'bom_line_ids': [
+                (0, 0, {'product_id': self.component_e.id, 'product_qty': 1.0,}),
+                (0, 0, {'product_id': self.kit_2.id, 'product_qty': 2.0,}),
+            ]
+        })
         bom_kit_3 = self.env['mrp.bom'].create({
             'product_tmpl_id': self.kit_3.product_tmpl_id.id,
             'product_qty': 1.0,
-            'type': 'phantom'})
-
-        BomLine.create({
-            'product_id': self.component_f.id,
-            'product_qty': 1.0,
-            'bom_id': bom_kit_3.id})
-        BomLine.create({
-            'product_id': self.component_g.id,
-            'product_qty': 2.0,
-            'bom_id': bom_kit_3.id})
-
-        BomLine.create({
+            'type': 'phantom',
+            'bom_line_ids': [
+                (0, 0, {'product_id': self.component_f.id, 'product_qty': 1.0,}),
+                (0, 0, {'product_id': self.component_g.id, 'product_qty': 2.0,}),
+            ]
+        })
+        self.env['mrp.bom.line'].create({
             'product_id': self.kit_3.id,
             'product_qty': 2.0,
             'bom_id': bom_kit_parent.id})

--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -69,21 +69,13 @@ class TestSaleMrpFlow(ValuationReconciliationTestCommon):
         cls.bom_kit_1 = cls.env['mrp.bom'].create({
             'product_tmpl_id': cls.kit_1.product_tmpl_id.id,
             'product_qty': 1.0,
-            'type': 'phantom'})
-
-        BomLine = cls.env['mrp.bom.line']
-        BomLine.create({
-            'product_id': cls.component_a.id,
-            'product_qty': 2.0,
-            'bom_id': cls.bom_kit_1.id})
-        BomLine.create({
-            'product_id': cls.component_b.id,
-            'product_qty': 1.0,
-            'bom_id': cls.bom_kit_1.id})
-        BomLine.create({
-            'product_id': cls.component_c.id,
-            'product_qty': 3.0,
-            'bom_id': cls.bom_kit_1.id})
+            'type': 'phantom',
+            'bom_line_ids': [
+                (0, 0, {'product_id': cls.component_a.id, 'product_qty': 2.0}),
+                (0, 0, {'product_id': cls.component_b.id, 'product_qty': 1.0}),
+                (0, 0, {'product_id': cls.component_c.id, 'product_qty': 3.0}),
+            ]
+        })
 
         # Create a kit 'kit_parent' :
         # ---------------------------
@@ -107,46 +99,34 @@ class TestSaleMrpFlow(ValuationReconciliationTestCommon):
         bom_kit_2 = cls.env['mrp.bom'].create({
             'product_tmpl_id': cls.kit_2.product_tmpl_id.id,
             'product_qty': 1.0,
-            'type': 'phantom'})
-
-        BomLine.create({
-            'product_id': cls.component_d.id,
-            'product_qty': 1.0,
-            'bom_id': bom_kit_2.id})
-        BomLine.create({
-            'product_id': cls.kit_1.id,
-            'product_qty': 2.0,
-            'bom_id': bom_kit_2.id})
+            'type': 'phantom',
+            'bom_line_ids': [
+                (0, 0, {'product_id': cls.component_d.id, 'product_qty': 1.0}),
+                (0, 0, {'product_id': cls.kit_1.id, 'product_qty': 2.0}),
+            ]
+        })
 
         bom_kit_parent = cls.env['mrp.bom'].create({
             'product_tmpl_id': cls.kit_parent.product_tmpl_id.id,
             'product_qty': 1.0,
-            'type': 'phantom'})
-
-        BomLine.create({
-            'product_id': cls.component_e.id,
-            'product_qty': 1.0,
-            'bom_id': bom_kit_parent.id})
-        BomLine.create({
-            'product_id': cls.kit_2.id,
-            'product_qty': 2.0,
-            'bom_id': bom_kit_parent.id})
+            'type': 'phantom',
+            'bom_line_ids': [
+                (0, 0, {'product_id': cls.component_e.id, 'product_qty': 1.0}),
+                (0, 0, {'product_id': cls.kit_2.id, 'product_qty': 2.0}),
+            ]
+        })
 
         bom_kit_3 = cls.env['mrp.bom'].create({
             'product_tmpl_id': cls.kit_3.product_tmpl_id.id,
             'product_qty': 1.0,
-            'type': 'phantom'})
+            'type': 'phantom',
+            'bom_line_ids': [
+                (0, 0, {'product_id': cls.component_f.id, 'product_qty': 1.0}),
+                (0, 0, {'product_id': cls.component_g.id, 'product_qty': 2.0}),
+            ]
+        })
 
-        BomLine.create({
-            'product_id': cls.component_f.id,
-            'product_qty': 1.0,
-            'bom_id': bom_kit_3.id})
-        BomLine.create({
-            'product_id': cls.component_g.id,
-            'product_qty': 2.0,
-            'bom_id': bom_kit_3.id})
-
-        BomLine.create({
+        cls.env['mrp.bom.line'].create({
             'product_id': cls.kit_3.id,
             'product_qty': 2.0,
             'bom_id': bom_kit_parent.id})
@@ -642,16 +622,11 @@ class TestSaleMrpFlow(ValuationReconciliationTestCommon):
         self.bom = self.env['mrp.bom'].create({
                 'product_tmpl_id': self.finished_product.product_tmpl_id.id,
                 'product_qty': 1.0,
-                'type': 'phantom'})
-        BomLine = self.env['mrp.bom.line']
-        BomLine.create({
-                'product_id': self.component1.id,
-                'product_qty': 2.0,
-                'bom_id': self.bom.id})
-        BomLine.create({
-                'product_id': self.component2.id,
-                'product_qty': 1.0,
-                'bom_id': self.bom.id})
+                'type': 'phantom',
+                'bom_line_ids': [
+                    (0, 0, {'product_id': self.component1.id, 'product_qty': 2.0,}),
+                    (0, 0, {'product_id': self.component2.id, 'product_qty': 1.0,})
+                ]})
 
         # Create a SO for a specific partner for three units of the finished product
         so_vals = {
@@ -1143,24 +1118,19 @@ class TestSaleMrpFlow(ValuationReconciliationTestCommon):
         bom_kit_uom_1 = self.env['mrp.bom'].create({
             'product_tmpl_id': kit_uom_1.product_tmpl_id.id,
             'product_qty': 1.0,
-            'type': 'phantom'})
-
-        BomLine = self.env['mrp.bom.line']
-        BomLine.create({
-            'product_id': component_uom_unit.id,
-            'product_qty': 2.0,
-            'product_uom_id': self.uom_dozen.id,
-            'bom_id': bom_kit_uom_1.id})
-        BomLine.create({
-            'product_id': component_uom_dozen.id,
-            'product_qty': 1.0,
-            'product_uom_id': self.uom_dozen.id,
-            'bom_id': bom_kit_uom_1.id})
-        BomLine.create({
-            'product_id': component_uom_kg.id,
-            'product_qty': 3.0,
-            'product_uom_id': self.uom_gm.id,
-            'bom_id': bom_kit_uom_1.id})
+            'type': 'phantom',
+            'bom_line_ids': [
+                (0, 0, {'product_id': component_uom_unit.id,
+                        'product_qty': 2.0,
+                        'product_uom_id': self.uom_dozen.id,}),
+                (0, 0, {'product_id': component_uom_dozen.id,
+                        'product_qty': 1.0,
+                        'product_uom_id': self.uom_dozen.id,}),
+                (0, 0, {'product_id': component_uom_kg.id,
+                        'product_qty': 3.0,
+                        'product_uom_id': self.uom_gm.id,}),
+            ]
+        })
 
         # Updating the quantities in stock to prevent
         # a 'Not enough inventory' warning message.
@@ -1250,40 +1220,33 @@ class TestSaleMrpFlow(ValuationReconciliationTestCommon):
         bom_kit_uom_1 = self.env['mrp.bom'].create({
             'product_tmpl_id': kit_uom_1.product_tmpl_id.id,
             'product_qty': 1.0,
-            'type': 'phantom'})
-
-        BomLine = self.env['mrp.bom.line']
-        BomLine.create({
-            'product_id': component_uom_unit.id,
-            'product_qty': 2.0,
-            'product_uom_id': self.uom_dozen.id,
-            'bom_id': bom_kit_uom_1.id})
-        BomLine.create({
-            'product_id': component_uom_dozen.id,
-            'product_qty': 1.0,
-            'product_uom_id': self.uom_dozen.id,
-            'bom_id': bom_kit_uom_1.id})
-        BomLine.create({
-            'product_id': component_uom_kg.id,
-            'product_qty': 5.0,
-            'product_uom_id': self.uom_gm.id,
-            'bom_id': bom_kit_uom_1.id})
+            'type': 'phantom',
+            'bom_line_ids': [
+                (0, 0, {'product_id': component_uom_unit.id,
+                        'product_qty': 2.0,
+                        'product_uom_id': self.uom_dozen.id,}),
+                (0, 0, {'product_id': component_uom_dozen.id,
+                        'product_qty': 1.0,
+                        'product_uom_id': self.uom_dozen.id,}),
+                (0, 0, {'product_id': component_uom_kg.id,
+                        'product_qty': 5.0,
+                        'product_uom_id': self.uom_gm.id,}),
+            ]
+        })
 
         bom_kit_uom_in_kit = self.env['mrp.bom'].create({
             'product_tmpl_id': kit_uom_in_kit.product_tmpl_id.id,
             'product_qty': 1.0,
-            'type': 'phantom'})
-
-        BomLine.create({
-            'product_id': component_uom_gm.id,
-            'product_qty': 3.0,
-            'product_uom_id': self.uom_kg.id,
-            'bom_id': bom_kit_uom_in_kit.id})
-        BomLine.create({
-            'product_id': kit_uom_1.id,
-            'product_qty': 2.0,
-            'product_uom_id': self.uom_dozen.id,
-            'bom_id': bom_kit_uom_in_kit.id})
+            'type': 'phantom',
+            'bom_line_ids': [
+                (0, 0, {'product_id': component_uom_gm.id,
+                        'product_qty': 3.0,
+                        'product_uom_id': self.uom_kg.id,}),
+                (0, 0, {'product_id': kit_uom_1.id,
+                        'product_qty': 2.0,
+                        'product_uom_id': self.uom_dozen.id,}),
+            ]
+        })
 
         # Create a simple warehouse to receives some products
         warehouse_1 = self.env['stock.warehouse'].create({
@@ -1503,9 +1466,15 @@ class TestSaleMrpFlow(ValuationReconciliationTestCommon):
         })
 
         # Create service type product
-        product_raw = self.env['product.product'].create({
+        product_service = self.env['product.product'].create({
             'name': 'raw Geyser',
             'type': 'service',
+        })
+
+        # Create non-service type product for BOM
+        product_consu = self.env['product.product'].create({
+            'name': 'water',
+            'type': 'consu',
         })
 
         # Create bom for finish product
@@ -1515,7 +1484,7 @@ class TestSaleMrpFlow(ValuationReconciliationTestCommon):
             'product_uom_id': self.env.ref('uom.product_uom_unit').id,
             'product_qty': 1.0,
             'type': 'normal',
-            'bom_line_ids': [(5, 0), (0, 0, {'product_id': product_raw.id})]
+            'bom_line_ids': [(5, 0), (0, 0, {'product_id': product_service.id}), (0, 0, {'product_id': product_consu.id})]
         })
 
         # Create sale order


### PR DESCRIPTION
We already restrict a manufacturing order from having no move_raw_ids
(i.e. components), but previous to this commit we did not restrict the
bill of material from having no bom_line_ids (i.e. components). This
was leading to an issue where when a replenishment of a manufactured
product without components occurred, then the manufacturing order
couldn't be confirmed. This would lead to multiple draft MOs were the
amount needed to be replenished would accumulate for each new draft.

Steps to reproduce:
1. create a bom for a new product (w/ manufacturing route) with no
   components
2. create and confirm a sales order for the new product
3. go to Replenishment and automate the product's replenishment
4. create a new sales order for the product

Expected result: 2 confirmed MOs where the quantity of the first MO
matches the first sale order's quantity and the 2nd MO matches the
second sale order's quantity

Actual result: 2 draft MOs where the first MO matches the quantity of
the first sale order and the second MO matches the quantity of the first
sale order + the quantity of the second sale order

This commit makes it so boms now require components and updates the demo
data and tests to properly meet this requirement.

Task: 2422698
Enterprise PR: odoo/enterprise#15476

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
