### PR TITLE
[FIX] requirements.txt: module 'stdnum.eu.vat' has no attribute '_country_codes'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,8 @@ pyparsing==2.1.10
 PyPDF2==1.26.0
 pyserial==3.1.1
 python-dateutil==2.5.3
+# vatnumber requirement. Last version compatible
+python-stdnum<=1.14
 pytz==2016.7
 pyusb==1.0.0
 PyYAML==3.12 ; python_version < '3.7'


### PR DESCRIPTION
The vatnumber is pinned to version 1.2 in the requirements.txt:
 -https://github.com/odoo/odoo/blob/85f3fe323c9105827931febda04745a55c1f44a4/requirements.txt#L41

but vatnumber does not have a pinned version to stdnum package

So, it is installed the last version even if it is not compatible

A new version was released of stdnum 1.15 on Jan 11, 2021
 - https://pypi.org/project/python-stdnum/1.15/

But it is not compatible with odoo@11.0 anymore because of
there is not exists the following attribute:
 - stdnum.eu.vat._country_codes or stdnum.eu.vat.country_codes

Used in the following line:
 - https://github.com/odoo/odoo/blob/85f3fe323c9105827931febda04745a55c1f44a4/addons/base_vat_autocomplete/models/res_partner.py#L15-L17

So, the following error will raised:

    2021-01-12 22:40:39,897 155 CRITICAL DB odoo.modules.module: Couldn't load module base_vat_autocomplete
    2021-01-12 22:40:39,897 155 CRITICAL DB odoo.modules.module: module 'stdnum.eu.vat' has no attribute '_country_codes'
    2021-01-12 22:40:39,905 155 WARNING DB odoo.modules.loading: Transient module states were reset
    2021-01-12 22:40:39,906 155 ERROR DB odoo.modules.registry: Failed to load registry
    Traceback (most recent call last):
    File "./modules/registry.py", line 85, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
    File "./modules/loading.py", line 380, in load_modules
    loaded_modules, update_module, models_to_check)
    File "./modules/loading.py", line 274, in load_marked_modules
    perform_checks=perform_checks, models_to_check=models_to_check
    File "./modules/loading.py", line 137, in load_module_graph
    load_openerp_module(package.name)
    File "./modules/module.py", line 368, in load_openerp_module
    __import__('odoo.addons.' + module_name)
    File "<frozen importlib._bootstrap>", line 969, in _find_and_load
    File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 664, in _load_unlocked
    File "<frozen importlib._bootstrap>", line 634, in _load_backward_compatible
    File "./modules/module.py", line 82, in load_module
    exec(open(modfile, 'rb').read(), new_mod.__dict__)
    File "<string>", line 4, in <module>
    File "./base_vat_autocomplete/models/__init__.py", line 4, in <module>
    from . import res_partner
    File "./base_vat_autocomplete/models/res_partner.py", line 17, in <module>
    stdnum_vat.country_codes = stdnum_vat._country_codes
    AttributeError: module 'stdnum.eu.vat' has no attribute '_country_codes'
    2021-01-12 22:40:39,907 155 CRITICAL DB odoo.service.server: Failed to initialize database `DB`.
    Traceback (most recent call last):
    File "./service/server.py", line 1043, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
    File "./modules/registry.py", line 85, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
    File "./modules/loading.py", line 380, in load_modules
    loaded_modules, update_module, models_to_check)
    File "./modules/loading.py", line 274, in load_marked_modules
    perform_checks=perform_checks, models_to_check=models_to_check
    File "./modules/loading.py", line 137, in load_module_graph
    load_openerp_module(package.name)
    File "./modules/module.py", line 368, in load_openerp_module
    __import__('odoo.addons.' + module_name)
    File "<frozen importlib._bootstrap>", line 969, in _find_and_load
    File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 664, in _load_unlocked
    File "<frozen importlib._bootstrap>", line 634, in _load_backward_compatible
    File "./modules/module.py", line 82, in load_module
    exec(open(modfile, 'rb').read(), new_mod.__dict__)
    File "<string>", line 4, in <module>
    File "./base_vat_autocomplete/models/__init__.py", line 4, in <module>
    from . import res_partner
    File "./base_vat_autocomplete/models/res_partner.py", line 17, in <module>
    stdnum_vat.country_codes = stdnum_vat._country_codes
    AttributeError: module 'stdnum.eu.vat' has no attribute '_country_codes'
    2021-01-12 22:40:39,908 155 INFO DB odoo.service.server: Initiating shutdown
    2021-01-12 22:40:39,908 155 INFO DB odoo.service.server: Hit CTRL-C again or send a second signal to force the shutdown.

Fixed pinning the last version compatible python-stdnum<=1.14


Disclaimer: I know odoo@11.0 is not supported anymore but I have created this PR in order to help other people still using this version for a few customer like us.
If you consider it could be merged we will be thankful :)

Regards!

cc @nim-odoo @mart-e 