### PR TITLE
[FIX] hr_expense & account: Cannot create unbalanced journal entry

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -592,6 +592,8 @@ class AccountMove(models.Model):
                 # A line with the same key does already exist, we only need one
                 # to modify it; we have to drop this one.
                 to_remove += line
+                # If we're removing lines, recomputing only the tax base amount is not enough.
+                recompute_tax_base_amount = False
             else:
                 taxes_map[grouping_key] = {
                     'tax_line': line,


### PR DESCRIPTION
Problem:
- Create expense report with 2 lines both with same tax.
- Approve the report and change accounting date to before company tax lock date
- Try posting the expense report

Before this commit an error 'Cannot create unbalanced journal entry'
is raised. This is related to flag recompute_tax_base_amount that was introduced in 226a1155124e

Solution:
- Set recompute_tax_base_amount=True if we must remove a tax line.

I added a test case so that it's easier to reproduce the issue.

PR #43006 is closely related to this issue. Maybe @jpp-odoo or @smetl could review this?

We have an enterprise customer currently with this issue.