### PR TITLE
[ADD] Model __deepcopy__ implementation

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6414,6 +6414,10 @@ class Model(AbstractModel):
     _abstract = False           # not abstract
     _transient = False          # not transient
 
+    def __deepcopy__(self, memodict={}):
+        return self.browse(self.ids)
+
+
 class TransientModel(Model):
     """ Model super-class for transient records, meant to be temporarily
     persistent, and regularly vacuum-cleaned.


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
There is no deepcopy support for an Odoo model instance.

Current behavior before PR:
```
>>> deepcopy(self.env.user)
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/usr/lib/python3.6/copy.py", line 180, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/usr/lib/python3.6/copy.py", line 280, in _reconstruct
    state = deepcopy(state, memo)
  File "/usr/lib/python3.6/copy.py", line 150, in deepcopy
    y = copier(x, memo)
  File "/usr/lib/python3.6/copy.py", line 240, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib/python3.6/copy.py", line 180, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/usr/lib/python3.6/copy.py", line 274, in _reconstruct
    y = func(*args)
  File "/usr/lib/python3.6/copyreg.py", line 88, in __newobj__
    return cls.__new__(cls, *args)
TypeError: __new__() missing 3 required positional arguments: 'cr', 'uid', and 'context'
```

Desired behavior after PR is merged:
```
>>> deepcopy(self.env.user)
>>> res.users[1]
```



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
