### PR TITLE
[FIX] point_of_sale: already reconciled stock_account_move_line

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -654,9 +654,9 @@ class PosSession(models.Model):
         ).mapped('move_lines')
         stock_account_move_lines = self.env['account.move'].search([('stock_move_id', 'in', stock_moves.ids)]).mapped('line_ids')
         for account_id in stock_output_lines:
-            ( stock_output_lines[account_id].filtered(lambda aml: not aml.reconciled)
+            ( stock_output_lines[account_id]
             | stock_account_move_lines.filtered(lambda aml: aml.account_id == account_id)
-            ).reconcile()
+            ).filtered(lambda aml: not aml.reconciled).reconcile()
         return data
 
     def _get_extra_move_lines_vals(self):


### PR DESCRIPTION
It may happen that the customer did reconcile some of his account.move.line
prior the closing of the session. As it is not possible to reconcile
an already reconciled account.move.line, it triggers an error.

After discussing with JCB, it turns out that it is safe enough to ignore
the account.move.line that are already reconciled.

opws:
2374559
2376187
2377958
2391395
2425197
