### PR TITLE
[FIX] board,stock: cannot add stock on hand report to dashboard

### DIFF
--- a/addons/board/static/src/js/add_to_board_menu.js
+++ b/addons/board/static/src/js/add_to_board_menu.js
@@ -49,7 +49,9 @@ var AddToBoardMenu = Widget.extend({
      */
     closeMenu: function () {
         this.isOpen = false;
-        this._render();
+        if (this.action.id && this.action.type === 'ir.actions.act_window') {
+            this._render();
+        }
     },
 
     //--------------------------------------------------------------------------

--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -6480,6 +6480,7 @@ msgstr ""
 
 #. module: stock
 #: code:addons/stock/models/stock_quant.py:0
+#: model:ir.actions.act_window,name:stock.dashboard_open_quants
 #: model_terms:ir.ui.view,arch_db:stock.product_form_view_procurement_button
 #: model_terms:ir.ui.view,arch_db:stock.product_product_view_form_easy_inherit_stock
 #: model_terms:ir.ui.view,arch_db:stock.product_template_form_view_procurement_button

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -627,6 +627,10 @@ class StockQuant(models.Model):
                 """
         }
 
+        target_action = self.env.ref('stock.dashboard_open_quants', False)
+        if target_action:
+            action['id'] = target_action.id
+
         if self._is_inventory_mode():
             action['view_id'] = self.env.ref('stock.view_stock_quant_tree_editable').id
             # fixme: erase the following condition when it'll be possible to create a new record

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -172,6 +172,11 @@
         <field name="domain">[('product_id.product_tmpl_id', '=', active_id)]</field>
         <field name="res_model">stock.quant</field>
     </record>
+    <record model="ir.actions.act_window" id="dashboard_open_quants"> <!-- Used in dashboard -->
+        <field name="name">Update Quantity</field>
+        <field name="context">{'search_default_internal_loc': 1, 'search_default_productgroup':1, 'search_default_locationgroup':1}</field>
+        <field name="res_model">stock.quant</field>
+    </record>
     <record model="ir.actions.act_window" id="location_open_quants"> <!-- Used in location -->
         <field name="context">{'search_default_productgroup': 1}</field>
         <field name="domain">[('location_id', 'child_of', active_ids)]</field>


### PR DESCRIPTION
Steps:
- Install Inventory and Dashboard
- Go to Inventory > Reporting > Inventory Report
- Click Favorites
- Add to my Dashboard is missing
- Open the Favorites dropdown again
- Click Add to my Dashboard

Bug:
Error: Could not add filter to dashboard

Explanation:
This report action window is created dynamically by the server action
`action_view_quants`. The `id` isn't present, but it's not needed to
display the view. However, in order to create a dashboard item, the `id`
of an action is required as seen here:
https://github.com/odoo/odoo/blob/cfb5e6e82a773fee0342d5e0417bae4efeb7f0bb/addons/board/controllers/main.py#L16

This commit adds the ID of a new simple `ir.actions.act_window`. Reusing
`product_template_open_quants` is not possible because, when refreshing
the page, the view hasn't got any `active_ids`.

The menu item only appears after reopening the Favorites dropdown
because the frontend checks if the `id` of the action is present here:
https://github.com/odoo/odoo/blob/cfb5e6e82a773fee0342d5e0417bae4efeb7f0bb/addons/board/static/src/js/add_to_board_menu.js#L35-L40
but re-renders it every time the dropdown is closed, no matter what:
https://github.com/odoo/odoo/blob/cfb5e6e82a773fee0342d5e0417bae4efeb7f0bb/addons/board/static/src/js/add_to_board_menu.js#L50-L53

This commit also prevents the item from appearing after clicking
multiple times on the button.

opw:2426986