### PR TITLE
[FIX] account: typo for return default_account_id value

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -640,13 +640,14 @@ class AccountJournal(models.Model):
         a logic based on accounts.
 
         :param domain:  An additional domain to be applied on the account.move.line model.
-        :return:        The balance expressed in the journal's currency.
+        :return:        Tuple having balance expressed in journal's currency
+                        along with the total number of move lines having the same account as of the journal's default account.
         '''
         self.ensure_one()
         self.env['account.move.line'].check_access_rights('read')
 
         if not self.default_account_id:
-            return 0.0
+            return 0.0, 0
 
         domain = (domain or []) + [
             ('account_id', 'in', tuple(self.default_account_id.ids)),


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Migration request fail : https://www.odoo.com/web#id=2422756&action=333&active_id=241&model=project.task&view_type=form&cids=2&menu_id=4720
Issue facing in v14 migrated database
In customer migrated database Accounting Dashboard not open it will gives the following error

Odoo Server Error
```python
Traceback (most recent call last):
  File "/home/mga/workspace/odoo/14.0/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/home/mga/workspace/odoo/14.0/odoo/http.py", line 683, in dispatch
    result = self._call_function(**self.params)
  File "/home/mga/workspace/odoo/14.0/odoo/http.py", line 359, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/home/mga/workspace/odoo/14.0/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/home/mga/workspace/odoo/14.0/odoo/http.py", line 347, in checked_call
    result = self.endpoint(*a, **kw)
  File "/home/mga/workspace/odoo/14.0/odoo/http.py", line 912, in __call__
    return self.method(*args, **kw)
  File "/home/mga/workspace/odoo/14.0/odoo/http.py", line 531, in response_wrap
    response = f(*args, **kw)
  File "/home/mga/workspace/odoo/14.0/addons/web/controllers/main.py", line 1335, in search_read
    return self.do_search_read(model, fields, offset, limit, domain, sort)
  File "/home/mga/workspace/odoo/14.0/addons/web/controllers/main.py", line 1354, in do_search_read
    return Model.web_search_read(domain, fields, offset=offset, limit=limit, order=sort)
  File "/home/mga/workspace/odoo/14.0/addons/web/models/models.py", line 53, in web_search_read
    records = self.search_read(domain, fields, offset=offset, limit=limit, order=order)
  File "/home/mga/workspace/odoo/14.0/odoo/models.py", line 4832, in search_read
    result = records.read(fields)
  File "/home/mga/workspace/odoo/14.0/odoo/models.py", line 3018, in read
    return self._read_format(fnames=fields, load=load)
  File "/home/mga/workspace/odoo/14.0/odoo/models.py", line 3038, in _read_format
    vals[name] = convert(record[name], record, use_name_get)
  File "/home/mga/workspace/odoo/14.0/odoo/models.py", line 5659, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "/home/mga/workspace/odoo/14.0/odoo/fields.py", line 999, in __get__
    self.compute_value(recs)
  File "/home/mga/workspace/odoo/14.0/odoo/fields.py", line 1138, in compute_value
    records._compute_field_value(self)
  File "/home/mga/workspace/odoo/14.0/addons/mail/models/mail_thread.py", line 412, in _compute_field_value
    return super()._compute_field_value(field)
  File "/home/mga/workspace/odoo/14.0/odoo/models.py", line 4054, in _compute_field_value
    getattr(self, field.compute)()
  File "/home/mga/workspace/odoo/14.0/addons/account/models/account_journal_dashboard.py", line 20, in _kanban_dashboard
    journal.kanban_dashboard = json.dumps(journal.get_journal_dashboard_datas())
  File "/home/mga/workspace/odoo/14.0/addons/account_check_printing/models/account_journal.py", line 118, in get_journal_dashboard_datas
    super(AccountJournal, self).get_journal_dashboard_datas(),
  File "/home/mga/workspace/odoo/14.0/addons/account/models/account_journal_dashboard.py", line 234, in get_journal_dashboard_datas
    domain=[('move_id.state', '=', 'posted')])
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/mga/workspace/odoo/14.0/odoo/http.py", line 639, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/mga/workspace/odoo/14.0/odoo/http.py", line 315, in _handle_exception
    raise exception.with_traceback(None) from new_cause
TypeError: 'float' object is not iterable
 ```

Current behavior before PR:

In migrated database Accounting Dashboard not open
Desired behavior after PR is merged:

In migrated database Accounting Dashboard is open

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
