### PR TITLE
[FIX] l10n_latam_invoice_document: Allow manual_documents to use additional sequence

### DIFF
--- a/addons/l10n_latam_invoice_document/models/account_move.py
+++ b/addons/l10n_latam_invoice_document/models/account_move.py
@@ -64,7 +64,7 @@ class AccountMove(models.Model):
         * If move use document and is in draft state and has not been posted before we restart name to '/' (this is
            when we change the document type) """
         without_doc_type = self.filtered(lambda x: x.journal_id.l10n_latam_use_documents and not x.l10n_latam_document_type_id)
-        manual_documents = self.filtered(lambda x: x.journal_id.l10n_latam_use_documents and x.l10n_latam_manual_document_number)
+        manual_documents = self.filtered(lambda x: x.journal_id.l10n_latam_use_documents and x.l10n_latam_manual_document_number and not x.env.context.get("compute_manual_name", False)))
         (without_doc_type + manual_documents.filtered(lambda x: not x.name or x.name and x.state == 'draft' and not x.posted_before)).name = '/'
         # if we change document or journal and we are in draft and not posted, we clean number so that is recomputed in super
         self.filtered(

--- a/addons/l10n_latam_invoice_document/models/account_move.py
+++ b/addons/l10n_latam_invoice_document/models/account_move.py
@@ -64,7 +64,7 @@ class AccountMove(models.Model):
         * If move use document and is in draft state and has not been posted before we restart name to '/' (this is
            when we change the document type) """
         without_doc_type = self.filtered(lambda x: x.journal_id.l10n_latam_use_documents and not x.l10n_latam_document_type_id)
-        manual_documents = self.filtered(lambda x: x.journal_id.l10n_latam_use_documents and x.l10n_latam_manual_document_number and not x.env.context.get("compute_manual_name", False)))
+        manual_documents = self.filtered(lambda x: x.journal_id.l10n_latam_use_documents and x.l10n_latam_manual_document_number and not x.env.context.get("compute_manual_name", False))
         (without_doc_type + manual_documents.filtered(lambda x: not x.name or x.name and x.state == 'draft' and not x.posted_before)).name = '/'
         # if we change document or journal and we are in draft and not posted, we clean number so that is recomputed in super
         self.filtered(


### PR DESCRIPTION
#### Description of the issue/feature this PR addresses:
Without this fix validating a manual sequence in localizations with a different sequencing on `l10n_latam_document_number` would leave the "/" as the move.name; this allow extra flexibility without affecting other localizations or breaking the stable policy

#### Current behavior before PR:
Some localizations like l10n_do and l10n_hn require a different sequencing from the `move.name` in the field `l10n_latam_document_number` as per issue https://github.com/odoo/odoo/issues/64159


#### Desired behavior after PR is merged:
Have a manual sequence on `l10n_latam_document_number`, while allowing an internal sequence on `move.name`

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
