### PR TITLE
[FIX] sale_timesheet: Timesheet based invoicing does not work for subtasks

### DIFF
--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -236,7 +236,8 @@ class ProjectTask(models.Model):
     def _subtask_write_values(self, values):
         result = super(ProjectTask, self)._subtask_write_values(values)
         # changing the partner on a task will reset the sale line of its subtasks
-        if 'partner_id' in result:
+        # if a sale line is not beeing set
+        if 'partner_id' in result and 'sale_line_id' not in result:
             result['sale_line_id'] = False
         elif 'sale_line_id' in result:
             result.pop('sale_line_id')


### PR DESCRIPTION
Steps to reproduce:

1. Enable Project Subtasks
2. On the "Office Design" Project, select a Task and create a subtask for it
3. Go to the Project Overview and Create Sales Order
4. Enter timesheets: 11 hours for the parent task, and 10 hours for the subtask
5.  On the created Sales Order check the invoiced time

Current behavior:
The 11 hours form the parent task are shown as delivered in the Sales Order, but the 10 hours from the subtask are not.

Expected behavior:
Both the parent ans subtask time should be shown as delivered, so that it can be invoices.

Closes #63930

opw:2426098