### PR TITLE
[Fix] `proxy_mode = True` option does NOT work for X-Forwarded-Port

### DIFF
--- a/odoo/service/wsgi_server.py
+++ b/odoo/service/wsgi_server.py
@@ -108,7 +108,7 @@ try:
     from werkzeug.middleware.proxy_fix import ProxyFix as ProxyFix_
     # 0.15 also supports port and prefix, but 0.14 only forwarded for, proto
     # and host so replicate that
-    ProxyFix = lambda app: ProxyFix_(app, x_for=1, x_proto=1, x_host=1)
+    ProxyFix = lambda app: ProxyFix_(app, x_for=1, x_proto=1, x_host=1, x_port=1)
 except ImportError:
     # werkzeug < 0.15
     from werkzeug.contrib.fixers import ProxyFix

--- a/odoo/service/wsgi_server.py
+++ b/odoo/service/wsgi_server.py
@@ -107,7 +107,7 @@ try:
     # werkzeug >= 0.15
     from werkzeug.middleware.proxy_fix import ProxyFix as ProxyFix_
     # 0.15 also supports port and prefix, but 0.14 only forwarded for, proto
-    # and host so replicate that
+    # and host
     ProxyFix = lambda app: ProxyFix_(app, x_for=1, x_proto=1, x_host=1, x_port=1)
 except ImportError:
     # werkzeug < 0.15


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Odoo cannot work behind proxy, due to ignored X-Forwarded-Port,
if proxy works on non-default port


Current behavior before PR:
- Actions depending on redirects, such as Login/Logout and a few other actions,
  are broken, if proxy does not use default ports.
- Broken modules:
  -  OAuth2 Authentication
  -  Odoo Payments by Adyen Payment Acquirer
  -  Payment Acquirer
  -  Forum
  -  eLearning
  -  Website
- So, Odoo is broken as a whole and it is NOT usable in a such scenario.


Desired behavior after PR is merged:
- Odoo working behind proxy without depending on the choice of the port in the proxy.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
