### PR TITLE
[FIX] mrp: Correct material status of MO after check availability

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -680,7 +680,7 @@ class MrpProduction(models.Model):
         moves_in_first_operation = self.move_raw_ids.filtered(lambda m: m.bom_line_id in bom_line_ids)
         if all(move.state == 'assigned' for move in moves_in_first_operation):
             return 'assigned'
-        return 'confirmed'
+        return 'waiting'
 
     def action_confirm(self):
         self._check_company()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses:
- When a MO is confirmed, it generates other activities (based on routes) to procure
materials for its need, and the material status will be Waiting another operation.
But when we click on Check Availability, if we didn't have enough materials yet,
the material status is changed to Waiting. This does not make sense and should
still be Waiting another operation.
- Fix: Change the return value of `_get_ready_to_produce_state` method from `confirm` to `waiting`

## Current behavior before PR:
- After creating WH/MO/00002 and mark it as todo, it will trigger another MO to supply materials, and its Material availability will be Waiting Another Operation
![image](https://user-images.githubusercontent.com/45560757/103414364-37f40b80-4bb0-11eb-892b-cc01b733a17f.png)
- Click Check Availability on WH/MO/00002, then the Material availability is changed to Waiting, even when the materials are not ready yet 
![image](https://user-images.githubusercontent.com/45560757/103414564-15aebd80-4bb1-11eb-80e2-ed0bfd11e219.png)

## Desired behavior after PR is merged:
- MO's material availability will still be Waiting Another Operation after click on Check Availability, if the materials are not procured enough
![image](https://user-images.githubusercontent.com/45560757/103414839-26136800-4bb2-11eb-8076-e50af80ce22c.png)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
