### PR TITLE
[IMP] base: improve qweb barcode widget

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -489,6 +489,9 @@ class IrActionsReport(models.Model):
             barcode_type = 'EAN13'
             if len(value) in (11, 12):
                 value = '0%s' % value
+        elif barcode_type == 'auto':
+            symbology_guess = {8: 'EAN8', 13: 'EAN13'}
+            barcode_type = symbology_guess.get(len(value), 'Code128')
         # add QR_quiet type for QR type with no border (not in 13.0 since there is quiet argument)
         if barcode_type == 'QR_quiet':
             kwargs['quiet'] = 1

--- a/odoo/addons/base/tests/test_qweb.py
+++ b/odoo/addons/base/tests/test_qweb.py
@@ -542,6 +542,35 @@ class TestQWebNS(TransactionCase):
         rendered = view2.with_context(lang=current_lang).render().strip()
         self.assertEqual(rendered, b'9/000/000*00')
 
+    def test_render_barcode(self):
+        engine = self.env['ir.qweb']
+        partner = self.env['res.partner'].create({
+            'name': 'bacode_test',
+            'barcode': 'test'
+        })
+
+        field = etree.Element('div', {
+            't-field': u'partner.barcode',
+            't-options': u"{'widget': 'barcode', 'width': 100, 'height': 30}"
+        })
+        rendered = engine.render(field, {'partner': partner}).strip().decode()
+        self.assertRegex(rendered,r'<div><img alt="Barcode test" src="data:image/png;base64,\S+"></div>')
+
+        partner.barcode = '4012345678901'
+        field = etree.Element('div', {
+            't-field': u'partner.barcode',
+            't-options': u"{'widget': 'barcode', 'symbology': 'EAN13', 'width': 100, 'height': 30, 'img_style': 'width:100%;', 'img_alt': 'Barcode'}"
+        })
+        ean_rendered = engine.render(field, {'partner': partner}).strip().decode()
+        self.assertRegex(ean_rendered,r'<div><img style="width:100%;" alt="Barcode" src="data:image/png;base64,\S+"></div>')
+
+        field = etree.Element('div', {
+            't-field': u'partner.barcode',
+            't-options': u"{'widget': 'barcode', 'symbology': 'auto', 'width': 100, 'height': 30, 'img_style': 'width:100%;', 'img_alt': 'Barcode'}"
+        })
+        auto_rendered = engine.render(field, {'partner': partner}).strip().decode()
+        self.assertRegex(auto_rendered,r'<div><img style="width:100%;" alt="Barcode" src="data:image/png;base64,\S+"></div>')
+
 
 from copy import deepcopy
 class FileSystemLoader(object):


### PR DESCRIPTION
When printing barcodes for a large amount of records, wkhtmltopdf will
make the same amount of http requests to the server in order to retrieve
barcodes. This can lead to performance issues or wkhtml to crash.

Fortunately, an already existsing qweb widget exists that include
barcodes images as inline base64.

With this commit, the web widget is a bit improved to accept attributes
for the generated image tag. Each option dictionary key starting with
`img_` will be converted into a tag attribute with the corresponding
value.

e.g.: `'img_alt': 'Barcode'` will result in `<img alt="Barcode"...`

The `alt` img attribute now defaults to `'Barcode %s' % value` with the
barcode value.

Also, the `quiet` reportlab option is also avalaible in the widget
options, as well as the `mask` option.

Finally, if the `symbology` option is not given, the widget defaults to
`Code128`. If `symbology` is set to `auto`, the action report will try
to guess the barcode type, based on the len of the value.

Cherry-pick of db8b3f1dbf780287fe807ab8d05f2858f3fa03f1

This backport of an improvement will permit to fix existing databases
that use the route `/report/barcode/...` in their reports with a large
amout of barcodes to print.