### PR TITLE
[IMP]web: clean file name

### DIFF
--- a/addons/web/controllers/pivot.py
+++ b/addons/web/controllers/pivot.py
@@ -5,9 +5,9 @@ from collections import deque
 import io
 import json
 
-from odoo import http
-from odoo.http import request
-from odoo.tools import ustr
+from odoo import http, _
+from odoo.http import content_disposition, request
+from odoo.tools import ustr, osutil
 from odoo.tools.misc import xlsxwriter
 
 
@@ -102,9 +102,10 @@ class TableExporter(http.Controller):
 
         workbook.close()
         xlsx_data = output.getvalue()
+        filename = osutil.clean_filename(_("Pivot %(title)s (%(model_name)s)", title=jdata['title'], model_name=jdata['model']))
         response = request.make_response(xlsx_data,
             headers=[('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'),
-                    ('Content-Disposition', 'attachment; filename=table.xlsx')],
+                    ('Content-Disposition', content_disposition(filename + '.xlsx'))],
             cookies={'fileToken': token})
 
         return response

--- a/addons/web/static/src/js/views/pivot/pivot_controller.js
+++ b/addons/web/static/src/js/views/pivot/pivot_controller.js
@@ -140,6 +140,7 @@ odoo.define('web.PivotController', function (require) {
             }
             const table = this.model.exportData();
             table.title = this.title;
+            table.model = this.modelName;
             session.get_file({
                 url: '/web/pivot/export_xlsx',
                 data: { data: JSON.stringify(table) },

--- a/odoo/tools/__init__.py
+++ b/odoo/tools/__init__.py
@@ -5,7 +5,6 @@ from . import _monkeypatches
 from . import pycompat
 from . import win32
 from . import appdirs
-from . import osutil
 from . import pdf
 from . import cloc
 from .config import config
@@ -21,3 +20,4 @@ from .xml_utils import *
 from .date_utils import *
 from .convert import *
 from .template_inheritance import *
+from . import osutil

--- a/odoo/tools/osutil.py
+++ b/odoo/tools/osutil.py
@@ -4,15 +4,57 @@
 """
 Some functions related to the os and os.path module
 """
-from contextlib import contextmanager
 import logging
 import os
-from os.path import join as opj
+import re
 import tempfile
 import zipfile
 
+from contextlib import contextmanager
+from os.path import join as opj
+
+from .translate import _
+
 _logger = logging.getLogger(__name__)
 
+WINDOWS_RESERVED = re.compile(r'''
+    ^
+    # forbidden stems: reserved keywords
+    (:?CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])
+    # even with an extension this is recommended against
+    (:?\..*)?
+    $
+''', flags=re.IGNORECASE | re.VERBOSE)
+def clean_filename(name, replacement=''):
+    """ Strips or replaces possibly problematic or annoying characters our of
+    the input string, in order to make it a valid filename in most operating
+    systems (including dropping reserved Windows filenames).
+
+    If this results in an empty string, results in "Untitled" (localized).
+
+    Allows:
+
+    * any alphanumeric character (unicode)
+    * underscore (_) as that's innocuous
+    * dot (.) except in leading position to avoid creating dotfiles
+    * dash (-) except in leading position to avoid annoyance / confusion with
+      command options
+    * brackets ([ and ]), while they correspond to shell *character class*
+      they're a common way to mark / tag files especially on windows
+    * parenthesis ("(" and ")"), a more natural though less common version of
+      the former
+    * space (" ")
+
+    :param str name: file name to clean up
+    :param str replacement:
+        replacement string to use for sequences of problematic input, by default
+        an empty string to remove them entirely, each contiguous sequence of
+        problems is replaced by a single replacement
+    :rtype: str
+    """
+    if WINDOWS_RESERVED.match(name):
+        return _("Untitled")
+    return re.sub(r'[^\w_.()\[\] -]+', replacement, name).lstrip('.-') or _("Untitled")
 
 def listdir(dir, recursive=False):
     """Allow to recursively get the file listing following symlinks, returns


### PR DESCRIPTION
The purpose of this task is to clean up and provide clear export
file names.

Before this commit, When exporting data:
   - from a pivot view, the file is named 'table'
   - from a listview, the file is named after the model technical name

After this commit, Name of the different export files as follows:
   - for list view quick export and standard record export, the file
     is named as 'model_description (model technical name)'
   - for pivot view quick export, the file is named as
     'Pivot of model_description (model technical name)'

Task-Id: 2237840
PR: #64123

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
