### PR TITLE
[FIX] website_event: hide registered badge when registration is cancelled

### DIFF
--- a/addons/website_event/models/event.py
+++ b/addons/website_event/models/event.py
@@ -45,7 +45,8 @@ class Event(models.Model):
         if self.env.user != self.env['website'].get_current_website().user_id:
             email = self.env.user.partner_id.email
             for event in self:
-                domain = ['&', '|', ('email', '=', email), ('partner_id', '=', self.env.user.partner_id.id), ('event_id', '=', event.id)]
+                domain = ['&','&', '|', ('email', '=', email), ('partner_id', '=', self.env.user.partner_id.id),
+                          ('event_id', '=', event.id), ('state', '!=', 'cancel')]
                 event.is_participating = self.env['event.registration'].search_count(domain)
 
     @api.multi


### PR DESCRIPTION
Before this commit, a participating badge was displayed on the event even if the user's registration has been cancelled which is not a correct behaviour.
After this commit, the participating badge will be hidden if all the user's registration have been cancelled.

Task-2432546

Signed-off-by: Noureddine Bensebia <neb@odoo.com>

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
