### PR TITLE
[FIX] purchase: right partner in journal items from created bill

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -761,22 +761,17 @@ class PurchaseOrderLine(models.Model):
         if float_compare(qty, 0.0, precision_rounding=self.product_uom.rounding) <= 0:
             qty = 0.0
 
-        if self.currency_id == move.company_id.currency_id:
-            currency = False
-        else:
-            currency = move.currency_id
-
         return {
             'name': '%s: %s' % (self.order_id.name, self.name),
             'move_id': move.id,
-            'currency_id': currency and currency.id or False,
+            'currency_id': move.currency_id.id,
             'purchase_line_id': self.id,
             'date_maturity': move.invoice_date_due,
             'product_uom_id': self.product_uom.id,
             'product_id': self.product_id.id,
             'price_unit': self.price_unit,
             'quantity': qty,
-            'partner_id': move.partner_id.id,
+            'partner_id': move.commercial_partner_id.id,
             'analytic_account_id': self.account_analytic_id.id,
             'analytic_tag_ids': [(6, 0, self.analytic_tag_ids.ids)],
             'tax_ids': [(6, 0, self.taxes_id.ids)],


### PR DESCRIPTION
When we create a bill from a purchase with a partner which belongs to a company,
 some Journal Items got the individual instead of the company as partner.
Accounting dev team confirms that all these items must have the company commercial_partner_id so the company and
not the individual.
This can lead to this issue where Bills are not grouped into the company when the filter "Partner Company" is used.

Using 'move.commercial_partner_id.id' instead of 'move.partner_id.id' will resolve this issue.
How we handle 'currency_id' is also corrected.

opw-2391404