### PR TITLE
[FIX] web_editor: fix post-JW revert button edition

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
@@ -144,8 +144,6 @@ var LinkDialog = Dialog.extend({
 
         this.data.text = this.data.text.replace(/[ \t\r\n]+/g, ' ');
 
-        this.__editorEditable = this.props.__editorEditable;
-
         var allBtnClassSuffixes = /(^|\s+)btn(-[a-z0-9_-]*)?/gi;
         var allBtnShapes = /\s*(rounded-circle|flat)\s*/gi;
         this.data.className = this.data.iniClassName


### PR DESCRIPTION
Failed to remove a line at conflict resolution during JW revert at [1].

[1]: https://github.com/odoo/odoo/commit/e5572c317a7775a58675ed73efc89b5c9f6c0c39

task-2424849
