### PR TITLE
[FIX] web_editor: prevent switching to text tools immediately

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1097,7 +1097,6 @@ var SnippetsMenu = Widget.extend({
 
         const $autoFocusEls = $('.o_we_snippet_autofocus');
         this._activateSnippet($autoFocusEls.length ? $autoFocusEls.first() : false);
-        this._textToolsSwitchingEnabled = true;
 
         // Add tooltips on we-title elements whose text overflows
         this.$el.tooltip({
@@ -1129,6 +1128,12 @@ var SnippetsMenu = Widget.extend({
             // animation). (TODO wait for real animation end)
             setTimeout(() => {
                 this.$window.trigger('resize');
+
+                // Hacky way to prevent to switch to text tools on editor
+                // start. Only allow switching after some delay. Switching to
+                // tools is only useful for out-of-snippet texts anyway, so
+                // snippet texts can still be enabled immediately.
+                this._mutex.exec(() => this._textToolsSwitchingEnabled = true);
             }, 1000);
         });
     },

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2546,8 +2546,16 @@ var SnippetsMenu = Widget.extend({
         if (!this._textToolsSwitchingEnabled) {
             return;
         }
-        if (!$.summernote.core.range.create()) {
-            // Sometimes not enough...
+        const range = $.summernote.core.range.create();
+        if (!range) {
+            return;
+        }
+        if (range.sc === range.ec && range.sc.nodeType === Node.ELEMENT_NODE
+                && range.sc.classList.contains('oe_structure')
+                && range.sc.children.length === 0) {
+            // Do not switch to text tools if the cursor is in an empty
+            // oe_structure (to encourage using snippets there and actually
+            // avoid breaking tours which suppose the snippet list is visible).
             return;
         }
         this.textEditorPanelEl.classList.add('d-block');


### PR DESCRIPTION
On editor start, "the cursor enters editable text" at a "random" time
thus switching immediately to text tools or not depending on the fact
text tools switching was initialized or not. We now only allow to do so
after some fixed delay after the editor is ready, to prevent any
automatic switching on editor start (which may break tours).

Part of https://github.com/odoo/odoo/pull/60383
task-2352339

This commit has been merged twice as it was lost during JW revert.

X-original-commit: 8b296c02720f97aa66deb0feb8c2c4648d882e0a
