### PR TITLE
[FIX] stock: scrap wrong issuficient quantity wizard

### DIFF
--- a/addons/stock/models/stock_scrap.py
+++ b/addons/stock/models/stock_scrap.py
@@ -106,9 +106,6 @@ class StockScrap(models.Model):
 
     def _prepare_move_values(self):
         self.ensure_one()
-        location_id = self.location_id.id
-        if self.picking_id and self.picking_id.picking_type_code == 'incoming':
-            location_id = self.picking_id.location_dest_id.id
         return {
             'name': self.name,
             'origin': self.origin or self.picking_id.name or self.name,
@@ -117,13 +114,13 @@ class StockScrap(models.Model):
             'product_uom': self.product_uom_id.id,
             'state': 'draft',
             'product_uom_qty': self.scrap_qty,
-            'location_id': location_id,
+            'location_id': self.location_id.id,
             'scrapped': True,
             'location_dest_id': self.scrap_location_id.id,
             'move_line_ids': [(0, 0, {'product_id': self.product_id.id,
                                            'product_uom_id': self.product_uom_id.id, 
                                            'qty_done': self.scrap_qty,
-                                           'location_id': location_id,
+                                           'location_id': self.location_id.id,
                                            'location_dest_id': self.scrap_location_id.id,
                                            'package_id': self.package_id.id, 
                                            'owner_id': self.owner_id.id,
@@ -158,11 +155,8 @@ class StockScrap(models.Model):
         if self.product_id.type != 'product':
             return self.do_scrap()
         precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
-        location_id = self.location_id
-        if self.picking_id and self.picking_id.picking_type_code == 'incoming':
-            location_id = self.picking_id.location_dest_id
         available_qty = sum(self.env['stock.quant']._gather(self.product_id,
-                                                            location_id,
+                                                            self.location_id,
                                                             self.lot_id,
                                                             self.package_id,
                                                             self.owner_id,


### PR DESCRIPTION
revert commit 72c36aaf9004392773845406b2dc248017bb2e0c due to commit 47219e96e19b6c5badf7d4e99043817dc68812ac
First commit is now useless and on top of that it ignores the putaway
strategies.

opw-2412699
