### PR TITLE
[IMP] website: test a website style can properly be edited

### DIFF
--- a/addons/website/static/tests/tours/website_style_edition.js
+++ b/addons/website/static/tests/tours/website_style_edition.js
@@ -1,0 +1,34 @@
+odoo.define("website.tour.website_style_edition", function (require) {
+"use strict";
+
+const tour = require("web_tour.tour");
+
+const TARGET_FONT_SIZE = 30;
+
+tour.register("website_style_edition", {
+    test: true,
+    url: "/",
+}, [{
+    content: "Enter edit mode",
+    trigger: 'a[data-action=edit]',
+}, {
+    content: "Go to theme options",
+    trigger: '.o_we_customize_theme_btn',
+}, {
+    content: "Change font size",
+    trigger: '[data-variable="font-size-base"] input',
+    run: `text_blur ${TARGET_FONT_SIZE}`,
+}, {
+    content: "Save",
+    trigger: '[data-action="save"]',
+}, {
+    content: "Check the font size was properly adapted",
+    trigger: 'body:not(.editor_enable) #wrapwrap',
+    run: function (actions) {
+        const style = window.getComputedStyle(this.$anchor[0]);
+        if (style.fontSize !== `${TARGET_FONT_SIZE}px`) {
+            console.error(`Expected the font-size to be equal to ${TARGET_FONT_SIZE}px but found ${style.fontSize} instead`);
+        }
+    },
+}]);
+});

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -189,3 +189,6 @@ class TestUi(odoo.tests.HttpCase):
             """,
         }])
         self.start_tour("/", 'snippet_version', login='admin')
+
+    def test_08_website_style_custo(self):
+        self.start_tour("/", "website_style_edition", login="admin")

--- a/addons/website/views/assets.xml
+++ b/addons/website/views/assets.xml
@@ -28,6 +28,7 @@
         <script type="text/javascript" src="/website/static/tests/tours/public_user_editor.js"/>
         <script type="text/javascript" src="/website/static/tests/tours/website_navbar_menu.js"/>
         <script type="text/javascript" src="/website/static/tests/tours/snippet_version.js"/>
+        <script type="text/javascript" src="/website/static/tests/tours/website_style_edition.js"/>
     </xpath>
 </template>
 


### PR DESCRIPTION
This test at least ensures that a SCSS edition through the editor can
properly be done and indirectly tests that the assets order is correct
(in prevision of a future asset refactoring).
