### PR TITLE
[FIX] web_editor: allow mass mailing users to access the editor

### DIFF
--- a/addons/web_editor/models/ir_ui_view.py
+++ b/addons/web_editor/models/ir_ui_view.py
@@ -27,6 +27,29 @@ class IrUiView(models.Model):
 
         return super(IrUiView, self)._render(values=values, engine=engine, minimal_qcontext=minimal_qcontext)
 
+    @api.model
+    def read_template(self, xml_id):
+        if xml_id == 'web_editor.colorpicker' and self.env.user.has_group('base.group_user'):
+            # TODO this should be handled another way but was required as a
+            # stable fix in 14.0. The views are now private by default: they
+            # can be read thanks to read_template provided they declare a group
+            # that the user has and that the user has read access rights.
+            #
+            # For the case 'read_template web_editor.colorpicker', it works for
+            # website editor users as the view has the base.group_user group
+            # *and they have access rights thanks to publisher/designer groups*.
+            # For mass mailing users, no such group exists though so they simply
+            # do not have the rights to read that template anymore. Seems safer
+            # to force it for this template only while waiting for a better
+            # access rights refactoring.
+            #
+            # Note: using 'render_public_asset' which allows to bypass rights if
+            # the user has the group the view requires was also a solution.
+            # However, that would turn the 'read' into a 'render', which is
+            # a less stable change.
+            self = self.sudo()
+        return super().read_template(xml_id)
+
     #------------------------------------------------------
     # Save from html
     #------------------------------------------------------


### PR DESCRIPTION
Mass mailing users with low access rights were not able to access the
editor anymore if the website application was not installed (or any
other app giving ir.ui.view read access rights to the related users).

This commit fixes the problem but should be handled another way in a
future master refactoring. The problem was that the views are now
private by default: they can be read thanks to read_template provided
they declare a group that the user has and that the user has read access
rights.

For the case 'read_template web_editor.colorpicker', it works for
website editor users as the view has the base.group_user group
*and they have access rights thanks to publisher/designer groups*.
For mass mailing users, no such group exists though so they simply
do not have the rights to read that template anymore. Seems safer
to force it for this template only while waiting for a better
access rights refactoring.

Note: using 'render_public_asset' which allows to bypass rights if
the user has the group the view requires was also a solution.
However, that would turn the 'read' into a 'render', which is
a less stable change.

task-2412544
