### PR TITLE
[FIX] web: SampleServer: fix randomly failing test

### DIFF
--- a/addons/web/static/tests/views/sample_server_tests.js
+++ b/addons/web/static/tests/views/sample_server_tests.js
@@ -105,13 +105,11 @@ odoo.define('web.sample_server_tests', function (require) {
                     );
                 }
             }
-            function assertBetween(fieldName, min, max, decimal = 1) {
+            function assertBetween(fieldName, min, max, isFloat = false) {
+                const val = rec[fieldName];
                 assert.ok(
-                    min <= rec[fieldName] && rec[fieldName] < max &&
-                    rec[fieldName].toString().split(".").length === decimal,
-                    `Field "${fieldName}" is between ${min} and ${max} and is ${
-                        decimal === 1 ? "an integer" : "a float number"
-                    }`
+                    min <= val && val < max && (isFloat || parseInt(val, 10) === val),
+                    `Field "${fieldName}" is between ${min} and ${max} ${!isFloat ? 'and is an integer ' : ''}: ${val}`
                 );
             }
 
@@ -129,7 +127,7 @@ odoo.define('web.sample_server_tests', function (require) {
             assert.ok(SAMPLE_TEXTS.includes(rec.description));
             assertFormat('birthday', /\d{4}-\d{2}-\d{2}/);
             assertFormat('arrival_date', /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/);
-            assertBetween('height', 0, MAX_FLOAT, 2);
+            assertBetween('height', 0, MAX_FLOAT, true);
             assertBetween('color', 0, MAX_COLOR_INT);
             assertBetween('age', 0, MAX_INTEGER);
             assertBetween('salary', 0, MAX_MONETARY);


### PR DESCRIPTION
Commit [1] recently tweaked the way floats are generated in the
SampleServer, as they are now rounded to 2 decimals. As a
consequence it sometimes generates integers for float fields (e.g.
5 for 5.00). This is also what the real server does, so it's fine.
However, a test was asserting that float fields were floats, so
this test sometimes failed and thus needed to be adapted.

[1] https://github.com/odoo/odoo/commit/81f2bc7

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
