### PR TITLE
[FIX] account: make group_id readonly

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -76,7 +76,7 @@ class AccountAccount(models.Model):
     company_id = fields.Many2one('res.company', string='Company', required=True, readonly=True,
         default=lambda self: self.env.company)
     tag_ids = fields.Many2many('account.account.tag', 'account_account_account_tag', string='Tags', help="Optional tags you may want to assign for custom reporting")
-    group_id = fields.Many2one('account.group', compute='_compute_account_group', store=True, readonly=False)
+    group_id = fields.Many2one('account.group', compute='_compute_account_group', store=True, readonly=True)
     root_id = fields.Many2one('account.root', compute='_compute_account_root', store=True)
     allowed_journal_ids = fields.Many2many('account.journal', string="Allowed Journals", help="Define in which journals this account can be used. If empty, can be used in all journals.")
 


### PR DESCRIPTION
WHY: it's computed field that is not supposed to be editable. In previous task
it was asked to make it visible, not editable.

---

opw-2431011

https://github.com/odoo/odoo/commit/8b7861ddabf92f85aff7665cb5bd79922676f545
task-2300936

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
