### PR TITLE
[FIX] account_check_printing: always compute "amount in words"

### DIFF
--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -67,7 +67,7 @@ class AccountPayment(models.Model):
     @api.depends('payment_method_id', 'currency_id', 'amount')
     def _compute_check_amount_in_words(self):
         for pay in self:
-            if pay.currency_id and pay.payment_method_id.code == 'check_printing':
+            if pay.currency_id:
                 pay.check_amount_in_words = pay.currency_id.amount_to_text(pay.amount)
             else:
                 pay.check_amount_in_words = False


### PR DESCRIPTION
the field can be used in reports for any payment method

---

opw-2423290

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
