### PR TITLE
[FIX] website_sale: Sort product by website sequence in website sale.

### DIFF
--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -43,6 +43,9 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="website_sale.product_template_view_tree"/>
         <field name="arch" type="xml">
+            <xpath expr="/tree" position="attributes">
+              <attribute name="default_order">website_sequence</attribute>
+            </xpath>
             <field name="sequence" position="replace">
                 <field name="website_sequence" widget="handle"/>
             </field>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When sorting product sequence in product list view in web sale. User can not see the correct sorting result .
This pr fix it.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
