### PR TITLE
add option open_on_click on form_many2many_tags

### DIFF
--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -101,7 +101,7 @@
                                     <group string="Control-Access" groups="account.group_account_manager">
                                         <div class="text-muted" colspan="2">Keep empty for no control</div>
                                         <field name="type_control_ids" widget="many2many_tags"/>
-                                        <field name="account_control_ids" widget="many2many_tags"/>
+                                        <field name="account_control_ids" widget="many2many_tags" open_on_click="True"/>
                                         <field name="restrict_mode_hash_table" groups="account.group_account_readonly" attrs="{'invisible': [('type', 'in', ['bank', 'cash'])]}"/>
                                     </group>
                                     <!-- email alias -->
@@ -226,7 +226,7 @@
                     <sheet>
                         <group>
                             <field name="name" placeholder="e.g. GAAP, IFRS, ..."/>
-                            <field name="excluded_journal_ids" widget="many2many_tags" options="{'no_create': True}"/>
+                            <field name="excluded_journal_ids" widget="many2many_tags" open_on_click="True" options="{'no_create': True}"/>
                             <field name="sequence" groups="base.group_no_one"/>
                             <field name="company_id" groups="base.group_multi_company"/>
                         </group>

--- a/addons/account/views/product_view.xml
+++ b/addons/account/views/product_view.xml
@@ -70,10 +70,10 @@
                     </page>
                 </page>
                 <xpath expr="//div[@name='pricing']" position="after">
-                    <field name="taxes_id" widget="many2many_tags" context="{'default_type_tax_use':'sale', 'search_default_sale': 1, 'search_default_service': type == 'service', 'search_default_goods': type == 'consu'}"/>
+                    <field name="taxes_id" widget="many2many_tags" open_on_click="True" context="{'default_type_tax_use':'sale', 'search_default_sale': 1, 'search_default_service': type == 'service', 'search_default_goods': type == 'consu'}"/>
                 </xpath>
                 <group name="bill" position="inside">
-                    <field name="supplier_taxes_id" widget="many2many_tags" context="{'default_type_tax_use':'purchase', 'search_default_purchase': 1, 'search_default_service': type == 'service', 'search_default_goods': type == 'consu'}"/>
+                    <field name="supplier_taxes_id" widget="many2many_tags" open_on_click="True" context="{'default_type_tax_use':'purchase', 'search_default_purchase': 1, 'search_default_service': type == 'service', 'search_default_goods': type == 'consu'}"/>
                 </group>
             </field>
         </record>

--- a/addons/purchase/views/product_views.xml
+++ b/addons/purchase/views/product_views.xml
@@ -83,7 +83,7 @@
                     <attribute name="attrs">{'readonly': [('purchase_ok', '=', 0)]}</attribute>
                 </field>
                 <field name='supplier_taxes_id' position="replace" >
-                     <field name="supplier_taxes_id" colspan="2" widget="many2many_tags" attrs="{'readonly':[('purchase_ok','=',0)]}" context="{'default_type_tax_use':'purchase'}"/>
+                     <field name="supplier_taxes_id" open_on_click="True" colspan="2" widget="many2many_tags" attrs="{'readonly':[('purchase_ok','=',0)]}" context="{'default_type_tax_use':'purchase'}"/>
                 </field>
             </field>
         </record>

--- a/addons/sale_product_configurator/views/sale_views.xml
+++ b/addons/sale_product_configurator/views/sale_views.xml
@@ -8,7 +8,7 @@
             <xpath expr="//group[@name='sale']" position="after">
                 <group name="options" groups="product.group_product_variant">
                     <group string="Options">
-                        <field name="optional_product_ids" widget="many2many_tags" options="{'color_field': 'color'}" domain="[('id', '!=', active_id), '|', ('company_id', '=', company_id), ('company_id', '=', False)]" />
+                        <field name="optional_product_ids" widget="many2many_tags" open_on_click="True" options="{'color_field': 'color'}" domain="[('id', '!=', active_id), '|', ('company_id', '=', company_id), ('company_id', '=', False)]" />
                     </group>
                 </group>
             </xpath>

--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -1287,7 +1287,7 @@
         <t t-set="colornames" t-value="['No color', 'Red', 'Orange', 'Yellow', 'Light blue', 'Dark purple', 'Salmon pink', 'Medium blue', 'Dark blue', 'Fushia', 'Green', 'Purple']"/>
         <div t-attf-class="badge badge-pill #{hasDropdown ? 'dropdown' : ''} o_tag_color_#{color}" t-att-data-color="color" t-att-data-index="el_index" t-att-data-id="el.id" t-attf-title="Tag color: #{colornames[color]}">
             <t t-set="_badge_text">
-                <span class="o_badge_text" t-att-title="el.display_name"><span role="img" t-attf-aria-label="Tag color: #{colornames[color]}"/><t t-esc="el.display_name"/></span>
+                <span t-attf-class="o_badge_text #{openRecord ? 'o_open_record' : ''}" t-att-data-id="el.id" t-att-title="el.display_name"><span role="img" t-attf-aria-label="Tag color: #{colornames[color]}"/><t t-esc="el.display_name"/></span>
             </t>
             <t t-if="hasDropdown">
                 <a role="button" href="#" class="dropdown-toggle o-no-caret" data-toggle="dropdown" aria-expanded="false">
@@ -1309,17 +1309,17 @@
 <t t-name="FieldMany2ManyTag.colorpicker">
     <div class="o_colorpicker dropdown-menu tagcolor_dropdown_menu" role="menu">
         <ul>
-            <li><a role="menuitem" href="#" t-att-data-id="tag_id" class="o_tag_color_1" data-color="1" title="Red" aria-label="Red"/></li>
-            <li><a role="menuitem" href="#" t-att-data-id="tag_id" class="o_tag_color_2" data-color="2" title="Orange" aria-label="Orange"/></li>
-            <li><a role="menuitem" href="#" t-att-data-id="tag_id" class="o_tag_color_3" data-color="3" title="Yellow" aria-label="Yellow"/></li>
-            <li><a role="menuitem" href="#" t-att-data-id="tag_id" class="o_tag_color_4" data-color="4" title="Light blue" aria-label="Light blue"/></li>
-            <li><a role="menuitem" href="#" t-att-data-id="tag_id" class="o_tag_color_5" data-color="5" title="Dark purple" aria-label="Dark purple"/></li>
-            <li><a role="menuitem" href="#" t-att-data-id="tag_id" class="o_tag_color_6" data-color="6" title="Salmon pink" aria-label="Salmon pink"/></li>
-            <li><a role="menuitem" href="#" t-att-data-id="tag_id" class="o_tag_color_7" data-color="7" title="Medium blue" aria-label="Medium blue"/></li>
-            <li><a role="menuitem" href="#" t-att-data-id="tag_id" class="o_tag_color_8" data-color="8" title="Dark blue" aria-label="Dark blue"/></li>
-            <li><a role="menuitem" href="#" t-att-data-id="tag_id" class="o_tag_color_9" data-color="9" title="Fushia" aria-label="Fushia"/></li>
-            <li><a role="menuitem" href="#" t-att-data-id="tag_id" class="o_tag_color_10" data-color="10" title="Green" aria-label="Green"/></li>
-            <li><a role="menuitem" href="#" t-att-data-id="tag_id" class="o_tag_color_11" data-color="11" title="Purple" aria-label="Purple"/></li>
+            <li><a role="menuitem" href="#" t-att-data-id="tag_id" class="o_tag_color o_tag_color_1" data-color="1" title="Red" aria-label="Red"/></li>
+            <li><a role="menuitem" href="#" t-att-data-id="tag_id" class="o_tag_color o_tag_color_2" data-color="2" title="Orange" aria-label="Orange"/></li>
+            <li><a role="menuitem" href="#" t-att-data-id="tag_id" class="o_tag_color o_tag_color_3" data-color="3" title="Yellow" aria-label="Yellow"/></li>
+            <li><a role="menuitem" href="#" t-att-data-id="tag_id" class="o_tag_color o_tag_color_4" data-color="4" title="Light blue" aria-label="Light blue"/></li>
+            <li><a role="menuitem" href="#" t-att-data-id="tag_id" class="o_tag_color o_tag_color_5" data-color="5" title="Dark purple" aria-label="Dark purple"/></li>
+            <li><a role="menuitem" href="#" t-att-data-id="tag_id" class="o_tag_color o_tag_color_6" data-color="6" title="Salmon pink" aria-label="Salmon pink"/></li>
+            <li><a role="menuitem" href="#" t-att-data-id="tag_id" class="o_tag_color o_tag_color_7" data-color="7" title="Medium blue" aria-label="Medium blue"/></li>
+            <li><a role="menuitem" href="#" t-att-data-id="tag_id" class="o_tag_color o_tag_color_8" data-color="8" title="Dark blue" aria-label="Dark blue"/></li>
+            <li><a role="menuitem" href="#" t-att-data-id="tag_id" class="o_tag_color o_tag_color_9" data-color="9" title="Fushia" aria-label="Fushia"/></li>
+            <li><a role="menuitem" href="#" t-att-data-id="tag_id" class="o_tag_color o_tag_color_10" data-color="10" title="Green" aria-label="Green"/></li>
+            <li><a role="menuitem" href="#" t-att-data-id="tag_id" class="o_tag_color o_tag_color_11" data-color="11" title="Purple" aria-label="Purple"/></li>
             <li> <!-- checkbox for tag color 0 -->
                 <div role="menuitem" class="o_hide_in_kanban"
                      t-att-data-id="tag_id"
@@ -1329,6 +1329,9 @@
                         <label for="o_hide_in_kanban_checkbox" class="custom-control-label">Hide in Kanban</label>
                     </div>
                 </div>
+            </li>
+            <li t-if="widget.openRecord"> <!-- option to open record -->
+                <a role="menuitem" href="#" t-att-data-id="tag_id" class="o_open_record">Open</a>
             </li>
         </ul>
     </div>

--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -96,8 +96,8 @@
                             <field name="website_id" options="{'no_create': True}" groups="website.group_multi_website"/>
                             <field name="website_sequence" groups="base.group_no_one"/>
                             <field name="public_categ_ids" widget="many2many_tags" string="Categories"/>
-                            <field name="alternative_product_ids" widget="many2many_tags" domain="[('id', '!=', active_id), '|', ('company_id', '=', company_id), ('company_id', '=', False)]"/>
-                            <field name="accessory_product_ids" widget="many2many_tags"/>
+                            <field name="alternative_product_ids" widget="many2many_tags" open_on_click="True" domain="[('id', '!=', active_id), '|', ('company_id', '=', company_id), ('company_id', '=', False)]"/>
+                            <field name="accessory_product_ids" widget="many2many_tags" open_on_click="True"/>
                             <field name="website_ribbon_id" groups="base.group_no_one"/>
                         </group>
                     </group>

--- a/odoo/addons/base/rng/common.rng
+++ b/odoo/addons/base/rng/common.rng
@@ -266,6 +266,7 @@
             <rng:optional><rng:attribute name="write_model" /></rng:optional>
             <rng:optional><rng:attribute name="write_field" /></rng:optional>
             <rng:optional><rng:attribute name="text" /></rng:optional>
+            <rng:optional><rng:attribute name="open_on_click" /></rng:optional>
             <rng:optional><rng:attribute name="optional" /></rng:optional>
             <rng:optional><rng:attribute name="decoration-bf"/></rng:optional>
             <rng:optional><rng:attribute name="decoration-it"/></rng:optional>


### PR DESCRIPTION
PURPOSE
Allow the user to access records set in a many2many_tags widget. 

SPECIFICATION
has to be an option (no need to access the formview of tags)

Add a new 'open_on_click' boolean option on the many2many_tags widget, the default value is False.

NB: The following changes should only be applied on the formview version of the many2many_tags.

When 'open_on_click'=True
    if there is a 'color' option (i.e. colorpicker) set on the widget, add an 'Open' item at the bottom of the colorpicker
    else, when clicking on a badge-pill
        if the formview is in readonly mode, redirect to the formview of the badge-pill record
        if the formview is in edit mode, open the formview of the badge-pill record in a modal in edit mode
            NB: like what the external link of many2one widget currently does

Set 'open_on_click'=True on the following fields:
    account_control_ids in account.view_account_journal_form
    excluded_journal_ids in account.view_account_journal_group_form
    taxes_id, supplier_taxes_id, optional_product_ids, alternative_product_ids, and accessory_product_ids in product.product_template_form_view

TASK 2393552

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
