### PR TITLE
[FIX] account: Allow sharing outstanding accounts on bank journals

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -307,46 +307,6 @@ class AccountJournal(models.Model):
         if self._cr.fetchone():
             raise UserError(_("You can't change the company of your journal since there are some journal entries linked to it."))
 
-    @api.constrains('default_account_id', 'payment_debit_account_id', 'payment_credit_account_id')
-    def _check_journal_not_shared_accounts(self):
-        liquidity_journals = self.filtered(lambda journal: journal.type in ('bank', 'cash'))
-
-        accounts = liquidity_journals.default_account_id \
-                   + liquidity_journals.payment_debit_account_id \
-                   + liquidity_journals.payment_credit_account_id
-
-        if not accounts:
-            return
-
-        self.env['account.journal'].flush([
-            'default_account_id',
-            'payment_debit_account_id',
-            'payment_credit_account_id',
-        ])
-        self._cr.execute('''
-            SELECT
-                account.name,
-                ARRAY_AGG(DISTINCT journal.name) AS journal_names
-            FROM account_account account
-            LEFT JOIN account_journal journal ON
-                journal.default_account_id = account.id
-                OR
-                journal.payment_debit_account_id = account.id
-                OR
-                journal.payment_credit_account_id = account.id
-            WHERE account.id IN %s
-            AND journal.type IN ('bank', 'cash')
-            GROUP BY account.name
-            HAVING COUNT(DISTINCT journal.id) > 1
-        ''', [tuple(accounts.ids)])
-        res = self._cr.fetchone()
-        if res:
-            raise ValidationError(_(
-                "The account %(account_name)s can't be shared between multiple journals: %(journals)s",
-                account_name=res[0],
-                journals=', '.join(res[1])
-            ))
-
     @api.constrains('type', 'default_account_id')
     def _check_type_default_account_id_type(self):
         for journal in self:

--- a/addons/account/tests/test_account_journal.py
+++ b/addons/account/tests/test_account_journal.py
@@ -18,22 +18,6 @@ class TestAccountJournal(AccountTestInvoicingCommon):
         with self.assertRaises(ValidationError), self.cr.savepoint():
             journal_bank.default_account_id.currency_id = self.company_data['currency']
 
-    def test_constraint_shared_accounts(self):
-        ''' Ensure the bank/outstanding accounts are not shared between multiple journals. '''
-        journal_bank = self.company_data['default_journal_bank']
-
-        account_fields = (
-            'default_account_id',
-            'payment_debit_account_id',
-            'payment_credit_account_id',
-        )
-        for account_field in account_fields:
-            with self.assertRaises(ValidationError), self.cr.savepoint():
-                journal_bank.copy(default={
-                    'name': 'test_constraint_shared_accounts %s' % account_field,
-                    account_field: journal_bank[account_field].id,
-                })
-
     def test_changing_journal_company(self):
         ''' Ensure you can't change the company of an account.journal if there are some journal entries '''
 


### PR DESCRIPTION
In the bank reconciliation widget, allow matching a payment (blue lines) owned by another bank journal as the statement line one if both journal are sharing the same outstanding account.
It implies to remove the constraint preventing such accounts sharing.

The purpose is the following.
Suppose you are working with payment acquirers generating payments on a bank journal A.
At the end of the month, the bank journal B is debited to pay the payment acquirer.
At this point, you get a statement line on journal B you need to match with payments generated on A.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
