### PR TITLE
[FIX] web: dropdown remains always open on Mobile

### DIFF
--- a/addons/web/static/src/js/views/pivot/pivot_renderer.js
+++ b/addons/web/static/src/js/views/pivot/pivot_renderer.js
@@ -47,9 +47,7 @@ odoo.define('web.PivotRenderer', function (require) {
 
             onPatched(() => this._updateTooltip());
 
-            if (!this.env.device.isMobile) {
-                useExternalListener(window, 'click', this._resetState);
-            }
+            useExternalListener(window, 'click', this._resetState);
         }
 
         //----------------------------------------------------------------------


### PR DESCRIPTION
Before this commit, on pivot view when a user adds some groupBy the
dropdown menu remains always open.

This commit restore the same behaviour like on desktop.

Steps to reproduce:
* Open an app with a Pivot view
* Select the Pivot view
* Add one "groupBy"
* The dropdown remains open => BUG

Task ID: 2439742

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
