### PR TITLE
[FIX] core: allocate port for headless chrome only once per process

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -671,6 +671,20 @@ class ChromeBrowserException(Exception):
     pass
 
 
+DEVTOOLS_PORT = None
+
+
+def get_devtools_port():
+    global DEVTOOLS_PORT
+    if not DEVTOOLS_PORT:
+        with socket.socket() as s:
+            s.bind(('localhost', 0))
+            if hasattr(socket, 'SO_REUSEADDR'):
+                s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            _, DEVTOOLS_PORT = s.getsockname()
+    return DEVTOOLS_PORT
+
+
 class ChromeBrowser():
     """ Helper object to control a Chrome headless process. """
 
@@ -680,7 +694,7 @@ class ChromeBrowser():
         if websocket is None:
             self._logger.warning("websocket-client module is not installed")
             raise unittest.SkipTest("websocket-client module is not installed")
-        self.devtools_port = None
+        self.devtools_port = get_devtools_port()
         self.ws_url = ''  # WebSocketUrl
         self.ws = None  # websocket
         self.request_id = 0
@@ -775,11 +789,6 @@ class ChromeBrowser():
     def _chrome_start(self):
         if self.chrome_pid is not None:
             return
-        with socket.socket() as s:
-            s.bind(('localhost', 0))
-            if hasattr(socket, 'SO_REUSEADDR'):
-                s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            _, self.devtools_port = s.getsockname()
 
         switches = {
             '--headless': '',


### PR DESCRIPTION
this should decrase chance of birthday attack on running few odoo instance in
test mode in the same time. This is actually happens in odoo.sh

For more info see https://github.com/odoo/odoo/commit/a3371a467b227b9cf57d582808bf3a252bcf1fa9#

---

opw-2378464

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
