### PR TITLE
keep focus on searchbar when Tab pressed

### DIFF
--- a/addons/web/static/src/js/control_panel/search_bar.js
+++ b/addons/web/static/src/js/control_panel/search_bar.js
@@ -421,6 +421,7 @@ odoo.define('web.SearchBar', function (require) {
                     /* falls through */
                 case 'Tab':
                     if (this.state.inputValue.length) {
+                        ev.preventDefault(); // keep the focus inside the search bar
                         this._selectSource(currentItem);
                     }
                     break;


### PR DESCRIPTION
PURPOSE
When searchbar has autocomplete and user press Tab key then focus goes out of searchbar input while it should keep focus on searchbar so that user can do search on other term.

SPEC
When searching on searchbar and pressing Tab key should keep focus on searchbar input so that user can search again.

TASK 2393772

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
