### PR TITLE
[FIX] Account: Better error message for unique sequence

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -8155,7 +8155,10 @@ msgstr ""
 #. module: account
 #: code:addons/account/models/account_move.py:0
 #, python-format
-msgid "Posted journal entry must have an unique sequence number per company."
+msgid ""
+"Posted journal entry must have an unique sequence number per company.\n"
+"These sequences numbers already exist:\n"
+"%s"
 msgstr ""
 
 #. module: account

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1489,7 +1489,10 @@ class AccountMove(models.Model):
         ''', [tuple(moves.ids)])
         res = self._cr.fetchone()
         if res:
-            raise ValidationError(_('Posted journal entry must have an unique sequence number per company.'))
+            wrong_moves = self.env['account.move'].browse(res)
+            raise ValidationError(_('Posted journal entry must have an unique sequence number per company.\n'
+                                    'These sequences numbers already exist:\n'
+                                    '%s') % ('\n'.join([m.name for m in wrong_moves])))
 
     @api.constrains('ref', 'type', 'partner_id', 'journal_id', 'invoice_date')
     def _check_duplicate_supplier_reference(self):


### PR DESCRIPTION
When the user close a POS session, if the sequence of a journal
is using the sub-sequence for a date range, but does not use a date
in the format, the same sequence number is coming back in the next
range.

With that change, the faulty sequence is displayed to help fixing
the problem on a functionnal level.

To reproduce, you can:
- use a v13 database.
- create a sequence that use the sub-sequence date range
without placeholder
- create a move in the first range
- create a move in the next range
- the message should trigger

opw-2414464

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
