### PR TITLE
[FIX] repair: Add storable/cosumable product in Operation

### DIFF
--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -154,7 +154,7 @@
                             <form string="Fees">
                                 <group>
                                     <field name="company_id" invisible="1" force_save="1"/>
-                                    <field name="product_id" required="True"/>
+                                    <field name="product_id" required="True" domain="[('type', '=', 'service')]"/>
                                     <field name="name"/>
                                     <field name="product_uom_category_id" invisible="1"/>
                                     <label for="product_uom_qty"/>
@@ -170,7 +170,7 @@
                             </form>
                             <tree string="Fees" editable="bottom">
                                 <field name="company_id" invisible="1" force_save="1"/>
-                                <field name="product_id" required="True"/>
+                                <field name="product_id" required="True" domain="[('type', '=', 'service')]"/>
                                 <field name='name' optional="show"/>
                                 <field name="product_uom_qty" string="Quantity"/>
                                 <field name="product_uom_category_id" invisible="1"/>


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a storable/consumable product P
- Create a repair order RO
- Add P in an operation lin

Bug:

Only service product must be selectable in operation

opw:2423004