### PR TITLE
allow to switch to year view from mini calendar

### DIFF
--- a/addons/web/static/src/js/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/js/views/calendar/calendar_controller.js
@@ -225,9 +225,10 @@ var CalendarController = AbstractController.extend({
         if (modelData.target_date.format('YYYY-MM-DD') === event.data.date.format('YYYY-MM-DD')) {
             // When clicking on same date, toggle between the two views
             switch (modelData.scale) {
+                case 'year': this.model.setScale('month'); break;
                 case 'month': this.model.setScale('week'); break;
                 case 'week': this.model.setScale('day'); break;
-                case 'day': this.model.setScale('month'); break;
+                case 'day': this.model.setScale('year'); break;
             }
         } else if (modelData.target_date.week() === event.data.date.week()) {
             // When clicking on a date in the same week, switch to day view

--- a/addons/web/static/tests/views/calendar_tests.js
+++ b/addons/web/static/tests/views/calendar_tests.js
@@ -1616,7 +1616,7 @@ QUnit.module('Views', {
     });
 
     QUnit.test('use mini calendar', async function (assert) {
-        assert.expect(12);
+        assert.expect(14);
 
         var calendar = await createCalendarView({
             View: CalendarView,
@@ -1650,7 +1650,15 @@ QUnit.module('Views', {
         await testUtils.dom.click(calendar.$('.o_calendar_mini a:contains(18)'));
         assert.containsOnce(calendar, '.fc-timeGridDay-view', "should be in day mode");
         assert.containsN(calendar, '.fc-event', 2, "should display 2 events on the day");
-        // Clicking on the same day should toggle between day, month and week views
+        // Clicking on the same day should toggle between day, week, month and year views
+        await testUtils.dom.click(calendar.$('.o_calendar_mini a:contains(18)'));
+        const events = [...calendar.el.querySelectorAll("[data-event-id]")].map(elem => {
+            return elem.getAttribute('data-event-id');
+        });
+        const yearEventsLength = Array.from(new Set(events)).length;
+        assert.containsOnce(calendar, '.fc-dayGridYear-view', "should be in year mode");
+        assert.strictEqual(yearEventsLength, 7, "should display 8 events on the year");
+
         await testUtils.dom.click(calendar.$('.o_calendar_mini a:contains(18)'));
         assert.containsOnce(calendar, '.fc-dayGridMonth-view', "should be in month mode");
         assert.containsN(calendar, '.fc-event', 7, "should display 7 events on the month (event 5 is on multiple weeks and generates to .fc-event)");


### PR DESCRIPTION
PURPOSE
When clicking on mini calendar day several times, calendar mode is switched but it switches between Day, Week and Month, Year mode is never switched when clicking on the date in mini calendar.

SPEC
When clicking on date in mini calendar it should switch between Day, Week, Month and Year view when date is clicked several times.

TASK 2387799


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
