### PR TITLE
[FIX] stock_account: validating svl from different companies

### DIFF
--- a/addons/stock_account/models/stock_valuation_layer.py
+++ b/addons/stock_account/models/stock_valuation_layer.py
@@ -47,8 +47,8 @@ class StockValuationLayer(models.Model):
         if am_vals:
             account_moves = self.env['account.move'].sudo().create(am_vals)
             account_moves._post()
-        if self.company_id.anglo_saxon_accounting:
+        for svl in self:
             # Eventually reconcile together the invoice and valuation accounting entries on the stock interim accounts
-            for svl in self:
+            if svl.company_id.anglo_saxon_accounting:
                 svl.stock_move_id._get_related_invoices()._stock_account_anglo_saxon_reconcile_valuation(product=svl.product_id)
 


### PR DESCRIPTION
Commit 7fa9ec263876 create accounting entries from stock_account in
batch. The test on `self.company_id.anglo_saxon_accounting` is
problematic in case of multi recordset. Instead, this commit evaluate
the company_id for each record of `self`.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
