### PR TITLE
[FIX] repair: be able to put service on repair fees

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -749,7 +749,7 @@ class RepairFee(models.Model):
     name = fields.Text('Description', index=True, required=True)
     product_id = fields.Many2one(
         'product.product', 'Product', check_company=True,
-        domain="[('type', 'in', ['product', 'consu']), '|', ('company_id', '=', company_id), ('company_id', '=', False)]")
+        domain="[('type', '=', 'service'), '|', ('company_id', '=', company_id), ('company_id', '=', False)]")
     product_uom_qty = fields.Float('Quantity', digits='Product Unit of Measure', required=True, default=1.0)
     price_unit = fields.Float('Unit Price', required=True, digits='Product Price')
     product_uom = fields.Many2one('uom.uom', 'Product Unit of Measure', required=True, domain="[('category_id', '=', product_uom_category_id)]")


### PR DESCRIPTION
commit 38711e9f9c7a06017d284d75e31198fa9ae3cf37 prevent multi company issues.
But it goes a little too far in restriction and prevent to put a service
in the repair fee. Which is a feature since user would like to register
and invoice human resources in maintenance cost.
