### PR TITLE
[FIX] website,portal: set default lang in website

### DIFF
--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -45,9 +45,6 @@
     </template>
 
     <template id="language_selector" name="Language Selector">
-        <t t-if="lang not in (lg[0] for lg in languages)">
-            <t t-set="lang" t-value="website.default_lang_id.code"/>
-        </t>
         <t t-set="active_lang" t-value="list(filter(lambda lg : lg[0] == lang, languages))[0]"/>
         <t t-set="language_selector_visible" t-value="len(languages) &gt; 1"/>
         <div t-attf-class="js_language_selector #{_div_classes}" t-if="language_selector_visible">

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -1812,6 +1812,12 @@
 </template>
 
 <template id="language_selector" inherit_id="portal.language_selector">
+    <xpath expr="//t[@t-set='active_lang']" position="before">
+        <t t-if="lang not in (lg[0] for lg in languages)">
+            <t t-set="lang" t-value="website.default_lang_id.code"/>
+        </t>
+    </xpath>
+
     <!-- Always show the language selector on editable websites -->
     <xpath expr="//t[@t-set='language_selector_visible']" position="after">
         <t t-set="language_selector_visible" t-value="language_selector_visible or (website and (editable or translatable))"/>


### PR DESCRIPTION
BEFORE it was mistakenly done in portal module, but ``website`` may be not available there

---

original commit https://github.com/odoo/odoo/commit/e9ef98410fa6acba165f3056d9c52f8e68cc768b
opw-2416586

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
