### PR TITLE
[FIX] crm: correctly handle won lost at create

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -509,7 +509,7 @@ class Lead(models.Model):
 
         for lead, values in zip(leads, vals_list):
             if any(field in ['active', 'stage_id'] for field in values):
-                lead._handle_won_lost(vals)
+                lead._handle_won_lost(values)
 
         return leads
 


### PR DESCRIPTION
Fix typo preventing a correct management of won/lost when creating
multiple leads in a row.
