### PR TITLE
[FIX] website_sale_coupon: Change parameters for method "cart"

### DIFF
--- a/addons/website_sale_coupon/controllers/main.py
+++ b/addons/website_sale_coupon/controllers/main.py
@@ -23,10 +23,10 @@ class WebsiteSale(WebsiteSale):
         return super(WebsiteSale, self).payment(**post)
 
     @http.route(['/shop/cart'], type='http', auth="public", website=True)
-    def cart(self, **post):
+    def cart(self, access_token=None, revive='', **post):
         order = request.website.sale_get_order()
         order.recompute_coupon_lines()
-        return super(WebsiteSale, self).cart(**post)
+        return super(WebsiteSale, self).cart(access_token=access_token, revive=revive, **post)
 
     # Override
     # Add in the rendering the free_shipping_line

--- a/doc/cla/corporate/dynapps.md
+++ b/doc/cla/corporate/dynapps.md
@@ -1,6 +1,6 @@
-Belgium, 2015-06-04
+Belgium, 2021-01-25
 
-DynApps N.V. agrees to the terms of the Odoo Corporate Contributor License
+DynApps agrees to the terms of the Odoo Corporate Contributor License
 Agreement v1.0.
 
 I declare that I am authorized and able to make this agreement and sign this
@@ -8,13 +8,8 @@ declaration.
 
 Signed,
 
-Pieter Paulussen pieter.paulussen@dynapps.be https://github.com/PieterPaulussen
+Axel Priem axel.priem@dynapps.be https://github.com/axelpriem
 
 List of contributors:
 
-Pieter Paulussen pieter.paulussen@dynapps.be https://github.com/PieterPaulussen
-Raf Ven raf.ven@dynapps.be https://github.com/rven
-Kurt Schmitz kurt.schmitz@dynapps.be https://github.com/kurt-schmitz
-Rod Schouteden rod.schouteden@dynapps.be https://github.com/schout-it
-Eric Lembregts eric.lembregts@dynapps.be https://github.com/lembregtse
-Pieter Paulussen pieter.paulussen@dynapps.be https://github.com/PieterPaulussen
+Axel Priem axel.priem@dynapps.be https://github.com/axelpriem

--- a/doc/cla/corporate/dynapps.md
+++ b/doc/cla/corporate/dynapps.md
@@ -1,6 +1,6 @@
-Belgium, 2021-01-25
+Belgium, 2015-06-04
 
-DynApps agrees to the terms of the Odoo Corporate Contributor License
+DynApps N.V. agrees to the terms of the Odoo Corporate Contributor License
 Agreement v1.0.
 
 I declare that I am authorized and able to make this agreement and sign this
@@ -8,8 +8,14 @@ declaration.
 
 Signed,
 
-Axel Priem axel.priem@dynapps.be https://github.com/axelpriem
+Raf Ven raf.ven@dynapps.be https://github.com/rven
 
 List of contributors:
 
+Raf Ven raf.ven@dynapps.be https://github.com/rven
+Kurt Schmitz kurt.schmitz@dynapps.be https://github.com/kurt-schmitz
+Rod Schouteden rod.schouteden@dynapps.be https://github.com/schout-it
+Eric Lembregts eric.lembregts@dynapps.be https://github.com/lembregtse
+Pieter Paulussen pieter.paulussen@dynapps.be https://github.com/PieterPaulussen (up to 2019-10-01)
+Bart Van Bossche bart.vanbossche@dynapps.be https://github.com/bartvanbossche-dynapps
 Axel Priem axel.priem@dynapps.be https://github.com/axelpriem


### PR DESCRIPTION
The original method in website_sale is defined as:
def cart(self, access_token=None, revive='', **post):

So we must include parameters access_token and revive here. Otherwise we might get an error if another module also inherits the same method (with the correct parameters). If the method from website_sale_coupon is processed first, one parameter (post) is expected. So when another module tries to pass three parameters, an error will appear.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
