### PR TITLE
[FIX] sale_project : use human readable field

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -66,8 +66,8 @@ class ProjectTask(models.Model):
                 if not task.sale_line_id.is_service or task.sale_line_id.is_expense:
                     raise ValidationError(_(
                         'You cannot link the order item %(order_id)s - %(product_id)s to this task because it is a re-invoiced expense.',
-                        order_id=task.sale_line_id.order_id.id,
-                        product_id=task.sale_line_id.product_id.name,
+                        order_id=task.sale_line_id.order_id.name,
+                        product_id=task.sale_line_id.product_id.display_name,
                     ))
 
     def unlink(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fine tuning of https://github.com/odoo/odoo/commit/9ffd6a62366ce75d125bcab8e1858a05b7c34c74

- Use the ID of sale order it not the most friendly
- In case of product with variantes, it is more friendly to use display_name


cc @mart-e , @sswapnesh 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
