### PR TITLE
[IMP] mail: notify user when activity is assigned to a user without access to the document

### DIFF
--- a/addons/mail/static/src/components/activity/activity.xml
+++ b/addons/mail/static/src/components/activity/activity.xml
@@ -48,8 +48,14 @@
                             </div>
                         </t>
                         <a class="o_Activity_detailsButton btn btn-link" t-on-click="_onClickDetailsButton" role="button">
-                            <i class="fa fa-info-circle" role="img" title="Info"/>
+                            <t t-if="activity.assigneeCanAccess ">
+                                <i class="fa fa-info-circle" role="img" title="Info"/>
+                            </t>
+                            <t t-else="">
+                                <i class="fa fa-info-circle" style="color:red" role="img" title="Info"/>
+                            </t>
                         </a>
+
                     </div>
 
                     <t t-if="state.areDetailsVisible">
@@ -76,6 +82,11 @@
                                     <dd class="o_Activity_detailsAssignation">
                                         <img class="o_Activity_detailsUserAvatar o_Activity_detailsAssignationUserAvatar" t-attf-src="/web/image/res.users/{{ activity.assignee.id }}/image_128" t-att-title="activity.assignee.nameOrDisplayName" t-att-alt="activity.assignee.nameOrDisplayName"/>
                                         <t t-esc="activity.assignee.nameOrDisplayName"/>
+                                        <t t-if="assigneeCanAccess == False">
+                                            <div class="text-danger">
+                                                Warning: This user does not have access to this document
+                                            </div>
+                                        </t>
                                     </dd>
                                 </t>
                                 <dt>Due on</dt>

--- a/addons/mail/static/src/models/activity/activity.js
+++ b/addons/mail/static/src/models/activity/activity.js
@@ -37,6 +37,9 @@ function factory(dependencies) {
          */
         static convertData(data) {
             const data2 = {};
+            if ('assignee_can_access' in data) {
+                data2.assigneeCanAccess = data.assignee_can_access
+            }
             if ('activity_category' in data) {
                 data2.category = data.activity_category;
             }
@@ -283,6 +286,7 @@ function factory(dependencies) {
         creator: many2one('mail.user'),
         dateCreate: attr(),
         dateDeadline: attr(),
+        assigneeCanAccess: attr(),
         force_next: attr({
             default: false,
         }),

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -112,7 +112,11 @@
         <field name="arch" type="xml">
             <form string="Log an Activity" create="false">
                 <sheet string="Activity">
+                    <div class="alert alert-info text-center" role="alert" attrs="{'invisible' :[('assignee_can_access','=',True)]}">
+                        The assigned user does not have access to this document.
+                    </div>
                     <group invisible="1">
+                        <field name="assignee_can_access" invisible="1" />
                         <field name="activity_category" invisible="1" />
                         <field name="res_model" invisible="1"/>
                         <field name="res_model_id" invisible="1"/>


### PR DESCRIPTION
Before this commit, when manually creating or modifying an activity assigned to a user without proper access to the document,
an error was raised to the user (the one who creates or modifies the activity).

This commit removes this check and on the other hand creates alert messages informing the user of the issue both in the create/edit view and in the chatter.

The "_check_assignation_access method" located in the mail_activity model has been refactored and renamed in order to allow for the computation of a field allowing to display the alert messages, the method only assignes the value False to this field and does not raise an error as this is not the desired behaviour (we want the user to be still able to create/modify the activity and in the same time notify them in the view and chatter), for the same reason the assignee access right checks have been removed when a user wants to create or modify an activity.

Task-1904288

Signed-off-by: nounoubensebia <neb@odoo.com>

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
