### PR TITLE
[IMP] website_slides: 'last action on' for better student progress analysis

### DIFF
--- a/addons/website_slides/models/res_partner.py
+++ b/addons/website_slides/models/res_partner.py
@@ -57,7 +57,15 @@ class ResPartner(models.Model):
                 partner.slide_channel_company_count = 0
 
     def action_view_courses(self):
-        action = self.env["ir.actions.actions"]._for_xml_id("website_slides.slide_channel_action_overview")
+        """ View partners courses. In singleton mode, return courses followed
+        by all its contacts (if company) or by himself (if not a company).
+        Otherwise simply set a domain on required partners. """
+        action = self.env["ir.actions.actions"]._for_xml_id("website_slides.slide_channel_partner_action")
         action['name'] = _('Followed Courses')
-        action['domain'] = ['|', ('partner_ids', 'in', self.ids), ('partner_ids', 'in', self.child_ids.ids)]
+        if len(self) == 1 and self.is_company:
+            action['domain'] = [('partner_id', 'in', self.child_ids.ids)]
+        elif len(self) == 1:
+            action['context'] = {'search_default_partner_id': self.id}
+        else:
+            action['domain'] = [('partner_id', 'in', self.ids)]
         return action

--- a/addons/website_slides/views/slide_channel_partner_views.xml
+++ b/addons/website_slides/views/slide_channel_partner_views.xml
@@ -9,6 +9,11 @@
                     <field name="partner_id"/>
                     <field name="partner_email"/>
                     <field name="channel_id"/>
+                     <separator/>
+                    <filter string="Completed" name="filter_completed" domain="[('completed', '=', True)]"/>
+                    <group expand="0" string="Group By">
+                        <filter string="Channel" name="groupby_channel_id" context="{'group_by': 'channel_id'}"/>
+                    </group>
                 </search>
             </field>
         </record>
@@ -18,21 +23,71 @@
             <field name="model">slide.channel.partner</field>
             <field name="arch" type="xml">
                 <tree string="Attendees" editable="top">
-                    <field name="create_date"/>
-                    <field name="partner_id" string="Contact"/>
-                    <field name="partner_email"/>
-                    <field name="channel_id" string="Channel" invisible="context.get('default_channel_id',False)" />
-                    <field name="completion" string="Progress" widget="progressbar" />
+                    <field name="channel_id" string="Course Name"/>
+                    <field name="channel_user_id"/>
+                    <field name="partner_email" string="Email"/>
+                    <field name="create_date" string="Enrolled On"/>
+                    <field name="write_date" string="Last Action On"/>
+                    <field name="completion" string="Progress" widget="progressbar"/>
+                    <field name="channel_type" optional="hide"/>
+                    <field name="channel_visibility" optional="hide"/>
+                    <field name="channel_enroll" widget="badge"
+                        decoration-success="channel_enroll == 'public'"
+                        decoration-info="channel_enroll == 'invite'"
+                        decoration-warning="channel_enroll == 'payment'"
+                        optional="hide"/>
+                    <field name="channel_website_id" groups="website.group_multi_website" optional="hide"/>
                     <button name="unlink" title="Remove" icon="fa-times" type="object"/>
                 </tree>
+            </field>
+        </record>
+
+        <record id="slide_channel_partner_view_kanban" model="ir.ui.view">
+            <field name="name">slide.channel.partner.view.kanban</field>
+            <field name="model">slide.channel.partner</field>
+            <field name="arch" type="xml">
+                <kanban string="Followed Courses">
+                    <templates>
+                        <t t-name="kanban-box">
+                            <div t-attf-class="oe_kanban_color oe_kanban_card">
+                                <div class="o_kanban_card_header">
+                                    <div class="o_kanban_card_header_title mb-3">
+                                        <strong class="o_kanban_record_title oe_partner_heading">
+                                            <field name="channel_id"/>
+                                        </strong>
+                                        <br/>
+                                        <field name="partner_id"/>
+                                    </div>
+                                </div>
+                                <div class="o_kanban_record_bottom">
+                                    <div class="oe_kanban_bottom_left">
+                                        <field name="completion" widget="progressbar"/>
+                                    </div>
+                                    <div class="oe_kanban_bottom_right">
+                                        <field name="channel_user_id" widget="many2one_avatar_user"/>
+                                    </div>
+                                </div>
+                            </div>
+                        </t>
+                    </templates>
+                </kanban>
             </field>
         </record>
 
         <record id="slide_channel_partner_action" model="ir.actions.act_window">
             <field name="name">Attendees</field>
             <field name="res_model">slide.channel.partner</field>
-            <field name="view_mode">tree,form</field>
+            <field name="view_mode">tree,form,kanban</field>
             <field name="search_view_id" ref="website_slides.slide_channel_partner_view_search"/>
         </record>
+
+        <record id="slide_channel_partner_action_report" model="ir.actions.act_window">
+            <field name="name">Attendees</field>
+            <field name="res_model">slide.channel.partner</field>
+            <field name="view_mode">tree,kanban</field>
+            <field name="search_view_id" ref="website_slides.slide_channel_partner_view_search"/>
+            <field name="context">{'search_default_groupby_channel': 1}</field>
+        </record>
+
     </data>
 </odoo>

--- a/addons/website_slides/views/website_slides_menu_views.xml
+++ b/addons/website_slides/views/website_slides_menu_views.xml
@@ -50,15 +50,20 @@
         parent="website_slides_menu_report"
         sequence="2"
         action="slide_slide_action_report"/>
+    <menuitem name="Attendees"
+        id="website_slides_menu_report_attendees"
+        parent="website_slides_menu_report"
+        sequence="5"
+        action="slide_channel_partner_action_report"/>
     <menuitem name="Reviews"
         id="website_slides_menu_report_reviews"
         parent="website_slides_menu_report"
-        sequence="6"
+        sequence="10"
         action="rating_rating_action_slide_channel_report"/>
     <menuitem name="Quizzes"
         id="website_slides_menu_report_quizzes"
         parent="website_slides_menu_report"
-        sequence="7"
+        sequence="15"
         action="slide_question_action_report"/>
 
     <!-- Settings sub-menu -->

--- a/addons/website_slides_forum/views/website_slides_menu_views.xml
+++ b/addons/website_slides_forum/views/website_slides_menu_views.xml
@@ -18,6 +18,6 @@
     <menuitem name="Forum"
         id="website_slides_menu_report_forum"
         parent="website_slides.website_slides_menu_report"
-        sequence="8"
+        sequence="20"
         action="forum_post_action_report"/>
 </odoo>


### PR DESCRIPTION
currently, when we click on the stat button "x Courses" on a contact we land
on the dashboard of the courses that this user follows. but we would like to
have more information about the progress of this student on each course. for
instance, more than the progress, we may want to see when was the last time
our student was active on a course.

below listed are the major changes done for this improvement.

in elearning view of contact form :

1. replaced the view from the stat button by a view list and added
   default search filter = contact in contact module.
2. added new column 'last action on' where it is the date from
   the last action.
3. changed the existing view to the following order of columns listed below
   'course name', 'responsible', 'enrolled on', 'last action on' and 'progress'
   besides that, 'course type', 'visibility', 'enroll policy' and 'website'
   are changed into conditional columns.

in e-learning module:

1. renamed 'created on' to 'enrolled on' as it will be more meaningfull to the
   context
2. in member view, 'last action on' field is added next to
   'enrolled on '.
3. added a default search filter with the name of the course in member view,
   so that we can display all the attendees from all courses.
4. added a new menu "attendees" under the reporting menu which has the following
 columns : enrolled on, contact, email, course name, responsible,  last action on
  and progress with a default group filter of 'channel_id'

Task-Id : 2409447