### PR TITLE
pivot dropdown remain open

### DIFF
--- a/addons/web/static/src/js/views/pivot/pivot_controller.js
+++ b/addons/web/static/src/js/views/pivot/pivot_controller.js
@@ -53,19 +53,10 @@ var PivotController = AbstractController.extend({
      * @override
      */
     start: function () {
-        var self = this;
         this.$el.toggleClass('o_enable_linking', this.enableLinking);
         this.$fieldSelection = this.$('.o_field_selection');
         core.bus.on('click', this, function () {
             this.$fieldSelection.empty();
-        });
-        $(window).on('mousedown', this, function (ev) {
-            if ($(ev.target).parents('.o_pivot_measures_list').length ||
-                $(ev.target).parents('.o_pivot_field_menu').length) {
-                return;
-            }
-            self.$fieldSelection.empty();
-            $(".o_pivot_measures_list.show").parent().dropdown("toggle");
         });
         return this._super();
     },

--- a/addons/web/static/src/js/views/pivot/pivot_controller.js
+++ b/addons/web/static/src/js/views/pivot/pivot_controller.js
@@ -53,10 +53,19 @@ var PivotController = AbstractController.extend({
      * @override
      */
     start: function () {
+        var self = this;
         this.$el.toggleClass('o_enable_linking', this.enableLinking);
         this.$fieldSelection = this.$('.o_field_selection');
         core.bus.on('click', this, function () {
             this.$fieldSelection.empty();
+        });
+        $(window).on('mousedown', this, function (ev) {
+            if ($(ev.target).parents('.o_pivot_measures_list').length ||
+                $(ev.target).parents('.o_pivot_field_menu').length) {
+                return;
+            }
+            self.$fieldSelection.empty();
+            $(".o_pivot_measures_list.show").parent().dropdown("toggle");
         });
         return this._super();
     },

--- a/addons/web/static/src/scss/pivot_view.scss
+++ b/addons/web/static/src/scss/pivot_view.scss
@@ -88,3 +88,12 @@
         top: 9px;
     }
 }
+
+// Show measure dropdown top of all other dropdowns
+.o_control_panel {
+    > .o_cp_left {
+        .o_pivot_measures_list {
+            z-index: 1001;
+        }
+    }
+}

--- a/addons/web/static/tests/views/pivot_tests.js
+++ b/addons/web/static/tests/views/pivot_tests.js
@@ -1982,6 +1982,42 @@ QUnit.module('Views', {
         pivot.destroy();
     });
 
+    QUnit.test('Click on the measure list and open groupby list and vice versa', async function (assert) {
+        assert.expect(5);
+
+        const pivot = await createView({
+            View: PivotView,
+            model: "partner",
+            data: this.data,
+            arch: `<pivot/>`,
+        });
+
+        // open the "Measures" menu
+        await testUtils.dom.click(pivot.$buttons[0].querySelector('button'));
+        assert.isVisible(pivot.$buttons[0].querySelector('.o_pivot_measures_list'),
+            "measures menu should be displayed");
+
+        // Simulate mousedown on closed header and open a column groupby
+        testUtils.triggerMouseEvent(pivot.$('thead .o_pivot_header_cell_closed'), "mousedown");
+        // testUtils.triggerMouseEvent($cell, "mouseup");
+        pivot.$('thead .o_pivot_header_cell_closed').click();
+        // the menu should still be open
+        assert.isNotVisible(pivot.$buttons[0].querySelector('.o_pivot_measures_list'),
+            "measures menu should not be displayed");
+        assert.containsOnce(pivot, '.o_pivot_field_menu',
+            "the field selector menu should be displayed");
+
+        // Simulate mousedown on measure menu and open the "Measures" menu again
+        testUtils.triggerMouseEvent(pivot.$buttons.find('button'), "mousedown");
+        await testUtils.dom.click(pivot.$buttons[0].querySelector('button'));
+        assert.isVisible(pivot.$buttons[0].querySelector('.o_pivot_measures_list'),
+            "measures menu should be displayed");
+        assert.containsNone(pivot, '.o_pivot_field_menu',
+            "the field selector menu should not be displayed");
+
+        pivot.destroy();
+    });
+
     QUnit.module('Sort in comparison mode', {
         beforeEach: function () {
             this.data.partner.records[0].date = '2016-12-15';

--- a/addons/web/static/tests/views/pivot_tests.js
+++ b/addons/web/static/tests/views/pivot_tests.js
@@ -1982,42 +1982,6 @@ QUnit.module('Views', {
         pivot.destroy();
     });
 
-    QUnit.test('Click on the measure list and open groupby list and vice versa', async function (assert) {
-        assert.expect(5);
-
-        const pivot = await createView({
-            View: PivotView,
-            model: "partner",
-            data: this.data,
-            arch: `<pivot/>`,
-        });
-
-        // open the "Measures" menu
-        await testUtils.dom.click(pivot.$buttons[0].querySelector('button'));
-        assert.isVisible(pivot.$buttons[0].querySelector('.o_pivot_measures_list'),
-            "measures menu should be displayed");
-
-        // Simulate mousedown on closed header and open a column groupby
-        testUtils.triggerMouseEvent(pivot.$('thead .o_pivot_header_cell_closed'), "mousedown");
-        // testUtils.triggerMouseEvent($cell, "mouseup");
-        pivot.$('thead .o_pivot_header_cell_closed').click();
-        // the menu should still be open
-        assert.isNotVisible(pivot.$buttons[0].querySelector('.o_pivot_measures_list'),
-            "measures menu should not be displayed");
-        assert.containsOnce(pivot, '.o_pivot_field_menu',
-            "the field selector menu should be displayed");
-
-        // Simulate mousedown on measure menu and open the "Measures" menu again
-        testUtils.triggerMouseEvent(pivot.$buttons.find('button'), "mousedown");
-        await testUtils.dom.click(pivot.$buttons[0].querySelector('button'));
-        assert.isVisible(pivot.$buttons[0].querySelector('.o_pivot_measures_list'),
-            "measures menu should be displayed");
-        assert.containsNone(pivot, '.o_pivot_field_menu',
-            "the field selector menu should not be displayed");
-
-        pivot.destroy();
-    });
-
     QUnit.module('Sort in comparison mode', {
         beforeEach: function () {
             this.data.partner.records[0].date = '2016-12-15';


### PR DESCRIPTION
PURPOSE
When clicking on pivot header so it will open groupby dropdown now click on measures button, it will not close groupby dropdown and measures dropdown will overlap groupby dropdown, same happens reverse as well, dropdown should not overlap each other, opening dropdown should close previous dropdown.

SPEC
When opening groupby dropdown and then opening a measures dropdown or vice versa it should close previous dropdown and then open current dropdown

TASK 2422447


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
