### PR TITLE
[IMP] mail: use mock server in tests instead of manual create

### DIFF
--- a/addons/mail/static/src/components/composer/composer_tests.js
+++ b/addons/mail/static/src/components/composer/composer_tests.js
@@ -128,8 +128,9 @@ QUnit.test('composer text input: basic rendering when logging note', async funct
 QUnit.test('composer text input: basic rendering when linked thread is a mail.channel', async function (assert) {
     assert.expect(4);
 
+    this.data['mail.channel'].records.push({ id: 20 });
     await this.start();
-    const thread = this.env.models['mail.thread'].create({
+    const thread = this.env.models['mail.thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });

--- a/addons/mail/static/src/components/composer_suggestion/composer_suggestion_channel_tests.js
+++ b/addons/mail/static/src/components/composer_suggestion/composer_suggestion_channel_tests.js
@@ -47,16 +47,11 @@ QUnit.test('channel mention suggestion displayed', async function (assert) {
         id: 20,
         model: 'mail.channel',
     });
-    const channel = this.env.models['mail.thread'].create({
-        id: 7,
-        name: "General",
-        model: 'mail.channel',
-    });
     await this.createComposerSuggestion({
         composerLocalId: thread.composer.localId,
         isActive: true,
         modelName: 'mail.thread',
-        recordLocalId: channel.localId,
+        recordLocalId: thread.localId,
     });
 
     assert.containsOnce(
@@ -69,22 +64,20 @@ QUnit.test('channel mention suggestion displayed', async function (assert) {
 QUnit.test('channel mention suggestion correct data', async function (assert) {
     assert.expect(3);
 
-    this.data['mail.channel'].records.push({ id: 20 });
+    this.data['mail.channel'].records.push({
+        id: 20,
+        name: "General",
+    });
     await this.start();
     const thread = this.env.models['mail.thread'].findFromIdentifyingData({
         id: 20,
-        model: 'mail.channel',
-    });
-    const channel = this.env.models['mail.thread'].create({
-        id: 7,
-        name: "General",
         model: 'mail.channel',
     });
     await this.createComposerSuggestion({
         composerLocalId: thread.composer.localId,
         isActive: true,
         modelName: 'mail.thread',
-        recordLocalId: channel.localId,
+        recordLocalId: thread.localId,
     });
 
     assert.containsOnce(
@@ -113,16 +106,11 @@ QUnit.test('channel mention suggestion active', async function (assert) {
         id: 20,
         model: 'mail.channel',
     });
-    const channel = this.env.models['mail.thread'].create({
-        id: 7,
-        name: "General",
-        model: 'mail.channel',
-    });
     await this.createComposerSuggestion({
         composerLocalId: thread.composer.localId,
         isActive: true,
         modelName: 'mail.thread',
-        recordLocalId: channel.localId,
+        recordLocalId: thread.localId,
     });
 
     assert.containsOnce(

--- a/addons/mail/static/src/components/message/message_tests.js
+++ b/addons/mail/static/src/components/message/message_tests.js
@@ -120,8 +120,9 @@ QUnit.test('basic rendering', async function (assert) {
 QUnit.test('moderation: as author, moderated channel with pending moderation message', async function (assert) {
     assert.expect(1);
 
+    this.data['mail.channel'].records.push({ id: 20 });
     await this.start();
-    const thread = this.env.models['mail.thread'].create({
+    const thread = this.env.models['mail.thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
     });
@@ -144,11 +145,14 @@ QUnit.test('moderation: as author, moderated channel with pending moderation mes
 QUnit.test('moderation: as moderator, moderated channel with pending moderation message', async function (assert) {
     assert.expect(9);
 
+    this.data['mail.channel'].records.push({
+        id: 20,
+        is_moderator: true,
+    });
     await this.start();
-    const thread = this.env.models['mail.thread'].create({
+    const thread = this.env.models['mail.thread'].findFromIdentifyingData({
         id: 20,
         model: 'mail.channel',
-        moderators: [['link', this.env.messaging.currentPartner]],
     });
     const message = this.env.models['mail.message'].create({
         author: [['insert', { id: 7, display_name: "Demo User" }]],
@@ -190,13 +194,15 @@ QUnit.test('moderation: as moderator, moderated channel with pending moderation 
 QUnit.test('Notification Sent', async function (assert) {
     assert.expect(9);
 
+    this.data['mail.channel'].records.push({ id: 11 });
     await this.start();
+    const thread = this.env.models['mail.thread'].findFromIdentifyingData({
+        id: 11,
+        model: 'mail.channel',
+    });
     const threadViewer = this.env.models['mail.thread_viewer'].create({
         hasThreadView: true,
-        thread: [['create', {
-            id: 11,
-            model: 'mail.channel',
-        }]],
+        thread: [['link', thread]],
     });
     const message = this.env.models['mail.message'].create({
         id: 10,
@@ -284,13 +290,15 @@ QUnit.test('Notification Error', async function (assert) {
         openResendActionDef.resolve();
     });
 
+    this.data['mail.channel'].records.push({ id: 11 });
     await this.start({ env: { bus } });
+    const thread = this.env.models['mail.thread'].findFromIdentifyingData({
+        id: 11,
+        model: 'mail.channel',
+    });
     const threadViewer = this.env.models['mail.thread_viewer'].create({
         hasThreadView: true,
-        thread: [['create', {
-            id: 11,
-            model: 'mail.channel',
-        }]],
+        thread: [['link', thread]],
     });
     const message = this.env.models['mail.message'].create({
         id: 10,
@@ -337,18 +345,22 @@ QUnit.test('Notification Error', async function (assert) {
 QUnit.test("'channel_fetch' notification received is correctly handled", async function (assert) {
     assert.expect(3);
 
+    this.data['res.partner'].records.push({
+        display_name: "Recipient",
+        id: 11,
+    });
+    this.data['mail.channel'].records.push({
+        channel_type: 'chat',
+        id: 11,
+        members: [this.data.currentPartnerId, 11],
+    });
     await this.start();
     const currentPartner = this.env.models['mail.partner'].insert({
         id: this.env.messaging.currentPartner.id,
         display_name: "Demo User",
     });
-    const thread = this.env.models['mail.thread'].create({
-        channel_type: 'chat',
+    const thread = this.env.models['mail.thread'].findFromIdentifyingData({
         id: 11,
-        members: [
-            [['link', currentPartner]],
-            [['insert', { id: 11, display_name: "Recipient" }]]
-        ],
         model: 'mail.channel',
     });
     const threadViewer = this.env.models['mail.thread_viewer'].create({
@@ -399,18 +411,22 @@ QUnit.test("'channel_fetch' notification received is correctly handled", async f
 QUnit.test("'channel_seen' notification received is correctly handled", async function (assert) {
     assert.expect(3);
 
+    this.data['res.partner'].records.push({
+        display_name: "Recipient",
+        id: 11,
+    });
+    this.data['mail.channel'].records.push({
+        channel_type: 'chat',
+        id: 11,
+        members: [this.data.currentPartnerId, 11],
+    });
     await this.start();
     const currentPartner = this.env.models['mail.partner'].insert({
         id: this.env.messaging.currentPartner.id,
         display_name: "Demo User",
     });
-    const thread = this.env.models['mail.thread'].create({
-        channel_type: 'chat',
+    const thread = this.env.models['mail.thread'].findFromIdentifyingData({
         id: 11,
-        members: [
-            [['link', currentPartner]],
-            [['insert', { id: 11, display_name: "Recipient" }]]
-        ],
         model: 'mail.channel',
     });
     const threadViewer = this.env.models['mail.thread_viewer'].create({
@@ -460,18 +476,22 @@ QUnit.test("'channel_seen' notification received is correctly handled", async fu
 QUnit.test("'channel_fetch' notification then 'channel_seen' received  are correctly handled", async function (assert) {
     assert.expect(4);
 
+    this.data['res.partner'].records.push({
+        display_name: "Recipient",
+        id: 11,
+    });
+    this.data['mail.channel'].records.push({
+        channel_type: 'chat',
+        id: 11,
+        members: [this.data.currentPartnerId, 11],
+    });
     await this.start();
     const currentPartner = this.env.models['mail.partner'].insert({
         id: this.env.messaging.currentPartner.id,
         display_name: "Demo User",
     });
-    const thread = this.env.models['mail.thread'].create({
-        channel_type: 'chat',
+    const thread = this.env.models['mail.thread'].findFromIdentifyingData({
         id: 11,
-        members: [
-            [['link', currentPartner]],
-            [['insert', { id: 11, display_name: "Recipient" }]]
-        ],
         model: 'mail.channel',
     });
     const threadViewer = this.env.models['mail.thread_viewer'].create({

--- a/addons/mail/static/src/components/thread_view/thread_view_tests.js
+++ b/addons/mail/static/src/components/thread_view/thread_view_tests.js
@@ -62,25 +62,29 @@ QUnit.module('thread_view_tests.js', {
 QUnit.test('dragover files on thread with composer', async function (assert) {
     assert.expect(1);
 
-    await this.start();
-    const thread = this.env.models['mail.thread'].create({
+    this.data['res.partner'].records.push(
+        {
+            email: "john@example.com",
+            id: 9,
+            name: "John",
+        },
+        {
+            email: "fred@example.com",
+            id: 10,
+            name: "Fred",
+        },
+    );
+    this.data['mail.channel'].records.push({
         channel_type: 'channel',
         id: 100,
-        members: [['insert', [
-            {
-                email: "john@example.com",
-                id: 9,
-                name: "John",
-            },
-            {
-                email: "fred@example.com",
-                id: 10,
-                name: "Fred",
-            },
-        ]]],
-        model: 'mail.channel',
+        members: [this.data.currentPartnerId, 9, 10],
         name: "General",
         public: 'public',
+    });
+    await this.start();
+    const thread = this.env.models['mail.thread'].findFromIdentifyingData({
+        id: 100,
+        model: 'mail.channel',
     });
     const threadViewer = this.env.models['mail.thread_viewer'].create({
         hasThreadView: true,
@@ -107,25 +111,29 @@ QUnit.test('message list desc order', async function (assert) {
             res_id: 100,
         });
     }
-    await this.start();
-    const thread = this.env.models['mail.thread'].create({
+    this.data['res.partner'].records.push(
+        {
+            email: "john@example.com",
+            id: 9,
+            name: "John",
+        },
+        {
+            email: "fred@example.com",
+            id: 10,
+            name: "Fred",
+        },
+    );
+    this.data['mail.channel'].records.push({
         channel_type: 'channel',
         id: 100,
-        members: [['insert', [
-            {
-                email: "john@example.com",
-                id: 9,
-                name: "John",
-            },
-            {
-                email: "fred@example.com",
-                id: 10,
-                name: "Fred",
-            },
-        ]]],
-        model: 'mail.channel',
+        members: [this.data.currentPartnerId,9,10],
         name: "General",
         public: 'public',
+    });
+    await this.start();
+    const thread = this.env.models['mail.thread'].findFromIdentifyingData({
+        id: 100,
+        model: 'mail.channel',
     });
     const threadViewer = this.env.models['mail.thread_viewer'].create({
         hasThreadView: true,
@@ -201,25 +209,29 @@ QUnit.test('message list asc order', async function (assert) {
             res_id: 100,
         });
     }
-    await this.start();
-    const thread = this.env.models['mail.thread'].create({
+    this.data['res.partner'].records.push(
+        {
+            email: "john@example.com",
+            id: 9,
+            name: "John",
+        },
+        {
+            email: "fred@example.com",
+            id: 10,
+            name: "Fred",
+        },
+    );
+    this.data['mail.channel'].records.push({
         channel_type: 'channel',
         id: 100,
-        members: [['insert', [
-            {
-                email: "john@example.com",
-                id: 9,
-                name: "John",
-            },
-            {
-                email: "fred@example.com",
-                id: 10,
-                name: "Fred",
-            },
-        ]]],
-        model: 'mail.channel',
+        members: [this.data.currentPartnerId,9,10],
         name: "General",
         public: 'public',
+    });
+    await this.start();
+    const thread = this.env.models['mail.thread'].findFromIdentifyingData({
+        id: 100,
+        model: 'mail.channel',
     });
     const threadViewer = this.env.models['mail.thread_viewer'].create({
         hasThreadView: true,
@@ -445,6 +457,13 @@ QUnit.test('mark channel as fetched and seen when a new message is loaded if com
 QUnit.test('show message subject if thread is mailing channel', async function (assert) {
     assert.expect(3);
 
+    this.data['mail.channel'].records.push({
+        channel_type: 'channel',
+        id: 100,
+        mass_mailing: true,
+        name: "General",
+        public: 'public',
+    });
     this.data['mail.message'].records.push({
         body: "not empty",
         channel_ids: [100],
@@ -453,13 +472,9 @@ QUnit.test('show message subject if thread is mailing channel', async function (
         subject: "Salutations, voyageur",
     });
     await this.start();
-    const thread = this.env.models['mail.thread'].create({
-        channel_type: 'channel',
+    const thread = this.env.models['mail.thread'].findFromIdentifyingData({
         id: 100,
-        mass_mailing: true,
         model: 'mail.channel',
-        name: "General",
-        public: 'public',
     });
     const threadViewer = this.env.models['mail.thread_viewer'].create({
         hasThreadView: true,


### PR DESCRIPTION
[IMP] mail: use mock server in tests instead of manual create

In this commit, we replaced occurences of manual creations
(using ".create") with the use of "this.data"

task-id:2336360


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
