### PR TITLE
[FIX] misc: Babel; handle 'kur' (kurdish) locale

### DIFF
--- a/addons/web_editor/models/ir_qweb.py
+++ b/addons/web_editor/models/ir_qweb.py
@@ -32,6 +32,7 @@ import odoo.modules
 from odoo import api, models, fields
 from odoo.tools import ustr, posix_to_ldml, pycompat
 from odoo.tools import html_escape as escape
+from odoo.tools.misc import babel_locale_parse
 from odoo.addons.base.models import ir_qweb
 
 REMOTE_CONNECTION_TIMEOUT = 2.5
@@ -211,7 +212,7 @@ class Date(models.AbstractModel):
                 return attrs
 
             lg = self.env['res.lang']._lang_get(self.env.user.lang)
-            locale = babel.Locale.parse(lg.code)
+            locale = babel_locale_parse(lg.code)
             babel_format = value_format = posix_to_ldml(lg.date_format, locale=locale)
 
             if record[field_name]:
@@ -244,7 +245,7 @@ class DateTime(models.AbstractModel):
         if options.get('inherit_branding'):
             value = record[field_name]
             lg = self.env['res.lang']._lang_get(self.env.user.lang)
-            locale = babel.Locale.parse(lg.code)
+            locale = babel_locale_parse(lg.code)
             babel_format = value_format = posix_to_ldml('%s %s' % (lg.date_format, lg.time_format), locale=locale)
             tz = record.env.context.get('tz') or self.env.user.tz
 

--- a/addons/website_event_track/controllers/main.py
+++ b/addons/website_event_track/controllers/main.py
@@ -10,6 +10,7 @@ from werkzeug.exceptions import NotFound
 from odoo import fields, http
 from odoo.http import request
 from odoo.tools import html_escape as escape, html2plaintext
+from odoo.tools.misc import babel_locale_parse
 
 
 class WebsiteEventTrackController(http.Controller):
@@ -29,7 +30,7 @@ class WebsiteEventTrackController(http.Controller):
             :param dt_time: datetime object
             :param lang_code: language code (eg. en_US)
         """
-        locale = babel.Locale.parse(lang_code)
+        locale = babel_locale_parse(lang_code)
         return babel.dates.format_time(dt_time, format='short', locale=locale)
 
     def _prepare_calendar(self, event, event_track_ids):

--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -10,6 +10,7 @@ from lxml import etree
 import math
 
 from odoo.tools import html_escape as escape, posix_to_ldml, safe_eval, float_utils, format_date, pycompat
+from odoo.tools.misc import babel_locale_parse
 
 import logging
 _logger = logging.getLogger(__name__)
@@ -232,7 +233,7 @@ class DateTimeConverter(models.AbstractModel):
         if not value:
             return ''
         lang = self.user_lang()
-        locale = babel.Locale.parse(lang.code)
+        locale = babel_locale_parse(lang.code)
 
         if isinstance(value, pycompat.string_types):
             value = fields.Datetime.from_string(value)
@@ -521,7 +522,7 @@ class DurationConverter(models.AbstractModel):
     def value_to_html(self, value, options):
         units = dict(TIMEDELTA_UNITS)
 
-        locale = babel.Locale.parse(self.user_lang().code)
+        locale = babel_locale_parse(self.user_lang().code)
         factor = units[options.get('unit', 'second')]
         round_to = units[options.get('round', 'second')]
 
@@ -574,7 +575,7 @@ class RelativeDatetimeConverter(models.AbstractModel):
 
     @api.model
     def value_to_html(self, value, options):
-        locale = babel.Locale.parse(self.user_lang().code)
+        locale = babel_locale_parse(self.user_lang().code)
 
         if isinstance(value, pycompat.string_types):
             value = fields.Datetime.from_string(value)

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -1132,6 +1132,15 @@ else:
     def html_escape(text):
         return werkzeug.utils.escape(text)
 
+def babel_locale_parse(lang_code):
+    try:
+        return babel.Locale.parse(lang_code)
+    except:
+        try:
+            return babel.Locale.default()
+        except:
+            return babel.Locale.parse("en_US")
+
 def formatLang(env, value, digits=None, grouping=True, monetary=False, dp=False, currency_obj=False):
     """
         Assuming 'Account' decimal.precision=3:
@@ -1194,7 +1203,7 @@ def format_date(env, value, lang_code=False, date_format=False):
             value = odoo.fields.Datetime.from_string(value)
 
     lang = env['res.lang']._lang_get(lang_code or env.context.get('lang') or 'en_US')
-    locale = babel.Locale.parse(lang.code)
+    locale = babel_locale_parse(lang.code)
     if not date_format:
         date_format = posix_to_ldml(lang.date_format, locale=locale)
 


### PR DESCRIPTION
Issue

	- add a new language with locale code KUR (for Kurdish)
	- print any report with a datetime on it (RFQ for example)

Cause

	Babel (version < 2.7.0) does not handle locale "KUR".

Solution

	If locale "KUR" (code for macro-language "Kurdish") is provided,
	then use "CKB" (code for individual language "Central Kurdish") instead.
	If wrong locale or not managed by Babel, then use "en_US" as locale.

opw-2416482