### PR TITLE
[FIX] account: sending several invoices at one

### DIFF
--- a/addons/account/wizard/account_invoice_send.py
+++ b/addons/account/wizard/account_invoice_send.py
@@ -57,13 +57,14 @@ class AccountInvoiceSend(models.TransientModel):
     @api.onchange('is_email')
     def onchange_is_email(self):
         if self.is_email:
+            res_ids = self._context.get('active_ids')
             if not self.composer_id:
-                res_ids = self._context.get('active_ids')
                 self.composer_id = self.env['mail.compose.message'].create({
                     'composition_mode': 'comment' if len(res_ids) == 1 else 'mass_mail',
                     'template_id': self.template_id.id
                 })
             else:
+                self.composer_id.composition_mode = 'comment' if len(res_ids) == 1 else 'mass_mail'
                 self.composer_id.template_id = self.template_id.id
             self.composer_id.onchange_template_id_wrapper()
 


### PR DESCRIPTION
When sending several invoices, customers also receive those that do not
concern them.

To reproduce the error:
(Need mailcatcher)
1. Go to Invoicing
2. Select two invoices
    - Status must be "Posted"
    - Customers must be different
3. Action > Send & Print
4. Uncheck "Print", then click on "Send"
5. Repeat 2-4

Err: Each customer receives both invoices. (In some cases, a third mail
is event sent). Each customer must receive his own invoices.

The mail composer wasn't correctly configured.

OPW-2422117