### PR TITLE
[REF] mail: adapts the attachment component for extension

### DIFF
--- a/addons/mail/static/src/components/attachment/attachment.js
+++ b/addons/mail/static/src/components/attachment/attachment.js
@@ -4,6 +4,11 @@ odoo.define('mail/static/src/components/attachment/attachment.js', function (req
 const useShouldUpdateBasedOnProps = require('mail/static/src/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props.js');
 const useStore = require('mail/static/src/component_hooks/use_store/use_store.js');
 
+const {
+    isEventHandled,
+    markEventHandled,
+} = require('mail/static/src/utils/utils.js');
+
 const components = {
     AttachmentDeleteConfirmDialog: require('mail/static/src/components/attachment_delete_confirm_dialog/attachment_delete_confirm_dialog.js'),
 };
@@ -110,7 +115,7 @@ class Attachment extends Component {
      * @param {MouseEvent} ev
      */
     _onClickDownload(ev) {
-        ev.stopPropagation();
+        markEventHandled(ev, 'Attachment.clickDownload');
         this.env.services.navigate(`/web/content/ir.attachment/${this.attachment.id}/datas`, { download: true });
     }
 
@@ -122,6 +127,12 @@ class Attachment extends Component {
      */
     _onClickImage(ev) {
         if (!this.attachment.isViewable) {
+            return;
+        }
+        if (isEventHandled(ev, 'Attachment.clickDownload')) {
+            return;
+        }
+        if (isEventHandled(ev, 'Attachment.clickUnlink')) {
             return;
         }
         this.env.models['mail.attachment'].view({
@@ -137,7 +148,7 @@ class Attachment extends Component {
      * @param {MouseEvent} ev
      */
     _onClickUnlink(ev) {
-        ev.stopPropagation();
+        markEventHandled(ev, 'Attachment.clickUnlink');
         if (!this.attachment) {
             return;
         }

--- a/addons/mail/static/src/components/attachment/attachment.scss
+++ b/addons/mail/static/src/components/attachment/attachment.scss
@@ -5,7 +5,7 @@
 .o_Attachment {
     display: flex;
 
-    &:hover .o_Attachment_asideItemUnlink.o-pretty {
+    &:hover .o-pretty .o_Attachment_asideItemUnlink {
         transform: translateX(0);
     }
 }
@@ -22,7 +22,6 @@
 
 .o_Attachment_aside {
     position: relative;
-    overflow: hidden;
 
     &:not(.o-has-multiple-action) {
         min-width: 50px;
@@ -43,10 +42,25 @@
     justify-content: center;
 }
 
-.o_Attachment_asideItemUnlink.o-pretty {
+.o-pretty {
     position: absolute;
-    top: 0;
-    transform: translateX(100%);
+    overflow: hidden;
+    width: 100%;
+    height: 100%;
+
+    .o_Attachment_asideItemUnlink {
+        position: absolute;
+        top: 0;
+        transform: translateX(100%);
+    }
+}
+
+.o_Attachment_asideItemUnlink {
+    height: 100%;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .o_Attachment_details {
@@ -150,19 +164,18 @@
 .o_Attachment_asideItemUnlink {
     cursor: pointer;
 
-    &:not(.o-pretty):hover {
+    &:hover {
         background-color: gray('400');
     }
+}
 
-    &.o-pretty {
-        color: white;
-        background-color: $o-brand-primary;
+.o-pretty .o_Attachment_asideItemUnlink {
+    color: white;
+    background-color: $o-brand-primary;
 
-        &:hover {
-            background-color: darken($o-brand-primary, 10%);
-        }
+    &:hover {
+        background-color: darken($o-brand-primary, 10%);
     }
-
 }
 
 .o_Attachment_asideItemUploaded {
@@ -194,7 +207,7 @@
 // Animation
 // ------------------------------------------------------------------
 
-.o_Attachment_asideItemUnlink.o-pretty {
+.o-pretty > .o_Attachment_asideItemUnlink {
     transition: transform 0.3s ease 0s;
 }
 

--- a/addons/mail/static/src/components/attachment/attachment.xml
+++ b/addons/mail/static/src/components/attachment/attachment.xml
@@ -82,16 +82,18 @@
                                 <i class="fa fa-spin fa-spinner"/>
                             </div>
                         </t>
+                        <!-- Remove button -->
+                        <t t-if="props.isEditable">
+                            <div class="o_Attachment_asideItem" t-att-class="{ 'o-pretty': attachment.isLinkedToComposer }">
+                                <div class="o_Attachment_asideItemUnlink" t-on-click="_onClickUnlink" title="Remove">
+                                    <i class="fa fa-times"/>
+                                </div>
+                            </div>
+                        </t>
                         <!-- Uploaded icon -->
                         <t t-if="!attachment.isUploading and attachment.isLinkedToComposer">
                             <div class="o_Attachment_asideItem o_Attachment_asideItemUploaded" title="Uploaded">
                                 <i class="fa fa-check"/>
-                            </div>
-                        </t>
-                        <!-- Remove button -->
-                        <t t-if="props.isEditable">
-                            <div class="o_Attachment_asideItem o_Attachment_asideItemUnlink" t-att-class="{ 'o-pretty': attachment.isLinkedToComposer }" t-on-click="_onClickUnlink" title="Remove">
-                                <i class="fa fa-times"/>
                             </div>
                         </t>
                         <!-- Download button -->


### PR DESCRIPTION
This commit adds two changes to the Attachment component:

* increase the specificity of an overflow rule so it is not applied
when unnecessary.

* replaces the usage of the native `event.stopPropagation()`
by the event handling of mail.utils.

part of task-2360547