### PR TITLE
[FIX] pos_cache: add pos to product

### DIFF
--- a/addons/pos_cache/static/src/js/pos_cache.js
+++ b/addons/pos_cache/static/src/js/pos_cache.js
@@ -40,6 +40,7 @@ models.PosModel = models.PosModel.extend({
             return records.then(function (products) {
                 self.db.add_products(_.map(products, function (product) {
                     product.categ = _.findWhere(self.product_categories, {'id': product.categ_id[0]});
+                    product.pos = self;
                     return new models.Product({}, product);
                 }));
             });


### PR DESCRIPTION
When adding a product to the order, the total will be updated but the
orderline will not be displayed

To reproduce the error:
1. Go to Point Of Sale
2. New Session
3. Click on a product so it will be added to the order

Err: The order's total is correctly updated but the line is not
displayed.

When displaying an orderline, the system wants to use the product's unit
name (`t-esc="props.line.get_unit().name"`). To do so, it uses one
specific variable of the current product, `pos`:
https://github.com/odoo/odoo/blob/abff1ca94bcc829250b63fd9677890988b796819/addons/point_of_sale/static/src/js/models.js#L1518-L1528
When using the standard Point of Sale, this variable is added on products
loading (L446) :
https://github.com/odoo/odoo/blob/abff1ca94bcc829250b63fd9677890988b796819/addons/point_of_sale/static/src/js/models.js#L438-L448
However, this variable is not set when using the pos_cache module.

OPW-2431221