### PR TITLE
[FIX] sale_project: use correct variable on validation

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -67,7 +67,7 @@ class ProjectTask(models.Model):
                     raise ValidationError(_(
                         'You cannot link the order item %(order_id)s - %(product_id)s to this task because it is a re-invoiced expense.',
                         order_id=task.sale_line_id.order_id.id,
-                        product_name=task.sale_line_id.product_id.name,
+                        product_id=task.sale_line_id.product_id.name,
                     ))
 
     def unlink(self):


### PR DESCRIPTION
`product_name` is correct variable name.

Followup on https://github.com/odoo/odoo/blame/755bdbeb04a769bf1fcf9157f74d6a5deb4ad48d/addons/sale_project/models/project.py#L68

Fixes #64097

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
