### PR TITLE
[12.0] Use version 2.8.3 of psycopg2 when installing on Python 3.8

### DIFF
--- a/doc/cla/individual/luquedaniel.md
+++ b/doc/cla/individual/luquedaniel.md
@@ -1,0 +1,11 @@
+Spain, 2021-01-15
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Daniel Luque danielluque14@gmail.com https://github.com/LuqueDaniel

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,8 +24,8 @@ Pillow==4.0.0 ; python_version < '3.7'
 Pillow==6.1.0 ; python_version >= '3.7'
 psutil==4.3.1; sys_platform != 'win32'
 psutil==5.6.3; sys_platform == 'win32'
-psycopg2==2.7.3.1; sys_platform != 'win32'
-psycopg2==2.8.3; sys_platform == 'win32'
+psycopg2==2.7.3.1; sys_platform != 'win32' and python_version < '3.8'
+psycopg2==2.8.3; sys_platform == 'win32' or python_version >= '3.8'
 pydot==1.2.3
 pyldap==2.4.28; sys_platform != 'win32'
 pyparsing==2.1.10


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

Run Odoo on Ubuntu 20.04 + Python 3.8

### Current behavior before PR:

Psycopg2 package doesn't install, command `python -m pip install -r requirements.txt`. Error:

```
    default:     psycopg/psycopgmodule.c: In function ‘psyco_is_main_interp’:
    default:     psycopg/psycopgmodule.c:685:18: error: dereferencing pointer to incomplete type ‘PyInterpreterState’ {aka ‘struct _is’}
    default:       685 |     while (interp->next)
    default:           |                  ^~
    default:     error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
    default:     ----------------------------------------
    default: ERROR: Command errored out with exit status 1
```

### Desired behavior after PR is merged:

Install psycopg2 2.8.3 instead of 2.7.3.1 if Python >= 3.8




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
