### PR TITLE
[FIX] point_of_sale: Sales Team set on POS didn't appear on invoice

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -401,6 +401,8 @@ class PosOrder(models.Model):
             'invoice_line_ids': [(0, None, self._prepare_invoice_line(line)) for line in self.lines],
             'invoice_cash_rounding_id': self.config_id.rounding_method.id if self.config_id.cash_rounding else False
         }
+        if self.crm_team_id:
+            vals['team_id'] = self.crm_team_id.id
         return vals
 
     def action_pos_order_invoice(self):


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a sales team ST and a POS session PS
- Set ST on PS
- Open PS and make an invoice I from an order

Bug:

The sales team set on I was not ST

opw:2418806