### PR TITLE
[FIX] base_vat: fix ABN check for Australia

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -474,6 +474,20 @@ class ResPartner(models.Model):
             return any(re.compile(rx).match(vat) for rx in all_gstin_re)
         return False
 
+    def check_vat_au(self, vat):
+        '''
+        The Australian equivalent of a VAT number is an ABN number.
+        TFN (Australia Tax file numbers) are private and not to be
+        entered into systems or publicly displayed, so ABN numbers
+        are the public facing number that legally must be displayed
+        on all invoices
+        '''
+        check_func = getattr(stdnum.util.get_cc_module('au', 'abn'), 'is_valid', None)
+        if not check_func:
+            vat = vat.replace(" ", "")
+            return len(vat) == 11 and vat.isdigit()
+        return check_func(vat)
+
     def format_vat_ch(self, vat):
         stdnum_vat_format = getattr(stdnum.util.get_cc_module('ch', 'vat'), 'format', None)
         return stdnum_vat_format('CH' + vat)[2:] if stdnum_vat_format else vat


### PR DESCRIPTION
The Australian equivalent of a VAT number is an ABN number.
In Australia TFN are private and not meant to be entered into
systems or publicly displayed.
ABN numbers are the public facing number that legally must be displayed
on all tax invoices and legal documents.

This fix will override the 'tfn' check done via stdnum for AU companies
with 'abn' check

opw-2415142

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
