### PR TITLE
Master calendar change pill color avd

### DIFF
--- a/addons/google_calendar/static/src/js/google_calendar.js
+++ b/addons/google_calendar/static/src/js/google_calendar.js
@@ -192,7 +192,7 @@ const GoogleCalendarRenderer = CalendarRenderer.include({
 
     _initGooglePillButton: function() {
         this.$googleStopButton.css({"cursor":"pointer", "font-size":"0.9em"});
-        var switchBadgeClass = (elem) => {elem.toggleClass('badge-success'); elem.toggleClass('badge-danger');};
+        var switchBadgeClass = (elem) => {elem.toggleClass('badge-primary'); elem.toggleClass('badge-danger');};
         this.$('.o_stop_google_sync_button').hover(() => {
             switchBadgeClass(this.$googleStopButton);
             this.$googleStopButton.html("<i class='fa mr-2 fa-times'/>".concat(_t("Stop the Synchronization")));
@@ -213,7 +213,7 @@ const GoogleCalendarRenderer = CalendarRenderer.include({
     _getGoogleStopButton: function () {
         return  $('<span/>', {
             html: _t("Synched with Google"),
-            class: 'w-100 badge badge-pill badge-success border-0 o_stop_google_sync_button'
+            class: 'w-100 badge badge-pill badge-primary border-0 o_stop_google_sync_button'
         })
         .prepend($('<i/>', {class: "fa mr-2 fa-check"}));
     },

--- a/addons/google_calendar/static/src/scss/google_calendar.scss
+++ b/addons/google_calendar/static/src/scss/google_calendar.scss
@@ -1,0 +1,5 @@
+.o_calendar_sidebar {
+    .badge-primary {
+        background-color: $o-enterprise-primary-color;
+    }
+}

--- a/addons/google_calendar/views/google_calendar_templates.xml
+++ b/addons/google_calendar/views/google_calendar_templates.xml
@@ -5,6 +5,9 @@
             <script type="text/javascript" src="/google_calendar/static/src/js/google_calendar_popover.js"></script>
             <script type="text/javascript" src="/google_calendar/static/src/js/google_calendar.js"></script>
         </xpath>
+        <xpath expr="link[last()]" position="after">
+            <link rel="stylesheet" type="text/scss" href="/google_calendar/static/src/scss/google_calendar.scss"/>
+        </xpath>
     </template>
 
     <template id="qunit_suite" name="google_calendar_tests" inherit_id="web.qunit_suite_tests">

--- a/addons/microsoft_calendar/static/src/js/microsoft_calendar.js
+++ b/addons/microsoft_calendar/static/src/js/microsoft_calendar.js
@@ -189,7 +189,7 @@ const MicrosoftCalendarRenderer = CalendarRenderer.include({
 
     _initMicrosoftPillButton: function() {
         this.$microsoftStopButton.css({"cursor":"pointer", "font-size":"0.9em"});
-        var switchBadgeClass = (elem) => {elem.toggleClass('badge-success'); elem.toggleClass('badge-danger');};
+        var switchBadgeClass = (elem) => {elem.toggleClass('badge-primary'); elem.toggleClass('badge-danger');};
         this.$('.o_stop_microsoft_sync_button').hover(() => {
             switchBadgeClass(this.$microsoftStopButton);
             this.$microsoftStopButton.html("<i class='fa mr-2 fa-times'/>".concat(_t("Stop the Synchronization")));
@@ -210,7 +210,7 @@ const MicrosoftCalendarRenderer = CalendarRenderer.include({
     _getMicrosoftStopButton: function () {
         return  $('<span/>', {
             html: _t("Synched with Outlook"),
-            class: 'w-100 badge badge-pill badge-success border-0 o_stop_microsoft_sync_button'
+            class: 'w-100 badge badge-pill badge-primary border-0 o_stop_microsoft_sync_button'
         })
         .prepend($('<i/>', {class: "fa mr-2 fa-check"}));
     },

--- a/addons/microsoft_calendar/static/src/scss/microsoft_calendar.scss
+++ b/addons/microsoft_calendar/static/src/scss/microsoft_calendar.scss
@@ -1,0 +1,5 @@
+.o_calendar_sidebar {
+    .badge-primary {
+        background-color: $o-enterprise-primary-color;
+    }
+}

--- a/addons/microsoft_calendar/views/microsoft_calendar_templates.xml
+++ b/addons/microsoft_calendar/views/microsoft_calendar_templates.xml
@@ -5,5 +5,8 @@
             <script type="text/javascript" src="/microsoft_calendar/static/src/js/microsoft_calendar_popover.js"></script>
             <script type="text/javascript" src="/microsoft_calendar/static/src/js/microsoft_calendar.js"></script>
         </xpath>
+        <xpath expr="link[last()]" position="after">
+            <link rel="stylesheet" type="text/scss" href="/microsoft_calendar/static/src/scss/microsoft_calendar.scss"/>
+        </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Change the color of "synced with microsoft/google" pill button to match
Odoo default theme.

Current behavior before PR: Pill button color set to badge-success.

Desired behavior after PR is merged: Pill button color set to $o-enterprise-primary-color.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
