### PR TITLE
[FIX] survey: avoid retrospective computation

### DIFF
--- a/addons/survey/models/survey_user.py
+++ b/addons/survey/models/survey_user.py
@@ -78,7 +78,7 @@ class SurveyUserInput(models.Model):
                 score = (sum(user_input.user_input_line_ids.mapped('answer_score')) / total_possible_score) * 100
                 user_input.quizz_score = round(score, 2) if score > 0 else 0
 
-    @api.depends('quizz_score', 'survey_id.passing_score')
+    @api.depends('quizz_score', 'survey_id')
     def _compute_quizz_passed(self):
         for user_input in self:
             user_input.quizz_passed = user_input.quizz_score >= user_input.survey_id.passing_score

--- a/addons/survey/tests/test_certification_flow.py
+++ b/addons/survey/tests/test_certification_flow.py
@@ -138,6 +138,10 @@ class TestCertificationFlow(common.SurveyCase, HttpCase):
         self.assertEqual(user_inputs.quizz_score, 87.5)
         self.assertTrue(user_inputs.quizz_passed)
 
+        # Check that the certification is still successfull even if passing_score of certification is modified
+        certification.write({'passing_score': 90})
+        self.assertTrue(user_inputs.quizz_passed)
+
         # Check answer correction is taken into account
         self.assertNotIn("I think they're great!", user_inputs.mapped('user_input_line_ids.value_free_text'))
         self.assertIn("Just kidding, I don't like it...", user_inputs.mapped('user_input_line_ids.value_free_text'))


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Avoid retrospective computation if `passing_score` is changed

@nim-odoo




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
