### PR TITLE
[FIX] mail: get current company activities

### DIFF
--- a/addons/mail/static/src/js/systray/systray_activity_menu.js
+++ b/addons/mail/static/src/js/systray/systray_activity_menu.js
@@ -131,7 +131,13 @@ var ActivityMenu = Widget.extend({
             res_model:  data.res_model,
             views: [[false, 'kanban'], [false, 'form']],
             search_view_id: [false],
-            domain: [['activity_user_id', '=', session.uid]],
+            domain: [
+                ['activity_user_id', '=', session.uid],
+                // filter activities on current company
+                '|',
+                ['company_id', '=', false],
+                ['company_id', 'child_of', [session.company_id]]
+            ],
             context:context,
         }, {
             clear_breadcrumbs: true,


### PR DESCRIPTION
In a multi-company configuration, when checking the documents that have
one activity (e.g., a TODO activity), it shows all companies' documents

To reproduce the error:
(Install Documents. Let C1 be the current company)
1. Create a second company C2
2. Go to Documents > Configuration > Folders
3. Create a folder F
	- Company must be C1
4. Go to folder F and upload a document D
5. Schedule an activity on D:
	- a To Do activity, with Due Date set to today
6. Switch to company C2
7. On top bar, check your activities
8. Click on "1 Today"

Err: The system displays all documents that have an activity scheduled for
today. In our case, you see document D. Since you switched to company
C2, you should not see this document. This error can even lead to a more
problematic situation: in step 4, create a "Request Document" instead of
uploading a file. In step 8, an AccessError will be raised and you will
no longer be able to consult the documents that have a scheduled activity.

When clicking on "1 Today", the server searches for documents that have
an activity scheduled for today. However, this search does not contain
any filters on companies. In most cases, the search domain will be
improved on server-side, thanks to the access rules. But in some cases
(e.g., using the Documents module), there isn't any rule about companies.

This fix only concerns version 12 (from version 13 onwards, the user can
see several companies' data at the same time).

OPW-2416152