### PR TITLE
[FIX] base_vat: fix suggestion for AU TFN

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -20,7 +20,7 @@ _ref_vat = {
     'al': 'ALJ91402501L',
     'ar': 'AR200-5536168-2 or 20055361682',
     'at': 'ATU12345675',
-    'au': '83 914 571 673',
+    'au': '123456782',
     'be': 'BE0477472701',
     'bg': 'BG1234567892',
     'ch': 'CHE-123.456.788 TVA or CHE-123.456.788 MWST or CHE-123.456.788 IVA',  # Swiss by Yannick Vaucher @ Camptocamp


### PR DESCRIPTION
TFN is a numerical identification code that registers natural or legal
persons in Australia. This 8 or 9 digits code is required to fill the
tax return whether you are an employee or you run your own business.
https://en.wikipedia.org/wiki/Tax_file_number#Check_digit

ABN is a 11 digits code that identifies your business or profession to the
government and others. The ABN does not replace the TFN.
https://business.gov.au/Registrations/Register-for-an-Australian-business-number-ABN

opw-2415142

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
