### PR TITLE
[FIX] point_of_sale: cannot close rescue session with Cash Control

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -245,7 +245,7 @@ class PosSession(models.Model):
             values = {}
             if not session.start_at:
                 values['start_at'] = fields.Datetime.now()
-            if session.config_id.cash_control:
+            if session.config_id.cash_control and not session.rescue:
                 last_sessions = self.env['pos.session'].search([('config_id', '=', self.config_id.id)]).ids
                 # last session includes the new one already.
                 if len(last_sessions) > 1:

--- a/addons/point_of_sale/views/pos_session_view.xml
+++ b/addons/point_of_sale/views/pos_session_view.xml
@@ -9,7 +9,8 @@
                     <button name="open_cashbox_pos" type="object" string="Open Session"
                         attrs="{'invisible' : ['|', ('cash_control', '=', False), ('state', '!=', 'new_session')]}" class="oe_highlight"
                          context="{'balance': 'start'}"/>
-                    <button name="open_frontend_cb" type="object" string="Continue Selling" states="opening_control,opened"/>
+                    <button name="open_frontend_cb" type="object" string="Continue Selling"
+                        attrs="{'invisible' : ['|', ('rescue', '=', True), ('state', 'not in', ['opening_control', 'opened'])]}"/>
                     <button id="end_session_opened" name="action_pos_session_closing_control" type="object" string="End of Session"
                         attrs="{'invisible' : ['|', ('cash_control', '=', False),('state', '!=', 'opened')]}"
                         class="oe_highlight"/>
@@ -24,6 +25,7 @@
                 <sheet>
                     <field name="cash_register_id" invisible="1"/>
                     <field name="failed_pickings" invisible="1"/>
+                    <field name="rescue" invisible="1"/>
                     <div class="oe_button_box" name="button_box">
                         <button name="action_view_order"
                             class="oe_stat_button"


### PR DESCRIPTION
Steps:
- Go to Point of Sale > Shop > Settings
- Activate "Advanced Cash Control"
- Start a new Shop session
- Once in the POS go offline
- Create some orders
- Close the POS UI in the top-right corner
- Go back online
- Close the session and post the entries
- Start a new session
- Create an order
- Close the POS UI
- Close the session and post the entries
- Go to Orders > Sessions
- Click the rescue session
- Click "Continue Selling"

Bug:
The user is redirected to the POS dashboard instead of opening the UI.

Explanation:
First, you cannot "Continue Selling" in a rescue session as seen here:
https://github.com/odoo/odoo/blob/b826c96ad39fc887a735c6ca839e3796aa18dac5/addons/point_of_sale/controllers/main.py#L17-L22
This commit removes the button from the UI in this case.

Then, after it has been created, the rescue session should be open and
not in the 'opening_control' state as seen here:
https://github.com/odoo/odoo/blob/9a8ebcc7cb05572681444ddb2511ccea4cee5565/addons/point_of_sale/models/pos_order.py#L98-L99
This is not the case anymore since https://github.com/odoo/odoo/commit/d21420d87ad8a269a0f30b3d9c0a3cee8c46cb14

opw:2427972