### PR TITLE
[FIX] sale: fix downpayment percentage computation (tax included)

### DIFF
--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -106,7 +106,10 @@ class SaleAdvancePaymentInv(models.TransientModel):
     def _get_advance_details(self, order):
         context = {'lang': order.partner_id.lang}
         if self.advance_payment_method == 'percentage':
-            amount = order.amount_untaxed * self.amount / 100
+            if self.product_id.taxes_id.price_include:
+                amount = order.amount_total * self.amount / 100
+            else:
+                amount = order.amount_untaxed * self.amount / 100
             name = _("Down payment of %s%%") % (self.amount)
         else:
             amount = self.fixed_amount


### PR DESCRIPTION
Create a standard tax that is included in the product price.
Add that tax to a product and the down payment product.
Create a sales order (i.e. 1 line, 115$ total, 15% tax incl).
Create a percentage down payment invoice, i.e. 50%.

The downpayment amount will be 50% of the untaxed amount,
i.e. 100$ @ 50% = 50$ with tax already included, so actually
lower than 50%

opw-2426294

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
