### PR TITLE
[FIX] sale_timesheet: condition always False

### DIFF
--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -350,7 +350,7 @@ class ProjectTask(models.Model):
         if not self.commercial_partner_id or not self.allow_billable:
             return False
         domain = [('is_service', '=', True), ('order_partner_id', 'child_of', self.commercial_partner_id.id), ('is_expense', '=', False), ('state', 'in', ['sale', 'done'])]
-        if self.project_id.bill_type == 'customer_type' and self.project_sale_order_id:
+        if self.project_id.bill_type == 'customer_project' and self.project_sale_order_id:
             domain.append(('order_id', '=?', self.project_sale_order_id.id))
         sale_lines = self.env['sale.order.line'].search(domain)
         for line in sale_lines:


### PR DESCRIPTION
Before this commit, we check if the bill_type in the project is equal
to 'customer_type' but this field can only be either 'customer_task' or
'customer_project'. Thus, this condition will always be False.

This commit changes the condition to check if the bill_type is equal to
'customer_project'. Then, this condition can be True if the project has
a SOL and his bill_type field is equal to 'customer_project'.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
