### PR TITLE
[FIX] portal: Due in %d days is not translated

### DIFF
--- a/addons/portal/i18n/portal.pot
+++ b/addons/portal/i18n/portal.pot
@@ -19,7 +19,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/portal/static/src/js/portal_sidebar.js:43
 #, python-format
-msgid "%d days overdue"
+msgid "%1d days overdue"
 msgstr ""
 
 #. module: portal
@@ -321,7 +321,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/portal/static/src/js/portal_sidebar.js:41
 #, python-format
-msgid "Due in %d days"
+msgid "Due in %1d days"
 msgstr ""
 
 #. module: portal

--- a/addons/portal/static/src/js/portal_sidebar.js
+++ b/addons/portal/static/src/js/portal_sidebar.js
@@ -5,6 +5,7 @@ var config = require('web.config');
 var core = require('web.core');
 var Widget = require('web.Widget');
 var time = require('web.time');
+var session = require('web.session');
 
 var _t = core._t;
 
@@ -35,14 +36,18 @@ var PortalSidebar = Widget.extend({
                 diff = dateTime.diff(today, 'days', true),
                 displayStr;
 
-            if (diff === 0){
-                displayStr = _t('Due today');
-            } else if (diff > 0) {
-                displayStr = _.str.sprintf(_t('Due in %d days'), Math.abs(diff));
-            } else {
-                displayStr = _.str.sprintf(_t('%d days overdue'), Math.abs(diff));
-            }
-             $(el).text(displayStr);
+            session.is_bound.then(function (){
+                if (diff === 0){
+                    displayStr = _t('Due today');
+                } else if (diff > 0) {
+                    // Workaround: force uniqueness of these two translations. We use %1d because the string
+                    // with %d is already used in mail and mail's translations are not sent to the frontend.
+                    displayStr = _.str.sprintf(_t('Due in %1d days'), Math.abs(diff));
+                } else {
+                    displayStr = _.str.sprintf(_t('%1d days overdue'), Math.abs(diff));
+                }
+                $(el).text(displayStr);
+            });
         });
     },
     /**


### PR DESCRIPTION
Steps:
- Install Invoicing and load French
- Go to Invoicing
- Click an invoice due in the future
- Click Preview
- Switch the preview to French by modifying the URL like this: example.com/my/invoices/6 -> example.com/fr_FR/my/invoices/6

Bug:
"Due in %d days" is still displayed in English. The rest of the page is in French.

Explanation:
This is due to two things:
1. `mail` and `portal` are both installed and we cannot have more than one `code` translation of a source [1]. Since `mail` is loaded before, alphabetically, `portal` doesn't add the duplicated translations with its own module name. When loading a web page, only the modules returned by `_get_translation_frontend_modules_domain()` are sent to the frontend. `mail` is not one of them and the duplicated translations are not sent. Since sending all the `mail` translations is overkill, this commit is modifying the format string. This won't change the text outcome, but will make the new sources unique and make the backend send these translations to the frontend.
2. Translations in `portal_sidebar.js` are queried before the translation DB [2] is made. This results in an empty array and `_t()` returns the source. `session.is_bound` will wait until the app is fully loaded before querying.

[1] https://github.com/odoo/odoo/blob/ad2d96db8ad3e1fd7af2edda218fc34c0c1d259a/odoo/addons/base/models/ir_translation.py#L290
[2] https://github.com/odoo/odoo/blob/0de069b8ca9fb005ba5b076984f5677de25889ee/addons/web/static/src/js/core/translation.js#L51

opw:2421501