### PR TITLE
[IMP] l10n_ch: remove old, now useless, setting

### DIFF
--- a/addons/l10n_ch/views/res_config_settings_views.xml
+++ b/addons/l10n_ch/views/res_config_settings_views.xml
@@ -9,15 +9,6 @@
                 <xpath expr="//div[@id='invoicing_settings']" position="inside">
                     <div class="col-12 col-lg-6 o_setting_box" id="l10n_ch-isr_print_bank">
                         <div class="o_setting_left_pane">
-                            <field name="l10n_ch_print_qrcode"/>
-                        </div>
-                        <div class="o_setting_right_pane">
-                            <label for="l10n_ch_print_qrcode"/>
-                            <div class="text-muted">
-                                Append the QR Code ISR at the end of customer invoices for Swiss customers
-                            </div>
-                        </div>
-                        <div class="o_setting_left_pane">
                             <field name="l10n_ch_isr_print_bank_location"/>
                         </div>
                         <div class="o_setting_right_pane">


### PR DESCRIPTION
This setting was introduced with the original implementation of the Swiss QR codes, when they were not yet legally supported. They are now, so we don't use it anymore.

