### PR TITLE
[FIX] mail: missing dependecies to compute _onChangeThreadViews

### DIFF
--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -2021,6 +2021,7 @@ function factory(dependencies) {
         onChangeThreadView: attr({
             compute: '_onChangeThreadViews',
             dependencies: [
+                'needactionMessagesAsOriginThread',
                 'threadViews',
             ],
         }),


### PR DESCRIPTION
Without `needActionMessageAsOriginThread` the markAllAsRead isn't correctly
triggered, especialy if you open direct link to a document inside a new
tab (e.g. from the inbox).

task-2426366