### PR TITLE
[FIX] account: Currency id in rounding line

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -792,7 +792,7 @@ class AccountMove(models.Model):
                 'amount_currency': diff_amount_currency,
                 'partner_id': self.partner_id.id,
                 'move_id': self.id,
-                'currency_id': self.currency_id,
+                'currency_id': self.currency_id.id,
                 'company_id': self.company_id.id,
                 'company_currency_id': self.company_id.currency_id.id,
                 'is_rounding_line': True,

--- a/doc/cla/corporate/simpit.md
+++ b/doc/cla/corporate/simpit.md
@@ -1,0 +1,17 @@
+Switzerland, 2021-01-20
+
+simpit GmbH agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Dario Bösch boesch@simpit.ch https://github.com/simpit-boesch
+
+List of contributors:
+
+Dario Bösch boesch@simpit.ch https://github.com/simpit-boesch
+Lukas Eisner eisner@simpit.ch https://github.com/simpit-eisner
+Mario Burger burger@simpit.ch https://github.com/marioburger


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Fixing a bug on posting outgoing invoices with rounding lines

Current behavior before PR: If an invoice which is rounded (by rounding the tax amount) is posted, an error is raised because the rounding line can't be created:

> Can't adapt type 'res.currency'

Desired behavior after PR is merged: invoice can be posted without error by passing the id of the currency instead the object itself


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
