### PR TITLE
[IMP] base, website_crm_partner_assign: increase geoloc precision

### DIFF
--- a/addons/website_crm_partner_assign/models/crm_lead.py
+++ b/addons/website_crm_partner_assign/models/crm_lead.py
@@ -12,8 +12,8 @@ from odoo.tools import html_escape
 class CrmLead(models.Model):
     _inherit = "crm.lead"
 
-    partner_latitude = fields.Float('Geo Latitude', digits=(16, 5))
-    partner_longitude = fields.Float('Geo Longitude', digits=(16, 5))
+    partner_latitude = fields.Float('Geo Latitude', digits=(10, 7))
+    partner_longitude = fields.Float('Geo Longitude', digits=(10, 7))
     partner_assigned_id = fields.Many2one('res.partner', 'Assigned Partner', tracking=True, domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]", help="Partner this case has been forwarded/assigned to.", index=True)
     partner_declined_ids = fields.Many2many(
         'res.partner',

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -198,8 +198,8 @@ class Partner(models.Model):
     city = fields.Char()
     state_id = fields.Many2one("res.country.state", string='State', ondelete='restrict', domain="[('country_id', '=?', country_id)]")
     country_id = fields.Many2one('res.country', string='Country', ondelete='restrict')
-    partner_latitude = fields.Float(string='Geo Latitude', digits=(16, 5))
-    partner_longitude = fields.Float(string='Geo Longitude', digits=(16, 5))
+    partner_latitude = fields.Float(string='Geo Latitude', digits=(10, 7))
+    partner_longitude = fields.Float(string='Geo Longitude', digits=(10, 7))
     email = fields.Char()
     email_formatted = fields.Char(
         'Formatted Email', compute='_compute_email_formatted',


### PR DESCRIPTION
Before this commit:

    - The precision on geolocalisation fields were set to (16,5) which
      caused rounding when data was comming from Goolge.

After this commit:

    - The precision on geolocalisation fields are set to (10,7) which is
      aligned with what Google does.

This precision of (10,7) is actually already used in the Sign App.

task-2426985

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
