### PR TITLE
[FIX] core: compute editable field with a default should not recompute

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -755,19 +755,9 @@ class MassMailing(models.Model):
     # ------------------------------------------------------
 
     def _get_default_mailing_domain(self):
-        default_mailing_domain = self.default_get(['mailing_domain']).get('mailing_domain')
+        mailing_domain = []
         if self.mailing_model_name == 'mailing.list' and self.contact_list_ids:
             mailing_domain = [('list_ids', 'in', self.contact_list_ids.ids)]
-        elif default_mailing_domain:
-            default_mailing_domain = literal_eval(default_mailing_domain) if isinstance(default_mailing_domain, str) else default_mailing_domain
-            try:
-                self.env[self.mailing_model_real].search(default_mailing_domain, limit=1)
-            except:
-                mailing_domain = []
-            else:
-                mailing_domain = default_mailing_domain
-        else:
-            mailing_domain = []
 
         if self.mailing_type == 'mail' and 'is_blacklisted' in self.env[self.mailing_model_name]._fields:
             mailing_domain = expression.AND([[('is_blacklisted', '=', False)], mailing_domain])

--- a/addons/mass_mailing/tests/test_mailing_internals.py
+++ b/addons/mass_mailing/tests/test_mailing_internals.py
@@ -117,7 +117,7 @@ class TestMassMailValues(MassMailCommon):
         ))
         self.assertEqual(
             literal_eval(mailing_form.mailing_domain),
-            ['&', ('is_blacklisted', '=', False), ('email', 'ilike', 'test.example.com')]
+            [('email', 'ilike', 'test.example.com')],
         )
         self.assertEqual(mailing_form.mailing_model_real, 'res.partner')
 

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -741,7 +741,7 @@ class Task(models.Model):
             task.repeat_show_dow = task.recurring_task and task.repeat_unit == 'week'
             task.repeat_show_month = task.recurring_task and task.repeat_unit == 'year'
 
-    @api.depends('recurring_task', 'repeat_unit')
+    @api.depends('recurring_task')
     def _compute_repeat(self):
         rec_fields = self._get_recurrence_fields()
         defaults = self.default_get(rec_fields)

--- a/odoo/addons/test_new_api/tests/test_onchange.py
+++ b/odoo/addons/test_new_api/tests/test_onchange.py
@@ -497,13 +497,13 @@ class TestOnChange(SavepointCaseWithUserDemo):
 
         self.env.cache.invalidate()
         Message = self.env['test_new_api.related']
-        result = Message.onchange(value, ['message', 'message_name', 'message_currency'], field_onchange)
+        result = Message.onchange(value, 'message', field_onchange)
 
         self.assertEqual(result['value'], onchange_result)
 
         self.env.cache.invalidate()
         Message = self.env(user=self.user_demo.id)['test_new_api.related']
-        result = Message.onchange(value, ['message', 'message_name', 'message_currency'], field_onchange)
+        result = Message.onchange(value, 'message', field_onchange)
 
         self.assertEqual(result['value'], onchange_result)
 
@@ -741,6 +741,16 @@ class TestComputeOnchange(common.TransactionCase):
         form.foo = "foo6"
         self.assertEqual(form.bar, "foo6r")
         self.assertEqual(form.baz, "baz5")
+
+    def test_onchange_default(self):
+        form = common.Form(self.env['test_new_api.compute.onchange'].with_context(
+            default_active=True, default_foo="foo", default_baz="baz",
+        ))
+        # 'baz' is computed editable, so when given a default value it should
+        # 'not be recomputed, even if a dependency also has a default value
+        self.assertEqual(form.foo, "foo")
+        self.assertEqual(form.bar, "foor")
+        self.assertEqual(form.baz, "baz")
 
     def test_onchange_once(self):
         """ Modifies `foo` field which will trigger an onchange method and

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6208,16 +6208,10 @@ Fields:
         todo = list(unique(itertools.chain(names, nametree))) if first_call else list(names)
         done = set()
 
-        # dummy assignment: trigger invalidations on the record
-        for name in todo:
-            if name == 'id':
-                continue
-            value = record[name]
-            field = self._fields[name]
-            if field.type == 'many2one' and field.delegate and not value:
-                # do not nullify all fields of parent record for new records
-                continue
-            record[name] = value
+        # mark fields to do as modified to trigger recomputations
+        protected = [self._fields[name] for name in names]
+        with self.env.protecting(protected, record):
+            record.modified(todo)
 
         result = {'warnings': OrderedSet()}
 


### PR DESCRIPTION
Consider a model with a field F and a computed editable field G that
depends on F.  Assume we open a form view, and both F and G have a
default value.  The first onchange should return F and G with their
respective default values.  In other words, the field G should not be
recomputed even if its dependency F was assigned a default value.

The use-case that showed the issue is batch payments.  When adding a new
payment in the one2many field of a batch, the new payment should use the
batch's payment method by default.  The default value for the payment's
method is assigned by context on the one2many field in the view.  Before
this patch, the new payment's method was given by the computation of the
field, and its default value was ignored.

Side note: another test was fixed, but that's because the test was not
consistent with the way Odoo 14.0 manages defaults and onchanges.