### PR TITLE
[IMP] survey: improves the survey answer page view

### DIFF
--- a/addons/survey/models/survey_user_input.py
+++ b/addons/survey/models/survey_user_input.py
@@ -749,7 +749,7 @@ class SurveyUserInputLine(models.Model):
                     answer_score = question_answer.answer_score
                     answer_is_correct = question_answer.is_correct
         # for all other scored question cases, record question answer_score (can be: pos or 0)
-        elif question.is_scored_question:
+        elif question.question_type in ['date', 'datetime', 'numerical_box']:
             answer = vals.get('value_%s' % answer_type)
             if answer_type == 'numerical_box':
                 answer = float(answer)

--- a/addons/survey/static/src/scss/survey_templates_form.scss
+++ b/addons/survey/static/src/scss/survey_templates_form.scss
@@ -104,6 +104,19 @@ _::-webkit-full-page-media, _:future, :root .o_survey_wrap {
         }
     }
 
+    div.bg-danger, div.bg-success, div.o_survey_question_skipped {
+        .o_survey_question_char_box,
+        .o_survey_question_date,
+        .o_survey_question_datetime,
+        .o_survey_question_numerical_box,
+        .o_survey_question_text_box {
+            border: 0;
+            color: $white !important;
+            font-weight: $font-weight-bold;
+            height: 2rem;
+        }
+    }
+
     .o_survey_form_date .input-group-append {
         right: 0;
         bottom: 5px;
@@ -121,14 +134,14 @@ _::-webkit-full-page-media, _:future, :root .o_survey_wrap {
         i {
             top: 0px;
             font-size: large;
-            &.fa-check-circle,&.fa-check-square {
+            &.fa-check-circle {
                 display: none;
             }
         }
 
         &.o_survey_selected i {
             display: none;
-            &.fa-check-circle,&.fa-check-square {
+            &.fa-check-circle {
                 display: inline;
             }
         }
@@ -430,14 +443,16 @@ _::-webkit-full-page-media, _:future, :root .o_survey_wrap {
         &.bg-success, &.bg-danger {
             opacity: 0.6;
         }
+
         &.o_survey_selected {
             background-color: $gray-600;
             opacity: 1;
         }
-        i.fa-square-o, i.fa-circle-thin {
+        i.fa-circle-thin {
             display: none;
         }
     }
+
     .o_survey_question_matrix {
         th {
             /* important needed to force override bg-primary set on th in the template */
@@ -452,5 +467,13 @@ _::-webkit-full-page-media, _:future, :root .o_survey_wrap {
         i.fa-check-square, i.fa-check-circle, i.o_survey_matrix_empty_checkbox {
             color: $gray-600;
         }
+    }
+
+    .o_survey_question_skipped {
+        background-color: darken($warning, 10%);
+    }
+
+    .o_survey_choice_question_skipped {
+        color: darken($warning, 10%);
     }
 }

--- a/addons/survey/views/survey_question_views.xml
+++ b/addons/survey/views/survey_question_views.xml
@@ -116,11 +116,11 @@
                             <group>
                                 <group attrs="{'invisible': [('question_type', 'not in', ['char_box', 'numerical_box', 'date', 'datetime'])]}">
                                     <field name="answer_numerical_box" string="Correct Answer"
-                                        attrs="{'invisible': [('question_type', '!=', 'numerical_box')]}" class="oe_inline"/>
+                                        attrs="{'invisible': [('question_type', '!=', 'numerical_box')], 'required': [('is_scored_question', '=', True), ('question_type', '=', 'numerical_box')]}" class="oe_inline"/>
                                     <field name="answer_date" string="Correct Answer"
-                                        attrs="{'invisible': [('question_type', '!=', 'date')]}" class="oe_inline"/>
+                                        attrs="{'invisible': [('question_type', '!=', 'date')], 'required': [('is_scored_question', '=', True), ('question_type', '=', 'date')]}" class="oe_inline"/>
                                     <field name="answer_datetime" string="Correct Answer"
-                                        attrs="{'invisible': [('question_type', '!=', 'datetime')]}" class="oe_inline"/>
+                                        attrs="{'invisible': [('question_type', '!=', 'datetime')], 'required': [('is_scored_question', '=', True), ('question_type', '=', 'datetime')]}" class="oe_inline"/>
 
                                     <field name="validation_email" attrs="{'invisible': [('question_type', '!=', 'char_box')]}"/>
                                     <field name="save_as_email" attrs="{'invisible': ['|', ('validation_email', '=', False), ('question_type', '!=', 'char_box')]}"/>

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -427,7 +427,7 @@
                 <t t-foreach='question.suggested_answer_ids' t-as='label'>
                     <t t-set="item_idx" t-value="label_index"/>
                     <t t-set="answer_selected" t-value="answer_line and answer_line.suggested_answer_id.id == label.id"/>
-                    <t t-set="is_correct" t-value="label.answer_score > 0.0"/>
+                    <t t-set="is_correct" t-value="label.is_correct"/>
 
                     <!--Used for print mode with corrections -->
                     <t t-set="answer_class" t-if="not has_correct_answer" t-value="''" />
@@ -445,8 +445,15 @@
                                t-att-name='question.id'
                                t-att-checked="'checked' if answer_selected else None"
                                t-att-data-selection-key="letters[item_idx] if useKeySelection else ''"/>
-                        <i class="fa fa-check-circle float-right mt-1 position-relative"></i>
-                        <i class="fa fa-circle-thin float-right mt-1 position-relative"></i>
+                        <t t-if="has_correct_answer and answer_selected">
+                            <!-- While displaying results: change icons to have a check mark for a right answer and a cross for a wrong one -->
+                            <i t-if="is_correct" class="float-right mt-1 position-relative d-inline fa fa-check-circle"/>
+                            <i t-else="" class="float-right mt-1 position-relative d-inline fa fa-times-circle"/>
+                        </t>
+                        <t t-else="">
+                            <i class="fa fa-check-circle float-right mt-1 position-relative"></i>
+                            <i class="fa fa-circle-thin float-right mt-1 position-relative"></i>
+                        </t>
                         <t t-call="survey.question_suggested_value_image"/>
                     </label>
                 </t>
@@ -491,7 +498,7 @@
                     <t t-set="item_idx" t-value="label_index"/>
                     <t t-set="answer_line" t-value="answer_lines.filtered(lambda line: line.suggested_answer_id == label)"/>
                     <t t-set="answer_selected" t-value="answer_line and answer_line.suggested_answer_id.id == label.id"/>
-                    <t t-set="is_correct" t-value="label.answer_score > 0.0"/>
+                    <t t-set="is_correct" t-value="label.is_correct"/>
 
                     <!--Used for print mode with corrections -->
                     <t t-set="answer_class" t-if="not has_correct_answer" t-value="''" />
@@ -507,8 +514,15 @@
                                t-att-checked="'checked' if answer_line else None"
                                t-att-data-selection-key="letters[item_idx] if useKeySelection else ''"/>
                         <span class="ml-2" t-field='label.value'/>
-                        <i class="fa fa-check-square float-right mt-1 position-relative"></i>
-                        <i class="fa fa-square-o float-right mt-1 position-relative"></i>
+                        <t t-if="has_correct_answer and answer_selected">
+                            <!-- While displaying results: change icons to have a check mark for a right answer and a cross for a wrong one -->
+                            <i t-if="is_correct" class="float-right mt-1 position-relative d-inline fa fa-check-circle"/>
+                            <i t-else="" class="float-right mt-1 position-relative d-inline fa fa-times-circle"/>
+                        </t>
+                        <t t-else="">
+                            <i class="fa fa-check-circle float-right mt-1 position-relative"></i>
+                            <i class="fa fa-circle-thin float-right mt-1 position-relative"></i>
+                        </t>
                         <t t-call="survey.question_suggested_value_image"/>
                     </label>
                 </t>
@@ -525,8 +539,8 @@
                                t-att-checked="comment_line and 'checked' or None"
                                t-att-data-selection-key="letters[item_idx] if useKeySelection else ''"/>
                         <span class="ml-2" t-field="question.comments_message" />
-                        <i class="fa fa-check-square float-right mt-1 position-relative"></i>
-                        <i class="fa fa-square-o float-right mt-1 position-relative"></i>
+                        <i class="fa fa-check-circle float-right mt-1 position-relative"></i>
+                        <i class="fa fa-circle-thin float-right mt-1 position-relative"></i>
                     </label>
                 </div>
                 <div t-attf-class="o_survey_comment_container mt-3 py-0 px-1 #{'d-none' if not comment_line else ''}">

--- a/addons/survey/views/survey_templates_print.xml
+++ b/addons/survey/views/survey_templates_print.xml
@@ -21,7 +21,7 @@
                                             (any(q in questions_to_display for q in question.question_ids)
                                             or not is_html_empty(question.description))">
                                     <hr t-if="question != survey.page_ids[0]" />
-                                    <div class="o_page_header">
+                                    <div class="o_page_header mb-5">
                                         <h1 t-field='question.title' />
                                         <div t-if="question.description" t-field='question.description' class="oe_no_empty"/>
                                     </div>
@@ -34,15 +34,72 @@
                                             <span t-if="question.constr_mandatory" class="text-danger">*</span>
                                             <span t-if="scoring_display_correction" class="badge badge-pill" t-att-data-score-question="question.id"></span>
                                         </h2>
-                                        <t t-if="question.description"><div class="text-muted oe_no_empty" t-field='question.description'/></t>
-                                        <t t-if="question.question_type == 'text_box'"><t t-call="survey.question_text_box"/></t>
-                                        <t t-if="question.question_type == 'char_box'"><t t-call="survey.question_char_box"/></t>
-                                        <t t-if="question.question_type == 'numerical_box'"><t t-call="survey.question_numerical_box"/></t>
-                                        <t t-if="question.question_type == 'date'"><t t-call="survey.question_date"/></t>
-                                        <t t-if="question.question_type == 'datetime'"><t t-call="survey.question_datetime"/></t>
-                                        <t t-if="question.question_type == 'simple_choice'"><t t-call="survey.question_simple_choice"/></t>
-                                        <t t-if="question.question_type == 'multiple_choice'"><t t-call="survey.question_multiple_choice"/></t>
-                                        <t t-if="question.question_type == 'matrix'"><t t-call="survey.question_matrix"/></t>
+                                        <div class="text-muted oe_no_empty mt-1" t-if="not is_html_empty(question.description)" t-field='question.description'/>
+                                        <t t-if="question.question_type in ['numerical_box', 'date', 'datetime', 'text_box', 'char_box']">
+                                            <t t-if="answer_lines">
+                                                <t t-set="answer_line" t-value="answer_lines[0]"/>
+                                                <t t-if="answer_line.skipped">
+                                                    <!-- question was skipped, display an orange block with the text "Skipped" in place of the answer -->
+                                                    <div class="row no-gutters">
+                                                        <div class="col-12 col-md-6 col-lg-4 rounded pl-4 o_survey_question_skipped">
+                                                            <input type="text"
+                                                                t-attf-class="form-control font-italic o_survey_question_{{question.question_type}} bg-transparent rounded-0 p-0" value="Skipped"/>
+                                                        </div>
+                                                    </div>
+                                                </t>
+                                                <t t-elif="answer_line.survey_id.scoring_type != 'no_scoring' and question.question_type in ['numerical_box', 'date', 'datetime'] and question['answer_%s' % question.question_type]">
+                                                    <div class="row no-gutters">
+                                                        <div t-attf-class="col-12 col-md-6 col-lg-4 rounded pl-4 #{'bg-success' if answer_line.answer_is_correct else 'bg-danger'}">
+                                                            <t t-if="question.question_type == 'numerical_box'" t-call="survey.question_numerical_box"/>
+                                                            <t t-if="question.question_type == 'date'" t-call="survey.question_date"/>
+                                                            <t t-if="question.question_type == 'datetime'" t-call="survey.question_datetime"/>
+                                                        </div>
+                                                    </div>
+                                                </t>
+                                                <t t-else="">
+                                                    <t t-if="question.question_type == 'text_box'" t-call="survey.question_text_box"/>
+                                                    <t t-if="question.question_type == 'char_box'" t-call="survey.question_char_box"/>
+                                                    <t t-if="question.question_type == 'numerical_box'" t-call="survey.question_numerical_box"/>
+                                                    <t t-if="question.question_type == 'date'" t-call="survey.question_date"/>
+                                                    <t t-if="question.question_type == 'datetime'" t-call="survey.question_datetime"/>
+                                                </t>
+                                                <t t-if="answer_lines.survey_id.scoring_type != 'no_scoring'
+                                                    and question.question_type in ['numerical_box', 'date', 'datetime']
+                                                    and question['answer_%s' % question.question_type]
+                                                    and not answer_line.answer_is_correct">
+                                                    <div class="row no-gutters">
+                                                        <t t-set="correct_answer" t-value="question['answer_%s' % question.question_type ]"/>
+                                                        <div class="col-12 text-success mt-1">
+                                                            The correct answer was:
+                                                            <strong t-esc="correct_answer" t-if="question.question_type == 'numerical_box'"/>
+                                                            <strong t-esc="format_date(correct_answer)" t-if="question.question_type == 'date'"/>
+                                                            <strong t-esc="format_datetime(correct_answer)" t-if="question.question_type == 'datetime'"/>
+                                                        </div>
+                                                    </div>
+                                                </t>
+                                            </t>
+                                            <t t-else="">
+                                                <t t-if="question.question_type == 'text_box'" t-call="survey.question_text_box"/>
+                                                <t t-if="question.question_type == 'char_box'" t-call="survey.question_char_box"/>
+                                                <t t-if="question.question_type == 'numerical_box'" t-call="survey.question_numerical_box"/>
+                                                <t t-if="question.question_type == 'date'" t-call="survey.question_date"/>
+                                                <t t-if="question.question_type == 'datetime'" t-call="survey.question_datetime"/>
+                                            </t>
+                                        </t>
+                                        <t t-if="question.question_type == 'simple_choice'" t-call="survey.question_simple_choice"/>
+                                        <t t-if="question.question_type == 'multiple_choice'" t-call="survey.question_multiple_choice"/>
+                                        <t t-if="question.question_type == 'matrix'" t-call="survey.question_matrix"/>
+                                        <t t-if="question.question_type in ['simple_choice', 'multiple_choice','matrix']">
+                                            <t t-if="answer_lines">
+                                                <t t-if="answer_lines[0].skipped">
+                                                    <div class="row no-gutters">
+                                                        <div class="col-12 o_survey_choice_question_skipped mt-1">
+                                                            This question was skipped
+                                                        </div>
+                                                    </div>
+                                                </t>
+                                            </t>
+                                        </t>
                                         <div class="o_survey_question_error overflow-hidden border-0 py-0 px-3 alert alert-danger" role="alert"></div>
                                     </div>
                                 </t>

--- a/addons/survey/views/survey_templates_statistics.xml
+++ b/addons/survey/views/survey_templates_statistics.xml
@@ -75,7 +75,7 @@
                     <span class="badge badge-info ml-1" t-field='question.matrix_subtype'/>
                 </t>
                 <!-- Scoring info -->
-                <t t-if="question.is_scored_question">
+                <t t-if="question.question_type in ['numerical_box', 'date', 'datetime']">
                     <span class="badge badge-success mr-1"><span t-esc="question_data['right_inputs_count']" class="mr-1"/>Correct</span>
                     <t t-if="question.question_type in ['simple_choice', 'multiple_choice']">
                         <span class="badge badge-warning mr-1" t-if="question.question_type == 'multiple_choice'">
@@ -273,17 +273,17 @@
                         <tr t-foreach="question_data['common_lines']" t-as="common_line">
                             <td>
                                 <t t-if="question.question_type == 'numerical_box'">
-                                    <t t-set="right_answer" t-value="question.is_scored_question and common_line[0] == question.answer_numerical_box"/>
+                                    <t t-set="right_answer" t-value="common_line[0] == question.answer_numerical_box"/>
                                     <span t-call="survey.survey_remove_unnecessary_decimals"><t t-set="value_to_format" t-value="common_line[0]"/></span>
                                     <i t-if="right_answer" class="fa fa-check"/>
                                 </t>
                                 <t t-elif="question.question_type == 'date'">
-                                    <t t-set="right_answer" t-value="question.is_scored_question and common_line[0] == question.answer_date"/>
+                                    <t t-set="right_answer" t-value="common_line[0] == question.answer_date"/>
                                     <span t-esc="common_line[0]" t-options='{"widget": "date"}'/>
                                     <i t-if="right_answer" class="fa fa-check"/>
                                 </t>
                                 <t t-elif="question.question_type == 'datetime'">
-                                    <t t-set="right_answer" t-value="question.is_scored_question and common_line[0] == question.answer_datetime"/>
+                                    <t t-set="right_answer" t-value="common_line[0] == question.answer_datetime"/>
                                     <span t-esc="common_line[0]" t-options='{"widget": "datetime"}'/>
                                     <i t-if="right_answer" class="fa fa-check"/>
                                 </t>


### PR DESCRIPTION
PURPOSE
We are able to add scoring for date, datetime and integer question types.
The way results are displayed can be improved, that's  the main purpose of this PR.


Current
1) There is no correct answer displayed on answer page.
2)  Input field for point is visible whether score is checked or not.

To be
1) Show correct answer For date,datetime and integer in the result page (and also for live survey):
2) Display the input for the score only if score is checked.
3) Trigger the warning "All "Is a scored question = True" and "Question Type: Date" questions need an answer" on the "Save" of the question, not the survey itself.
Same way we trigger the missing title:(make it mandatory if score is checked)
LINKS

PR
Task 2276724

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr