### PR TITLE
[IMP] mail: fix chatter infinity scroll issue

### DIFF
--- a/addons/mail/static/src/components/chatter/chatter.js
+++ b/addons/mail/static/src/components/chatter/chatter.js
@@ -79,10 +79,23 @@ class Chatter extends Component {
      * @returns {Element|undefined} Scrollable Element
      */
     getScrollableElement() {
+        if (this.props.getScrollableElement) {
+            return this.props.getScrollableElement();
+        }
         if (!this._scrollPanelRef.el) {
             return;
         }
         return this._scrollPanelRef.el;
+    }
+
+    /**
+     * @param {MouseEvent} ev
+     */
+    onScroll(ev) {
+        if (!this._threadRef.comp) {
+            return;
+        }
+        this._threadRef.comp.onScroll(ev);
     }
 
     //--------------------------------------------------------------------------
@@ -134,10 +147,7 @@ class Chatter extends Component {
      * @param {MouseEvent} ev
      */
     _onScrollPanelScroll(ev) {
-        if (!this._threadRef.comp) {
-            return;
-        }
-        this._threadRef.comp.onScroll(ev);
+        this.onScroll(ev);
     }
 
 }
@@ -146,6 +156,14 @@ Object.assign(Chatter, {
     components,
     props: {
         chatterLocalId: String,
+        /**
+         * Function returns the exact scrollable element from the parent
+         * to manage proper scroll heights which affects the load more messages.
+         */
+        getScrollableElement: {
+            type: Function,
+            optional: true,
+        },
     },
     template: 'mail.Chatter',
 });

--- a/addons/mail/static/src/components/chatter_container/chatter_container.js
+++ b/addons/mail/static/src/components/chatter_container/chatter_container.js
@@ -10,6 +10,7 @@ const { Component } = owl;
 
 const components = { Chatter };
 
+const { useRef } = owl.hooks;
 /**
  * This component abstracts chatter component to its parent, so that it can be
  * mounted and receive chatter data even when a chatter component cannot be
@@ -40,6 +41,7 @@ class ChatterContainer extends Component {
             return { chatter: this.chatter };
         });
         useUpdate({ func: () => this._update() });
+        this._chatterRef = useRef('chatter');
     }
 
     /**
@@ -62,6 +64,17 @@ class ChatterContainer extends Component {
         }
     }
 
+    /**
+     * @private
+     * @param {MouseEvent} ev
+     */
+    onScroll(ev) {
+        if (!this._chatterRef.comp) {
+            return;
+        }
+        this._chatterRef.comp.onScroll(ev);
+    }
+
     //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------
@@ -71,6 +84,8 @@ class ChatterContainer extends Component {
      */
     _insertFromProps(props) {
         const values = Object.assign({}, props);
+        // getScrollableElement is not required as a model field for chatter
+        delete values.getScrollableElement;
         if (values.threadId === undefined) {
             values.threadId = clear();
         }
@@ -95,6 +110,15 @@ class ChatterContainer extends Component {
 Object.assign(ChatterContainer, {
     components,
     props: {
+        /**
+         * Function returns the exact scrollable element from the parent
+         * to manage proper scroll heights which affects the load more messages.
+         * In our case, the whole form view content is scrollabe if it is not aside.
+         */
+        getScrollableElement: {
+            type: Function,
+            optional: true,
+        },
         hasActivities: {
             type: Boolean,
             optional: true,

--- a/addons/mail/static/src/components/chatter_container/chatter_container.xml
+++ b/addons/mail/static/src/components/chatter_container/chatter_container.xml
@@ -4,7 +4,11 @@
     <t t-name="mail.ChatterContainer" owl="1">
         <div class="o_ChatterContainer">
             <t t-if="chatter">
-                <Chatter chatterLocalId="chatter.localId"/>
+                <Chatter
+                    chatterLocalId="chatter.localId"
+                    getScrollableElement= "props.getScrollableElement"
+                    t-ref="chatter"
+                />
             </t>
             <t t-else="">
                 <div class="o_ChatterContainer_noChatter"><i class="o_ChatterContainer_noChatterIcon fa fa-spinner fa-spin"/>Please wait...</div>

--- a/addons/mail/static/src/widgets/form_renderer/form_renderer.js
+++ b/addons/mail/static/src/widgets/form_renderer/form_renderer.js
@@ -33,6 +33,13 @@ FormRenderer.include({
     /**
      * @override
      */
+    start() {
+        document.addEventListener('scroll', this._onScrollForm.bind(this), true);
+        return this._super(...arguments);
+    },
+    /**
+     * @override
+     */
     destroy() {
         this._super(...arguments);
         this._chatterContainerComponent = undefined;
@@ -40,6 +47,12 @@ FormRenderer.include({
         this.off('o_chatter_rendered', this);
         this.off('o_message_posted', this);
         owl.Component.env.bus.off('mail.thread:promptAddFollower-closed', this);
+    },
+    /**
+     * @returns {Element|undefined} Scrollable Element
+     */
+    getScrollableElement() {
+        return $(".o_content") && $(".o_content")[0];
     },
 
     //--------------------------------------------------------------------------
@@ -93,6 +106,7 @@ FormRenderer.include({
             isAttachmentBoxVisibleInitially: this.chatterFields.isAttachmentBoxVisibleInitially,
             threadId: this.state.res_id,
             threadModel: this.state.model,
+            getScrollableElement: this.getScrollableElement
         };
     },
     /**
@@ -182,4 +196,13 @@ FormRenderer.include({
      * @param {mail.thread} ev.data.thread
      */
     _onChatterRendered(ev) {},
+    /**
+     * @private
+     * @param {MouseEvent} ev
+     */
+    _onScrollForm(ev) {
+        if (this._chatterContainerComponent) {
+            this._chatterContainerComponent.componentRef.comp.onScroll(ev)
+        }
+    }
 });


### PR DESCRIPTION
**PURPOSE**

Ease the way users navigate in the chatter.

**SPECIFICATION**

When there are many messages in the chatter, on scrolling down to the bottom,
the next message batch will be automatically loaded(with a spinner) instead of
asking for a "load more.." click.

**LINKS**

TaskId: 2363032
