### PR TITLE
[FIX] crm: open reporting

### DIFF
--- a/addons/crm/report/crm_activity_report_views.xml
+++ b/addons/crm/report/crm_activity_report_views.xml
@@ -102,7 +102,6 @@
        <menuitem
             id="crm_activity_report_menu"
             name="Activities"
-            groups="sales_team.group_sale_manager"
             parent="crm_menu_report"
             action="crm_activity_report_action"
             sequence="3"/>

--- a/addons/crm/views/crm_menu_views.xml
+++ b/addons/crm/views/crm_menu_views.xml
@@ -59,7 +59,7 @@
         name="Reporting"
         parent="crm_menu_root"
         sequence="20"
-        groups="sales_team.group_sale_manager"/>
+        groups="sales_team.group_sale_salesman"/>
     <menuitem
         id="crm_opportunity_report_menu_lead"
         name="Leads"

--- a/addons/crm_iap_lead_website/__manifest__.py
+++ b/addons/crm_iap_lead_website/__manifest__.py
@@ -14,6 +14,7 @@
     ],
     'data': [
         'data/reveal_data.xml',
+        'security/ir_rules.xml',
         'security/ir.model.access.csv',
         'views/crm_lead_view.xml',
         'views/crm_reveal_views.xml',

--- a/addons/crm_iap_lead_website/security/ir.model.access.csv
+++ b/addons/crm_iap_lead_website/security/ir.model.access.csv
@@ -1,3 +1,5 @@
 id,name,model_id/id,group_id/id,perm_read,perm_write,perm_create,perm_unlink
-access_crm_reveal_rule,access_crm_reveal_rule,model_crm_reveal_rule,sales_team.group_sale_manager,1,1,1,1
-access_crm_reveal_view,access_crm_reveal_view,model_crm_reveal_view,sales_team.group_sale_manager,1,1,1,1
+access_crm_reveal_rule_manager,access_crm_reveal_rule_manager,model_crm_reveal_rule,sales_team.group_sale_manager,1,1,1,1
+access_crm_reveal_rule_salesman,access_crm_reveal_rule_salesman,model_crm_reveal_rule,sales_team.group_sale_salesman,1,0,0,0
+access_crm_reveal_view_manager,access_crm_reveal_view_manager,model_crm_reveal_view,sales_team.group_sale_manager,1,1,1,1
+access_crm_reveal_view_salesman,access_crm_reveal_view_salesman,model_crm_reveal_view,sales_team.group_sale_salesman,1,0,0,0

--- a/addons/crm_iap_lead_website/security/ir_rules.xml
+++ b/addons/crm_iap_lead_website/security/ir_rules.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <record id="ir_rule_crm_reveal_rule_all" model="ir.rule">
+        <field name="name">CRM Reveal Rules: All Rules</field>
+        <field name="model_id" ref="model_crm_reveal_rule"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
+    </record>
+    <record id="ir_rule_crm_reveal_rule_salesman" model="ir.rule">
+        <field name="name">CRM Reveal Rules: Personal / Global Rules</field>
+        <field name="model_id" ref="model_crm_reveal_rule"/>
+        <field name="domain_force">['|', ('user_id', '=', user.id), ('user_id', '=', False)]</field>
+        <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
+    </record>
+
+    <record id="ir_rule_crm_reveal_view_all" model="ir.rule">
+        <field name="name">CRM Reveal Views: All Views</field>
+        <field name="model_id" ref="model_crm_reveal_view"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
+    </record>
+    <record id="ir_rule_crm_reveal_view_salesman" model="ir.rule">
+        <field name="name">CRM Reveal Views: Personal / Global Views</field>
+        <field name="model_id" ref="model_crm_reveal_view"/>
+        <field name="domain_force">['|', ('reveal_rule_id.user_id', '=', user.id), ('reveal_rule_id.user_id', '=', False)]</field>
+        <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
+    </record>
+</odoo>

--- a/addons/website_crm_partner_assign/security/ir_rule.xml
+++ b/addons/website_crm_partner_assign/security/ir_rule.xml
@@ -22,4 +22,18 @@
             <field name="perm_read" eval="True"/>
         </record>
 
+    <record id="ir_rule_crm_partner_report_assign_all" model="ir.rule">
+         <field name="name">CRM partner assign report: All Assignations</field>
+         <field name="model_id" ref="model_crm_partner_report_assign"/>
+         <field name="domain_force">[(1, '=', 1)]</field>
+         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
+     </record>
+
+     <record id="ir_rule_crm_partner_report_assign_salesman" model="ir.rule">
+         <field name="name">CRM partner assign report: Personal / Global Assignations</field>
+         <field name="model_id" ref="model_crm_partner_report_assign"/>
+         <field name="domain_force">['|', ('user_id', '=', user.id), ('user_id', '=', False)]</field>
+         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
+     </record>
+
 </odoo>


### PR DESCRIPTION
The purpose of the task is to let users of all access right levels access
their reporting, and to make sure that it does not give them access to
the data that does not match their access rights. 

After applying this commit all crm user can access reporting menu,
the only difference being the records that they can or not access.

**TaskId - 2357311**

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
