### PR TITLE
[IMP] base: change default signature for admin

### DIFF
--- a/odoo/addons/base/data/res_users_data.xml
+++ b/odoo/addons/base/data/res_users_data.xml
@@ -19,7 +19,7 @@ System</span>]]></field>
             <field name="company_ids" eval="[(4, ref('main_company'))]"/>
             <field name="groups_id" eval="[(6,0,[])]"/>
             <field name="signature"><![CDATA[<span>-- <br/>
-Administrator</span>]]></field>
+Mitchell Admin</span>]]></field>
         </record>
 
         <!-- Default user with full access rights for newly created users -->


### PR DESCRIPTION
PURPOSE

Currently, the signature of the admin defaults to 'administrator'. Odoo
does not take into account the actual name of the user.  The onboarding
experience would be better if the signature was personalized
for the user.

SPECIFICATIONS

The default signature of the admin is his name (Mitchell Admin) instead of 'Administrator'.

LINKS

PR https://github.com/odoo/odoo/pull/63905
Task-2416715