### PR TITLE
[FIX] account: Crash when manually reconciling entries without a partner

### DIFF
--- a/addons/account/static/src/js/reconciliation/reconciliation_action.js
+++ b/addons/account/static/src/js/reconciliation/reconciliation_action.js
@@ -117,8 +117,12 @@ var StatementAction = AbstractAction.extend({
                                           'active_model': self.params.context.active_model};
                 }
                 var journal_id = self.params.context.journal_id;
-                if (self.model.context.active_id && self.model.context.active_model === 'account.journal') {
-                    journal_id = journal_id || self.model.context.active_id;
+                if (!journal_id && self.model.context.active_model === 'account.journal') {
+                    if (self.model.context.active_ids && self.model.context.active_ids.length){
+                        journal_id = self.model.context.active_ids[0];
+                    } else if (self.model.context.active_id) {
+                        journal_id = self.model.context.active_id;
+                    }
                 }
                 if (journal_id) {
                     var promise = self._rpc({


### PR DESCRIPTION
- Create a new journal entry in customer invoices
with credit and debit line but no a partner.
- In the dashboard, on the customer invoice card, hit the ... menu and
go to the aged receivable report
- Find the "unknown" partner section at the bottom and hit the
"Reconcile" button.

A security error on a account.journal record that does not exist
(id=None) will popup, blocking the action

opw-2426870

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
