### PR TITLE
[FIX] account: label for internal transfer

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -224,7 +224,7 @@ class AccountPayment(models.Model):
         }
 
         default_line_name = self.env['account.move.line']._get_default_line_name(
-            payment_display_name['%s-%s' % (self.payment_type, self.partner_type)],
+            _("Internal Transfer") if self.is_internal_transfer else payment_display_name['%s-%s' % (self.payment_type, self.partner_type)],
             self.amount,
             self.currency_id,
             self.date,


### PR DESCRIPTION
Create two differnt journals for two different bank accounts (A, B).
Create an Internal Transfer in bank A to send money, then reconcile.
Create an Internal Transfer in bank B to receive money, then try to
reconcile

Internal transfers are labeled 'Customer Reimbursement' and 'Customer
Payment' even if no external partner is involved in the process,

opw-2423161

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
