### PR TITLE
[FIX] mrp: fix reference issue in manufacture scheduling

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -119,13 +119,13 @@ class StockRule(models.Model):
         if location_id.get_warehouse().manufacture_steps == 'pbm_sam':
             # Use the procurement group created in _run_pull mrp override
             # Preserve the origin from the original stock move, if available
-            if len(values.get('move_dest_ids', [])) == 1 and values['move_dest_ids'][0].origin:
+            if len(values.get('move_dest_ids', [])) == 1 and values['move_dest_ids'][0].origin and values['group_id']:
                 origin = values['move_dest_ids'][0].origin
-            mo_values.update({
-                'name': values['group_id'].name,
-                'procurement_group_id': values['group_id'].id,
-                'origin': origin,
-            })
+                mo_values.update({
+                    'name': values['group_id'].name,
+                    'procurement_group_id': values['group_id'].id,
+                    'origin': origin,
+                })
         return mo_values
 
     def _get_date_planned(self, product_id, company_id, values):


### PR DESCRIPTION
Fine tuning of abf6c0ca88bde077b2b1826596626fbed61d43b3
When an user set its own routes for a manufactured product with
subcomponent BOM `_run_manufacture` could be called before
`_run_pull`.
As the call hold the same reference values of the original MO
the abovementioned fix fails by trying to use the provided values
to create the new MO, genering a conflict

opw-2378583

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
