### PR TITLE
[FIX] account: compute composition mode before changing template

### DIFF
--- a/addons/account/wizard/account_invoice_send.py
+++ b/addons/account/wizard/account_invoice_send.py
@@ -65,6 +65,7 @@ class AccountInvoiceSend(models.TransientModel):
                 })
             else:
                 self.composer_id.template_id = self.template_id.id
+                self._compute_composition_mode()
             self.composer_id.onchange_template_id_wrapper()
 
     @api.onchange('is_email')


### PR DESCRIPTION
From Invoice list view select 2+ invoices (A, B), click Action>send and print
In each invoice 2 invoices will be sent:
- In A, you'll find A and A
- In B, you'll find A and B

This occur because the composition_mode of the composer is computed
after the attachment has been generated.
When the composer has an attachment, it is included into
the sent mail along the relevant one, generated on the fly for each record.

opw-2428544

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
