### PR TITLE
[FIX] website_sale_delivery: Compute summary total amount on delivery update

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1416,7 +1416,7 @@
         <div class="card">
             <div class="card-body p-xl-0">
                 <div class="toggle_summary d-xl-none">
-                    <b>Your order: </b> <span t-field="website_sale_order.amount_total" t-options='{"widget": "monetary", "display_currency": website_sale_order.pricelist_id.currency_id}'/>
+                    <b>Your order: </b> <span id="amount_total_summary" t-field="website_sale_order.amount_total" t-options='{"widget": "monetary", "display_currency": website_sale_order.pricelist_id.currency_id}'/>
                     <span class='fa fa-chevron-down fa-border float-right' role="img" aria-label="Details" title="Details"></span>
                 </div>
                 <div t-if="not website_sale_order or not website_sale_order.website_order_line" class="alert alert-info">

--- a/addons/website_sale_delivery/static/src/js/website_sale_delivery.js
+++ b/addons/website_sale_delivery/static/src/js/website_sale_delivery.js
@@ -15,7 +15,7 @@ odoo.define('website_sale_delivery.checkout', function (require) {
         var $amount_delivery = $('#order_delivery span.oe_currency_value');
         var $amount_untaxed = $('#order_total_untaxed span.oe_currency_value');
         var $amount_tax = $('#order_total_taxes span.oe_currency_value');
-        var $amount_total = $('#order_total span.oe_currency_value');
+        var $amount_total = $('#order_total, #amount_total_summary').find('span.oe_currency_value');
         var $carrier_badge = $('#delivery_carrier input[name="delivery_type"][value=' + result.carrier_id + '] ~ .badge:not(.o_delivery_compute)');
         var $compute_badge = $('#delivery_carrier input[name="delivery_type"][value=' + result.carrier_id + '] ~ .o_delivery_compute');
         var $discount = $('#order_discounted');


### PR DESCRIPTION
Issue

	- Connect on smartphone (or use chrome debug mode to switch to mobile view)
	- Install "Ecommerce" module
	- Add a delivery method D with a price on product P
	  and publish it
	- Go to shop and add product P to your cart
	- Go to payment and switch delivery method

	Total amount above the summary is not updated.

Cause

	Update is done on JS when delivery method is changed.
	No targeting Total Amount in summary head card (seen only on small device).

Solution

	Add ID on Total Amount in summary head card element and update it with JS
	in same time as other fields (taxes, total, ...).

opw-2424355