### PR TITLE
[FIX] product: Don't order on inexistent column

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -67,7 +67,7 @@ class ProductProduct(models.Model):
     _description = "Product"
     _inherits = {'product.template': 'product_tmpl_id'}
     _inherit = ['mail.thread', 'mail.activity.mixin']
-    _order = 'default_code, name, id'
+    _order = 'default_code, id'
 
     # price: total price, context dependent (partner, pricelist, quantity)
     price = fields.Float(


### PR DESCRIPTION
Due to https://github.com/odoo/odoo/commit/1b454088e604d4800d8b085b428fdbfc6d7da2f0
generated order by are logging warnings on inexistent columns in DB.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
