### PR TITLE
[FIX] product_matrix: fix wrong grid selection

### DIFF
--- a/addons/product_matrix/static/src/js/section_and_note_widget.js
+++ b/addons/product_matrix/static/src/js/section_and_note_widget.js
@@ -76,9 +76,13 @@ SectionAndNoteFieldOne2Many.include({
                 // find one of the SO widget
                 // (not so lines because the grid values are computed on the SO)
                 // and get the grid information from its recordData.
-                var gridInfo = result.find(
+                var filtered_result = result.filter(
                     r => r.recordData.grid && r.recordData.grid.includes("header")
-                ).recordData.grid;
+                );
+                var prod = filtered_result.find(
+                    r => r.recordData.grid_product_tmpl_id && r.recordData.grid_product_tmpl_id.data.id == productTemplateId
+                )
+                var gridInfo = prod && prod.recordData.grid || filtered_result[0].recordData.grid;
                 // includes "header" is necessary to ensure the correct data is taken
                 // because the grid data isn't correctly updated in all widgets
                 // when in an new record environment.


### PR DESCRIPTION
1. Turn on "Variant Grid Entry" in Settings > Purcahse
2. Create a new RFQ in Purchase app
3. Select a variant product, e.g. Customizable Desk (CONFIG)
4. The popup wizard should show "Customizable Desk (CONFIG)" and its
options
5. Click "Close" to cancel it
6. Select another variant product, e.g. Conference Chair (CONFIG)
7. The popup wizard show the previous product (Customizable Desk)

This occur because the frontend receive multiple values but select the
first one available.

opw-2421798

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
