### PR TITLE
[FIX] web: calendar_controller: Adapt date to server format on update

### DIFF
--- a/addons/web/static/src/js/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/js/views/calendar/calendar_controller.js
@@ -18,8 +18,12 @@ var QuickCreate = require('web.CalendarQuickCreate');
 var _t = core._t;
 var QWeb = core.qweb;
 
-function dateToServer (date) {
-    return date.clone().utc().locale('en').format('YYYY-MM-DD HH:mm:ss');
+function dateToServer (date, fieldType) {
+    date = date.clone().locale('en');
+    if (fieldType === "date") {
+        return date.local().format('YYYY-MM-DD');
+    }
+    return date.utc().format('YYYY-MM-DD HH:mm:ss');
 }
 
 var CalendarController = AbstractController.extend({
@@ -151,7 +155,7 @@ var CalendarController = AbstractController.extend({
             self._rpc({
                 model: self.modelName,
                 method: 'get_unusual_days',
-                args: [self.model.data.start_date.format('YYYY-MM-DD'), self.model.data.end_date.format('YYYY-MM-DD')],
+                args: [dateToServer(self.model.data.start_date, 'date'), dateToServer(self.model.data.end_date, 'date')],
                 context: self.context,
             }).then(function (data) {
                 _.each(self.$el.find('td.fc-day'), function (td) {


### PR DESCRIPTION
Issue

	- Install "Time-Off" module
	- Set user language to "Arabic"
	- Open "Time-Off"

	Traceback raised.

Cause

	Python 'datetime' library does not manage arabic date.

Solution

	Convert date format for the "server".
	In this case, it will also translate arabic numbers.

	Also, adapt "dateToServer" to handle any format.

opw-2421268