### PR TITLE
[IMP] crm, crm_iap_lead_enrich, crm_iap_lead, sales_team: reporting u…

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1297,11 +1297,26 @@ class Lead(models.Model):
 
     @api.model
     def get_empty_list_help(self, help):
-        help_title, sub_title = "", ""
-        if self._context.get('default_type') == 'lead':
-            help_title = _('Create a new lead')
-        else:
+        help_title = _('No data found!')
+        sub_title = ""
+        if self.env.context.get('action_helper') == 'pipeline':
             help_title = _('Create an opportunity to start playing with your pipeline.')
+        elif self.env.context.get('action_helper') == 'leads':
+            help_title = _('Create a Lead')
+            sub_title = _('Leads are the qualification step before the creation of an opportunity.')
+        elif self.env.context.get('action_helper') == 'activities':
+            help_title = _('Looks like nothing is planned.')
+            sub_title = _('Schedule activities to keep track of everything you have to do.')
+        elif self.env.context.get('action_helper') == 'lead_analysis':
+            sub_title = _('This analysis shows you how many leads have been created per month.')
+        elif self.env.context.get('action_helper') == 'pipeline_analysis':
+            sub_title = _('Use this menu to have an overview of your Pipeline.')
+        elif self.env.context.get('action_helper') == 'opportunity_dashboard':
+            sub_title = _('Use this menu to have an overview of your Pipeline.')
+        elif self.env.context.get('action_helper') == 'lead_dashboard':
+            sub_title = _('This Dashboard allows you to see at a glance how well you are doing.')
+        else:
+            help_title = ""
         alias_record = self.env['mail.alias'].search([
             ('alias_name', '!=', False),
             ('alias_name', '!=', ''),

--- a/addons/crm/report/crm_opportunity_report_views.xml
+++ b/addons/crm/report/crm_opportunity_report_views.xml
@@ -112,7 +112,7 @@
             <field name="res_model">crm.lead</field>
             <field name="view_mode">graph,pivot,tree,form</field>
             <field name="search_view_id" ref="crm.crm_opportunity_report_view_search"/>
-            <field name="context">{'search_default_opportunity': True, 'search_default_current': True}</field>
+            <field name="context">{'search_default_opportunity': True,'search_default_current': True,'action_helper': 'pipeline_analysis'}</field>
             <field name="view_ids"
                    eval="[(5, 0, 0),
                           (0, 0, {'view_mode': 'graph', 'view_id': ref('crm_opportunity_report_view_graph')}),
@@ -138,6 +138,7 @@
                 'default_type': 'lead',
                 'search_default_lead': True,
                 'search_default_filter_create_date': 1,
+                'action_helper': 'lead_analysis'
             }</field>
             <field name="view_ids"
                    eval="[(5, 0, 0),

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -488,7 +488,7 @@
             <field name="priority" eval="1"/>
             <field name="arch" type="xml">
                 <kanban default_group_by="stage_id" class="o_kanban_small_column o_opportunity_kanban" on_create="quick_create" quick_create_view="crm.quick_create_opportunity_form"
-                    archivable="false" sample="1">
+                    archivable="false">
                     <field name="stage_id" options='{"group_by_tooltip": {"requirements": "Description"}}'/>
                     <field name="color"/>
                     <field name="priority"/>
@@ -641,7 +641,7 @@
             <field name="model">crm.lead</field>
             <field name="priority">1</field>
             <field name="arch" type="xml">
-                <tree string="Opportunities" sample="1" multi_edit="1">
+                <tree string="Opportunities" multi_edit="1">
                     <field name="date_deadline" invisible="1"/>
                     <field name="create_date" optional="hide"/>
                     <field name="name" string="Opportunity" readonly="1"/>
@@ -737,7 +737,7 @@
             <field name="name">crm.lead.view.graph</field>
             <field name="model">crm.lead</field>
             <field name="arch" type="xml">
-                <graph string="Opportunities" sample="1">
+                <graph string="Opportunities">
                     <field name="stage_id" type="col"/>
                     <field name="user_id" type="row"/>
                     <field name="color" invisible="1"/>
@@ -749,7 +749,7 @@
             <field name="name">crm.lead.view.pivot</field>
             <field name="model">crm.lead</field>
             <field name="arch" type="xml">
-                <pivot string="Pipeline Analysis" sample="1">
+                <pivot string="Pipeline Analysis">
                     <field name="create_date" interval="month" type="row"/>
                     <field name="stage_id" type="col"/>
                     <field name="expected_revenue" type="measure"/>
@@ -862,6 +862,7 @@ if record:
                     'default_type':'lead',
                     'search_default_type': 'lead',
                     'search_default_to_process':1,
+                    'action_helper': 'leads',
                 }
             </field>
         </record>
@@ -914,7 +915,7 @@ if record:
             <field name="domain">[('activity_ids','!=',False)]</field>
             <field name="search_view_id" ref="crm.view_crm_case_my_activities_filter"/>
             <field name="context">{'default_type': 'opportunity',
-                    'search_default_assigned_to_me': 1}
+                    'search_default_assigned_to_me': 1,'action_helper': 'activities'}
             </field>
         </record>
 
@@ -932,7 +933,7 @@ if record:
             <field name="view_mode">kanban,tree,graph,pivot,form,calendar,activity</field>
             <field name="domain">[('type','=','opportunity')]</field>
             <field name="context">{
-                    'default_type': 'opportunity',
+                    'default_type': 'opportunity'
                 }
             </field>
             <field name="search_view_id" ref="crm.view_crm_case_opportunities_filter"/>
@@ -988,7 +989,8 @@ if record:
             <field name="domain">[('type','=','opportunity')]</field>
             <field name="context">{
                     'default_type': 'opportunity',
-                    'search_default_assigned_to_me': 1
+                    'search_default_assigned_to_me': 1,
+                    'action_helper': 'pipeline'
             }</field>
             <field name="search_view_id" ref="crm.view_crm_case_opportunities_filter"/>
         </record>

--- a/addons/crm_iap_lead/models/crm_iap_lead_mining_request.py
+++ b/addons/crm_iap_lead/models/crm_iap_lead_mining_request.py
@@ -251,13 +251,45 @@ class CRMLeadMiningRequest(models.Model):
         </p>""")
         return action
 
+    @api.model
+    def action_try_button(self):
+        last_action = self.env['crm.iap.lead.mining.request'].search([('user_id', '=', self.env.uid)], order='create_date desc', limit=1)
+        return {
+            'name': _('Try Again'),
+            'res_model': 'crm.iap.lead.mining.request',
+            'views': [[False, 'form']],
+            'target': 'new',
+            'domain': [('type', '=', 'opportunity')],
+            'type': 'ir.actions.act_window',
+            'res_id':self.id,
+            'context': {'is_modal': True,'default_type': 'opportunity',
+                        'default_lead_number':last_action.lead_number,
+                        'default_country_ids':last_action.country_ids.ids,
+                        'default_search_type': last_action.search_type,
+                        'default_state_ids': last_action.state_ids.ids,
+                        'default_industry_ids':last_action.industry_ids.ids,
+                        'default_filter_on_size':last_action.filter_on_size,
+                        'default_company_size_min':last_action.company_size_min,
+                        'default_company_size_max':last_action.company_size_max,
+                        'default_team_id':last_action.team_id.id,
+                        'default_user_id':last_action.user_id.id,
+                        'default_tag_ids':last_action.tag_ids.ids,
+                        'default_contact_number':last_action.contact_number,
+                        'default_contact_filter_type':last_action.contact_filter_type,
+                        'default_preferred_role_id':last_action.preferred_role_id.id,
+                        'default_role_ids':last_action.role_ids.ids}
+        }
+
     def action_get_opportunity_action(self):
+        action_id = self.env.ref('crm_iap_lead.action_try_again').id
         self.ensure_one()
         action = self.env["ir.actions.actions"]._for_xml_id("crm.crm_lead_opportunities")
         action['domain'] = [('id', 'in', self.lead_ids.ids), ('type', '=', 'opportunity')]
         action['help'] = _("""<p class="o_view_nocontent_empty_folder">
-            No opportunities found
+            No leads found
         </p><p>
-            No opportunities could be generated according to your search criteria
-        </p>""")
+            Your search criteria did not return any leads.
+        </p>
+        <a type="action" name="%(action_id)s" class="text-primary">Try Again</a>
+         """)% {'action_id': action_id}
         return action

--- a/addons/crm_iap_lead/views/crm_iap_lead_views.xml
+++ b/addons/crm_iap_lead/views/crm_iap_lead_views.xml
@@ -53,7 +53,7 @@
                         <group name="companies">
                             <field name="country_ids" widget="many2many_tags" attrs="{'readonly': [('state', '!=', 'draft')]}" required="True" options="{'no_create': True, 'no_open': True}"/>
                             <field name="state_ids" widget="many2many_tags" attrs="{'invisible': [('country_ids', '=', [])], 'readonly': [('state', '!=', 'draft')]}" domain="[('country_id', 'in', country_ids)]" options="{'no_create': True, 'no_open': True}"/>
-                            <field name="industry_ids" widget="many2many_tags" attrs="{'readonly': [('state', '!=', 'draft')]}" options="{'no_create': True, 'no_open': True}" class="o_industry"/>
+                            <field name="industry_ids" widget="many2many_tags" attrs="{'readonly': [('state', '!=', 'draft')]}" options="{'no_create': True, 'no_open': True}" class="o_industry" required="1"/>
                             <field name="filter_on_size" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
                             <label for="company_size_min" attrs="{'invisible': [('filter_on_size', '=', False)]}"/>
                             <div attrs="{'invisible': [('filter_on_size', '=', False)]}">
@@ -143,6 +143,13 @@
         <field name="view_mode">tree,form</field>
     </record>
 
+    <record id="action_try_again" model="ir.actions.server">
+            <field name="name">Crm: Try Again</field>
+            <field name="model_id" ref="crm_iap_lead.model_crm_iap_lead_mining_request"/>
+            <field name="code">
+                action = model.action_try_button()
+            </field>
+    </record>
     <!-- This menu is display in CRM app when crm_iap_lead is installed-->
     <menuitem
         id="crm_menu_lead_generation"

--- a/addons/crm_iap_lead_enrich/models/crm_lead.py
+++ b/addons/crm_iap_lead_enrich/models/crm_lead.py
@@ -29,7 +29,7 @@ class Lead(models.Model):
             self.show_enrich_button = False
             return
         for lead in self:
-            if not lead.active or not lead.email_from or lead.iap_enrich_done or lead.reveal_id or lead.probability == 100:
+            if not lead.active or not lead.email_from or lead.iap_enrich_done or lead.reveal_id or lead.probability == 100 or not lead.email_state == "correct":
                 lead.show_enrich_button = False
             else:
                 lead.show_enrich_button = True

--- a/addons/sales_team/views/crm_tag_views.xml
+++ b/addons/sales_team/views/crm_tag_views.xml
@@ -19,7 +19,7 @@
                     </div>
                     <group>
                         <group>
-                            <field name="color" required="True"/>
+                            <field name="color" required="True" widget="color_picker"/>
                         </group>
                     </group>
                 </sheet>


### PR DESCRIPTION
…sability improvements

in this commit some reporting usability improvements are done
in crm, lead generation and iap services.

general usability improvements done are listed below,
 - new color picker widget for the color field in crm tag form view.
 - the enrich button now appear as soon as the email field is set with
   something that looks like an email address.
 - the results obtained without having an industry set seem very random
   and not actionable at all, so the industry field made required.
 - some action helpers are updated for the menus my activities, leads,
   leads analysis, pipeline analysis and dashboard.
 - a new try again link is given in the helper message of lead generation,
   it will opens the lead generation modal with the previously entered
   search criterions, and sample data are removed from kanban, list,
   graph, dashboard and cohort views.

task-id: 2393253

