### PR TITLE
[IMP] website: keep loader alive until editor is opened

### DIFF
--- a/addons/website/models/ir_module_module.py
+++ b/addons/website/models/ir_module_module.py
@@ -361,10 +361,14 @@ class IrModuleModule(models.Model):
         self._theme_upgrade_upstream()
 
         active_todo = self.env['ir.actions.todo'].search([('state', '=', 'open')], limit=1)
+        result = None
         if active_todo:
-            return active_todo.action_launch()
+            result = active_todo.action_launch()
         else:
-            return website.button_go_website(mode_edit=True)
+            result = website.button_go_website(mode_edit=True)
+        if result.get('url') and 'enable_editor' in result['url']:
+            result['url'] = result['url'].replace('enable_editor', 'with_loader=1&enable_editor')
+        return result
 
     def button_remove_theme(self):
         """Remove the current theme of the current website."""

--- a/addons/website/static/src/js/menu/edit.js
+++ b/addons/website/static/src/js/menu/edit.js
@@ -41,7 +41,10 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
             },
         });
         this._editorAutoStart = (context.editable && window.location.search.indexOf('enable_editor') >= 0);
-        var url = window.location.href.replace(/([?&])&*enable_editor[^&#]*&?/, '\$1');
+
+        var url = new URL(window.location.href)
+        url.searchParams.delete('enable_editor')
+        url.searchParams.delete('with_loader')
         window.history.replaceState({}, null, url);
     },
     /**
@@ -94,6 +97,7 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
             this.$welcomeMessage.detach(); // detach from the readonly rendering before the clone by summernote
         }
         this.editModeEnable = true;
+
         await new EditorMenu(this).prependTo(document.body);
         this._addEditorMessages();
         var res = await new Promise(function (resolve, reject) {
@@ -103,9 +107,16 @@ var EditPageMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
                 onFailure: reject,
             });
         });
+
+        const $loader = $('div.o_theme_install_loader_container');
+        if ($loader) {
+            $loader.remove();
+        }
+
         // Trigger a mousedown on the main edition area to focus it,
         // which is required for Summernote to activate.
         this.$editorMessageElements.mousedown();
+
         return res;
     },
     /**

--- a/addons/website/static/src/scss/website.editor.ui.scss
+++ b/addons/website/static/src/scss/website.editor.ui.scss
@@ -60,3 +60,18 @@ $o-we-switch-inactive-color: #F7F7F7 !default;
         }
     }
 }
+
+// LOADER (v14 only)
+.o_theme_install_loader_container {
+    background-color: rgba($o-shadow-color, .9);
+    pointer-events: all;
+    // above menu bar
+    z-index: $zindex-modal - 1;
+}
+.o_theme_install_loader {
+    position: relative;
+    display: inline-block;
+    width: 400px;
+    height: 220px;
+    background-image: url('/website/static/src/img/theme_loader.gif');
+}

--- a/addons/website/views/website_navbar_templates.xml
+++ b/addons/website/views/website_navbar_templates.xml
@@ -20,6 +20,9 @@
             <t t-set="body_classname" t-value="(body_classname if body_classname else '') + (' o_connected_user' if env['ir.ui.view'].user_has_groups('base.group_user') else '')"/>
         </xpath>
         <xpath expr="//div[@id='wrapwrap']" position="before">
+            <div t-if="'with_loader' in request.params" class="o_theme_install_loader_container position-fixed fixed-top fixed-left h-100 w-100 d-flex justify-content-center align-items-center">
+                <div class="o_theme_install_loader"/>
+            </div>
             <nav groups="base.group_user" t-if="website" id="oe_main_menu_navbar" class="o_main_navbar">
                 <ul id="oe_applications">
                     <li class="dropdown active">


### PR DESCRIPTION
Before this commit the navigation toolbar was accessible after selecting
a theme before the editor was opened, which on slow connections made it
possible for users to leave the screen and miss the tour

After this commit the loader animation of the theme installation is
blocking the access to the screen until the editor is opened thus
preventing user to navigate elsewhere before seeing the tour

partial backport of PR62029

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
