### PR TITLE
[FIX] stock: Add index for free reservation

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -3,7 +3,7 @@
 
 from collections import Counter
 
-from odoo import _, api, fields, models
+from odoo import _, api, fields, tools, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools import OrderedSet
 from odoo.tools.float_utils import float_compare, float_is_zero, float_round
@@ -173,6 +173,15 @@ class StockMoveLine(models.Model):
                 message = _('You can only process 1.0 %s of products with unique serial number.', self.product_id.uom_id.name)
                 res['warning'] = {'title': _('Warning'), 'message': message}
         return res
+
+    def init(self):
+        if not tools.index_exists(self._cr, 'stock_move_line_free_reservation_index'):
+            self._cr.execute("""
+                CREATE INDEX stock_move_line_free_reservation_index
+                ON
+                    stock_move_line (id, company_id, product_id, lot_id, location_id, owner_id, package_id)
+                WHERE
+                    (state IS NULL OR state NOT IN ('cancel', 'done')) AND product_qty > 0""")
 
     @api.model_create_multi
     def create(self, vals_list):


### PR DESCRIPTION
Free reservation is called each time an extra quantity is
used on a move (and for each immediate transfer). It means
that the function is called many times on a database with an
inventoy activity. Also _free_reservation method do a search
on fields that are not indexed, and is slow on large database.

This index is specific to _free_reservation.
On a live database with an important stock, the queries dropped from 265ms
to 1.5ms.
