### PR TITLE
[FIX] pos_hr: prevent unauthorized login with unexisting badge id

### DIFF
--- a/addons/pos_hr/static/src/js/screens.js
+++ b/addons/pos_hr/static/src/js/screens.js
@@ -90,8 +90,10 @@ var LoginScreenWidget = ScreenWidget.extend({
      */
     barcode_cashier_action: function(code) {
         var self = this;
-        return this._super(code).then(function () {
-            self.unlock_screen();
+        return this._super(code).then(function (unlock) {
+            if (unlock) {
+                self.unlock_screen();
+            }
         });
     },
 


### PR DESCRIPTION
STEPS:
* Activate in the POS setting the option "Login with Employees"
* Scan any cashier barcode (e.g. generate one for another employee that is not
specified in pos.config)

BEFORE: you are logged in as default user

AFTER: you stay in login page and see error message

WHY: promise argument was ignored

https://github.com/odoo/odoo/blob/6b6e4a8fb7665370ad7bed13c2814051779bf1bc/addons/pos_hr/static/src/js/screens.js#L31
https://github.com/odoo/odoo/blob/6b6e4a8fb7665370ad7bed13c2814051779bf1bc/addons/pos_hr/static/src/js/screens.js#L38

---

opw-2422957

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
