### PR TITLE
[FIX] purchase: avoid updating data_planned on section/note

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -196,7 +196,7 @@ class PurchaseOrder(models.Model):
     @api.onchange('date_planned')
     def onchange_date_planned(self):
         if self.date_planned:
-            self.order_line.date_planned = self.date_planned
+            self.order_line.filtered(lambda line: not line.display_type).date_planned = self.date_planned
 
     @api.model
     def create(self, vals):


### PR DESCRIPTION
Do not update the date_planned of section/note purchase lines when the
date is changed on the order.

Based on f3ebab6eb52e3dc8be1f030aecfff348a22f7e09

opw-2429853

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
