### PR TITLE
[FIX] web: disable jQuery htmlPrefilter

### DIFF
--- a/addons/web/static/src/js/libs/jquery.js
+++ b/addons/web/static/src/js/libs/jquery.js
@@ -120,4 +120,13 @@ $.fn.extend({
         });
     },
 });
+
+// Disable html prefilter to avoid potential xss vulnerability. This issue is
+// fixed in jQuery 3.5.0 with a equivalent patch.
+// See https://nvd.nist.gov/vuln/detail/CVE-2020-11022
+// See https://github.com/jquery/jquery/security/advisories/GHSA-gxr4-xjj5-5px2
+$.htmlPrefilter = function (html) {
+    return html;
+};
+
 });


### PR DESCRIPTION
This commit patches jQuery to disable the prefilter that modifies
and filters strings passed through jQuery manipulation methods
like html() or append(). This function introduces a potential xss
vulnerability [1], even though it's unlikely to be exploitable in
Odoo. We decided to fix it anyway as the fix is harmless and
suggested by jQuery themselves [2]. This issue has been fixed in
jQuery 3.5.0 with a similar patch [3].

[1] https://nvd.nist.gov/vuln/detail/CVE-2020-11022
[2] https://github.com/jquery/jquery/security/advisories/GHSA-gxr4-xjj5-5px2
[3] https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/

opw~2416541

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
