### PR TITLE
[FIX] account,hr_expense: Fix unbalanced journal entry created by exp…

### DIFF
--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -447,3 +447,33 @@ class TestExpenseLinesRights(TestExpenseCommon):
             expense_line.with_user(self.user_manager).write({'account_id': self.account_expense.id})
         with self.assertRaises(UserError):
             expense_line.with_user(self.user_manager).write({'analytic_account_id': self.analytic_account.id})
+
+    def test_expenses_with_tax_and_lockdate(self):
+        ''' Test creating a journal entry for multiple expenses using taxes. A lock date is set in order to trigger
+        the recomputation of the taxes base amount.
+        '''
+        self.env.company.tax_lock_date = '2020-02-01'
+
+        expense = self.env['hr.expense.sheet'].create({
+            'name': 'Expense for John Smith',
+            'employee_id': self.employee.id,
+            'accounting_date': '2020-01-01'
+        })
+
+        for i in range(2):
+            expense_line = self.env['hr.expense'].create({
+                'name': 'Car Travel Expenses',
+                'employee_id': self.employee.id,
+                'product_id': self.product_expense.id,
+                'unit_amount': 350.00,
+                'tax_ids': [(6, 0, [self.tax.id])],
+                'sheet_id': expense.id,
+                'analytic_account_id': self.analytic_account.id,
+            })
+            expense_line._onchange_product_id()
+
+        expense.action_submit_sheet()
+        expense.approve_expense_sheets()
+
+        # Assert not "Cannot create unbalanced journal entry" error.
+        expense.action_sheet_move_create()


### PR DESCRIPTION
…enses

Suppose the journal entry contains 2 identical expenses using the same tax in a locked period. Your journal entry looks like:
- exp1:		amount
- tax_exp1:	tax_amount
- total:		- amount - tax_amount
- exp2:		amount
- tax_exp2:	tax_amount
- total:		- amount - tax_amount

This is because the expense are creating manually their tax lines.
When posting, the "Cannot create unbalanced journal entry" is raised because the date is automatically set to the next available date after the lock date and then, _onchange_currency is triggered on the journal entry.
Because tax_base_amount is expressed in the company's currency and the rate has changed, _recompute_tax_lines is called with recompute_tax_base_amount=True.
The tricky part is the journal entry always group tax lines together as much as possible but don't update the tax amount due to the recompute_tax_base_amount parameter.
Before this commit, one of the tax lines was removed and the other wasn't updated leading to the unbalanced journal entry. After this commit, there is no modification except the tax_base_amount that is made with the recompute_tax_base_amount parameter.

co-author: elmeriniemela (https://github.com/odoo/odoo/pull/63985)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
