### PR TITLE
[FIX][14.0] calendar.recurrence : _compute_name for weekly rules

### DIFF
--- a/addons/calendar/models/calendar_recurrence.py
+++ b/addons/calendar/models/calendar_recurrence.py
@@ -134,10 +134,10 @@ class RecurrenceRule(models.Model):
             else:
                 end = ''
 
-            if recurrence.rrule_type == 'weeky':
+            if recurrence.rrule_type == 'weekly':
                 weekdays = recurrence._get_week_days()
                 weekday_fields = (self._fields[weekday_to_field(w)] for w in weekdays)
-                on = _("on %s,") % ", ".join([field.string for field in weekday_fields])
+                on = _("on %s, ") % ", ".join([field.string for field in weekday_fields])
             elif recurrence.rrule_type == 'monthly':
                 if recurrence.month_by == 'day':
                     weekday_label = dict(BYDAY_SELECTION)[recurrence.byday]
@@ -427,7 +427,7 @@ class RecurrenceRule(models.Model):
         :return: tuple of rrule weekdays for this recurrence.
         """
         return tuple(
-            rrule.weekday(weekday_index)
+            weekday_index
             for weekday_index, weekday in {
                 rrule.MO.weekday: self.mo,
                 rrule.TU.weekday: self.tu,


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

A typo in compute name was preventing the block from executing

Moreover, `_get_week_day` was returning instances of rrule.weekday class instead of weekday integers, thus not matching any of the keys in `RRULE_WEEKDAY_TO_FIELD`.

Also added a missing space after the comma to the "on" string

**Current behavior before PR:**

On weekly calendar recurrences, the weekdays where ignored in the name

**Desired behavior after PR is merged:**

On weekly calendar recurrence, the weekdays are included into the name



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
