### PR TITLE
[IMP] partner_autocomplete: remove child_ids handling

### DIFF
--- a/addons/partner_autocomplete/models/res_partner.py
+++ b/addons/partner_autocomplete/models/res_partner.py
@@ -33,12 +33,6 @@ class ResPartner(models.Model):
     def _format_data_company(self, company):
         self._replace_location_code_by_id(company)
 
-        if company.get('child_ids'):
-            child_ids = []
-            for child in company.get('child_ids'):
-                child_ids.append(self._replace_location_code_by_id(child))
-            company['child_ids'] = child_ids
-
         if company.get('additional_info'):
             company['additional_info'] = json.dumps(company['additional_info'])
 

--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_fieldchar.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_fieldchar.js
@@ -120,14 +120,11 @@ var FieldAutocomplete = FieldChar.extend({
 
             // Some fields are unnecessary in res.company
             if (self.model === 'res.company') {
-                var fields = 'comment,child_ids,bank_ids,additional_info'.split(',');
+                var fields = 'comment,bank_ids,additional_info'.split(',');
                 fields.forEach(function (field) {
                     delete data.company[field];
                 });
             }
-
-            self._setOne2ManyField('child_ids', data.company.child_ids);
-            delete data.company.child_ids;
 
             self._setOne2ManyField('bank_ids', data.company.bank_ids);
             delete data.company.bank_ids;


### PR DESCRIPTION
child_ids is not return by /enrich route anymore.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
