### PR TITLE
[ADD] {google,fetchmail}_gmail: OAuth for gmail servers

### DIFF
--- a/addons/fetchmail/models/fetchmail.py
+++ b/addons/fetchmail/models/fetchmail.py
@@ -103,7 +103,7 @@ odoo_mailgate: "|/path/to/odoo-mailgate.py --host=localhost -u %(uid)d -p PASSWO
                 connection = IMAP4_SSL(self.server, int(self.port))
             else:
                 connection = IMAP4(self.server, int(self.port))
-            connection.login(self.user, self.password)
+            self._imap_login(connection)
         elif self.server_type == 'pop':
             if self.is_ssl:
                 connection = POP3_SSL(self.server, int(self.port))
@@ -116,6 +116,15 @@ odoo_mailgate: "|/path/to/odoo-mailgate.py --host=localhost -u %(uid)d -p PASSWO
         # Add timeout on socket
         connection.sock.settimeout(MAIL_TIMEOUT)
         return connection
+
+    def _imap_login(self, connection):
+        """Authenticate the IMAP connection.
+
+        Can be overridden in other module for different authentication methods.
+
+        :param connection: The IMAP connection to authenticate
+        """
+        connection.login(self.user, self.password)
 
     def button_confirm_login(self):
         for server in self:

--- a/addons/fetchmail_gmail/__init__.py
+++ b/addons/fetchmail_gmail/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/fetchmail_gmail/__manifest__.py
+++ b/addons/fetchmail_gmail/__manifest__.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    "name": "Fetchmail Gmail",
+    "version": "0.1",
+    "category": "Hidden",
+    "description": "Google authentication for fetch mail",
+    "depends": [
+        "google_gmail",
+        "fetchmail",
+    ],
+    "data": ["views/fetchmail_server_views.xml"],
+    "auto_install": True,
+    "license": "OEEL-1",
+}

--- a/addons/fetchmail_gmail/models/__init__.py
+++ b/addons/fetchmail_gmail/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import fetchmail_server

--- a/addons/fetchmail_gmail/models/fetchmail_server.py
+++ b/addons/fetchmail_gmail/models/fetchmail_server.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models, _
+from odoo.exceptions import UserError
+
+
+class FetchmailServer(models.Model):
+    _name = 'fetchmail.server'
+    _inherit = ['fetchmail.server', 'google.gmail.mixin']
+
+    @api.constrains('use_google_gmail_service', 'server', 'server_type')
+    def _check_use_google_gmail_service(self):
+        if any(server.use_google_gmail_service and server.server_type != 'imap' for server in self):
+            raise UserError(_('Gmail authentication only supports IMAP server type.'))
+
+    @api.onchange('use_google_gmail_service')
+    def _onchange_use_google_gmail_service(self):
+        """Set the default configuration for a IMAP Gmail server."""
+        if self.use_google_gmail_service:
+            self.server = 'imap.gmail.com'
+            self.server_type = 'imap'
+            self.is_ssl = True
+            self.port = 993
+        else:
+            self.password = ''
+            self.server = ''
+            self.server_type = 'pop'
+            self.is_ssl = False
+            self.google_gmail_authorization_code = False
+            self.google_gmail_refresh_token = False
+
+    def _imap_login(self, connection):
+        """Authenticate the IMAP connection.
+
+        If the mail server is Gmail, we use the OAuth2 authentication protocol.
+        """
+        if self.use_google_gmail_service:
+            auth_string = self._generate_oauth2_string(self.user, self.google_gmail_refresh_token)
+            connection.authenticate('XOAUTH2', lambda x: auth_string)
+            connection.select('INBOX')
+        else:
+            super(FetchmailServer, self)._imap_login(connection)

--- a/addons/fetchmail_gmail/views/fetchmail_server_views.xml
+++ b/addons/fetchmail_gmail/views/fetchmail_server_views.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="fetchmail_server_view_form" model="ir.ui.view">
+        <field name="name">fetchmail.server.view.form.inherit.gmail</field>
+        <field name="model">fetchmail.server</field>
+        <field name="inherit_id" ref="fetchmail.view_email_server_form"/>
+        <field name="arch" type="xml">
+            <field name="server" position="before">
+                <field name="use_google_gmail_service" string="Gmail" attrs="{'readonly': [('state', '=', 'done')]}"/>
+            </field>
+            <field name="user" position="after">
+                <field string="Authorization Code" name="google_gmail_authorization_code" password="True"
+                    attrs="{'required': [('use_google_gmail_service', '=', True)], 'invisible': [('use_google_gmail_service', '=', False)], 'readonly': [('state', '=', 'done')]}"
+                    class="text-break mw-100"/>
+                <field name="google_gmail_uri"
+                    class="fa fa-arrow-right oe_edit_only"
+                    widget="url"
+                    text=" Get an Authorization Code"
+                    attrs="{'invisible': ['|', ('use_google_gmail_service', '=', False), ('google_gmail_uri', '=', False)]}"
+                    nolabel="1"/>
+                <div class="alert alert-warning" role="alert"
+                    attrs="{'invisible': ['|', ('use_google_gmail_service', '=', False), ('google_gmail_uri', '!=', False)]}">
+                    Setup your Gmail API credentials to link a Gmail account.
+                </div>
+            </field>
+            <field name="password" position="attributes">
+                <attribute name="attrs">{'required' : [('server_type', '!=', 'local'), ('use_google_gmail_service', '=', False), ('password', '!=', False)], 'invisible' : [('use_google_gmail_service', '=', True)]}</attribute>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/addons/google_account/models/google_service.py
+++ b/addons/google_account/models/google_service.py
@@ -120,6 +120,41 @@ class GoogleService(models.TransientModel):
             error_msg = _("Something went wrong during your token generation. Maybe your Authorization Code is invalid")
             raise self.env['res.config.settings'].get_config_warning(error_msg)
 
+    @api.model
+    def _get_access_token(self, refresh_token, service, scope):
+        """Fetch the access token thanks to the refresh token."""
+        get_config_warning = self.env['res.config.settings'].get_config_warning
+        get_param = self.env['ir.config_parameter'].sudo().get_param
+        client_id = get_param('google_%s_client_id' % service, default=False)
+        client_secret = get_param('google_%s_client_secret' % service, default=False)
+
+        if not client_id or not client_secret:
+            raise get_config_warning(_('Google %s is not yet configured.', service.title()))
+
+        if not refresh_token:
+            raise get_config_warning(_('The refresh token for authentication is not set.'))
+
+        try:
+            result = requests.post(
+                GOOGLE_TOKEN_ENDPOINT,
+                data={
+                    'client_id': client_id,
+                    'client_secret': client_secret,
+                    'refresh_token': refresh_token,
+                    'grant_type': 'refresh_token',
+                    'scope': scope,
+                },
+                headers={'Content-type': 'application/x-www-form-urlencoded'},
+                timeout=TIMEOUT,
+            )
+            result.raise_for_status()
+        except requests.HTTPError:
+            raise get_config_warning(
+                _('Something went wrong during the token generation. Please request again an authorization code .')
+            )
+
+        return result.json().get('access_token')
+
     # FIXME : this method update a field defined in google_calendar module. Since it is used only in that module, maybe it should be moved.
     @api.model
     def _refresh_google_token_json(self, refresh_token, service):  # exchange_AUTHORIZATION vs Token (service = calendar)

--- a/addons/google_gmail/__init__.py
+++ b/addons/google_gmail/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/google_gmail/__manifest__.py
+++ b/addons/google_gmail/__manifest__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    "name": "Google Gmail",
+    "version": "0.1",
+    "category": "Hidden",
+    "description": "Gmail support for incoming / outgoing mail servers",
+    "depends": [
+        "mail",
+        "google_account",
+    ],
+    "data": [
+        "views/ir_mail_server_views.xml",
+        "views/res_config_settings_views.xml",
+    ],
+    "auto_install": True,
+    "license": "OEEL-1",
+}

--- a/addons/google_gmail/models/__init__.py
+++ b/addons/google_gmail/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import google_gmail_mixin
+from . import ir_mail_server
+from . import res_config_settings

--- a/addons/google_gmail/models/google_gmail_mixin.py
+++ b/addons/google_gmail/models/google_gmail_mixin.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class GoogleGmailMixin(models.AbstractModel):
+
+    _name = 'google.gmail.mixin'
+    _description = 'Google Gmail Mixin'
+
+    _service_scope = 'https://mail.google.com/'
+
+    use_google_gmail_service = fields.Boolean('Gmail Authentication')
+    google_gmail_authorization_code = fields.Char(string='Authorization Code', groups='base.group_system')
+    google_gmail_refresh_token = fields.Char(string='Refresh Token', groups='base.group_system')
+    google_gmail_uri = fields.Char(compute='_compute_gmail_uri', string='URI', help='The URL to generate the authorization code from Google')
+
+    @api.depends('google_gmail_authorization_code')
+    def _compute_gmail_uri(self):
+        Config = self.env['ir.config_parameter'].sudo()
+        google_gmail_client_id = Config.get_param('google_gmail_client_id')
+        google_gmail_client_secret = Config.get_param('google_gmail_client_secret')
+
+        if not google_gmail_client_id or not google_gmail_client_secret:
+            self.google_gmail_uri = False
+        else:
+            google_gmail_uri = self.env['google.service']._get_google_token_uri('gmail', scope=self._service_scope)
+            self.google_gmail_uri = google_gmail_uri
+
+    @api.model
+    def create(self, values):
+        if values.get('google_gmail_authorization_code'):
+            # Generate the refresh token
+            values['google_gmail_refresh_token'] = self.env['google.service'].generate_refresh_token(
+                'gmail', values['google_gmail_authorization_code'])
+
+        return super(GoogleGmailMixin, self).create(values)
+
+    def write(self, values):
+        authorization_code = values.get('google_gmail_authorization_code')
+        if (
+            authorization_code
+            and not all(authorization_code == code for code in self.mapped('google_gmail_authorization_code'))
+        ):
+            # Update the refresh token
+            values['google_gmail_refresh_token'] = self.env['google.service'].generate_refresh_token(
+                'gmail', authorization_code)
+
+        return super(GoogleGmailMixin, self).write(values)
+
+    def _generate_oauth2_string(self, user, refresh_token):
+        """Generate a OAuth2 string which can be used for authentication.
+
+        :param user: Email address of the Gmail account to authenticate
+        :param refresh_token: Refresh token for the given Gmail account
+
+        :return: The SASL argument for the OAuth2 mechanism.
+        """
+        access_token = self.env['google.service']._get_access_token(refresh_token, 'gmail', self._service_scope)
+        return 'user=%s\1auth=Bearer %s\1\1' % (user, access_token)

--- a/addons/google_gmail/models/ir_mail_server.py
+++ b/addons/google_gmail/models/ir_mail_server.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import base64
+
+from odoo import models, api
+
+
+class IrMailServer(models.Model):
+    """Represents an SMTP server, able to send outgoing emails, with SSL and TLS capabilities."""
+
+    _name = 'ir.mail_server'
+    _inherit = ['ir.mail_server', 'google.gmail.mixin']
+
+    @api.onchange('smtp_encryption')
+    def _onchange_encryption(self):
+        if not self.use_google_gmail_service:
+            super(IrMailServer, self)._onchange_encryption()
+
+    @api.onchange('use_google_gmail_service')
+    def _onchange_use_google_gmail_service(self):
+        if self.use_google_gmail_service:
+            self.smtp_host = 'smtp.gmail.com'
+            self.smtp_encryption = 'starttls'
+            self.smtp_port = 587
+        else:
+            self.smtp_encryption = 'none'
+            self.google_gmail_authorization_code = False
+            self.google_gmail_refresh_token = False
+
+    def _smtp_login(self, connection, smtp_user, smtp_password):
+        if len(self) == 1 and self.use_google_gmail_service:
+            auth_string = self._generate_oauth2_string(smtp_user, self.google_gmail_refresh_token)
+            oauth_param = base64.b64encode(auth_string.encode()).decode()
+            connection.ehlo()
+            connection.docmd('AUTH', f'XOAUTH2 {oauth_param}')
+        else:
+            super(IrMailServer, self)._smtp_login(connection, smtp_user, smtp_password)

--- a/addons/google_gmail/models/res_config_settings.py
+++ b/addons/google_gmail/models/res_config_settings.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    google_gmail_client_identifier = fields.Char("Gmail Client Id", config_parameter='google_gmail_client_id')
+    google_gmail_client_secret = fields.Char("Gmail Client Secret", config_parameter='google_gmail_client_secret')

--- a/addons/google_gmail/views/ir_mail_server_views.xml
+++ b/addons/google_gmail/views/ir_mail_server_views.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="ir_mail_server_view_form" model="ir.ui.view">
+        <field name="name">ir.mail_server.view.form.inherit.gmail</field>
+        <field name="model">ir.mail_server</field>
+        <field name="inherit_id" ref="base.ir_mail_server_form"/>
+        <field name="arch" type="xml">
+            <field name="smtp_host" position="before">
+                <field name="use_google_gmail_service" string="Gmail"/>
+            </field>
+            <field name="smtp_user" position="after">
+                <field string="Authorization Code" name="google_gmail_authorization_code" password="True"
+                    attrs="{'required': [('use_google_gmail_service', '=', True)], 'invisible': [('use_google_gmail_service', '=', False)]}"/>
+                <field name="google_gmail_uri"
+                    class="fa fa-arrow-right oe_edit_only"
+                    widget="url"
+                    text=" Get an Authorization Code"
+                    attrs="{'invisible': ['|', ('use_google_gmail_service', '=', False), ('google_gmail_uri', '=', False)]}"
+                    nolabel="1"/>
+                <div class="alert alert-warning" role="alert"
+                    attrs="{'invisible': ['|', ('use_google_gmail_service', '=', False), ('google_gmail_uri', '!=', False)]}">
+                    Setup your Gmail API credentials to link a Gmail account.
+                </div>
+            </field>
+            <field name="smtp_pass" position="attributes">
+                <attribute name="attrs">{'invisible' : [('use_google_gmail_service', '=', True)]}</attribute>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/addons/google_gmail/views/res_config_settings_views.xml
+++ b/addons/google_gmail/views/res_config_settings_views.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="res_config_settings_view_form" model="ir.ui.view">
+            <field name="name">res.config.settings.view.form.inherit.google_gmail</field>
+            <field name="model">res.config.settings</field>
+            <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
+            <field name="arch" type="xml">
+                <div id="emails" position="inside">
+                    <div class="col-12 col-lg-6 o_setting_box" id="google_gmail_setting"
+                        attrs="{'invisible': [('external_email_server_default', '=', False)]}">
+                        <div class="o_setting_right_pane">
+                            <span class="o_form_label">Gmail Credentials</span>
+                            <div class="text-muted">
+                                Send and receive email with your Gmail account.
+                            </div>
+                            <div class="content-group">
+                                <div class="row mt16" id="gmail_client_identifier">
+                                    <label string="Client ID" for="google_gmail_client_identifier" class="col-lg-3 o_light_label"/>
+                                    <field name="google_gmail_client_identifier" class="ml-2"/>
+                                </div>
+                                <div class="row mt16" id="gmail_client_secret">
+                                    <label string="Client Secret" for="google_gmail_client_secret" class="col-lg-3 o_light_label"/>
+                                    <field name="google_gmail_client_secret" class="ml-2"/>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Purpose
=======
Less secured apps are no longer supported by google, therefore, we need
to transition to the OAuth2 authentication system.

Specifications
==============
On the external server configuration in the main settings, users will
have to activate Gmail support.

Then, on incoming / outgoing mail servers forms, they will have to
introduce an authorization code that they will have fetched via a link
on the form.

Task 2170676