### PR TITLE
[FIX] web: fix the RedirectWarningHandler dialog not closing

### DIFF
--- a/addons/web/static/src/js/services/crash_manager.js
+++ b/addons/web/static/src/js/services/crash_manager.js
@@ -360,7 +360,8 @@ var RedirectWarningHandler = Widget.extend(ExceptionHandler, {
                         {
                             additional_context: additional_context,
                         });
-                }},
+                        self.destroy();
+                }, close: true},
                 {text: _t("Cancel"), click: function() { self.destroy(); }, close: true}
             ]
         }, {

--- a/addons/web/static/tests/services/crash_manager_tests.js
+++ b/addons/web/static/tests/services/crash_manager_tests.js
@@ -1,0 +1,62 @@
+odoo.define('web.crash_manager_tests', function (require) {
+    "use strict";
+    const CrashManager = require('web.CrashManager').CrashManager;
+    const Bus = require('web.Bus');
+    const testUtils = require('web.test_utils');
+    const core = require('web.core');
+    const createActionManager = testUtils.createActionManager;
+    
+QUnit.module('Services', {}, function() {
+
+    QUnit.module('CrashManager');
+
+    QUnit.test("Execute an action and close the RedirectWarning when clicking on the primary button", async function (assert) {
+        assert.expect(4);
+
+        var dummy_action_name = "crash_manager_tests_dummy_action";
+        var dummy_action = function() {
+                assert.step('do_action');
+            };
+        core.action_registry.add(dummy_action_name, dummy_action);
+
+        // What we want to test is a do-action triggered by the crashManagerService
+        // the intercept feature of testUtilsMock is not fit for this, because it is too low in the hierarchy
+        const bus = new Bus();
+        bus.on('do-action', null, payload => {
+            const { action, options } = payload;
+            actionManager.doAction(action, options);
+        });
+
+        var actionManager = await createActionManager({
+            actions: [dummy_action],
+            services: {
+                crash_manager: CrashManager,
+            },
+            bus
+        });
+        actionManager.call('crash_manager', 'rpc_error', {
+            code: 200,
+            data: {
+                name: "odoo.exceptions.RedirectWarning",
+                arguments: [
+                    "crash_manager_tests_warning_modal_text",
+                    dummy_action_name,
+                    "crash_manager_tests_button_text",
+                    null,
+                ]
+            }
+        });
+        await testUtils.nextTick();
+
+        var modal_selector = 'div.modal:contains("crash_manager_tests_warning_modal_text")';
+        assert.containsOnce($, modal_selector, "Warning Modal should be opened");
+
+        await testUtils.dom.click($(modal_selector).find('button.btn-primary'));
+
+        assert.containsNone($, modal_selector, "Warning Modal should be closed");
+        assert.verifySteps(['do_action'], "Warning Modal Primary Button Action should be executed");
+        
+        actionManager.destroy();
+    });
+});
+});

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -698,6 +698,7 @@
         <script type="text/javascript" src="/web/static/tests/qweb_tests.js"></script>
         <script type="text/javascript" src="/web/static/tests/mockserver_tests.js"></script>
 
+        <script type="text/javascript" src="/web/static/tests/services/crash_manager_tests.js"></script>
         <script type="text/javascript" src="/web/static/tests/services/data_manager_tests.js"></script>
         <script type="text/javascript" src="/web/static/tests/services/notification_service_tests.js"></script>
 


### PR DESCRIPTION
Impacted versions :
- 14.0 and higher

Steps to reproduce :
```
1. generate an odoo.exceptions.RedirectWarning
2. click on the primary button
```

Current behavior :
```
1. the action (argument of the RedirectWarning) is properly executed
2. the WarningDialog is not closed
```

Expected behavior :
```
1. the action should still be properly executed
2. the WarningDialog should be closed
```

Tests :
Added a test to ensure this behavior will not be overwritten in the future.
The test is for the CrashManager service, and evaluates the following sequence :
```
Entry: CrashManager receives a odoo.exceptions.RedirectWarning (code 200) via rpc_error
Asserts:
	- The RedirectWarning modal (WarningDialog) should be opened
	 	* Upon clicking on the primary button :
	- The modal should be closed
	- The action passed as an argument of the odoo.exceptions.RedirectWarning should be executed
```

Origin :
the incorrect behavior was introduced with :
https://github.com/odoo/odoo/commit/b3d9647695065ea582e4a6b0603f3ebf9fde6976

Task ID: 2430100
