### PR TITLE
[IMP] website(_*): prevent wrong multi website access during dispatch

### DIFF
--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -129,7 +129,7 @@ class WebsiteMultiMixin(models.AbstractModel):
     def can_access_from_current_website(self, website_id=False):
         can_access = True
         for record in self:
-            if (website_id or record.website_id.id) not in (False, request.website.id):
+            if (website_id or record.website_id.id) not in (False, request.env['website'].get_current_website().id):
                 can_access = False
                 continue
         return can_access

--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -155,9 +155,6 @@ class WebsiteBlog(http.Controller):
     ], type='http', auth="public", website=True, sitemap=True)
     def blog(self, blog=None, tag=None, page=1, search=None, **opt):
         Blog = request.env['blog.blog']
-        if blog and not blog.can_access_from_current_website():
-            raise werkzeug.exceptions.NotFound()
-
         blogs = Blog.search(request.website.website_domain(), order="create_date asc, id asc")
 
         if not blog and len(blogs) == 1:
@@ -221,9 +218,6 @@ class WebsiteBlog(http.Controller):
          - 'nav_list': a dict [year][month] for archives navigation
          - 'next_post': next blog post, to direct the user towards the next interesting post
         """
-        if not blog.can_access_from_current_website():
-            raise werkzeug.exceptions.NotFound()
-
         BlogPost = request.env['blog.post']
         date_begin, date_end = post.get('date_begin'), post.get('date_end')
 

--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -169,9 +169,6 @@ class WebsiteEventController(http.Controller):
 
     @http.route(['''/event/<model("event.event"):event>/page/<path:page>'''], type='http', auth="public", website=True, sitemap=False)
     def event_page(self, event, page, **post):
-        if not event.can_access_from_current_website():
-            raise werkzeug.exceptions.NotFound()
-
         values = {
             'event': event,
         }
@@ -193,9 +190,6 @@ class WebsiteEventController(http.Controller):
 
     @http.route(['''/event/<model("event.event"):event>'''], type='http', auth="public", website=True, sitemap=True)
     def event(self, event, **post):
-        if not event.can_access_from_current_website():
-            raise werkzeug.exceptions.NotFound()
-
         if event.menu_id and event.menu_id.child_id:
             target_url = event.menu_id.child_id[0].url
         else:
@@ -206,9 +200,6 @@ class WebsiteEventController(http.Controller):
 
     @http.route(['''/event/<model("event.event"):event>/register'''], type='http', auth="public", website=True, sitemap=False)
     def event_register(self, event, **post):
-        if not event.can_access_from_current_website():
-            raise werkzeug.exceptions.NotFound()
-
         values = self._prepare_event_register_values(event, **post)
         return request.render("website_event.event_description_full", values)
 
@@ -300,9 +291,6 @@ class WebsiteEventController(http.Controller):
 
     @http.route(['/event/<model("event.event"):event>/registration/new'], type='json', auth="public", methods=['POST'], website=True)
     def registration_new(self, event, **post):
-        if not event.can_access_from_current_website():
-            raise werkzeug.exceptions.NotFound()
-
         tickets = self._process_tickets_form(event, post)
         availability_check = True
         if event.seats_limited:
@@ -398,9 +386,6 @@ class WebsiteEventController(http.Controller):
 
     @http.route(['''/event/<model("event.event"):event>/registration/confirm'''], type='http', auth="public", methods=['POST'], website=True)
     def registration_confirm(self, event, **post):
-        if not event.can_access_from_current_website():
-            raise werkzeug.exceptions.NotFound()
-
         registrations = self._process_attendees_form(event, post)
         attendees_sudo = self._create_attendees_from_registration_post(event, registrations)
 

--- a/addons/website_event_exhibitor/controllers/exhibitor.py
+++ b/addons/website_event_exhibitor/controllers/exhibitor.py
@@ -34,9 +34,6 @@ class ExhibitorController(WebsiteEventController):
         '/event/<model("event.event"):event>/exhibitor'
     ], type='http', auth="public", website=True, sitemap=False)
     def event_exhibitors(self, event, **searches):
-        if not event.can_access_from_current_website():
-            raise NotFound()
-
         return request.render(
             "website_event_exhibitor.event_exhibitors",
             self._event_exhibitors_get_values(event, **searches)
@@ -117,9 +114,6 @@ class ExhibitorController(WebsiteEventController):
     @http.route(['''/event/<model("event.event", "[('exhibitor_menu', '=', True)]"):event>/exhibitor/<model("event.sponsor", "[('event_id', '=', event.id)]"):sponsor>'''],
                 type='http', auth="public", website=True, sitemap=True)
     def event_exhibitor(self, event, sponsor, **options):
-        if not event.can_access_from_current_website():
-            raise NotFound()
-
         try:
             sponsor.check_access_rule('read')
         except exceptions.AccessError:

--- a/addons/website_event_meet/controllers/community.py
+++ b/addons/website_event_meet/controllers/community.py
@@ -35,9 +35,6 @@ class WebsiteEventMeetController(EventCommunityController):
         :param event: event for which we display the meeting rooms
         :param lang: lang id used to perform a search
         """
-        if not event.can_access_from_current_website():
-            raise Forbidden()
-
         return request.render(
             "website_event_meet.event_meet",
             self._event_meeting_rooms_get_values(event, lang=lang)
@@ -77,7 +74,7 @@ class WebsiteEventMeetController(EventCommunityController):
     @http.route("/event/<model('event.event'):event>/meeting_room_create",
                 type="http", auth="public", methods=["POST"], website=True)
     def create_meeting_room(self, event, **post):
-        if not event or not event.can_access_from_current_website() or (not event.is_published and not request.env.user.user_has_groups('base.group_user')) or not event.meeting_room_allow_creation:
+        if not event or (not event.is_published and not request.env.user.user_has_groups('base.group_user')) or not event.meeting_room_allow_creation:
             raise Forbidden()
 
         name = post.get("name")
@@ -122,7 +119,7 @@ class WebsiteEventMeetController(EventCommunityController):
         :param event: Event for which we display the meeting rooms
         :param meeting_room: Meeting Room to display
         """
-        if not event.can_access_from_current_website() or meeting_room not in event.sudo().meeting_room_ids:
+        if meeting_room not in event.sudo().meeting_room_ids:
             raise NotFound()
 
         try:

--- a/addons/website_event_meet_quiz/controllers/community.py
+++ b/addons/website_event_meet_quiz/controllers/community.py
@@ -12,9 +12,6 @@ class WebsiteEventTrackQuizMeetController(EventCommunityController):
 
     @http.route(['/event/<model("event.event"):event>/community'], type='http', auth="public", website=True, sitemap=False)
     def community(self, event, page=1, lang=None, **kwargs):
-        if not event.can_access_from_current_website():
-            raise Forbidden()
-
         # website_event_track_quiz
         values = self._get_community_leaderboard_render_values(event, kwargs.get('search'), page)
 

--- a/addons/website_event_track/controllers/event_track.py
+++ b/addons/website_event_track/controllers/event_track.py
@@ -52,9 +52,6 @@ class EventTrackController(http.Controller):
           * 'search': search string;
           * 'tags': list of tag IDs for filtering;
         """
-        if not event.can_access_from_current_website():
-            raise NotFound()
-
         return request.render(
             "website_event_track.tracks_session",
             self._event_tracks_get_values(event, tag=tag, **searches)
@@ -153,9 +150,6 @@ class EventTrackController(http.Controller):
 
     @http.route(['''/event/<model("event.event"):event>/agenda'''], type='http', auth="public", website=True, sitemap=False)
     def event_agenda(self, event, tag=None, **post):
-        if not event.can_access_from_current_website():
-            raise NotFound()
-
         event = event.with_context(tz=event.date_tz or 'UTC')
         vals = {
             'event': event,
@@ -394,16 +388,10 @@ class EventTrackController(http.Controller):
 
     @http.route(['''/event/<model("event.event"):event>/track_proposal'''], type='http', auth="public", website=True, sitemap=False)
     def event_track_proposal(self, event, **post):
-        if not event.can_access_from_current_website():
-            raise NotFound()
-
         return request.render("website_event_track.event_track_proposal", {'event': event, 'main_object': event})
 
     @http.route(['''/event/<model("event.event"):event>/track_proposal/post'''], type='http', auth="public", methods=['POST'], website=True)
     def event_track_proposal_post(self, event, **post):
-        if not event.can_access_from_current_website():
-            raise NotFound()
-
         tags = []
         for tag in event.allowed_track_tag_ids:
             if post.get('tag_' + str(tag.id)):

--- a/addons/website_forum/controllers/main.py
+++ b/addons/website_forum/controllers/main.py
@@ -90,9 +90,6 @@ class WebsiteForum(WebsiteProfile):
                  '''/forum/<model("forum.forum"):forum>/tag/<model("forum.tag"):tag>/questions/page/<int:page>''',
                  ], type='http', auth="public", website=True, sitemap=sitemap_forum)
     def questions(self, forum, tag=None, page=1, filters='all', my=None, sorting=None, search='', **post):
-        if not forum.can_access_from_current_website():
-            raise werkzeug.exceptions.NotFound()
-
         Post = request.env['forum.post']
 
         domain = [('forum_id', '=', forum.id), ('parent_id', '=', False), ('state', '=', 'active'), ('can_view', '=', True)]

--- a/addons/website_hr_recruitment/controllers/main.py
+++ b/addons/website_hr_recruitment/controllers/main.py
@@ -82,9 +82,6 @@ class WebsiteHrRecruitment(http.Controller):
 
     @http.route('''/jobs/detail/<model("hr.job"):job>''', type='http', auth="public", website=True, sitemap=True)
     def jobs_detail(self, job, **kwargs):
-        if not job.can_access_from_current_website():
-            raise NotFound()
-
         return request.render("website_hr_recruitment.detail", {
             'job': job,
             'main_object': job,
@@ -92,9 +89,6 @@ class WebsiteHrRecruitment(http.Controller):
 
     @http.route('''/jobs/apply/<model("hr.job"):job>''', type='http', auth="public", website=True, sitemap=True)
     def jobs_apply(self, job, **kwargs):
-        if not job.can_access_from_current_website():
-            raise NotFound()
-
         error = {}
         default = {}
         if 'website_hr_recruitment_error' in request.session:

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -305,9 +305,6 @@ class WebsiteSale(http.Controller):
 
     @http.route(['/shop/<model("product.template"):product>'], type='http', auth="public", website=True, sitemap=True)
     def product(self, product, category='', search='', **kwargs):
-        if not product.can_access_from_current_website():
-            raise NotFound()
-
         return request.render("website_sale.product", self._prepare_product_values(product, category, search, **kwargs))
 
     @http.route(['/shop/product/<model("product.template"):product>'], type='http', auth="public", website=True, sitemap=False)

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -453,9 +453,6 @@ class WebsiteSlides(WebsiteProfile):
         """
         Will return all necessary data to display the requested slide_channel along with a possible category.
         """
-        if not channel.can_access_from_current_website():
-            raise werkzeug.exceptions.NotFound()
-
         domain = self._get_channel_slides_base_domain(channel)
 
         pager_url = "/slides/%s" % (channel.id)


### PR DESCRIPTION
Before this commit, routes were prevented to be accessed if the route model was
not accessible from the current website, eg you couldn't access blog1 which is
set to website2 from website 1.
That would raise a 404 even from admin/editor.

This commit introduce that behavior at a lowel level in a generic way, instead
of having to write it on every route.

Note that routes without a model converter won't benefit from this.

Closes #63499
