### PR TITLE
[IMP] base,web{site}: allow prefetching assets + apply at login page

### DIFF
--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -565,6 +565,13 @@
 
     <template id="web.login" name="Login">
         <t t-call="web.login_layout">
+            <t t-set="head_login">
+                <t t-call-assets="web.assets_backend" t-js="false" prefetch="true" backend="true"/>
+                <t t-call-assets="web.assets_common" t-css="false" prefetch="true" backend="true"/>
+                <t t-call-assets="web.assets_backend" t-css="false" prefetch="true" backend="true"/>
+                <t t-call-assets="web.assets_backend_prod_only" t-css="false" prefetch="true" backend="true"/>
+            </t>
+            <t t-set="head" t-value="(head or '') + head_login"/>
             <form class="oe_login_form" role="form" t-attf-action="/web/login" method="post" onsubmit="this.action = '/web/login' + location.hash">
                 <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
 

--- a/addons/website/models/ir_qweb.py
+++ b/addons/website/models/ir_qweb.py
@@ -17,7 +17,7 @@ re_background_image = re.compile(r"(background-image\s*:\s*url\(\s*['\"]?\s*)([^
 class AssetsBundleMultiWebsite(AssetsBundle):
     def _get_asset_url_values(self, id, unique, extra, name, sep, type):
         website_id = self.env.context.get('website_id')
-        website_id_path = website_id and ('%s/' % website_id) or ''
+        website_id_path = not self.backend and website_id and ('%s/' % website_id) or ''
         extra = website_id_path + extra
         res = super(AssetsBundleMultiWebsite, self)._get_asset_url_values(id, unique, extra, name, sep, type)
         return res


### PR DESCRIPTION
1. Add new t-call-assets attributes

* prefetch="true"

  It adds assets as `<link rel="prefetch" href="..."/>`

  This tells browser to load resource with lowest priority and save in cache.

* backend="true"

  It's needed to avoid adding extra website tags in assets url, because otherwise
  we prefetch wrong url

3. Apply prefetching to /web/login page

   This speeds up opening backend when browser doesn't have cached assets.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
