### PR TITLE
[FIX] mail: mark all need action as read

### DIFF
--- a/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview.js
+++ b/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview.js
@@ -119,7 +119,6 @@ class ThreadNeedactionPreview extends Component {
             // handled in `_onClickMarkAsRead`
             return;
         }
-        this.thread.markNeedactionMessagesAsOriginThreadAsRead();
         this.thread.open();
         if (!this.env.messaging.device.isMobile) {
             this.env.messaging.messagingMenu.close();
@@ -131,7 +130,10 @@ class ThreadNeedactionPreview extends Component {
      * @param {MouseEvent} ev
      */
     _onClickMarkAsRead(ev) {
-        this.thread.markNeedactionMessagesAsOriginThreadAsRead();
+        this.env.models['mail.message'].markAllAsRead([
+            ['model', '=', this.thread.model],
+            ['res_id', '=', this.thread.id],
+        ]);
     }
 
 }

--- a/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview_tests.js
+++ b/addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview_tests.js
@@ -44,7 +44,7 @@ QUnit.module('thread_needaction_preview_tests.js', {
 });
 
 QUnit.test('mark as read', async function (assert) {
-    assert.expect(4);
+    assert.expect(5);
 
     this.data['mail.message'].records.push({
         id: 21,
@@ -63,8 +63,16 @@ QUnit.test('mark as read', async function (assert) {
         hasChatWindow: true,
         hasMessagingMenu: true,
         async mockRPC(route, args) {
-            if (route.includes('set_message_done')) {
-                assert.step('set_message_done');
+            if (route.includes('mark_all_as_read')) {
+                assert.step('mark_all_as_read');
+                assert.deepEqual(
+                    args.kwargs.domain,
+                    [
+                        ['model', '=', 'res.partner'],
+                        ['res_id', '=', 11],
+                    ],
+                    "should mark all as read the correct thread"
+                );
             }
             return this._super(...arguments);
         },
@@ -87,8 +95,8 @@ QUnit.test('mark as read', async function (assert) {
         document.querySelector('.o_ThreadNeedactionPreview_markAsRead').click()
     );
     assert.verifySteps(
-        ['set_message_done'],
-        "should have marked the message as read"
+        ['mark_all_as_read'],
+        "should have marked the thread as read"
     );
     assert.containsNone(
         document.body,
@@ -98,7 +106,7 @@ QUnit.test('mark as read', async function (assert) {
 });
 
 QUnit.test('click on preview should mark as read and open the thread', async function (assert) {
-    assert.expect(5);
+    assert.expect(6);
 
     this.data['mail.message'].records.push({
         id: 21,
@@ -117,8 +125,16 @@ QUnit.test('click on preview should mark as read and open the thread', async fun
         hasChatWindow: true,
         hasMessagingMenu: true,
         async mockRPC(route, args) {
-            if (route.includes('set_message_done')) {
-                assert.step('set_message_done');
+            if (route.includes('mark_all_as_read')) {
+                assert.step('mark_all_as_read');
+                assert.deepEqual(
+                    args.kwargs.domain,
+                    [
+                        ['model', '=', 'res.partner'],
+                        ['res_id', '=', 11],
+                    ],
+                    "should mark all as read the correct thread"
+                );
             }
             return this._super(...arguments);
         },
@@ -146,7 +162,7 @@ QUnit.test('click on preview should mark as read and open the thread', async fun
         document.querySelector('.o_ThreadNeedactionPreview').click()
     );
     assert.verifySteps(
-        ['set_message_done'],
+        ['mark_all_as_read'],
         "should have marked the message as read on clicking on the preview"
     );
     assert.containsOnce(

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -1520,9 +1520,6 @@ function factory(dependencies) {
             if (this.channel_type === 'chat' && !this.areFollowersLoaded) {
                 this.refreshFollowers();
             }
-            if (this.needactionMessagesAsOriginThread.length > 0) {
-                this.markNeedactionMessagesAsOriginThreadAsRead();
-            }
         }
 
         /**

--- a/addons/mail/static/src/models/thread_view/thread_view.js
+++ b/addons/mail/static/src/models/thread_view/thread_view.js
@@ -138,7 +138,10 @@ function factory(dependencies) {
             this.update({ componentHintList: clear() });
             this.addComponentHint('change-of-thread-cache');
             if (this.threadCache) {
-                this.threadCache.update({ isCacheRefreshRequested: true });
+                this.threadCache.update({
+                    isCacheRefreshRequested: true,
+                    isMarkAllAsReadRequested: true,
+                });
             }
             this.update({ lastVisibleMessage: [['unlink']] });
         }


### PR DESCRIPTION
using markAsRead only mark message stored inside the frontend.
By using markAllAsRead, we mark all the message regardless of the frontend.

task-2426357