### PR TITLE
[FIX] base: do not check dependencies of uninstallable addons

### DIFF
--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -645,7 +645,8 @@ class Module(models.Model):
             i += 1
             if module.state not in ('installed', 'to upgrade'):
                 raise UserError(_("Can not upgrade module '%s'. It is not installed.") % (module.name,))
-            self.check_external_dependencies(module.name, 'to upgrade')
+            if self.get_module_info(module.name).get("installable", True):
+                self.check_external_dependencies(module.name, 'to upgrade')
             for dep in Dependency.search([('name', '=', module.name)]):
                 if (
                     dep.module_id.state == 'installed'
@@ -658,6 +659,8 @@ class Module(models.Model):
 
         to_install = []
         for module in todo:
+            if not self.get_module_info(module.name).get("installable", True):
+                continue
             for dep in module.dependencies_id:
                 if dep.state == 'unknown':
                     raise UserError(_('You try to upgrade the module %s that depends on the module: %s.\nBut this module is not available in your system.') % (module.name, dep.name,))


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

When an installed module is not installable, we don't want
to check its dependencies because they may not be available.
Erroring out on such dependencies is not needed because
the module will not be loaded anyway. On the contrary, such
errors prevent starting a database which would otherwise
function normally.

Such errors occur when doing incremental migrations where
it happens that addons are installed (from the previous version)
but not migrated yet and therefore not installable.
When we migrate and update lower level dependencies Odoo marks
higher level addons as "to upgrade" even if they are not installable.
That is usually harmless, except when such addons have
dependencies that are themselves not available.
This PR fixes that.

**Current behavior before PR:**

Errors about (external) dependencies of installed addons that are not installable, and a database that does not start.

**Desired behavior after PR is merged:**

No stack traces, only the usual logs about addons not being available, and a database that otherwise starts normally.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
