### PR TITLE
[12.0+][FIX] website_rating layout in languages with longer words.

### DIFF
--- a/addons/website_rating/static/src/scss/website_rating.scss
+++ b/addons/website_rating/static/src/scss/website_rating.scss
@@ -17,6 +17,7 @@ $o-w-rating-star-color: #FACC2E;
 
         .o_website_rating_table_star_num{
             min-width: 30px;
+            white-space: nowrap;
         }
         .o_website_rating_select[style*="opacity: 1"] {
             cursor: pointer;


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
In some languages, like french, the strings take more characters, and the rating table renders ugly.
With this fix we avoid a line-break in the "n stars" string, making it pretty again. 

Steps to reproduce:
1. Install french language
2. Activate Discussions & Rating on products
3. Look at the ugly rating layout

**Reproduced in 12.0, 13.0, 14.0**

**Current behavior before PR:**
![image](https://user-images.githubusercontent.com/1914185/104823163-d9bd5e80-5826-11eb-89bc-6e06a50cf59d.png)

**Desired behavior after PR is merged:**
![image](https://user-images.githubusercontent.com/1914185/104823167-eb066b00-5826-11eb-84b2-55c8f8dd5b33.png)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
