### PR TITLE
[IMP] pad: open external links in new tab

### DIFF
--- a/addons/pad/static/src/js/pad.js
+++ b/addons/pad/static/src/js/pad.js
@@ -163,6 +163,11 @@ var FieldPad = AbstractField.extend({
                     .removeClass('oe_pad_loading')
                     .html('<div class="oe_pad_readonly"><div>');
                 self.$('.oe_pad_readonly').html(data);
+                _.each(self.$('a'), (link) => {
+                    if (link.hostname !== window.location.hostname && link.target === "") {
+                        link.target = "_blank";
+                    }
+                });
             }).guardedCatch(function () {
                 self.$('.oe_pad_content').text(_t('Unable to load pad'));
             });

--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -514,6 +514,8 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
             top: '+5px',
         });
         this.$el.append($button);
+        $.summernote.eventHandler.modules.linkDialog.options = _.extend({},
+            $.summernote.eventHandler.modules.linkDialog.options, {forceNewWindow: true});
     },
     /**
      * @private

--- a/addons/web_editor/static/src/js/editor/rte.summernote.js
+++ b/addons/web_editor/static/src/js/editor/rte.summernote.js
@@ -450,6 +450,7 @@ eventHandler.modules.linkDialog.showLinkDialog = function ($editable, $dialog, l
 
     var def = new $.Deferred();
     topBus.trigger('link_dialog_demand', {
+        options: eventHandler.modules.linkDialog.options,
         $editable: $editable,
         linkInfo: linkInfo,
         onSave: function (linkInfo) {

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
@@ -270,7 +270,8 @@ var LinkDialog = Dialog.extend({
             (type ? (` btn btn-${style}${type}`) : '') +
             (shapeClasses ? (` ${shapeClasses}`) : '') +
             (size ? (' btn-' + size) : '');
-        var isNewWindow = this.$('input[name="is_new_window"]').prop('checked');
+        var isNewWindow = this.options.forceNewWindow ?
+            this._isFromAnotherHostName(url) : this.$('input[name="is_new_window"]').prop('checked');
         if (url.indexOf('@') >= 0 && url.indexOf('mailto:') < 0 && !url.match(/^http[s]?/i)) {
             url = ('mailto:' + url);
         } else if (url.indexOf(location.origin) === 0 && this.$('#o_link_dialog_url_strip_domain').prop("checked")) {
@@ -291,6 +292,21 @@ var LinkDialog = Dialog.extend({
     _updateOptionsUI: function () {
         const el = this.el.querySelector('[name="link_style_color"]:checked');
         $(this.buttonOptsCollapseEl).collapse(el && el.value ? 'show' : 'hide');
+    },
+    /**
+     * @private
+     */
+    _isFromAnotherHostName: function (url) {
+        if (url.includes(window.location.hostname)) {
+            return false;
+        }
+        try {
+            const Url = URL || window.URL || window.webkitURL;
+            const urlObj = url.startsWith('/') ? new Url(url, window.location.origin) : new Url(url);
+            return (urlObj.origin !== window.location.origin);
+        } catch (ignored) {
+            return true;
+        }
     },
 
     //--------------------------------------------------------------------------

--- a/addons/web_editor/static/src/xml/wysiwyg.xml
+++ b/addons/web_editor/static/src/xml/wysiwyg.xml
@@ -526,7 +526,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="form-group row">
+                <div class="form-group row" t-if="!widget.options.forceNewWindow">
                     <div class="offset-md-3 col-md-9">
                         <label class="o_switch">
                             <input type="checkbox" name="is_new_window" t-att-checked="widget.data.isNewWindow ? 'checked' : undefined"/>


### PR DESCRIPTION
This commit aims to change the behaviour of <a> links in readonly pad
widgets.

If the <a> redirects to a page that isn't in the domain (hostname
different of the current location hostname), we open it in a new
browser tab by adding a target.

Limitation : If you use the collaborative pad for a while and then
go back to a web editor html field, you'll have to edit each link
in order that the link opens a new tab by clicking on it.

task-2377544

Description of the issue/feature this PR addresses:

- Opens the external <a> links in new tab of the browser when clicked. 

Current behavior before PR:

- All <a> links are opened in the current tab.

Desired behavior after PR is merged:

- Open external <a> links in new tab of the browser when clicked. 
- Open internal (from the domain point of view) links in the current tab when clicked.
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
