### PR TITLE
[FIX] account: Fix statement line rounding issue multi-currency

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -1024,6 +1024,9 @@ class AccountBankStatementLine(models.Model):
         '''
 
         self.ensure_one()
+        journal = self.journal_id
+        company_currency = journal.company_id.currency_id
+        foreign_currency = self.foreign_currency_id or journal.currency_id or company_currency
 
         liquidity_lines, suspense_lines, other_lines = self._seek_for_lines()
 
@@ -1040,6 +1043,7 @@ class AccountBankStatementLine(models.Model):
         reconciliation_overview = []
 
         total_balance = liquidity_lines.balance
+        total_amount_currency = liquidity_lines.amount_currency
 
         # Step 1: Split 'lines_vals_list' into two batches:
         # - The existing account.move.lines that need to be reconciled with the statement line.
@@ -1061,6 +1065,7 @@ class AccountBankStatementLine(models.Model):
                 # Newly created account.move.line from scratch.
                 line_vals = self._prepare_counterpart_move_line_vals(vals)
                 total_balance += line_vals['debit'] - line_vals['credit']
+                total_amount_currency += line_vals['amount_currency']
 
                 reconciliation_overview.append({
                     'line_vals': line_vals,
@@ -1072,6 +1077,7 @@ class AccountBankStatementLine(models.Model):
         for line, counterpart_vals in zip(existing_lines, to_process_vals):
             line_vals = self._prepare_counterpart_move_line_vals(counterpart_vals, move_line=line)
             balance = line_vals['debit'] - line_vals['credit']
+            amount_currency = line_vals['amount_currency']
 
             reconciliation_vals = {
                 'line_vals': line_vals,
@@ -1084,7 +1090,7 @@ class AccountBankStatementLine(models.Model):
                 payment_vals = self.env['account.payment.register']\
                     .with_context(active_model='account.move.line', active_ids=line.ids)\
                     .create({
-                        'amount': abs(line_vals['amount_currency']) if line_vals['currency_id'] else abs(balance),
+                        'amount': abs(amount_currency) if line_vals['currency_id'] else abs(balance),
                         'payment_date': self.date,
                         'payment_type': 'inbound' if balance < 0.0 else 'outbound',
                         'journal_id': self.journal_id.id,
@@ -1127,8 +1133,21 @@ class AccountBankStatementLine(models.Model):
             reconciliation_overview.append(reconciliation_vals)
 
             total_balance += balance
+            total_amount_currency += amount_currency
 
-        # Step 3: If the journal entry is not yet balanced, create an open balance.
+        # Step 3: Fix rounding issue due to currency conversions.
+        # Add the remaining balance on the first encountered line starting with the custom ones.
+
+        if foreign_currency.is_zero(total_amount_currency) and not company_currency.is_zero(total_balance):
+            vals = reconciliation_overview[0]['line_vals']
+            new_balance = vals['debit'] - vals['credit'] - total_balance
+            vals.update({
+                'debit': new_balance if new_balance > 0.0 else 0.0,
+                'credit': -new_balance if new_balance < 0.0 else 0.0,
+            })
+            total_balance = 0.0
+
+        # Step 4: If the journal entry is not yet balanced, create an open balance.
 
         if self.company_currency_id.round(total_balance):
             counterpart_vals = {


### PR DESCRIPTION
When reconciling a statement line with multiple lines in a multi-currency environment, it could lead to a rounding issue due to the currency rates. It could lead to an auto-generated open-balance of 0.01 amount to auto-balance the journal entry but the result is wrong since the partner has an open amount left on the receivable/payable account.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
