### PR TITLE
[MERGE] sales_team, crm, crm_iap_*: improve reporting usability

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -13,7 +13,7 @@ from odoo.addons.phone_validation.tools import phone_validation
 from odoo.exceptions import UserError, AccessError
 from odoo.osv import expression
 from odoo.tools.translate import _
-from odoo.tools import date_utils, email_re, email_split
+from odoo.tools import date_utils, email_re, email_split, is_html_empty
 
 from . import crm_stage
 
@@ -979,6 +979,13 @@ class Lead(models.Model):
 
     @api.model
     def get_empty_list_help(self, help):
+        """ This method returns the action helpers for the leads. If help is already provided
+            on the action, the same is returned. Otherwise, we build the help message which
+            contains the alias responsible for creating the lead (if available) and return it.
+        """
+        if not is_html_empty(help):
+            return help
+
         help_title, sub_title = "", ""
         if self._context.get('default_type') == 'lead':
             help_title = _('Create a new lead')

--- a/addons/crm/report/crm_opportunity_report_views.xml
+++ b/addons/crm/report/crm_opportunity_report_views.xml
@@ -118,11 +118,13 @@
                           (0, 0, {'view_mode': 'graph', 'view_id': ref('crm_opportunity_report_view_graph')}),
                           (0, 0, {'view_mode': 'pivot', 'view_id': ref('crm_opportunity_report_view_pivot')}),
                           (0, 0, {'view_mode': 'tree', 'view_id': ref('crm_case_tree_view_oppor')})]"/>
-             <field name="help">Pipeline Analysis gives you an instant access to
-                your opportunities with information such as the expected revenue, planned cost,
-                missed deadlines or the number of interactions per opportunity. This report is
-                mainly used by the sales manager in order to do the periodic review with the
-                teams of the sales pipeline.</field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    No data found!
+                </p><p>
+                    Use this menu to have an overview of your Pipeline.
+                </p>
+            </field>
         </record>
 
         <record id="crm_opportunity_report_menu" model="ir.ui.menu">
@@ -143,7 +145,13 @@
                    eval="[(5, 0, 0),
                           (0, 0, {'view_mode': 'graph', 'view_id': ref('crm_opportunity_report_view_graph_lead')}),
                           (0, 0, {'view_mode': 'pivot', 'view_id': ref('crm_opportunity_report_view_pivot_lead')})]"/>
-            <field name="help">This report analyses the source of your leads.</field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    No data found!
+                </p><p>
+                    This analysis shows you how many leads have been created per month.
+                </p>
+            </field>
         </record>
 
         <record id="crm_opportunity_report_menu_lead" model="ir.ui.menu">

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -882,6 +882,13 @@ if record:
                     'search_default_to_process':1,
                 }
             </field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    Create a Lead
+                </p><p>
+                    Leads are the qualification step before the creation of an opportunity.
+                </p>
+            </field>
         </record>
 
         <record id="crm_lead_all_leads_view_tree" model="ir.actions.act_window.view">
@@ -933,6 +940,13 @@ if record:
             <field name="search_view_id" ref="crm.view_crm_case_my_activities_filter"/>
             <field name="context">{'default_type': 'opportunity',
                     'search_default_assigned_to_me': 1}
+            </field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    Looks like nothing is planned.
+                </p><p>
+                    Schedule activities to keep track of everything you have to do.
+                </p>
             </field>
         </record>
 

--- a/addons/crm_iap_lead/models/crm_iap_lead_mining_request.py
+++ b/addons/crm_iap_lead/models/crm_iap_lead_mining_request.py
@@ -245,29 +245,52 @@ class CRMLeadMiningRequest(models.Model):
         if results:
             self._create_leads_from_response(results)
             self.state = 'done'
-        if self.lead_type == 'lead':
-            return self.action_get_lead_action()
-        elif self.lead_type == 'opportunity':
-            return self.action_get_opportunity_action()
+            if self.lead_type == 'lead':
+                return self.action_get_lead_action()
+            elif self.lead_type == 'opportunity':
+                return self.action_get_opportunity_action()
+        else:
+            return self._action_try_again()
 
     def action_get_lead_action(self):
         self.ensure_one()
         action = self.env["ir.actions.actions"]._for_xml_id("crm.crm_lead_all_leads")
         action['domain'] = [('id', 'in', self.lead_ids.ids), ('type', '=', 'lead')]
-        action['help'] = _("""<p class="o_view_nocontent_empty_folder">
-            No leads found
-        </p><p>
-            No leads could be generated according to your search criteria
-        </p>""")
         return action
+
+    def _action_try_again(self):
+        last_mining_request = self.env['crm.iap.lead.mining.request'].search([('user_id', '=', self.env.uid)], order='create_date desc', limit=1)
+        return {
+            'name': _('Generate Leads'),
+            'res_model': 'crm.iap.lead.mining.request',
+            'views': [[False, 'form']],
+            'target': 'new',
+            'type': 'ir.actions.act_window',
+            'context': {
+                'show_warning': True,
+                'is_modal': True, 'default_state': 'draft',
+                'default_lead_type': last_mining_request.lead_type,
+                'default_lead_number':last_mining_request.lead_number,
+                'default_search_type': last_mining_request.search_type,
+                'default_country_ids':last_mining_request.country_ids.ids,
+                'default_state_ids': last_mining_request.state_ids.ids,
+                'default_industry_ids':last_mining_request.industry_ids.ids,
+                'default_filter_on_size':last_mining_request.filter_on_size,
+                'default_company_size_min':last_mining_request.company_size_min,
+                'default_company_size_max':last_mining_request.company_size_max,
+                'default_team_id':last_mining_request.team_id.id,
+                'default_user_id':last_mining_request.user_id.id,
+                'default_tag_ids':last_mining_request.tag_ids.ids,
+                'default_contact_number':last_mining_request.contact_number,
+                'default_contact_filter_type':last_mining_request.contact_filter_type,
+                'default_preferred_role_id':last_mining_request.preferred_role_id.id,
+                'default_role_ids':last_mining_request.role_ids.ids,
+                'default_seniority_id':last_mining_request.seniority_id.id,
+            }
+        }
 
     def action_get_opportunity_action(self):
         self.ensure_one()
         action = self.env["ir.actions.actions"]._for_xml_id("crm.crm_lead_opportunities")
         action['domain'] = [('id', 'in', self.lead_ids.ids), ('type', '=', 'opportunity')]
-        action['help'] = _("""<p class="o_view_nocontent_empty_folder">
-            No opportunities found
-        </p><p>
-            No opportunities could be generated according to your search criteria
-        </p>""")
         return action

--- a/addons/crm_iap_lead/views/crm_iap_lead_views.xml
+++ b/addons/crm_iap_lead/views/crm_iap_lead_views.xml
@@ -10,6 +10,9 @@
                     <button name="action_submit" type="object" string="Retry" states="error" class="oe_highlight"/>
                     <field name="state" widget="statusbar" statusbar_visible="draft,done" invisible="context.get('is_modal')"/>
                 </header>
+                <div class="alert alert-danger text-center" role="alert" invisible="not (context.get('show_warning') and context.get('is_modal'))">
+                    Your request did not return any result. No credits were used.
+                </div>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
                         <button name="action_get_opportunity_action" class="oe_stat_button" type="object" icon="fa-handshake-o" attrs="{'invisible': ['|', ('lead_type', '!=', 'opportunity'), ('state', '!=' , 'done')]}">
@@ -53,7 +56,7 @@
                         <group name="companies">
                             <field name="country_ids" widget="many2many_tags" attrs="{'readonly': [('state', '!=', 'draft')]}" required="True" options="{'no_create': True, 'no_open': True}"/>
                             <field name="state_ids" widget="many2many_tags" attrs="{'invisible': [('country_ids', '=', [])], 'readonly': [('state', '!=', 'draft')]}" domain="[('country_id', 'in', country_ids)]" options="{'no_create': True, 'no_open': True}"/>
-                            <field name="industry_ids" widget="many2many_tags" attrs="{'readonly': [('state', '!=', 'draft')]}" options="{'no_create': True, 'no_open': True}" class="o_industry"/>
+                            <field name="industry_ids" widget="many2many_tags" attrs="{'readonly': [('state', '!=', 'draft')]}" options="{'no_create': True, 'no_open': True}" class="o_industry" required="1"/>
                             <field name="filter_on_size" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
                             <label for="company_size_min" attrs="{'invisible': [('filter_on_size', '=', False)]}"/>
                             <div attrs="{'invisible': [('filter_on_size', '=', False)]}">

--- a/addons/crm_iap_lead/views/mail_templates.xml
+++ b/addons/crm_iap_lead/views/mail_templates.xml
@@ -4,6 +4,7 @@
     <template id="enrich_company" inherit_id="iap_mail.enrich_company">
         <xpath expr="//div[hasclass('o_partner_autocomplete_enrich_info')]" position="inside">
             <t t-if="people_data">
+                <t t-set="hasPhoneNumbers" t-value="any([people['phone'] for people in people_data])"/>
                 <div style="font-size:16px; margin: 9px 0;">
                     <b>Contacts</b>
                 </div>
@@ -14,17 +15,15 @@
                     border-right-style: solid;border-right-color: #eeeeee;border-right-width: 1px;" t-if="people_data">
                     <thead>
                         <tr style="background-color: #eeeeee">
-                            <th style="padding: 5px; width: 20%;">
+                            <th t-attf-style="padding: 5px; width: {{hasPhoneNumbers and '30%;' or '50%;'}}">
+                                <img style="vertical-align: text-top;" src="web_editor/font_to_img/61447/rgb(102,102,102)/13"/>
                                 Name
                             </th>
-                            <th style="padding: 5px; width: 20%;">
-                                Title
-                            </th>
-                            <th style="padding: 5px; width: 30%;">
+                            <th t-attf-style="padding: 5px; width: {{hasPhoneNumbers and '40%;' or '50%;'}}">
                                 <img style="vertical-align: text-top;" src="web_editor/font_to_img/61664/rgb(102,102,102)/13"/>
                                 Email
                             </th>
-                            <th style="padding: 5px; width: 30%;">
+                            <th style="padding: 5px; width: 30%;" t-if="hasPhoneNumbers">
                                 <img style="vertical-align: text-top;" src="web_editor/font_to_img/61589/rgb(102,102,102)/13"/>
                                 Phone
                             </th>
@@ -34,17 +33,19 @@
                         <t t-foreach="people_data" t-as="people">
                             <tr t-att-style="people_odd and 'background-color:#eeeeee' or None">
                                 <td style="padding: 5px">
-                                    <t t-esc="people['full_name'] or ''"/>
-                                </td>
-                                <td style="padding: 5px">
-                                    <t t-esc="people['title'] or ''"/>
+                                    <t t-set="fullName" t-value="people['full_name'] or ''"/>
+                                    <t t-set="title" t-value="people['title'] or ''"/>
+                                    <t t-if="fullName">
+                                        <h5 style="margin: 0;"><t t-esc="fullName"/><t t-if="title">,</t></h5>
+                                    </t>
+                                    <small t-esc="title" t-if="title"/>
                                 </td>
                                 <td style="padding: 5px">
                                     <a t-if="people['email']" t-attf-href="mailto:{{people['email']}}" target="_top">
                                         <t t-esc="people['email']"/>
                                     </a>
                                 </td>
-                                <td style="padding: 5px">
+                                <td style="padding: 5px" t-if="hasPhoneNumbers">
                                     <a t-if="people['phone']" t-attf-href="tel:{{people['phone']}}">
                                         <t t-esc="people['phone']"/>
                                     </a>

--- a/addons/crm_iap_lead_enrich/data/mail_templates.xml
+++ b/addons/crm_iap_lead_enrich/data/mail_templates.xml
@@ -2,21 +2,21 @@
 <odoo><data noupdate="1">
     <!-- VIEWS USED FOR MESSAGING -->
     <template id="mail_message_lead_enrich_notfound">
-        <p>Lead Enrichment based on email address</p>
+        <p>Lead Enrichment (based on email address)</p>
         <div style="background-color:#ffffff;padding:15px;">
             <span> No company data found based on the email address or email address is one of an email provider. No credit was consumed. </span>
         </div>
     </template>
 
     <template id="mail_message_lead_enrich_no_email">
-        <p>Lead Enrichment based on email address</p>
+        <p>Lead Enrichment (based on email address)</p>
         <div style="background-color:#ffffff;padding:15px;">
-            <span>Enrichment could not be done as no email address was provided.</span>
+            <span>Enrichment could not be done because the email address does not look valid.</span>
         </div>
     </template>
 
     <template id="mail_message_lead_enrich_no_credit">
-        <p>Lead enriched based on email address</p>
+        <p>Lead enriched (based on email address)</p>
         <div style="background-color:#ffffff;padding:15px;">
             <span>Your balance for Lead Enrichment is insufficient. Please go to your <a t-attf-href="{{url}}" target="_blank">IAP account</a> to buy credits.</span>
         </div>

--- a/addons/crm_iap_lead_enrich/models/crm_lead.py
+++ b/addons/crm_iap_lead_enrich/models/crm_lead.py
@@ -24,7 +24,7 @@ class Lead(models.Model):
             self.show_enrich_button = False
             return
         for lead in self:
-            if not lead.active or not lead.email_from or lead.iap_enrich_done or lead.reveal_id or lead.probability == 100:
+            if not lead.active or not lead.email_from or lead.email_state == 'incorrect' or lead.iap_enrich_done or lead.reveal_id or lead.probability == 100:
                 lead.show_enrich_button = False
             else:
                 lead.show_enrich_button = True

--- a/addons/sales_team/views/crm_tag_views.xml
+++ b/addons/sales_team/views/crm_tag_views.xml
@@ -17,7 +17,7 @@
                     </div>
                     <group>
                         <group>
-                            <field name="color" required="True"/>
+                            <field name="color" required="True" widget="color_picker"/>
                         </group>
                     </group>
                 </sheet>


### PR DESCRIPTION
PURPOSE

Purpose of this merge is to improve reporting usability
and views in crm, lead generation and iap services.

SPECIFICATIONS

Some usability improvements going to be done by this merge are listed
below.

Improve the action helpers for the actions bound to below listed menus
for better usability:

  * My Activities
  * Leads
  * Leads Analysis

Along with that, this commit also improves the following:

  * while generating leads, make 'Industries' field required on the modal so
    that results obtained are actionable instead of random leads;
  * after trying to generate leads, if no result is found, the same pop-up
    opens again with same criteria and displays a waring in the pop-up. It
    informs users that leads are not found and no credits are spent for their
    last search;
  * improve the warning message for unsuccessful enrichment due to invalid
    email;

This merge adds the color_picker widget for setting valid color of
CRM tags in the form view.

With this merge, the 'Enrich' button on lead now appears only after the
email is set and valid, which previously appeared even if no email is set
or if the value is not a valid email.

Right now, for the fetched contacts through enrichment, we display
name and title in separate columns (in the chatter), that leaves
lesser space for email and phone.

With this commit, we merge name and title columns, and provide a bit
extra space to email and phone so that chances for them being wrapped
in a new line are less. Also, if phone number is not available in any
contacts, the 'Phone' column is hidden, giving even more space for the
Name/Title and Email columns.

LINKS

COM PR odoo/odoo#64075
ENT PR odoo/enterprise#15561
Task ID-2393253

