### PR TITLE
[FIX] stock: run scheduler actions as super user

### DIFF
--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -381,18 +381,17 @@ class ProcurementGroup(models.Model):
     def _run_scheduler_tasks(self, use_new_cursor=False, company_id=False):
         # Minimum stock rules
         self.sudo()._procure_orderpoint_confirm(use_new_cursor=use_new_cursor, company_id=company_id)
+        if use_new_cursor:
+            self._cr.commit()
 
         # Search all confirmed stock_moves and try to assign them
         domain = self._get_moves_to_assign_domain(company_id)
         moves_to_assign = self.env['stock.move'].search(domain, limit=None,
             order='priority desc, date_expected asc')
         for moves_chunk in split_every(100, moves_to_assign.ids):
-            self.env['stock.move'].browse(moves_chunk)._action_assign()
+            self.env['stock.move'].browse(moves_chunk).sudo()._action_assign()
             if use_new_cursor:
                 self._cr.commit()
-
-        if use_new_cursor:
-            self._cr.commit()
 
         # Merge duplicated quants
         self.env['stock.quant']._merge_quants()


### PR DESCRIPTION
In `run_scheduler`, we are running certain functions as super user to
avoid inter company and access rights issues.  This commit moves up the
`sudo()` call such that it applies to the whole function, instead of
only the `procure_orderpoint_confirm`.

In addition a commit call is moved up to apply after the
`procure_orderpoint_confirm` call (as it was, it was applied after the
`_action_assign` loop, but there is in fact already a commit in that
loop, this lead to a somewhat random behavior where the replenish rules
were sometimes rolled back and sometimes not)

opw-2394706
