### PR TITLE
fix horizontal scroll position not preserved

### DIFF
--- a/addons/web/static/src/js/chrome/web_client.js
+++ b/addons/web/static/src/js/chrome/web_client.js
@@ -273,7 +273,7 @@ return AbstractWebClient.extend({
      */
     _onScrollTo: function (ev) {
         var offset = {top: ev.data.top, left: ev.data.left || 0};
-        if (!offset.top) {
+        if (ev.data.selector) {
             offset = dom.getPosition(document.querySelector(ev.data.selector));
             // Substract the position of the action_manager as it is the scrolling part
             offset.top -= dom.getPosition(this.action_manager.el).top;


### PR DESCRIPTION
PURPOSE
When there is a horizontal scroll and user scrolls horizontally and go to other view(form view by clicking any record) and comeback to previous view then horizontal scroll is not preserved

SPEC
Scrolling horizontally and then go to form view and come back to previous view should preserve scroll position.
Also consider case for kanban view where there are too many columns and user click on 'Add Column' user should be scrolled to new column element.

TASK 2418275



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
