### PR TITLE
[FIX] hr_fleet: mobility card on employee not repercuted on vehicle

### DIFF
--- a/addons/hr_fleet/models/fleet_vehicle.py
+++ b/addons/hr_fleet/models/fleet_vehicle.py
@@ -9,7 +9,7 @@ class FleetVehicle(models.Model):
 
     mobility_card = fields.Char(compute='_compute_mobility_card', store=True)
 
-    @api.depends('driver_id')
+    @api.depends('driver_id', 'driver_id.user_ids.employee_id.mobility_card')
     def _compute_mobility_card(self):
         for vehicle in self:
             vehicle.mobility_card = vehicle.driver_id.user_ids[:1].employee_id.mobility_card


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a partner P linked to an employee E and a vehicle V
- Let's change the mobility card of E with 12345

Bug:

The mobility card on V was not changed.

opw:2431316