### PR TITLE
[IMP] core: -S alternative for --stop-after-init

### DIFF
--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -275,7 +275,7 @@ class configmanager(object):
         group.add_option('--shell-interface', dest='shell_interface', type="string",
                          help="Specify a preferred REPL to use in shell mode. Supported REPLs are: "
                               "[ipython|ptpython|bpython|python]")
-        group.add_option("--stop-after-init", action="store_true", dest="stop_after_init", my_default=False,
+        group.add_option('-S', "--stop-after-init", action="store_true", dest="stop_after_init", my_default=False,
                           help="stop the server after its initialization")
         group.add_option("--osv-memory-count-limit", dest="osv_memory_count_limit", my_default=False,
                          help="Force a limit on the maximum number of records kept in the virtual "


### PR DESCRIPTION
This command is often used by developers and we often need to add or
remove it in a way that we can't add it in scripts. It is also kind of
long to type each time.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
