### PR TITLE
[FIX] stock: lots ids disapear after onchange.

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -479,7 +479,7 @@ class StockMove(models.Model):
             )
             lots_by_move_id_list.append({by_move['move_id'][0]: by_move['lot_ids'] for by_move in lots_by_move_id})
         for move in self:
-            move.lot_ids = lots_by_move_id_list[0 if move.picking_type_id.show_reserved else 1].get(move.id, [])
+            move.lot_ids = lots_by_move_id_list[0 if move.picking_type_id.show_reserved else 1].get(move._origin.id, [])
 
     def _set_lot_ids(self):
         for move in self:


### PR DESCRIPTION
Use case to reproduce:
- Go to MO form produce at least 2 units of a product with a component
tracked by serial number.
- Edit the producing quantity to 1.0
- Save
- Edit the producing quantity to 2.0

The move lines are removed.

It happens because the lot_ids field is empty and thus the setter remove
the existing stock.move.line. It's empty because the compute try to do
a match on existing id. However the stock.move.line in the onchange
could have a new virtual id.

fine tuning of commit 8dfee8cb2d60942641b73eaa6489b02aa378c5ac
