### PR TITLE
[REF] website: remove compatibility code for header mono-editable zones

### DIFF
--- a/addons/website/static/src/js/editor/wysiwyg_multizone.js
+++ b/addons/website/static/src/js/editor/wysiwyg_multizone.js
@@ -85,15 +85,6 @@ var WysiwygMultizone = Wysiwyg.extend({
             }
         }
 
-        // TODO remove this code in master by migrating users who did not
-        // receive the XML change about the 'oe_structure_solo' class (the
-        // header original XML is now correct but we changed specs after
-        // release to not allow multi snippets drop zones in the header).
-        const $headerZones = this._getEditableArea().filter((i, el) => el.closest('header#top') !== null);
-        // oe_structure_multi to ease custo in stable
-        const selector = '.oe_structure[id*="oe_structure"]:not(.oe_structure_multi)';
-        $headerZones.find(selector).addBack(selector).addClass('oe_structure_solo');
-
         return this._super.apply(this, arguments).then(() => {
             // Showing Mega Menu snippets if one dropdown is already opened
             if (this.$('.o_mega_menu').hasClass('show')) {


### PR DESCRIPTION
In 14.0 stable version, we merged [1] with JS compatibility code to
support the change. This commit now removes that compatibility code
thanks to related migration script.

[1]: https://github.com/odoo/odoo/pull/61835
