### PR TITLE
[FIX] stock : impossible to delivery twice same SN

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -76,6 +76,8 @@ class StockQuant(models.Model):
     @api.constrains('quantity')
     def check_quantity(self):
         for quant in self:
+            if quant.location_id.usage in ('supplier', 'customer', 'inventory'):
+                continue
             if float_compare(quant.quantity, 1, precision_rounding=quant.product_uom_id.rounding) > 0 and quant.lot_id and quant.product_id.tracking == 'serial':
                 message_base = _('A serial number should only be linked to a single product.')
                 message_quant = _('Please check the following serial number (name, id): ')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
V12 to V14.

Go to runbot : https://5624305-12-0.runbot55.odoo.com/web#id=31&action=326&active_id=2&model=stock.picking&view_type=form&menu_id=186
- create a product A with serial number 0001
- make an inventory : product A, SN : 0001, qty : 1
- validate inventory
- create an outgoing picking (to customer location)
- add product A qty 1.
- validate picking (note : the SN 0001 is used)
The product A with SN 0001 is find in the warehouse (for any reason)
- make an inventory : product A, SN : 0001, qty : 1
- validate inventory
Now try to move the product A with SN 0001 
- create an outgoing picking (to customer location)
- add product A qty 1.
- validate picking 
--> Issue it is impossible to validate the picking


Note : it is fast patch. The best solution is during an inventory of a product with SN, Odoo should make a movement from where the quant here (in this case in the customer location) if the quant exist. And not from inventory.

@nim-odoo

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
