### PR TITLE
[IMP] web: Add a basic progress bar widget

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -3050,7 +3050,7 @@ var FieldProgressBar = AbstractField.extend({
  * - human_number : If set, the numbers are shown using human_numbers in readonly rendering, default : formatValue is used.
  * - format_type : If set, overrides the formatType of the field used in the formatValue.
  */
-var FieldBasicProgressBar = FieldInteger.extend({
+const FieldBasicProgressBar = FieldInteger.extend({
     description: _lt("Basic Progress Bar"),
     template: "BasicProgressBar",
     events: _.extend({}, FieldInteger.prototype.events, {
@@ -3094,7 +3094,7 @@ var FieldBasicProgressBar = FieldInteger.extend({
      */
     _renderEdit: function () {
         this._render_value();
-        if (this.enable_edit_text) {    
+        if (this.enable_edit_text) {
             if (this.edit_max_value) {
                 this._prepareInput(this.$input).appendTo(this.$('.o_basic_progressbar_unit'));
             } else {
@@ -3115,9 +3115,9 @@ var FieldBasicProgressBar = FieldInteger.extend({
      * @param {Number} v
      */
     _render_value: function (v, fromDragAndDrop) {
-        var value = this.edit_max_value ? (this.recordData[this.nodeOptions.progress_value_field] || this.progress_value) : this.value;
-        var maxValue = this.edit_max_value ? this.value : (this.recordData[this.nodeOptions.max_value_field] || this.max_value);
-        var parsed = this._parseInput(v);
+        let value = this.edit_max_value ? (this.recordData[this.nodeOptions.progress_value_field] || this.progress_value) : this.value;
+        let maxValue = this.edit_max_value ? this.value : (this.recordData[this.nodeOptions.max_value_field] || this.max_value);
+        const parsed = this._parseInput(v);
         if (parsed !== null) {
             if (this.edit_max_value) {
                 maxValue = parsed;
@@ -3128,7 +3128,7 @@ var FieldBasicProgressBar = FieldInteger.extend({
         value = value || 0;
         maxValue = maxValue || 0;
 
-        var widthComplete;
+        let widthComplete;
         if (value <= maxValue) {
             widthComplete = value / maxValue * 100;
         } else {
@@ -3179,7 +3179,7 @@ var FieldBasicProgressBar = FieldInteger.extend({
         return this.$('.o_basic_progressbar_value').text();
     },
     /**
-     * Override method to manage keydown event done elsewhere than in the input field. 
+     * Override method to manage keydown event done elsewhere than in the input field.
      * 
      * @override
      */
@@ -3205,7 +3205,7 @@ var FieldBasicProgressBar = FieldInteger.extend({
     /**
      * Handle mousedown event on the progressbar to begin to follow the mouse on the bar.
      * 
-     * @param {*} event 
+     * @param {*} event
      * @private
      */
     _onMousedown: function (event) {
@@ -3259,8 +3259,8 @@ var FieldBasicProgressBar = FieldInteger.extend({
      */
     _onProgressKeydown: function (event) {
         if (this.enable_drag_and_drop) {
-            var increment = (this.step > 0 ? this.step : 1);
-            var value = null;
+            const increment = (this.step > 0 ? this.step : 1);
+            let value = null;
             if (event.keyCode === $.ui.keyCode.UP || event.keyCode === $.ui.keyCode.RIGHT) {
                 value = this._parseValue(this._getValue()) + increment;
             } else if (event.keyCode === $.ui.keyCode.DOWN || event.keyCode === $.ui.keyCode.LEFT) {
@@ -3299,21 +3299,21 @@ var FieldBasicProgressBar = FieldInteger.extend({
     /**
      * Get the value of the click on the progress bar
      * 
-     * @param {Event} event 
+     * @param {Event} event
      */
     _get_progress_value: function (event) {
-        var $target = $(event.currentTarget);
-        var numValue = Math.floor((event.pageX - $target.offset().left) / $target.outerWidth() * this.max_value);
+        const $target = $(event.currentTarget);
+        let numValue = Math.floor((event.pageX - $target.offset().left) / $target.outerWidth() * this.max_value);
         if (this.step > 0) {
             numValue = Math.round(numValue / this.step) * this.step;
         }
         return numValue;
     },
     /**
-     * Parse Input. 
+     * Parse Input.
      * If the value is already a number, returns it.
-     * Else, try to parse it, if it fails, returns null, else returns the parsed value. 
-     * @param {*} value 
+     * Else, try to parse it, if it fails, returns null, else returns the parsed value.
+     * @param {*} value
      */
     _parseInput: function (value) {
         if (!isNaN(value)) {
@@ -3339,21 +3339,21 @@ var FieldBasicProgressBar = FieldInteger.extend({
  * 
  * /!\ If you use it in kanban with draggable cards, it's highly recommended to keep drag_and_drop with its default value (false)
  */
-var FieldQuicklyEditableBasicProgressBar = FieldBasicProgressBar.extend({
+const FieldQuicklyEditableBasicProgressBar = FieldBasicProgressBar.extend({
     events: _.extend({}, FieldBasicProgressBar.prototype.events, {
         'click .o_progressbar': '_onQuickEditClick',
     }),
     init: function () {
         this._super.apply(this, arguments);
         this.originalCanWrite = this.canWrite;
-        this.editable = this.canWrite;
+        this.editable = false;
         this.isFirstEdition = true;
     },
     /**
      * In this quick edit mode, we will by-pass the _notifyChanges called by the other library functions which are meant to
      * be called in a real edit mode.
      * 
-     * The storage function will be the _setValue function called in the @see _onBlurQuickEdit and @see _on_update 
+     * The storage function will be the _setValue function called in the @see _onBlurQuickEdit and @see _on_update
      * (only called with drag and drop) function
      * 
      * @override
@@ -3393,7 +3393,7 @@ var FieldQuicklyEditableBasicProgressBar = FieldBasicProgressBar.extend({
             if (!this.edit_max_value) {
                 this.enable_drag_and_drop = (this.nodeOptions.drag_and_drop || false);
             }
-            if (this.enable_edit_text) {    
+            if (this.enable_edit_text) {
                 if (this.edit_max_value) {
                     this.$('.o_basic_progressbar_unit').empty();
                 } else {
@@ -3416,12 +3416,7 @@ var FieldQuicklyEditableBasicProgressBar = FieldBasicProgressBar.extend({
         }
     },
     _onBlurQuickEdit: function (event) {
-        var condition = true;
-        if (event.type === "click") {
-            var isInProgressBar = $(event.target).closest(".o_progressbar:not(.o_progressbar_readonly)").length;
-            condition = !isInProgressBar;
-        }
-        if (condition && this.editable) {
+        if (this.editable && (event.type !== "click" || !$(event.target).closest(".o_progressbar:not(.o_progressbar_readonly)").length)) {
             this.editable = false;
             var value = this._getValue();
             this.canWrite = this.originalCanWrite;

--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -3042,6 +3042,7 @@ var FieldBasicProgressBar = AbstractField.extend({
         'keydown .o_progress_keydown': '_onKeydown',
         'mousedown .o_progress': '_onMousedown',
         'mousemove .o_progress': '_onMousemove',
+        'mouseout .o_progress': '_onMouseout',
     },
     supportedFieldTypes: ['integer', 'float'],
     init: function () {
@@ -3120,6 +3121,16 @@ var FieldBasicProgressBar = AbstractField.extend({
             this.$('.o_progress_keydown').focus();
         }
     },
+    _onKeydown: function (event){
+        if (this.canWrite) {
+            var increment = (this.step > 0 ? this.step : 1);
+            if(event.keyCode === $.ui.keyCode.UP || event.keyCode === $.ui.keyCode.RIGHT){
+                this.on_update(this.value + increment);
+            } else if (event.keyCode === $.ui.keyCode.DOWN || event.keyCode === $.ui.keyCode.LEFT) {
+                this.on_update(this.value - increment);
+            }
+        }
+    },
     _onMousedown:function(event) {
         if (this.canWrite) {
             this.moused_down = true;
@@ -3131,14 +3142,11 @@ var FieldBasicProgressBar = AbstractField.extend({
             this._render_value(this.get_progress_value(event));
         }
     },
-    _onKeydown: function (event){
-        if (this.canWrite) {
-            var increment = (this.step > 0 ? this.step : 1);
-            if(event.keyCode === $.ui.keyCode.UP || event.keyCode === $.ui.keyCode.RIGHT){
-                this.on_update(this.value + increment);
-            } else if (event.keyCode === $.ui.keyCode.DOWN || event.keyCode === $.ui.keyCode.LEFT) {
-                this.on_update(this.value - increment);
-            }
+    _onMouseout:function(event) {
+        if (this.moused_down) {
+            // Update the value of the field before going out of the progress bar.
+            this.on_update(this.get_progress_value(event));
+            this.moused_down = false;
         }
     },
     isSet: function () {

--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -3027,6 +3027,126 @@ var FieldProgressBar = AbstractField.extend({
 });
 
 /**
+ * Node options:
+ *
+ * - max_field: get the max_value for the widget from a field which must be present in the view
+ * - max_num: A numeric max_value for the widget if the max_field is not found or set (default: 100)
+ * - title: title of the bar, displayed on top of the bar options
+ * - step: Round the clicked value on the progressbar to the nearest multiple of step (default: 5, min: 1)
+ */
+var FieldBasicProgressBar = AbstractField.extend({
+    description: _lt("Basic Progress Bar"),
+    template: "BasicProgressBar",
+    events: {
+        'click .o_progress': '_onClick',
+        'keydown .o_progress_keydown': '_onKeydown',
+        'mousedown .o_progress': '_onMousedown',
+        'mousemove .o_progress': '_onMousemove',
+    },
+    supportedFieldTypes: ['integer', 'float'],
+    init: function () {
+        this._super.apply(this, arguments);
+        this.canWrite = !this.nodeOptions.readonly && this.mode === 'edit';
+        this.max_value = this.recordData[this.nodeOptions.max_field] || this.nodeOptions.max_num || 100;
+        this.step = this.nodeOptions.step !== undefined ? this.nodeOptions.step : 5;
+        this.title = _t(this.attrs.title || this.nodeOptions.title) || '';
+        this.moused_down = false;
+    },
+    _render: function () {
+        this._render_value();
+        return this._super();
+    },
+    /**
+     * Updates the widget with value
+     *
+     * @param {Number} value
+     */
+    on_update: function (value) {
+        // _setValues accepts string and will parse it
+        var formattedValue = this._formatValue(value);
+        this._setValue(formattedValue);
+    },
+    /**
+     * Get the value of the click on the progress bar
+     * 
+     * @param {Event} event 
+     */
+    get_progress_value: function (event) {
+        var $target = $(event.currentTarget);
+        var numValue = Math.floor((event.pageX - $target.offset().left) / $target.outerWidth() * this.max_value);
+        if(this.step > 0){
+            numValue = Math.round(numValue/this.step)*this.step;
+        }
+        return numValue;
+    },
+    /**
+     * Renders the value
+     *
+     * @private
+     * @param {Number} v
+     */
+    _render_value: function (v) {
+        var value = this.value;
+        var max_value = this.max_value;
+        if (!isNaN(v)) {
+            value = v;
+        }
+        value = value || 0;
+        max_value = max_value || 0;
+
+        var widthComplete;
+        if (value <= max_value) {
+            widthComplete = value/max_value * 100;
+        } else {
+            widthComplete = 100;
+        }
+
+        this.$('.o_progress').toggleClass('o_progress_overflow', value > max_value)
+            .attr('aria-valuemin', '0')
+            .attr('aria-valuemax', max_value)
+            .attr('aria-valuenow', value);
+        this.$('.o_progressbar_complete').css('width', widthComplete + '%');
+
+        if (max_value !== 100) {
+            this.$('.o_progressbar_value').text(utils.human_number(value) + " / " + utils.human_number(max_value));
+        } else {
+            this.$('.o_progressbar_value').text(utils.human_number(value) + "%");
+        }
+    },
+    _onClick: function (event) {
+        this.moused_down = false;
+        if (this.canWrite) {
+            this.on_update(this.get_progress_value(event));
+            this.$('.o_progress_keydown').focus();
+        }
+    },
+    _onMousedown:function(event) {
+        if (this.canWrite) {
+            this.moused_down = true;
+            this._render_value(this.get_progress_value(event));
+        }
+    },
+    _onMousemove:function(event) {
+        if (this.moused_down) {
+            this._render_value(this.get_progress_value(event));
+        }
+    },
+    _onKeydown: function (event){
+        if (this.canWrite) {
+            var increment = (this.step > 0 ? this.step : 1);
+            if(event.keyCode === $.ui.keyCode.UP || event.keyCode === $.ui.keyCode.RIGHT){
+                this.on_update(this.value + increment);
+            } else if (event.keyCode === $.ui.keyCode.DOWN || event.keyCode === $.ui.keyCode.LEFT) {
+                this.on_update(this.value - increment);
+            }
+        }
+    },
+    isSet: function () {
+        return true;
+    },
+});
+
+/**
  * This widget is intended to be used on boolean fields. It toggles a button
  * switching between a green bullet / gray bullet.
 */
@@ -3798,6 +3918,7 @@ return {
     FieldPercentPie: FieldPercentPie,
     FieldPhone: FieldPhone,
     FieldProgressBar: FieldProgressBar,
+    FieldBasicProgressBar: FieldBasicProgressBar,
     FieldText: FieldText,
     ListFieldText: ListFieldText,
     FieldToggleBoolean: FieldToggleBoolean,

--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -3033,6 +3033,7 @@ var FieldProgressBar = AbstractField.extend({
  * - max_num: A numeric max_value for the widget if the max_field is not found or set (default: 100)
  * - title: title of the bar, displayed on top of the bar options
  * - step: Round the clicked value on the progressbar to the nearest multiple of step (default: 5, min: 1)
+ * - percentage: boolean option : If set, the value should be presented as a percentage.
  */
 var FieldBasicProgressBar = AbstractField.extend({
     description: _lt("Basic Progress Bar"),
@@ -3042,19 +3043,24 @@ var FieldBasicProgressBar = AbstractField.extend({
         'keydown .o_progress_keydown': '_onKeydown',
         'mousedown .o_progress': '_onMousedown',
         'mousemove .o_progress': '_onMousemove',
-        'mouseout .o_progress': '_onMouseout',
+        'mouseleave .o_progress': '_onMouseleave',
     },
     supportedFieldTypes: ['integer', 'float'],
     init: function () {
         this._super.apply(this, arguments);
         this.canWrite = !this.nodeOptions.readonly && this.mode === 'edit';
         this.max_value = this.recordData[this.nodeOptions.max_field] || this.nodeOptions.max_num || 100;
+        this.percentage = this.nodeOptions.percentage || false;
         this.step = this.nodeOptions.step !== undefined ? this.nodeOptions.step : 5;
         this.title = _t(this.attrs.title || this.nodeOptions.title) || '';
         this.moused_down = false;
     },
     _render: function () {
         this._render_value();
+        if(!this.canWrite) {
+            this.$('.o_progressbar_thumb').addClass("o_progressbar_thumb_readonly");
+            this.$('.o_progressbar_complete').addClass("o_progressbar_complete_readonly");
+        }
         return this._super();
     },
     /**
@@ -3108,10 +3114,10 @@ var FieldBasicProgressBar = AbstractField.extend({
             .attr('aria-valuenow', value);
         this.$('.o_progressbar_complete').css('width', widthComplete + '%');
 
-        if (max_value !== 100) {
-            this.$('.o_progressbar_value').text(utils.human_number(value) + " / " + utils.human_number(max_value));
-        } else {
+        if (this.percentage) {
             this.$('.o_progressbar_value').text(utils.human_number(value) + "%");
+        } else {
+            this.$('.o_progressbar_value').text(utils.human_number(value) + " / " + utils.human_number(max_value));
         }
     },
     _onClick: function (event) {
@@ -3142,7 +3148,7 @@ var FieldBasicProgressBar = AbstractField.extend({
             this._render_value(this.get_progress_value(event));
         }
     },
-    _onMouseout:function(event) {
+    _onMouseleave:function(event) {
         if (this.moused_down) {
             // Update the value of the field before going out of the progress bar.
             this.on_update(this.get_progress_value(event));

--- a/addons/web/static/src/js/fields/field_registry.js
+++ b/addons/web/static/src/js/fields/field_registry.js
@@ -65,6 +65,7 @@ registry
     .add('float_factor', basic_fields.FieldFloatFactor)
     .add('float_toggle', basic_fields.FieldFloatToggle)
     .add('progressbar', basic_fields.FieldProgressBar)
+    .add('basic_progressbar', basic_fields.FieldBasicProgressBar)
     .add('toggle_button', basic_fields.FieldToggleBoolean)
     .add('dashboard_graph', basic_fields.JournalDashboardGraph)
     .add('ace', basic_fields.AceEditor)

--- a/addons/web/static/src/js/fields/field_registry.js
+++ b/addons/web/static/src/js/fields/field_registry.js
@@ -66,6 +66,7 @@ registry
     .add('float_toggle', basic_fields.FieldFloatToggle)
     .add('progressbar', basic_fields.FieldProgressBar)
     .add('basic_progressbar', basic_fields.FieldBasicProgressBar)
+    .add('quick_edit_progressbar', basic_fields.FieldQuicklyEditableBasicProgressBar)
     .add('toggle_button', basic_fields.FieldToggleBoolean)
     .add('dashboard_graph', basic_fields.JournalDashboardGraph)
     .add('ace', basic_fields.AceEditor)

--- a/addons/web/static/src/scss/fields.scss
+++ b/addons/web/static/src/scss/fields.scss
@@ -530,6 +530,13 @@
         @include o-text-overflow;
         transition: none; // remove transition to prevent badges from flickering at reload
     }
+
+    // Use hidden-like input in fields to handle key-events without displaying anything 
+    input.o_hidden_input {
+        border: 0;
+        padding: 0;
+        width: 0;
+    }
 }
 
 span.o_field_copy:empty {

--- a/addons/web/static/src/scss/kanban_view.scss
+++ b/addons/web/static/src/scss/kanban_view.scss
@@ -348,7 +348,7 @@
             .o_progressbar_title {
                 flex: 0 0 auto;
             }
-            .o_progress {
+            .o_progress, .o_basic_progress {
                 flex: 1 1 auto;
                 margin-top: 3px;
             }
@@ -361,6 +361,17 @@
             input.o_progressbar_value {
                 width: 15%;
                 margin-left: 8px;
+            }
+            .o_basic_progressbar_value, .o_basic_progressbar_unit {
+                flex: 0 0 auto;
+                width: auto;
+                height: 100%;
+                text-align: right;
+                input {
+                    vertical-align: middle;
+                    width: 6rem;
+                    height: 100%;                
+                }
             }
         }
 

--- a/addons/web/static/src/scss/progress_bar.scss
+++ b/addons/web/static/src/scss/progress_bar.scss
@@ -26,6 +26,23 @@
             background-color: $o-brand-primary;
             height: 100%;
         }
+
+        .o_progressbar_thumb {
+            float: right;
+            border-radius: 50%;
+            background-color: lighten($o-brand-primary, 5%);
+            width: 13px;
+            height: 13px;
+            margin-right: -7px;
+
+            &:focus, &:active {
+                background-color: lighten($o-brand-primary, 10%);
+            }
+
+            &:active {
+                cursor: grabbing;
+            }
+        }
     }
 
     .o_progressbar_value {

--- a/addons/web/static/src/scss/progress_bar.scss
+++ b/addons/web/static/src/scss/progress_bar.scss
@@ -25,9 +25,29 @@
         .o_progressbar_complete {
             background-color: $o-brand-primary;
             height: 100%;
+        }
+
+    }
+
+    .o_basic_progress {
+        width: 100px;
+        height: 15px;
+        vertical-align: middle;
+
+        border: 1px solid $o-brand-secondary;
+        overflow: hidden;
+
+        background-color: white;
+        &.o_progress_overflow {
+            background-color: $o-brand-secondary;
+        }
+
+        .o_progressbar_complete {
+            background-color: $o-brand-primary;
+            height: 100%;
 
             &.o_progressbar_complete_readonly {
-                background-color: lighten($o-brand-secondary, 35%) !important;
+                background-color: $o-brand-secondary !important;
             }
         }
 
@@ -50,7 +70,7 @@
 
             &.o_progressbar_thumb_readonly {
                 cursor: default !important;
-                background-color: lighten($o-brand-secondary, 25%) !important;
+                display: none;
             }
         }
     }
@@ -59,5 +79,18 @@
         width: 100px;
         white-space: nowrap;
         padding-left: 10px;
+    }
+
+    .o_basic_progressbar_value {
+        white-space: nowrap;
+        padding-left: 10px;
+
+        .o_input {
+            width: 50px;
+        }
+    }
+
+    .o_basic_progressbar_unit {
+        white-space: nowrap;
     }
 }

--- a/addons/web/static/src/scss/progress_bar.scss
+++ b/addons/web/static/src/scss/progress_bar.scss
@@ -92,5 +92,10 @@
 
     .o_basic_progressbar_unit {
         white-space: nowrap;
+        padding-left: 4px;
+        
+        .o_input {
+            width: 50px;
+        }
     }
 }

--- a/addons/web/static/src/scss/progress_bar.scss
+++ b/addons/web/static/src/scss/progress_bar.scss
@@ -25,9 +25,14 @@
         .o_progressbar_complete {
             background-color: $o-brand-primary;
             height: 100%;
+
+            &.o_progressbar_complete_readonly {
+                background-color: lighten($o-brand-secondary, 35%) !important;
+            }
         }
 
         .o_progressbar_thumb {
+            cursor: pointer;
             float: right;
             border-radius: 50%;
             background-color: lighten($o-brand-primary, 5%);
@@ -41,6 +46,11 @@
 
             &:active {
                 cursor: grabbing;
+            }
+
+            &.o_progressbar_thumb_readonly {
+                cursor: default !important;
+                background-color: lighten($o-brand-secondary, 25%) !important;
             }
         }
     }

--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -1350,7 +1350,7 @@
                 <span class="o_progressbar_thumb">
                 </span>
             </div>
-        </div></input><div class="o_basic_progressbar_value"/><div class="o_progressbar_unit"/>
+        </div></input><div class="o_basic_progressbar_value"/><div class="o_basic_progressbar_unit"/>
     </div>
 </t>
 <t t-name="FieldPercentPie">

--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -1345,12 +1345,12 @@
 </t>
 <t t-name="BasicProgressBar">
     <div class="o_progressbar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-        <div t-if="widget.title" class="o_progressbar_title"><t t-esc="widget.title"/></div><input class="o_progress_keydown o_hidden_input"><div class="o_progress">
+        <div t-if="widget.title" class="o_progressbar_title"><t t-esc="widget.title"/></div><input class="o_progress_keydown o_hidden_input"><div class="o_basic_progress">
             <div class="o_progressbar_complete">
                 <span class="o_progressbar_thumb">
                 </span>
             </div>
-        </div></input><div class="o_progressbar_value"/>
+        </div></input><div class="o_basic_progressbar_value"/><div class="o_progressbar_unit"/>
     </div>
 </t>
 <t t-name="FieldPercentPie">

--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -1346,7 +1346,10 @@
 <t t-name="BasicProgressBar">
     <div class="o_progressbar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
         <div t-if="widget.title" class="o_progressbar_title"><t t-esc="widget.title"/></div><input class="o_progress_keydown o_hidden_input"><div class="o_progress">
-            <div class="o_progressbar_complete"/>
+            <div class="o_progressbar_complete">
+                <span class="o_progressbar_thumb">
+                </span>
+            </div>
         </div></input><div class="o_progressbar_value"/>
     </div>
 </t>

--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -1343,6 +1343,13 @@
         </div><div class="o_progressbar_value"/>
     </div>
 </t>
+<t t-name="BasicProgressBar">
+    <div class="o_progressbar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+        <div t-if="widget.title" class="o_progressbar_title"><t t-esc="widget.title"/></div><input class="o_progress_keydown o_hidden_input"><div class="o_progress">
+            <div class="o_progressbar_complete"/>
+        </div></input><div class="o_progressbar_value"/>
+    </div>
+</t>
 <t t-name="FieldPercentPie">
     <div class="o_field_percent_pie">
         <div class="o_pie">

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -7692,7 +7692,7 @@ QUnit.module('basic_fields', {
             }
         };
 
-        var form = await createView({
+        const form = await createView({
             View: FormView,
             model: 'partner',
             data: this.data,
@@ -7739,7 +7739,7 @@ QUnit.module('basic_fields', {
         assert.expect(4);
         this.data.partner.records[0].int_field = 99;
 
-        var form = await createView({
+        const form = await createView({
             View: FormView,
             model: 'partner',
             data: this.data,
@@ -7752,15 +7752,15 @@ QUnit.module('basic_fields', {
                 return this._super.apply(this, arguments);
             }
         });
-        var $view = $('#qunit-fixture').contents();
+        const $view = $('#qunit-fixture').contents();
         $view.prependTo('body'); // => select with click position
 
         assert.strictEqual(form.$('.o_basic_progressbar_value').text(), '99',
             'Initial value should be correct');
 
-        var $progressBarEl = form.$('.o_basic_progress');
-        var top = $progressBarEl.offset().top + 5;
-        var left = $progressBarEl.offset().left + 5;
+        const $progressBarEl = form.$('.o_basic_progress');
+        const top = $progressBarEl.offset().top + 5;
+        const left = $progressBarEl.offset().left + 5;
         try {
             testUtils.triggerPositionalMouseEvent(left, top, "click");
         } catch (e) {
@@ -7782,7 +7782,7 @@ QUnit.module('basic_fields', {
         this.data.partner.records[0].int_field = 99;
         // Warning : Different behaviour than the one in ProgressBar
 
-        var form = await createView({
+        const form = await createView({
             View: FormView,
             model: 'partner',
             data: this.data,
@@ -7798,7 +7798,7 @@ QUnit.module('basic_fields', {
                 return this._super.apply(this, arguments);
             }
         });
-        var $view = $('#qunit-fixture').contents();
+        const $view = $('#qunit-fixture').contents();
         $view.prependTo('body'); // => select with click position
 
         assert.ok(form.$('.o_form_view').hasClass('o_form_editable'), 'Form in edit mode');
@@ -7806,9 +7806,9 @@ QUnit.module('basic_fields', {
         assert.strictEqual(form.$('.o_basic_progressbar_value .o_input').val(), '99',
             'Initial value should be correct');
 
-        var $progressBarEl = form.$('.o_basic_progress');
-        var top = $progressBarEl.offset().top + 5;
-        var left = $progressBarEl.offset().left + 5;
+        const $progressBarEl = form.$('.o_basic_progress');
+        const top = $progressBarEl.offset().top + 5;
+        const left = $progressBarEl.offset().left + 5;
         try {
             testUtils.dom.triggerPositionalMouseEvent(left, top, "click");
         } catch (e) {
@@ -7855,7 +7855,7 @@ QUnit.module('basic_fields', {
         assert.expect(5);
         this.data.partner.records[0].int_field = 99;
 
-        var form = await createView({
+        const form = await createView({
             View: FormView,
             model: 'partner',
             data: this.data,
@@ -7880,7 +7880,7 @@ QUnit.module('basic_fields', {
         assert.strictEqual(form.$('.o_basic_progressbar_value .o_input').val(), '99',
             'Initial value should be correct');
 
-        var $valInput = form.$('.o_basic_progressbar_value .o_input');
+        const $valInput = form.$('.o_basic_progressbar_value .o_input');
         assert.strictEqual($valInput.val(), '99', 'Initial value in input is correct');
         $valInput.focus();
         $valInput.val("");
@@ -7898,7 +7898,7 @@ QUnit.module('basic_fields', {
         assert.expect(2);
         this.data.partner.records[0].int_field = 99;
 
-        var form = await createView({
+        const form = await createView({
             View: FormView,
             model: 'partner',
             data: this.data,
@@ -7920,7 +7920,7 @@ QUnit.module('basic_fields', {
         assert.expect(2);
         this.data.partner.records[0].int_field = 99;
 
-        var form = await createView({
+        const form = await createView({
             View: FormView,
             model: 'partner',
             data: this.data,
@@ -7942,7 +7942,7 @@ QUnit.module('basic_fields', {
         assert.expect(2);
         this.data.partner.records[0].int_field = 99;
 
-        var form = await createView({
+        const form = await createView({
             View: FormView,
             model: 'partner',
             data: this.data,
@@ -7964,7 +7964,7 @@ QUnit.module('basic_fields', {
         assert.expect(6);
         this.data.partner.records[0].int_field = 99;
 
-        var form = await createView({
+        const form = await createView({
             View: FormView,
             model: 'partner',
             data: this.data,
@@ -7991,7 +7991,7 @@ QUnit.module('basic_fields', {
         assert.strictEqual(form.$('.o_basic_progressbar_unit').text(), ' / 0',
             'Initial value should be correct');
 
-        var $valInput = form.$('.o_basic_progressbar_value .o_input');
+        const $valInput = form.$('.o_basic_progressbar_value .o_input');
         assert.strictEqual($valInput.val(), '99', 'Initial value in input is correct');
         $valInput.focus();
         $valInput.val("");
@@ -8013,7 +8013,7 @@ QUnit.module('basic_fields', {
 
         // Warning : Different behaviour than the ProgressBar : If you want to edit a value as a max value, the widget must be used in this "max value" field.
         //           And, thus, use the "value" field as an option. This field must be present in the view, indeed.
-        var form = await createView({
+        const form = await createView({
             View: FormView,
             model: 'partner',
             data: this.data,
@@ -8041,7 +8041,7 @@ QUnit.module('basic_fields', {
         assert.strictEqual(form.$('.o_basic_progressbar_unit .o_input').val(), '0.4',
             'Initial value should be correct');
 
-        var $valInput = form.$('.o_basic_progressbar_unit .o_input');
+        const $valInput = form.$('.o_basic_progressbar_unit .o_input');
         assert.strictEqual($valInput.val(), "0.4", 'Initial value in input is correct');
         $valInput.focus();
         $valInput.val("");
@@ -8061,7 +8061,7 @@ QUnit.module('basic_fields', {
         assert.expect(7);
         this.data.partner.records[0].int_field = 99;
 
-        var form = await createView({
+        const form = await createView({
             View: FormView,
             model: 'partner',
             data: this.data,
@@ -8096,7 +8096,7 @@ QUnit.module('basic_fields', {
         assert.expect(5);
         this.data.partner.records[0].int_field = 99;
 
-        var form = await createView({
+        const form = await createView({
             View: FormView,
             model: 'partner',
             data: this.data,
@@ -8122,7 +8122,7 @@ QUnit.module('basic_fields', {
 
         assert.ok(form.$('.o_form_view').hasClass('o_form_editable'), 'Form in edit mode');
 
-        var $valInput = form.$('.o_basic_progressbar_value .o_input');
+        const $valInput = form.$('.o_basic_progressbar_value .o_input');
         assert.strictEqual($valInput.val(), '99', 'Initial value in input is correct');
         document.execCommand('insertText', false, 'ninety nine');
         await testUtils.form.clickSave(form);
@@ -8137,7 +8137,7 @@ QUnit.module('basic_fields', {
         assert.expect(4);
         this.data.partner.records[0].qux = 99;
 
-        var form = await createView({
+        const form = await createView({
             View: FormView,
             model: 'partner',
             data: this.data,
@@ -8163,7 +8163,7 @@ QUnit.module('basic_fields', {
 
         assert.ok(form.$('.o_form_view').hasClass('o_form_editable'), 'Form in edit mode');
 
-        var $valInput = form.$('.o_basic_progressbar_value .o_input');
+        const $valInput = form.$('.o_basic_progressbar_value .o_input');
         assert.strictEqual($valInput.val(), '99:0', 'Initial value in input is correct');
         $valInput.val("");
         $valInput.focus();
@@ -8182,7 +8182,7 @@ QUnit.module('basic_fields', {
         assert.expect(6);
         this.data.partner.records[0].int_field = 99;
 
-        var kanban = await createView({
+        const kanban = await createView({
             View: KanbanView,
             model: 'partner',
             data: this.data,
@@ -8205,7 +8205,7 @@ QUnit.module('basic_fields', {
 
         await testUtilsDom.click(kanban.$('.o_progressbar'));
 
-        var $valInput = kanban.$('.o_basic_progressbar_unit .o_input');
+        const $valInput = kanban.$('.o_basic_progressbar_unit .o_input');
         assert.strictEqual($valInput.val(), "0.4", 'Initial value in input is correct');
         await testUtils.fields.editAndTrigger($valInput, '69', ['input', 'blur']);
 
@@ -8223,7 +8223,7 @@ QUnit.module('basic_fields', {
         assert.expect(3);
         this.data.partner.records[0].int_field = 99;
 
-        var kanban = await createView({
+        const kanban = await createView({
             View: KanbanView,
             model: 'partner',
             data: this.data,
@@ -8244,7 +8244,7 @@ QUnit.module('basic_fields', {
 
         await testUtilsDom.click(kanban.$('.o_progressbar'));
 
-        var $valInput = kanban.$('.o_basic_progressbar_value .o_input');
+        const $valInput = kanban.$('.o_basic_progressbar_value .o_input');
         assert.strictEqual($valInput.val(), "99", 'Initial value in input is correct');
         await testUtils.fields.editAndTrigger($valInput, '42', ['input', 'blur']);
 
@@ -8258,7 +8258,7 @@ QUnit.module('basic_fields', {
         assert.expect(3);
         this.data.partner.records[0].int_field = 99;
 
-        var kanban = await createView({
+        const kanban = await createView({
             View: KanbanView,
             model: 'partner',
             data: this.data,
@@ -8274,7 +8274,7 @@ QUnit.module('basic_fields', {
                   '</kanban>',
             domain: [['id', '=', 1]],
         });
-        var $view = $('#qunit-fixture').contents();
+        const $view = $('#qunit-fixture').contents();
         $view.prependTo('body'); // => select with click position
 
         assert.strictEqual(kanban.$('.o_basic_progressbar_value').text(), '99',
@@ -8282,11 +8282,11 @@ QUnit.module('basic_fields', {
 
         await testUtilsDom.click(kanban.$('.o_progressbar'));
 
-        var $valInput = kanban.$('.o_basic_progressbar_value .o_input');
+        const $valInput = kanban.$('.o_basic_progressbar_value .o_input');
         assert.strictEqual($valInput.val(), "99", 'Initial value in input is correct');
-        var $progressBarEl = kanban.$('.o_basic_progress');
-        var top = $progressBarEl.offset().top + 5;
-        var left = $progressBarEl.offset().left + 1;
+        const $progressBarEl = kanban.$('.o_basic_progress');
+        const top = $progressBarEl.offset().top + 5;
+        const left = $progressBarEl.offset().left + 1;
         try {
             testUtils.dom.triggerPositionalMouseEvent(left, top, "click");
         } catch (e) {


### PR DESCRIPTION
=============================================================

Disclaimer : The purpose of this PR may be ambiguous.
The first objective was to make the progressbar editable with the click.
Given the current implementation of the progressbar widget, an
inheritence wasn't possible to achieve it. Technically, the init
function of the progressbar cannot be inherited without re-writing it
completly. Thus, the first development lead to a new widget with the
purpose to have an click-editable progressbar.

This commit may change the objective of the PR and could lead to a
refactoring of the progressbar widget. Yet, the developer (tle) didn't
take the responsability to directly trash the progressbar, as it was not
meant in the first specification of the task. It may be
interesting to discuss it between the js framework guru and the PO.

==============================================================

This commit aims to add a new progress bar called basic_progressbar
which, basically, allows user to see integer or float represented on a
progressbar.

This wigdet is configurable (see node options in the widget
specifications) and with default options, it :
- Allows user to edit value through an input.
- Shows the value as a percentage.
- The max value of the bar is 100%.
- The number is formatted depending on its type (integer or float)

Developer may want to tune it and use it :
- with the default maximum value spelled out ("/ 100") and not
  represented as a percentage : 'percentage' (boolean);
- with a different maximum value : max_value_num (a number),
  'max_value_field' (a field present in the view);
- with an editable progressbar (with the mouse or the arrows) :
  'drag_and_drop' (boolean);
- with a human number format : 'human_number' (boolean);
- with a different than default format type : 'format_type' (string e.g.
  "float" or "integer");
- to show the field as the maximum value and not as the progress value :
  'edit_max_value' (boolean)
- with this last option ('edit_max_value') and use a other field as
  progress value : 'progress_value_field' (a field present in the view)

Technical comment :
- The _doAction function is called when the input change or when the
  progressbar is updated with the click or the keyboard arrows.
- The _allowEdit functions allows other developpers to tune the
  conditions which allows one to edit the widget in some views/context.
  As it is used with a logical OR, condition can only add cases and not
  restrict the default one.

------------------------------------------------------------------

Furthermore, this commit adds a new quick_edit_progressbar which
inherits from the basic_progressbar and can be used in a readonly
context such as kanban views or list views.

This quick_edit_progressbar can be edited once the user click on it and
returns to readonly mode once the user either blur the input or click
outside the quick_edit_progressbar widget.

Technical comment :
- The value is updated (sent to server by rpc) only when the field is
blurred, this behaviour could be tuned for further needs by overriding
_valueChanged. The behaviour is a design choice.
- The window click listener is only added if the widget is edited once
and is not re-added if the widget is edited-blurred-edited. Furthermore
this listener is only added when using the drag and drop option with
this widget.

------------------------------------------------------------------

PR : #64239
task-2412223

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
