### PR TITLE
[FIX] account: Hide 'Cut-off' button on invoice if not posted entry

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -995,7 +995,7 @@
                                                 string="Cut-Off"
                                                 aria-label="Change Period"
                                                 class="float-right"
-                                                attrs="{'invisible': [('account_internal_group', 'not in', ('income', 'expense'))], 'column_invisible': [('parent.move_type', '=', 'entry')]}"
+                                                attrs="{'invisible': [('account_internal_group', 'not in', ('income', 'expense'))], 'column_invisible': ['|', ('parent.move_type', '=', 'entry'), ('parent.state', '!=', 'posted')]}"
                                                 context="{'hide_automatic_options': 1, 'default_action': 'change_period'}"/>
 
                                         <!-- Others fields -->


### PR DESCRIPTION
If the journal entry is not posted, the 'Cut-off' button must not be visible on invoice lines.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
