### PR TITLE
[FIX] website: prevent navigation during load if new content menu opened

### DIFF
--- a/addons/website/static/src/js/menu/new_content.js
+++ b/addons/website/static/src/js/menu/new_content.js
@@ -184,6 +184,8 @@ var NewContentMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
             self.$newContentMenuChoices.removeClass('o_hidden');
             $('body').addClass('o_new_content_open');
             self.$('> a').focus();
+
+            wUtils.removeLoader();
         });
     },
 

--- a/addons/website/static/src/js/utils.js
+++ b/addons/website/static/src/js/utils.js
@@ -263,6 +263,16 @@ function sendRequest(route, params) {
     form.submit();
 }
 
+/**
+ * Removes the navigation-blocking fullscreen loader from the DOM
+ */
+function removeLoader() {
+    const $loader = $('#o_website_page_loader');
+    if ($loader) {
+        $loader.remove();
+    }
+}
+
 return {
     loadAnchors: loadAnchors,
     autocompleteWithPages: autocompleteWithPages,
@@ -270,5 +280,6 @@ return {
     prompt: prompt,
     sendRequest: sendRequest,
     websiteDomain: websiteDomain,
+    removeLoader: removeLoader,
 };
 });

--- a/addons/website/static/src/scss/website.ui.scss
+++ b/addons/website/static/src/scss/website.ui.scss
@@ -126,6 +126,13 @@ body.o_connected_user {
     }
 }
 
+// BLOCKING LOADER
+#o_website_page_loader {
+    @include o-position-absolute(0, 0, 0, 0);
+    z-index: $zindex-modal - 1;
+    background-color: rgba(0, 0, 0, 0.8);
+}
+
 // MODALS
 body .modal {
     &.o_technical_modal {

--- a/addons/website/views/website_navbar_templates.xml
+++ b/addons/website/views/website_navbar_templates.xml
@@ -20,6 +20,7 @@
             <t t-set="body_classname" t-value="(body_classname if body_classname else '') + (' o_connected_user' if env['ir.ui.view'].user_has_groups('base.group_user') else '')"/>
         </xpath>
         <xpath expr="//div[@id='wrapwrap']" position="before">
+            <div t-if="'enable_new_content' in request.params" id="o_website_page_loader"/>
             <nav groups="base.group_user" t-if="website" id="oe_main_menu_navbar" class="o_main_navbar">
                 <ul id="oe_applications">
                     <li class="dropdown active">


### PR DESCRIPTION
Before this commit the new content menu only appeared once the page was
fully loaded. Because of this users with slow connections could navigate
elsewhere before noticing that the new option they enabled had appeared.

After this commit a navigation-blocking overlay similar to the
background of the menu is temporarily added to the page until the new
content menu can be displayed.

The div is put inside #wrapwrap in order to be later reused as the theme
install loader blocking div which does not exist in 14.0.

task-2439775

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
