### PR TITLE
[FIX] website: an erroneous Google font makes website not editable

### DIFF
--- a/addons/web/static/src/js/core/ajax.js
+++ b/addons/web/static/src/js/core/ajax.js
@@ -164,6 +164,8 @@ var loadCSS = (function () {
             urlDefs[url] = new Promise(function (resolve, reject) {
                 $link.on('load', function () {
                     resolve();
+                }).on('error', function () {
+                    reject(new Error("Couldn't load css dependency: " + $link[0].href));
                 });
             });
             $('head').append($link);

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -159,7 +159,7 @@ const FontFamilyPickerUserValueWidget = SelectUserValueWidget.extend({
                 {
                     text: _t("Save & Reload"),
                     classes: 'btn-primary',
-                    click: () => {
+                    click: async () => {
                         const inputEl = dialog.el.querySelector('.o_input_google_font');
                         // if font page link (what is expected)
                         let m = inputEl.value.match(/\bspecimen\/([\w+]+)/);
@@ -171,6 +171,24 @@ const FontFamilyPickerUserValueWidget = SelectUserValueWidget.extend({
                                 return;
                             }
                         }
+
+                        let isValidFamily = false;
+
+                        try {
+                            const result = await fetch("https://fonts.googleapis.com/css?family=" + m[1], {method: 'HEAD'});
+                            // Google fonts server returns a 400 status code if family is not valid.
+                            if (result.ok) {
+                                isValidFamily = true;
+                            }
+                        } catch (error) {
+                            console.error(error);
+                        }
+
+                        if (!isValidFamily) {
+                            inputEl.classList.add('is-invalid');
+                            return;
+                        }
+
                         const font = m[1].replace(/\+/g, ' ');
                         this.googleFonts.push(font);
                         this.trigger_up('google_fonts_custo_request', {


### PR DESCRIPTION
Steps:
- Go to "Website" > "Go to Website"
- Click Edit in the top right corner
- Click Options
- Select "Add a Google Font" in the Font Family field
- Insert an erroneous Google Font link (e.g. https://fonts.google.com/specimen/Robotoj )
- Save & Reload
- Click Edit again

Bug:
The Edit button is not responding anymore

Explanation:
We try to `@import` the link in multiple files.
For example, here: https://github.com/odoo/odoo/blob/70eb39b0cf30c1acf9a7116e109874b60e27aa2c/addons/website/static/src/scss/website.scss#L10
An erroneous font family results in an error 400 from the Google Fonts
server. This prevents parts of the JS to load and makes it impossible to
enter the edition mode.

`EditPageMenu` handles the behavior when clicking on the Edit button.
This menu depends on `website.compiled_assets_wysiwyg` as seen here:
https://github.com/odoo/odoo/blob/b02a99bec709b5a6dc4dabb6cb81435dadc24e7e/addons/website/static/src/js/menu/edit.js#L10-L14
Since there is an error generating the file, the Promise fails but the
error is not handled:
https://github.com/odoo/odoo/blob/70eb39b0cf30c1acf9a7116e109874b60e27aa2c/addons/web/static/src/js/core/ajax.js#L164-L168
This commit prevents CSS loading errors from silently failing. The crash
screen will only show up if the user is logged in and has edition
rights.

This commit also prevents the user from posting the form if the font is
not accessible. At the moment, querying an unknown Google font from a
script will result in a CORS error. A valid one will pass just fine. In
case Google changes the behavior of these queries and allows the 400 to
be sent, the fix also checks if the query returned an `ok` status code.

opw:2439073