### PR TITLE
[FIX] purchase_stock: do not include internal notes in generated PO

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -439,7 +439,7 @@ class PurchaseOrderLine(models.Model):
         product = self.product_id.with_context(lang=self.order_id.dest_address_id.lang or self.env.user.lang)
         description_picking = product._get_description(self.order_id.picking_type_id)
         if self.product_description_variants:
-            description_picking += self.product_description_variants
+            description_picking += "\n" + self.product_description_variants
         date_planned = self.date_planned or self.order_id.date_planned
         return {
             # truncate to 2000 to avoid triggering index limit error
@@ -470,15 +470,15 @@ class PurchaseOrderLine(models.Model):
 
     @api.model
     def _prepare_purchase_order_line_from_procurement(self, product_id, product_qty, product_uom, company_id, values, po):
-        line_description = product_id._get_description(po.picking_type_id)
+        line_description = ''
         if values.get('product_description_variants'):
-            line_description += values['product_description_variants']
+            line_description = values['product_description_variants']
         supplier = values.get('supplier')
         res = self._prepare_purchase_order_line(product_id, product_qty, product_uom, company_id, supplier, po)
         # We need to keep the vendor name set in _prepare_purchase_order_line. To avoid redundancy
         # in the line name, we add the line_description only if different from the product name.
         # This way, we shoud not lose any valuable information.
-        if product_id.name != line_description:
+        if line_description and product_id.name != line_description:
             res['name'] += '\n' + line_description
         res['move_dest_ids'] = [(4, x.id) for x in values.get('move_dest_ids', [])]
         res['orderpoint_id'] = values.get('orderpoint_id', False) and values.get('orderpoint_id').id
@@ -500,9 +500,9 @@ class PurchaseOrderLine(models.Model):
         args can be merged. If it returns an empty record then a new line will
         be created.
         """
-        description_picking = product_id._get_description(self.order_id.picking_type_id) or ''
+        description_picking = ''
         if values.get('product_description_variants'):
-            description_picking += values['product_description_variants']
+            description_picking = values['product_description_variants']
         lines = self.filtered(
             lambda l: l.propagate_cancel == values['propagate_cancel']
             and ((values['orderpoint_id'] and not values['move_dest_ids']) and l.orderpoint_id == values['orderpoint_id'] or True)

--- a/addons/purchase_stock/tests/test_purchase_lead_time.py
+++ b/addons/purchase_stock/tests/test_purchase_lead_time.py
@@ -244,7 +244,7 @@ class TestPurchaseLeadTime(PurchaseTestCommon):
         purchase_order = self.env['purchase.order.line'].search([('product_id', '=', self.t_shirt.id)], limit=1).order_id
         order_line_description = purchase_order.order_line.product_id._get_description(purchase_order.picking_type_id)
         self.assertEqual(len(purchase_order.order_line), 1, 'wrong number of order line is created')
-        self.assertEqual(purchase_order.order_line.name, t_shirt.display_name + "\n" + order_line_description + "Color (Red)", 'wrong description in po lines')
+        self.assertEqual(purchase_order.order_line.name, t_shirt.display_name + "\n" + "Color (Red)", 'wrong description in po lines')
 
         procurement_values['product_description_variants'] = 'Color (Red)'
         order_2_values = procurement_values
@@ -264,12 +264,12 @@ class TestPurchaseLeadTime(PurchaseTestCommon):
             self.t_shirt.name, '/', self.env.company, order_3_values)
         ])
         self.assertEqual(len(purchase_order.order_line), 2, 'line with different custom value should not be merged')
-        self.assertEqual(purchase_order.order_line.filtered(lambda x: x.product_qty == 15).name, t_shirt.display_name + "\n" + order_line_description + "Color (Red)", 'wrong description in po lines')
-        self.assertEqual(purchase_order.order_line.filtered(lambda x: x.product_qty == 10).name, t_shirt.display_name + "\n" + order_line_description + "Color (Green)", 'wrong description in po lines')
+        self.assertEqual(purchase_order.order_line.filtered(lambda x: x.product_qty == 15).name, t_shirt.display_name + "\n" + "Color (Red)", 'wrong description in po lines')
+        self.assertEqual(purchase_order.order_line.filtered(lambda x: x.product_qty == 10).name, t_shirt.display_name + "\n" + "Color (Green)", 'wrong description in po lines')
 
         purchase_order.button_confirm()
-        self.assertEqual(purchase_order.picking_ids[0].move_ids_without_package.filtered(lambda x: x.product_uom_qty == 15).description_picking, order_line_description + "Color (Red)", 'wrong description in picking')
-        self.assertEqual(purchase_order.picking_ids[0].move_ids_without_package.filtered(lambda x: x.product_uom_qty == 10).description_picking, order_line_description + "Color (Green)", 'wrong description in picking')
+        self.assertEqual(purchase_order.picking_ids[0].move_ids_without_package.filtered(lambda x: x.product_uom_qty == 15).description_picking, order_line_description + "\nColor (Red)", 'wrong description in picking')
+        self.assertEqual(purchase_order.picking_ids[0].move_ids_without_package.filtered(lambda x: x.product_uom_qty == 10).description_picking, order_line_description + "\nColor (Green)", 'wrong description in picking')
 
     def test_reordering_days_to_purchase(self):
         company = self.env.ref('base.main_company')

--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -21,6 +21,7 @@ class TestReorderingRule(SavepointCase):
         product_form = Form(cls.env['product.product'])
         product_form.name = 'Product A'
         product_form.type = 'product'
+        product_form.description = 'Internal Notes'
         with product_form.seller_ids.new() as seller:
             seller.name = cls.partner
         product_form.route_ids.add(cls.env.ref('purchase_stock.route_warehouse0_buy'))
@@ -66,6 +67,7 @@ class TestReorderingRule(SavepointCase):
         # On the po generated, the source document should be the name of the reordering rule
         self.assertEqual(order_point.name, purchase_order.origin, 'Source document on purchase order should be the name of the reordering rule.')
         self.assertEqual(purchase_order.order_line.product_qty, 10)
+        self.assertEqual(purchase_order.order_line.name, 'Product A')
 
         # Increase the quantity on the RFQ before confirming it
         purchase_order.order_line.product_qty = 12


### PR DESCRIPTION
Behavior prior to this commit:

When a PO is generated (via reordering rule, mto rule, or manual replenish),
the description on the PO line includes the internal notes.

Behavior after this commit:

The description on the PO line does not include the internal notes.

opw-24222438  (partial)