### PR TITLE
[FIX] point_of_sale : wrong lot during return

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -950,7 +950,10 @@ class PosOrder(models.Model):
                 qty_done = 0
                 pack_lots = []
                 pos_pack_lots = PosPackOperationLot.search([('order_id', '=', order.id), ('product_id', '=', move.product_id.id)])
-
+                if order.location_id == move.location_id:
+                    pos_pack_lots = pos_pack_lots.filtered(lambda x: x.pos_order_line_id.qty >= 0)
+                else:
+                    pos_pack_lots = pos_pack_lots.filtered(lambda x: x.pos_order_line_id.qty < 0)
                 if pos_pack_lots and lots_necessary:
                     for pos_pack_lot in pos_pack_lots:
                         stock_production_lot = StockProductionLot.search([('name', '=', pos_pack_lot.lot_name), ('product_id', '=', move.product_id.id)])


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- goto runbot : https://5797194-12-0.runbot38.odoo.com/pos/web/?debug=true#action=pos.ui
- create a product A with SN, with a unit of the category with `is_pos_groupable` is False
- add in stock 1 x product A with SN : 00001
- add in stock 1 x product A with SN : 00002
- go to POS
- sale product A with SN : 00001
- confirm order
- create a new order
- make a return of SN : 00001 (select product, write 00001, then use +/- button)
- sale product with SN : 00002 (select product, write 00002)
- confirm order

--> two picking (one for return and an other for sale) are created but the lot are wrongly attributed.

Before:
![image](https://user-images.githubusercontent.com/16716992/105139852-22ab3680-5af7-11eb-9bbe-a39f4b37e693.png)
![image](https://user-images.githubusercontent.com/16716992/105139955-453d4f80-5af7-11eb-8741-7c0965d915a4.png)
![image](https://user-images.githubusercontent.com/16716992/105139989-525a3e80-5af7-11eb-815a-b8546014b940.png)
![image](https://user-images.githubusercontent.com/16716992/105140008-5e460080-5af7-11eb-9a74-44932d039a4c.png)

After:
![image](https://user-images.githubusercontent.com/16716992/105140447-022fac00-5af8-11eb-93fa-74152d8f3c56.png)


@simongoffin 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
