### PR TITLE
[FIX] account: set payment method properly when creating a new payment directly from the batch payment

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -337,6 +337,10 @@ class AccountPayment(models.Model):
         ''' Compute the 'payment_method_id' field.
         This field is not computed in '_compute_payment_method_fields' because it's a stored editable one.
         '''
+        if self._context.get('default_payment_method_id'):
+            self.write({'payment_method_id': self._context['default_payment_method_id']})
+            return
+
         for pay in self:
             if pay.payment_type == 'inbound':
                 available_payment_methods = pay.journal_id.inbound_payment_method_ids


### PR DESCRIPTION
Before this, when creating a batch payment and making directly a payment by clicking "create" in the o2m widget, this payment used the default payment method from the journal. So, the payment method was sometimes different between the batch and the payment, causing a constraint to fail when saving the batch.

This buggy behavior was introduced by the payments refactoring: payment_method_id is now an editable computed field, and it ignored the default value passed in context.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
