### PR TITLE
[FIX] core: exists() with string ids

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4679,7 +4679,7 @@ Fields:
         """
         ids, new_ids = [], []
         for i in self._ids:
-            (ids if isinstance(i, int) else new_ids).append(i)
+            (new_ids if isinstance(i, NewId) else ids).append(i)
         if not ids:
             return self
         query = """SELECT id FROM "%s" WHERE id IN %%s""" % self._table


### PR DESCRIPTION
The call model.browse('xxx').exists() should not return the record.
Instead, it should fail as the string 'xxx' is not a valid ID.