### PR TITLE
[FIX] web: editable list: can unselect row

### DIFF
--- a/addons/web/static/src/js/views/list/list_editable_renderer.js
+++ b/addons/web/static/src/js/views/list/list_editable_renderer.js
@@ -1817,7 +1817,7 @@ ListRenderer.include({
 
         // ignore clicks if there is a modal, except if the list is in the last
         // (active) modal
-        var $modal = $('.modal:last');
+        var $modal = $('body > .modal:last');
         if ($modal.length) {
             var $listModal = this.$el.closest('.modal');
             if ($modal.prop('id') !== $listModal.prop('id')) {

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -8245,6 +8245,38 @@ QUnit.module('Views', {
         form.destroy();
     });
 
+    QUnit.test('editable list alongside html field: click out to unselect the row', async function (assert) {
+        assert.expect(5);
+
+        const form = await createView({
+            View: FormView,
+            model: 'foo',
+            data: this.data,
+            arch: `
+                <form>
+                    <field name="text" widget="html"/>
+                    <field name="o2m">
+                        <tree editable="bottom">
+                            <field name="display_name"/>
+                        </tree>
+                    </field>
+                </form>`,
+        });
+
+        assert.containsNone(form, '.o_data_row');
+
+        await testUtils.dom.click(form.$('.o_field_x2many_list_row_add > a'));
+        assert.containsOnce(form, '.o_data_row');
+        assert.hasClass(form.$('.o_data_row'), 'o_selected_row');
+
+        // click outside to unselect the row
+        await testUtils.dom.click(document.body);
+        assert.containsOnce(form, '.o_data_row');
+        assert.doesNotHaveClass(form.$('.o_data_row'), 'o_selected_row');
+
+        form.destroy();
+    });
+
     QUnit.test('list grouped by date:month', async function (assert) {
         assert.expect(1);
 


### PR DESCRIPTION
Since commit [1], it is no longer possible to unselect a row in a
one2many editable list if there is an html field in the form view.
The reason is that there is a '.modal' element (several actually)
in the DOM of the html field. This element is considered as an
opened dialog by the list rendered, which is wrong. This commit
refines the selector that determines whether there is an opened
dialog or not.

[1] 7d04ec7cca4f355295a06c1ce6f112b6cc533c87

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
