### PR TITLE
[FIX] web: QUnit post-test remaining DOM elements

### DIFF
--- a/addons/web/static/tests/helpers/qunit_config.js
+++ b/addons/web/static/tests/helpers/qunit_config.js
@@ -183,6 +183,7 @@ QUnit.on('OdooAfterTestHook', function (info) {
     // check for leftovers in #qunit-fixture
     const qunitFixture = document.getElementById('qunit-fixture');
     if (qunitFixture.children.length) {
+        console.error(`Test ${info.moduleName} > ${info.testName}`);
         console.error('#qunit-fixture still contains elements:' +
             '\n#qunit-fixture HTML:\n' + qunitFixture.outerHTML);
         QUnit.pushFailure(`#qunit-fixture still contains elements`);

--- a/addons/web/static/tests/helpers/qunit_config.js
+++ b/addons/web/static/tests/helpers/qunit_config.js
@@ -183,9 +183,9 @@ QUnit.on('OdooAfterTestHook', function (info) {
     // check for leftovers in #qunit-fixture
     const qunitFixture = document.getElementById('qunit-fixture');
     if (qunitFixture.children.length) {
-        // console.error('#qunit-fixture still contains elements:' +
-        //     '\n#qunit-fixture HTML:\n' + qunitFixture.outerHTML);
-        // QUnit.pushFailure(`#qunit-fixture still contains elements`);
+        console.error('#qunit-fixture still contains elements:' +
+            '\n#qunit-fixture HTML:\n' + qunitFixture.outerHTML);
+        QUnit.pushFailure(`#qunit-fixture still contains elements`);
         toRemove.push(...qunitFixture.children);
     }
 

--- a/addons/web/tests/test_js.py
+++ b/addons/web/tests/test_js.py
@@ -12,7 +12,7 @@ class WebSuite(odoo.tests.HttpCase):
 
     def test_js(self):
         # webclient desktop test suite
-        self.browser_js('/web/tests?mod=web', "", "", login='admin', timeout=1800)
+        self.browser_js('/web/tests?mod=web&failfast', "", "", login='admin', timeout=1800)
 
     def test_check_suite(self):
         # verify no js test is using `QUnit.only` as it forbid any other test to be executed


### PR DESCRIPTION
This PR restores the QUnit post-test which checks for remaining DOM elements in either the document's body or the `#qunit-fixture` element.

Also, it properly outputs the module and test names in case of error.
