### PR TITLE
[IMP] calendar: schedule reminders using triggers

### DIFF
--- a/addons/calendar/data/calendar_cron.xml
+++ b/addons/calendar/data/calendar_cron.xml
@@ -6,11 +6,11 @@
             <field name="name">Calendar: Event Reminder</field>
             <field name="model_id" ref="model_calendar_alarm_manager"/>
             <field name="state">code</field>
-            <field name="code">model.get_next_mail()</field>
+            <field name="code">model._send_reminder_email()</field>
             <field eval="True" name="active" />
             <field name="user_id" ref="base.user_root" />
-            <field name="interval_number">30</field>
-            <field name="interval_type">minutes</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
             <field name="numbercall">-1</field>
             <field eval="False" name="doall" />
         </record>

--- a/addons/calendar/data/calendar_cron.xml
+++ b/addons/calendar/data/calendar_cron.xml
@@ -7,7 +7,7 @@
             <field name="model_id" ref="model_calendar_alarm_manager"/>
             <field name="state">code</field>
             <field name="code">model.get_next_mail()</field>
-            <field eval="False" name="active" />
+            <field eval="True" name="active" />
             <field name="user_id" ref="base.user_root" />
             <field name="interval_number">30</field>
             <field name="interval_type">minutes</field>

--- a/addons/calendar/models/calendar_alarm.py
+++ b/addons/calendar/models/calendar_alarm.py
@@ -49,26 +49,3 @@ class Alarm(models.Model):
             key: value for key, value in self._fields['alarm_type']._description_selection(self.env)
         }[self.alarm_type]
         self.name = "%s - %s %s" % (display_alarm_type, self.duration, display_interval)
-
-    def _update_cron(self):
-        try:
-            cron = self.env['ir.model.data'].sudo().get_object('calendar', 'ir_cron_scheduler_alarm')
-        except ValueError:
-            return False
-        return cron.toggle(model=self._name, domain=[('alarm_type', '=', 'email')])
-
-    @api.model
-    def create(self, values):
-        result = super(Alarm, self).create(values)
-        self._update_cron()
-        return result
-
-    def write(self, values):
-        result = super(Alarm, self).write(values)
-        self._update_cron()
-        return result
-
-    def unlink(self):
-        result = super(Alarm, self).unlink()
-        self._update_cron()
-        return result

--- a/addons/calendar/models/calendar_alarm_manager.py
+++ b/addons/calendar/models/calendar_alarm_manager.py
@@ -74,6 +74,7 @@ class AlarmManager(models.AbstractModel):
             first_alarm_max_value = "(now() at time zone 'utc' + interval '%s' second )"
             tuple_params += (seconds,)
 
+        self.flush()
         self._cr.execute("""
             WITH calcul_delta AS (%s)
             SELECT *

--- a/addons/calendar/models/calendar_recurrence.py
+++ b/addons/calendar/models/calendar_recurrence.py
@@ -284,7 +284,7 @@ class RecurrenceRule(models.Model):
         :param dstart: if provided, only write events starting from this point in time
         """
         events = self._get_events_from(dtstart) if dtstart else self.calendar_event_ids
-        return events.with_context(no_mail_to_attendees=True, dont_notify=True).write(dict(values, recurrence_update='self_only'))
+        return events.with_context(no_mail_to_attendees=True).write(dict(values, recurrence_update='self_only'))
 
     def _rrule_serialize(self):
         """


### PR DESCRIPTION


The calendar reminders are emails or web notifications sent moments
before an event start. The mechanism to send web notifications is
controlled by the browser, it fetches all the future notifications and
uses `setTimeout()` to delay them. The mechanism to send emails was
controlled by a cron, every 30 minutes the cron would look for the
coming events and send the mail reminder.

The cron was running every 30 minutes even if there was no event. The
best precision was 30 minutes.

The new mechanism use cron triggers, every time one add email reminders,
triggers are created to call the cron at the precise moment the alarm is
set. The cron no longer send emails for events in the coming 30 minutes
as those will be triggered too.

---

**[REF] calendar: remove cron activation code**

There is code that automatically enable or disable the cron whether it
exists alarms. As alarms are automatically added, the cron is actually
always enabled.

Task: 2416741
