### PR TITLE
[FIX] account: restricted fields on notes

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4025,6 +4025,12 @@ class AccountMoveLine(models.Model):
             # Don't copy the name of a payment term line.
             if line.move_id.is_invoice() and line.account_id.user_type_id.type in ('receivable', 'payable'):
                 values['name'] = ''
+            # Don't copy restricted fields of notes
+            if line.display_type in ('line_section', 'line_note'):
+                values['amount_currency'] = 0
+                values['debit'] = 0
+                values['credit'] = 0
+                values['account_id'] = False
             if self._context.get('include_business_fields'):
                 line._copy_data_extend_business_fields(values)
         return res


### PR DESCRIPTION
During 12.0->13.0 migration, some use cases are solved using notes.
Those notes contain values for restricted fields. Instead of losing 
data,
we keep the values and don't copy them to avoid issues in use cases 
like 
"create credit note from invoice".

