### PR TITLE
[FIX] stock: product search by location

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -217,14 +217,28 @@ class Product(models.Model):
         other_locations = locations - hierarchical_locations
         loc_domain = []
         dest_loc_domain = []
+
+        # To avoid to have a giant request which will cause memory error, minimize the domain
+        def minimize_domain_parent_path(location_parent_path):
+            # Sorted to get the most "parent" first
+            result = []
+            location_parent_path = sorted(location_parent_path)
+            ids_encounter = set()
+            for location_parent in location_parent_path:
+                ids_parent = location_parent.split('/')[:-1]  # Remove last one because always finish by '/'
+                if not (ids_encounter & set(ids_parent)):  # If there is a intersection, parent_path is already take in account
+                    ids_encounter.add(ids_parent[-1])  # Add only myself
+                    result.append(location_parent)
+            return result
+
         # this optimizes [('location_id', 'child_of', hierarchical_locations.ids)]
         # by avoiding the ORM to search for children locations and injecting a
         # lot of location ids into the main query
-        for location in hierarchical_locations:
+        for parent_path in minimize_domain_parent_path(hierarchical_locations.mapped('parent_path')):
             loc_domain = loc_domain and ['|'] + loc_domain or loc_domain
-            loc_domain.append(('location_id.parent_path', '=like', location.parent_path + '%'))
+            loc_domain.append(('location_id.parent_path', '=like', parent_path + '%'))
             dest_loc_domain = dest_loc_domain and ['|'] + dest_loc_domain or dest_loc_domain
-            dest_loc_domain.append(('location_dest_id.parent_path', '=like', location.parent_path + '%'))
+            dest_loc_domain.append(('location_dest_id.parent_path', '=like', parent_path + '%'))
         if other_locations:
             loc_domain = loc_domain and ['|'] + loc_domain or loc_domain
             loc_domain = loc_domain + [('location_id', operator, other_locations.ids)]


### PR DESCRIPTION
Issues
- In a database with a lot of locations (more than 10K)
- Search by location in the product tree view with the complete name of
the most "parent" location
- We get a memorry error due to a giant SQL request:
`psycopg2.ProgrammingError: memory exausted at near "(" ...`
It is due to the `_get_domain_locations_new` which return a giant domain
with a tons of `(location_id.parent_path', '=like', ...)` for location.
Because the `_get_domain_locations` makes a ilike on the complete name,
it will match parent but also all child of this parent (because of the
complete works expected if there are loc of type 'view' between).
If there are 10K child location of `WH/Stock`, it will
match all child and the `_get_domain_locations_new` will return
a extremely huge domain with a lot of useless condition.

To Solve
Minimize the domain created by the
`_get_domain_locations_new`, avoid duplicate `parent_path` condition:
e.g. `'|', ('location_id.parent_path', '=like', 'WH/Stock/%')
('location_id.parent_path', '=like', 'WH/Stock/Shell/%')`
can be represented only by the first condition.
We can also search all childs and add condition on ids before
but it removes the optimization done in this method.

opw-2379464
