### PR TITLE
[FIX] mrp: ensure serial numbers are used once

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -433,6 +433,14 @@ class MrpWorkorder(models.Model):
         if float_compare(self.qty_producing, 0, precision_rounding=self.product_uom_id.rounding) <= 0:
             raise UserError(_('Please set the quantity you are currently producing. It should be different from zero.'))
 
+        # Ensure serial numbers are used once
+        if self.product_id.tracking == 'serial' and self.finished_lot_id:
+            line = self.finished_workorder_line_ids.filtered(
+                lambda line: line.lot_id.id == self.finished_lot_id.id
+            )
+            if line:
+                raise UserError(_('You cannot produce the same serial number twice.'))
+
         # If last work order, then post lots used
         if not self.next_work_order_id:
             self._update_finished_move()


### PR DESCRIPTION
Steps:
- Install mrp_workorder
- Go to MRP > Master Data > Products
- Create a Product (1)
  - Inventory
    - Route: Manufacture
    - Tracking: By Unique Serial Number
- Create a Bill of Material for (1)
  - Routing:
    - Create a new routing with two operations:
      - Start Next Operation: Once some products are processed
      - Duration Computation: Set duration manually
  - Add a new component
    - Product Type: Storable Product
- Go to Operations > Manufacturing Orders
- Create a new one:
  - Product: (1)
  - Quantity to Produce: 5
- Click Mark as ToDo > Plan > Work Orders
- Click the first work order
- Process it
- Open the web console
- Enter this: `odoo.__DEBUG__.services['web.core'].bus.trigger('barcode_scanned', "BBBAR", $(".o_web_client")[0]);`
- Click Record Production
- Repeat the two last points

Bug:
Using the same serial number is authorized.

Explanation:
We have to use two operations because, if it's the last one,
`_update_finished_move()` ensures all the products have a unique serial
number as seen here:
https://github.com/odoo/odoo/blob/a5ac0fad7d1e288ac1995369a9a64c2e54125c27/addons/mrp/models/mrp_abstract_workorder.py#L259-L264

When trying to add the second serial number manually, we get the
following error upon creation: "The combination of serial number and
product must be unique across a company !". However, this error does not
prevent the user from clicking Record Production and adding a duplicate.
The same applies to scanned serial numbers. They bypass the creation
check and directly enter the code in the field.

This commit prevents clicking Record Production if the serial number has
already been used in the manufacturing order. This way, both manual and
scanned serial numbers are taken care of. Adding empty serial numbers
is authorized as stated in this test:
https://github.com/odoo/odoo/blob/fe1c381b67ff78d48bb50fd731717324cf03a719/addons/mrp/tests/test_workorder_operation.py#L765-L771

opw:2366412