### PR TITLE
[FIX] account_facturx: Parse pdf attachment

### DIFF
--- a/addons/account/models/account_invoice.py
+++ b/addons/account/models/account_invoice.py
@@ -831,7 +831,7 @@ class AccountInvoice(models.Model):
         destination_emails = email_split((msg_dict.get('to') or '') + ',' + (msg_dict.get('cc') or ''))
         alias_names = [mail_to.split('@')[0] for mail_to in destination_emails]
         journal = self.env['account.journal'].search([
-            ('type', '=', 'purchase'), ('alias_name', 'in', alias_names)
+            ('type', 'in', ('purchase', 'sale')), ('alias_name', 'in', alias_names)
         ], limit=1)
 
         # Create the message and the bill.
@@ -839,7 +839,7 @@ class AccountInvoice(models.Model):
         if journal:
             values['journal_id'] = journal.id
         # Passing `type` in context so that _default_journal(...) can correctly set journal for new vendor bill
-        invoice = super(AccountInvoice, self.with_context(type=values.get('type'))).message_new(msg_dict, values)
+        invoice = super(AccountInvoice, self.with_context(type=values.get('type'), journal_type=journal.type)).message_new(msg_dict, values)
 
         # Subscribe internal users on the newly created bill
         partners = self.env['res.partner'].browse(seen_partner_ids)


### PR DESCRIPTION
Issue

	- Init an instances of Odoo saas-12.3 and v14.0.
        - Install "Accounting" app on instance A & B.
        - Set your email server on instance A & B.
        - Activate 'External email server' in settings of instance A.
        - Set an email alias for "Vendor Bills" on instance A.
        - Send a "Customer Invoice" from instance B to alias of instance A.
        - Fetch for new mail (in case new vendor bill don't appear) on instance A.
        - Open the new Vendor bill on instance A.

	Data are not parsed from pdf attachment.

Cause

	Context is missing 'journal_type' key, but instead, 'type' key is provided.

Solution

	Replace `context['journal_type']` by context.get('journal_type', '') in case not
	defined in context.
	If not, check if `type` is instead in the context.

opw-2411002