### PR TITLE
[IMP] delivery: Add name to separator for better inheritance

### DIFF
--- a/addons/delivery/views/delivery_view.xml
+++ b/addons/delivery/views/delivery_view.xml
@@ -204,7 +204,7 @@
             <field name="arch" type="xml">
               <data>
                 <xpath expr="//page[@name='extra']" position="inside">
-                <separator string="Delivery Information"/>
+                <separator name='delivery_information' string="Delivery Information"/>
                 <group>
                     <group name='carrier_data'>
                         <field name="carrier_id" attrs="{'readonly': [('state', 'in', ('done', 'cancel'))]}" options="{'no_create': True, 'no_open': True}"/>


### PR DESCRIPTION
Currently, the `<separator string="Delivery Information"` is unreachable
in a deterministic way due to the lack of a unique/valid selector.

With this change the separator can be easily select by its name, making
it is easier to manipulate it when inheriting the view.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
