### PR TITLE
[FIX] delivery: package weight depends on 'picking_id' context key

### DIFF
--- a/addons/delivery/models/stock_picking.py
+++ b/addons/delivery/models/stock_picking.py
@@ -12,6 +12,7 @@ class StockQuantPackage(models.Model):
     _inherit = "stock.quant.package"
 
     @api.depends('quant_ids')
+    @api.depends_context('picking_id')
     def _compute_weight(self):
         for package in self:
             weight = 0.0


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Weight of the package is wrong if we set the `picking_id` context key while we already hit the `weight` field before (without the context key).

Current behavior before PR:

```python
>>> package.weight
10
>>> package.with_context(picking_id=picking.id).weight    # Value taken from the cache
10
```

Desired behavior after PR is merged:

```python
>>> package.weight
10
>>> package.with_context(picking_id=picking.id).weight    # Value recomputed as the 'picking_id' context key is set
5
```

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
