### PR TITLE
[FIX] purchase, purchase_product_matrix: Impossible to add a line

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -227,7 +227,7 @@
                                     <field
                                         name="product_id"
                                         attrs="{
-                                            'readonly': [('state', 'in', ('purchase', 'to approve','done', 'cancel'))],
+                                            'readonly': [('state', 'in', ('to approve','done', 'cancel'))],
                                             'required': [('display_type', '=', False)],
                                         }"
                                         context="{'partner_id':parent.partner_id, 'quantity':product_qty,'uom':product_uom, 'company_id': parent.company_id}"

--- a/addons/purchase_product_matrix/views/purchase_views.xml
+++ b/addons/purchase_product_matrix/views/purchase_views.xml
@@ -15,7 +15,7 @@
           <field name="product_template_id"
             string="Product"
             attrs="{
-                'readonly': [('state', 'in', ('purchase', 'to approve','done', 'cancel'))],
+                'readonly': [('state', 'in', ('to approve','done', 'cancel'))],
                 'required': [('display_type', '=', False)],
             }"
             options="{'no_open': True}"


### PR DESCRIPTION
Steps to reproduce the bug:

- Create PO and add a product P1 on it
- Confirm the PO
- Try to add an other product P2 on PO

Bug:

The field product_id was in readonly when the state of the PO is purchase

In 13.0, it is possible to add P2 when PO is in state purchase
To lock a PO, the state done [Locked] already exists

opw:2421785