### PR TITLE
[IMP] sale{_timesheet}: Order upsell activity for prepaid services

### DIFF
--- a/addons/sale_timesheet/models/product.py
+++ b/addons/sale_timesheet/models/product.py
@@ -21,6 +21,8 @@ class ProductTemplate(models.Model):
     # override domain
     project_id = fields.Many2one(domain="[('allow_billable', '=', True), ('pricing_type', '=', 'task_rate'), ('allow_timesheets', 'in', [service_policy == 'delivered_timesheet' or '', True])]")
     project_template_id = fields.Many2one(domain="[('allow_billable', '=', True), ('pricing_type', 'in', ('fixed_rate', 'employee_rate')), ('allow_timesheets', 'in', [service_policy == 'delivered_timesheet' or '', True])]")
+    service_upsell_warning = fields.Boolean('Upsell Warning', help="The salesperson in charge will be assigned an activity informing him of an upselling opportunity once the selected threshold is reached.")
+    service_upsell_threshold = fields.Float('Threshold', help="Percentage of time delivered compared to the prepaid amount that must be reached for the upselling opportunity activity to be triggered.")
 
     def _default_visible_expense_policy(self):
         visibility = self.user_has_groups('project.group_project_user')

--- a/addons/sale_timesheet/tests/__init__.py
+++ b/addons/sale_timesheet/tests/__init__.py
@@ -9,3 +9,4 @@ from . import test_reinvoice
 from . import test_reporting
 from . import test_project_overview
 from . import test_project_billing_multicompany
+from . import test_upsell_warning

--- a/addons/sale_timesheet/tests/test_upsell_warning.py
+++ b/addons/sale_timesheet/tests/test_upsell_warning.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import tagged
+
+from .common import TestCommonSaleTimesheet
+
+
+@tagged('-at_install', 'post_install')
+class TestUpsellWarning(TestCommonSaleTimesheet):
+    def test_display_upsell_warning(self):
+        """ Test to display an upsell warning
+
+
+            We display an upsell warning in SO when this following condition is satisfy in its SOL:
+            (qty_delivered / product_uom_qty) >= product_id.service_upsell_threshold
+
+            Test Case:
+            =========
+            1) Configure the upsell warning in prepaid service product
+            2) Create SO with a SOL containing this updated product,
+            3) Create Project and Task,
+            4) Timesheet in the task to satisfy the condition for the SOL to display an upsell warning,
+            5) Check if the SO has an 'sale.mail_act_sale_upsell' activity.
+        """
+        # 1) Configure the upsell warning in prepaid service product
+        self.product_order_timesheet1.write({
+            'service_upsell_warning': True,
+            'service_upsell_threshold': 0.6,
+        })
+
+        # 2) Create SO with a SOL containing this updated product
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'partner_invoice_id': self.partner_a.id,
+            'partner_shipping_id': self.partner_a.id,
+        })
+
+        self.env['sale.order.line'].create({
+            'order_id': so.id,
+            'name': self.product_order_timesheet1.name,
+            'product_id': self.product_order_timesheet1.id,
+            'product_uom_qty': 10,
+            'price_unit': self.product_order_timesheet1.list_price,
+        })
+        so.action_confirm()
+
+        # 3) Create Project and Task
+        project = self.env['project.project'].create({
+            'name': 'Project',
+            'allow_timesheets': True,
+            'allow_billable': True,
+            'partner_id': self.partner_a.id,
+            'analytic_account_id': self.analytic_account_sale.id,
+        })
+        task = self.env['project.task'].create({
+            'name': 'Task Test',
+            'project_id': project.id,
+        })
+        task._compute_sale_line()
+
+        # 4) Timesheet in the task to satisfy the condition for the SOL to display an upsell warning
+        timesheet = self.env['account.analytic.line'].create({
+            'name': 'Test Line',
+            'unit_amount': 5,
+            'employee_id': self.employee_manager.id,
+            'project_id': project.id,
+            'task_id': task.id,
+        })
+        timesheet._compute_so_line()
+        so.order_line._compute_qty_delivered()
+        so.order_line._compute_invoice_status()
+        so._get_invoice_status()
+        # Normally this method is called at the end of _get_invoice_status and other compute method. Here, we simulate for invoice_status field
+        so._compute_field_value(so._fields['invoice_status'])
+
+        self.assertEqual(len(so.activity_search(['sale.mail_act_sale_upsell'])), 0, 'No upsell warning should appear in the SO.')
+        timesheet.write({
+            'unit_amount': 6,
+        })
+        timesheet._compute_so_line()
+        so.order_line._compute_qty_delivered()
+        so.order_line._compute_invoice_status()
+        so._get_invoice_status()
+        # Normally this method is called at the end of _get_invoice_status and other compute method. Here, we simulate for invoice_status field
+        so._compute_field_value(so._fields['invoice_status'])
+
+        # 5) Check if the SO has an 'sale.mail_act_sale_upsell' activity.
+        self.assertEqual(len(so.activity_search(['sale.mail_act_sale_upsell'])), 1, 'A upsell warning should appear in the SO.')

--- a/addons/sale_timesheet/views/product_views.xml
+++ b/addons/sale_timesheet/views/product_views.xml
@@ -11,6 +11,8 @@
             </xpath>
             <xpath expr="//field[@name='service_type']" position="after">
                 <field name="service_policy" widget="radio" attrs="{'invisible': [('type','!=','service')]}"/>
+                <field name="service_upsell_warning" attrs="{'invisible': ['|', ('type', '!=', 'service'), ('service_policy', '!=', 'ordered_timesheet')]}" />
+                <field name="service_upsell_threshold" attrs="{'invisible': ['|', '|', ('type', '!=', 'service'), ('service_policy', '!=', 'ordered_timesheet'), ('service_upsell_warning', '=', False)]}" widget="percentage"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Purpose
======
When offering services, it is critical to make sure that the time being
delivered is billable. Otherwise, the company is loosing money.

## Details

Two fields have been created in product.template:

1. service_upsell_warning
2. service_upsell_threshold

The first one is a boolean, if it is checked then the second one is
displayed to add a threshold. This threshold is used to create an upsell
activity because the (qty_delivered / qty_ordered) in a SOL of this product
is greater than the threshold defined in the product.

Moreover, when the following condition for a SOL:
(delivered quantity / ordered quantity) >= threshold set in the product
is True, then we display an upsell warning for the corresponding
SO. The problem is we don't check if the warning has already displayed
by a certain SOL. Thus, each time we timesheet for this SOL, we display
one more time.

To avoid to spam the salesman, we add a new boolean field in 
sale.order.line, this field will be True if the warning upsell activity is 
shown thanks to the SOL.

A method is added in sale module to create the upsell activity for each SO.
This method is used in sale_timesheet module to avoid duplicated code.

Finally, an unit test has been added to check the feature.

task-2411291