### PR TITLE
[FIX] account: Set memo to ref if not payment_reference

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -445,10 +445,10 @@ class AccountMove(models.Model):
 
         self._recompute_dynamic_lines(recompute_tax_base_amount=True)
 
-    @api.onchange('payment_reference')
+    @api.onchange('payment_reference', 'ref')
     def _onchange_payment_reference(self):
         for line in self.line_ids.filtered(lambda line: line.account_id.user_type_id.type in ('receivable', 'payable')):
-            line.name = self.payment_reference
+            line.name = self.payment_reference or self.ref
 
     @api.onchange('invoice_vendor_bill_id')
     def _onchange_invoice_vendor_bill(self):


### PR DESCRIPTION
Issue

	- Install "Accounting" module
	- Create a new bill :
	- Set vendor
	- Set no payment reference
	- Set a bill reference
	- Add products to bill
	- Confirm and click on Register Payment

	Memo field has no value.

Cause

	The memo field is based on lines name.
	Lines name is computed in `_onchange_payment_reference`
	and depends only on payment_referecence.

Solution

	If no `payment_reference`, fallback on `ref` to set line name.

opw-2440389