### PR TITLE
[FIX] account: reconciliation models: allow disabling bypass of match…

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -803,7 +803,8 @@ class AccountReconcileModel(models.Model):
         # We check the amount criteria of the reconciliation model, and select the
         # candidates if they pass the verification. Candidates from the first priority
         # level (even already selected) bypass this check, and are selected anyway.
-        if priorities & {1,2} or self._check_rule_propositions(st_line, candidates):
+        disable_bypass = self.env['ir.config_parameter'].sudo().get_param('account.disable_rec_models_bypass')
+        if (not disable_bypass and priorities & {1,2}) or self._check_rule_propositions(st_line, candidates):
             rslt = {
                 'model': self,
                 'aml_ids': [candidate['aml_id'] for candidate in candidates],


### PR DESCRIPTION
…ing amount check for more advanced cases

Reconciliation models can now create partial payment on invoices. Because of that, the default behavior is not anymore to fully pay the invoice and create an open balance write off.

In some cases, though, this is what we want (exchange difference, ...). The solution for that is to create a reconciliation model with write off lines (telling it it must only apply if there is a 90% percent match on the amount, for example), and then create another one not checking the amount to just match the things to reconcile partially by using the partner.

However, as it is now, reconciliation models always bypass the check made on the amount in case the statement line's label matches the invoice's payment reference exactly. This can lead to cases where we are matching elements we shouldn't with the rule doing the write off.

Example:

- use only two 'invoice matching' reconciliation models, in the following application sequence:
	- model 1, matching partner if with amount matching percentage is 90%, and doing a write-off for the unmatched amount
	- model 2, matching partner with no amount matching percentage, and no write off

- create an invoice with payment refrence INV1 for partner A, amount: 100

- create an invoice with payment refernce INV2 for partner A, amount: 200

- create a statement with two lines:
	- line 1, with 99 for partner A, label= INV1.
	- line 2, with 1 for partner A, label= INV2.

- Open the reconciliation widget

==> Before the fix:
model 1 is applied on both statement lines, as their label match payment references. This is what we want for line 1, but probably not for line 2, which will create a write off of 199, while we'd have wished for a partial payment, leaving the invoice with 199 open.

==> After the fix
The behavior is the same unless the config_parameter is set. If it is:
	- line 1 will be matched by model 1 (as 99 - 9,9 < 100 < 99 + 9,9). INV1 will be paid with a write off of 1.
	- line 2 will not be matched by model 1 (as 200 is not between 1 - 0,1 and 1 + 0,1), but it will be by model 2 (since line 2 and INV 2 share the same partner). So, INV2 will be partially reconciled with line 2.

OPW 2419030

