### PR TITLE
[FIX] project: Show create button on multiEdit

### DIFF
--- a/addons/web/static/src/js/views/list/list_controller.js
+++ b/addons/web/static/src/js/views/list/list_controller.js
@@ -603,7 +603,7 @@ var ListController = BasicController.extend({
     _toggleCreateButton: function () {
         if (this.hasButtons) {
             var state = this.model.get(this.handle);
-            var createHidden = this.renderer.isEditable() && state.groupedBy.length && state.data.length;
+            var createHidden = this.editable && state.groupedBy.length && state.data.length;
             this.$buttons.find('.o_list_button_add').toggleClass('o_hidden', !!createHidden);
         }
     },

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -9059,6 +9059,44 @@ QUnit.module('Views', {
         list.destroy();
     });
 
+    QUnit.test('control panel buttons in multi editable grouped list views', async function (assert) {
+        assert.expect(8);
+
+        const list = await createView({
+            View: ListView,
+            model: 'foo',
+            data: this.data,
+            groupBy: ['foo'],
+            arch:
+                `<tree multi_edit="1">
+                    <field name="foo"/>
+                    <field name="int_field"/>
+                </tree>`,
+        });
+
+        assert.containsNone(list, '.o_data_row', "all groups should be closed");
+        assert.isVisible(list.$buttons.find('.o_list_button_add'),
+            "should have a visible Create button");
+
+        await testUtils.dom.click(list.$('.o_group_header:first'));
+        assert.containsN(list, '.o_data_row', 1, "first group should be opened");
+        assert.isVisible(list.$buttons.find('.o_list_button_add'),
+            "should have a visible Create button");
+
+        await testUtils.dom.click(list.$('.o_data_row:eq(0) .o_list_record_selector input'));
+        assert.containsOnce(list, '.o_data_row:eq(0) .o_list_record_selector input:enabled',
+            "should have selected first record");
+        assert.isVisible(list.$buttons.find('.o_list_button_add'),
+            "should have a visible Create button");
+
+        await testUtils.dom.click(list.$('.o_group_header:last'));
+        assert.containsN(list, '.o_data_row', 2, "two groups should be opened");
+        assert.isVisible(list.$buttons.find('.o_list_button_add'),
+            "should have a visible Create button");
+
+        list.destroy();
+    });
+
     QUnit.test('edit a line and discard it in grouped editable', async function (assert) {
         assert.expect(5);
 


### PR DESCRIPTION
What are the steps to reproduce your issue ?

    1. Install project
    2. Open any project
    3. Switch to list view and display by Stage
    4. Open categoryA and select some records
    5. Open CategoryB

What is currently happening ?

    The button create is not displayed

What are you expecting to happen ?

    Don't hide create button

opw-2423701