### PR TITLE
[FIX] base: specify the charset the the SMTP headers

### DIFF
--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -288,6 +288,8 @@ class IrMailServer(models.Model):
         body = body or u''
 
         msg = EmailMessage(policy=email.policy.SMTP)
+        msg.set_charset('utf-8')
+
         if not message_id:
             if object_id:
                 message_id = tools.generate_tracking_message_id(object_id)


### PR DESCRIPTION
Bug
===
Since 18299d7e5051cdad29854bc7280db5002a209500 we use the new Python API
to send email. So we now use EmailMessage instead of MIMEText.

But we forgot to specify the charset for the headers (the charset is
specified for the body and for the alternative body but not for the
headers itself).

Task 2393865