### PR TITLE
[REV] account: don't try to support tax exigibility modification on a tax if a draft entry is using it

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -648,11 +648,11 @@ class AccountMove(models.Model):
 
             if not tax_line and not taxes_map_entry['grouping_dict']:
                 continue
+            elif tax_line and recompute_tax_base_amount:
+                tax_line.tax_base_amount = taxes_map_entry['tax_base_amount']
             elif tax_line and not taxes_map_entry['grouping_dict']:
                 # The tax line is no longer used, drop it.
                 self.line_ids -= tax_line
-            elif tax_line and recompute_tax_base_amount:
-                tax_line.tax_base_amount = taxes_map_entry['tax_base_amount']
             elif tax_line:
                 tax_line.update({
                     'amount_currency': taxes_map_entry['amount_currency'],

--- a/addons/account/tests/test_invoice_taxes.py
+++ b/addons/account/tests/test_invoice_taxes.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from odoo import fields
 from odoo.addons.account.tests.account_test_savepoint import AccountTestInvoicingCommon
 from odoo.tests import tagged, Form
 
@@ -663,55 +662,3 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
             (50, self.percent_tax_3_incl),
         ], currency_id=self.currency_data['currency'], invoice_payment_term_id=self.pay_terms_a)
         invoice.post()
-
-    def test_changing_tax_to_caba_after_create_invoice(self):
-        tax_waiting_account = self.env['account.account'].create({
-            'name': 'TAX_WAIT',
-            'code': 'TWAIT',
-            'user_type_id': self.env.ref('account.data_account_type_current_liabilities').id,
-            'reconcile': True,
-            'company_id': self.company_data['company'].id,
-        })
-        sale_tax = self.company_data['default_tax_sale']
-        invoice = self._create_invoice([
-            (100, sale_tax),
-        ])
-        # turn on cash basis on the same tax that was used
-        self.company_data['company'].tax_exigibility = True
-        sale_tax.write({
-            'tax_exigibility': 'on_payment',
-            'cash_basis_transition_account_id': tax_waiting_account.id,
-            'cash_basis_base_account_id': self.company_data['default_account_revenue'],
-        })
-        invoice.post()
-
-        tax_lines = invoice.line_ids.filtered('tax_line_id')
-        self.assertEqual(len(tax_lines), 1, 'Should have only 1 tax line')
-        self.assertNotEqual(tax_lines.price_unit, 0.0)
-        self.assertEqual(tax_lines.tax_base_amount, 100.0)
-        self.assertEqual(tax_lines.account_id.name, 'TAX_WAIT')
-
-    def test_recompute_tax_when_change_currency(self):
-        """
-        - In a multi currency company, create an invoice with the domestic
-          currency ($);
-        - Add a product (100$) with taxes;
-        -  Change the currency to a foreign one (€);
-        - The product don't change of amount but only of currency (500€);
-        - Save the invoice, and print it.
-        """
-        invoice = self._create_invoice([
-            (100, self.percent_tax_1),
-        ])
-        tax_line = invoice.line_ids.filtered('tax_line_id')
-        self.env['res.currency.rate'].create({
-            'name': fields.Date.to_string(fields.Date.today()),
-            'rate': 4.0,
-            'currency_id': self.currency_data['currency'].id,
-            'company_id': self.env.company.id,
-        })
-        with Form(invoice) as invoice_form:
-            invoice_form.currency_id = self.currency_data['currency']
-
-        self.assertEqual(tax_line.tax_base_amount, 25, 'Should convert tax base amount to company currency')
-        self.assertEqual(tax_line.balance, -5.25, 'Should convert balance to company currency')


### PR DESCRIPTION
This reverts commit 9d4b22fbf6469ada08c28bc2afcd5b5492eac52a.

We don't want to support this use case, as this kind of configuration change in the middle of creating an invoice is a very narrow corner case that can be avoided easily. Supporting it for tax exigibility would mean we also need to support it for repartition lines, amounts, affect base, ... This would be a lot of overhead for nothing.

