### PR TITLE
Fixes multi-warehouse settings

### DIFF
--- a/addons/sale_mrp/tests/test_sale_mrp_procurement.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_procurement.py
@@ -77,10 +77,10 @@ class TestSaleMrpProcurement(TransactionCase):
         self.env.ref('stock.route_warehouse0_mto').active = True
         # Create warehouse
         self.customer_location = self.env['ir.model.data'].xmlid_to_res_id('stock.stock_location_customers')
-        warehouse_form = Form(self.env['stock.warehouse'])
-        warehouse_form.name = 'Test Warehouse'
-        warehouse_form.code = 'TWH'
-        self.warehouse = warehouse_form.save()
+        self.warehouse = self.env['stock.warehouse'].create({
+            'name': 'Test Warehouse',
+            'code': 'TWH'
+        })
 
         self.uom_unit = self.env.ref('uom.product_uom_unit')
 

--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -7851,3 +7851,9 @@ msgstr ""
 #, python-format
 msgid "You can't desactivate the multi-location if you have more than once warehouse by company"
 msgstr ""
+
+#. module: stock
+#: code:addons/stock/models/stock_warehouse.py:0
+#, python-format
+msgid "Creating a new warehouse will automatically activate the Storage Locations setting"
+msgstr ""

--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -7845,3 +7845,9 @@ msgstr ""
 #, python-format
 msgid "should be replenished to reach the maximum of"
 msgstr ""
+
+#. module: stock
+#: code:addons/stock/models/res_config_settings.py:0
+#, python-format
+msgid "You can't desactivate the multi-location if you have more than once warehouse by company"
+msgstr ""

--- a/addons/stock/models/res_config_settings.py
+++ b/addons/stock/models/res_config_settings.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
 
 
 class ResConfigSettings(models.TransientModel):
@@ -58,6 +59,12 @@ class ResConfigSettings(models.TransientModel):
             self.group_stock_multi_locations = True
 
     def set_values(self):
+        warehouse_grp = self.env.ref('stock.group_stock_multi_warehouses')
+        location_grp = self.env.ref('stock.group_stock_multi_locations')
+        base_user = self.env.ref('base.group_user')
+        if not self.group_stock_multi_locations and location_grp in base_user.implied_ids and warehouse_grp in base_user.implied_ids:
+            raise UserError(_("You can't desactivate the multi-location if you have more than once warehouse by company"))
+
         res = super(ResConfigSettings, self).set_values()
 
         if not self.user_has_groups('stock.group_stock_manager'):

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -90,6 +90,18 @@ class Warehouse(models.Model):
         ('warehouse_code_uniq', 'unique(code, company_id)', 'The code of the warehouse must be unique per company!'),
     ]
 
+    @api.onchange('company_id')
+    def _onchange_company_id(self):
+        group_user = self.env.ref('base.group_user')
+        group_stock_multi_warehouses = self.env.ref('stock.group_stock_multi_warehouses')
+        if group_stock_multi_warehouses not in group_user.implied_ids:
+            return {
+                'warning': {
+                    'title': _('Warning'),
+                    'message': _('Creating a new warehouse will automatically activate the Storage Locations setting')
+                }
+            }
+
     @api.depends('name')
     def _compute_warehouse_count(self):
         for warehouse in self:

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -225,9 +225,9 @@ class Warehouse(models.Model):
                                     (', '.join(picking_type_using_locations.mapped('name')), warehouse.name))
                 warehouse.view_location_id.write({'active': vals['active']})
 
-                rule_ids = self.env['stock.rule'].with_context(active_test=False).search([('warehouse_id', '=', self.id)])
+                rule_ids = self.env['stock.rule'].with_context(active_test=False).search([('warehouse_id', '=', warehouse.id)])
                 # Only modify route that apply on this warehouse.
-                route_ids = warehouse.route_ids.filtered(lambda r: len(r.warehouse_ids) == 1).write({'active': vals['active']})
+                warehouse.route_ids.filtered(lambda r: len(r.warehouse_ids) == 1).write({'active': vals['active']})
                 rule_ids.write({'active': vals['active']})
 
                 if warehouse.active:

--- a/addons/stock_dropshipping/tests/test_crossdock.py
+++ b/addons/stock_dropshipping/tests/test_crossdock.py
@@ -13,12 +13,12 @@ class TestCrossdock(common.TransactionCase):
         supplier_crossdock = self.env['res.partner'].create({'name': "Crossdocking supplier"})
 
         # I first create a warehouse with pick-pack-ship and reception in 2 steps
-        wh_f = Form(self.env['stock.warehouse'])
-        wh_f.name = 'WareHouse PickPackShip'
-        wh_f.code = 'whpps'
-        wh_f.reception_steps = 'two_steps'
-        wh_f.delivery_steps = 'pick_pack_ship'
-        wh_pps = wh_f.save()
+        wh_pps = self.env['stock.warehouse'].create({
+            'name': 'WareHouse PickPackShip',
+            'code': 'whpps',
+            'reception_steps': 'two_steps',
+            'delivery_steps': 'pick_pack_ship',
+        })
 
         # Check that cross-dock route is active
         self.assertTrue(wh_pps.crossdock_route_id.active,


### PR DESCRIPTION
[FIX] stock: fix multi-archive

[FIX] stock: add warning when creating second warehouse

Add a warning to explain that create a second
warehouse will activate the multi-location automatically.
   
[FIX] stock: avoid not logical settings

When we create a second warehouse on a company, the
multi-warehouse and the multi-location is automatically
activated. But a user can deactivate manually the multi-location
which leads to a misconfiguration (no sense to have multi-warehouse
without multi-location)
Add a UserError to avoid this case.
    
task-2439909