### PR TITLE
[FIX] bus: Resume all /longpolling/poll threads on ctrl-c

### DIFF
--- a/addons/bus/models/bus.py
+++ b/addons/bus/models/bus.py
@@ -8,6 +8,7 @@ import threading
 import time
 
 import odoo
+import odoo.service.server as servermod
 from odoo import api, fields, models, SUPERUSER_ID
 from odoo.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT
 from odoo.tools import date_utils
@@ -100,7 +101,9 @@ class ImDispatch(object):
         self.channels = {}
         self.started = False
 
-    def poll(self, dbname, channels, last, options=None, timeout=TIMEOUT):
+    def poll(self, dbname, channels, last, options=None, timeout=None):
+        if timeout is None:
+            timeout = TIMEOUT
         if options is None:
             options = {}
         # Dont hang ctrl-c for a poll request, we need to bypass private
@@ -170,6 +173,15 @@ class ImDispatch(object):
                     for event in events:
                         event.set()
 
+    def wakeup_workers(self):
+        """
+        Wake up all http workers that are waiting for an event, useful
+        on server shutdown when they can't reveive anymore messages.
+        """
+        for events in self.channels.values():
+            for event in events:
+                event.set()
+
     def run(self):
         while True:
             try:
@@ -197,3 +209,5 @@ dispatch = None
 if not odoo.multi_process or odoo.evented:
     # We only use the event dispatcher in threaded and gevent mode
     dispatch = ImDispatch()
+    if servermod.server:
+        servermod.server.on_stop(dispatch.wakeup_workers)


### PR DESCRIPTION
Start odoo in threading mode with bus installed. Login in the browser
using any internal user. Make sure the browser call the
/longpolling/poll uri. While the browser is waiting for a response, stop
the server. The server takes up to 50 seconds to stop.

When started in threading mode, a request to /longpolling/poll is served
by a casual http thread. It searches for messages enqueued in the bus
and returns them. If there are no message for the user in the queue yet,
it creates a `threading.Event`, attach it to the user in a shared
dictionnary and `wait()` on it with a timeout of 50 secondes (hardcoded
value). When the bus thread (the one responsible to listen on the
database) receives new messages, it `set()` the events which resume any
http thread that was waiting.

Because when we stop the server, there is no way to server new requests,
there are no way new messages arrive in the bus. All the threads that
were waiting for a new message will just wait until the event timeouts
which slow down the shutdown of the server.

Now we actively `set()` all events in order to resume all those workers
when we stop the server.

The `ImDispatch.poll` signature has been changed too so it is possible
to change (via code) the hardcoded default. The function was using the
object referenced by `TIMEOUT` at the time the function was defined,
using `timeout None` then `if None: timeout=TIMEOUT` ensure we lookup
the variable.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
