### PR TITLE
[FIX] point_of_sale: respect setting only_round_cash_method

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -370,7 +370,10 @@ class PosOrder(models.Model):
     def action_pos_order_paid(self):
         self.ensure_one()
 
-        if not self.config_id.cash_rounding:
+        # TODO: add support for mix of cash and non-cash payments when both cash_rounding and only_round_cash_method are True
+        if not self.config_id.cash_rounding \
+           or self.config_id.only_round_cash_method \
+           and not any(p.payment_method_id.is_cash_count for p in self.payment_ids):
             total = self.amount_total
         else:
             total = float_round(self.amount_total, precision_rounding=self.config_id.rounding_method.rounding, rounding_method=self.config_id.rounding_method.rounding_method)

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -3337,10 +3337,14 @@ exports.Order = Backbone.Model.extend({
         if(!this.pos.config.cash_rounding)
             return false;
 
+        const only_cash = this.pos.config.only_round_cash_method;
         var lines = this.paymentlines.models;
 
         for(var i = 0; i < lines.length; i++) {
             var line = lines[i];
+            if (only_cash && !line.payment_method.is_cash_count)
+                continue;
+
             if(!utils.float_is_zero(line.amount - round_pr(line.amount, this.pos.cash_rounding[0].rounding), 6))
                 return line;
         }


### PR DESCRIPTION
STEPS:
* configure rounding:
  - cash_rounding=True
  - only_round_cash_method=True
  - round method: 1.0 Down

* open a session
* add products with subtotal in decimals (such as 6.35)
* select Bank payment method and process the order

BEFORE: error "You have to round your payments lines"

AFTER: order is processed and marked as paid

---

https://github.com/odoo/odoo/commit/42425996e36d9cb1fc1391402cf6d00df4aea019
opw-2426027

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
