### PR TITLE
[ADD] {google,fetchmail}_gmail: OAuth for gmail servers

### DIFF
--- a/addons/fetchmail/views/fetchmail_views.xml
+++ b/addons/fetchmail/views/fetchmail_views.xml
@@ -31,8 +31,8 @@
                     <sheet>
                      <group col="4">
                         <field name="name"/>
-                        <field name="server_type"/>
                         <field name="date"/>
+                        <field name="server_type" widget="radio"/>
                      </group>
                      <notebook>
                         <page string="Server &amp; Login" name="server_login_details">

--- a/addons/fetchmail_gmail/__init__.py
+++ b/addons/fetchmail_gmail/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/fetchmail_gmail/__manifest__.py
+++ b/addons/fetchmail_gmail/__manifest__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    "name": "Fetchmail Gmail",
+    "version": "0.1",
+    "category": "Hidden",
+    "description": "Google authentication for fetch mail",
+    "depends": [
+        "google_gmail",
+        "fetchmail",
+    ],
+    "data": [
+        "views/fetchmail_server_views.xml",
+    ],
+    "auto_install": True,
+    "license": "LGPL-3",
+}

--- a/addons/fetchmail_gmail/models/__init__.py
+++ b/addons/fetchmail_gmail/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import fetchmail_server

--- a/addons/fetchmail_gmail/models/fetchmail_server.py
+++ b/addons/fetchmail_gmail/models/fetchmail_server.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from imaplib import IMAP4, IMAP4_SSL
+
+from odoo import api, fields, models
+from odoo.addons.fetchmail.models.fetchmail import MAIL_TIMEOUT
+
+
+class FetchmailServer(models.Model):
+    _name = 'fetchmail.server'
+    _inherit = ['fetchmail.server', 'google.gmail.mixin']
+
+    server_type = fields.Selection(selection_add=[('gmail', 'Gmail OAuth Authentication')], ondelete={'gmail': 'set default'})
+
+    @api.onchange('server_type', 'is_ssl', 'object_id')
+    def onchange_server_type(self):
+        """Set the default configuration for a IMAP Gmail server."""
+        if self.server_type == 'gmail':
+            self.server = 'imap.gmail.com'
+            self.is_ssl = True
+            self.port = 993
+        else:
+            self.google_gmail_authorization_code = False
+            self.google_gmail_refresh_token = False
+            super(FetchmailServer, self).onchange_server_type()
+
+    def connect(self):
+        """Connect to the mail server.
+
+        If the mail server is Gmail, we use the OAuth2 authentication protocol.
+        """
+        self.ensure_one()
+        if self.server_type == 'gmail':
+            if self.is_ssl:
+                connection = IMAP4_SSL(self.server, int(self.port))
+            else:
+                connection = IMAP4(self.server, int(self.port))
+            auth_string = self._generate_oauth2_string(self.user, self.google_gmail_refresh_token)
+            connection.authenticate('XOAUTH2', lambda x: auth_string)
+            connection.select('INBOX')
+            connection.sock.settimeout(MAIL_TIMEOUT)
+            return connection
+
+        return super(FetchmailServer, self).connect()
+
+    def _get_connection_type(self):
+        """Return which connection must be used for this mail server (IMAP or POP).
+
+        The Gmail mail server used an IMAP connection.
+        """
+        self.ensure_one()
+        if self.server_type == 'gmail':
+            return 'imap'
+
+        return super(FetchmailServer, self)._get_connection_type()

--- a/addons/fetchmail_gmail/views/fetchmail_server_views.xml
+++ b/addons/fetchmail_gmail/views/fetchmail_server_views.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="fetchmail_server_view_form" model="ir.ui.view">
+        <field name="name">fetchmail.server.view.form.inherit.gmail</field>
+        <field name="model">fetchmail.server</field>
+        <field name="inherit_id" ref="fetchmail.view_email_server_form"/>
+        <field name="arch" type="xml">
+            <field name="user" position="after">
+                <field string="Authorization Code" name="google_gmail_authorization_code" password="True"
+                    attrs="{'required': [('server_type', '=', 'gmail')], 'invisible': [('server_type', '!=', 'gmail')], 'readonly': [('state', '=', 'done')]}"
+                    class="text-break mw-100"/>
+                <field name="google_gmail_uri"
+                    class="fa fa-arrow-right oe_edit_only"
+                    widget="url"
+                    text=" Get an Authorization Code"
+                    attrs="{'invisible': ['|', ('server_type', '!=', 'gmail'), ('google_gmail_uri', '=', False)]}"
+                    nolabel="1"/>
+                <div class="alert alert-warning" role="alert"
+                    attrs="{'invisible': ['|', ('server_type', '!=', 'gmail'), ('google_gmail_uri', '!=', False)]}">
+                    Setup your Gmail API credentials to link a Gmail account.
+                </div>
+            </field>
+            <field name="password" position="attributes">
+                <attribute name="attrs">
+                    {'required' : [('server_type', '!=', 'local'), ('server_type', '!=', 'gmail'), ('password', '!=', False)], 'invisible' : [('server_type', '=', 'gmail')]}
+                </attribute>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/addons/google_gmail/__init__.py
+++ b/addons/google_gmail/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/google_gmail/__manifest__.py
+++ b/addons/google_gmail/__manifest__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    "name": "Google Gmail",
+    "version": "0.1",
+    "category": "Hidden",
+    "description": "Gmail support for incoming / outgoing mail servers",
+    "depends": [
+        "mail",
+        "google_account",
+    ],
+    "data": [
+        "views/ir_mail_server_views.xml",
+        "views/res_config_settings_views.xml",
+    ],
+    "auto_install": True,
+    "license": "LGPL-3",
+}

--- a/addons/google_gmail/models/__init__.py
+++ b/addons/google_gmail/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import google_gmail_mixin
+from . import ir_mail_server
+from . import res_config_settings

--- a/addons/google_gmail/models/google_gmail_mixin.py
+++ b/addons/google_gmail/models/google_gmail_mixin.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class GoogleGmailMixin(models.AbstractModel):
+
+    _name = 'google.gmail.mixin'
+    _description = 'Google Gmail Mixin'
+
+    _service_scope = 'https://mail.google.com/'
+
+    google_gmail_authorization_code = fields.Char(string='Authorization Code', groups='base.group_system')
+    google_gmail_refresh_token = fields.Char(string='Refresh Token', groups='base.group_system')
+    google_gmail_uri = fields.Char(compute='_compute_gmail_uri', string='URI',
+        help='The URL to generate the authorization code from Google')
+
+    @api.depends('google_gmail_authorization_code')
+    def _compute_gmail_uri(self):
+        Config = self.env['ir.config_parameter'].sudo()
+        google_gmail_client_id = Config.get_param('google_gmail_client_id')
+        google_gmail_client_secret = Config.get_param('google_gmail_client_secret')
+
+        if not google_gmail_client_id or not google_gmail_client_secret:
+            self.google_gmail_uri = False
+        else:
+            self.google_gmail_uri = self.env['google.service']._get_google_token_uri(
+                'gmail',
+                scope=self._service_scope,
+            )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if vals.get('google_gmail_authorization_code'):
+                # Generate the refresh token
+                vals['google_gmail_refresh_token'] = self.env['google.service'].generate_refresh_token(
+                    'gmail', vals['google_gmail_authorization_code'])
+
+        return super(GoogleGmailMixin, self).create(vals_list)
+
+    def write(self, values):
+        authorization_code = values.get('google_gmail_authorization_code')
+        if (
+            authorization_code
+            and not all(authorization_code == code for code in self.mapped('google_gmail_authorization_code'))
+        ):
+            # Update the refresh token
+            values['google_gmail_refresh_token'] = self.env['google.service'].generate_refresh_token(
+                'gmail', authorization_code)
+
+        return super(GoogleGmailMixin, self).write(values)
+
+    def _generate_oauth2_string(self, user, refresh_token):
+        """Generate a OAuth2 string which can be used for authentication.
+
+        :param user: Email address of the Gmail account to authenticate
+        :param refresh_token: Refresh token for the given Gmail account
+
+        :return: The SASL argument for the OAuth2 mechanism.
+        """
+        access_token = self.env['google.service']._get_access_token(refresh_token, 'gmail', self._service_scope)
+        return f'user={user}\1auth=Bearer {access_token}\1\1'

--- a/addons/google_gmail/models/ir_mail_server.py
+++ b/addons/google_gmail/models/ir_mail_server.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import base64
+
+from odoo import fields, models, api
+
+
+class IrMailServer(models.Model):
+    """Represents an SMTP server, able to send outgoing emails, with SSL and TLS capabilities."""
+
+    _name = 'ir.mail_server'
+    _inherit = ['ir.mail_server', 'google.gmail.mixin']
+
+    smtp_authentication = fields.Selection(selection_add=[('gmail', 'Gmail OAuth Authentication')], ondelete={'gmail': 'set default'})
+
+    @api.onchange('smtp_encryption')
+    def _onchange_encryption(self):
+        if self.smtp_authentication != 'gmail':
+            super(IrMailServer, self)._onchange_encryption()
+
+    @api.onchange('smtp_authentication')
+    def _onchange_smtp_authentication(self):
+        if self.smtp_authentication == 'gmail':
+            self.smtp_host = 'smtp.gmail.com'
+            self.smtp_encryption = 'starttls'
+            self.smtp_port = 587
+        else:
+            self.smtp_encryption = 'none'
+            self.google_gmail_authorization_code = False
+            self.google_gmail_refresh_token = False
+
+    def _smtp_login(self, connection, smtp_user, smtp_password):
+        if len(self) == 1 and self.smtp_authentication == 'gmail':
+            auth_string = self._generate_oauth2_string(smtp_user, self.google_gmail_refresh_token)
+            oauth_param = base64.b64encode(auth_string.encode()).decode()
+            connection.ehlo()
+            connection.docmd('AUTH', f'XOAUTH2 {oauth_param}')
+        else:
+            super(IrMailServer, self)._smtp_login(connection, smtp_user, smtp_password)

--- a/addons/google_gmail/models/res_config_settings.py
+++ b/addons/google_gmail/models/res_config_settings.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    google_gmail_client_identifier = fields.Char('Gmail Client Id', config_parameter='google_gmail_client_id')
+    google_gmail_client_secret = fields.Char('Gmail Client Secret', config_parameter='google_gmail_client_secret')

--- a/addons/google_gmail/views/ir_mail_server_views.xml
+++ b/addons/google_gmail/views/ir_mail_server_views.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="ir_mail_server_view_form" model="ir.ui.view">
+        <field name="name">ir.mail_server.view.form.inherit.gmail</field>
+        <field name="model">ir.mail_server</field>
+        <field name="inherit_id" ref="base.ir_mail_server_form"/>
+        <field name="arch" type="xml">
+            <field name="smtp_user" position="after">
+                <field string="Authorization Code" name="google_gmail_authorization_code" password="True"
+                    attrs="{'required': [('smtp_authentication', '=', 'gmail')], 'invisible': [('smtp_authentication', '!=', 'gmail')]}"/>
+                <field name="google_gmail_uri"
+                    class="fa fa-arrow-right oe_edit_only"
+                    widget="url"
+                    text=" Get an Authorization Code"
+                    attrs="{'invisible': ['|', ('smtp_authentication', '!=', 'gmail'), ('google_gmail_uri', '=', False)]}"
+                    nolabel="1"/>
+                <div class="alert alert-warning" role="alert"
+                    attrs="{'invisible': ['|', ('smtp_authentication', '!=', 'gmail'), ('google_gmail_uri', '!=', False)]}">
+                    Setup your Gmail API credentials to link a Gmail account.
+                </div>
+            </field>
+            <field name="smtp_user" position="attributes">
+                <attribute name="attrs">{'invisible' : [('smtp_authentication', '!=', 'login'), ('smtp_authentication', '!=', 'gmail')]}</attribute>
+            </field>
+            <field name="smtp_pass" position="attributes">
+                <attribute name="attrs">{'invisible' : [('smtp_authentication', '=', 'gmail')]}</attribute>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/addons/google_gmail/views/res_config_settings_views.xml
+++ b/addons/google_gmail/views/res_config_settings_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="res_config_settings_view_form" model="ir.ui.view">
+            <field name="name">res.config.settings.view.form.inherit.google_gmail</field>
+            <field name="model">res.config.settings</field>
+            <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
+            <field name="arch" type="xml">
+                <div id="msg_module_google_gmail" position="replace">
+                    <div class="row mt16" id="gmail_client_identifier">
+                        <label string="Client ID" for="google_gmail_client_identifier" class="col-lg-3 o_light_label"/>
+                        <field name="google_gmail_client_identifier" class="ml-2" attrs="{'required': [('module_google_gmail', '=', True), ('external_email_server_default', '=', True)]}"/>
+                    </div>
+                    <div class="row mt16" id="gmail_client_secret">
+                        <label string="Client Secret" for="google_gmail_client_secret" class="col-lg-3 o_light_label"/>
+                        <field name="google_gmail_client_secret" class="ml-2" attrs="{'required': [('module_google_gmail', '=', True), ('external_email_server_default', '=', True)]}"/>
+                    </div>
+                </div>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/mail/models/res_config_settings.py
+++ b/addons/mail/models/res_config_settings.py
@@ -15,6 +15,7 @@ class ResConfigSettings(models.TransientModel):
     alias_domain = fields.Char(
         'Alias Domain', config_parameter='mail.catchall.domain',
         help="If you have setup a catch-all email domain redirected to the Odoo server, enter the domain name here.")
+    module_google_gmail = fields.Boolean('Support gmail authentication')
     restrict_template_rendering = fields.Boolean(
         'Restrict Template Rendering',
         config_parameter='mail.restrict.template.rendering',

--- a/addons/mail/views/res_config_settings_views.xml
+++ b/addons/mail/views/res_config_settings_views.xml
@@ -66,6 +66,22 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="col-12 col-lg-6 o_setting_box" id="google_gmail_setting"
+                            attrs="{'invisible': [('external_email_server_default', '=', False)]}">
+                            <div class="o_setting_left_pane">
+                                <field name="module_google_gmail"/>
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label string="Gmail Credentials" for="module_google_gmail"/>
+                                <a href="https://console.developers.google.com/" title="Get Gmail API credentials" class="o_doc_link" target="_blank"/>
+                                <div class="text-muted">
+                                    Send and receive email with your Gmail account.
+                                </div>
+                                <div class="content-group" attrs="{'invisible': [('module_google_gmail','=',False)]}" id="msg_module_google_gmail">
+                                    <div class="mt16 text-warning"><strong>Save</strong> this page and come back here to set up the feature.</div>
+                                </div>
+                            </div>
+                        </div>
                         <div class="col-12 col-lg-6 o_setting_box">
                             <div class="o_setting_right_pane">
                                 <span class="o_form_label">Custom ICE server list</span>

--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -226,16 +226,19 @@ class IrMailServer(models.Model):
         elif not host:
             mail_server, smtp_from = self.sudo()._find_mail_server(smtp_from)
 
+        if not mail_server:
+            mail_server = self.env['ir.mail_server']
+
         ssl_context = None
         if mail_server:
             smtp_server = mail_server.smtp_host
             smtp_port = mail_server.smtp_port
-            if mail_server.smtp_authentication == "login":
-                smtp_user = mail_server.smtp_user
-                smtp_password = mail_server.smtp_pass
-            else:
+            if mail_server.smtp_authentication == "certificate":
                 smtp_user = None
                 smtp_password = None
+            else:
+                smtp_user = mail_server.smtp_user
+                smtp_password = mail_server.smtp_pass
             smtp_encryption = mail_server.smtp_encryption
             smtp_debug = smtp_debug or mail_server.smtp_debug
             from_filter = mail_server.from_filter
@@ -314,7 +317,7 @@ class IrMailServer(models.Model):
             local, at, domain = smtp_user.rpartition('@')
             if at:
                 smtp_user = local + at + idna.encode(domain).decode('ascii')
-            connection.login(smtp_user, smtp_password or '')
+            mail_server._smtp_login(connection, smtp_user, smtp_password or '')
 
         # Some methods of SMTP don't check whether EHLO/HELO was sent.
         # Anyway, as it may have been sent by login(), all subsequent usages should consider this command as sent.
@@ -326,6 +329,18 @@ class IrMailServer(models.Model):
         connection.smtp_from = smtp_from
 
         return connection
+
+    def _smtp_login(self, connection, smtp_user, smtp_password):
+        """Authenticate the SMTP connection.
+
+        Can be overridden in other modules for different authentication methods. Can be
+        called on the model itself or on a singleton.
+
+        :param connection: The SMTP connection to authenticate
+        :param smtp_user: The user to used for the authentication
+        :param smtp_password: The password to used for the authentication
+        """
+        connection.login(smtp_user, smtp_password)
 
     def build_email(self, email_from, email_to, subject, body, email_cc=None, email_bcc=None, reply_to=False,
                     attachments=None, message_id=None, references=None, object_id=False, subtype='plain', headers=None,


### PR DESCRIPTION
Purpose
=======
Less secured apps are no longer supported by google, therefore, we need
to transition to the OAuth2 authentication system.

Specifications
==============
On the external server configuration in the main settings, users will
have to activate Gmail support.

Then, on incoming / outgoing mail servers forms, they will have to
introduce an authorization code that they will have fetched via a link
on the form.

Task-2170676