### PR TITLE
[FIX] point_of_sale: no unecessary customer display update


### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -2187,7 +2187,9 @@ exports.Paymentline = Backbone.Model.extend({
     set_amount: function(value){
         this.order.assert_editable();
         this.amount = round_di(parseFloat(value) || 0, this.pos.currency.decimals);
-        this.pos.send_current_order_to_customer_facing_display();
+        if (this.pos.config.iface_customer_facing_display) {
+            this.pos.send_current_order_to_customer_facing_display();
+        }
         this.trigger('change',this);
     },
     // returns the amount of money on this paymentline


### PR DESCRIPTION

In b72b08cf090a some update of customer display were removed, but when
the payment amount is updated, we would compute the customer display
even when there is no display.

opw-2412780
