### PR TITLE
[FIX] odoo/fields.py: fix removing translations on writing ''

### DIFF
--- a/odoo/addons/base/tests/test_translate.py
+++ b/odoo/addons/base/tests/test_translate.py
@@ -502,7 +502,13 @@ class TestTranslationWrite(TransactionCase):
             {'src': 'None Name', 'value': 'French Name', 'lang': 'fr_FR'},
         ])
 
-    def test_05_remove_multi(self):
+    def test_05_remove_multi_empty_string(self):
+        self._test_05_remove_multi("")
+
+    def test_05_remove_multi_false(self):
+        self._test_05_remove_multi(False)
+
+    def _test_05_remove_multi(self, empty_value):
         self.env['res.lang'].load_lang('fr_FR')
 
         langs = self.env['res.lang'].get_installed()
@@ -512,39 +518,27 @@ class TestTranslationWrite(TransactionCase):
         belgium = self.env.ref('base.be')
         # vat_label is translatable and not required
         belgium.with_context(lang='en_US').write({'vat_label': 'VAT'})
+        belgium.with_context(lang='fr_FR').write({'vat_label': 'TVA'})
 
-        # create translations if not exists
-        self.env['ir.translation']._upsert_translations([{
-            'type': 'model',
-            'name': 'res.country,vat_label',
-            'lang': 'en_US',
-            'res_id': belgium.id,
-            'src': 'VAT',
-            'value': 'VAT',
-            'state': 'translated',
-        }, {
-            'type': 'model',
-            'name': 'res.country,vat_label',
-            'lang': 'fr_FR',
-            'res_id': belgium.id,
-            'src': 'VAT',
-            'value': 'TVA',
-            'state': 'translated',
-        }])
+        translations = self.env['ir.translation'].search([
+            ('name', '=', 'res.country,vat_label'),
+            ('res_id', '=', belgium.id),
+        ])
+        self.assertEqual(len(translations), 2, "Translations are not created")
 
         # remove the value
-        belgium.with_context(lang='fr_FR').write({'vat_label': False})
+        belgium.with_context(lang='fr_FR').write({'vat_label': empty_value})
         # should recover the initial value from db
-        self.assertEqual(
-            False, belgium.with_context(lang='fr_FR').vat_label,
+        self.assertFalse(
+            belgium.with_context(lang='fr_FR').vat_label,
             "Value was not reset"
         )
-        self.assertEqual(
-            False, belgium.with_context(lang='en_US').vat_label,
+        self.assertFalse(
+            belgium.with_context(lang='en_US').vat_label,
             "Value was not reset in other languages"
         )
-        self.assertEqual(
-            False, belgium.with_context(lang=None).vat_label,
+        self.assertFalse(
+            belgium.with_context(lang=None).vat_label,
             "Value was not reset on the field model"
         )
 

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1438,7 +1438,7 @@ class _String(Field):
                 update_trans = True
             elif lang != 'en_US' and lang is not None:
                 # update the translations only except if emptying
-                update_column = cache_value is None
+                update_column = not cache_value
                 update_trans = True
             # else: lang = None
 
@@ -1448,7 +1448,7 @@ class _String(Field):
             for rid in real_recs._ids:
                 # cache_value is already in database format
                 towrite[rid][self.name] = cache_value
-            if self.translate is True and cache_value is not None:
+            if self.translate is True and cache_value:
                 tname = "%s,%s" % (records._name, self.name)
                 records.env['ir.translation']._set_source(tname, real_recs._ids, value)
             if self.translate:
@@ -1471,7 +1471,7 @@ class _String(Field):
                     source_recs[self.name] = value
                     source_value = value
                 tname = "%s,%s" % (self.model_name, self.name)
-                if value is None:
+                if not value:
                     records.env['ir.translation'].search([
                         ('name', '=', tname),
                         ('type', '=', 'model'),


### PR DESCRIPTION
cache_value could be empty string rather than None. I'm not sure why it was
different before.

STEPS:
* install an app that adds menu Products (e.g. Sales)
* activate second language and switch to it
* create new product, set some value to field description ("Internal Notes"),
save
* click edit, remove description, save

BEFORE: the value is not removed

AFTER: value is empty, translations are removed

---

https://github.com/odoo/odoo/commit/543a5523a30c993f60eba3c6d56d54dea2857eb3#
opw-2426724

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
