### PR TITLE
[FIX] base: remove studio_customization from `to update` modules.

### DIFF
--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -647,7 +647,11 @@ class Module(models.Model):
                 raise UserError(_("Can not upgrade module '%s'. It is not installed.") % (module.name,))
             self.check_external_dependencies(module.name, 'to upgrade')
             for dep in Dependency.search([('name', '=', module.name)]):
-                if dep.module_id.state == 'installed' and dep.module_id not in todo:
+                if (
+                    dep.module_id.state == 'installed'
+                    and dep.module_id not in todo
+                    and dep.module_id.name != 'studio_customization'
+                ):
                     todo.append(dep.module_id)
 
         self.browse(module.id for module in todo).write({'state': 'to upgrade'})


### PR DESCRIPTION
Since odoo/enterprise@937b9214cbe92a6e0c0f14acb6c9bfebf9125a06, studio has a dependency on web_studio
to auto remove customization on studio uninstall.

This adds as side effect to mark `studio_customization` with a `to_upgrade` state when any of its dependency
is updated (-u all). Unfortunately module `studio_customization` is not updatable, leading to a state remaining in `to upgrade`
 after registry loading, locking cron execution.

This fix adds an excplicit and not very elegant condition on module name to filter module
`studio_customization` when resolving depedencies in button_upgrade.

A cleaner fix would be to use the `imported` flag. Anyway this may break other behaviours and is to risky
in stable and will be experimented in master.

Slightly linked to closed #43880