### PR TITLE
[FIX] web_editor: fix icon color preview not getting reset correctly

### DIFF
--- a/addons/web_editor/static/src/js/editor/rte.summernote.js
+++ b/addons/web_editor/static/src/js/editor/rte.summernote.js
@@ -63,7 +63,12 @@ renderer.createPalette = function ($container, options) {
 
                 const r = range.create();
                 const targetNode = r.sc;
-                const targetElement = targetNode.nodeType === Node.ELEMENT_NODE ? targetNode : targetNode.parentNode;
+                let targetElement;
+                if (targetNode.nodeType === Node.ELEMENT_NODE) {
+                    targetElement = targetNode.childNodes[r.so] || targetNode;
+                } else {
+                    targetElement = targetNode.parentNode;
+                }
                 colorpicker = new ColorPaletteWidget(parent, {
                     excluded: ['transparent_grayscale'],
                     $editable: rte.Class.prototype.editable(), // Our parent is the root widget, we can't retrieve the editable section from it...


### PR DESCRIPTION
Previously, hovering a color or background color while having an icon
selected would preview the color, but upon leaving that color, it would
be reset to the equivalent (text color or background color) from its
parent instead. This was caused by the fact that the font-color code
created a range from the current selection, and used its starting
container to read the currently selected color, but because icons
typically have no content, the range start container was set to the
icon's container instead of the icon itself, causing the initial color
to be considered that of the container, and would reset to that color
instead of the icon's own initial color

This commit fixes that by setting the target node as the first node of
the range when possible (which is also what the font-applying code does)
