### PR TITLE
[FIX] payment_authorize: send the full reference for s2s transactions

### DIFF
--- a/addons/payment_authorize/models/authorize_request.py
+++ b/addons/payment_authorize/models/authorize_request.py
@@ -212,7 +212,8 @@ class AuthorizeAPI():
                         }
                     },
                     'order': {
-                        'invoiceNumber': reference[:20]
+                        'invoiceNumber': reference[:20],
+                        'description': reference[:255],
                     }
                 }
 
@@ -265,7 +266,8 @@ class AuthorizeAPI():
                         }
                     },
                     'order': {
-                        'invoiceNumber': reference[:20]
+                        'invoiceNumber': reference[:20],
+                        'description': reference[:255],
                     }
                 }
 


### PR DESCRIPTION
invoiceNumber is limited to 20 characters so if the reference in Odoo
is longer we send an incomplete reference. This makes it hard to match
up S2S payment.transactions in Odoo with their counterparts in the
Authorize.net portal.

To solve this send the full reference in the description field (which
has a max length of 255 characters [1]).

[1] https://developer.authorize.net/api/reference/index.html#payment-transactions-charge-a-customer-profile
