### PR TITLE
[FIX] mail: fix the attachment and document count in sync

### DIFF
--- a/addons/hr/views/hr_job_views.xml
+++ b/addons/hr/views/hr_job_views.xml
@@ -33,7 +33,7 @@
                         </div>
                     </sheet>
                     <div class="oe_chatter">
-                        <field name="message_follower_ids" widget="mail_followers"/>
+                        <field name="message_follower_ids" widget="mail_followers" options="{'post_refresh': 'always'}"/>
                     </div>
                 </form>
             </field>

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -116,7 +116,7 @@
                 <div class="oe_chatter">
                     <field name="message_follower_ids" widget="mail_followers"/>
                     <field name="activity_ids" widget="mail_activity"/>
-                    <field name="message_ids" widget="mail_thread"/>
+                    <field name="message_ids" widget="mail_thread" options="{'post_refresh': 'always'}"/>
                 </div>
                 </form>
             </field>

--- a/addons/mail/static/src/js/chatter.js
+++ b/addons/mail/static/src/js/chatter.js
@@ -75,6 +75,9 @@ var Chatter = Widget.extend({
         }
         if (mailFields.mail_followers) {
             this.fields.followers = new Followers(this, mailFields.mail_followers, record, options);
+            const fieldsInfo = record.fieldsInfo[options.viewType || record.viewType];
+            const nodeOptions = fieldsInfo[mailFields.mail_followers].options || {};
+            this.reloadOnUploadAttachment = nodeOptions.post_refresh == 'always';
         }
         if (mailFields.mail_thread) {
             this.fields.thread = new ThreadField(this, mailFields.mail_thread, record, options);
@@ -601,10 +604,10 @@ var Chatter = Widget.extend({
      * @private
      */
     _onReloadAttachmentBox: function () {
+        this._reloadAttachmentBox();
         if (this.reloadOnUploadAttachment) {
             this.trigger_up('reload', { keepChanges: true });
         }
-        this._reloadAttachmentBox();
     },
     /**
      * @private


### PR DESCRIPTION
Before this commit, when there is  two counter of document attachment, One at
Header and One with Attachment, both counter do not change in sync when document
added from Document Header or with Attachment.

So in this commit, we fix it by reload the attachment.

LINKS
PR: #63875
Task-Id: 2338867

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
