### PR TITLE
[FIX] account: Fix 'change_account' automatic entry wizard

### DIFF
--- a/addons/account/wizard/account_automatic_entry_wizard.py
+++ b/addons/account/wizard/account_automatic_entry_wizard.py
@@ -47,7 +47,7 @@ class AutomaticEntryWizard(models.TransientModel):
     @api.constrains('percentage', 'action')
     def _constraint_percentage(self):
         for record in self:
-            if not (0.0 < record.percentage <= 100.0):
+            if not (0.0 < record.percentage <= 100.0) and record.action == 'change_period':
                 raise UserError(_("Percentage must be between 0 and 100"))
             if record.percentage != 100 and record.action != 'change_period':
                 raise UserError(_("Percentage can only be set for Change Period method"))


### PR DESCRIPTION
Percentage is not used when change_account is selected. Then, the constraint must not be triggered in that case.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
