### PR TITLE
[FIX] account_facturx: Parse pdf invoice attachment from any Odoo >= v12.0

### DIFF
--- a/addons/account_facturx/models/account_invoice.py
+++ b/addons/account_facturx/models/account_invoice.py
@@ -295,13 +295,11 @@ class AccountInvoice(models.Model):
                         # '[::2]' because it's a list [fn_1, content_1, fn_2, content_2, ..., fn_n, content_2]
                         for filename_obj, content_obj in list(pycompat.izip(embedded_files, embedded_files[1:]))[::2]:
                             content = content_obj.getObject()['/EF']['/F'].getData()
-
-                            if filename_obj == 'factur-x.xml':
-                                try:
-                                    tree = etree.fromstring(content)
-                                except:
-                                    continue
-
+                            try:
+                                tree = etree.fromstring(content)
+                            except:
+                                continue
+                            if tree.tag == '{urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100}CrossIndustryInvoice':
                                 self._import_facturx_invoice(tree)
                                 buffer.close()
                                 return res


### PR DESCRIPTION
Issue

	- Init an instances of Odoo v12.0 'A' (or saas-12.3 or 13.0) and v14.0.
	- Install "Accounting" app on instance A & B.
	- Set your email server on instance A & B.
	- Activate 'External email server' in settings of instance A.
	- Set an email alias for "Vendor Bills" on instance A.
	- Send a "Customer Invoice" to from instance B to alias of instance B.
	- Fetch for new mail (in case new vendor bill don't appear).
	- Open new Vendor bill.

	Data are not parsed from pdf attachment.

Cause

	Filename formating has changed in v14.0 :
	- X < v14.0 : 'factur-x.xml'
	- X >= v14.0 : 'INV_2020_12_0001_facturx.xml'

Solution

	Don't check filename anymore since can be changed or can come
	from other services than Odoo.
	Instead, ensure there is a specific tag in the xml tree.

opw-2411002