### PR TITLE
[IMP] account: warn msg decimal accuracy on modification

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -13632,8 +13632,7 @@ msgstr ""
 #, python-format
 msgid ""
 "You cannot reduce the number of decimal places of a currency which has "
-"already been used to make accounting entries. If you really need to do that,"
-" please contact tech support."
+"already been used to make accounting entries."
 msgstr ""
 
 #. module: account

--- a/addons/account/models/res_currency.py
+++ b/addons/account/models/res_currency.py
@@ -24,7 +24,7 @@ class ResCurrency(models.Model):
             rounding_val = vals['rounding']
             for record in self:
                 if (rounding_val > record.rounding or rounding_val == 0) and record._has_accounting_entries():
-                    raise UserError(_("You cannot reduce the number of decimal places of a currency which has already been used to make accounting entries. If you really need to do that, please contact tech support."))
+                    raise UserError(_("You cannot reduce the number of decimal places of a currency which has already been used to make accounting entries."))
 
         return super(ResCurrency, self).write(vals)
 

--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -26056,6 +26056,13 @@ msgid ""
 msgstr ""
 
 #. module: base
+#: model_terms:ir.ui.view,arch_db:base.view_currency_form
+msgid ""
+"You won't be able to reduce the number of decimal places of a currency which"
+" has already been used to make accounting entries."
+msgstr ""
+
+#. module: base
 #: code:addons/base/models/ir_mail_server.py:0
 #, python-format
 msgid ""

--- a/odoo/addons/base/views/res_currency_views.xml
+++ b/odoo/addons/base/views/res_currency_views.xml
@@ -134,6 +134,10 @@
                             </group>
                         </group>
 
+                        <div class="oe_edit_only alert alert-info" role="alert">
+                            You won't be able to reduce the number of decimal places of a currency which has already been used to make accounting entries. 
+                        </div>
+
                         <group groups="base.group_no_one">
                             <group string="Price Accuracy">
                                 <field name="rounding"/>


### PR DESCRIPTION
commit 31e1322b40ab33bf81d4c000f2b2a3f3eb8d0958 is allowing the
customer to increase is decimal accuracy for currency without
consequences but triggering issue upon lowering it if entries
already exist.
+ Remove the redirection to the support.

Let's ensure that the behavior is consistent and the users are
warned on first modification. To do so, adding an alert msg
in addition of the blocking message in case of lowering the decimal
accuracy after already creating accounting entries.

opw-2428857

