### PR TITLE
[FIX] web: disallow event popup y-overflow in calendar view

### DIFF
--- a/addons/web/static/src/scss/web_calendar.scss
+++ b/addons/web/static/src/scss/web_calendar.scss
@@ -677,6 +677,8 @@ $o-cw-filter-avatar-size: 20px;
     .o_cw_popover_fields_secondary {
         max-height: 170px; // Fallback for old browsers
         max-height: 25vh;
+        overflow-y: auto;
+        padding-bottom: 1px; // prevents the scrollbar to show when not needed
 
         &::-webkit-scrollbar {
             background: gray('200');


### PR DESCRIPTION
Go to calendar
Have an event with a long description
In day/week/month view click the event to see the event popup

The description will overflow the length of the popup

opw-2421554

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
