### PR TITLE
[FIX] delivery: avoid retrospective computation

### DIFF
--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -124,7 +124,7 @@ class SaleOrder(models.Model):
         return sol
 
     @api.depends('state', 'order_line.invoice_status', 'order_line.invoice_lines',
-                 'order_line.is_delivery', 'order_line.is_downpayment', 'order_line.product_id.invoice_policy')
+                 'order_line.is_delivery', 'order_line.is_downpayment')
     def _get_invoiced(self):
         super(SaleOrder, self)._get_invoiced()
         for order in self:


### PR DESCRIPTION
If we're to change the invoice policy of a product we'd provoke a
chained computation of every sale line and sale order containing such
product. This change goes along with the policy of applying such changes
only to future orders, as stated here: https://github.com/odoo/odoo/pull/61135

cc @Tecnativa TT27309


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
