### PR TITLE
[FIX] core: marking of recursive computed fields

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5827,7 +5827,7 @@ Fields:
                 tocompute = list(tocompute)
 
             # process what to compute
-            for field, records in tocompute:
+            for field, records, create in tocompute:
                 records -= self.env.protected(field)
                 if not records:
                     continue
@@ -5843,19 +5843,19 @@ Fields:
                     self.env.cache.invalidate([(field, records._ids)])
                 # recursively trigger recomputation of field's dependents
                 if field.recursive:
-                    recursively_marked.modified([field.name])
+                    recursively_marked.modified([field.name], create)
 
     def _modified_triggers(self, tree, create=False):
         """ Return an iterator traversing a tree of field triggers on ``self``,
         traversing backwards field dependencies along the way, and yielding
-        pairs ``(field, records)`` to recompute.
+        tuple ``(field, records, created)`` to recompute.
         """
         if not self:
             return
 
         # first yield what to compute
         for field in tree.get(None, ()):
-            yield field, self
+            yield field, self, create
 
         # then traverse dependencies backwards, and proceed recursively
         for key, val in tree.items():


### PR DESCRIPTION
Use the right optimization when marking recursive computed fields after
record creation: the recursive call to modified() should take the flag
'create' that determines when to skip inversing many2one fields.  This
saves quite a few queries when creating records with recursive computed
fields.  This optimization is validated in Odoo 14.0.

See revision 9fe4fe404b73e9ab18ab6b3b913f075c64bb6954.

This completes https://github.com/odoo/odoo/pull/63979 and https://github.com/odoo/odoo/pull/64060.