### PR TITLE
[FIX] sale_timesheet: multi-company access rights issue

### DIFF
--- a/addons/sale_timesheet/models/sale_order.py
+++ b/addons/sale_timesheet/models/sale_order.py
@@ -78,8 +78,8 @@ class SaleOrderLine(models.Model):
 
     qty_delivered_method = fields.Selection(selection_add=[('timesheet', 'Timesheets')])
     analytic_line_ids = fields.One2many(domain=[('project_id', '=', False)])  # only analytic lines, not timesheets (since this field determine if SO line came from expense)
-    remaining_hours_available = fields.Boolean(compute='_compute_remaining_hours_available')
-    remaining_hours = fields.Float('Remaining Hours on SO', compute='_compute_remaining_hours')
+    remaining_hours_available = fields.Boolean(compute='_compute_remaining_hours_available', compute_sudo=True)
+    remaining_hours = fields.Float('Remaining Hours on SO', compute='_compute_remaining_hours', compute_sudo=True)
 
     def name_get(self):
         res = super(SaleOrderLine, self).name_get()


### PR DESCRIPTION
 - When trying to timesheet on a task that is linked to a sale order
   line from a different company than the user's current one.
   An error is triggered due multi company access rights issue.

   This is due to two computed fields that are not computed in sudo
   mode.
   They make more sense as `computed_sudo` fields as they are only
   computed stats and are not leaking private data.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
