### PR TITLE
Master event visual glitches neb

### DIFF
--- a/addons/event/models/event_ticket.py
+++ b/addons/event/models/event_ticket.py
@@ -148,3 +148,10 @@ class EventTicket(models.Model):
             return ticket.start_sale_date <= current_date
         else:
             return True
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_if_registrations(self):
+        if self.registration_ids:
+            raise UserError(_(
+                "The following tickets cannot be deleted while they have one or more registrations linked to them:\n- %s",
+                '\n- '.join(self.mapped('name'))))

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -149,7 +149,7 @@
         <div id="o_wevent_tickets" class="bg-white shadow-sm o_wevent_js_ticket_details" data-folded-by-default="0">
             <t t-set="tickets" t-value="event.event_ticket_ids.filtered(lambda ticket: not ticket.is_expired)"/>
             <!-- If some tickets expired and there is only one type left, we keep the same layout -->
-            <t t-if="len(event.event_ticket_ids) &gt; 1">
+            <t t-if="len(event.event_ticket_ids) &gt; 1 or tickets.description">
                 <div class="d-flex justify-content-between align-items-center py-2 pl-3 pr-2 border-bottom">
                     <div id="price-range" class="pr-3 d-none"/>
                     <span t-if="not event.event_registrations_open" class="text-danger">

--- a/addons/website_event_sale/views/website_event_templates.xml
+++ b/addons/website_event_sale/views/website_event_templates.xml
@@ -25,7 +25,7 @@
     </xpath>
     <!-- Add price information on tickets (mono ticket, aka not in collapse) -->
     <xpath expr="//div[hasclass('o_wevent_registration_single')]//h6" position="after">
-        <div class="px-2 text-dark mr-2 border-right d-flex align-items-center align-self-stretch">
+        <div class="px-2 text-dark mr-2 d-flex align-items-center align-self-stretch">
             <t t-if="tickets.price">
                 <t t-if="(tickets.price-website.get_current_pricelist().currency_id._convert(tickets.price_reduce, event.company_id.sudo().currency_id, event.company_id, datetime.date.today())) &gt; 1 and website.get_current_pricelist().discount_policy == 'without_discount'">
                     <del class="text-danger mr-1" t-field="tickets.price" t-options="{'widget': 'monetary', 'from_currency': event.company_id.sudo().currency_id, 'display_currency': website.get_current_pricelist().currency_id}"/>

--- a/addons/website_event_track/static/src/js/website_event_track.js
+++ b/addons/website_event_track/static/src/js/website_event_track.js
@@ -19,14 +19,24 @@ publicWidget.registry.websiteEventTrack = publicWidget.Widget.extend({
      */
     _onEventTrackSearchInput: function (ev) {
         ev.preventDefault();
-
         var text = $(ev.currentTarget).val();
-        var filter = _.str.sprintf(':containsLike(%s)', text);
-
-        $('#search_summary').removeClass('invisible');
         var $tracks = $('.event_track');
-        $('#search_number').text($tracks.filter(filter).length);
-        $tracks.removeClass('invisible').not(filter).addClass('invisible');
+
+        //check if the user is performing a search; i.e., text is not empty
+        if (text) {
+            function filterTracks(index, element) {
+                //when filtering elements only check the text content
+                return this.textContent.toLowerCase().includes(text.toLowerCase());
+            }
+            $('#search_summary').removeClass('invisible');
+            $('#search_number').text($tracks.filter(filterTracks).length);
+
+            $tracks.removeClass('invisible').not(filterTracks).addClass('invisible');
+        } else {
+            //if no search is being performed; hide the result count text
+            $('#search_summary').addClass('invisible');
+            $tracks.removeClass('invisible')
+        }
     },
 });
 });


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
- If a single ticket is set for an event, its description is not displayed
- The filter count ( X results) is still displayed even when no search is performed (empty field)
- Scary technical error message when trying to delete an event ticket linked to a registration 
Desired behavior after PR is merged:
- Description is displayed when a single ticket is set for an event
- The search results count (X results) is hidden when no search is being performed
- A better plain English message is displayed when a ticket linked to a registration is deleted

Task-2427778



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
