### PR TITLE
[FIX] website,website_sale: Dynamic products isn't visible if category deleted

### DIFF
--- a/addons/website/static/src/snippets/s_dynamic_snippet/000.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/000.js
@@ -94,14 +94,14 @@ const DynamicSnippet = publicWidget.Widget.extend({
      * domain if needed.
      * @private
      */
-    _getSearchDomain: function () {
+    _getSearchDomain: async function () {
         return [];
     },
     /**
      * Fetches the data.
      * @private
      */
-    _fetchData: function () {
+    _fetchData: async function () {
         if (this._isConfigComplete()) {
             return this._rpc(
                 {
@@ -110,7 +110,7 @@ const DynamicSnippet = publicWidget.Widget.extend({
                         'filter_id': parseInt(this.$el.get(0).dataset.filterId),
                         'template_key': this.$el.get(0).dataset.templateKey,
                         'limit': parseInt(this.$el.get(0).dataset.numberOfRecords),
-                        'search_domain': this._getSearchDomain()
+                        'search_domain': await this._getSearchDomain()
                     },
                 })
                 .then(


### PR DESCRIPTION
Issue

	- Install "Ecommerce" app
	- Go to 'Shop' page and edit it
	- Add a "Dynamic Products" block
	- Click on it to edit it :
	-  Select any template
	-  Select `Desks` as product category
	-  Save
	- Go to "Website -> Configuration -> eCommerce Categories"
	- Delete the "Desks" category
	- Go back to Shop page

	Error : "Record does not exist or has been deleted".

Cause

	The search domain is looking for child categories of dataset.productCategoryId
	(who does not exist anymore in the above case).
	`child_of` do a browse() to fetch the records, and therefore generate
	an error if category not found.

Solution

	Check if dataset.productCategoryId exist before updating domain.

opw-2416231