### PR TITLE
[12.0+][FIX] website_rating: Round float percentages

### DIFF
--- a/addons/website_rating/static/src/xml/website_mail.xml
+++ b/addons/website_rating/static/src/xml/website_mail.xml
@@ -46,7 +46,7 @@
                                     </div>
                                 </td>
                                 <td class="o_website_rating_table_percent">
-                                    <strong><t t-esc="percent['percent']"/>%</strong>
+                                    <strong><t t-esc="Math.round(percent['percent'])"/>%</strong>
                                 </td>
                                 <td class="o_website_rating_table_reset">
                                     <a href="#" role="button" class="btn btn-link o_website_rating_select_text" t-att-data-star="percent['num']">Remove selection</a>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
The ratings stats are shown without rounding, resulting in long useless numbers that mess with the layout.

**Steps to reproduce:**

1. Activate Discussions & Rating on products
2. Add the following reviews: 1x one start, 2x five star
3. Look at the resulting percentages

**Current behavior before PR:**

![image](https://user-images.githubusercontent.com/1914185/104957399-dbb12a00-59ac-11eb-91cc-c59e755ef24f.png)


**Desired behavior after PR is merged:**

![image](https://user-images.githubusercontent.com/1914185/104957430-e8358280-59ac-11eb-9cab-312fbe5369a7.png)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
