### PR TITLE
[FIX] point_of_sale: Field crm_team_id not defined

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -401,8 +401,6 @@ class PosOrder(models.Model):
             'invoice_line_ids': [(0, None, self._prepare_invoice_line(line)) for line in self.lines],
             'invoice_cash_rounding_id': self.config_id.rounding_method.id if self.config_id.cash_rounding else False
         }
-        if self.crm_team_id:
-            vals['team_id'] = self.crm_team_id.id
         return vals
 
     def action_pos_order_invoice(self):


### PR DESCRIPTION
Introduced by https://github.com/odoo/odoo/commit/61e5389236ad767827ef2fe039aa78b20848298e

The field crm_team_id is defined in module pos_sale and the function _prepare_invoice
is already overwritten to take the crm_team_id field into account

opw:2418806