### PR TITLE
[FIX] pos_hr: fix login screen barcode security

### DIFF
--- a/addons/pos_hr/static/src/js/screens.js
+++ b/addons/pos_hr/static/src/js/screens.js
@@ -43,7 +43,11 @@ ScreenWidget.include({
     },
     show: function() {
         this._super();
-        this.pos.barcode_reader.set_action_callback('cashier', _.bind(this.barcode_cashier_action, this));
+        if (this.gui.get_current_screen() == 'login'){
+            this.pos.barcode_reader.save_callbacks();
+            this.pos.barcode_reader.reset_action_callbacks();
+            this.pos.barcode_reader.set_action_callback('cashier', _.bind(this.barcode_cashier_action, this));
+        }
     },
 });
 
@@ -92,6 +96,7 @@ var LoginScreenWidget = ScreenWidget.extend({
     },
 
     unlock_screen: function() {
+        this.pos.barcode_reader.restore_callbacks();
         var screen = (this.gui.pos.get_order() ? this.gui.pos.get_order().get_screen_data('previous-screen') : this.gui.startup_screen) || this.gui.startup_screen;
         this.gui.show_screen(screen);
     }


### PR DESCRIPTION
Activate in the POS setting the option "Login with Employees" and
choose employee A
In the employee module, set the PIN and the badge id of the employee A
Set a barcode for a product P available in the POS
Open a POS session, scan the barcode of P

You are in the session with the default user and P in the current order.
This occur because the login page does recognize every barcode and call
the related action, even if it should be blocked. Clearing the callbacks
while in login page fix the issue

opw-2411061

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
