### PR TITLE
[FIX] pos_restaurant: Use order printers with HTTPS

### DIFF
--- a/addons/pos_restaurant/static/src/js/multiprint.js
+++ b/addons/pos_restaurant/static/src/js/multiprint.js
@@ -60,9 +60,9 @@ models.load_models({
             if(active_printers[printers[i].id]){
                 var url = printers[i].proxy_ip || '';
                 if(url.indexOf('//') < 0){
-                    url = 'http://'+url;
+                    url = window.location.protocol + '//' + url;
                 }
-                if(url.indexOf(':',url.indexOf('//')+2) < 0){
+                if(url.indexOf(':',url.indexOf('//')+2) < 0 && window.location.protocol === 'http'){
                     url = url+':8069';
                 }
                 var printer = new Printer(self,{url:url});


### PR DESCRIPTION
The protocol and port to use when printing orders were hardcoded. This
resulted in errors when using the POS in HTTPS as the browser blocked
non-HTTPS requests on the page.

TaskID: 2413240



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
