### PR TITLE
[FIX] product_margin: create test invoice in UTC timezone

### DIFF
--- a/addons/product_margin/tests/test_product_margin.py
+++ b/addons/product_margin/tests/test_product_margin.py
@@ -10,7 +10,7 @@ class TestProductMargin(common.TransactionCase):
     def create_account_invoice(self, invoice_type, partner, product, quantity=0.0, price_unit=0.0):
         """ Create an invoice as in a view by triggering its onchange methods"""
 
-        invoice_form = Form(self.env['account.move'].with_context(default_type=invoice_type))
+        invoice_form = Form(self.env['account.move'].with_context(default_type=invoice_type, tz='UTC'))
         invoice_form.partner_id = partner
         with invoice_form.invoice_line_ids.new() as line:
             line.product_id = product


### PR DESCRIPTION
In test_product_margin, a test form is used to create account moves. The
account move `date` field defaults to fields.Date.context_today which
itself will use the user time zone. When demo data are installed, the
timezone of the `system` is `Europe/Brussels`.

As a consequence, when the test runs on 2020-12-31 23:45:00 the account
moves are created with a date in 2021 and the test crashes.

With this commit, the account moves are created with a context_today in
the `UTC` timezone.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
