### PR TITLE
[FIX] hr(_expense),mail: Fix the attachment count in chatter and stat…

### DIFF
--- a/addons/hr/views/hr_job_views.xml
+++ b/addons/hr/views/hr_job_views.xml
@@ -39,7 +39,7 @@
                         </notebook>
                     </sheet>
                     <div class="oe_chatter">
-                        <field name="message_follower_ids" options="{'open_attachments': True}"/>
+                        <field name="message_follower_ids" options="{'open_attachments': True, 'post_refresh': 'always'}"/>
                     </div>
                 </form>
             </field>

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -172,7 +172,7 @@
                 <div class="oe_chatter">
                     <field name="message_follower_ids"/>
                     <field name="activity_ids"/>
-                    <field name="message_ids"/>
+                    <field name="message_ids" options="{'post_refresh': 'always'}"/>
                 </div>
                 </form>
             </field>

--- a/addons/mail/static/src/components/attachment_delete_confirm_dialog/attachment_delete_confirm_dialog.js
+++ b/addons/mail/static/src/components/attachment_delete_confirm_dialog/attachment_delete_confirm_dialog.js
@@ -73,6 +73,7 @@ class AttachmentDeleteConfirmDialog extends Component {
         this._dialogRef.comp._close();
         this.attachment.remove();
         this.trigger('o-attachment-removed', { attachmentLocalId: this.props.attachmentLocalId });
+        this.trigger('o-attachments-changed');
     }
 
 }

--- a/addons/mail/static/src/js/basic_view.js
+++ b/addons/mail/static/src/js/basic_view.js
@@ -14,7 +14,7 @@ BasicView.include({
             hasActivityIds: this._hasField('activity_ids'),
             hasMessageFollowerIds: this._hasField('message_follower_ids'),
             hasMessageIds: this._hasField('message_ids'),
-            hasRecordReloadOnAttachmentsChanged: post_refresh === 'always',
+            hasRecordReloadOnAttachmentsChanged: post_refresh === 'always' || followers_post_refresh === 'always',
             hasRecordReloadOnMessagePosted: !!post_refresh,
             hasRecordReloadOnFollowersUpdate: !!followers_post_refresh,
             isAttachmentBoxVisibleInitially: (


### PR DESCRIPTION
… button

Before this commit, when there is two count of attachment, One in
chatter and second one as stat button in the form view. both counter
does not sync when new attchment is uploaded from any of the place.

Currently, We have options `ReloadOnAttachmentsChanged` in message_ids field
which will reload the attachment and refresh the page but it will
only reload if post_refresh is `always` in message_ids.

So in this commit, we create options `ReloadOnAttachmentsChanged` for
message_follower_ids field which reload the attachment and refresh the page.

LINKS
PR: #63981
Task-Id: 2338867

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
