### PR TITLE
[FIX] l10n_latam_invoice_document: Remove l10n_ar constraint on base module

### DIFF
--- a/addons/l10n_latam_invoice_document/models/account_move.py
+++ b/addons/l10n_latam_invoice_document/models/account_move.py
@@ -164,8 +164,7 @@ class AccountMove(models.Model):
         for rec in self.filtered('l10n_latam_document_type_id.internal_type'):
             internal_type = rec.l10n_latam_document_type_id.internal_type
             invoice_type = rec.type
-            if internal_type in ['debit_note', 'invoice'] and invoice_type in ['out_refund', 'in_refund'] and \
-               rec.l10n_latam_document_type_id.code != '99':
+            if internal_type in ['debit_note', 'invoice'] and invoice_type in ['out_refund', 'in_refund']:
                 raise ValidationError(_('You can not use a %s document type with a refund invoice') % internal_type)
             elif internal_type == 'credit_note' and invoice_type in ['out_invoice', 'in_invoice']:
                 raise ValidationError(_('You can not use a %s document type with a invoice') % (internal_type))


### PR DESCRIPTION
#### Description of the issue/feature this PR addresses:
Documents with `l10n_latam_document_type_id.code == '99'` just exists on **l10n_ar** https://github.com/odoo/odoo/blob/13.0/addons/l10n_ar/data/l10n_latam.document.type.csv#L74 making this error arise on other localizations which don't use it.

This was mistakenly introduced on https://github.com/odoo/odoo/commit/7748e0e87fd3f4677a4026ed06516d36e8d52ad5

If needed, this method should be inherited inside l10n_ar and add this additional validation.

#### Current behavior before PR:
Install `l10n_latam_invoice_document` on a migrated database which does not respect this constraint https://github.com/odoo/odoo/blob/13.0/addons/l10n_latam_invoice_document/models/account_move.py#L167-L169, and you won't be able to upgrade / install another localization based on this module. 

#### Desired behavior after PR is merged:
Successful installation / migration

cc: @jco-odoo @zaoral @jjscarafia 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
