### PR TITLE
[REV] account: reverse entry when account move line contains 0 in cre…

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -598,7 +598,7 @@ class AccountMoveLine(models.Model):
             #computing the `reconciled` field.
             reconciled = False
             digits_rounding_precision = line.company_id.currency_id.rounding
-            if (line.matched_debit_ids or line.matched_credit_ids) and float_is_zero(amount, precision_rounding=digits_rounding_precision):
+            if float_is_zero(amount, precision_rounding=digits_rounding_precision):
                 if line.currency_id and line.amount_currency:
                     if float_is_zero(amount_residual_currency, precision_rounding=line.currency_id.rounding):
                         reconciled = True


### PR DESCRIPTION
…dit or debit

This fix partly reverts the commit db691dbebf27d2c0169b1528dd79862decd0b05e
The latter is fully reverted in v13: 6a5271b7f4109a4f2a20378698fbe479d73ed9cb

When having an invoice with total equals to 0, it still adds a line to
the follow-up report.

To reproduce the error:
1. Go to Accounting > Customers > Invoices
2. Create an invoice without Payment Terms and product at 0$ to have a total of 0$
3. Go to Accounting > Customers > Follow-up Reports > [Select the partner]
4. The invoice is present with a total due of 0$

Err: the invoice shouldn't be in the follow-up report.

OPW-2419268