### PR TITLE
Iraqi currency rounding

### DIFF
--- a/odoo/addons/base/data/res_currency_data.xml
+++ b/odoo/addons/base/data/res_currency_data.xml
@@ -819,7 +819,7 @@
         <record id="IQD" model="res.currency">
             <field name="name">IQD</field>
             <field name="symbol"> ع.د</field>
-            <field name="rounding">0.001</field>
+            <field name="rounding">1</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dinar</field>
             <field name="currency_subunit_label">Fils</field>


### PR DESCRIPTION
Iraqi currency don't have rounding.

I've updated this file to remove the default 3 decimal places.
it shows annoying and extraneous 0s for every financial transaction in the system.

Now, all transactions will be free from 0s and the user can focus on the real monetary value.