### PR TITLE
[IMP] mail: filter out portal users in activity popup

### DIFF
--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -136,7 +136,7 @@
                         </group>
                         <group>
                             <field name="date_deadline"/>
-                            <field name="user_id"/>
+                            <field name="user_id" domain="[('share', '=', False)]"/>
                         </group>
                     </group>
                     <field name="note" placeholder="Log a note..."/>


### PR DESCRIPTION
WHY: there is no way for portal users to use those activities. On the other
hand, you may have few internal users and thousands of portal users and seeing
those in "Assigned to" dropdown doesn't make any sense

---

opw-2416946

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
