### PR TITLE
[FIX] web_editor: allow to center button with summernote

### DIFF
--- a/addons/web_editor/static/lib/summernote/src/js/module/Editor.js
+++ b/addons/web_editor/static/lib/summernote/src/js/module/Editor.js
@@ -317,9 +317,19 @@ define([
       this[commands[idx]] = (function (sCmd) {
         return function ($editable, value) {
           beforeCommand($editable);
+          var parentEl = window.getSelection().baseNode.parentElement;
+          var centeredButton = (sCmd === 'justifyCenter' && parentEl.classList.contains('btn'));
+          if (centeredButton) {
+            // This hack remove the class .btn from button during --> document.execCommand('justifyCenter')
+            // because the Chrome browser doesnt want apply 'text-align: center' on nodes with centered children.
+            parentEl.classList.remove('btn')
+          }
 
           document.execCommand(sCmd, false, value);
 
+          if (centeredButton) {
+            parentEl.classList.add('btn')
+          }
           afterCommand($editable, true);
         };
       })(commands[idx]);


### PR DESCRIPTION
Before this commit, it was not possible to center a button using the
editor option 'align center'.

It is because, using document.execCommand(), the Chrome browser doesnt
want apply 'text-align: center' on nodes with centered children. And
the buttons have the boostrap class '.btn' which adds text-align:
center.

So the hack here is removing the class .btn from button during the
execution of document.execCommand() when needed.

task-2423935

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
