### PR TITLE
[IMP] website_event_*: globally improve usability & layouts of online events

### DIFF
--- a/addons/website_event_exhibitor/views/event_templates_sponsor.xml
+++ b/addons/website_event_exhibitor/views/event_templates_sponsor.xml
@@ -6,8 +6,24 @@
         <div class="container mt32 mb16 d-none d-md-block d-print-none" t-if="event.sponsor_ids">
             <div t-attf-class="d-flex flex-wrap mb-5 #{'' if (len(event.sponsor_ids) > 10) else 'justify-content-md-center'}">
                 <t t-foreach="event.sponsor_ids" t-as="sponsor">
+                    <t t-set="tooltip">
+                        <span t-field="sponsor.name" class="h4 mb-0"/>
+                        <div t-if="sponsor.url" class="d-flex align-items-baseline">
+                            <i class="fa fa-home mr-2"/><a t-att-href="sponsor.url" class="text-truncate"><span t-field="sponsor.url"/></a>
+                        </div>
+                        <div t-if="sponsor.email" class="d-flex align-items-baseline">
+                            <i class="fa fa-envelope mr-2"/><a t-att-mailto="sponsor.email" class="text-break"><span t-field="sponsor.email"/></a>
+                        </div>
+                        <div t-if="sponsor.phone" class="d-flex align-items-baseline">
+                            <i class="fa fa-phone mr-2"/><span t-field="sponsor.phone" class="text-break"/>
+                        </div>
+                        <div t-elif="sponsor.mobile" class="d-flex align-items-baseline">
+                            <i class="fa fa-phone mr-2"/><span t-field="sponsor.mobile" class="text-break"/>
+                        </div>
+                    </t>
                     <t t-if="sponsor.url">
-                        <a class="o_wevent_sponsor o_wevent_sponsor_card" target="_blank" t-att-href="sponsor.url">
+                        <a class="o_wevent_sponsor o_wevent_sponsor_card" target="_blank" t-att-href="sponsor.url"
+                            data-html="true" data-toggle="popover" data-placement="bottom" t-att-data-content="tooltip">
                             <div class="h-100 shadow-sm p-2">
                                 <span t-field="sponsor.image_128"
                                     t-options='{"widget": "image", "class": "img img-fluid"}'/>
@@ -17,7 +33,8 @@
                         </a>
                     </t>
                     <t t-if="not sponsor.url">
-                        <div class="o_wevent_sponsor o_wevent_sponsor_card">
+                        <div class="o_wevent_sponsor o_wevent_sponsor_card"
+                            data-html="true" data-toggle="popover" data-placement="bottom" t-att-data-content="tooltip">
                             <div class="h-100 shadow-sm p-2">
                                 <span t-field="sponsor.image_128"
                                     t-options='{"widget": "image", "class": "img img-fluid"}'/>

--- a/addons/website_event_track/data/event_track_data.xml
+++ b/addons/website_event_track/data/event_track_data.xml
@@ -5,36 +5,63 @@
             <field name="name">Proposal</field>
             <field name="sequence">1</field>
             <field name="color">1</field>
+            <field name="legend_blocked">Blocked</field>
+            <field name="legend_done">Ready for Next Stage</field>
+            <field name="legend_normal">In Progress</field>
+            <field name="visibility">unlisted</field>
+            <field name="is_accessible">False</field>
         </record>
         <record id="event_track_stage1" model="event.track.stage">
             <field name="name">Confirmed</field>
             <field name="sequence">2</field>
             <field name="mail_template_id" ref="mail_template_data_track_confirmation"/>
             <field name="color">2</field>
+            <field name="legend_blocked">Blocked</field>
+            <field name="legend_done">Ready for Next Stage</field>
+            <field name="legend_normal">In Progress</field>
+            <field name="visibility">private</field>
+            <field name="is_accessible">False</field>
         </record>
         <record id="event_track_stage2" model="event.track.stage">
             <field name="name">Announced</field>
             <field name="sequence">3</field>
             <field name="color">3</field>
-            <field name="is_accepted" eval="True"/>
+            <field name="legend_blocked">Blocked</field>
+            <field name="legend_done">Ready for Next Stage</field>
+            <field name="legend_normal">In Progress</field>
+            <field name="visibility">public</field>
+            <field name="is_accessible">False</field>
         </record>
         <record id="event_track_stage3" model="event.track.stage">
             <field name="name">Published</field>
             <field name="sequence">4</field>
             <field name="color">4</field>
-            <field name="is_accepted" eval="True"/>
-            <field name="is_done" eval="True"/>
+            <field name="legend_blocked">Blocked</field>
+            <field name="legend_done">Ready for Next Stage</field>
+            <field name="legend_normal">In Progress</field>
+            <field name="visibility">public</field>
+            <field name="is_accessible">True</field>
         </record>
         <record id="event_track_stage4" model="event.track.stage">
             <field name="name">Refused</field>
             <field name="sequence">5</field>
             <field name="color">5</field>
             <field name="fold" eval="True"/>
+            <field name="legend_blocked">Blocked</field>
+            <field name="legend_done">Ready for Next Stage</field>
+            <field name="legend_normal">In Progress</field>
+            <field name="visibility">unlisted</field>
+            <field name="is_accessible">False</field>
         </record>
         <record id="event_track_stage5" model="event.track.stage">
             <field name="name">Cancelled</field>
             <field name="sequence">6</field>
             <field name="fold" eval="True"/>
+            <field name="legend_blocked">Blocked</field>
+            <field name="legend_done">Ready for Next Stage</field>
+            <field name="legend_normal">In Progress</field>
+            <field name="visibility">unlisted</field>
+            <field name="is_accessible">False</field>
             <field name="is_cancel" eval="True"/>
         </record>
     </data>

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -246,6 +246,21 @@ class Track(models.Model):
             if track.partner_id:
                 track.contact_phone = track.partner_id.phone
 
+    @api.depends('partner_name', 'partner_function', 'partner_company_name')
+    def _compute_partner_tag_line(self):
+        for track in self:
+            tag_line = False
+            if track.partner_name:
+                tag_line = track.partner_name
+                if track.partner_function:
+                    tag_line = '%s, %s' % (tag_line, track.partner_function)
+                    if track.partner_company_name:
+                        tag_line = _('%s at %s', tag_line, track.partner_company_name)
+                else:
+                    if track.partner_company_name:
+                        tag_line = _('%s from %s', tag_line, track.partner_company_name)
+            track.partner_tag_line = tag_line
+
     # TIME
 
     @api.depends('date', 'duration')

--- a/addons/website_event_track/models/event_track_stage.py
+++ b/addons/website_event_track/models/event_track_stage.py
@@ -16,17 +16,22 @@ class TrackStage(models.Model):
         'mail.template', string='Email Template',
         domain=[('model', '=', 'event.track')],
         help="If set an email will be sent to the customer when the track reaches this step.")
+    visibility = fields.Selection([
+        ('public', 'Public'),
+        ('private', 'Private'),
+        ('unlisted', 'Unlisted')
+    ], string='Visibility', required=True, default='private',
+        help="Impacts the visibility of your tracks on the frontend.\n"\
+            "- Public: The tracks will be visible for all users.\n"\
+            "- Private: The tracks will be visible for the administrators only.\n"\
+            "- Unlisted: The tracks will not be visible for all users."
+    )
+    is_accessible = fields.Boolean(string='Accessiblity',
+        help="If checked, the access link of the tracks will be provided")
     fold = fields.Boolean(
         string='Folded in Kanban',
         help='This stage is folded in the kanban view when there are no records in that stage to display.')
-    is_accepted = fields.Boolean(
-        string='Accepted Stage',
-        help='Accepted tracks are displayed in agenda views but not accessible.')
-    is_done = fields.Boolean(
-        string='Done Stage',
-        help='Done tracks are automatically published so that they are available in frontend.')
     is_cancel = fields.Boolean(string='Canceled Stage')
-    is_done = fields.Boolean()
     color = fields.Integer(string='Color')
     legend_blocked = fields.Char(
         'Red Kanban Label', default=lambda s: _('Blocked'), translate=True, required=True,

--- a/addons/website_event_track/models/event_track_stage.py
+++ b/addons/website_event_track/models/event_track_stage.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import _, fields, models
 
 
 class TrackStage(models.Model):
@@ -10,6 +10,7 @@ class TrackStage(models.Model):
     _order = 'sequence, id'
 
     name = fields.Char(string='Stage Name', required=True, translate=True)
+    description = fields.Text(string='Description', translate=True)
     sequence = fields.Integer(string='Sequence', default=1)
     mail_template_id = fields.Many2one(
         'mail.template', string='Email Template',
@@ -27,3 +28,12 @@ class TrackStage(models.Model):
     is_cancel = fields.Boolean(string='Canceled Stage')
     is_done = fields.Boolean()
     color = fields.Integer(string='Color')
+    legend_blocked = fields.Char(
+        'Red Kanban Label', default=lambda s: _('Blocked'), translate=True, required=True,
+        help='Override the default value displayed for the blocked state for kanban selection.')
+    legend_done = fields.Char(
+        'Green Kanban Label', default=lambda s: _('Ready for Next Stage'), translate=True, required=True,
+        help='Override the default value displayed for the done state for kanban selection.')
+    legend_normal = fields.Char(
+        'Grey Kanban Label', default=lambda s: _('In Progress'), translate=True, required=True,
+        help='Override the default value displayed for the normal state for kanban selection.')

--- a/addons/website_event_track/static/src/js/website_event_track.js
+++ b/addons/website_event_track/static/src/js/website_event_track.js
@@ -9,6 +9,67 @@ publicWidget.registry.websiteEventTrack = publicWidget.Widget.extend({
         'input #event_track_search': '_onEventTrackSearchInput',
     },
 
+    /**
+     * @override
+     */
+    start: function () {
+        this._super.apply(this, arguments).then(() => {
+
+            let current = null;
+            let focus = false;
+            let timer = null;
+
+            let onEnter = () => { focus = true; };
+            let onLeave = () => {
+                if (focus) {
+                    hide();
+                    focus = false;
+                    clearTimeout(timer);
+                }
+            };
+
+            let show = () => {
+                if (current) {
+                    $(current).popover('show');
+                    const $popover = $('#' + current.getAttribute('aria-describedby'));
+                    $popover.on('mouseenter', onEnter);
+                    $popover.on('mouseleave', onLeave);
+                }
+            };
+
+            let hide = () => {
+                if (current) {
+                    const $popover = $('#' + current.getAttribute('aria-describedby'));
+                    $popover.off('mouseenter', onEnter);
+                    $popover.off('mouseleave', onLeave);
+                    $(current).popover('hide');
+                    let hover = $('[data-toggle="popover"]:hover');
+                    if (hover.length === 0) {
+                        current = null;
+                    } else {
+                        current = hover.get(0);
+                        show();
+                    }
+                }
+            };
+
+            this.$el.find('[data-toggle="popover"]').popover({
+                trigger: 'manual'
+            }).on('mouseenter', function () {
+                if (!current) {
+                    current = this;
+                    show();
+                }
+            }).on('mouseleave', function () {
+                if (current === this) {
+                    timer = setTimeout(() => {
+                        if (!focus) { hide(); }
+                    }, 200);
+                }
+            });
+        });
+    },
+
     //--------------------------------------------------------------------------
     // Handlers
     //--------------------------------------------------------------------------

--- a/addons/website_event_track/views/event_track_stage_views.xml
+++ b/addons/website_event_track/views/event_track_stage_views.xml
@@ -32,6 +32,28 @@
                             <field name="color" widget="color_picker"/>
                         </group>
                     </group>
+                    <group string="Stage Description and Tooltips">
+                        <p class="text-muted" colspan="2">
+                            You can define here labels that will be displayed for the state instead
+                            of the default labels in the kanban view.
+                        </p>
+                        <label for="legend_normal" string=" " class="o_status"
+                            title="Task in progress. Click to block or set as done."
+                            aria-label="Task in progress. Click to block or set as done." role="img"/>
+                        <field name="legend_normal" nolabel="1"/>
+                        <label for="legend_blocked" string=" " class="o_status o_status_red"
+                            title="Task is blocked. Click to unblock or set as done."
+                            aria-label="Task is blocked. Click to unblock or set as done." role="img"/>
+                        <field name="legend_blocked" nolabel="1"/>
+                        <label for="legend_done" string=" " class="o_status o_status_green"
+                            title="This step is done. Click to block or set in progress."
+                            aria-label="This step is done. Click to block or set in progress." role="img"/>
+                        <field name="legend_done" nolabel="1"/>
+                        <p class="text-muted" colspan="2">
+                            You can also add a description to help your coworkers understand the meaning and purpose of the stage.
+                        </p>
+                        <field name="description" placeholder="Add a description..." nolabel="1" colspan="2"/>
+                    </group>
                 </sheet>
             </form>
         </field>

--- a/addons/website_event_track/views/event_track_stage_views.xml
+++ b/addons/website_event_track/views/event_track_stage_views.xml
@@ -22,13 +22,13 @@
                         <group>
                             <field name="name"/>
                             <field name="mail_template_id"/>
-                            <field name="sequence" groups="base.group_no_one"/>
+                            <field name="visibility"/>
+                            <field name="is_accessible"/>
+                            <field name="is_cancel"/>
                         </group>
                         <group>
+                            <field name="sequence" groups="base.group_no_one"/>
                             <field name="fold"/>
-                            <field name="is_accepted"/>
-                            <field name="is_done"/>
-                            <field name="is_cancel"/>
                             <field name="color" widget="color_picker"/>
                         </group>
                     </group>
@@ -66,8 +66,8 @@
             <tree string="Track Stage">
                 <field name="sequence" widget="handle" groups="event.group_event_manager"/>
                 <field name="name"/>
-                <field name="is_accepted"/>
-                <field name="is_done"/>
+                <field name="visibility"/>
+                <field name="is_accessible"/>
                 <field name="is_cancel"/>
                 <field name="fold"/>
             </tree>

--- a/addons/website_event_track/views/event_track_templates_agenda.xml
+++ b/addons/website_event_track/views/event_track_templates_agenda.xml
@@ -159,11 +159,9 @@
             <small t-if="track.is_track_live and not track.is_track_done and track.website_published"
                 class="mx-1 badge badge-danger rounded-sm">Live
             </small>
-            <small t-if="not track.website_published and is_event_user and track.stage_id.is_accepted"
+            <small t-if="(not track.website_published or track.stage_id.visibility != 'public') and is_event_user"
                    title="Unpublished"
                    class="ml-1 badge badge-danger o_wevent_online_badge_unpublished rounded-sm">Unpublished</small>
-            <small t-if="not track.stage_id.is_accepted" title="Not Accepted"
-                   class="ml-1 badge badge-danger o_wevent_online_badge_unpublished rounded-sm">Not Accepted</small>
             <span t-if="option_track_wishlist">
                 <t t-call="website_event_track.track_widget_reminder">
                     <t t-set="reminder_light" t-value="True"/>
@@ -175,7 +173,7 @@
 
         <div class="o_we_agenda_card_content d-flex flex-column justify-content-center my-1">
             <div class="o_we_agenda_card_title">
-                <t t-if="track.website_published or is_event_user">
+                <t t-if="track.stage_id.is_accessible or is_event_user">
                     <a t-att-href="'/event/%s/track/%s' % (slug(event), slug(track))" class="text-black text-bold">
                         <t t-esc="track.name"/>
                     </a>

--- a/addons/website_event_track/views/event_track_templates_list.xml
+++ b/addons/website_event_track/views/event_track_templates_list.xml
@@ -141,18 +141,18 @@
             <h5 class="m-0 text-danger">Live Now</h5>
             <hr class="mt-2 pb-1 mb-1"/>
         </div>
-        <div t-foreach="tracks_live" t-as="track" class="col-md-6 col-lg-3 mb-4">
-            <t t-call="website_event_track.tracks_cards_track"/>
-        </div>
+        <t t-call="website_event_track.track_cards_section">
+            <t t-set="tracks" t-value="tracks_live"/>
+        </t>
     </div>
     <div class="row mb-3" t-if="tracks_soon">
         <div class="col-12">
             <h5 class="m-0 text-danger">Coming soon ...</h5>
             <hr class="mt-2 pb-1 mb-1"/>
         </div>
-        <div t-foreach="tracks_soon" t-as="track" class="col-md-6 col-lg-3 mb-4">
-            <t t-call="website_event_track.tracks_cards_track"/>
-        </div>
+        <t t-call="website_event_track.track_cards_section">
+            <t t-set="tracks" t-value="tracks_soon"/>
+        </t>
     </div>
 </template>
 
@@ -219,7 +219,7 @@
                                     </t>
                                 </div>
                                 <span class="h5 mb0">
-                                    <a t-if="track.is_published or is_event_user"
+                                    <a t-if="track.stage_id.is_accessible or is_event_user"
                                         class="mr-2"
                                         t-att-href="track.website_url">
                                         <span t-field="track.name"/>
@@ -227,7 +227,7 @@
                                     <t t-else="">
                                         <span class="mr-2" t-field="track.name"/>
                                     </t>
-                                    <span t-if="not track.is_published and is_event_user"
+                                    <span t-if="(not track.website_published or track.stage_id.visibility != 'public') and is_event_user"
                                         class="badge badge-danger o_wevent_online_badge_unpublished">
                                         Unpublished
                                     </span>
@@ -300,71 +300,82 @@
 <!-- TOOL TEMPLATES -->
 <!-- ============================================================ -->
 
-<template id="tracks_cards_track" name="Track Card">
-    <a t-att-href="'/event/%s/track/%s' % (slug(track.event_id), slug(track))" class="text-decoration-none">
-        <article t-att-class="'h-100 card rounded-0 border-0 shadow-sm o_wesession_track_card %s' % ('o_wesession_track_card_unpublished' if not track.is_published else '')"
-            itemscope="itemscope" itemtype="http://schema.org/Event">
-            <div class="h-100 row no-gutters">
-                <header class="overflow-hidden bg-secondary col-12">
-                    <small t-if="not track.is_published" class="o_wesession_track_card_header_badge bg-danger">
-                        <i class="fa fa-ban mr-2"/>Unpublished
-                    </small>
+<template id="track_cards_section" name="Track Cards">
+    <div t-foreach="tracks" t-as="track" class="col-md-6 col-lg-3 mb-4">
+        <t t-if="track.stage_id.is_accessible or is_event_user">
+            <a t-att-href="'/event/%s/track/%s' % (slug(track.event_id), slug(track))" class="text-decoration-none">
+                <t t-call="website_event_track.track_card"/>
+            </a>
+        </t>
+        <t t-else="">
+            <t t-call="website_event_track.track_card"/>
+        </t>
+    </div>
+</template>
 
-                    <div t-if="track.website_image_url" class="card-img-top"
-                        t-attf-style="padding-top: 50%; background-image: url(#{track.website_image_url}); background-size: cover; background-position:center">
-                        <span t-if="option_track_wishlist and not track.is_track_live" class="position-absolute h3 mt-2 mr-2" style="right: 0; top: 0;">
-                            <t t-call="website_event_track.track_widget_reminder">
-                                <t t-set="reminder_light" t-value="True"/>
-                                <t t-set="light_theme" t-value="True"/>
-                            </t>
-                        </span>
-                    </div>
-                    <div t-else="" class="o_wesession_gradient card-img-top position-relative"
-                        style="padding-top: 50%;">
-                        <span t-if="option_track_wishlist" class="position-absolute h3 mt-2 mr-2" style="right: 0; top: 0;">
-                            <t t-call="website_event_track.track_widget_reminder">
-                                <t t-set="reminder_light" t-value="True"/>
-                            </t>
-                        </span>
-                        <i class="fa fa-glass fa-2x mx-2 mb-3 position-absolute text-white-75" style="right:0; bottom: 0;"/>
-                    </div>
-                </header>
-                <div class="col-12">
-                    <main class="card-body">
-                        <!-- Title -->
-                        <h5 class="card-title mt-0 mb-0 text-truncate">
-                            <span t-field="track.name" itemprop="name"/>
-                        </h5>
-                        <!-- Tags> -->
-                        <div>
-                            <t t-foreach="track.tag_ids" t-as="tag">
-                                <t t-if="tag.color" t-call="website_event_track.track_tag_badge_info"/>
-                            </t>
-                        </div>
-                    </main>
+<template id="track_card" name="Track Card">
+    <article t-att-class="'h-100 card rounded-0 border-0 shadow-sm o_wesession_track_card %s' % ('o_wesession_track_card_unpublished' if not track.website_published or track.stage_id.visibility != 'public' else '')"
+        itemscope="itemscope" itemtype="http://schema.org/Event">
+        <div class="h-100 row no-gutters">
+            <header class="overflow-hidden bg-secondary col-12">
+                <small t-if="(not track.website_published or track.stage_id.visibility != 'public') and is_event_user" class="o_wesession_track_card_header_badge bg-danger">
+                    <i class="fa fa-ban mr-2"/>Unpublished
+                </small>
+
+                <div t-if="track.website_image_url" class="card-img-top"
+                    t-attf-style="padding-top: 50%; background-image: url(#{track.website_image_url}); background-size: cover; background-position:center">
+                    <span t-if="option_track_wishlist and not track.is_track_live" class="position-absolute h3 mt-2 mr-2" style="right: 0; top: 0;">
+                        <t t-call="website_event_track.track_widget_reminder">
+                            <t t-set="reminder_light" t-value="True"/>
+                            <t t-set="light_theme" t-value="True"/>
+                        </t>
+                    </span>
                 </div>
-                <!-- Footer -->
-                <footer class="small align-self-end w-100 card-footer">
-                    <div class="d-flex justify-content-between align-items-center">
-                        <!-- Speaker -->
-                        <span class="text-muted text-truncate" t-field="track.partner_name" itemprop="performer"/>
-                        <!-- Starts -->
-                        <span class="text-muted ml-auto">
-                            <t t-if="track.is_track_upcoming &gt; 0">In
-                                <span class="text-muted ml-auto" t-field="track.track_start_remaining" itemprop="duration"
-                                    t-options="{'widget': 'duration', 'digital': False, 'format': 'short', 'unit': 'second', 'round': 'minute'}"/>
-                            </t>
-                            <t t-else="">
-                                <span class="text-muted ml-auto" t-field="track.track_start_relative" itemprop="duration"
-                                    t-options="{'widget': 'duration', 'digital': False, 'format': 'short', 'unit': 'second', 'round': 'minute'}"/>
-                                ago
-                            </t>
-                        </span>
+                <div t-else="" class="o_wesession_gradient card-img-top position-relative"
+                    style="padding-top: 50%;">
+                    <span t-if="option_track_wishlist" class="position-absolute h3 mt-2 mr-2" style="right: 0; top: 0;">
+                        <t t-call="website_event_track.track_widget_reminder">
+                            <t t-set="reminder_light" t-value="True"/>
+                        </t>
+                    </span>
+                    <i class="fa fa-glass fa-2x mx-2 mb-3 position-absolute text-white-75" style="right:0; bottom: 0;"/>
+                </div>
+            </header>
+            <div class="col-12">
+                <main class="card-body">
+                    <!-- Title -->
+                    <h5 class="card-title mt-0 mb-0 text-truncate">
+                        <span t-field="track.name" itemprop="name"/>
+                    </h5>
+                    <!-- Tags> -->
+                    <div>
+                        <t t-foreach="track.tag_ids" t-as="tag">
+                            <t t-if="tag.color" t-call="website_event_track.track_tag_badge_info"/>
+                        </t>
                     </div>
-                </footer>
+                </main>
             </div>
-        </article>
-    </a>
+            <!-- Footer -->
+            <footer class="small align-self-end w-100 card-footer">
+                <div class="d-flex justify-content-between align-items-center">
+                    <!-- Speaker -->
+                    <span class="text-muted text-truncate" t-field="track.partner_name" itemprop="performer"/>
+                    <!-- Starts -->
+                    <span class="text-muted ml-auto">
+                        <t t-if="track.is_track_upcoming &gt; 0">In
+                            <span class="text-muted ml-auto" t-field="track.track_start_remaining" itemprop="duration"
+                                t-options="{'widget': 'duration', 'digital': False, 'format': 'short', 'unit': 'second', 'round': 'minute'}"/>
+                        </t>
+                        <t t-else="">
+                            <span class="text-muted ml-auto" t-field="track.track_start_relative" itemprop="duration"
+                                t-options="{'widget': 'duration', 'digital': False, 'format': 'short', 'unit': 'second', 'round': 'minute'}"/>
+                            ago
+                        </t>
+                    </span>
+                </div>
+            </footer>
+        </div>
+    </article>
 </template>
 
 <!-- Searched tags -->

--- a/addons/website_event_track/views/event_track_views.xml
+++ b/addons/website_event_track/views/event_track_views.xml
@@ -17,13 +17,16 @@
         <field name="model">event.track</field>
         <field name="arch" type="xml">
             <kanban default_group_by="stage_id">
+                <field name="color"/>
+                <field name="partner_id"/>
+                <field name="stage_id" options='{"group_by_tooltip": {"description": "Description"}}'/>
+                <field name="website_url"/>
+                <field name="activity_ids"/>
+                <field name="activity_state"/>
+                <field name="legend_blocked"/>
+                <field name="legend_normal"/>
+                <field name="legend_done"/>
                 <templates>
-                    <field name="color"/>
-                    <field name="partner_id"/>
-                    <field name="stage_id"/>
-                    <field name="website_url"/>
-                    <field name="activity_ids"/>
-                    <field name="activity_state"/>
                     <progressbar field="kanban_state" colors='{"done": "success", "blocked": "danger"}'/>
                     <t t-name="kanban-box">
                         <div t-attf-class="{{!selection_mode ? 'oe_kanban_color_' + kanban_getcolor(record.color.raw_value) : ''}} oe_kanban_card oe_kanban_global_click">
@@ -139,6 +142,9 @@
                         </button>
                         <field name="is_published" widget="website_redirect_button"/>
                     </div>
+                    <field name="legend_blocked" invisible="1"/>
+                    <field name="legend_normal" invisible="1"/>
+                    <field name="legend_done" invisible="1"/>
                     <widget name="web_ribbon" text="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <field name="kanban_state" widget="state_selection" class="ml-3 float-right"/>
                     <field name="website_image" widget="image" class="oe_avatar"/>

--- a/addons/website_event_track_quiz/data/quiz_demo.xml
+++ b/addons/website_event_track_quiz/data/quiz_demo.xml
@@ -14,19 +14,20 @@
         <field name="text_value">Wood</field>
         <field name="sequence">1</field>
         <field name="awarded_points">1</field>
-        <field name="comment">Correct ! You're really smart !</field>
+        <field name="is_correct">True</field>
+        <field name="comment">You're really smart !</field>
         <field name="question_id" ref="event_7_track_1_question_0"/>
     </record>
     <record id="event_7_track_1_question_0_1" model="event.quiz.answer">
         <field name="text_value">Music</field>
         <field name="sequence">2</field>
-        <field name="comment">Incorrect ! Even if there will be some.</field>
+        <field name="comment">Even if there will be some.</field>
         <field name="question_id" ref="event_7_track_1_question_0"/>
     </record>
     <record id="event_7_track_1_question_0_2" model="event.quiz.answer">
         <field name="text_value">Open Source Apps</field>
         <field name="sequence">3</field>
-        <field name="comment">Incorrect ! OpenWood is not an Open Source congres about Apps.</field>
+        <field name="comment">OpenWood is not an Open Source congres about Apps.</field>
         <field name="question_id" ref="event_7_track_1_question_0"/>
     </record>
     <record id="event_7_track_1_question_1" model="event.quiz.question">
@@ -38,13 +39,13 @@
         <field name="text_value">Trees !</field>
         <field name="sequence">1</field>
         <field name="awarded_points">1</field>
-        <field name="comment">Correct !</field>
+        <field name="is_correct">True</field>
         <field name="question_id" ref="event_7_track_1_question_1"/>
     </record>
     <record id="event_7_track_1_question_1_1" model="event.quiz.answer">
         <field name="text_value">Stores !</field>
         <field name="sequence">2</field>
-        <field name="comment">Incorrect ! Lumbers need first to be cut from trees!</field>
+        <field name="comment">Lumbers need first to be cut from trees!</field>
         <field name="question_id" ref="event_7_track_1_question_1"/>
     </record>
 
@@ -64,14 +65,15 @@
     <record id="event_7_track_5_question_0_0" model="event.quiz.answer">
         <field name="text_value">Yes</field>
         <field name="sequence">1</field>
-        <field name="comment">Incorrect! In order to avoid accident, you need to secure any product of this kind during transportation!</field>
+        <field name="comment">In order to avoid accident, you need to secure any product of this kind during transportation!</field>
         <field name="question_id" ref="event_7_track_5_question_0"/>
     </record>
     <record id="event_7_track_5_question_0_1" model="event.quiz.answer">
         <field name="text_value">No</field>
         <field name="sequence">2</field>
         <field name="awarded_points">1</field>
-        <field name="comment">Correct! Even if you have a big trunk, some long products need to be secured.</field>
+        <field name="is_correct">True</field>
+        <field name="comment">Even if you have a big trunk, some long products need to be secured.</field>
         <field name="question_id" ref="event_7_track_5_question_0"/>
     </record>
     <record id="event_7_track_5_question_1" model="event.quiz.question">
@@ -82,20 +84,20 @@
     <record id="event_7_track_5_question_1_0" model="event.quiz.answer">
         <field name="text_value">Hammer</field>
         <field name="sequence">1</field>
-        <field name="comment">Incorrect! Hammer won't be of any help here!</field>
+        <field name="comment">Hammer won't be of any help here!</field>
         <field name="question_id" ref="event_7_track_5_question_1"/>
     </record>
     <record id="event_7_track_5_question_1_1" model="event.quiz.answer">
         <field name="text_value">Tie-down straps and other wooden blocks</field>
         <field name="sequence">2</field>
         <field name="awarded_points">1</field>
-        <field name="comment">Correct!</field>
+        <field name="is_correct">True</field>
         <field name="question_id" ref="event_7_track_5_question_1"/>
     </record>
         <record id="event_7_track_5_question_1_2" model="event.quiz.answer">
         <field name="text_value">Scotch tape</field>
         <field name="sequence">3</field>
-        <field name="comment">Incorrect! Well, it could work but you will need a lot of tape!</field>
+        <field name="comment">Well, it could work but you will need a lot of tape!</field>
         <field name="question_id" ref="event_7_track_5_question_1"/>
     </record>
 
@@ -116,19 +118,17 @@
         <field name="text_value">Concrete Blocks Wall</field>
         <field name="sequence">1</field>
         <field name="awarded_points">1</field>
-        <field name="comment">Correct!</field>
+        <field name="is_correct">True</field>
         <field name="question_id" ref="event_7_track_13_question_0"/>
     </record>
     <record id="event_7_track_13_question_0_1" model="event.quiz.answer">
         <field name="text_value">Steel Wall</field>
         <field name="sequence">2</field>
-        <field name="comment">Incorrect!</field>
         <field name="question_id" ref="event_7_track_13_question_0"/>
     </record>
     <record id="event_7_track_13_question_0_2" model="event.quiz.answer">
         <field name="text_value">Mud Wall</field>
         <field name="sequence">3</field>
-        <field name="comment">Incorrect!</field>
         <field name="question_id" ref="event_7_track_13_question_0"/>
     </record>
 

--- a/addons/website_event_track_quiz/static/src/js/event_quiz.js
+++ b/addons/website_event_track_quiz/static/src/js/event_quiz.js
@@ -41,7 +41,8 @@ var Quiz = publicWidget.Widget.extend({
             completed: false,
             isMember: false,
             progressBar: false,
-            isEventUser: false
+            isEventUser: false,
+            unlimitedTries: false
         });
         this.quiz = quizData || false;
         if (this.quiz) {
@@ -114,11 +115,13 @@ var Quiz = publicWidget.Widget.extend({
      * Decorate the answers according to state
      */
     _disableAnswers: function () {
-        var self = this;
         this.$('.o_quiz_js_quiz_question').addClass('completed-disabled');
-        this.$('input[type=radio]').each(function () {
-            $(this).prop('disabled', self.track.completed);
-        });
+        this.$('input[type=radio]').prop('disabled', true);
+    },
+
+    _enableAnswers: function() {
+        this.$('.o_quiz_js_quiz_question').removeClass('completed-disabled');
+        this.$('input[type=radio]').prop('disabled', false);
     },
 
     /**
@@ -132,29 +135,30 @@ var Quiz = publicWidget.Widget.extend({
         this.$('.o_quiz_js_quiz_question').each(function () {
             var $question = $(this);
             var questionId = $question.data('questionId');
-            var isCorrect = self.quiz.answers[questionId].is_correct;
+            var answer = self.quiz.answers[questionId];
             $question.find('a.o_quiz_quiz_answer').each(function () {
                 var $answer = $(this);
                 $answer.find('i.fa').addClass('d-none');
-                if ($answer.find('input[type=radio]')[0].checked) {
-                    if (isCorrect) {
-                        $answer.removeClass('list-group-item-danger').addClass('list-group-item-success');
+                if ($answer.find('input[type=radio]').is(':checked')) {
+                    if (answer.is_correct) {
                         $answer.find('i.fa-check-circle').removeClass('d-none');
+                        $answer.find('span.o_quiz_quiz_answer_text').addClass('text-success');
                     } else {
-                        $answer.removeClass('list-group-item-success').addClass('list-group-item-danger');
-                        $answer.find('i.fa-times-circle').removeClass('d-none');
                         $answer.find('label input').prop('checked', false);
+                        $answer.find('i.fa-times-circle').removeClass('d-none');
+                        $answer.find('span.o_quiz_quiz_answer_text').addClass('text-danger');
+                    }
+                    if (answer.awarded_points > 0) {
+                        var $badge = QWeb.render('quiz.badge', {'answer': answer});
+                        $answer.append($badge);
                     }
                 } else {
-                    $answer.removeClass('list-group-item-danger list-group-item-success');
                     $answer.find('i.fa-circle').removeClass('d-none');
                 }
             });
-            var comment = self.quiz.answers[questionId].comment;
-            if (comment) {
-                $question.find('.o_quiz_quiz_answer_info').removeClass('d-none');
-                $question.find('.o_quiz_quiz_answer_comment').text(comment);
-            }
+            var $list = $question.find('.list-group');
+            var $comment = QWeb.render('quiz.comment', {'answer': answer});
+            $list.append($comment);
         });
     },
 
@@ -217,6 +221,27 @@ var Quiz = publicWidget.Widget.extend({
         });
     },
 
+    /**
+     * Remove the answer decorators
+     */
+    _resetQuiz: function () {
+        this.$('.o_quiz_js_quiz_question').each(function () {
+            var $question = $(this);
+            $question.find('a.o_quiz_quiz_answer').each(function () {
+                var $answer = $(this);
+                $answer.find('i.fa').addClass('d-none');
+                $answer.find('i.fa-circle').removeClass('d-none');
+                $answer.find('span.o_quiz_quiz_answer_text').removeClass('text-danger text-success');
+                $answer.find('span.badge').remove();
+            });
+            var $info = $question.find('.o_quiz_quiz_answer_info');
+            $info.remove();
+        });
+        this.track.completed = false;
+        this._enableAnswers();
+        this._renderValidationInfo();
+    },
+
     //--------------------------------------------------------------------------
     // Handlers
     //--------------------------------------------------------------------------
@@ -247,9 +272,7 @@ var Quiz = publicWidget.Widget.extend({
                 event_id: this.track.eventId,
                 track_id: this.track.id
             }
-        }).then(function () {
-            window.location.reload();
-        });
+        }).then(this._resetQuiz.bind(this));
     },
 
 });

--- a/addons/website_event_track_quiz/static/src/xml/quiz_templates.xml
+++ b/addons/website_event_track_quiz/static/src/xml/quiz_templates.xml
@@ -27,39 +27,66 @@
                                 <span t-esc="answer.text_value"/>
                             </a>
                         </t>
-                        <div class="o_quiz_quiz_answer_info list-group-item list-group-item-info d-none">
-                            <i class="fa fa-info-circle"/>
-                            <span class="o_quiz_quiz_answer_comment"/>
-                        </div>
                     </div>
-                </div>
-                <div t-if="!widget.track.completed" class="o_quiz_js_quiz_validation border-top pt-3"/>
-                <div t-else="" class="row">
-                    <div class="o_quiz_js_quiz_validation col py-2 bg-100 mb-2 border-bottom"/>
                 </div>
             </div>
         </div>
     </t>
 
+    <t t-name="quiz.badge">
+        <span class="badge badge-warning ml-2">
+            <span>+ <t t-esc="answer.awarded_points"/></span>
+            <span t-if="answer.awarded_points == 1">Point</span>
+            <span t-else="">Points</span>
+        </span>
+    </t>
+
+    <t t-name="quiz.comment">
+        <t t-if="answer.is_correct">
+            <div class="o_quiz_quiz_answer_info list-group-item list-group-item-success">
+                <i class="fa fa-info-circle"/>
+                Correct.
+                <t t-if="answer.comment">
+                    <br/>
+                    <t t-esc="answer.comment"/>
+                </t>
+            </div>
+        </t>
+        <t t-else="">
+            <div class="o_quiz_quiz_answer_info list-group-item list-group-item-danger">
+                <i class="fa fa-info-circle"/>
+                Incorrect. The correct answer was: <t t-esc="answer.correct_answer_ids"/>
+                <t t-if="answer.comment">
+                    <br/>
+                    <t t-esc="answer.comment"/>
+                </t>
+            </div>
+        </t>
+    </t>
+
     <t t-name="quiz.validation">
-        <div id="validation">
-            <div class="d-flex align-items-center justify-content-between">
-                <div t-att-class="'d-flex align-items-center' + (widget.track.completed ? ' alert alert-success my-0 py-1 px-3' : '')">
-                    <button t-if="!widget.track.completed" role="button" title="Check answers" aria-label="Check answers"
-                        class="btn btn-primary text-uppercase font-weight-bold o_quiz_js_quiz_submit">Check your answers</button>
-                    <b t-else="" class="my-0 h5">Done !</b>
-                    <span class="my-0 h5" style="line-height: 1">
-                        <span t-if="widget.track.completed" role="button" title="Succeed and gain karma" aria-label="Succeed and gain karma" class="badge badge-pill badge-warning text-white font-weight-bold ml-3 px-2">
-                            + <t t-esc="widget.quiz.quizPointsGained || 0"/> Points
-                        </span>
-                    </span>
-                </div>
-                <div class="flex-grow-1 text-right">
-                    <button t-if="widget.track.isEventUser"
-                       class="d-none d-md-inline-block btn btn-light border o_quiz_js_quiz_reset">
-                        Reset
-                    </button>
-                </div>
+        <div id="validation" class="d-md-flex">
+            <div class="flex-grow-1">
+                <button t-if="!widget.track.completed" role="button" title="Check answers" aria-label="Check answers"
+                    class="btn btn-primary text-uppercase font-weight-bold o_quiz_js_quiz_submit">
+                    Check your answers
+                </button>
+                <t t-else="">
+                    <div t-if="widget.quiz.quizPointsGained > 0" class="alert alert-warning mr-md-3">
+                        Congratulations, you scored a total of <span t-esc="widget.quiz.quizPointsGained" class="font-weight-bold"/>
+                        <span t-if="widget.quiz.quizPointsGained == 1">point!</span>
+                        <span t-else="">points!</span>
+                    </div>
+                    <div t-else="" class="alert alert-warning mr-md-3">
+                        Oopsie, you did not score any point on this quiz.
+                    </div>
+                </t>
+            </div>
+            <div class="o_quiz_js_quiz_actions mt-3 mt-md-0">
+                <button t-if="widget.track.isEventUser or widget.track.unlimitedTries"
+                    class="btn border o_quiz_js_quiz_reset">
+                    Reset
+                </button>
             </div>
         </div>
     </t>

--- a/addons/website_event_track_quiz/views/event_quiz_question_views.xml
+++ b/addons/website_event_track_quiz/views/event_quiz_question_views.xml
@@ -46,7 +46,7 @@
                 <sheet>
                     <h1>
                         <field name="name" default_focus="1"
-                            placeholder="e.g. According to Douglas, what should you pay most attention to?"/>
+                            placeholder="e.g. What is Joe's favorite motto?"/>
                     </h1>
                     <group>
                         <field name="quiz_id"/>
@@ -57,6 +57,7 @@
                             <tree editable="bottom" create="true" delete="true">
                                 <field name="sequence" widget="handle"/>
                                 <field name="text_value"/>
+                                <field name="is_correct"/>
                                 <field name="awarded_points"/>
                                 <field name="comment"/>
                             </tree>

--- a/addons/website_event_track_quiz/views/event_quiz_templates.xml
+++ b/addons/website_event_track_quiz/views/event_quiz_templates.xml
@@ -9,7 +9,8 @@
             t-att-data-completed="1 if quiz_completed else 0"
             t-att-data-quiz-attempts-count="quiz_attempts_count or 0"
             t-att-data-quiz-points-gained="quiz_points"
-            t-att-data-is-event-user="is_event_user or 0">
+            t-att-data-is-event-user="is_event_user or 0"
+            t-att-data-unlimited-tries="track.quiz_id.unlimited_tries">
             <t t-foreach="track.quiz_id.question_ids" t-as="question">
                 <t t-call="website_event_track_quiz.quiz_question"/>
             </t>
@@ -28,8 +29,8 @@
             <div class="list-group">
                 <t t-foreach="question['answer_ids']" t-as="answer">
                     <a t-att-data-answer-id="answer['id']" href="#"
-                        t-att-data-text="answer['text_value']" t-att-data-is-correct="answer['is_correct']" t-att-data-comment="answer['comment']"
-                        t-att-class="'o_quiz_quiz_answer list-group-item list-group-item-action d-flex align-items-center %s' % ('list-group-item-success' if slid_completed and answer['is_correct'] else '')">
+                        t-att-data-text="answer['text_value']"
+                        class="o_quiz_quiz_answer list-group-item list-group-item-action d-flex align-items-center">
                         <label class="my-0 d-flex align-items-center justify-content-center mr-2">
                             <input type="radio"
                                 t-att-name="question['id']"
@@ -43,10 +44,6 @@
                         <span t-esc="answer['text_value']"/>
                     </a>
                 </t>
-                <div class="o_quiz_quiz_answer_info list-group-item list-group-item-info d-none">
-                    <i class="fa fa-info-circle"/>
-                    <span class="o_quiz_quiz_answer_comment"/>
-                </div>
             </div>
         </div>
     </template>

--- a/addons/website_event_track_quiz/views/event_quiz_views.xml
+++ b/addons/website_event_track_quiz/views/event_quiz_views.xml
@@ -39,8 +39,13 @@
                             placeholder="e.g. Test your Knowledge"/>
                     </h1>
                     <group>
-                        <field name="event_track_id"/>
-                        <field name="event_id"/>
+                        <group>
+                            <field name="unlimited_tries" string="Allow multiple tries"/>
+                        </group>
+                        <group groups="base.group_no_one">
+                            <field name="event_track_id"/>
+                            <field name="event_id"/>
+                        </group>
                     </group>
                     <group name="questions" string="Questions">
                         <field name="question_ids" nolabel="1"


### PR DESCRIPTION
PURPOSE

Add a few minor usability features as well as a few layout adjustments for the
'event' modules following our big 14.0 rework.

SPECIFICATION

- Add "Allow multiple tries" option for the track quizzes.
- New layout for the track quizzes.
- Add "Hide and show" feature for the tracks.
- Add a dynamic countdown for the tracks.
- Add a new popover for the exhibitors.
- Minor changes and layout adjustments.

See underlying commits for more details.

Task-2347597
ENT PR odoo/enterprise#15745
UPG PR odoo/upgrade#2332
