### PR TITLE
[FIX] stock: Wrong active warehouse on forecasted qty button

### DIFF
--- a/addons/stock/report/report_stock_forecasted.py
+++ b/addons/stock/report/report_stock_forecasted.py
@@ -227,7 +227,8 @@ class ReplenishmentReport(models.AbstractModel):
         res['warehouses'] = self.env['stock.warehouse'].search_read(fields=['id', 'name', 'code'])
         res['active_warehouse'] = self.env.context.get('warehouse', False)
         if not res['active_warehouse']:
-            res['active_warehouse'] = self.env.context.get('allowed_company_ids')[0]
+            company_id = self.env.context.get('allowed_company_ids')[0]
+            res['active_warehouse'] = self.env['stock.warehouse'].search([('company_id', '=', company_id)], limit=1).id
         return res
 
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Until now, when no matches were found between warehouse ids and the context.allowed_company id, clicking the forecasted_qty button on a product would lead to a traceback.
This is because in get_filter_state, the 'active_warehouse' used to correspond to a company id, which was irrelevant.

**Current behavior before PR:**
We modify get_filter_state so that 'active_warehouse' now corresponds to a warehouse with that company id instead.

**Desired behavior after PR is merged:**
Clicking the forecasted_qty button on a product not lead to a traceback in any circumstance.

opw-2418559
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
