### PR TITLE
[FIX] stock: from `from_date` domain

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -143,7 +143,7 @@ class Product(models.Model):
             domain_move_in_done = list(domain_move_in)
             domain_move_out_done = list(domain_move_out)
         if from_date:
-            date_date_expected_domain_from = [('date', '<=', from_date)]
+            date_date_expected_domain_from = [('date', '>=', from_date)]
             domain_move_in += date_date_expected_domain_from
             domain_move_out += date_date_expected_domain_from
         if to_date:


### PR DESCRIPTION
Commit c2c9d6d143 changed the inequality sign unintentionally.
This commit change it to the right value

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
