### PR TITLE
[FIX] website_rating: add website rating microdata

### DIFF
--- a/addons/website_rating/static/src/js/portal_chatter.js
+++ b/addons/website_rating/static/src/js/portal_chatter.js
@@ -125,7 +125,9 @@ PortalChatter.include({
                     });
                 }
             });
-            self.set('rating_card_values', ratingData);
+            self.set('rating_card_values', Object.assign({}, ratingData, {
+                total: result['rating_stats']['total']
+            }));
         });
     },
     /**

--- a/addons/website_rating/static/src/xml/portal_chatter.xml
+++ b/addons/website_rating/static/src/xml/portal_chatter.xml
@@ -19,6 +19,8 @@
     <t t-extend="portal.chatter_messages">
         <t t-jquery="t[t-raw='message.body']" t-operation="before">
             <t t-if="message['rating_value']">
+                <t t-set="_itemprop" t-value="'reviewRating'"/>
+                <t t-set="_itemtype" t-value="'https://schema.org/Rating'"/>
                 <t t-call="website_rating.rating_stars_static">
                     <t t-set="val" t-value="message.rating_value"/>
                 </t>
@@ -32,6 +34,16 @@
                 <t t-set="is_publisher" t-value="widget.options['is_user_publisher']"/>
                 <t t-set="rating" t-value="message.rating"/>
             </t>
+        </t>
+         <t t-jquery=".o_portal_chatter_message" t-operation="attributes">
+            <attribute name="itemprop">review</attribute>
+            <attribute name="itemscope">itemscope</attribute>
+            <attribute name="itemtype">https://schema.org/Review</attribute>
+        </t>
+        <t t-jquery="t[t-raw='message.body']" t-operation="after">
+            <meta itemprop="author" t-att-content="message.author_id[1]"/>
+            <meta itemprop="datePublished" t-att-content="message.published_date_str.split(',')[0]"/>
+            <meta itemprop="reviewBody" t-att-content="message.body"/>
         </t>
     </t>
 

--- a/addons/website_rating/static/src/xml/portal_tools.xml
+++ b/addons/website_rating/static/src/xml/portal_tools.xml
@@ -4,7 +4,18 @@
         <t t-set="val_integer" t-value="Math.floor(val)"/>
         <t t-set="val_decimal" t-value="val - val_integer"/>
         <t t-set="empty_star" t-value="5 - (val_integer+Math.ceil(val_decimal))"/>
-        <div class="o_website_rating_static" t-att-style="inline_mode ? 'display:inline' : ''" t-attf-aria-label="#{val} stars on 5" t-attf-title="#{val} stars on 5">
+        <div t-att="val and {
+            'itemprop': _itemprop or 'aggregateRating',
+            'itemscope': 'itemscope',
+            'itemtype': _itemtype or 'https://schema.org/AggregateRating'
+        }"
+        class="o_website_rating_static" t-att-style="inline_mode ? 'display:inline' : ''"
+        t-attf-aria-label="#{val} stars on 5" t-attf-title="#{val} stars on 5">
+            <t t-if="val">
+                <meta itemprop="ratingValue" t-att-content="val"/>
+                <meta itemprop="bestRating" content="5"/>
+                <meta t-if="total" itemprop="ratingCount" t-att-content="total"/>
+            </t>
             <t t-foreach="_.range(0, val_integer)" t-as="num">
                 <i class="fa fa-star" role="img"></i>
             </t>
@@ -25,6 +36,7 @@
                     <h1><t t-esc="widget.get('rating_card_values')['avg']"/></h1>
                     <t t-call="website_rating.rating_stars_static">
                         <t t-set="val" t-value="widget.get('rating_card_values')['avg'] || 0"/>
+                        <t t-set="total" t-value="widget.get('rating_card_values')['total']"/>
                     </t>
                     <t t-call="portal.chatter_message_count"/>
                 </div>


### PR DESCRIPTION
CONTEXT: [ecommerce product page with a 'Discussion and Rating'
template activated].

The Google 'rich results test' on this page gives warnings about:
- Missing field "aggregateRating"
- Missing field "review"

The goal of this PR is to override website rating templates
to add missing microdata.

task-2412588