### PR TITLE
[FIX] stock: prevent from deleting reserved lines

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -490,7 +490,7 @@ class StockMove(models.Model):
                 mls = move.move_line_ids
             mls = mls.filtered(lambda ml: ml.lot_id)
             for ml in mls:
-                if ml.lot_id not in move.lot_ids:
+                if ml.qty_done and ml.lot_id not in move.lot_ids:
                     move_lines_commands.append((2, ml.id))
             ls = move.move_line_ids.lot_id
             for lot in move.lot_ids:


### PR DESCRIPTION
When using a tracked product in a MO, the lot/serial number reservation
disappears even if the product is still reserved.

To reproduce the error:
(Need mrp)
1. Create two products P and P_compo
	- Both are storable
	- P_compo is tracked by lots
2. Update P_compo's quantity
	- Set the on hand quantity of lot L to 5
3. Create a MO
	- Product: P
	- Quantity: 5
	- Add a line: (Product: P_compo, To Consume: 5)
4. Confirm
5. Check availability
	- The P_compo's reserved quantity has been updated to 5. If you
click on the line's details, you can see that 5 P_compo has been
reserved from lot L
6. Back to the MO, in edit mode, change the done quantity: 3/5
	- There are still 5 reserved P_compo
7. Click on the P_compo's line details

ERR: the line we saw on step 5 disappeared. The MO says that 5 P_compo
are reserved, but when checking which lot is reserved, the latter is
no more visible. Moreover, if you click on "Confirm" (so you leave the
"Detailed Operations" pop-up), the "Reserved" field of the line will be
reset.

The lot reservation should stay so the user can complete the "Done"
field.

OPW-2420347