### PR TITLE
[FIX] account: Fix empty 'account_type' in automatic entry wizard

### DIFF
--- a/addons/account/wizard/account_automatic_entry_wizard_views.xml
+++ b/addons/account/wizard/account_automatic_entry_wizard_views.xml
@@ -8,6 +8,7 @@
                 <form>
                     <field name="account_type" invisible="1"/>
                     <field name="company_id" invisible="1"/>
+                    <field name="move_line_ids" invisible="1"/>
                     <field name="display_currency_helper" invisible="1"/>
                     <div attrs="{'invisible': [('display_currency_helper', '=', False)]}"  class="alert alert-info text-center" role="status">
                         The selected destination account is set to use a specific currency. Every entry transferred to it will be converted into this currency, causing


### PR DESCRIPTION
Since 'move_line_ids' isn't inside the view, `account_type` is never computed and then, the accrual account is never displayed/editable on the view.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
