### PR TITLE
[Fix] Use Bearer Authorization header instead of the URI query-string parameter for Oauth2 Access Tokens

### DIFF
--- a/addons/auth_oauth/models/res_users.py
+++ b/addons/auth_oauth/models/res_users.py
@@ -25,7 +25,7 @@ class ResUsers(models.Model):
 
     @api.model
     def _auth_oauth_rpc(self, endpoint, access_token):
-        return requests.get(endpoint, params={'access_token': access_token}).json()
+        return requests.get(endpoint, headers={'Authorization': 'Bearer %s' % access_token}).json()
 
     @api.model
     def _auth_oauth_validate(self, provider, access_token):


### PR DESCRIPTION

Description of the issue/feature this PR addresses:

fixes issue odoo/odoo#63963
closes PR #63970

Current behavior before PR:
- Access Tokens are logged
- URI query-string parameter is used as a placement for the Access Tokens sent to the Oauth2 provider API endpoints

Desired behavior after PR is merged:
- Access Tokens NOT logged
- Bearer Authorization header used instead of the URI query-string parameter


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
