### PR TITLE
[FIX] point_of_sale: Multicompany tax

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -2000,8 +2000,8 @@ exports.Orderline = Backbone.Model.extend({
         var taxtotal = 0;
 
         var product =  this.get_product();
-        var taxes_ids = product.taxes_id;
         var taxes =  this.pos.taxes;
+        var taxes_ids = _.filter(product.taxes_id, t => t in this.pos.taxes_by_id);
         var taxdetail = {};
         var product_taxes = [];
 


### PR DESCRIPTION
Steps to reproduce the bug:

- Create a multi-company environment with two companies A & B
- Create two sales taxes TA & TB, one for company A & one for company B
- Created a shared product P and assign both TA & TB
- Login with user having access of both companies
- Open POS session and select P

Bug:

A traceback was raised

opw:2422866