### PR TITLE
[FIX] QWeb: Raise QWebException if 'last_path_node' is not set.

### DIFF
--- a/odoo/addons/base/models/qweb.py
+++ b/odoo/addons/base/models/qweb.py
@@ -359,7 +359,7 @@ class QWeb(object):
                 raise e
             except Exception as e:
                 template = options.get('caller_template', template)
-                path = options['last_path_node']
+                path = options.get('last_path_node')
                 raise QWebException("load could not load template", e, path, name=template)
 
         if document is None:


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Raise QWebException instead of a KeyError exception.

**Current behavior before PR:**
When a website Qweb view has inheritance issues like, for example: `<xpath expr="//form/ul/t/li[hasclass('nav-item')]">`, we get the following exception + traceback, which is not very informative:

```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/home/odoo/src/odoo/odoo/http.py", line 806, in dispatch
    r = self._call_function(**self.params)
  File "/home/odoo/src/odoo/odoo/http.py", line 359, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/home/odoo/src/odoo/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/home/odoo/src/odoo/odoo/http.py", line 350, in checked_call
    result.flatten()
  File "/home/odoo/src/odoo/odoo/http.py", line 1242, in flatten
    self.response.append(self.render())
  File "/home/odoo/src/odoo/odoo/http.py", line 1235, in render
    return env["ir.ui.view"]._render_template(self.template, self.qcontext)
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_ui_view.py", line 1708, in _render_template
    return self.browse(self.get_view_id(template))._render(values, engine)
  File "/home/odoo/src/odoo/addons/website/models/ir_ui_view.py", line 402, in _render
    return super(View, self)._render(values, engine=engine, minimal_qcontext=minimal_qcontext)
  File "/home/odoo/src/odoo/addons/web_editor/models/ir_ui_view.py", line 28, in _render
    return super(IrUiView, self)._render(values=values, engine=engine, minimal_qcontext=minimal_qcontext)
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_ui_view.py", line 1716, in _render
    return self.env[engine]._render(self.id, qcontext)
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_qweb.py", line 55, in _render
    result = super(IrQWeb, self)._render(id_or_xml_id, values=values, **context)
  File "/home/odoo/src/odoo/odoo/addons/base/models/qweb.py", line 258, in _render
    self.compile(template, options)(self, body.append, values or {})
  File "<decorator-gen-66>", line 2, in compile
  File "/home/odoo/src/odoo/odoo/tools/cache.py", line 90, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_qweb.py", line 110, in compile
    return super(IrQWeb, self).compile(id_or_xml_id, options=options)
  File "/home/odoo/src/odoo/odoo/addons/base/models/qweb.py", line 275, in compile
    element, document = self.get_template(template, options)
  File "/home/odoo/src/odoo/odoo/addons/base/models/qweb.py", line 363, in get_template
    path = options['last_path_node']
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/home/odoo/src/odoo/odoo/http.py", line 806, in dispatch
    r = self._call_function(**self.params)
  File "/home/odoo/src/odoo/odoo/http.py", line 359, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/home/odoo/src/odoo/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/home/odoo/src/odoo/odoo/http.py", line 350, in checked_call
    result.flatten()
  File "/home/odoo/src/odoo/odoo/http.py", line 1242, in flatten
    self.response.append(self.render())
  File "/home/odoo/src/odoo/odoo/http.py", line 1235, in render
    return env["ir.ui.view"]._render_template(self.template, self.qcontext)
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_ui_view.py", line 1708, in _render_template
    return self.browse(self.get_view_id(template))._render(values, engine)
  File "/home/odoo/src/odoo/addons/website/models/ir_ui_view.py", line 402, in _render
    return super(View, self)._render(values, engine=engine, minimal_qcontext=minimal_qcontext)
  File "/home/odoo/src/odoo/addons/web_editor/models/ir_ui_view.py", line 28, in _render
    return super(IrUiView, self)._render(values=values, engine=engine, minimal_qcontext=minimal_qcontext)
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_ui_view.py", line 1716, in _render
    return self.env[engine]._render(self.id, qcontext)
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_qweb.py", line 55, in _render
    result = super(IrQWeb, self)._render(id_or_xml_id, values=values, **context)
  File "/home/odoo/src/odoo/odoo/addons/base/models/qweb.py", line 258, in _render
    self.compile(template, options)(self, body.append, values or {})
  File "<decorator-gen-66>", line 2, in compile
  File "/home/odoo/src/odoo/odoo/tools/cache.py", line 90, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_qweb.py", line 110, in compile
    return super(IrQWeb, self).compile(id_or_xml_id, options=options)
  File "/home/odoo/src/odoo/odoo/addons/base/models/qweb.py", line 275, in compile
    element, document = self.get_template(template, options)
  File "/home/odoo/src/odoo/odoo/addons/base/models/qweb.py", line 363, in get_template
    path = options['last_path_node']
KeyError: 'last_path_node'
```


**Desired behavior after PR is merged:**

Clearly the developer's intention is to raise QWebException instead, that provides more information:
```
Traceback (most recent call last):
  File "/home/odoo/.local/lib/python3.7/site-packages/werkzeug/serving.py", line 270, in run_wsgi
    execute(self.server.app)
  File "/home/odoo/.local/lib/python3.7/site-packages/werkzeug/serving.py", line 258, in execute
    application_iter = app(environ, start_response)
  File "/home/odoo/src/odoo/odoo/service/server.py", line 440, in app
    return self.app(e, s)
  File "/home/odoo/src/odoo/odoo/service/wsgi_server.py", line 124, in application
    return application_unproxied(environ, start_response)
  File "/home/odoo/src/odoo/odoo/service/wsgi_server.py", line 99, in application_unproxied
    result = odoo.http.root(environ, start_response)
  File "/home/odoo/src/odoo/odoo/http.py", line 1295, in __call__
    return self.dispatch(environ, start_response)
  File "/home/odoo/src/odoo/odoo/http.py", line 1263, in __call__
    return self.app(environ, start_wrapped)
  File "/home/odoo/.local/lib/python3.7/site-packages/werkzeug/wsgi.py", line 766, in __call__
    return self.app(environ, start_response)
  File "/home/odoo/src/odoo/odoo/http.py", line 1465, in dispatch
    result = ir_http._dispatch()
  File "/home/odoo/src/odoo/addons/website_sale/models/ir_http.py", line 15, in _dispatch
    return super(IrHttp, cls)._dispatch()
  File "/home/odoo/src/odoo/addons/website/models/ir_http.py", line 181, in _dispatch
    response = super(Http, cls)._dispatch()
  File "/home/odoo/src/odoo/addons/auth_signup/models/ir_http.py", line 19, in _dispatch
    return super(Http, cls)._dispatch()
  File "/home/odoo/src/odoo/addons/web_editor/models/ir_http.py", line 21, in _dispatch
    return super(IrHttp, cls)._dispatch()
  File "/home/odoo/src/odoo/addons/utm/models/ir_http.py", line 29, in _dispatch
    response = super(IrHttp, cls)._dispatch()
  File "/home/odoo/src/odoo/addons/http_routing/models/ir_http.py", line 512, in _dispatch
    result = super(IrHttp, cls)._dispatch()
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_http.py", line 241, in _dispatch
    return cls._handle_exception(e)
  File "/home/odoo/src/odoo/addons/utm/models/ir_http.py", line 34, in _handle_exception
    response = super(IrHttp, cls)._handle_exception(exc)
  File "/home/odoo/src/odoo/addons/http_routing/models/ir_http.py", line 644, in _handle_exception
    values = cls._get_values_500_error(env, values, exception)
  File "/home/odoo/src/odoo/addons/website/models/ir_http.py", line 357, in _get_values_500_error
    et = etree.fromstring(view.with_context(inherit_branding=False).read_combined(['arch'])['arch'])
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_ui_view.py", line 809, in read_combined
    arch = root.apply_view_inheritance(arch_tree, self.model)
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_ui_view.py", line 750, in apply_view_inheritance
    return self._apply_view_inheritance(source, inherit_tree)
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_ui_view.py", line 759, in _apply_view_inheritance
    source = view._apply_view_inheritance(source, inherit_tree)
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_ui_view.py", line 758, in _apply_view_inheritance
    source = view.apply_inheritance_specs(source, arch_tree)
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_ui_view.py", line 735, in apply_inheritance_specs
    self.handle_view_error(str(e))
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_ui_view.py", line 673, in handle_view_error
    raise ValueError(formatted_message).with_traceback(from_traceback) from from_exception
ValueError: Element '<xpath expr="//form/ul/t/li[hasclass('nav-item')]">' cannot be located in parent view

View name: products_attributes
Error context:
 view: ir.ui.view(3656,)
 view.parent: ir.ui.view(2620,) - - -
```


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
