### PR TITLE
[WIP][FIX] base: merge pdfs with pikepdf

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,8 +18,7 @@ Jinja2==2.10.1; python_version < '3.8'
 # bullseye version, focal patched 2.10
 Jinja2==2.11.2; python_version >= '3.8'
 libsass==0.17.0
-lxml==3.7.1 ; sys_platform != 'win32' and python_version < '3.7'
-lxml==4.3.2 ; sys_platform != 'win32' and python_version == '3.7'
+lxml==4.3.2 ; sys_platform != 'win32' and python_version <= '3.7'
 lxml==4.6.1 ; sys_platform != 'win32' and python_version > '3.7'
 lxml ; sys_platform == 'win32'
 Mako==1.0.7
@@ -27,9 +26,9 @@ MarkupSafe==1.1.0
 num2words==0.5.6
 ofxparse==0.19
 passlib==1.7.1
-Pillow==5.4.1 ; python_version <= '3.7' and sys_platform != 'win32'
+pikepdf==1.19.0
 Pillow==6.1.0 ; python_version <= '3.7' and sys_platform == 'win32'
-Pillow==8.0.1 ; python_version > '3.7'
+Pillow==8.0.1 ; python_version > '3.7' or sys_platform != 'win32'
 polib==1.1.0
 psutil==5.6.6
 psycopg2==2.7.7; sys_platform != 'win32' and python_version < '3.8'


### PR DESCRIPTION
PyPDF2 has been unmaintained for years and is no longer receiving
bugfixes. It cannot read vendor bills that customers get from suppliers
because of encryption, lack of fault-tolerance for deviations from the
PDF spec and bugs. pikepdf is actively maintained and much more
fault-tolerant, and does not have these issues.

It's possible to upload PDF's PyPDF2 can't read by uploading them
through the Documents app and then creating bills from them. This then
results in exceptions when attempting to print multiple original vendor
bills. This fix uses pikepdf instead of PyPDF2 when combining PDF's,
which causes this issue to disappear.

pikepdf has been pinned to 1.19.0 for maximum compatibility with Debian
bullseye and Ubuntu focal. bullseye uses pikepdf 1.17.3, but it has a
pybind11 compatibility issue, for which a fix was backported from 1.19:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=975202#10 . focal uses
pikepdf 1.10.3. It's not impacted by the pybind11 issue because that
occurs since pybind11 2.6, and focal has 2.4. Finally, the
latest Fedora is on 1.19.3. Together this means that while the pin is
on 1.19.0, no features introduced after 1.10.3 should
be used.

Related tickets: 2359929, 2389679, 2412497