### PR TITLE
[FIX] account: Bank account not selectable

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -67,7 +67,7 @@ class AccountJournal(models.Model):
         comodel_name='account.account', check_company=True, copy=False, ondelete='restrict',
         string='Default Account',
         domain="[('deprecated', '=', False), ('company_id', '=', company_id),"
-               "('user_type_id', '=', default_account_type),"
+               "'|', ('user_type_id', '=', default_account_type), ('user_type_id', 'in', type_control_ids),"
                "('user_type_id.type', 'not in', ('receivable', 'payable'))]")
     payment_debit_account_id = fields.Many2one(
         comodel_name='account.account', check_company=True, copy=False, ondelete='restrict',


### PR DESCRIPTION
Steps to reproduce the bug:

- Go to Accounting>Configuration>Journals
- Create a new bank journal J

Bug:

Impossible to select a bank account.

PS: In some cases, default_account_id with a different default_account_type are needed

Example for Bank journal, accounts with type Credit Card are needed.

opw:2424109