### PR TITLE
[FIX] l10n_ar, l10n_latam_invoice_document: Move Argentinian constraint from base module to localization module

### DIFF
--- a/addons/l10n_latam_invoice_document/models/account_move.py
+++ b/addons/l10n_latam_invoice_document/models/account_move.py
@@ -164,8 +164,7 @@ class AccountMove(models.Model):
         for rec in self.filtered('l10n_latam_document_type_id.internal_type'):
             internal_type = rec.l10n_latam_document_type_id.internal_type
             invoice_type = rec.type
-            if internal_type in ['debit_note', 'invoice'] and invoice_type in ['out_refund', 'in_refund'] and \
-               rec.l10n_latam_document_type_id.code != '99':
+            if internal_type in ['debit_note', 'invoice'] and invoice_type in ['out_refund', 'in_refund']:
                 raise ValidationError(_('You can not use a %s document type with a refund invoice') % internal_type)
             elif internal_type == 'credit_note' and invoice_type in ['out_invoice', 'in_invoice']:
                 raise ValidationError(_('You can not use a %s document type with a invoice') % (internal_type))


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

Error in the constraint when other localizations use l10n_latam_invoice_document module. 

### Current behavior before PR:

This Argentinean constraint is interfering in other localizations

### Desired behavior after PR is merged:

This constraint will not will not interfere in other localizations


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
