### PR TITLE
[FIX] sale_margin/sale_order.py: use the correct currency

### DIFF
--- a/addons/sale_margin/models/sale_order.py
+++ b/addons/sale_margin/models/sale_order.py
@@ -12,7 +12,7 @@ class SaleOrderLine(models.Model):
     purchase_price = fields.Float(string='Cost', digits=dp.get_precision('Product Price'))
 
     def _compute_margin(self, order_id, product_id, product_uom_id):
-        frm_cur = self.env.user.company_id.currency_id
+        frm_cur = order_id.company_id.currency_id or self.env.user.company_id.currency_id
         to_cur = order_id.pricelist_id.currency_id
         purchase_price = product_id.standard_price
         if product_uom_id != product_id.uom_id:


### PR DESCRIPTION
Current behavior before PR:
In intercompany flows, the currency to calculate from is based on
the company of the superuser. If the company of the superuser has
the same currency as the purchasing company but not the selling
company, the conversion is between the same currency and the cost
shown on the sale order is incorrect, leading to a (sometimes)
negative margin.

Desired behavior after PR is merged:
This fix uses the currency of the company of the sale order instead,
since the cost of the product in the selling company is always in
the main currency of the company.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
