### PR TITLE
[FIX] website_sale: correctly use fiscal position to compute price

### DIFF
--- a/addons/website_sale/models/product.py
+++ b/addons/website_sale/models/product.py
@@ -313,7 +313,9 @@ class ProductTemplate(models.Model):
             product = self.env['product.product'].browse(combination_info['product_id']) or self
 
             tax_display = self.env.user.has_group('account.group_show_line_subtotals_tax_excluded') and 'total_excluded' or 'total_included'
-            taxes = partner.property_account_position_id.map_tax(product.sudo().taxes_id.filtered(lambda x: x.company_id == company_id), product, partner)
+            Fpos_sudo = self.env['account.fiscal.position'].sudo()
+            fpos_id = Fpos_sudo.with_context(force_company=company_id.id).get_fiscal_position(partner.id)
+            taxes = Fpos_sudo.browse(fpos_id).map_tax(product.sudo().taxes_id.filtered(lambda x: x.company_id == company_id), product, partner)
 
             # The list_price is always the price of one.
             quantity_1 = 1

--- a/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
+++ b/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
@@ -62,3 +62,55 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueSe
         self.assertEqual(pricelist.currency_id.compare_amounts(combination_info['price'], 2222 * discount_rate * currency_ratio * tax_ratio), 0)
         self.assertEqual(pricelist.currency_id.compare_amounts(combination_info['list_price'], 2222 * currency_ratio * tax_ratio), 0)
         self.assertEqual(combination_info['has_discounted_price'], True)
+
+    def test_get_combination_info_with_fpos(self):
+        self.env.user.partner_id.country_id = False
+        current_website = self.env['website'].get_current_website()
+        pricelist = current_website.get_current_pricelist()
+        (self.env['product.pricelist'].search([]) - pricelist).write({'active': False})
+
+        test_product = self.env['product.template'].create({
+            'name': 'Test Product',
+            'price': 2000,
+        }).with_context(website_id=current_website.id)
+
+        # Add fixed price for pricelist
+        pricelist.item_ids = self.env['product.pricelist.item'].create({
+            'applied_on': "1_product",
+            'base': "list_price",
+            'compute_price': "fixed",
+            'fixed_price': 500,
+            'product_tmpl_id': test_product.id,
+        })
+        # Add 15% tax on product
+        tax15 = self.env['account.tax'].create({'name': "Test tax 15", 'amount': 15})
+        tax0 = self.env['account.tax'].create({'name': "Test tax 0", 'amount': 0})
+        test_product.taxes_id = tax15
+
+        # Enable tax included
+        group_tax_included = self.env.ref('account.group_show_line_subtotals_tax_included').with_context(active_test=False)
+        group_tax_excluded = self.env.ref('account.group_show_line_subtotals_tax_excluded').with_context(active_test=False)
+        group_tax_excluded.users -= self.env.user
+        group_tax_included.users |= self.env.user
+
+        # Create fiscal position for belgium mapping taxes 15% -> 0%
+        fpos = self.env['account.fiscal.position'].create({
+            'name': 'test',
+            'auto_apply': True,
+            'country_id': self.env.ref('base.be').id,
+        })
+        self.env['account.fiscal.position.tax'].create({
+            'position_id': fpos.id,
+            'tax_src_id': tax15.id,
+            'tax_dest_id': tax0.id,
+        })
+
+        combination_info = test_product._get_combination_info()
+        self.assertEqual(combination_info['price'], 575, "500$ + 15% tax")
+        self.assertEqual(combination_info['list_price'], 575, "500$ + 15% tax (2)")
+
+        # Now with fiscal position, taxes should be mapped
+        self.env.user.partner_id.country_id = self.env.ref('base.be').id
+        combination_info = test_product._get_combination_info()
+        self.assertEqual(combination_info['price'], 500, "500% + 0% tax (mapped from fp 15% -> 0% for BE)")
+        self.assertEqual(combination_info['list_price'], 500, "500% + 0% tax (mapped from fp 15% -> 0% for BE) (2)")


### PR DESCRIPTION
Before this commit, if the user had a fiscal position for his current country,
it wouldn't be used to compute the price of the products on the eshop.
Note that:
  - the price would be correct on the cart, as those prices are coming from a
    sale order which correctly retrieves the fiscal position.
  - if the fiscal position is directly set on the partner, prices are correct
    on the eshop

Step to reproduce:
  - Set Belgium as country on Portal user's partner
  - Create a 0% tax and a 15% tax
  - Create a fiscal position mapping 15% tax to 0% tax for Belgium country
    automatically detected
  - Create a product with 1000$ price and 15% tax set on it
  - Enable pricelist and select tax included in settings
  - Create a pricelist for Belgium and add a rule for the product you created
    to set a fixed price of 500$
  - Now visit eshop with Portal user

The test product show 575$ instead of 500$ in eshop, while it will correctly
show 500$ in cart.

opw-2423215
