### PR TITLE
[FIX] web: Display PDF correctly (broken font)

### DIFF
--- a/addons/web/static/lib/pdfjs/src/core/fonts.js
+++ b/addons/web/static/lib/pdfjs/src/core/fonts.js
@@ -4022,7 +4022,7 @@ var Font = (function FontClosure() {
       var isTrueType = !tables['CFF '];
       if (!isTrueType) {
         // OpenType font
-        if (header.version === 'OTTO' ||
+        if ((header.version === 'OTTO' && properties.type !== 'CIDFontType2') ||
             !tables.head || !tables.hhea || !tables.maxp || !tables.post) {
           // no major tables: throwing everything at CFFFont
           cffFile = new Stream(tables['CFF '].data);


### PR DESCRIPTION
What are the steps to reproduce your issue ?

    1. Install eSign
    2. Upload attached PDF (links below) as template

What is currently happening ?

    The font is broken

What are you expecting to happen ?

    Display PDF correctly

Patch: mozilla/pdf.js@977397e
See: https://github.com/mozilla/pdf.js/pull/6270/files

Corrupted pdf: 

https://github.com/mozilla/pdf.js/blob/977397ebfd1757706906694d49c3db9d3266583e/test/pdfs/issue215.pdf
https://github.com/mozilla/pdf.js/blob/977397ebfd1757706906694d49c3db9d3266583e/test/pdfs/bug1186827.pdf

opw-2410011
