### PR TITLE
[FIX] website_theme_install: stop copying fields for theme record templates

### DIFF
--- a/addons/website_theme_install/models/theme_models.py
+++ b/addons/website_theme_install/models/theme_models.py
@@ -201,23 +201,23 @@ class Theme(models.AbstractModel):
 class IrUiView(models.Model):
     _inherit = 'ir.ui.view'
 
-    theme_template_id = fields.Many2one('theme.ir.ui.view')
+    theme_template_id = fields.Many2one('theme.ir.ui.view', copy=False)
 
 
 class IrAttachment(models.Model):
     _inherit = 'ir.attachment'
 
-    key = fields.Char()
-    theme_template_id = fields.Many2one('theme.ir.attachment')
+    key = fields.Char(copy=False)
+    theme_template_id = fields.Many2one('theme.ir.attachment', copy=False)
 
 
 class WebiteMenu(models.Model):
     _inherit = 'website.menu'
 
-    theme_template_id = fields.Many2one('theme.website.menu')
+    theme_template_id = fields.Many2one('theme.website.menu', copy=False)
 
 
 class WebsitePage(models.Model):
     _inherit = 'website.page'
 
-    theme_template_id = fields.Many2one('theme.website.page')
+    theme_template_id = fields.Many2one('theme.website.page', copy=False)


### PR DESCRIPTION
Themes define records which are used as templates for the creation of
base model records on theme installation on a website.
E.g. a "theme.ir.attachment" record's purpose is to be a template for an
"ir.attachment" record creation on theme installation on a website.

Those final records have extra fields to indicate from which theme
template they come from. If those records are ever to be duplicated,
they should not duplicate those links to the theme templates otherwise
it may cause issues when uninstalling/updating a theme (you want the
records linked to the theme to be deleted/updated but not the duplicated
ones, which do not act differently from user created ones).

Duplicate ones will be linked to the website anyway (just like "normal"
user created ones) and should only be automatically removed if that
website is deleted.

The issue is more visible from 14.0 where applying some modifications to
images via the editor (crop / filter / optimization / ...) will
duplicate the original image before modifying it.

Co-authored-by: Samuel Degueldre <sad@odoo.com>
