### PR TITLE
[FIX] stock: same id cause wrong inherit in setting

### DIFF
--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -47,7 +47,7 @@
                                     </div>
                                 </div>
                             </div>
-                            <div class="col-12 col-lg-6 o_setting_box" id="quality_control">
+                            <div class="col-12 col-lg-6 o_setting_box" id="stock_quality_control">
                                 <div class="o_setting_left_pane">
                                     <field name="module_quality_control" widget="upgrade_boolean"/>
                                 </div>


### PR DESCRIPTION
Both stock and mrp use the same id for quality setting. This caused some
wrong inheritance. Change the id in stock to fix the issue.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
