### PR TITLE
[FIX] hr_recruitment: be able to see archived applications

### DIFF
--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -176,7 +176,7 @@ class Applicant(models.Model):
 
     @api.depends('email_from')
     def _compute_application_count(self):
-        application_data = self.env['hr.applicant'].read_group([
+        application_data = self.env['hr.applicant'].with_context(active_test=False).read_group([
             ('email_from', 'in', list(set(self.mapped('email_from'))))], ['email_from'], ['email_from'])
         application_data_mapped = dict((data['email_from'], data['email_from_count']) for data in application_data)
         applicants = self.filtered(lambda applicant: applicant.email_from)

--- a/addons/hr_recruitment/views/hr_recruitment_views.xml
+++ b/addons/hr_recruitment/views/hr_recruitment_views.xml
@@ -85,6 +85,7 @@
                             class="oe_stat_button"
                             icon="fa-pencil"
                             type="object"
+                            context="{'active_test': False}"
                             attrs="{'invisible': [('application_count', '=', 0)]}">
                         <field name="application_count" widget="statinfo" string="Other Applications"/>
                     </button>


### PR DESCRIPTION
- create 2 applications in Odoo Recruitments with the same email
- Notice how they both have a stat button that indicates that this
applicant has another application.
- Refuse one of the 2 applications

The stat button disappear because it ignores archived records, while it
should indicate if someone has already applied in the past

opw-2423158

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
