### PR TITLE
[FIX] web: o_row style not applied on mobile

### DIFF
--- a/addons/hr_holidays/static/scss/hr_leave_mobile.scss
+++ b/addons/hr_holidays/static/scss/hr_leave_mobile.scss
@@ -1,6 +1,0 @@
-@include media-breakpoint-down(sm) {
-    .o_hr_holidays_dates {
-        display: flex;
-        flex-flow: column;
-    }
-}

--- a/addons/hr_holidays/views/hr_leave_template.xml
+++ b/addons/hr_holidays/views/hr_leave_template.xml
@@ -9,7 +9,6 @@
       <script type="text/javascript" src="/hr_holidays/static/src/models/partner/partner.js"/>
     </xpath>
     <xpath expr="link[last()]" position="after">
-      <link rel="stylesheet" type="text/scss" href="/hr_holidays/static/scss/hr_leave_mobile.scss"/>
       <link rel="stylesheet" type="text/scss" href="/hr_holidays/static/src/scss/time_off.scss"/>
       <link rel="stylesheet" type="text/scss" href="/hr_holidays/static/src/bugfix/bugfix.scss"/>
       <link rel="stylesheet" type="text/scss" href="/hr_holidays/static/src/components/partner_im_status_icon/partner_im_status_icon.scss"/>

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -239,7 +239,7 @@
                         <div>
                             <field name="date_from" invisible="1"/>
                             <field name="date_to" invisible="1"/>
-                            <div class="o_row o_row_readonly o_hr_holidays_dates">
+                            <div class="o_row o_row_readonly">
                                 <span class="oe_inline"
                                     attrs="{'invisible': ['|', ('request_unit_half', '=', True), ('request_unit_hours', '=', True)]}">
                                     From

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -157,7 +157,7 @@
                                 </button>
                                 <label for="product_uom_id" string="" class="oe_inline"/>
                                 <field name="product_uom_category_id" invisible="1"/>
-                                <field name="product_uom_id" options="{'no_open': True, 'no_create': True}" force_save="1" groups="uom.group_uom" attrs="{'readonly': [('state', '!=', 'draft')]}" class="oe_inline"/>
+                                <field name="product_uom_id" options="{'no_open': True, 'no_create': True}" force_save="1" groups="uom.group_uom" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
                                 <span class='text-bf'>To Produce</span>
                             </div>
                             <label for="lot_producing_id" attrs="{'invisible': ['|', ('state', '=', 'draft'), ('product_tracking', 'in', ('none', False))]}"/>

--- a/addons/web/static/src/scss/form_view.scss
+++ b/addons/web/static/src/scss/form_view.scss
@@ -54,34 +54,32 @@
         float: right!important;
     }
 
-    @include media-breakpoint-up(vsm, $o-extra-grid-breakpoints) {
-        .o_row {
-            &, &.o_field_widget { // Some field may want to use o_row as root and these rules must prevalue
-                display: flex;
-                width: auto!important;
-            }
+    .o_row {
+        &, &.o_field_widget { // Some field may want to use o_row as root and these rules must prevalue
+            display: flex;
+            width: auto!important;
+        }
 
-            align-items: baseline;
-            min-width: 50px;
-            margin: 0 (-$o-form-spacing-unit/2);
+        align-items: baseline;
+        min-width: 50px;
+        margin: 0 (-$o-form-spacing-unit/2);
 
-            > div, > span, > button, > label, > a, > input, > select { // > * did not add a level of priority to the rule
-                flex: 0 0 auto;
-                width: auto!important;
-                margin-right: $o-form-spacing-unit/2;
-                margin-left: $o-form-spacing-unit/2;
-            }
+        > div, > span, > button, > label, > a, > input, > select { // > * did not add a level of priority to the rule
+            flex: 0 0 auto;
+            width: auto!important;
+            margin-right: $o-form-spacing-unit/2;
+            margin-left: $o-form-spacing-unit/2;
+        }
 
-            > .o_row {
-                margin: 0;
-            }
-            > .btn {
-                padding-top: 0;
-                padding-bottom: 0;
-            }
-            > .o_field_boolean {
-                align-self: center;
-            }
+        > .o_row {
+            margin: 0;
+        }
+        > .btn {
+            padding-top: 0;
+            padding-bottom: 0;
+        }
+        > .o_field_boolean {
+            align-self: center;
         }
     }
 
@@ -136,16 +134,14 @@
             padding: 0.3rem;
         }
 
-        @include media-breakpoint-up(vsm, $o-extra-grid-breakpoints) {
-            .o_row {
-                > .o_field_widget, > div {
-                    flex: 1 1 auto;
-                    width: 0!important; // 3rd flex argument does not work with input (must be auto and real width 0)
+        .o_row {
+            > .o_field_widget, > div {
+                flex: 1 1 auto;
+                width: 0!important; // 3rd flex argument does not work with input (must be auto and real width 0)
 
-                    &.o_field_boolean, &.o_priority {
-                        flex: 0 0 auto;
-                        width: auto!important;
-                    }
+                &.o_field_boolean, &.o_priority {
+                    flex: 0 0 auto;
+                    width: auto!important;
                 }
             }
         }


### PR DESCRIPTION
Before this commit o_row class wasn't applied on mobile because
we wanted that each field take all width.

But we have noticed that this class is quite well used on desktop
and is often used for specic cases that we also want on mobile.
Example: Unit of measure (UOM) next to a numeric field.

So in this commit, we simply removed mobile media queries.
Due to the number of places where this class is used, fixes will
surely follow.

Related to task ID: 1929043