### PR TITLE
Master reco partial wan fwd oco

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -393,6 +393,8 @@ class AccountReconcileModel(models.Model):
 
         partner = partner or st_line.partner_id
 
+        has_full_write_off= any(rec_mod_line.amount == 100.0 for rec_mod_line in self.line_ids)
+
         lines_vals_list = []
         amls = self.env['account.move.line'].browse(aml_ids)
         st_line_residual_before = st_line_residual
@@ -403,6 +405,9 @@ class AccountReconcileModel(models.Model):
             if aml.balance * st_line_residual > 0:
                 # Meaning they have the same signs, so they can't be reconciled together
                 assigned_balance = -aml.amount_residual
+            elif has_full_write_off:
+                assigned_balance = -aml.amount_residual
+                st_line_residual -= min(-aml.amount_residual, st_line_residual, key=abs)
             else:
                 assigned_balance = min(-aml.amount_residual, st_line_residual, key=abs)
                 st_line_residual -= assigned_balance

--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -428,13 +428,8 @@ class AccountReconcileModel(models.Model):
             st_line_residual -= st_line.company_currency_id.round(line_vals['balance'])
 
         # Check we have enough information to create an open balance.
-        if not st_line.company_currency_id.is_zero(st_line_residual):
-            if st_line.amount > 0:
-                open_balance_account = partner.property_account_receivable_id
-            else:
-                open_balance_account = partner.property_account_payable_id
-            if not open_balance_account:
-                return []
+        if open_balance_vals and not open_balance_vals.get('account_id'):
+            return []
 
         return lines_vals_list + writeoff_vals_list
 


### PR DESCRIPTION
[FIX] account: reconciliation models: make auto_reconcile rules work properly with write-offs

- Create an invoice for 100
- Create a bank statement for 95
- Setup your reconciliation model so that it will match them and create a write-off for the remaining 5. Make it auto_reconciled.

=> Doing that, we expect the bank journal move to be created like this:

- 100 on payable/receivable, reconciled with the invoice
- 95 on the bank account
- 5 on the write-off account

This wasn't the case. Instead, Odoo created the following (correct from an accounting point of view, but weird):

- 95 on payable/receivable, reconciled with the invoice
- 5 on payable/receivable, not reconciled
- 95 on the bank account
- 5 on the write-off account

=> So an open balance of 5 was actually created. This was weird, and also caused an additional bug, as only the first payable/receivable line was reconciled with the invoice, making it only partially paid.

This commit restores the expected behavior.



[FIX] account: reconcile models: create write-offs properly when matching a statement line with no partner

Before that, write-offs were simply never created in this case ; only an open balance. This was (obviously) wrong.

Also, the partner set on the statement line was not modified, and kept empty. We fix that so that, when a statement line without is reconciled with lines sharing the same partner, this partner is also assigned to the statement line.

Task 2423231