### PR TITLE
[FIX] web: Close the warning box after clicking

### DIFF
--- a/addons/web/static/src/js/services/crash_manager.js
+++ b/addons/web/static/src/js/services/crash_manager.js
@@ -359,7 +359,7 @@ var RedirectWarningHandler = Widget.extend(ExceptionHandler, {
                         error.data.arguments[1],
                         {
                             additional_context: additional_context,
-                        });
+                        }).then(function() { self.destroy(); });
                 }},
                 {text: _t("Cancel"), click: function() { self.destroy(); }, close: true}
             ]


### PR DESCRIPTION
What are the steps to reproduce your issue ?

    1. Install "google_spreadsheet"
    2. Click on "Favorite" > "Add to Google Spreadsheet"

What is currently happening ?

    When clicking on "Go To The Configuration Panel" the box don't close itself

What are you expecting to happen ?

    Close the warning box after clicking on the button after redirection

opw-2425575