### PR TITLE
[IMP] mail: add separator when messageList is empty

### DIFF
--- a/addons/mail/static/src/components/activity_box/activity_box.js
+++ b/addons/mail/static/src/components/activity_box/activity_box.js
@@ -46,7 +46,7 @@ class ActivityBox extends Component {
      * @private
      */
     _onClickTitle() {
-        this.chatter.toggleActivityBoxVisibility();
+        this.chatter.toggleActivityListVisibility();
     }
 
 }

--- a/addons/mail/static/src/components/activity_box/activity_box.xml
+++ b/addons/mail/static/src/components/activity_box/activity_box.xml
@@ -7,10 +7,10 @@
                 <a role="button" class="o_ActivityBox_title btn" t-on-click="_onClickTitle">
                     <hr class="o_ActivityBox_titleLine" />
                     <span class="o_ActivityBox_titleText">
-                        <i class="fa fa-fw" t-att-class="chatter.isActivityBoxVisible ? 'fa-caret-down' : 'fa-caret-right'"/>
+                        <i class="fa fa-fw" t-att-class="chatter.isActivityListVisible ? 'fa-caret-down' : 'fa-caret-right'"/>
                         Planned activities
                     </span>
-                    <t t-if="!chatter.isActivityBoxVisible">
+                    <t t-if="!chatter.isActivityListVisible">
                         <span class="o_ActivityBox_titleBadges">
                             <t t-if="chatter.thread.overdueActivities.length > 0">
                                 <span class="o_ActivityBox_titleBadge badge rounded-circle badge-danger">
@@ -31,7 +31,7 @@
                     </t>
                     <hr class="o_ActivityBox_titleLine" />
                 </a>
-                <t t-if="chatter.isActivityBoxVisible">
+                <t t-if="chatter.isActivityListVisible">
                     <div class="o_ActivityList">
                         <t t-foreach="chatter.thread.activities" t-as="activity" t-key="activity.localId">
                             <Activity class="o_ActivityBox_activity" activityLocalId="activity.localId"/>

--- a/addons/mail/static/src/components/chatter/chatter.js
+++ b/addons/mail/static/src/components/chatter/chatter.js
@@ -35,7 +35,6 @@ class Chatter extends Component {
                 chatter: chatter ? chatter.__state : undefined,
                 composer: thread && thread.composer,
                 thread,
-                threadActivitiesLength: thread && thread.activities.length,
             };
         }, {
             compareDepth: {

--- a/addons/mail/static/src/components/chatter/chatter.scss
+++ b/addons/mail/static/src/components/chatter/chatter.scss
@@ -19,6 +19,19 @@
     }
 }
 
+.o_Chatter_emptyMessageList_separator {
+    display: flex;
+    align-items: center;
+}
+
+.o_Chatter_emptyMessageList_separatorLine {
+    flex: 1 1 auto;
+}
+
+.o_Chatter_emptyMessageList_separatorText {
+    margin: map-get($spacers, 0) map-get($spacers, 3);
+}
+
 .o_Chatter_scrollPanel {
     overflow-y: auto;
 }
@@ -39,4 +52,13 @@
         border-left-color: $border-color;
         border-right-color: $border-color;
     }
+}
+
+.o_Chatter_emptyMessageList_separator {
+    font-weight: $font-weight-bold;
+}
+
+.o_Chatter_emptyMessageList_separatorLine {
+    border-style: dashed;
+    border-color: gray('400');
 }

--- a/addons/mail/static/src/components/chatter/chatter.xml
+++ b/addons/mail/static/src/components/chatter/chatter.xml
@@ -31,13 +31,22 @@
                             threadLocalId="chatter.thread.localId"
                         />
                     </t>
-                    <t t-if="chatter.thread and chatter.hasActivities and chatter.thread.activities.length > 0">
+                    <t t-if="chatter.isActivityBoxVisible">
                         <ActivityBox
                             class="o_Chatter_activityBox"
                             chatterLocalId="chatter.localId"
                         />
                     </t>
                     <t t-if="chatter.threadView">
+                        <t t-if="chatter.threadView.nonEmptyMessages.length === 0 and (chatter.isActivityBoxVisible or chatter.isAttachmentBoxVisible)">
+                            <div class="o_Chatter_emptyMessageList_separator">
+                                <hr class="o_Chatter_emptyMessageList_separatorLine"/>
+                                <span class="o_Chatter_emptyMessageList_separatorText">
+                                    Messages
+                                </span>
+                                <hr class="o_Chatter_emptyMessageList_separatorLine"/>
+                            </div>
+                        </t>
                         <ThreadView
                             class="o_Chatter_thread"
                             hasComposer="false"

--- a/addons/mail/static/src/components/chatter_container/chatter_container.js
+++ b/addons/mail/static/src/components/chatter_container/chatter_container.js
@@ -96,7 +96,7 @@ class ChatterContainer extends Component {
 Object.assign(ChatterContainer, {
     components,
     props: {
-        hasActivities: {
+        hasActivityBox: {
             type: Boolean,
             optional: true,
         },

--- a/addons/mail/static/src/components/chatter_topbar/chatter_topbar.xml
+++ b/addons/mail/static/src/components/chatter_topbar/chatter_topbar.xml
@@ -29,7 +29,7 @@
                             Log note
                         </button>
                     </t>
-                    <t t-if="chatter.hasActivities">
+                    <t t-if="chatter.hasActivityBox">
                         <button class="btn btn-link o_ChatterTopbar_button o_ChatterTopbar_buttonScheduleActivity" type="button" t-att-disabled="chatter.isDisabled" t-on-click="_onClickScheduleActivity">
                             <i class="fa fa-clock-o"/>
                             Schedule activity

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -776,7 +776,7 @@ function factory(dependencies) {
         }
 
         async refreshActivities() {
-            if (!this.hasActivities) {
+            if (!this.hasActivityBox) {
                 return;
             }
             if (this.isTemporary) {
@@ -1594,7 +1594,7 @@ function factory(dependencies) {
     Thread.fields = {
         /**
          * Determines the `mail.activity` that belong to `this`, assuming `this`
-         * has activities (@see hasActivities).
+         * has activities (@see hasActivityBox).
          */
         activities: one2many('mail.activity', {
             inverse: 'thread',
@@ -1697,7 +1697,7 @@ function factory(dependencies) {
         /**
          * States whether `this` has activities (`mail.activity.mixin` server side).
          */
-        hasActivities: attr({
+        hasActivityBox: attr({
             default: false,
         }),
         /**

--- a/addons/mail/static/src/widgets/form_renderer/form_renderer.js
+++ b/addons/mail/static/src/widgets/form_renderer/form_renderer.js
@@ -88,7 +88,7 @@ FormRenderer.include({
      */
     _makeChatterContainerProps() {
         return {
-            hasActivities: this.chatterFields.hasActivityIds,
+            hasActivityBox: this.chatterFields.hasActivityIds,
             hasFollowers: this.chatterFields.hasMessageFollowerIds,
             hasMessageList: this.chatterFields.hasMessageIds,
             isAttachmentBoxVisibleInitially: this.chatterFields.isAttachmentBoxVisibleInitially,


### PR DESCRIPTION
**PURPOSE:**

When scrolling down on the message list, the "today" separator becomes hidden
and it's really hard to tell between messages and activities.

**SPECIFICATIONS:**

The separator will be displayed when the messages list is empty and attachments
and/or activities displayed

Also, applied proper names to the fields of chatter as per below:

-  Field `isActivityBoxVisible` is replaced by `isActivityListVisible`
-  Field `hasActivities` is replaced by `hasActivityBox`
-  Introduce `isActivityBoxVisible` field that depends on activityBox and
   activitites

**LINKS:**
PR #64306 
Task-2243529

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
