### PR TITLE
[IMP] uom: added mm uom for length of product package

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -291,7 +291,7 @@ class ProductTemplate(models.Model):
     @api.model
     def _get_length_uom_id_from_ir_config_parameter(self):
         """ Get the unit of measure to interpret the `length`, 'width', 'height' field.
-        By default, we considerer that length are expressed in meters. Users can configure
+        By default, we considerer that length are expressed in millimeters. Users can configure
         to express them in feet by adding an ir.config_parameter record with "product.volume_in_cubic_feet"
         as key and "1" as value.
         """
@@ -299,7 +299,7 @@ class ProductTemplate(models.Model):
         if product_length_in_feet_param == '1':
             return self.env.ref('uom.product_uom_foot')
         else:
-            return self.env.ref('uom.product_uom_meter')
+            return self.env.ref('uom.product_uom_millimeter')
 
     @api.model
     def _get_volume_uom_id_from_ir_config_parameter(self):

--- a/addons/uom/data/uom_data.xml
+++ b/addons/uom/data/uom_data.xml
@@ -55,6 +55,12 @@
         <field name="factor" eval="1.0"/>
         <field name="uom_type">reference</field>
     </record>
+    <record id="product_uom_millimeter" model="uom.uom">
+        <field name="category_id" ref="uom_categ_length"/>
+        <field name="name">mm</field>
+        <field name="factor" eval="1000"/>
+        <field name="uom_type">smaller</field>
+    </record>
     <record id="product_uom_km" model="uom.uom">
         <field name="category_id" ref="uom_categ_length"/>
         <field name="name">km</field>


### PR DESCRIPTION
Changed the uom of product package if product_length_in_feet_param
of ir config parameter for product is not 1. Previously its value
was meter.
For following fields updated the uom -
1) packaging_length
2) width
3) height

TaskId: 2418421

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
