### PR TITLE
[FIX] website_slide: ensure correct group

### DIFF
--- a/addons/website_slides/views/res_partner_views.xml
+++ b/addons/website_slides/views/res_partner_views.xml
@@ -5,7 +5,7 @@
         <field name="name">res.partner.view.form.inherit.slides</field>
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form"/>
-        <field name="groups_id" eval="[(4, ref('website_slides.group_website_slides_officer'))]"/>
+        <field name="groups_id" eval="[(6, 0, [ref('website_slides.group_website_slides_officer')])]"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@name='button_box']" position="inside">
                 <button class="oe_stat_button" type="object"


### PR DESCRIPTION
As this view use in attrs a field with a group, ensuring this view is
restricted to the same group is safe. Since 13.2, this view change the
group needed to use it, so ensuring the old group is removed during
migrations is safer.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
