### PR TITLE
[FIX] stock: multi-company routes management.

### DIFF
--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -190,7 +190,8 @@ class Route(models.Model):
     warehouse_domain_ids = fields.One2many('stock.warehouse', compute='_compute_warehouses')
     warehouse_ids = fields.Many2many(
         'stock.warehouse', 'stock_route_warehouse', 'route_id', 'warehouse_id',
-        'Warehouses', copy=False, domain="[('id', 'in', warehouse_domain_ids)]")
+        'Warehouses', copy=False, domain="[('id', 'in', warehouse_domain_ids)]",
+        check_company=True)
 
     @api.depends('company_id')
     def _compute_warehouses(self):
@@ -212,3 +213,7 @@ class Route(models.Model):
         for route in self:
             route.with_context(active_test=False).rule_ids.filtered(lambda ru: ru.active == route.active).toggle_active()
         super(Route, self).toggle_active()
+
+    def _check_company(self, fnames=None):
+        # Global routes can be linked to any product / warehouse.
+        super(Route, self.filtered('company_id'))._check_company(fnames)

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3261,6 +3261,9 @@ Fields:
         User with main company A, having access to company A and B, could be
         assigned or linked to records in company B.
         """
+        if not self:
+            return
+
         if fnames is None:
             fnames = self._fields
 


### PR DESCRIPTION
1) Modifying the company-related fields of a global route would
sometimes raise wrongly:

Global routes can be linked to products linked to specific companies,
but the check_company call would raise in that cases (if the
modification happens from the route, not from the product).

2) Improve routes management from the product view:

* When modifying the company of a product, remove the routes restricted
to other companies.
* Update the domain for the routes accordingly

3) Bring back the check_company on routes warehouses

Was removed in e7bdf82f59b1fb8cdd1ebe6bb5fadbed691d9a36 for the same
"bug" than the one of the products, but it can be safely brought back
with the new _check_company override.

Fixes #64480



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
