### PR TITLE
[FIX] website: page visibility 'connected' leads to a 403 when connected

### DIFF
--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -364,8 +364,7 @@ class View(models.Model):
                 else:
                     error = werkzeug.exceptions.Forbidden('website_visibility_password_required')
 
-            # elif self.visibility == 'restricted_group' and self.groups_id: or if groups_id set from backend
-            if self.visibility != 'password':
+            if self.visibility not in ('password', 'connected'):
                 try:
                     self._check_view_access()
                 except AccessError:


### PR DESCRIPTION
Steps:
- As admin, go to "Contact us" or any other page on the website (1)
- Go to Pages > Page Properties > Publish
- Change the visibility to Signed In
- Save
- As demo, go to (1)

Bug:
The user "demo" is signed in but is returned a 403 Forbidden

Explanation:
When landing on a page with visibility: 'connected', the only way to see
the page is to have a group matching the groups of the page as seen
here: https://github.com/odoo/odoo/blob/28b748a559e1ffb5fb7c3631bf77adba121b2ebf/odoo/addons/base/models/ir_ui_view.py#L625-L626
This fix lets any connected users see the page.

opw:2431700