### PR TITLE
[FIX] web: restore backbutton support for OWL components

### DIFF
--- a/addons/web/static/src/js/core/owl_dialog.js
+++ b/addons/web/static/src/js/core/owl_dialog.js
@@ -1,5 +1,7 @@
-odoo.define('web.OwlDialog', function () {
+odoo.define('web.OwlDialog', function (require) {
     "use strict";
+
+    const patchMixin = require('web.patchMixin');
 
     const { Component, hooks, misc } = owl;
     const { Portal } = misc;
@@ -269,5 +271,5 @@ odoo.define('web.OwlDialog', function () {
     };
     Dialog.template = 'web.OwlDialog';
 
-    return Dialog;
+    return patchMixin(Dialog);
 });

--- a/addons/web/static/src/js/core/popover.js
+++ b/addons/web/static/src/js/core/popover.js
@@ -1,5 +1,7 @@
-odoo.define('web.Popover', function () {
+odoo.define('web.Popover', function (require) {
     'use strict';
+
+    const patchMixin = require('web.patchMixin');
 
     const { Component, hooks, misc, QWeb } = owl;
     const { Portal } = misc;
@@ -77,6 +79,10 @@ odoo.define('web.Popover', function () {
             });
             window.addEventListener('resize', this._onResizeWindow);
             this._hasGlobalEventListeners = true;
+        }
+
+        _close() {
+            this.state.displayed = false;
         }
 
         /**
@@ -184,7 +190,7 @@ odoo.define('web.Popover', function () {
             if (this.popoverRef.el && this.popoverRef.el.contains(ev.target)) {
                 return;
             }
-            this.state.displayed = false;
+            this._close();
         }
 
         /**
@@ -192,7 +198,7 @@ odoo.define('web.Popover', function () {
          * @param {Event} ev
          */
         _onPopoverClose(ev) {
-            this.state.displayed = false;
+            this._close();
         }
 
         /**
@@ -312,5 +318,5 @@ odoo.define('web.Popover', function () {
 
     QWeb.registerComponent('Popover', Popover);
 
-    return Popover;
+    return patchMixin(Popover);
 });


### PR DESCRIPTION
This merge prepares the ground for the restoration of the "backbutton" support for OWL components in enterprise in odoo/enterprise#15731.

Related to task ID: 2347640