### PR TITLE
[FIX] web: Dialog widget should always call on_{attach|detach}_callback

### DIFF
--- a/addons/web/static/src/js/chrome/action_manager.js
+++ b/addons/web/static/src/js/chrome/action_manager.js
@@ -396,7 +396,7 @@ var ActionManager = Widget.extend({
                 widget.setParent(dialog);
                 dom.append(dialog.$el, widget.$el, {
                     in_DOM: true,
-                    callbacks: [{widget: dialog}, {widget: controller.widget}],
+                    callbacks: [{widget: controller.widget}],
                 });
                 widget.renderButtons(dialog.$footer);
                 dialog.rebindButtonBehavior();

--- a/addons/web/static/src/js/core/dialog.js
+++ b/addons/web/static/src/js/core/dialog.js
@@ -72,6 +72,9 @@ var Dialog = Widget.extend({
         this._opened = new Promise(function (resolve) {
             self._openedResolver = resolve;
         });
+        if (this.on_attach_callback) {
+            this._opened = this.opened(this.on_attach_callback);
+        }
         options = _.defaults(options || {}, {
             title: _t('Odoo'), subtitle: '',
             size: 'large',
@@ -256,6 +259,9 @@ var Dialog = Widget.extend({
 
         $('.tooltip').remove(); //remove open tooltip if any to prevent them staying when modal has disappeared
         if (this.$modal) {
+            if (this.on_detach_callback) {
+                this.on_detach_callback();
+            }
             this.$modal.modal('hide');
             this.$modal.remove();
         }

--- a/addons/web/static/tests/core/dialog_tests.js
+++ b/addons/web/static/tests/core/dialog_tests.js
@@ -124,6 +124,40 @@ QUnit.module('core', {}, function () {
 
         parent.destroy();
     });
+
+    QUnit.test("Ensure on_attach_callback and on_detach_callback are properly called", async function (assert) {
+        assert.expect(4);
+
+        const TestDialog = Dialog.extend({
+            on_attach_callback() {
+                assert.step('on_attach_callback');
+            },
+            on_detach_callback() {
+                assert.step('on_detach_callback');
+            },
+        });
+
+        const parent = await createEmptyParent();
+        const dialog = new TestDialog(parent, {
+            buttons: [
+                {
+                    text: "Close",
+                    classes: 'btn-primary',
+                    close: true,
+                },
+            ],
+            $content: $('<main/>'),
+        }).open();
+
+        await dialog.opened();
+
+        assert.verifySteps(['on_attach_callback']);
+
+        await testUtils.dom.click($('.modal[role="dialog"] .btn-primary'));
+        assert.verifySteps(['on_detach_callback']);
+
+        parent.destroy();
+    });
 });
 
 });


### PR DESCRIPTION
Before this commit, the `on_attach_callback` and `on_detach_callback`
callbacks are not called all the time on the `Dialog` widget when it's
attached/detached to the DOM. Relying on those callbacks could result in
unpredictable behaviours.

To be more precise, the `on_attach_callback` isn't executed on a regular
Dialog#open() call. But executing a client action into a Dialog will
execute it (due to being called by the ActionManager).

This difference prevents from properly binding those callbacks later on
through an extend or include of the Dialog widget as we have no way to
know if they have already been called or not (e.g. which can result in
calling them twice).

This commit normalize this situation by ensuring that the
`on_attach_callback` and `on_detach_callback` callbacks are properly
called by the Dialog widget and allows any extension of this widget to
rely on them. Therefore the ActionManager is adapted accordingly.

opw-2438534