### PR TITLE
[FIX] mail: prevents excessive extension of the width of the chatter

### DIFF
--- a/addons/mail/static/src/components/chatter/chatter.scss
+++ b/addons/mail/static/src/components/chatter/chatter.scss
@@ -7,6 +7,7 @@
     display: flex;
     flex: 1 1 auto;
     flex-direction: column;
+    width: map-get($sizes, 100);
 }
 
 .o_Chatter_composer {

--- a/addons/mail/static/src/components/chatter_container/chatter_container.scss
+++ b/addons/mail/static/src/components/chatter_container/chatter_container.scss
@@ -5,6 +5,7 @@
 .o_ChatterContainer {
     display: flex;
     flex: 1 1 auto;
+    width: map-get($sizes, 100);
 }
 
 .o_ChatterContainer_noChatter {


### PR DESCRIPTION
Before this commit, messages in the chatter that contained non wrapping
content could indefinitely extend the width of the chatter.

opw-2425351

