### PR TITLE
[FIX] l10n_fr_fec: Standard separator for CSV file

### DIFF
--- a/addons/l10n_fr_fec/wizard/account_fr_fec.py
+++ b/addons/l10n_fr_fec/wizard/account_fr_fec.py
@@ -399,7 +399,7 @@ class AccountFrFec(models.TransientModel):
         @return the value of the file
         """
         fecfile = io.BytesIO()
-        writer = pycompat.csv_writer(fecfile, delimiter='|', lineterminator='')
+        writer = pycompat.csv_writer(fecfile, delimiter=';', lineterminator='')
 
         rows_length = len(rows)
         for i, row in enumerate(rows):

--- a/addons/l10n_fr_fec/wizard/account_fr_fec_view.xml
+++ b/addons/l10n_fr_fec/wizard/account_fr_fec_view.xml
@@ -16,7 +16,7 @@
                 <page string="Technical Info">
                     <group>
                         <div>
-                        The encoding of this text file is UTF-8. The structure of file is CSV separated by pipe '|'.
+                        The encoding of this text file is UTF-8. The structure of file is CSV separated by pipe ';'.
                         </div>
                     </group>
                     <group>


### PR DESCRIPTION
The standard csv separator in France is semicolon

https://fr.wikipedia.org/wiki/Comma-separated_values

opw:2430241