### PR TITLE
[FIX] calendar_sms,hr_presence: add security rules for sms.templates

### DIFF
--- a/addons/calendar_sms/__manifest__.py
+++ b/addons/calendar_sms/__manifest__.py
@@ -9,6 +9,7 @@
     'version': '1.0',
     'depends': ['calendar', 'sms'],
     'data': [
+        'security/sms_security.xml',
         'data/sms_data.xml',
         'views/calendar_views.xml',
     ],

--- a/addons/calendar_sms/security/sms_security.xml
+++ b/addons/calendar_sms/security/sms_security.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="ir_rule_sms_template_system" model="ir.rule">
+        <field name="name">SMS Template: system administrator CRUD on calendar event templates</field>
+        <field name="model_id" ref="sms.model_sms_template"/>
+        <field name="groups" eval="[(4, ref('base.group_system'))]"/>
+        <field name="domain_force">[('model_id.model', '=', 'calendar.event'))]</field>
+    </record>
+</odoo>

--- a/addons/hr_presence/__manifest__.py
+++ b/addons/hr_presence/__manifest__.py
@@ -18,6 +18,7 @@ Allows to contact directly the employee in case of unjustified absence.
     """,
     'depends': ['hr', 'hr_holidays', 'sms'],
     'data': [
+        'security/sms_security.xml',
         'data/ir_actions_server.xml',
         'views/hr_employee_views.xml',
         'data/sms_data.xml',

--- a/addons/hr_presence/security/sms_security.xml
+++ b/addons/hr_presence/security/sms_security.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="ir_rule_sms_template_hr_manager" model="ir.rule">
+        <field name="name">SMS Template: hr manager CRUD on employee templates</field>
+        <field name="model_id" ref="sms.model_sms_template"/>
+        <field name="groups" eval="[(4, ref('hr.group_hr_manager'))]"/>
+        <field name="domain_force">[('model_id.model', '=', 'hr.employee')]</field>
+    </record>
+</odoo>


### PR DESCRIPTION
BEFORE: sms templates from these modules become inaccessible if any module from
the list below is installed

* crm_sms
* event_sms
* stock_sms
* enterprise/account_followup
* enterprise/marketing_automation_sms
* enterprise/sale_subscription

those modules add security rules for sms.templates, which adds additional
conditions to get access: at least one security rule has to be passed. So, we
need to add such rules to get access not only to Superuser

---

opw-2411116

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
