### PR TITLE
[I18N] fix quote in translation

### DIFF
--- a/addons/point_of_sale/i18n/ru.po
+++ b/addons/point_of_sale/i18n/ru.po
@@ -2733,7 +2733,7 @@ msgstr "Заказов найдено"
 #: code:addons/point_of_sale/static/src/xml/Screens/ProductScreen/ProductList.xml:0
 #, python-format
 msgid "No results found for \""
-msgstr "Нет результатов для `"
+msgstr "Нет результатов для \""
 
 #. module: point_of_sale
 #: code:addons/point_of_sale/wizard/pos_open_statement.py:0


### PR DESCRIPTION
Otherwise owl tries to interpret strings after ` as code

Chrome.js:83 Error: Invalid generated code while compiling template 'ProductList': Invalid or unexpected token
    at QWeb._compile (owl.js:1701)
    at QWeb.fn (owl.js:1565)
    at QWeb.render (owl.js:1617)
    at ProductList.__render (owl.js:4353)
    at ProductList.__prepareAndRender (owl.js:4342)

I fixed it in transifex, but it's not updated for unknow reason

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
