### PR TITLE
[IMP] phone_validation, crm, sms: improve phone/mobile search results

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -169,7 +169,6 @@ class Lead(models.Model):
         'Phone', tracking=50,
         compute='_compute_phone', inverse='_inverse_phone', readonly=False, store=True)
     mobile = fields.Char('Mobile', compute='_compute_partner_id_values', readonly=False, store=True)
-    phone_mobile_search = fields.Char('Phone/Mobile', store=False, search='_search_phone_mobile_search')
     phone_state = fields.Selection([
         ('correct', 'Correct'),
         ('incorrect', 'Incorrect')], string='Phone Quality', compute="_compute_phone_state", store=True)
@@ -427,31 +426,6 @@ class Lead(models.Model):
                 lead.ribbon_message = _('By saving this change, the customer phone number will also be updated.')
             else:
                 lead.ribbon_message = False
-
-    def _search_phone_mobile_search(self, operator, value):
-        if len(value) <= 2:
-            raise UserError(_('Please enter at least 3 digits when searching on phone / mobile.'))
-
-        query = f"""
-                SELECT model.id
-                FROM {self._table} model
-                WHERE REGEXP_REPLACE(model.phone, '[^\d+]+', '', 'g') SIMILAR TO CONCAT(%s, REGEXP_REPLACE(%s, '\D+', '', 'g'), '%%')
-                  OR REGEXP_REPLACE(model.mobile, '[^\d+]+', '', 'g') SIMILAR TO CONCAT(%s, REGEXP_REPLACE(%s, '\D+', '', 'g'), '%%')
-            """
-
-        # searching on +32485112233 should also finds 00485112233 (00 / + prefix are both valid)
-        # we therefore remove it from input value and search for both of them in db
-        if value.startswith('+') or value.startswith('00'):
-            value = value.replace('+', '').replace('00', '', 1)
-            starts_with = '00|\+'
-        else:
-            starts_with = '%'
-
-        self._cr.execute(query, (starts_with, value, starts_with, value))
-        res = self._cr.fetchall()
-        if not res:
-            return [(0, '=', 1)]
-        return [('id', 'in', [r[0] for r in res])]
 
     @api.onchange('phone', 'country_id', 'company_id')
     def _onchange_phone_validation(self):

--- a/addons/sms/views/res_partner_views.xml
+++ b/addons/sms/views/res_partner_views.xml
@@ -65,4 +65,15 @@
         <field name="binding_view_types">form</field>
     </record>
 
+    <record id="res_partner_view_search" model="ir.ui.view">
+        <field name="name">res.partner.view.search.inherit.sms</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_res_partner_filter"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='phone']" position="replace">
+                <field name="phone_mobile_search"/>
+            </xpath>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
Before this commit the user had to type in the exact same formatting to find contacts.
After this commit the user will be able to get better search results and does not have to type the same formatting.

To avoid code duplication, the existing search_mobile_phone method has been moved to the mail_thread_phone class, so that it could be used by both the crm and res_partner models.

Task-2435233

Signed-off-by: Noureddine Bensebia <neb@odoo.com>

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
