### PR TITLE
[FIX] website_sale_stock: No quantity in stock in the shop in multi companies

### DIFF
--- a/addons/website_sale_stock/models/product_template.py
+++ b/addons/website_sale_stock/models/product_template.py
@@ -27,7 +27,7 @@ class ProductTemplate(models.Model):
         if combination_info['product_id']:
             product = self.env['product.product'].sudo().browse(combination_info['product_id'])
             website = self.env['website'].get_current_website()
-            virtual_available = product.with_context(warehouse=website.warehouse_id.id).virtual_available
+            virtual_available = product.with_context(warehouse=website._website_warehouse().id).virtual_available
             combination_info.update({
                 'virtual_available': virtual_available,
                 'virtual_available_formatted': self.env['ir.qweb.field.float'].value_to_html(virtual_available, {'decimal_precision': 'Product Unit of Measure'}),

--- a/addons/website_sale_stock/models/sale_order.py
+++ b/addons/website_sale_stock/models/sale_order.py
@@ -20,8 +20,8 @@ class SaleOrder(models.Model):
                 # The quantity should be computed based on the warehouse of the website, not the
                 # warehouse of the SO.
                 website = self.env['website'].get_current_website()
-                if cart_qty > line.product_id.with_context(warehouse=website.warehouse_id.id).virtual_available and (line_id == line.id):
-                    qty = line.product_id.with_context(warehouse=website.warehouse_id.id).virtual_available - cart_qty
+                if cart_qty > line.product_id.with_context(warehouse=website._website_warehouse().id).virtual_available and (line_id == line.id):
+                    qty = line.product_id.with_context(warehouse=website._website_warehouse().id).virtual_available - cart_qty
                     new_val = super(SaleOrder, self)._cart_update(line.product_id.id, line.id, qty, 0, **kwargs)
                     values.update(new_val)
 

--- a/addons/website_sale_stock/models/website.py
+++ b/addons/website_sale_stock/models/website.py
@@ -20,3 +20,11 @@ class Website(models.Model):
             if warehouse_id:
                 values['warehouse_id'] = warehouse_id
         return values
+
+    def _website_warehouse(self):
+        self.ensure_one()
+        warehouse = self.warehouse_id
+        if not warehouse:
+            warehouses = self.env['stock.warehouse'].sudo().search([('company_id', '=', self.company_id.id)])
+            warehouse = warehouses if len(warehouses) == 1 else warehouse
+        return warehouse


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider two companies C1 and C2 and a shared storable product P
- Let's consider a website W1 for C1
- Multi warehouse is not activated (no possible to set a warehouse for W1)
- P shows inventory availability below a threshold and prevent sales if not enough stock
- Availability treshold of P = 3
- Create a PO of 5 P in C1
- Create a SO of 5 P in C2 with C1 as customer
- Go to the shop of W1 and click on P

Bug:

P was displayed as unvailable because no quantity in stock even if there are 5 P
on hand in C1.

PS: No warehouse was set for W1 and it's not possible to set it as multi warehouse is not activated.

opw:2422389