### PR TITLE
[IMP] crm : develop a smart calendar view from crm opportunity

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
+import pytz
 import threading
 from collections import OrderedDict, defaultdict
 from datetime import date, datetime, timedelta
@@ -1022,8 +1023,11 @@ class Lead(models.Model):
             message = _('You just beat your personal record for the past 7 days.')
         return message
 
-    def action_schedule_meeting(self):
+    def action_schedule_meeting(self, smart_calendar=True):
         """ Open meeting's calendar view to schedule meeting on current opportunity.
+
+            :param smart_calendar: boolean, to set to False if the view should not try to choose relevant
+              mode and initial date for calendar view, see ``_get_opportunity_meeting_view_parameters``
             :return dict: dictionary value for created Meeting view
         """
         self.ensure_one()
@@ -1031,18 +1035,97 @@ class Lead(models.Model):
         partner_ids = self.env.user.partner_id.ids
         if self.partner_id:
             partner_ids.append(self.partner_id.id)
+        current_opportunity_id = self.id if self.type == 'opportunity' else False
         action['context'] = {
-            'default_opportunity_id': self.id if self.type == 'opportunity' else False,
+            'default_opportunity_id': current_opportunity_id,
             'default_partner_id': self.partner_id.id,
             'default_partner_ids': partner_ids,
             'default_team_id': self.team_id.id,
             'default_name': self.name,
         }
+
+        # 'Smart' calendar view : get the most relevant time period to display to the user.
+        if current_opportunity_id and smart_calendar:
+            mode, initial_date = self._get_opportunity_meeting_view_parameters()
+            action['context'].update({'default_mode': mode, 'initial_date': initial_date})
+
         return action
+
+    def _get_opportunity_meeting_view_parameters(self):
+        """ Return the most relevant parameters for calendar view when viewing meetings linked to an opportunity.
+            If there are any meetings that are not finished yet, only consider those meetings,
+            since the user would prefer no to see past meetings. Otherwise, consider all meetings.
+            Allday events datetimes are used without taking tz into account.
+            -If there is no event, return week mode and false (The calendar will target 'now' by default)
+            -If there is only one, return week mode and date of the start of the event.
+            -If there are several events entirely on the same week, return week mode and start of first event.
+            -Else, return month mode and the date of the start of first event as initial date. (If they are
+            on the same month, this will display that month and therefore show all of them, which is expected)
+
+            :return tuple(mode, initial_date)
+                - mode: selected mode of the calendar view, 'week' or 'month'
+                - initial_date: date of the start of the first relevant meeting. The calendar will target that date.
+        """
+        self.ensure_one()
+        meeting_results = self.env["calendar.event"].search_read([('opportunity_id', '=', self.id)], ['start', 'stop', 'allday'])
+        if not meeting_results:
+            return "week", False
+
+        user_tz = self.env.user.tz or self.env.context.get('tz')
+        user_pytz = pytz.timezone(user_tz) if user_tz else pytz.utc
+
+        # meeting_dts will contain one tuple of datetimes per meeting : (Start, Stop)
+        # meetings_dts and now_dt are as per user time zone.
+        meeting_dts = []
+        now_dt = datetime.now().astimezone(user_pytz).replace(tzinfo=None)
+
+        # When creating an allday meeting, whatever the TZ, it will be stored the same e.g. 00.00.00->23.59.59 in utc or
+        # 08.00.00->18.00.00. Therefore we must not put it back in the user tz but take it raw.
+        for meeting in meeting_results:
+            if meeting.get('allday'):
+                meeting_dts.append((meeting.get('start'), meeting.get('stop')))
+            else:
+                meeting_dts.append((meeting.get('start').astimezone(user_pytz).replace(tzinfo=None),
+                                   meeting.get('stop').astimezone(user_pytz).replace(tzinfo=None)))
+
+        # If there are meetings that are still ongoing or to come, only take those.
+        unfinished_meeting_dts = [meeting_dt for meeting_dt in meeting_dts if meeting_dt[1] >= now_dt]
+        relevant_meeting_dts = unfinished_meeting_dts if unfinished_meeting_dts else meeting_dts
+        relevant_meeting_count = len(relevant_meeting_dts)
+
+        if relevant_meeting_count == 1:
+            return "week", relevant_meeting_dts[0][0].date()
+        else:
+            # Range of meetings
+            earliest_start_dt = min(relevant_meeting_dt[0] for relevant_meeting_dt in relevant_meeting_dts)
+            latest_stop_dt = max(relevant_meeting_dt[1] for relevant_meeting_dt in relevant_meeting_dts)
+
+            # The week start day depends on language. We fetch the week_start of user's language. 1 is monday.
+            lang_week_start = self.env["res.lang"].search_read([('code', '=', self.env.user.lang)], ['week_start'])
+            # We substract one to make week_start_index range 0-6 instead of 1-7
+            week_start_index = int(lang_week_start[0].get('week_start', '1')) - 1
+
+            # We compute the weekday of earliest_start_dt according to week_start_index. earliest_start_dt_index will be 0 if we are on the
+            # first day of the week and 6 on the last. weekday() returns 0 for monday and 6 for sunday. For instance, Tuesday in UK is the
+            # third day of the week, so earliest_start_dt_index is 2, and remaining_days_in_week includes tuesday, so it will be 5.
+            # The first term 7 is there to avoid negative left side on the modulo, improving readability.
+            earliest_start_dt_weekday = (7 + earliest_start_dt.weekday() - week_start_index) % 7
+            remaining_days_in_week = 7 - earliest_start_dt_weekday
+
+            # We compute the start of the week following the one containing the start of the first meeting.
+            next_week_start_date = earliest_start_dt.date() + timedelta(days=remaining_days_in_week)
+
+            # Latest_stop_dt must be before the start of following week. Limit is therefore set at midnight of first day, included.
+            meetings_in_same_week = latest_stop_dt <= datetime(next_week_start_date.year, next_week_start_date.month, next_week_start_date.day, 0, 0, 0)
+
+            if meetings_in_same_week:
+                return "week", earliest_start_dt.date()
+            else:
+                return "month", earliest_start_dt.date()
 
     def action_reschedule_meeting(self):
         self.ensure_one()
-        action = self.action_schedule_meeting()
+        action = self.action_schedule_meeting(smart_calendar=False)
         next_activity = self.activity_ids.filtered(lambda activity: activity.user_id == self.env.user)[:1]
         if next_activity.calendar_event_id:
             action['context']['initial_date'] = next_activity.calendar_event_id.start

--- a/addons/crm/tests/__init__.py
+++ b/addons/crm/tests/__init__.py
@@ -8,6 +8,7 @@ from . import test_crm_lead_convert_mass
 from . import test_crm_lead_duplicates
 from . import test_crm_lead_lost
 from . import test_crm_lead_merge
+from . import test_crm_lead_smart_calendar
 from . import test_crm_activity
 from . import test_crm_ui
 from . import test_crm_pls

--- a/addons/crm/tests/test_crm_lead_smart_calendar.py
+++ b/addons/crm/tests/test_crm_lead_smart_calendar.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import date, datetime
+from odoo.addons.mail.tests.common import mail_new_test_user
+from odoo.addons.crm.tests.common import TestCrmCommon
+from odoo.tests.common import tagged, users
+
+@tagged('post_install', '-at_install')
+class TestCRMLeadSmartCalendar(TestCrmCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestCRMLeadSmartCalendar, cls).setUpClass()
+        # weekstart index : 7 (sunday), tz : UTC -4 / -5
+        cls.user_NY_en_US = mail_new_test_user(
+            cls.env, login='user_NY_en_US', lang='en_US', tz='America/New_York',
+            name='user_NY_en_US User', email='user_NY_en_US@test.example.com',
+            notification_type='inbox',
+            groups='sales_team.group_sale_salesman_all_leads,base.group_partner_manager,crm.group_use_lead')
+        # weekstart index : 1 (monday), tz : UTC+0
+        cls.env['res.lang']._activate_lang('pt_PT')
+        cls.user_UTC_pt_PT = mail_new_test_user(
+            cls.env, login='user_UTC_pt_PT', lang='pt_PT', tz='Europe/Lisbon',
+            name='user_UTC_pt_PT User', email='user_UTC_pt_PT@test.example.com',
+            notification_type='inbox',
+            groups='sales_team.group_sale_salesman_all_leads,base.group_partner_manager,crm.group_use_lead')
+
+        cls.next_year = datetime.now().year + 1
+        cls.calendar_meeting_1 = cls.env['calendar.event'].create({
+            'name': 'calendar_meeting_1',
+            'start': datetime(2020, 12, 13, 17),
+            'stop': datetime(2020, 12, 13, 22)})
+        cls.calendar_meeting_2 = cls.env['calendar.event'].create({
+            'name': 'calendar_meeting_2',
+            'start': datetime(2020, 12, 13, 2),
+            'stop': datetime(2020, 12, 13, 3)})
+        cls.calendar_meeting_3 = cls.env['calendar.event'].create({
+            'name': 'calendar_meeting_3',
+            'start': datetime(cls.next_year, 5, 4, 12),
+            'stop': datetime(cls.next_year, 5, 4, 13)})
+        cls.calendar_meeting_4 = cls.env['calendar.event'].create({
+            'name': 'calendar_meeting_4',
+            'allday': True,
+            'start': datetime(2020, 12, 6, 0, 0, 0),
+            'stop': datetime(2020, 12, 6, 23, 59, 59)})
+        cls.calendar_meeting_5 = cls.env['calendar.event'].create({
+            'name': 'calendar_meeting_5',
+            'start': datetime(2020, 12, 13, 8),
+            'stop': datetime(2020, 12, 13, 18),
+            'allday': True})
+        cls.calendar_meeting_6 = cls.env['calendar.event'].create({
+            'name': 'calendar_meeting_6',
+            'start': datetime(2020, 12, 12, 0),
+            'stop': datetime(2020, 12, 19, 0)})
+
+    @users('user_NY_en_US')
+    def test_meeting_view_parameters_1(self):
+        lead_smart_calendar_1 = self.env['crm.lead'].create({'name': 'Lead 1  - user_NY_en_US'})
+
+        mode, initial_date = lead_smart_calendar_1._get_opportunity_meeting_view_parameters()
+        self.assertEqual(mode, 'week')
+        self.assertEqual(initial_date, False)
+
+        self.calendar_meeting_1.write({'opportunity_id': lead_smart_calendar_1.id})
+        mode, initial_date = lead_smart_calendar_1._get_opportunity_meeting_view_parameters()
+        self.assertEqual(mode, 'week')
+        self.assertEqual(initial_date, date(2020, 12, 13))
+
+        self.calendar_meeting_2.write({'opportunity_id': lead_smart_calendar_1.id})
+        mode, initial_date = lead_smart_calendar_1._get_opportunity_meeting_view_parameters()
+        self.assertEqual(mode, 'month')
+        self.assertEqual(initial_date, date(2020, 12, 12))
+
+        self.calendar_meeting_3.write({'opportunity_id': lead_smart_calendar_1.id})
+        mode, initial_date = lead_smart_calendar_1._get_opportunity_meeting_view_parameters()
+        self.assertEqual(mode, 'week')
+        self.assertEqual(initial_date, date(self.next_year, 5, 4))
+
+        lead_smart_calendar_2 = self.env['crm.lead'].create({'name': 'Lead 2 - user_NY_en_US'})
+
+        self.calendar_meeting_4.write({'opportunity_id': lead_smart_calendar_2.id})
+        mode, initial_date = lead_smart_calendar_2._get_opportunity_meeting_view_parameters()
+        self.assertEqual(mode, 'week')
+        self.assertEqual(initial_date, date(2020, 12, 6))
+
+        self.calendar_meeting_2.write({'opportunity_id': lead_smart_calendar_2.id})
+        mode, initial_date = lead_smart_calendar_2._get_opportunity_meeting_view_parameters()
+        self.assertEqual(mode, 'week')
+        self.assertEqual(initial_date, date(2020, 12, 6))
+
+        self.calendar_meeting_5.write({'opportunity_id': lead_smart_calendar_2.id})
+        mode, initial_date = lead_smart_calendar_2._get_opportunity_meeting_view_parameters()
+        self.assertEqual(mode, 'month')
+        self.assertEqual(initial_date, date(2020, 12, 6))
+
+    @users('user_UTC_pt_PT')
+    def test_meeting_view_parameters_2(self):
+
+        lead_smart_calendar_1 = self.env['crm.lead'].create({'name': 'Lead 1 - user_UTC_pt_PT'})
+
+        self.calendar_meeting_1.write({'opportunity_id': lead_smart_calendar_1.id})
+        self.calendar_meeting_2.write({'opportunity_id': lead_smart_calendar_1.id})
+        mode, initial_date = lead_smart_calendar_1._get_opportunity_meeting_view_parameters()
+        self.assertEqual(mode, 'week')
+        self.assertEqual(initial_date, date(2020, 12, 13))
+
+        self.calendar_meeting_3.write({'opportunity_id': lead_smart_calendar_1.id})
+        mode, initial_date = lead_smart_calendar_1._get_opportunity_meeting_view_parameters()
+        self.assertEqual(mode, 'week')
+        self.assertEqual(initial_date, date(self.next_year, 5, 4))
+
+        lead_smart_calendar_2 = self.env['crm.lead'].create({'name': 'Lead 2 - user_UTC_pt_PT'})
+
+        self.calendar_meeting_6.write({'opportunity_id': lead_smart_calendar_2.id})
+        mode, initial_date = lead_smart_calendar_2._get_opportunity_meeting_view_parameters()
+        self.assertEqual(mode, 'week')
+        self.assertEqual(initial_date, date(2020, 12, 12))


### PR DESCRIPTION
Before, when the user clicked on a crm opportunity "meetings" smart button,
the calendar view was centered on the present day, and with default mode
(week, month,...) as a scale. This behaviour lead to calendar views that
were possibly not including those meetings.

This smart calendar improves this by computing the target date and the scale
to make sure that the user is taken to the useful time period when using the
smart button from crm opportunity. The meetings considered are only the
relevant one, that is only the ones not finished yet, if there are some, and
all (finished) meetings otherwise. The calendar works as follows :
-If no meetings: show current week
-If one: show that week
-If more than one and same week : show that week
-If more than one and same month : show that month
-If more than one month, show month of the first meeting.

This is done according to user language week_start and timezone. This way,
the user always see what is the most relevant.

* web: This changes calendar_view.js. **This small change is in ingoing #63370**
It allows to enter an initial_date via context in calendar view.

Task-ID - 2431245
