### PR TITLE
[FIX] mail: fix placeholder scrollbar with long name

### DIFF
--- a/addons/mail/static/src/components/composer_text_input/composer_text_input.scss
+++ b/addons/mail/static/src/components/composer_text_input/composer_text_input.scss
@@ -22,6 +22,12 @@
     border: none;
     overflow: auto;
 
+    &::placeholder {
+        white-space: nowrap;
+        overflow-x: hidden;
+        text-overflow: ellipsis;
+    }
+
     &.o-composer-is-compact {
         // When composer is compact, textarea should not be rounded on the right as
         // buttons are glued to it


### PR DESCRIPTION
Currently, Chrome show a scrollbar when the placeholder is multilined.
Overflow hidden will avoid the scrollbar and we place a nowrap on the
placeholder text to avoid the multiline.

task-2416058