### PR TITLE
[IMP] doc: improve translations documentation for QWeb templates

### DIFF
--- a/addons/gamification/views/badge.xml
+++ b/addons/gamification/views/badge.xml
@@ -190,7 +190,13 @@
                                     <t t-if="record.comment.raw_value">
                                         <p class="o_kanban_record_subtitle"><em><field name="comment"/></em></p>
                                     </t>
-                                    <p>Granted by <a type="open"><field name="create_uid" /></a> the <t t-esc="moment(record.create_date.raw_value).format('L')" /></p>
+                                    <p>
+                                        <t t-set="trans_text">Granted by %%(user)s the %%(date)s</t>
+                                        <t t-set="trans_msg_parts" t-value="trans_text.replace('%%(date)s', moment(record.create_date.raw_value).format('L')).split('%%(user)s')"/>
+                                        <t t-esc="trans_msg_parts[0]"/>
+                                        <a type="open"><field name="create_uid" /></a>
+                                        <t t-esc="trans_msg_parts[1]"/>
+                                    </p>
                                 </div>
                             </div>
                         </div>

--- a/addons/mail/data/mail_templates.xml
+++ b/addons/mail/data/mail_templates.xml
@@ -315,8 +315,14 @@
 
         <template id="message_origin_link">
             <p>
-                <t t-if="edit">This <t t-esc="self.env['ir.model']._get(self._name).name.lower()"/> has been modified from:</t>
-                <t t-else="">This <t t-esc="self.env['ir.model']._get(self._name).name.lower()"/> has been created from:</t>
+                <t t-if="edit">
+                    <t t-set="trans_text">This %s has been modified from:</t>
+                    <t t-esc="trans_text % self.env['ir.model']._get(self._name).name.lower()"/>
+                </t>
+                <t t-else="">
+                    <t t-set="trans_text">This %s has been created from:</t>
+                    <t t-esc="trans_text % self.env['ir.model']._get(self._name).name.lower()"/>
+                </t>
                 <t t-foreach="origin" t-as="o">
                     <a href="#" t-att-data-oe-model="o._name" t-att-data-oe-id="o.id"> <t t-esc="o.display_name"/></a><span t-if="origin.ids[-1:] != o.ids">, </span>
                 </t>
@@ -326,12 +332,21 @@
         <!-- Mail gateway templates -->
         <template id="mail_bounce_catchall">
 <div>
-    <p>Hello <t t-esc="message['email_from']"/>,</p>
-    <p>The email sent to <t t-esc="message['to']"/> cannot be processed. This address
-    is used to collect replies and should not be used to directly contact <t t-esc="res_company.name"/>.</p>
+    <p>
+        <t t-set="trans_text">Hello %s,</t>
+        <t t-esc="trans_text % message['email_from']"/>
+    </p>
+    <p>
+        <t t-set="trans_text">The email sent to %%(address)s cannot be processed. This address
+    is used to collect replies and should not be used to directly contact %%(company)s.</t>
+        <t t-esc="trans_text % {'address':message['to'], 'company':res_company.name}"/>
+    </p>
     <p>Please contact us instead using <a t-att-href="'mailto:%s' % res_company.email"><t t-esc="res_company.email"/></a></p>
     <p>Regards,</p>
-    <p>The <t t-esc="res_company.name"/> team.</p>
+    <p>
+        <t t-set="trans_text">The %s team.</t>
+        <t t-esc="trans_text % res_company.name"/>
+    </p>
 </div>
 <blockquote><t t-esc="message['body']"/></blockquote>
         </template>
@@ -345,7 +360,10 @@
         <!-- Channel and moderation related data -->
         <template id="mail_channel_notify_moderation">
 <div>
-    <p>Hello <t t-esc='record.name'/></p>
+    <p>
+        <t t-set="trans_text">Hello %s,</t>
+        <t t-esc="trans_text % record.name"/>
+    </p>
     <p>You have messages to moderate, please go for the proceedings.</p><br/><br/>
     <div style="text-align: center;">
         <a href="/web#action=mail.action_discuss&amp;active_id=mail.box_moderation" style="background-color: #1abc9c; padding: 20px; text-decoration: none; color: #fff; border-radius: 5px; font-size: 16px;" class="o_default_snippet_text">Moderate Messages</a>
@@ -357,8 +375,14 @@
 
        <template id="mail_channel_send_guidelines">
 <div>
-<p>Hello <t t-esc="partner.name"/>,</p>
-<p>Please find below the guidelines of the <t t-esc="channel.name"/> channel.</p>
+<p>
+    <t t-set="trans_text">Hello %s,</t>
+    <t t-esc="trans_text % partner.name"/>
+</p>
+<p>
+    <t t-set="trans_text">Please find below the guidelines of the %s channel.</t>
+    <t t-esc="trans_text % channel.name"/>
+</p>
 <p>
 <t t-esc="channel.moderation_guidelines_msg"/>
 </p>

--- a/doc/reference/translations.rst
+++ b/doc/reference/translations.rst
@@ -55,6 +55,9 @@ Odoo automatically exports translatable strings from "data"-type content:
 * in non-QWeb views, all text nodes are exported as well as the content of
   the ``string``, ``help``, ``sum``, ``confirm`` and ``placeholder``
   attributes
+
+.. _implicitly_translated_attributes:
+
 * QWeb templates (both server-side and client-side), all text nodes are
   exported except inside ``t-translation="off"`` blocks, the content of the
   ``title``, ``alt``, ``label`` and ``placeholder`` attributes are also
@@ -208,6 +211,45 @@ or **do** evaluate dynamically the translatable content::
         missing_error: _lt('Missing Record'),
     };
 
+
+QWeb
+^^^^
+QWeb does not allow for the use of the "_(...)" or "_t(...)" mechanism in
+expressions.
+
+**Don't** put parameters in a text node beside its value.
+
+The following is wrong because some language might need to be
+grammatically organized differently around the value::
+
+    <span><t t-esc="var"/> Some text</span>
+
+The following is wrong because the context is lost for the translator::
+
+    <span>Prefix <t t-esc="var"/> Suffix</span>
+
+The following is wrong because the attribute is not one of the
+`implicitly translated attributes <#implicitly-translated-attributes>`_::
+
+    <span><t t-esc="'Prefix %s Suffix' % var"/></span>
+
+
+**Do** put the translatable pattern in a text node then combine it::
+
+    <t t-set="trans_text">You have %s pending messages</t>
+    <t t-esc="trans_text % var"/>
+
+or for messages with named parameters (do not forget to escape % as %%)::
+
+    <t t-set="trans_text">You have %%(current)s items but only %%(maximum)s are allowed.</t>
+    <t t-esc="trans_text % {'current': current, 'maximum': maximum}"/>
+
+This way the text to translate is:
+
+* inside a text node and thus correctly identified as translatable text
+* the full context is made available to the translator
+* the technical formatting of the variable(s) does not pollute the
+  translation messages
 
 .. _PO File: https://en.wikipedia.org/wiki/Gettext#Translating
 .. _msginit: https://www.gnu.org/software/gettext/manual/gettext.html#Creating

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -29,7 +29,7 @@ from odoo.tools import config, ConstantMapping, get_diff, pycompat, apply_inheri
 from odoo.tools.convert import _fix_multiple_roots
 from odoo.tools.json import scriptsafe as json_scriptsafe
 from odoo.tools import safe_eval
-from odoo.tools.view_validation import valid_view, get_variable_names, get_domain_identifiers, get_dict_asts
+from odoo.tools.view_validation import valid_view, get_variable_names, get_domain_identifiers, get_dict_asts, check_esc_message
 from odoo.tools.translate import xml_translate, TRANSLATED_ATTRS
 from odoo.tools.image import image_data_uri
 from odoo.models import check_method_name
@@ -386,6 +386,8 @@ actual arch.
                 view._valid_inheritance(view_arch)
                 view_def = view.read_combined(['arch'])
                 view_arch_utf8 = view_def['arch']
+                check_esc_message(view_arch, view.xml_id if view.xml_id else view.name, not self.env.su)
+                # TODO find a correct condition to detect interactive mode
                 if view.type == 'qweb':
                     continue
                 view_doc = etree.fromstring(view_arch_utf8)


### PR DESCRIPTION
Before this commit the documentation did not describe the way to produce
translated messages with variables within QWeb templates

After this commit the documentation contains a new section that
describes how to produce translated messages with variables within QWeb
templates

task-2428799

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
