### PR TITLE
[FIX] web: fix duplication on phone+sms button rerendering

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -1509,7 +1509,9 @@ var FieldEmail = InputField.extend({
      */
     _renderReadonly: function () {
         if (this.value) {
-            this.$el.text(this.value)
+            // Odoo legacy widgets can have multiple nodes inside their $el JQuery object
+            // so, select the proper one (other nodes are assumed not to contain proper data)
+            this.$el.closest("." + this.className).text(this.value)
                 .addClass('o_form_uri o_text_overflow')
                 .attr('href', this.prefix + ':' + this.value);
         } else {


### PR DESCRIPTION
STEPS:

* Add related phone field to a form (e.g. partner_id.phone to sale.order form)
* Use widget "phone" + activate sms feature
* Create a record
* Click edit, select partner that has phone specified (e.g. +1 234), edit
partner's phone (e.g. +1 234 555), save

BEFORE: ``+1 234 []SMS`` is converted to ``+1 234 555 +1 234 555``
AFTER: ``+1 234 555 []SMS``

WHY:
* FieldPhone is inherited from FieldEmail

  https://github.com/odoo/odoo/blob/0de069b8ca9fb005ba5b076984f5677de25889ee/addons/web/static/src/js/fields/basic_fields.js#L1549

* sms module adds SMS button to ``$el``

  https://github.com/odoo/odoo/blob/0de069b8ca9fb005ba5b076984f5677de25889ee/addons/sms/static/src/js/fields_phone_widget.js#L91

* So this commit filters ``$el`` before updating it

---

opw-2425949

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
