### PR TITLE
[FIX] mail: fix the position of the emoji widget in mobile

### DIFF
--- a/addons/mail/static/src/scss/emojis.scss
+++ b/addons/mail/static/src/scss/emojis.scss
@@ -54,17 +54,13 @@ $o-mail-emoji-height: 2rem;
     bottom: 40px;
 }
 
-@include media-breakpoint-down(sm) {
-    // This will fix the position issue for emoji widget on mobile screen.
+
+.o_xxs_form_view {
     .o_mail_emojis_dropdown {
         bottom: 50px;
     }
-    .o_mail_emojis_dropdown_textarea {
-        bottom: 40px;
-    }
     .o_mail_add_emoji {
         .dropdown-menu {
-            // This will fix the overflow issue for emoji dropdown on mobile screen by setting a max-width.
             max-width: 320px;
         }
     }


### PR DESCRIPTION
Bug
===
Since 569d35bc2dd3f2071c084e81331af0afad981202 a fix have been provided
to fix the vertical position of the emoji widget in mobile view.

But the fix have been done in a wrong way and we should use the Odoo CSS
class instead to detect mobile (and not a bootstrap media query).

Task 2253851