### PR TITLE
[FIX] base_automation: reset active_id(s) in onchange handler

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -291,7 +291,12 @@ class BaseAutomation(models.Model):
             def base_automation_onchange(self):
                 action_rule = self.env['base.automation'].browse(action_rule_id)
                 result = {}
-                server_action = action_rule.action_server_id.with_context(active_model=self._name, onchange_self=self)
+                server_action = action_rule.action_server_id.with_context(
+                    active_model=self._name,
+                    active_id=None,
+                    active_ids=[],
+                    onchange_self=self,
+                )
                 res = server_action.run()
                 if res:
                     if 'value' in res:


### PR DESCRIPTION
If we change ``active_model`` in context, we have to reset active_id(s),
otherwise we read a random records which may not exist.

STEPS:
1. Activate Developer mode
2. Go to Settings > Technical > Automation > Automated Actions
3. Define a new Automated Action with the following settings:
- Model: Lead/Opportunity
- Action To Do: Execute Python Code
- Trigger: Based on Form Modification
- Trigger Fields: Customer (crm.lead)
- Python Code:
```
raise Warning(records)
```
4. Go to Contacts, create a new contact and save it.
5. Click on the "Opportunities" Smart Button on the top left of the contact record.
6. Click "Create".

BEFORE: ``records`` in context read crm.lead, while id is for res.partner
record

AFTER: ``records`` is None

---

opw-2424392

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
