### PR TITLE
[FIX] purchase_requisition: Purchase Order Approval

### DIFF
--- a/addons/purchase_requisition/models/purchase.py
+++ b/addons/purchase_requisition/models/purchase.py
@@ -87,7 +87,8 @@ class PurchaseOrder(models.Model):
             if po.requisition_id.type_id.exclusive == 'exclusive':
                 others_po = po.requisition_id.mapped('purchase_ids').filtered(lambda r: r.id != po.id)
                 others_po.button_cancel()
-                po.requisition_id.action_done()
+                if po.state not in ['draft', 'sent', 'to approve']:
+                    po.requisition_id.action_done()
         return res
 
     @api.model


### PR DESCRIPTION
Steps to reproduce the bug:

- Create a user with only access rights, Inventory = Administrator, Purchase = user
- Enable feature Purchase order approval in Purchase > Settings
- Agreement Type = Exclusive, lines of Agreement, Quantity of Agreement
- Login as a new created user and navigate to a menu Purchase > Purchase agreement and
create a new Purchase agreement, confirm it
- From the button create two PO (having a total > 5000)
- Cancel one of the PO first and try to approve another one

Bug:

A UserError was riased: You have to cancel or validate every RFQ before closing the purchase requisition.

opw:2368999