### PR TITLE
[REV] project: revert "[FIX] project : chatter wrong place"

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -387,10 +387,11 @@
                             </div>
                         </page>
                     </notebook>
+
+                    <div class="oe_chatter">
+                        <field name="message_follower_ids" options="{'post_refresh':True}" help="Follow this project to automatically track the events associated to tasks and issues of this project." groups="base.group_user"/>
+                    </div>
                 </sheet>
-                <div class="oe_chatter">
-                    <field name="message_follower_ids" options="{'post_refresh':True}" help="Follow this project to automatically track the events associated to tasks and issues of this project." groups="base.group_user"/>
-                </div>
                 </form>
             </field>
         </record>


### PR DESCRIPTION
This reverts commit 1c7f135708ccca0ad2d54ec41964d5083f42a01b.

The placement of chatter in `project.project` is intentional:
it's in form sheet bg to prevent it taking 1/3rd of screen width
in XL screen configuration on the right side.

Reason to not want it is because the chatter has no conversation,
and chatter with no conversation is basically just follower widget
and attachment, both of which take up a very small area of screen.
By being aside, they would take about 1/3rd of screen with mostly
blank content.

Task-2410310