### PR TITLE
Revert "[FIX] google_drive: fix traceback when add filter"

### DIFF
--- a/addons/google_drive/i18n/google_drive.pot
+++ b/addons/google_drive/i18n/google_drive.pot
@@ -88,6 +88,12 @@ msgid "Creating google drive may only be done by one at a time."
 msgstr ""
 
 #. module: google_drive
+#: code:addons/google_drive/models/google_drive.py:161
+#, python-format
+msgid "The document filter must not include any 'dynamic' part, so it should not be based on the current time or current user, for example."
+msgstr ""
+
+#. module: google_drive
 #: model:ir.filters,name:google_drive.filter_partner
 msgid "Customer"
 msgstr ""

--- a/addons/google_drive/models/google_drive.py
+++ b/addons/google_drive/models/google_drive.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import ast
 import logging
 import json
 import re
@@ -10,7 +12,6 @@ import werkzeug.urls
 from odoo import api, fields, models
 from odoo.exceptions import RedirectWarning, UserError
 from odoo.tools import pycompat
-from odoo.tools.safe_eval import safe_eval
 from odoo.tools.translate import _
 
 from odoo.addons.google_account.models.google_service import GOOGLE_TOKEN_ENDPOINT, TIMEOUT
@@ -161,15 +162,17 @@ class GoogleDrive(models.Model):
             raise UserError(_("Creating google drive may only be done by one at a time."))
         # check if a model is configured with a template
         configs = self.search([('model_id', '=', res_model)])
-        eval_context = self.env['ir.actions.actions']._get_eval_context()
         config_values = []
         for config in configs.sudo():
             if config.filter_id:
                 if config.filter_id.user_id and config.filter_id.user_id.id != self.env.user.id:
                     #Private
                     continue
-                domain = [('id', 'in', [res_id])] + safe_eval(config.filter_id.domain, eval_context)
-                additionnal_context = safe_eval(config.filter_id.context)
+                try:
+                    domain = [('id', 'in', [res_id])] + ast.literal_eval(config.filter_id.domain)
+                except:
+                    raise UserError(_("The document filter must not include any 'dynamic' part, so it should not be based on the current time or current user, for example."))
+                additionnal_context = ast.literal_eval(config.filter_id.context)
                 google_doc_configs = self.env[config.filter_id.model_id].with_context(**additionnal_context).search(domain)
                 if google_doc_configs:
                     config_values.append({'id': config.id, 'name': config.name})
@@ -222,6 +225,9 @@ class GoogleDrive(models.Model):
     def _check_model_id(self):
         if self.filter_id and self.model_id.model != self.filter_id.model_id:
             return False
+        if self.model_id.model and self.filter_id:
+            # force an execution of the filter to verify compatibility
+            self.get_google_drive_config(self.model_id.model, 1)
         return True
 
     def get_google_scope(self):


### PR DESCRIPTION
This reverts commit 82f236d98e322efd84c873df54f8e728e1d2a1bf.

The fix is actually not solving all the issues, and also introduce
a behavior change. Actually, the expected result for filters like

<filter string="My Pipeline" name="my" domain="[('user_id', '=', uid)]"/>

will result into a evaluated filters, but invalid as the uid is set to
the person configuring the google configuration, not the user who will
use it.

As it is tricky (or even impossible) to solve the issue properly in all
the cases, we prefer to warn the user that the filter is invalid instead.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
