### PR TITLE
[FIX] account/purchase: onchange on purchase create bill does not work

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -911,7 +911,8 @@ class AccountMove(models.Model):
             # Recompute amls: update existing line or create new one for each payment term.
             new_terms_lines = self.env['account.move.line']
             for date_maturity, balance, amount_currency in to_compute:
-                if self.journal_id.company_id.currency_id.is_zero(balance) and len(to_compute) > 1:
+                currency = self.journal_id.company_id.currency_id
+                if currency and currency.is_zero(balance) and len(to_compute) > 1:
                     continue
 
                 if existing_terms_lines_index < len(existing_terms_lines):

--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -15,7 +15,7 @@ class AccountMove(models.Model):
         states={'draft': [('readonly', False)]},
         string='Purchase Order',
         help="Auto-complete from a past purchase order.")
-    
+
     def _get_invoice_reference(self):
         self.ensure_one()
         vendor_refs = [ref for ref in set(self.line_ids.mapped('purchase_line_id.order_id.partner_ref')) if ref]
@@ -48,6 +48,7 @@ class AccountMove(models.Model):
         self.fiscal_position_id = self.purchase_id.fiscal_position_id
         self.invoice_payment_term_id = self.purchase_id.payment_term_id
         self.currency_id = self.purchase_id.currency_id
+        self.company_id = self.purchase_id.company_id
 
         # Copy purchase lines.
         po_lines = self.purchase_id.order_line - self.line_ids.mapped('purchase_line_id')


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
In case the currency is not set during onchange all currency actions will throw a traceback

**Current behavior before PR:**
Traceback Fun
```
Odoo Server Error
Traceback (most recent call last):
  File ".../odoo/models.py", line 5099, in ensure_one
    _id, = self._ids
ValueError: not enough values to unpack (expected 1, got 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File ".../odoo/http.py", line 624, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File ".../odoo/http.py", line 310, in _handle_exception
    raise pycompat.reraise(type(exception), exception, sys.exc_info()[2])
  File ".../odoo/tools/pycompat.py", line 14, in reraise
    raise value
  File ".../odoo/http.py", line 669, in dispatch
    result = self._call_function(**self.params)
  File ".../odoo/http.py", line 350, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File ".../odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File ".../odoo/http.py", line 339, in checked_call
    result = self.endpoint(*a, **kw)
  File ".../odoo/http.py", line 915, in __call__
    return self.method(*args, **kw)
  File ".../odoo/http.py", line 515, in response_wrap
    response = f(*args, **kw)
  File ".../addons/web/controllers/main.py", line 1327, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File ".../addons/web/controllers/main.py", line 1319, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File ".../odoo/api.py", line 387, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File ".../odoo/api.py", line 374, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File ".../addons/account/models/account_move.py", line 1014, in onchange
    return super(AccountMove, self.with_context(recursive_onchanges=False)).onchange(values, field_name, field_onchange)
  File ".../odoo/models.py", line 6247, in onchange
    record._onchange_eval(name, field_onchange[name], result)
  File ".../odoo/models.py", line 6026, in _onchange_eval
    method_res = method(self)
  File ".../addons/purchase/models/account_invoice.py", line 75, in _onchange_purchase_auto_complete
    self._onchange_currency()
  File ".../addons/account/models/account_move.py", line 389, in _onchange_currency
    self._recompute_dynamic_lines(recompute_tax_base_amount=True)
  File ".../addons/account/models/account_move.py", line 1000, in _recompute_dynamic_lines
    invoice._recompute_payment_terms_lines()
  File ".../addons/account/models/account_move.py", line 962, in _recompute_payment_terms_lines
    new_terms_lines = _compute_diff_payment_terms_lines(self, existing_terms_lines, account, to_compute)
  File ".../addons/account/models/account_move.py", line 914, in _compute_diff_payment_terms_lines
    if self.journal_id.company_id.currency_id.is_zero(balance) and len(to_compute) > 1:
  File ".../odoo/addons/base/models/res_currency.py", line 171, in is_zero
    self.ensure_one()
  File ".../odoo/models.py", line 5102, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: res.currency()

```

**Desired behavior after PR is merged:**
Preparation of not yet saved purchase invoice works as expected



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
