### PR TITLE
[FIX] point_of_sale: some fields are now readonly in the views for po…

### DIFF
--- a/addons/point_of_sale/views/pos_payment_views.xml
+++ b/addons/point_of_sale/views/pos_payment_views.xml
@@ -4,17 +4,17 @@
         <field name="name">pos.payment.form</field>
         <field name="model">pos.payment</field>
         <field name="arch" type="xml">
-            <form string="Payments" create="0" delete="0">
+            <form string="Payments" create="0" edit="0" delete="0">
                 <sheet>
                     <group>
                         <field name="currency_id" invisible="1" />
                         <field name="name" />
                         <field name="amount" />
-                        <field name="pos_order_id" />
-                        <field name="payment_method_id" />
-                        <field name="card_type" attrs="{'invisible': [('card_type', '=', False)]}"/>
-                        <field name="cardholder_name" attrs="{'invisible': [('cardholder_name', '=', False)]}"/>
-                        <field name="transaction_id" attrs="{'invisible': [('transaction_id', '=', False)]}"/>
+                        <field name="pos_order_id" readonly="1"/>
+                        <field name="payment_method_id" readonly="1"/>
+                        <field name="card_type" readonly="1" attrs="{'invisible': [('card_type', '=', False)]}"/>
+                        <field name="cardholder_name" readonly="1" attrs="{'invisible': [('cardholder_name', '=', False)]}"/>
+                        <field name="transaction_id" readonly="1" attrs="{'invisible': [('transaction_id', '=', False)]}"/>
                         <field name="session_id" />
                     </group>
                 </sheet>

--- a/addons/point_of_sale/views/pos_session_view.xml
+++ b/addons/point_of_sale/views/pos_session_view.xml
@@ -4,7 +4,7 @@
         <field name="name">pos.session.form.view</field>
         <field name="model">pos.session</field>
         <field name="arch" type="xml">
-            <form string="Point of Sale Session" create="0">
+            <form string="Point of Sale Session" create="0" edit="0">
                 <header>
                     <button name="open_cashbox_pos" type="object" string="Open Session"
                         attrs="{'invisible' : ['|', ('cash_control', '=', False), ('state', '!=', 'new_session')]}" class="oe_highlight"
@@ -61,7 +61,7 @@
                         <field name="cash_control" invisible="1" />
                         <field name="user_id"/>
                         <field name="currency_id" invisible="1"/>
-                        <field name="config_id"/>
+                        <field name="config_id" readonly="1"/>
                         <field name="move_id" readonly="1" groups="account.group_account_readonly" />
                         <field name="start_at" attrs="{'invisible' : [('state', '=', 'opening_control')]}"/>
                         <field name="stop_at" attrs="{'invisible' : [('state', '!=', 'closed')]}"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The user was able to modify some fields in the pos_payment and pos_session.
Current behavior before PR:
Some fields were editable.
Desired behavior after PR is merged:
The fields are now readonly in the form view and the edit button has been removed.

Task id: 2394740