### PR TITLE
13.0 fix buttons alignement bvr

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -27,6 +27,9 @@ $o-we-zindex: $o-we-overlay-zindex + 1 !default;
     * {
         font-weight: inherit !important;
     }
+    .btn {
+        text-align: unset !important;
+    }
 }
 
 // EDITOR TOP BAR AND POPOVER


### PR DESCRIPTION
Before this commit, it was not possible to center a button using the
editor option 'align center'.

It is because, using document.execCommand(), the Chrome browser doesnt
want apply 'text-align: center' on nodes with centered children. And
the buttons have the boostrap class '.btn' which adds text-align:
center.

So the hack here is disabling the text-align property from the '.btn'
class during the execution of document.execCommand().

task-2423935



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
