### PR TITLE
[FIX] base_address_city: Duplicate complete address on contact creation

### DIFF
--- a/addons/base_address_city/models/res_partner.py
+++ b/addons/base_address_city/models/res_partner.py
@@ -19,7 +19,7 @@ class Partner(models.Model):
             self.city = self.city_id.name
             self.zip = self.city_id.zipcode
             self.state_id = self.city_id.state_id
-        else:
+        elif self._origin:
             self.city = False
             self.zip = False
             self.state_id = False


### PR DESCRIPTION
What are the steps to reproduce your issue ?

    1. Install contacts in a db with demo data
    2. Create a contact with complete address
    3. Click on Add button (edit mode)

What is currently happening ?

    The address get copied but not completely (no zip code, state, street)

What are you expecting to happen ?

    The whole address have to be copied

How to fix the bug ?

    Don't call the onchange if the record is not yet created

opw-2415891