### PR TITLE
[IMP] Add support for danish tax reporting

### DIFF
--- a/addons/l10n_dk/__manifest__.py
+++ b/addons/l10n_dk/__manifest__.py
@@ -3,9 +3,9 @@
 
 {
     'name': 'Denmark - Accounting',
-    'version': '1.0',
-    'author': 'Odoo House ApS',
-    'website': 'https://odoohouse.dk',
+    'version': '1.1.0',
+    'author': 'Odoo House ApS, VK DATA ApS',
+    'website': 'http://odoodanmark.dk',
     'category': 'Localization',
     'description': """
 
@@ -87,7 +87,6 @@ Produkt setup:
 
 .
 
-Copyright 2018 Odoo House ApS
     """,
     'depends': ['account', 'base_iban', 'base_vat'],
     'data': [
@@ -95,6 +94,7 @@ Copyright 2018 Odoo House ApS
         'data/l10n_dk_chart_template_data.xml',
         'data/account.account.template.csv',
         'data/l10n_dk_chart_template_post_data.xml',
+        'data/account_tax_report_data.xml',
         'data/account_tax_template_data.xml',
         'data/account_fiscal_position_template.xml',
         'data/account_fiscal_position_tax_template.xml',

--- a/addons/l10n_dk/data/account_tax_report_data.xml
+++ b/addons/l10n_dk/data/account_tax_report_data.xml
@@ -17,7 +17,7 @@
         <field name="name">Salgsmoms</field>
         <field name="code">Momsangivelse</field>
         <field name="sequence" eval="1"/>
-        <field name="parent_id" ref="l10n_dk.account_tax_report_line"/>
+        <field name="parent_id" ref="l10n_dk.account_tax_report"/>
         <field name="country_id" ref="base.dk"/>
     </record>
     <record id="account_tax_report_line_sales_tax" model="account.tax.report.line">

--- a/addons/l10n_dk/data/account_tax_report_data.xml
+++ b/addons/l10n_dk/data/account_tax_report_data.xml
@@ -46,7 +46,7 @@
         <field name="name">Fradrag</field>
         <field name="code">Momsangivelse</field>
         <field name="sequence" eval="2"/>
-        <field name="parent_id" ref="l10n_dk.account_tax_report_line"/>
+        <field name="parent_id" ref="l10n_dk.account_tax_report"/>
         <field name="country_id" ref="base.dk"/>
     </record>
     <record id="account_tax_report_line_deduction_purchase_tax" model="account.tax.report.line">

--- a/addons/l10n_dk/data/account_tax_report_data.xml
+++ b/addons/l10n_dk/data/account_tax_report_data.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="account_tax_report" model="account.tax.report.line">
+        <field name="name">Tax Report - Denmark</field>
+        <field name="sequence" eval="1"/>
+        <field name="country_id" ref="base.dk"/>
+    </record>
+
+    <record id="account_tax_report_line_vat_statement" model="account.tax.report.line">
+        <field name="name">Momsangivelse (positivt beløb = betale, negativt beløb = penge tilgode)</field>
+        <field name="sequence" eval="1"/>
+        <field name="parent_id" ref="l10n_dk.account_tax_report"/>
+        <field name="country_id" ref="base.dk"/>
+    </record>
+
+    <record id="account_tax_report_line_sales_group" model="account.tax.report.line">
+        <field name="name">Salgsmoms</field>
+        <field name="code">Momsangivelse</field>
+        <field name="sequence" eval="1"/>
+        <field name="parent_id" ref="l10n_dk.account_tax_report_line"/>
+        <field name="country_id" ref="base.dk"/>
+    </record>
+    <record id="account_tax_report_line_sales_tax" model="account.tax.report.line">
+        <field name="name">Salgsmoms (udgående moms)</field>
+        <field name="tag_name">Salgsmoms (udgående moms)</field>
+        <field name="sequence" eval="1"/>
+        <field name="parent_id" ref="l10n_dk.account_tax_report_line_sales_group"/>
+        <field name="country_id" ref="base.dk"/>
+    </record>
+    <record id="account_tax_report_line_international_purchase_products" model="account.tax.report.line">
+        <field name="name">Moms af varekøb i udlandet (både EU og lande uden for EU)</field>
+        <field name="tag_name">Moms af varekøb i udlandet (både EU og lande uden for EU)</field>
+        <field name="sequence" eval="2"/>
+        <field name="parent_id" ref="l10n_dk.account_tax_report_line_sales_group"/>
+        <field name="country_id" ref="base.dk"/>
+    </record>
+    <record id="account_tax_report_line_international_purchase_services" model="account.tax.report.line">
+        <field name="name">Moms af ydelseskøb i udlandet med omvendt betalingspligt</field>
+        <field name="tag_name">Moms af ydelseskøb i udlandet med omvendt betalingspligt</field>
+        <field name="sequence" eval="3"/>
+        <field name="parent_id" ref="l10n_dk.account_tax_report_line_sales_group"/>
+        <field name="country_id" ref="base.dk"/>
+    </record>
+
+    <record id="account_tax_report_line_deduction_group" model="account.tax.report.line">
+        <field name="name">Fradrag</field>
+        <field name="code">Momsangivelse</field>
+        <field name="sequence" eval="2"/>
+        <field name="parent_id" ref="l10n_dk.account_tax_report_line"/>
+        <field name="country_id" ref="base.dk"/>
+    </record>
+    <record id="account_tax_report_line_deduction_purchase_tax" model="account.tax.report.line">
+        <field name="name">Købsmoms (indgående moms)</field>
+        <field name="tag_name">Købsmoms (indgående moms)</field>
+        <field name="sequence" eval="1"/>
+        <field name="parent_id" ref="l10n_dk.account_tax_report_line_deduction_group"/>
+        <field name="country_id" ref="base.dk"/>
+    </record>
+    <record id="account_tax_report_line_deduction_oil_bottle_tax" model="account.tax.report.line">
+        <field name="name">Olie- og flaskegasafgift</field>
+        <field name="tag_name">Olie- og flaskegasafgift</field>
+        <field name="sequence" eval="2"/>
+        <field name="parent_id" ref="l10n_dk.account_tax_report_line_deduction_group"/>
+        <field name="country_id" ref="base.dk"/>
+    </record>
+    <record id="account_tax_report_line_deduction_electrical_tax" model="account.tax.report.line">
+        <field name="name">Elafgift</field>
+        <field name="tag_name">Elafgift</field>
+        <field name="sequence" eval="3"/>
+        <field name="parent_id" ref="l10n_dk.account_tax_report_line_deduction_group"/>
+        <field name="country_id" ref="base.dk"/>
+    </record>
+    <record id="account_tax_report_line_deduction_gas_tax" model="account.tax.report.line">
+        <field name="name">Naturgas- og bygasafgift</field>
+        <field name="tag_name">Naturgas- og bygasafgift</field>
+        <field name="sequence" eval="4"/>
+        <field name="parent_id" ref="l10n_dk.account_tax_report_line_deduction_group"/>
+        <field name="country_id" ref="base.dk"/>
+    </record>
+    <record id="account_tax_report_line_deduction_coal_tax" model="account.tax.report.line">
+        <field name="name">Kulafgift</field>
+        <field name="tag_name">Kulafgift</field>
+        <field name="sequence" eval="5"/>
+        <field name="parent_id" ref="l10n_dk.account_tax_report_line_deduction_group"/>
+        <field name="country_id" ref="base.dk"/>
+    </record>
+    <record id="account_tax_report_line_deduction_co2_tax" model="account.tax.report.line">
+        <field name="name">CO2-afgift</field>
+        <field name="tag_name">CO2-afgift</field>
+        <field name="sequence" eval="6"/>
+        <field name="parent_id" ref="l10n_dk.account_tax_report_line_deduction_group"/>
+        <field name="country_id" ref="base.dk"/>
+    </record>
+    <record id="account_tax_report_line_deduction_water_tax" model="account.tax.report.line">
+        <field name="name">Vandafgift</field>
+        <field name="tag_name">Vandafgift</field>
+        <field name="sequence" eval="7"/>
+        <field name="parent_id" ref="l10n_dk.account_tax_report_line_deduction_group"/>
+        <field name="country_id" ref="base.dk"/>
+    </record>
+
+
+    <record id="account_tax_report_line_additional_info" model="account.tax.report.line">
+        <field name="name">Supplerende oplysninger</field>
+        <field name="sequence" eval="2"/>
+        <field name="parent_id" ref="l10n_dk.account_tax_report"/>
+        <field name="country_id" ref="base.dk"/>
+    </record>
+    <record id="account_tax_report_line_section_a_products" model="account.tax.report.line">
+        <field name="name">Rubrik A = varer - Værdien uden moms af varekøb i andre EU-lande (EU-erhvervelser)</field>
+        <field name="tag_name">Rubrik A = varer - Værdien uden moms af varekøb i andre EU-lande (EU-erhvervelser)</field>
+        <field name="sequence" eval="1"/>
+        <field name="parent_id" ref="l10n_dk.account_tax_report_line_additional_info"/>
+        <field name="country_id" ref="base.dk"/>
+    </record>
+    <record id="account_tax_report_line_section_a_services" model="account.tax.report.line">
+        <field name="name">Rubrik A = ydelser - Værdien uden moms af ydelseskøb i andre EU-lande</field>
+        <field name="tag_name">Rubrik A = ydelser - Værdien uden moms af ydelseskøb i andre EU-lande</field>
+        <field name="sequence" eval="2"/>
+        <field name="parent_id" ref="l10n_dk.account_tax_report_line_additional_info"/>
+        <field name="country_id" ref="base.dk"/>
+    </record>
+    <record id="account_tax_report_line_section_b_product_eu" model="account.tax.report.line">
+        <field name="name">Rubrik B = varer (Værdien af varesalg uden moms til andre EU-lande. Indberettes til systemet EU-salg uden moms</field>
+        <field name="tag_name">Rubrik B = varer (Værdien af varesalg uden moms til andre EU-lande. Indberettes til systemet EU-salg uden moms</field>
+        <field name="sequence" eval="3"/>
+        <field name="parent_id" ref="l10n_dk.account_tax_report_line_additional_info"/>
+        <field name="country_id" ref="base.dk"/>
+    </record>
+    <record id="account_tax_report_line_section_b_products_non_eu" model="account.tax.report.line">
+        <field name="name">Rubrik B = varer - Indberettes ikke til EU-salg uden moms. Værdien af fx. installation og montage, fjernsalg og nye transportmidler til ikke-momsregistrerede kunder uden moms til andre EU-lande</field>
+        <field name="tag_name">Rubrik B = varer - Indberettes ikke til EU-salg uden moms. Værdien af fx. installation og montage, fjernsalg og nye transportmidler til ikke-momsregistrerede kunder uden moms til andre EU-lande</field>
+        <field name="sequence" eval="4"/>
+        <field name="parent_id" ref="l10n_dk.account_tax_report_line_additional_info"/>
+        <field name="country_id" ref="base.dk"/>
+    </record>
+    <record id="account_tax_report_line_section_b_services" model="account.tax.report.line">
+        <field name="name">Rubrik B = ydelser - Værdien af visse ydelsessalg uden moms til andre EU-lande. Indberettes til EU-salg uden moms</field>
+        <field name="tag_name">Rubrik B = ydelser - Værdien af visse ydelsessalg uden moms til andre EU-lande. Indberettes til EU-salg uden moms</field>
+        <field name="sequence" eval="5"/>
+        <field name="parent_id" ref="l10n_dk.account_tax_report_line_additional_info"/>
+        <field name="country_id" ref="base.dk"/>
+    </record>
+    <record id="account_tax_report_line_section_c" model="account.tax.report.line">
+        <field name="name">Rubrik C - Værdien af andre varer og ydelser, der leveres uden afgift her i landet, i andre EU-lande og til lande udenfor EU</field>
+        <field name="tag_name">Rubrik C - Værdien af andre varer og ydelser, der leveres uden afgift her i landet, i andre EU-lande og til lande udenfor EU</field>
+        <field name="sequence" eval="6"/>
+        <field name="parent_id" ref="l10n_dk.account_tax_report_line_additional_info"/>
+        <field name="country_id" ref="base.dk"/>
+    </record>
+
+</odoo>

--- a/addons/l10n_dk/data/account_tax_template_data.xml
+++ b/addons/l10n_dk/data/account_tax_template_data.xml
@@ -383,15 +383,15 @@
                 'repartition_type': 'base',
             }),
             (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('a8725'),
-                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_sales_tax')],
-            }),
-            (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8740'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_sales_tax')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('a8725'),
                 'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_purchase_tax')],
             }),
         ]"/>

--- a/addons/l10n_dk/data/account_tax_template_data.xml
+++ b/addons/l10n_dk/data/account_tax_template_data.xml
@@ -365,15 +365,15 @@
                 'repartition_type': 'base',
             }),
             (0,0, {
-                'factor_percent': -100,
-                'repartition_type': 'tax',
-                'account_id': ref('a8725'),
-                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_sales_tax')],
-            }),
-            (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8740'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_sales_tax')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('a8725'),
                 'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_purchase_tax')],
             }),
         ]"/>

--- a/addons/l10n_dk/data/account_tax_template_data.xml
+++ b/addons/l10n_dk/data/account_tax_template_data.xml
@@ -368,7 +368,7 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8740'),
-                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_sales_tax')],
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_purchase_tax')],
             }),
             (0,0, {
                 'factor_percent': -100,

--- a/addons/l10n_dk/data/account_tax_template_data.xml
+++ b/addons/l10n_dk/data/account_tax_template_data.xml
@@ -374,7 +374,7 @@
                 'factor_percent': -100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8725'),
-                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_purchase_tax')],
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_sales_tax')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),

--- a/addons/l10n_dk/data/account_tax_template_data.xml
+++ b/addons/l10n_dk/data/account_tax_template_data.xml
@@ -5,7 +5,7 @@
     <record id="tax110" model="account.tax.template">
         <field name="chart_template_id" ref="dk_chart_template"/>
         <field name="sequence">110</field>
-        <field name="name">Salgsmoms 25%</field>
+        <field name="name">Salgsmoms 25%, varer</field>
         <field name="description">25%</field>
         <field name="amount">25</field>
         <field name="amount_type">percent</field>
@@ -19,6 +19,7 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8720'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_sales_tax')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -30,6 +31,7 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8720'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_sales_tax')],
             }),
         ]"/>
     </record>
@@ -50,6 +52,7 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8720'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_sales_tax')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -61,6 +64,7 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8720'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_sales_tax')],
             }),
         ]"/>
     </record>
@@ -82,6 +86,7 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8758'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_section_c')],
             }),
             (0,0, {
                 'factor_percent': -100,
@@ -98,6 +103,7 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8758'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_section_c')],
             }),
             (0,0, {
                 'factor_percent': -100,
@@ -126,6 +132,7 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8754'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_section_b_product_eu')],
             }),
             (0,0, {
                 'factor_percent': -100,
@@ -142,6 +149,7 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8754'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_section_b_product_eu')],
             }),
             (0,0, {
                 'factor_percent': -100,
@@ -168,6 +176,7 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8755'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_section_b_services')],
             }),
             (0,0, {
                 'factor_percent': -100,
@@ -184,6 +193,7 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8755'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_section_b_services')],
             }),
             (0,0, {
                 'factor_percent': -100,
@@ -211,6 +221,7 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8758'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_section_c')],
             }),
             (0,0, {
                 'factor_percent': -100,
@@ -227,6 +238,7 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8758'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_section_c')],
             }),
             (0,0, {
                 'factor_percent': -100,
@@ -241,7 +253,7 @@
     <record id="tax400" model="account.tax.template">
         <field name="chart_template_id" ref="dk_chart_template"/>
         <field name="sequence">400</field>
-        <field name="name">Købsmoms 25%</field>
+        <field name="name">Købsmoms 25%, varer</field>
         <field name="description">25%</field>
         <field name="amount">25</field>
         <field name="amount_type">percent</field>
@@ -255,6 +267,7 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8740'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_purchase_tax')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -266,13 +279,14 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8740'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_purchase_tax')],
             }),
         ]"/>
     </record>
     <record id="tax410" model="account.tax.template">
         <field name="chart_template_id" ref="dk_chart_template"/>
         <field name="sequence">410</field>
-        <field name="name">Købsmoms 25% indeholdt</field>
+        <field name="name">Købsmoms 25% indeholdt, varer</field>
         <field name="description">25% indeholdt</field>
         <field name="amount">25</field>
         <field name="amount_type">percent</field>
@@ -287,6 +301,7 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8740'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_purchase_tax')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -298,6 +313,7 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8740'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_purchase_tax')],
             }),
         ]"/>
     </record>
@@ -318,6 +334,7 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8740'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_purchase_tax')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -329,6 +346,7 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8740'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_purchase_tax')],
             }),
         ]"/>
     </record>
@@ -350,11 +368,13 @@
                 'factor_percent': -100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8725'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_sales_tax')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8740'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_purchase_tax')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -366,11 +386,13 @@
                 'factor_percent': -100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8725'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_sales_tax')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8740'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_purchase_tax')],
             }),
         ]"/>
     </record>
@@ -391,6 +413,7 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8740'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_purchase_tax')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -402,6 +425,7 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8740'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_purchase_tax')],
             }),
         ]"/>
     </record>
@@ -425,16 +449,19 @@
                 'factor_percent': -25,
                 'repartition_type': 'tax',
                 'account_id': ref('a8730'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_international_purchase_services')],
             }),
             (0,0, {
                 'factor_percent': 25,
                 'repartition_type': 'tax',
                 'account_id': ref('a8740'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_purchase_tax')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8750'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_section_a_products')],
             }),
             (0,0, {
                 'factor_percent': -100,
@@ -451,16 +478,19 @@
                 'factor_percent': -25,
                 'repartition_type': 'tax',
                 'account_id': ref('a8730'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_international_purchase_services')],
             }),
             (0,0, {
                 'factor_percent': 25,
                 'repartition_type': 'tax',
                 'account_id': ref('a8740'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_purchase_tax')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8750'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_section_a_products')],
             }),
             (0,0, {
                 'factor_percent': -100,
@@ -488,16 +518,19 @@
                 'factor_percent': -25,
                 'repartition_type': 'tax',
                 'account_id': ref('a8731'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_international_purchase_services')],
             }),
             (0,0, {
                 'factor_percent': 25,
                 'repartition_type': 'tax',
                 'account_id': ref('a8740'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_purchase_tax')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8751'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_section_a_services')],
             }),
             (0,0, {
                 'factor_percent': -100,
@@ -514,16 +547,19 @@
                 'factor_percent': -25,
                 'repartition_type': 'tax',
                 'account_id': ref('a8731'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_international_purchase_services')],
             }),
             (0,0, {
                 'factor_percent': 25,
                 'repartition_type': 'tax',
                 'account_id': ref('a8740'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_purchase_tax')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8751'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_section_a_services')],
             }),
             (0,0, {
                 'factor_percent': -100,
@@ -552,11 +588,13 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8740'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_international_purchase_services')],
             }),
             (0,0, {
                 'factor_percent': -100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8730'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_purchase_tax')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -568,11 +606,13 @@
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8740'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_international_purchase_services')],
             }),
             (0,0, {
                 'factor_percent': -100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8730'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_purchase_tax')],
             }),
         ]"/>
     </record>
@@ -593,11 +633,13 @@
                 'factor_percent': -100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8731'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_international_purchase_services')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8740'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_purchase_tax')],
             }),
         ]"/>
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -609,11 +651,274 @@
                 'factor_percent': -100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8731'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_international_purchase_services')],
             }),
             (0,0, {
                 'factor_percent': 100,
                 'repartition_type': 'tax',
                 'account_id': ref('a8740'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_purchase_tax')],
+            }),
+        ]"/>
+    </record>
+
+    <record id="tax710" model="account.tax.template">
+        <field name="chart_template_id" ref="dk_chart_template"/>
+        <field name="sequence">710</field>
+        <field name="name">Olie- og flaskegasafgift</field>
+        <field name="description"></field>
+        <field name="amount">92.1400</field>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('a8775'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_oil_bottle_tax')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('a4275'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('a8775'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_oil_bottle_tax')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('a4275'),
+            }),
+        ]"/>
+    </record>
+    <record id="tax720" model="account.tax.template">
+        <field name="chart_template_id" ref="dk_chart_template"/>
+        <field name="sequence">720</field>
+        <field name="name">Elafgift</field>
+        <field name="description"></field>
+        <field name="amount">0.8880</field>
+        <field name="amount_type">fixed</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('a8775'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_electrical_tax')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('a4275'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('a8775'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_electrical_tax')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('a4275'),
+            }),
+        ]"/>
+    </record>
+    <record id="tax730" model="account.tax.template">
+        <field name="chart_template_id" ref="dk_chart_template"/>
+        <field name="sequence">730</field>
+        <field name="name">Naturgas- og bygasafgift</field>
+        <field name="description"></field>
+        <field name="amount">4.4490</field>
+        <field name="amount_type">fixed</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('a8780'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_gas_tax')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('a4271'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('a8780'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_gas_tax')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('a4271'),
+            }),
+        ]"/>
+    </record>
+    <record id="tax740" model="account.tax.template">
+        <field name="chart_template_id" ref="dk_chart_template"/>
+        <field name="sequence">740</field>
+        <field name="name">Kulafgift</field>
+        <field name="description"></field>
+        <field name="amount">92.1400</field>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('a8785'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_coal_tax')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('a4271'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('a8785'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_coal_tax')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('a4271'),
+            }),
+        ]"/>
+    </record>
+    <!-- CO2-afgift is rarely used anymore, but we indclude it as archived so that it can be customized when the need comes -->
+    <record id="tax750" model="account.tax.template">
+        <field name="chart_template_id" ref="dk_chart_template"/>
+        <field name="sequence">750</field>
+        <field name="name">CO2-afgift</field>
+        <field name="description"></field>
+        <field name="active">0</field>
+        <field name="amount">0</field>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('a8785'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_co2_tax')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('a4271'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('a8785'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_co2_tax')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('a4271'),
+            }),
+        ]"/>
+    </record>
+    <record id="tax760" model="account.tax.template">
+        <field name="chart_template_id" ref="dk_chart_template"/>
+        <field name="sequence">760</field>
+        <field name="name">Vandafgift</field>
+        <field name="description"></field>
+        <field name="amount">6.1800</field>
+        <field name="amount_type">fixed</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('a8795'),
+                'minus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_water_tax')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('a4275'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'base',
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('a8795'),
+                'plus_report_line_ids': [ref('l10n_dk.account_tax_report_line_deduction_water_tax')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('a4275'),
             }),
         ]"/>
     </record>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The new tax reporting in Odoo 13.0 was not properly configured during the migration from Odoo 12.0 to Odoo 13.0.
This will also apply for Odoo 14.0, once the changes are ported over

Current behavior before PR:
Currently, the tax report in Odoo accounting is not usable in Denmark without the need for heavy customization of the taxes in order to make it usable and it is also required by law for the system to be able to produce the statistical data for SKAT.

Desired behavior after PR is merged:
Once merged, the taxes in `l10n_dk` will be preconfigured for using the tax grids necessary for correct tax reporting in Denmark.
Any existing databases would however need to manually set the new tax grids on taxes and posted journal entries



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
