### PR TITLE
[FIX] account: dashboard view cash statements

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -518,7 +518,7 @@ class account_journal(models.Model):
         ctx = dict(self.env.context, default_journal_id=self.id)
         if ctx.get('search_default_journal', False):
             ctx.update(search_default_journal_id=self.id)
-            del ctx['search_default_journal']  # otherwise it will do a useless groupby in bank statements
+            ctx['search_default_journal'] = False  # otherwise it will do a useless groupby in bank statements
         ctx.pop('group_by', None)
         action = self.env['ir.actions.act_window']._for_xml_id(f"account.{action_name}")
         action['context'] = ctx

--- a/addons/account/views/account_bank_statement_views.xml
+++ b/addons/account/views/account_bank_statement_views.xml
@@ -105,7 +105,7 @@
                     <filter string="Validated" name="confirmed" domain="[('state','=','confirm')]"/>
                     <separator/>
                     <filter name="filter_date" date="date"/>
-                    <field name="journal_id" domain="[('type', '=', 'bank')]" />
+                    <field name="journal_id" domain="[('type', 'in', ('bank', 'cash'))]" />
                     <group expand="0" string="Group By">
                         <filter string="Journal" name="journal" context="{'group_by': 'journal_id'}"/>
                         <filter string="Status" name="status" context="{'group_by': 'state'}"/>

--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -60,7 +60,8 @@
                                     <span role="separator">View</span>
                                 </div>
                                 <div>
-                                    <a role="menuitem" type="object" name="open_action_with_context" context="{'action_name': 'action_bank_statement_tree', 'search_default_journal': True}">Statements</a>
+                                    <a t-if="journal_type == 'bank'" role="menuitem" type="object" name="open_action_with_context" context="{'action_name': 'action_bank_statement_tree', 'search_default_journal': True}">Statements</a>
+                                    <a t-if="journal_type == 'cash'" role="menuitem" type="object" name="open_action_with_context" context="{'action_name': 'action_view_bank_statement_tree', 'search_default_journal': True}">Statements</a>
                                 </div>
                                 <div>
                                     <a role="menuitem" type="object" name="open_action_with_context" context="{'action_name': 'action_bank_statement_line', 'search_default_journal': True}">Operations</a>


### PR DESCRIPTION
Fine tuning of 78286851034b8f3ef4dcab78e50b7220c0bdd213

The link to view Cash Statements on the dashboard openned the wrong
action.
Also in some cases, removing the context key `search_default_journal`
was not enough so we set it to `False` instead.

closes #64118




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
