### PR TITLE
[FIX] sale: Update price doesn't appear in new order

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -446,7 +446,7 @@ class SaleOrder(models.Model):
 
     @api.onchange('pricelist_id')
     def _onchange_pricelist_id(self):
-        if self.order_line and self.pricelist_id and self._origin.pricelist_id and self._origin.pricelist_id != self.pricelist_id:
+        if self.order_line and self.pricelist_id and self._origin.pricelist_id != self.pricelist_id:
             self.show_update_pricelist = True
         else:
             self.show_update_pricelist = False


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider two pricelist PL and
- Create a new order O
- Add a line L
- Set PL as pricelist

Bug:

The button Update pricelist didn't appear

Closes #64269

opw:2429987