### PR TITLE
[FIX] mail: fix notify domain for mass_post mode

### DIFF
--- a/addons/mail/wizard/mail_compose_message_view.xml
+++ b/addons/mail/wizard/mail_compose_message_view.xml
@@ -60,7 +60,7 @@
                         <field name="subject" placeholder="Subject..." required="True"/>
                         <!-- mass post -->
                         <field name="notify"
-                            attrs="{'invisible':['|', ('composition_mode', '!=', 'mass_post')]}"/>
+                            attrs="{'invisible': [('composition_mode', '!=', 'mass_post')]}"/>
                         <!-- mass mailing -->
                         <field name="no_auto_thread" attrs="{'invisible':[('composition_mode', '!=', 'mass_mail')]}"/>
                         <field name="reply_to" placeholder="Email address to redirect replies..."


### PR DESCRIPTION
This domains contains an obvious bug that forbids to open this view in `composition_mode=mass_post`.

@Tecnativa TT25941


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
