### PR TITLE
fix UI glitch on image widget when too smal image

### DIFF
--- a/addons/web/static/src/scss/fields.scss
+++ b/addons/web/static/src/scss/fields.scss
@@ -359,6 +359,7 @@
             background-color: $o-brand-primary;
             opacity: 0;
             transition: opacity ease 400ms;
+            min-width: 35px;
 
             > button.fa {
                 border: none;


### PR DESCRIPTION
PURPOSE
When image is too small and hovering over image shows glitch in UI, glitch should be removed and icons should be displayed properly.

SPEC
Remove UI glitch on how over small image.

TASK 2376452



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
