### PR TITLE
[FIX] Fix ir.module.category data (module_category_manufacturing_manu…

### DIFF
--- a/odoo/addons/base/data/ir_module_category_data.xml
+++ b/odoo/addons/base/data/ir_module_category_data.xml
@@ -54,7 +54,7 @@
             <field name="sequence">12</field>
         </record>
 
-        <record model="ir.module.category" id="module_category_manufacturing">
+        <record model="ir.module.category" id="module_category_manufacturing_manufacturing">
             <field name="name">Manufacturing</field>
             <field name="sequence">14</field>
         </record>


### PR DESCRIPTION
…facturing)

Description of the issue/feature this PR addresses:

- `module_category_manufacturing` has been renamed into `module_category_manufacturing_manufacturing`

Current behavior before PR:
- install a fresh database
- modules mrp* are affected to `module_category_manufacturing_manufacturing`
- category `module_category_manufacturing` has no modules

Desired behavior after PR is merged:
- the category `module_category_manufacturing` is not created






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
