### PR TITLE
[FIX] website_event_questions: don't duplicate answers


### DIFF
--- a/addons/website_event_questions/models/event.py
+++ b/addons/website_event_questions/models/event.py
@@ -84,8 +84,8 @@ class EventQuestion(models.Model):
         event_id = vals.get('event_id', False)
         if event_id:
             event = self.env['event.event'].browse([event_id])
-            if event.event_type_id.use_questions and event.event_type_id.question_ids:
-                vals['answer_ids'] = vals.get('answer_ids', []) + [(0, 0, {
+            if event.event_type_id.use_questions and event.event_type_id.question_ids and not vals.get('answer_ids'):
+                vals['answer_ids'] = [(0, 0, {
                     'name': answer.name,
                     'sequence': answer.sequence,
                 }) for answer in event.event_type_id.question_ids.filtered(lambda question: question.title == vals.get('title')).mapped('answer_ids')]


### PR DESCRIPTION

The answers are currently added to question from the event_type_id on
create. This caused that if you duplicated an event, the answers would
be duplicated since we go through create a second time.

opw-2425120
