### PR TITLE
[FIX] web_editor: review `public_render_template`

### DIFF
--- a/addons/web_editor/models/ir_ui_view.py
+++ b/addons/web_editor/models/ir_ui_view.py
@@ -29,6 +29,8 @@ class IrUiView(models.Model):
 
     @api.model
     def read_template(self, xml_id):
+        """ This method is deprecated
+        """
         if xml_id == 'web_editor.colorpicker' and self.env.user.has_group('base.group_user'):
             # TODO this should be handled another way but was required as a
             # stable fix in 14.0. The views are now private by default: they

--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -326,6 +326,8 @@ class View(models.Model):
 
     @api.model
     def read_template(self, xml_id):
+        """ This method is deprecated
+        """
         view = self._view_obj(self.get_view_id(xml_id))
         if view.visibility and view._handle_visibility(do_raise=False):
             self = self.sudo()

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1579,7 +1579,8 @@ actual arch.
 
     @api.model
     def read_template(self, xml_id):
-        """ Return a template content based on external id
+        """ This method is deprecated
+        Return a template content based on external id
         Read access on ir.ui.view required
         """
         template_id = self.get_view_id(xml_id)


### PR DESCRIPTION
The normal flow to render a template is now to use `render_public_asset`
which bypasses the read access rights if the user matches the groups
the view declares.

For public users, we still cannot use that as they do not have access
to calling model methods at all. The route `public_render_template` is
thus still needed, but it should use the `render_public_asset` util. In
master, it will only rely on it but as a stable fix, we still need to
use the whitelist as we cannot change the related views' group.

This commit also adds deprecated comments to the read_template method
which has been removed in master.

Related to task-2412544
