### PR TITLE
[FIX] purchase_stock: data insertion in multi company context failed

### DIFF
--- a/addons/purchase_stock/data/purchase_stock_data.xml
+++ b/addons/purchase_stock/data/purchase_stock_data.xml
@@ -9,7 +9,6 @@
         -->
         <record id="route_warehouse0_buy" model='stock.location.route'>
             <field name="name">Buy</field>
-            <field name="company_id"></field>
             <field name="sequence">5</field>
         </record>
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
https://github.com/odoo/odoo/issues/64480

Current behavior before PR:
Fail to insert `odoo/src/addons/purchase_stock/data/purchase_stock_data.xml`

Desired behavior after PR is merged:
Install data without issue

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
