### PR TITLE
[FIX] sale: Discount on re-invoicable product

### DIFF
--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -116,6 +116,7 @@ class AccountMoveLine(models.Model):
 
         # create the sale lines in batch
         new_sale_lines = self.env['sale.order.line'].create(sale_line_values_to_create)
+        new_sale_lines._onchange_discount()
 
         # build result map by replacing index with newly created record of sale.order.line
         result = {}


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a re-invoicable and expensable product P at 100€
- Let's consider a pricelist PL with 20% of visible discount on every product
- Let's consider a confirmed sale order SO with PL set on it
- Create an expense E with P at 100€ and reinvoice customer set to SO
- Generate the entries of E

Bug:

A new sale order line was created with 80€ as unit price and no discount instead of
20% discount.

opw:2423147