### PR TITLE
Remove required=True from po_lead

### DIFF
--- a/addons/purchase/models/res_company.py
+++ b/addons/purchase/models/res_company.py
@@ -6,7 +6,7 @@ from odoo import fields, models
 class Company(models.Model):
     _inherit = 'res.company'
 
-    po_lead = fields.Float(string='Purchase Lead Time', required=True,
+    po_lead = fields.Float(string='Purchase Lead Time',
         help="Margin of error for vendor lead times. When the system "
              "generates Purchase Orders for procuring products, "
              "they will be scheduled that many days earlier "


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
As `po_lead` is a float field and its default is 0.0 the required attribute is unnecessary.


Current behavior before PR:
Before this commit inheriting the account test classes in modules that depend on purchase would fail in setup due to po_lead not being set.

Desired behavior after PR is merged:
Able to inherit test classes that create companies with po_lead set when purchase module is loaded.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
