### PR TITLE
[IMP] base: change default signature for admin

### DIFF
--- a/odoo/addons/base/data/res_users_demo.xml
+++ b/odoo/addons/base/data/res_users_demo.xml
@@ -58,6 +58,9 @@
             <field name="image_1920" type="base64" file="base/static/img/partner_root-image.jpg"/>
         </record>
 
+        <record id="base.user_admin" model="res.users">
+            <field name="signature" type="xml"><span>-- <br/>Mitchell Admin</span></field>
+        </record>
 
         <!-- Portal : partner and user -->
         <record id="partner_demo_portal" model="res.partner">


### PR DESCRIPTION
PURPOSE

Currently, the signature of the admin defaults to 'administrator'. Odoo
does not take into account the actual name of the user.  The onboarding
experience would be better if the signature was personalized
for the user.

SPECIFICATIONS

The default signature of the admin is his name (Mitchell Admin) instead of 'Administrator'.

LINKS

PR https://github.com/odoo/odoo/pull/63914
Task-2416715