### PR TITLE
[FIX] base, website: replicate inherit_id update on cow view

### DIFF
--- a/addons/website/models/__init__.py
+++ b/addons/website/models/__init__.py
@@ -4,6 +4,7 @@
 from . import ir_actions
 from . import ir_attachment
 from . import ir_http
+from . import ir_module_module
 from . import ir_qweb
 from . import ir_qweb_fields
 from . import website

--- a/addons/website/models/ir_module_module.py
+++ b/addons/website/models/ir_module_module.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+
+class Module(models.Model):
+    _inherit = 'ir.module.module'
+
+    def _check(self):
+        super()._check()
+        View = self.env['ir.ui.view']
+        website_views_to_adapt = getattr(self.pool, 'website_views_to_adapt', [])
+        if website_views_to_adapt:
+            for view_replay in website_views_to_adapt:
+                cow_view = View.browse(view_replay[0])
+                View._load_records_write_on_cow(cow_view, view_replay[1], view_replay[2])
+            self.pool.website_views_to_adapt.clear()

--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -94,6 +94,14 @@ class View(models.Model):
 
         return True
 
+    def _load_records_write_on_cow(self, cow_view, inherit_id, values):
+        inherit_id = self.search([
+            ('key', '=', self.browse(inherit_id).key),
+            ('website_id', 'in', (False, cow_view.website_id.id)),
+        ], order='website_id', limit=1).id
+        values['inherit_id'] = inherit_id
+        cow_view.with_context(no_cow=True).write(values)
+
     def _create_all_specific_views(self, processed_modules):
         """ When creating a generic child view, we should
             also create that view under specific view trees (COW'd).

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1526,11 +1526,28 @@ actual arch.
             noupdate behavior on views having an ir.model.data.
         """
         if self.type == 'qweb':
-            # Update also specific views
             for cow_view in self._get_specific_views():
                 authorized_vals = {}
                 for key in values:
-                    if cow_view[key] == self[key]:
+                    if key != 'inherit_id' and cow_view[key] == self[key]:
                         authorized_vals[key] = values[key]
-                cow_view.write(authorized_vals)
+                # if inherit_id update, replicate change on cow view but
+                # only if that cow view inherit_id wasn't manually changed
+                inherit_id = values.get('inherit_id')
+                if inherit_id and self.inherit_id.id != inherit_id and \
+                   cow_view.inherit_id.key == self.inherit_id.key:
+                    self._load_records_write_on_cow(cow_view, inherit_id, authorized_vals)
+                else:
+                    cow_view.with_context(no_cow=True).write(authorized_vals)
         super(View, self)._load_records_write(values)
+
+    def _load_records_write_on_cow(self, cow_view, inherit_id, values):
+        # for modules updated before `website`, we need to
+        # store the change to replay later on cow views
+        if not hasattr(self.pool, 'website_views_to_adapt'):
+            self.pool.website_views_to_adapt = []
+        self.pool.website_views_to_adapt.append((
+            cow_view.id,
+            inherit_id,
+            values,
+        ))


### PR DESCRIPTION
Before this commit, only whitelisted fields would be updated on cow views
during a module update.
A field would be whitelisted if he had the same value than the original view,
see it as a heuristic to not write on modified fields.

But `inherit_id` is not that simple, even if the cow view has a different value
than its original view, it doesn't mean it was modified by the user, it is just
because of the cow mechanism that assigned a copied view as inherit_id, which
is just a copy ofthe original one.

We can thus consider `inherit_id` as unchanged and whitelist it if the `key` is
the same.

In practice, it means that cow'd views did not receive the `inherit_id` updates
as in commit c857756#diff-823e5db841dca1798ff1300e243059a4e1c93343598d2be5a1d1dcd1d2d0c273R537
where `portal.my_account_link` had its `inherit_id` changed from
`portal.frontend_layout` to `portal.user_dropdow`, see odoo/upgrade#2059:

Considering a module update changing `inherit_id` of D from A to B, the
following use cases are expected. Without this fix, D' never move:

```
CASE 1
  A    A'   B                      A    A'   B
  |    |                 =>                 / \
  D    D'                                  D   D'

CASE 2
  A    A'   B    B'               A    A'   B   B'
  |    |                 =>                 |   |
  D    D'                                   D   D'

CASE 3
    A    B                        A    B
   / \                   =>           / \
  D   D'                             D   D'

CASE 4
    A    B    B'                  A    B   B'
   / \                   =>            |   |
  D   D'                               D   D'
```