### PR TITLE
[FIX] web: respect redirection in /web/dbredirect

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -125,14 +125,8 @@ def ensure_db(redirect='/web/database/selector'):
         # may depend on data injected by the database route dispatcher.
         # Thus, we redirect the user to the same page but with the session cookie set.
         # This will force using the database route dispatcher...
-        r = request.httprequest
-        url_redirect = werkzeug.urls.url_parse(r.base_url)
-        if r.query_string:
-            # in P3, request.query_string is bytes, the rest is text, can't mix them
-            query_string = iri_to_uri(r.query_string)
-            url_redirect = url_redirect.replace(query=query_string)
         request.session.db = db
-        abort_and_redirect(url_redirect)
+        abort_and_redirect(request.httprequest.url)
 
     # if db not provided, use the session one
     if not db and request.session.db and http.db_filter([request.session.db]):

--- a/addons/web/tests/__init__.py
+++ b/addons/web/tests/__init__.py
@@ -6,3 +6,4 @@ from . import test_js
 from . import test_menu
 from . import test_serving_base
 from . import test_click_everywhere
+from . import test_controllers

--- a/addons/web/tests/test_controllers.py
+++ b/addons/web/tests/test_controllers.py
@@ -1,0 +1,27 @@
+from odoo.tests.common import get_db_name, HttpCase
+
+
+class FirstTimeVisitorCase(HttpCase):
+    def setUp(self):
+        super().setUp()
+        # Tests in this class are for `auth="none"` controllers, which we emulate
+        # removing session_id cookie; this way it's like a 1st time visitor
+        del self.opener.cookies["session_id"]
+
+    def test_dbredirect(self):
+        """Redirections to db-less requests work as expected."""
+        # Test a db-redirection to download a barcode.
+        # The barcode itself is not relevant. The important thing is that
+        # `/report/barcode` is an `auth="public"` controller, which requires a DB but
+        # not a login. Using `/web/dbredirect` should create a new `session_id` cookie
+        # automatically which points to the chosen DB. We test that system works.
+        response = self.url_open(
+            "/web/dbredirect?db={}&redirect=%2Freport%2Fbarcode%2FQR%2Ftest%3Fheight%3D1%26width%3D1".format(
+                get_db_name()
+            )
+        )
+        self.assertTrue(response.ok)
+        # The redirection took place as expected
+        self.assertEqual(
+            response.request.path_url, "/report/barcode/QR/test?height=1&width=1",
+        )


### PR DESCRIPTION
This controller is very useful for multi-db situations, but it was buggy and never respected the specified redirection.

Now it does, and it is tested also.

@Tecnativa TT25941




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
