### PR TITLE
[FIX] email sent from website form not accessible by user

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -893,13 +893,12 @@ class Message(models.Model):
                                          if message.get('model') == model and message.get('res_id') in mids.ids]
 
         # Calculate remaining ids: if not void, raise an error
+
         other_ids = other_ids.difference(set(document_related_ids))
         if not (other_ids and self.browse(other_ids).exists()):
             return
-        raise AccessError(
-            _('The requested operation cannot be completed due to security restrictions. Please contact your system administrator.\n\n(Document type: %s, Operation: %s)') % (self._description, operation)
-            + ' - ({} {}, {} {})'.format(_('Records:'), list(other_ids)[:6], _('User:'), self._uid)
-        )
+
+        super().check_access_rule(operation)
 
     @api.model
     def _get_record_name(self, values):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
the odoo user is not able to access emails sent via the website form as he does not satisfy one of these conditions :
- author_id == pid, uid (the author of the email is the odoobot)
- uid is in the recipients (the only recipient is the odoobot)
- uid us a member of a listern channel (not the case here)
- uid has read access to the related document (the email does not contain any documents)

an error is raised when a user tries to access an email because he does not satisfy any of the required conditions.

Desired behavior after PR is merged:

Rather then directly raising an error if none of the above mentioned conditions are met, a call to the super() method was added to allow fallback on normal mail.message checks, however, this could have an impact on all modules which use emails.

opw-<2419639>

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
