### PR TITLE
[FIX] stock: Product Moves displayed all companies moves

### DIFF
--- a/addons/stock/security/stock_security.xml
+++ b/addons/stock/security/stock_security.xml
@@ -97,6 +97,13 @@
         <field name="domain_force">['|','|',('company_id','=',False),('company_id','child_of',[user.company_id.id]),('location_dest_id.company_id', '=', False)]</field>
      </record>
 
+     <record model="ir.rule" id="stock_move_line_rule">
+         <field name="name">stock_move_line multi-company</field>
+        <field name="model_id" search="[('model','=','stock.move')]" model="ir.model"/>
+        <field name="global" eval="True"/>
+        <field name="domain_force">['|','|',('move_id.company_id','=',False),('move_id.company_id','child_of',[user.company_id.id]),('move_id.location_dest_id.company_id', '=', False)]</field>
+     </record>
+
     <record model="ir.rule" id="stock_quant_rule">
         <field name="name">stock_quant multi-company</field>
         <field name="model_id" ref="model_stock_quant"/>


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider two companies C1 and C2
- Let's consider a stoable product P
- Make a receipt transfer RT of 10 P in C1
- Log in C2
- Go to Inventory > Reporting > Product Moves

Bug:

RT was displayed in the report

opw:2426767