### PR TITLE
[IMP] web: prevent user from spamming a action button

### DIFF
--- a/addons/web/static/src/js/views/form/form_controller.js
+++ b/addons/web/static/src/js/views/form/form_controller.js
@@ -486,6 +486,9 @@ var FormController = BasicController.extend({
         // if the `close` attribute is set
         def.then(function () {
             self._enableButtons();
+            if (ev.data.callback) {
+                ev.data.callback();
+            }
             if (attrs.close) {
                 self.trigger_up('close_dialog');
             }

--- a/addons/web/static/src/js/views/form/form_renderer.js
+++ b/addons/web/static/src/js/views/form/form_renderer.js
@@ -358,11 +358,17 @@ var FormRenderer = BasicRenderer.extend({
     _addOnClickAction: function ($el, node) {
         if (node.attrs.special || node.attrs.confirm || node.attrs.type || $el.hasClass('oe_stat_button')) {
             var self = this;
+
             $el.on("click", function () {
-                self.trigger_up('button_clicked', {
-                    attrs: node.attrs,
-                    record: self.state,
-                });
+                if (! $el.prop('disabled')) {
+                    // Prevent users from spamming the button
+                    $el.prop('disabled', true);
+                    self.trigger_up('button_clicked', {
+                        attrs: node.attrs,
+                        record: self.state,
+                        callback: () => $el.removeAttr('disabled'),
+                    });
+                }
             });
         }
     },


### PR DESCRIPTION
Purpose
=======
Before, users can spam click a action button and it will trigger many
actions.

In the form view, we disable the buttons of the status bar after clicking
on it (and re-activate them when the action is done) but we do not do
that for the standard action buttons.

So now, the users should wait the end of the action before re-clicking
on the same button.

Task 2409395