### PR TITLE
[FIX] l10n_fr_pos_cert: do not allow to delete last line

### DIFF
--- a/addons/l10n_fr_pos_cert/static/src/js/pos.js
+++ b/addons/l10n_fr_pos_cert/static/src/js/pos.js
@@ -74,7 +74,11 @@ models.Orderline = models.Orderline.extend({
     set_quantity: function (quantity, keep_price) {
         var current_quantity = this.get_quantity();
         var new_quantity = parseFloat(quantity) || 0;
-        if (this.pos.is_french_country() && new_quantity < current_quantity && !this.reward_id && !(new_quantity === 0 && current_quantity === 1 && this.isLastLine())) {
+        if (
+            this.pos.is_french_country() && !this.reward_id &&
+            (new_quantity < current_quantity || new_quantity === 0 && current_quantity === 0 && quantity === "remove") &&
+            !(new_quantity === 0 && current_quantity === 1 && this.isLastLine())
+        ) {
             var quantity_to_decrease = current_quantity - new_quantity;
             this.pos.gui.show_popup("number", {
                 'title': _t("Decrease the quantity by"),

--- a/addons/l10n_fr_pos_cert/static/src/js/pos.js
+++ b/addons/l10n_fr_pos_cert/static/src/js/pos.js
@@ -100,7 +100,9 @@ models.Orderline = models.Orderline.extend({
                             }
                         });
 
-                        if (qty_decrease > current_total_quantity_remaining) {
+                        if(selected_orderline.isLastLine() && current_total_quantity_remaining === 0 && current_total_quantity_remaining < qty_decrease) {
+                            orderline_super.set_quantity.apply(selected_orderline, [-qty_decrease, true]);
+                        } else if (qty_decrease > current_total_quantity_remaining) {
                           this.pos.gui.show_popup("error", {
                               'title': _t("Order error"),
                               'body':  _t("Not allowed to take back more than was ordered."),


### PR DESCRIPTION
Have a POS
Add a product (quantity 1)
Hit the remove product (quantity goes to 0)
Hit the remove product (product is canceled from the order)

We should not be able to remove the product once added to the order,
just freely edit the quantity of the last line

Fine tuning of 716f33ccb92de65380c15d153d60e90721833e42

opw-2419592

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
