### PR TITLE
[FIX] web_editor: fix steps snippet line removed when change icon bg-col

### DIFF
--- a/addons/web_editor/static/src/js/editor/summernote.js
+++ b/addons/web_editor/static/src/js/editor/summernote.js
@@ -2279,7 +2279,8 @@ $.summernote.pluginEvents.applyFont = function (event, editor, layoutInfo, color
     }
 
     // remove node without attributes (move content), and merge the same nodes
-     var className2, style, style2;
+     var className2, style, style2, hasBefore, hasAfter;
+     var noContent = ['none', null, undefined];
      for (i=0; i<nodes.length; i++) {
       node = nodes[i];
 
@@ -2298,8 +2299,10 @@ $.summernote.pluginEvents.applyFont = function (event, editor, layoutInfo, color
       $font = $(node);
       className = dom.orderClass(node);
       style = dom.orderStyle(node);
+      hasBefore = noContent.indexOf(window.getComputedStyle(node, '::before').content) === -1;
+      hasAfter = noContent.indexOf(window.getComputedStyle(node, '::after').content) === -1;
 
-      if (!className && !style) {
+      if (!className && !style && !hasBefore && !hasAfter) {
         remove(node, node.parentNode);
         continue;
       }


### PR DESCRIPTION
Previously, when changing the background-color of an icon in the
s_process_steps snippet, the line that goes through the snippet would
disappear from that block. This was caused by our font-application code
attempting to remove extraneous DOM nodes when changing a font color or
backrgound-color, but not considering elements with a ::before or
::after pseudoelement has having content, and subsequently removing
them.

opw-2423785