### PR TITLE
[IMP] sale: set id on invoice block for easier xpath

### DIFF
--- a/addons/sale/report/invoice_report_templates.xml
+++ b/addons/sale/report/invoice_report_templates.xml
@@ -7,7 +7,7 @@
         <xpath expr="//address" position="before">
             <t t-if="o.partner_shipping_id and (o.partner_shipping_id != o.partner_id)">
                 <t t-set="information_block">
-                    <div groups="sale.group_delivery_invoice_address">
+                    <div groups="sale.group_delivery_invoice_address" name="shipping_address_block">
                         <strong>Shipping Address:</strong>
                         <div t-field="o.partner_shipping_id"
                             t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: allow safe & easy xpath operations.

Current behavior before PR: Removing the information block that is set through `report_invoice_document_inherit_sale` is really hard to `xpath` and replace stuff within. There's no easy and good way to do so.

Desired behavior after PR is merged: By setting a name on the element we can xpath both on the main block here and easily traverse into the subfields without a serious risky of breaking stuff. This greatly simplifies inheritance.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
