### PR TITLE
[FIX] website: fix a typo in the js file of the snippet popup

### DIFF
--- a/addons/website/static/src/snippets/s_popup/000.js
+++ b/addons/website/static/src/snippets/s_popup/000.js
@@ -45,7 +45,7 @@ const PopupWidget = publicWidget.Widget.extend({
         let delay = $main.data('showAfter');
 
         if (config.device.isMobile) {
-            if (display === 'onExit') {
+            if (display === 'mouseExit') {
                 display = 'afterDelay';
                 delay = 5000;
             }


### PR DESCRIPTION
We were using 'onExit' instead of 'mouseExit' as the value of the
data-attribute 'display' in the .js code of the s_popup.

task-2312878

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
