### PR TITLE
[FIX] website: do not allow pricelist columns drag and drop

### DIFF
--- a/addons/website/views/snippets/s_table_of_content.xml
+++ b/addons/website/views/snippets/s_table_of_content.xml
@@ -60,6 +60,12 @@
             <we-checkbox string="Sticky" data-select-class="s_table_of_content_navbar_sticky" data-no-preview="true"/>
         </div>
         <div data-js="TableOfContentMainColumns" data-selector=".s_table_of_content_navbar_wrap, .s_table_of_content_main"/>
+        <div data-js="sizing_x" data-selector=".s_table_of_content_navbar_wrap, .s_table_of_content_main"/>
+        <div data-selector=".s_table_of_content_navbar_wrap, .s_table_of_content_main"
+            data-drop-near=".s_table_of_content_navbar_wrap, .s_table_of_content_main"/>
+    </xpath>
+    <xpath expr="//div[@data-js='sizing_x']" position="attributes">
+        <attribute name="data-exclude" add=".s_table_of_content_navbar_wrap, .s_table_of_content_main" separator=","/>
     </xpath>
 </template>
 


### PR DESCRIPTION
Before this commit, it was possible to drag & drop a column of the
pricelist snippet in an other snippet. And so, break it.

After this commit, the drag and drop of a pricelist columns is only
allowed inside the pricelit snippet.

task-2312878

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
