### PR TITLE
[FIX] auth_signup: properly grab user lang from context

### DIFF
--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -127,7 +127,7 @@ class AuthSignupHome(Home):
         if values.get('password') != qcontext.get('confirm_password'):
             raise UserError(_("Passwords do not match; please retype them."))
         supported_lang_codes = [code for code, _ in request.env['res.lang'].get_installed()]
-        lang = request.context.get('lang', '').split('_')[0]
+        lang = request.context.get('lang', '')
         if lang in supported_lang_codes:
             values['lang'] = lang
         self._signup_with_values(qcontext.get('token'), values)


### PR DESCRIPTION
Follow up on d0a4b20d3660c09b1ebe203125d57c9a533c7957

The `lang` at this step is compared to the locale `code` (eg. fr_BE) so the
split is a mistake.

To reproduce the issue:
- change the language of a website to fr_BE only
- allow free signup
- register as a new user

Notice how the language of the user is set to en_US before this PR instead of
fr_BE as it should be.

closes #63616