### PR TITLE
[MERGE] crm: reorganize convert and merge tool methods

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -999,7 +999,7 @@ class Lead(models.Model):
         which fields has been merged and their new value. `self` is the resulting
         merge crm.lead record.
 
-        :param opportunities: see ``merge_dependences``
+        :param opportunities: see ``_merge_dependences``
         """
         # TODO JEM: mail template should be used instead of fix body, subject text
         self.ensure_one()
@@ -1016,7 +1016,7 @@ class Lead(models.Model):
         """ Move mail.message from the given opportunities to the current one. `self` is the
             crm.lead record destination for message of `opportunities`.
 
-        :param opportunities: see ``merge_dependences``
+        :param opportunities: see ``_merge_dependences``
         """
         self.ensure_one()
         for opportunity in opportunities:
@@ -1035,7 +1035,7 @@ class Lead(models.Model):
         """ Move attachments of given opportunities to the current one `self`, and rename
             the attachments having same name than native ones.
 
-        :param opportunities: see ``merge_dependences``
+        :param opportunities: see ``_merge_dependences``
         """
         self.ensure_one()
 
@@ -1057,7 +1057,7 @@ class Lead(models.Model):
                 attachment.write(values)
         return True
 
-    def merge_dependences(self, opportunities):
+    def _merge_dependences(self, opportunities):
         """ Merge dependences (messages, attachments, ...). These dependences will be
             transfered to `self`, the most important lead.
 
@@ -1102,7 +1102,7 @@ class Lead(models.Model):
             merged_data['team_id'] = team_id
 
         # merge other data (mail.message, attachments, ...) from tail into head
-        opportunities_head.merge_dependences(opportunities_tail)
+        opportunities_head._merge_dependences(opportunities_tail)
 
         # check if the stage is in the stages of the Sales Team. If not, assign the stage with the lowest sequence
         if merged_data.get('team_id'):
@@ -1149,11 +1149,11 @@ class Lead(models.Model):
             lead.write(vals)
 
         if user_ids or team_id:
-            self.handle_salesmen_assignment(user_ids, team_id)
+            self._handle_salesmen_assignment(user_ids=user_ids, team_id=team_id)
 
         return True
 
-    def handle_partner_assignment(self, force_partner_id=False, create_missing=True):
+    def _handle_partner_assignment(self, force_partner_id=False, create_missing=True):
         """ Update customer (partner_id) of leads. Purpose is to set the same
         partner on most leads; either through a newly created partner either
         through a given partner_id.
@@ -1169,7 +1169,7 @@ class Lead(models.Model):
                 partner = lead._create_customer()
                 lead.partner_id = partner.id
 
-    def handle_salesmen_assignment(self, user_ids=None, team_id=False):
+    def _handle_salesmen_assignment(self, user_ids=False, team_id=False):
         """ Assign salesmen and salesteam to a batch of leads.  If there are more
         leads than salesmen, these salesmen will be assigned in round-robin. E.g.
         4 salesmen (S1, S2, S3, S4) for 6 leads (L1, L2, ... L6) will assigned as
@@ -1179,7 +1179,7 @@ class Lead(models.Model):
         :param int team_id: salesteam to assign
         """
         update_vals = {'team_id': team_id} if team_id else {}
-        if not user_ids:
+        if not user_ids and team_id:
             self.write(update_vals)
         else:
             lead_ids = self.ids

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -291,6 +291,6 @@ class TestCRMLead(TestCrmCommon):
             subtype_xmlid='mail.mt_comment')
         self.assertEqual(message.author_id, self.user_sales_manager.partner_id)
 
-        new_lead.handle_partner_assignment(create_missing=True)
+        new_lead._handle_partner_assignment(create_missing=True)
         self.assertEqual(new_lead.partner_id.email, 'unknown.sender@test.example.com')
         self.assertEqual(new_lead.partner_id.team_id, self.sales_team_1)

--- a/addons/crm/tests/test_crm_lead_convert_mass.py
+++ b/addons/crm/tests/test_crm_lead_convert_mass.py
@@ -25,7 +25,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
             test_leads = self.env['crm.lead'].browse(test_leads.ids)
 
         with self.assertQueryCount(user_sales_manager=254):  # crm only: 251
-            test_leads.handle_salesmen_assignment(user_ids=user_ids, team_id=False)
+            test_leads._handle_salesmen_assignment(user_ids=user_ids, team_id=False)
 
         self.assertEqual(test_leads.team_id, self.sales_team_convert | self.sales_team_1)
         self.assertEqual(test_leads[0::3].user_id, self.user_sales_manager)
@@ -43,7 +43,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
             test_leads = self.env['crm.lead'].browse(test_leads.ids)
 
         with self.assertQueryCount(user_sales_manager=220):  # crm only: 215
-            test_leads.handle_salesmen_assignment(user_ids=user_ids, team_id=team_id)
+            test_leads._handle_salesmen_assignment(user_ids=user_ids, team_id=team_id)
 
         self.assertEqual(test_leads.team_id, self.sales_team_convert)
         self.assertEqual(test_leads[0::3].user_id, self.user_sales_manager)

--- a/addons/crm/wizard/crm_lead_to_opportunity.py
+++ b/addons/crm/wizard/crm_lead_to_opportunity.py
@@ -152,18 +152,18 @@ class Lead2OpportunityPartner(models.TransientModel):
                 self._convert_handle_partner(
                     lead, self.action, self.partner_id.id or lead.partner_id.id)
 
-            lead.convert_opportunity(lead.partner_id.id, [], False)
+            lead.convert_opportunity(lead.partner_id.id, user_ids=False, team_id=False)
 
         leads_to_allocate = leads
         if not self.force_assignment:
             leads_to_allocate = leads_to_allocate.filtered(lambda lead: not lead.user_id)
 
         if user_ids:
-            leads_to_allocate.handle_salesmen_assignment(user_ids, team_id=team_id)
+            leads_to_allocate._handle_salesmen_assignment(user_ids, team_id=team_id)
 
     def _convert_handle_partner(self, lead, action, partner_id):
         # used to propagate user_id (salesman) on created partners during conversion
-        lead.with_context(default_user_id=self.user_id.id).handle_partner_assignment(
+        lead.with_context(default_user_id=self.user_id.id)._handle_partner_assignment(
             force_partner_id=partner_id,
             create_missing=(action == 'create')
         )

--- a/addons/sale_crm/wizard/crm_opportunity_to_quotation.py
+++ b/addons/sale_crm/wizard/crm_opportunity_to_quotation.py
@@ -46,5 +46,5 @@ class Opportunity2Quotation(models.TransientModel):
         """
         self.ensure_one()
         if self.action != 'nothing':
-            self.lead_id.handle_partner_assignment(force_partner_id=self.partner_id.id, create_missing=(self.action == 'create'))
+            self.lead_id._handle_partner_assignment(force_partner_id=self.partner_id.id, create_missing=(self.action == 'create'))
         return self.lead_id.action_new_quotation()

--- a/addons/sales_team/tests/__init__.py
+++ b/addons/sales_team/tests/__init__.py
@@ -2,4 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import common
-from . import test_sales_team_membership
+from . import test_sales_team

--- a/addons/sales_team/tests/test_sales_team.py
+++ b/addons/sales_team/tests/test_sales_team.py
@@ -1,17 +1,26 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.addons.sales_team.tests.common import TestSalesMC
+from odoo.addons.sales_team.tests.common import TestSalesCommon
 
 
-class TestDefaultTeam(TestSalesMC):
+class TestDefaultTeam(TestSalesCommon):
     """Tests to check if correct default team is found."""
 
     @classmethod
     def setUpClass(cls):
         """Set up data for default team tests."""
         super(TestDefaultTeam, cls).setUpClass()
-
+        cls.company_2 = cls.env['res.company'].create({
+            'name': 'New Test Company',
+            'email': 'company.2@test.example.com',
+            'country_id': cls.env.ref('base.fr'),
+        })
+        cls.team_c2 = cls.env['crm.team'].create({
+            'name': 'C2 Team1',
+            'sequence': 1,
+            'company_id': cls.company_2.id,
+        })
         cls.team_sequence = cls.env['crm.team'].create({
             'name': 'Team LowSequence',
             'sequence': 0,

--- a/addons/website_crm/models/website_visitor.py
+++ b/addons/website_crm/models/website_visitor.py
@@ -38,7 +38,7 @@ class WebsiteVisitor(models.Model):
             partners = sorted_leads.mapped('partner_id')
             if not partners:
                 main_lead = self.lead_ids[0]
-                main_lead.handle_partner_assignment(create_missing=True)
+                main_lead._handle_partner_assignment(create_missing=True)
                 self.partner_id = main_lead.partner_id.id
             return True
         return check

--- a/addons/website_crm_partner_assign/models/crm_lead.py
+++ b/addons/website_crm_partner_assign/models/crm_lead.py
@@ -68,7 +68,7 @@ class CrmLead(models.Model):
             lead.assign_geo_localize(lead.partner_latitude, lead.partner_longitude)
             partner = self.env['res.partner'].browse(partner_id)
             if partner.user_id:
-                lead.handle_salesmen_assignment(partner.user_id.ids, team_id=partner.team_id.id)
+                lead._handle_salesmen_assignment(user_ids=partner.user_id.ids, team_id=partner.team_id.id)
             lead.write({'partner_assigned_id': partner_id})
         return res
 


### PR DESCRIPTION
PURPOSE

Prepare sales team membership and lead assignment improvements by
reorganizing and cleaning some code bits.

SPECIFICATIONS

Reorganize sales team tests to ease addition and modifications of tests
when adding multi-membership and lead assignment features.

Separate business methods from tool methods. It eases their discovering and
their re-use through various other methods and models. Moreover it helps
reading business oriented methods without being disturbed by tools.

Tools methods should be private by default to indicate those are not part of
official convert or merge API for leads. In this commit we make convert and
merge tool methods private, keeping only main API methods public.

LINKS

Task ID-2428882
Prepares Task ID-2086889
COM PR odoo/odoo#64196
ENT PT odoo/enterprise#15610