### PR TITLE
[IMP] No need to create module  when exporting translation files

### DIFF
--- a/odoo/addons/base/wizard/base_export_language_views.xml
+++ b/odoo/addons/base/wizard/base_export_language_views.xml
@@ -11,7 +11,7 @@
                     <group states="choose" string="Export Settings">
                         <field name="lang"/>
                         <field name="format"/>
-                        <field name="modules" widget="many2many_tags"/>
+                        <field name="modules" widget="many2many_tags" options="{'no_create':True}"/>
                     </group>
                     <div states="get">
                         <h2>Export Complete</h2>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Disable module creation when exporting translation files

Current behavior before PR:
<img width="821" alt="image" src="https://user-images.githubusercontent.com/5561864/103731790-eff63e00-5020-11eb-962d-ff939357533b.png">

Desired behavior after PR is merged:
<img width="804" alt="image" src="https://user-images.githubusercontent.com/5561864/103731840-161bde00-5021-11eb-84f6-d4986dc2e2be.png">




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
