### PR TITLE
[FW][FIX] purchase,purchase_stock: use correct company on PO creation

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -200,13 +200,15 @@ class PurchaseOrder(models.Model):
 
     @api.model
     def create(self, vals):
+        company_id = vals.get('company_id', self.default_get(['company_id'])['company_id'])
+        # Ensures default picking type and currency are taken from the right company.
+        self_comp = self.with_company(company_id)
         if vals.get('name', 'New') == 'New':
-            company_id = vals.get("company_id", self.env.company.id)
             seq_date = None
             if 'date_order' in vals:
                 seq_date = fields.Datetime.context_timestamp(self, fields.Datetime.to_datetime(vals['date_order']))
-            vals['name'] = self.env['ir.sequence'].with_company(company_id).next_by_code('purchase.order', sequence_date=seq_date) or '/'
-        return super(PurchaseOrder, self).create(vals)
+            vals['name'] = self_comp.env['ir.sequence'].next_by_code('purchase.order', sequence_date=seq_date) or '/'
+        return super(PurchaseOrder, self_comp).create(vals)
 
     def unlink(self):
         for order in self:


### PR DESCRIPTION
The picking_type and currency were taken from the current company, even if the
purchase order is created in another company.

Fixes #35026

X-original-commit: d080a5ea6b63832a6df00dce60c0b531d306241a

Forward-port of: #64245





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
