### PR TITLE
[MERGE] partner_autocomplete: enrich user companies

### DIFF
--- a/addons/partner_autocomplete/models/__init__.py
+++ b/addons/partner_autocomplete/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import iap_autocomplete_api
 from . import res_partner
 from . import res_company
 from . import res_config_settings

--- a/addons/partner_autocomplete/models/__init__.py
+++ b/addons/partner_autocomplete/models/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import iap_autocomplete_api
+from . import ir_http
 from . import res_partner
 from . import res_company
 from . import res_config_settings

--- a/addons/partner_autocomplete/models/iap_autocomplete_api.py
+++ b/addons/partner_autocomplete/models/iap_autocomplete_api.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+
+from odoo import api, models, exceptions, _
+from odoo.addons.iap.tools import iap_tools
+from requests.exceptions import HTTPError
+
+_logger = logging.getLogger(__name__)
+
+
+class IapAutocompleteEnrichAPI(models.AbstractModel):
+    _name = 'iap.autocomplete.api'
+    _description = 'IAP Partner Autocomplete API'
+    _DEFAULT_ENDPOINT = 'https://partner-autocomplete.odoo.com'
+
+    @api.model
+    def _contact_iap(self, local_endpoint, action, params, timeout=15):
+        if self.env.registry.in_test_mode():
+            raise exceptions.ValidationError(_('Test mode'))
+        account = self.env['iap.account'].get('partner_autocomplete')
+        if not account.account_token:
+            raise ValueError(_('No account token'))
+        params.update({
+            'db_uuid': self.env['ir.config_parameter'].sudo().get_param('database.uuid'),
+            'account_token': account.account_token,
+            'country_code': self.env.company.country_id.code,
+            'zip': self.env.company.zip,
+        })
+        base_url = self.env['ir.config_parameter'].sudo().get_param('iap.partner_autocomplete.endpoint', self._DEFAULT_ENDPOINT)
+        return iap_tools.iap_jsonrpc(base_url + local_endpoint + '/' + action, params=params, timeout=timeout)
+
+    @api.model
+    def _request_partner_autocomplete(self, action, params, timeout=15):
+        """ Contact endpoint to get autocomplete data.
+
+        :return tuple: results, error code
+        """
+        try:
+            results = self._contact_iap('/iap/partner_autocomplete', action, params, timeout=timeout)
+        except exceptions.ValidationError:
+            return False, 'Insufficient Credit'
+        except (ConnectionError, HTTPError, exceptions.AccessError, exceptions.UserError) as exception:
+            _logger.error('Autocomplete API error: %s', str(exception))
+            return False, str(exception)
+        except iap_tools.InsufficientCreditError as exception:
+            _logger.warning('Insufficient Credits for Autocomplete Service: %s', str(exception))
+            return False, 'Insufficient Credit'
+        except ValueError:
+            return False, 'No account token'
+        return results, False

--- a/addons/partner_autocomplete/models/ir_http.py
+++ b/addons/partner_autocomplete/models/ir_http.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+from odoo.http import request
+
+
+class Http(models.AbstractModel):
+    _inherit = 'ir.http'
+
+    def session_info(self):
+        """ Add information about iap enrich to perform """
+        session_info = super(Http, self).session_info()
+        if session_info.get('is_admin'):
+            session_info['iap_company_enrich'] = not request.env.user.company_id.iap_enrich_auto_done
+        return session_info

--- a/addons/partner_autocomplete/models/res_company.py
+++ b/addons/partner_autocomplete/models/res_company.py
@@ -3,6 +3,7 @@
 
 import json
 import logging
+import threading
 
 from odoo.addons.iap.tools import iap_tools
 from odoo import api, fields, models, tools, _
@@ -22,6 +23,13 @@ class ResCompany(models.Model):
     def _inverse_partner_gid(self):
         for company in self:
             company.partner_id.partner_gid = company.partner_gid
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        res = super().create(vals_list)
+        if not getattr(threading.currentThread(), 'testing', False):
+            res.iap_enrich_auto()
+        return res
 
     def iap_enrich_auto(self):
         """ Enrich company. This method should be called by automatic processes

--- a/addons/partner_autocomplete/models/res_company.py
+++ b/addons/partner_autocomplete/models/res_company.py
@@ -1,14 +1,120 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+import json
+import logging
+
+from odoo.addons.iap.tools import iap_tools
+from odoo import api, fields, models, tools, _
+
+_logger = logging.getLogger(__name__)
+
+COMPANY_AC_TIMEOUT = 5
+
 
 class ResCompany(models.Model):
     _name = 'res.company'
     _inherit = 'res.company'
 
     partner_gid = fields.Integer('Company database ID', related="partner_id.partner_gid", inverse="_inverse_partner_gid", store=True)
+    iap_enrich_auto_done = fields.Boolean('Enrich Done')
 
     def _inverse_partner_gid(self):
         for company in self:
             company.partner_id.partner_gid = company.partner_gid
+
+    def iap_enrich_auto(self):
+        """ Enrich company. This method should be called by automatic processes
+        and a protection is added to avoid doing enrich in a loop. """
+        if self.env.user._is_system():
+            for company in self.filtered(lambda company: not company.iap_enrich_auto_done):
+                company._enrich()
+            self.iap_enrich_auto_done = True
+        return True
+
+    def _enrich(self):
+        """ This method calls the partner autocomplete service from IAP to enrich
+        partner related fields of the company.
+
+        :return bool: either done, either failed """
+        self.ensure_one()
+        _logger.info("Starting enrich of company %s (%s)", self.name, self.id)
+
+        company_domain = self._get_company_domain()
+        if not company_domain:
+            return False
+
+        company_data = self.env['res.partner'].enrich_company(company_domain, False, self.vat, timeout=COMPANY_AC_TIMEOUT)
+        if company_data.get('error'):
+            return False
+        additional_data = company_data.pop('additional_info', False)
+
+        # Keep only truthy values that are not already set on the target partner
+        # Erase image_1920 even if something is in it. Indeed as partner_autocomplete is probably installed as a
+        # core app (mail -> iap -> partner_autocomplete auto install chain) it is unlikely that people already
+        # updated their company logo.
+        self.env['res.partner']._iap_replace_logo(company_data)
+        company_data = {field: value for field, value in company_data.items()
+                        if field in self.partner_id._fields and value and (field == 'image_1920' or not self.partner_id[field])}
+
+        # for company and childs: from state_id / country_id name_get like to IDs
+        company_data.update(self._enrich_extract_m2o_id(company_data, ['state_id', 'country_id']))
+        if company_data.get('child_ids'):
+            company_data['child_ids'] = [
+                dict(child_data, **self._enrich_extract_m2o_id(child_data, ['state_id', 'country_id']))
+                for child_data in company_data['child_ids']
+            ]
+
+        # handle o2m values, e.g. {'bank_ids': ['acc_number': 'BE012012012', 'acc_holder_name': 'MyWebsite']}
+        self._enrich_replace_o2m_creation(company_data)
+
+        self.partner_id.write(company_data)
+
+        if additional_data:
+            template_values = json.loads(additional_data)
+            template_values['flavor_text'] = _("Company auto-completed by Odoo Partner Autocomplete Service")
+            self.partner_id.message_post_with_view(
+                'iap_mail.enrich_company',
+                values=template_values,
+                subtype_id=self.env.ref('mail.mt_note').id,
+            )
+        return True
+
+    def _enrich_extract_m2o_id(self, iap_data, m2o_fields):
+        """ Extract m2O ids from data (because of res.partner._format_data_company) """
+        extracted_data = {}
+        for m2o_field in m2o_fields:
+            relation_data = iap_data.get(m2o_field)
+            if relation_data and isinstance(relation_data, dict):
+                extracted_data[m2o_field] = relation_data.get('id', False)
+        return extracted_data
+
+    def _enrich_replace_o2m_creation(self, iap_data):
+        for o2m_field, values in iap_data.items():
+            if isinstance(values, list):
+                commands = [(
+                    0, 0, create_value
+                ) for create_value in values if isinstance(create_value, dict)]
+                if commands:
+                    iap_data[o2m_field] = commands
+                else:
+                    iap_data.pop(o2m_field, None)
+        return iap_data
+
+    def _get_company_domain(self):
+        """ Extract the company domain to be used by IAP services.
+        The domain is extracted from the website or the email information.
+        e.g:
+            - www.info.proximus.be -> proximus.be
+            - info@proximus.be -> proximus.be """
+        self.ensure_one()
+
+        company_domain = tools.email_domain_extract(self.email) if self.email else False
+        if company_domain and company_domain not in iap_tools._MAIL_DOMAIN_BLACKLIST:
+            return company_domain
+
+        company_domain = tools.url_domain_extract(self.website) if self.website else False
+        if not company_domain or company_domain in ['localhost', 'example.com']:
+            return False
+
+        return company_domain

--- a/addons/partner_autocomplete/models/res_partner_autocomplete_sync.py
+++ b/addons/partner_autocomplete/models/res_partner_autocomplete_sync.py
@@ -25,7 +25,7 @@ class ResPartnerAutocompleteSync(models.Model):
 
             if partner.vat and partner._is_vat_syncable(partner.vat):
                 params['vat'] = partner.vat
-                result, error = partner._rpc_remote_api('update', params)
+                _, error = self.env['iap.autocomplete.api']._request_partner_autocomplete('update', params)
                 if error:
                     _logger.error('Send Partner to sync failed: %s' % str(error))
 

--- a/addons/partner_autocomplete/static/src/js/web_company_autocomplete.js
+++ b/addons/partner_autocomplete/static/src/js/web_company_autocomplete.js
@@ -1,0 +1,26 @@
+odoo.define('web.company_autocomplete', function (require) {
+"use strict";
+
+const AbstractWebClient = require('web.AbstractWebClient');
+const session = require('web.session');
+
+return AbstractWebClient.include({
+
+    start: function () {
+        if (session.iap_company_enrich) {
+            const current_company_id = session.user_companies.current_company[0];
+            this._rpc({
+                model: 'res.company',
+                method: 'iap_enrich_auto',
+                args: [current_company_id],
+            }, {
+                shadow: true,
+            });
+        }
+
+        return this._super.apply(this, arguments);
+    },
+
+});
+
+});

--- a/addons/partner_autocomplete/tests/__init__.py
+++ b/addons/partner_autocomplete/tests/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import models
+from . import test_res_company

--- a/addons/partner_autocomplete/tests/common.py
+++ b/addons/partner_autocomplete/tests/common.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from odoo import exceptions
+from odoo.addons.iap.tools import iap_tools
+from odoo.addons.partner_autocomplete.models.iap_autocomplete_api import IapAutocompleteEnrichAPI
+from odoo.tests import common
+
+
+class MockIAPPartnerAutocomplete(common.BaseCase):
+    """ Mock PartnerAutocomplete IAP calls for testing purpose.
+
+    Example of company_data {
+      'partner_gid': 51580, 'website': 'mywebsite.be',
+      'additional_info': {
+        "name": "Mywebsite",
+        "description": "Mywebsite is the largest of Belgium\'s custom companies and part of Mywebsite Group.",
+        "facebook": "mywebsitebe", "twitter": "mywebsite", "linkedin": "company/mywebsite",
+        "twitter_followers": 99999, "twitter_bio": "This is the official Twitter account of MyWebsite.",
+        "industry_group": "Technology Hardware & Equipment", "sub_industry": "Computer Networking",
+        "industry": "Communications Equipment",
+        "sector": ["Information Technology", "Technology Hardware & Equipment"],
+        "sector_primary": "Information Technology"
+        "tech": ["Tealium", "Hotjar", "Google Analytics", "Instagram", "Facebook Advertiser", "Facebook Connect", "Google Tag Manager", "Mandrill", "Bazaarvoice", "Mailgun", "Conversio"],
+        "email": [], "crunchbase": "organization/mywebsite-group",
+        "phone_numbers": ["+32 800 00 000", "+32 800 00 001", "+32 800 00 002"],
+        "timezone": "Europe/Brussels", "timezone_url": "https://time.is/Brussels",
+        "company_type": "private", "employees": 15000.0, "annual_revenue": 0.0, "estimated_annual_revenue": false, "founded_year": 0,
+        "logo": "https://logo.clearbit.com/mywebsite.be"},
+      'child_ids': [{
+        'is_company': False, 'type': 'contact', 'city': False, 'email': False,
+        'name': 'Client support - SMEs', 'street': 'False False', 'phone': '0800 00 500',
+        'zip': False, 'country_id': False, 'state_id': False}, {
+        'is_company': False, 'type': 'contact', 'city': False, 'email': False,
+        'name': 'Client Support - Large Business', 'street': 'False False', 'phone': '0800 00 501',
+        'zip': False, 'country_id': False, 'state_id': False}],
+      'city': 'Brussel', 'vat': 'BE0202239951',
+      'email': False, 'logo': 'https://logo.clearbit.com/mywebsite.be',
+      'name': 'Proximus', 'zip': '1000', 'ignored': False, 'phone': '+32 800 00 800',
+      'bank_ids': [{
+        'acc_number': 'BE012012012', 'acc_holder_name': 'MyWebsite'}, {
+        'acc_number': 'BE013013013', 'acc_holder_name': 'MyWebsite Online'}],
+      'street': 'Rue Perdues 27',
+      'country_code': 'de', 'country_name': 'Germany',
+      'state_id': False
+    }
+    """
+
+    @classmethod
+    def _init_mock_partner_autocomplete(cls):
+        super(MockIAPPartnerAutocomplete, cls).setUpClass()
+        cls.base_de = cls.env.ref('base.de')
+        cls.base_be = cls.env.ref('base.be')
+        cls.be_state_bw = cls.env['res.country.state'].create({'name': 'Béwééé dis', 'code': 'bw', 'country_id': cls.base_be.id})
+
+    @contextmanager
+    def mockPartnerAutocomplete(self, default_data=None, sim_error=None):
+        def _contact_iap(local_endpoint, action, params, timeout):
+            sim_result = {
+                'partner_gid': '9876', 'website': 'https://www.heinrich.de',
+                'additional_info': {},
+                'city': 'Mönchengladbach',
+                'email': False, 'logo': 'https://logo.clearbit.com/heinrichsroofing.com',
+                'name': 'Heinrich', 'zip': '41179', 'ignored': False, 'phone': '+49 0000 112233',
+                'street': 'Mennrather Str. 123456',
+                'country_code': self.base_de.code, 'country_name': self.base_de.name,
+                'state_id': False,
+                'child_ids': [{
+                    'is_company': False, 'type': 'contact', 'city': 'Orcq',
+                    'name': 'Heinrich Support'
+                }, {
+                    'is_company': False, 'type': 'contact', 'email': 'heinrich.clien@test.example.com',
+                    'name': 'Heinrich Client Support', 'street': 'Rue des Bourlottes, 9', 'phone': '0456 00 11 22',
+                    'zip': '1367', 'country_code': self.base_be.code, 'country_name': self.base_be.name,
+                    'state_code': self.be_state_bw.code, 'state_name': self.be_state_bw.name
+                }],
+            }
+            if default_data:
+                sim_result.update(default_data)
+            # mock enrich only currently, to update further
+            if action == 'enrich':
+                if sim_error and sim_error == 'credit':
+                    raise iap_tools.InsufficientCreditError('InsufficientCreditError')
+                elif sim_error and sim_error == 'jsonrpc_exception':
+                    raise exceptions.AccessError(
+                        'The url that this service requested returned an error. Please contact the author of the app. The url it tried to contact was ' + local_endpoint
+                    )
+                elif sim_error and sim_error == 'token':
+                    raise ValueError('No account token')
+                return {'company_data': sim_result}
+
+        try:
+            with patch.object(IapAutocompleteEnrichAPI, '_contact_iap', side_effect=_contact_iap):
+                yield
+        finally:
+            pass

--- a/addons/partner_autocomplete/tests/common.py
+++ b/addons/partner_autocomplete/tests/common.py
@@ -51,7 +51,6 @@ class MockIAPPartnerAutocomplete(common.BaseCase):
 
     @classmethod
     def _init_mock_partner_autocomplete(cls):
-        super(MockIAPPartnerAutocomplete, cls).setUpClass()
         cls.base_de = cls.env.ref('base.de')
         cls.base_be = cls.env.ref('base.be')
         cls.be_state_bw = cls.env['res.country.state'].create({'name': 'Béwééé dis', 'code': 'bw', 'country_id': cls.base_be.id})

--- a/addons/partner_autocomplete/tests/test_res_company.py
+++ b/addons/partner_autocomplete/tests/test_res_company.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import common
+from odoo.addons.partner_autocomplete.tests.common import MockIAPPartnerAutocomplete
+
+class TestResCompany(common.TransactionCase, MockIAPPartnerAutocomplete):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestResCompany, cls).setUpClass()
+        cls._init_mock_partner_autocomplete()
+
+    def test_enrich(self):
+        company = self.env['res.company'].create({'name': "Test Company 1"})
+        with self.mockPartnerAutocomplete():
+            res = company._enrich()
+            self.assertFalse(res)
+
+        company.write({'email': 'friedrich@heinrich.de'})
+        with self.mockPartnerAutocomplete():
+            # asserts are synchronized with default mock values
+            res = company._enrich()
+            self.assertTrue(res)
+            self.assertEqual(company.country_id, self.env.ref('base.de'))
+            self.assertEqual(len(company.partner_id.child_ids), 2)
+
+    def test_extract_company_domain(self):
+        company_1 = self.env['res.company'].create({'name': "Test Company 1"})
+
+        company_1.website = 'http://www.info.proximus.be/faq/test'
+        self.assertEqual(company_1._get_company_domain(), "proximus.be")
+
+        company_1.email = 'info@waterlink.be'
+        self.assertEqual(company_1._get_company_domain(), "waterlink.be")
+
+        company_1.website = False
+        company_1.email = False
+        self.assertEqual(company_1._get_company_domain(), False)
+
+        company_1.email = "at@"
+        self.assertEqual(company_1._get_company_domain(), False)
+
+        company_1.website = "http://superFalsyWebsiteName"
+        self.assertEqual(company_1._get_company_domain(), False)
+
+        company_1.website = "http://www.superwebsite.com"
+        self.assertEqual(company_1._get_company_domain(), 'superwebsite.com')
+
+        company_1.website = "http://superwebsite.com"
+        self.assertEqual(company_1._get_company_domain(), 'superwebsite.com')
+
+        company_1.website = "http://localhost:8069/%7Eguido/Python.html"
+        self.assertEqual(company_1._get_company_domain(), False)
+
+        company_1.website = "http://runbot.odoo.com"
+        self.assertEqual(company_1._get_company_domain(), 'odoo.com')
+
+        company_1.website = "http://www.example.com/biniou"
+        self.assertEqual(company_1._get_company_domain(), False)
+
+        company_1.website = "http://www.cwi.nl:80/%7Eguido/Python.html"
+        self.assertEqual(company_1._get_company_domain(), "cwi.nl")

--- a/addons/partner_autocomplete/views/partner_autocomplete_assets.xml
+++ b/addons/partner_autocomplete/views/partner_autocomplete_assets.xml
@@ -6,6 +6,7 @@
             <script type="text/javascript" src="/partner_autocomplete/static/src/js/partner_autocomplete_core.js" />
             <script type="text/javascript" src="/partner_autocomplete/static/src/js/partner_autocomplete_fieldchar.js" />
             <script type="text/javascript" src="/partner_autocomplete/static/src/js/partner_autocomplete_many2one.js" />
+            <script type="text/javascript" src="/partner_autocomplete/static/src/js/web_company_autocomplete.js" />
         </xpath>
     </template>
 

--- a/addons/partner_autocomplete/views/res_company_views.xml
+++ b/addons/partner_autocomplete/views/res_company_views.xml
@@ -11,8 +11,9 @@
             <xpath expr="//field[@name='vat']" position="attributes">
                 <attribute name="widget">field_partner_autocomplete</attribute>
             </xpath>
-            <xpath expr="//field[last()]" position="after">
-                <field name="partner_gid" invisible="True"/>
+            <xpath expr="//field[@name='company_registry']" position="after">
+                <field name="partner_gid" invisible="1"/>
+                <field name="iap_enrich_auto_done" invisible="1"/>
             </xpath>
         </field>
     </record>

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -13,6 +13,7 @@ import time
 
 from email.utils import getaddresses
 from lxml import etree
+from urllib.parse import urlparse
 from werkzeug import urls
 import idna
 
@@ -548,6 +549,28 @@ def email_normalize(text):
     if not emails or len(emails) != 1:
         return False
     return emails[0].lower()
+
+
+def email_domain_extract(email):
+    """ Extract the company domain to be used by IAP services notably. Domain
+    is extracted from email information e.g:
+        - info@proximus.be -> proximus.be
+    """
+    normalized_email = email_normalize(email)
+    if normalized_email:
+        return normalized_email.split('@')[1]
+    return False
+
+def url_domain_extract(url):
+    """ Extract the company domain to be used by IAP services notably. Domain
+    is extracted from an URL e.g:
+        - www.info.proximus.be -> proximus.be
+    """
+    parser_results = urlparse(url)
+    company_hostname = parser_results.hostname
+    if company_hostname and '.' in company_hostname:
+        return '.'.join(company_hostname.split('.')[-2:])  # remove subdomains
+    return False
 
 def email_escape_char(email_address):
     """ Escape problematic characters in the given email address string"""


### PR DESCRIPTION
In order to make a wow effect right after DB install we enrich the base
company based on the given email address or company website at install.
In order to achieve that goal we use the partner_autocomplete service from
IAP. It uses free credits that are offered to new clients on saas platform.

Only the fields that are not filled yet are enriched to avoid erasing user
entered data, except logo. Indeed as partner_autocomplete is probably installed
as a core app (mail -> iap -> partner_autocomplete auto install chain) it is
unlikely that people already updated their company logo.

We consider that having a call to IAP consuming a token is ok for a standard
use case, especially that

  * if no iap service is configured call to IAP won't add much timing;
  * on Odoo SaaS free credits are given and company is enriched;
  * on custom SaaS with custom iap service, at db creation probably no
    credits are given and call will simply give no results back;

We decided to call IAP asynchronously at client web load. Session combined to
a boolean field on company model allows to do this call only once per company.
Doing this allows to avoid adding yet another post init hook. It also eases
behavior tweak through inheritance.

This call is limited to admin for obvious security reasons as well as
performance reason (limiting calls to external providers). As call will be
done once per company generally admin is the first person to log into the
its newly created Odoo.

In addition to enriching companies on the fly, we also enrich companies
when creating them. It allows to have an enrich on companies existing
before using autocomplete, and have results of enrich directly at create
for companies created after installing this module.

LINKS

Task ID-2322455
PR odoo/odoo#64600
PR odoo/upgrade#2086

Co-Authored-By: David Beguin <dbe@odoo.com>
Co-Authored-By: Thibault Delavallee <tde@odoo.com>