### PR TITLE
[FIX] web: correct formating date

### DIFF
--- a/addons/web/static/src/js/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/js/views/calendar/calendar_controller.js
@@ -151,7 +151,10 @@ var CalendarController = AbstractController.extend({
             self._rpc({
                 model: self.modelName,
                 method: 'get_unusual_days',
-                args: [self.model.data.start_date.format('YYYY-MM-DD'), self.model.data.end_date.format('YYYY-MM-DD')],
+                args: [
+                    self.model.data.start_date.clone().locale('en').format('YYYY-MM-DD'),
+                    self.model.data.end_date.clone().locale('en').format('YYYY-MM-DD')
+                ],
                 context: self.context,
             }).then(function (data) {
                 _.each(self.$el.find('td.fc-day'), function (td) {


### PR DESCRIPTION
FYI: numbers in arabic localization are not arabic (also known as "western
arabic"), but "eastern arabic":
* western arabic: 0	1	2	3	4	5	6	7	8	9	10
* eastern arabic: ٠	١	٢	٣	٤	٥	٦	٧	٨	٩	١٠

STEPS:
* install ans switch to arabic language
* install hr_holidays app
* open hr_holidays app

BEFORE:
ValueError: time data '٢٠٢٠-١١-٢٧' does not match format '%Y-%m-%d'

AFTER: no error, dates are formated in western arabic

---

opw-2422915

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
