### PR TITLE
[FIX] calendar: synchronize email_from and author_id when sending ema…

### DIFF
--- a/addons/calendar/models/calendar.py
+++ b/addons/calendar/models/calendar.py
@@ -203,6 +203,7 @@ class Attendee(models.Model):
                 email_values = {
                     'model': None,  # We don't want to have the mail in the tchatter while in queue!
                     'res_id': None,
+                    'author_id': attendee.event_id.user_id.partner_id.id or self.env.user.partner_id.id,
                 }
                 if ics_file:
                     email_values['attachment_ids'] = [


### PR DESCRIPTION
…il to attendees

When emails related to calendar events are sent email_from is set from
templates like invite template. Author of those email is however not set
and current user is used as default value.

In this commit we do as done in templates and try to set event responsible
as user, and fall back on current user if not set.

This notably solves an issue when using website_calendar. Appointments are
done using public user and mails have public user as author. This leads to
emails not being accessible or having a false email_from.

Task ID-2413792
