### PR TITLE
[FIX] stock: Stock Move Source Location from a Scrap

### DIFF
--- a/addons/stock/models/stock_scrap.py
+++ b/addons/stock/models/stock_scrap.py
@@ -108,7 +108,12 @@ class StockScrap(models.Model):
         self.ensure_one()
         location_id = self.location_id.id
         if self.picking_id and self.picking_id.picking_type_code == 'incoming':
-            location_id = self.picking_id.location_dest_id.id
+            for move_line in self.picking_id.move_line_ids:
+                if move_line.product_id == self.product_id:
+                    location_id = move_line.location_id if move_line.state != 'done' else move_line.location_dest_id
+                    break
+            else:
+                location_id = self.picking_id.location_dest_id.id
         return {
             'name': self.name,
             'origin': self.origin or self.picking_id.name or self.name,


### PR DESCRIPTION
Steps to reproduce the bug:

- Enable multi-location, warehouse and route
- Enable "Is a Return Location?" for WH/Stock location (Not assign to child location due to put-away rules)
- Create a child location for WH/Stock, Example "WH/Stock/Shelf1"
- Create Putaway Rules for the child location from step 1
- Create a product and adjust stock into WH/Stock/Shelf1 (Example adjust 500 unit for Office Chair)
- Create sales order to delivery the 500 unit to customer
- Reserved 500 unit and validate Delivery Order transfer
- Return the goods to WH/Stock
- Validate the return goods with 500 unit back to stock
- Scrap the 500 units goods
- Upon product selected the source location will automatically select the child location WH/Stock/Shelf1 (base on stock move)
- Update quantity to 500 unit and click on "Done" button on the Scrap wizard
- You will get warning that "The product [FURN_7777] Office Chair is not available in sufficient quantity in WH/Stock/Shelf 1."
where checked the stock is available in Shelf1. Then ignore the warning click on confirm button
- Check Scrap record is showing correct from Shelf1 to Scrap location

Bug:

Check product stock move it is from WH/Stock to Scarp instead of WH/Stock/Shelf1 to Scrap

opw:2412699