### PR TITLE
[FIX] web: one2many and onchange on shared x2many WIP


### DIFF
--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -253,6 +253,7 @@ var BasicModel = AbstractModel.extend({
      */
     applyDefaultValues: function (recordID, values, options) {
         options = options || {};
+        var defs = [];
         var record = this.localData[recordID];
         var viewType = options.viewType || record.viewType;
         var fieldNames = options.fieldNames || Object.keys(record.fieldsInfo[viewType]);
@@ -279,10 +280,16 @@ var BasicModel = AbstractModel.extend({
                     values[fieldName] = null;
                 }
             }
+            else if (!(fieldName in values)) {
+                field = record.fields[fieldName];
+                if (field.type === 'one2many' || field.type === 'many2many') {
+                    var commands = this._generateX2ManyCommands(record, {fieldNames: [fieldName]})[fieldName];
+                    defs.push(this._processX2ManyCommands(record, fieldName, commands, options));
+                }
+            }
         }
 
         // parse each value and create dataPoints for relational fields
-        var defs = [];
         for (fieldName in values) {
             field = record.fields[fieldName];
             record.data[fieldName] = null;

--- a/addons/web/static/tests/fields/relational_fields/field_one2many_tests.js
+++ b/addons/web/static/tests/fields/relational_fields/field_one2many_tests.js
@@ -1549,6 +1549,57 @@ QUnit.module('fields', {}, function () {
             form.destroy();
         });
 
+        QUnit.test('onchange on one2many and contained x2many in list and form view', async function (assert) {
+            assert.expect(3);
+
+            this.data.partner.onchanges = {
+                foo: function (obj) {
+                  obj.p = [[0, false, { turtles: [[0, false, { turtle_foo: 'hello'}]] }]];
+                },
+            };
+
+            var form = await createView({
+                View: FormView,
+                model: 'partner',
+                data: this.data,
+                arch: '<form>' +
+                    '<field name="foo"/>' +
+                    '<field name="p">' +
+                    '<tree>' +
+                    '<field name="turtles"/>' +
+                    '</tree>' +
+                    '<form>' +
+                    '<field name="turtles">' +
+                    '<tree editable="top">' +
+                    '<field name="turtle_foo"/>' +
+                    '</tree>' +
+                    '</field>' +
+                    '</form>' +
+                    '</field>' +
+                    '</form>',
+                archs: {
+                    'turtle,false,list': '<tree editable="top"><field name="turtle_foo"/></tree>',
+                    'turtle,false,search': '<search></search>',
+                },
+            });
+
+
+            assert.containsOnce(form, '.o_data_row',
+                "the onchange should have created one record in the relation");
+
+            // open the created o2m record in a form view
+            await testUtils.dom.click(form.$('.o_data_row'));
+
+            assert.strictEqual($('.modal').length, 1, "should have opened a dialog");
+            assert.strictEqual($('.modal .o_data_row').length, 1,
+                "there should be one record in the one2many in the dialog");
+
+            // add a many2many subrecord, test pass if there is no error
+            await testUtils.dom.click($('.modal .o_field_x2many_list_row_add a'));
+
+            form.destroy();
+        });
+
         QUnit.test('embedded one2many with handle widget with minimum setValue calls', async function (assert) {
             var done = assert.async();
             assert.expect(20);


### PR DESCRIPTION

If we have an onchange that adds line on a one2many itself containing an
x2many shared between two subviews, we could get an error when opening
one of the views.

This is because we handle several cases (new record, existing record,
new record not coming from onchange) but if we have eg.:

```
<form>
  <field name="one2manyField">
    <tree><field name="x2manyField"/></tree>
    <form><field name="x2manyField"/></form>
  </field>
</form>
```

if an onchange add a line to one2manyField, we will have established
changes value for x2manyField and when we open the form view we keep
these values without getting a new Datapoint which would have the
correct fields/fieldsInfo corresponding to x2manyField inside the form
view and not x2manyField inside the tree view.

This change is a WIP (work in progress) ugly hack that seems to work for
this given case.

Without the fix, the added test fails with:

  TypeError: Cannot read property 'list' of undefined
    at Class._getOptionalColumnsStorageKeyParts
    (/web/static/src/js/views/list/list_renderer.js:259:48)

opw-2422806
