### PR TITLE
[FIX] account: Fix automatic entry wizard with change_account

### DIFF
--- a/addons/account/wizard/account_automatic_entry_wizard.py
+++ b/addons/account/wizard/account_automatic_entry_wizard.py
@@ -49,8 +49,6 @@ class AutomaticEntryWizard(models.TransientModel):
         for record in self:
             if not (0.0 < record.percentage <= 100.0) and record.action == 'change_period':
                 raise UserError(_("Percentage must be between 0 and 100"))
-            if record.percentage != 100 and record.action != 'change_period':
-                raise UserError(_("Percentage can only be set for Change Period method"))
 
     @api.depends('percentage', 'move_line_ids')
     def _compute_total_amount(self):


### PR DESCRIPTION
'percentage' is computed by default whatever the wizard action (change_period/change_account) but there is a constraint raised when the percentage is != 100 in change_account.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
