### PR TITLE
[IMP] mrp_workorder: Update WO readiness behaviour

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1095,6 +1095,8 @@ class MrpProduction(models.Model):
     def action_assign(self):
         for production in self:
             production.move_raw_ids._action_assign()
+            if production.workorder_ids:
+                production.workorder_ids[0]._action_assign()
         return True
 
     def button_plan(self):

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -59,6 +59,7 @@ class MrpWorkorder(models.Model):
     is_produced = fields.Boolean(string="Has Been Produced",
         compute='_compute_is_produced')
     state = fields.Selection([
+        ('waiting', 'Waiting for components'),
         ('pending', 'Waiting for another WO'),
         ('ready', 'Ready'),
         ('progress', 'In Progress'),
@@ -451,8 +452,10 @@ class MrpWorkorder(models.Model):
                     })
 
             for workorders in workorders_by_bom.values():
-                if workorders[0].state == 'pending':
+                if self.production_id.components_availability_state == 'available':
                     workorders[0].state = 'ready'
+                else:
+                    workorders[0].state = 'waiting'
                 for workorder in workorders:
                     workorder._start_nextworkorder()
 

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -412,7 +412,7 @@ class MrpWorkorder(models.Model):
 
     def _action_assign(self):
         if self.production_id.components_availability_state == 'available':
-             return self.write({'state' : 'ready'})
+            return self.write({'state' : 'ready'})
         return self.write({'state' : 'waiting'})
 
     def _action_confirm(self):

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -701,8 +701,8 @@ class MrpWorkorder(models.Model):
             FROM mrp_workorder wo1, mrp_workorder wo2
             WHERE
                 wo1.id IN %s
-                AND wo1.state IN ('pending','ready')
-                AND wo2.state IN ('pending','ready')
+                AND wo1.state IN ('waiting', 'pending', 'ready')
+                AND wo2.state IN ('waiting', 'pending', 'ready')
                 AND wo1.id != wo2.id
                 AND wo1.workcenter_id = wo2.workcenter_id
                 AND (DATE_TRUNC('second', wo2.date_planned_start), DATE_TRUNC('second', wo2.date_planned_finished))

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -410,6 +410,11 @@ class MrpWorkorder(models.Model):
         to_confirm._action_confirm()
         return res
 
+    def _action_assign(self):
+        if self.production_id.components_availability_state == 'available':
+             return self.write({'state' : 'ready'})
+        return self.write({'state' : 'waiting'})
+
     def _action_confirm(self):
         workorders_by_production = defaultdict(lambda: self.env['mrp.workorder'])
         for workorder in self:
@@ -452,10 +457,7 @@ class MrpWorkorder(models.Model):
                     })
 
             for workorders in workorders_by_bom.values():
-                if self.production_id.components_availability_state == 'available':
-                    workorders[0].state = 'ready'
-                else:
-                    workorders[0].state = 'waiting'
+                workorders[0]._action_assign()
                 for workorder in workorders:
                     workorder._start_nextworkorder()
 

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -82,7 +82,7 @@
                 <field name="duration_expected" widget="float_time"/>
                 <field name="duration" widget="mrp_time_counter"
                   attrs="{'invisible': [('production_state','=', 'draft')], 'readonly': [('is_user_working', '=', True)]}"/>
-                <field name="state" widget="badge" decoration-success="state == 'done'" decoration-info="state not in ('done', 'cancel')" attrs="{'invisible': [('production_state', 'in', ('draft', 'done'))]}"/>
+                <field name="state" widget="badge" decoration-warning="state == 'waiting'" decoration-success="state == 'done'" decoration-info="state not in ('waiting', 'done', 'cancel')" attrs="{'invisible': [('production_state', 'in', ('draft', 'done'))]}"/>
                 <button name="button_start" type="object" string="Start" class="btn-success"
                   attrs="{'invisible': ['|', '|', '|', ('production_state','in', ('draft', 'done', 'cancel')), ('working_state', '=', 'blocked'), ('state', '=', 'done'), ('is_user_working', '!=', False)]}"/>
                 <button name="button_pending" type="object" string="Pause" class="btn-warning"
@@ -127,7 +127,7 @@
             <field name="working_state" invisible="1"/>
             <field name="production_state" invisible="1"/>
             <header>
-                <field name="state" widget="statusbar" statusbar_visible="pending,ready,progress,done"/>
+                <field name="state" widget="statusbar" statusbar_visible="waiting,pending,ready,progress,done"/>
             </header>
                 <div class="oe_button_box" name="button_box">
                     <button class="oe_stat_button" name="action_see_move_scrap" type="object" icon="fa-arrows-v" attrs="{'invisible': [('scrap_count', '=', 0)]}">
@@ -230,6 +230,7 @@
                 <filter string="In Progress" name="progress" domain="[('state', '=', 'progress')]"/>
                 <filter string="Ready" name="ready" domain="[('state', '=', 'ready')]"/>
                 <filter string="Pending" name="pending" domain="[('state', '=', 'pending')]"/>
+                <filter string="Waiting" name="pending" domain="[('state', '=', 'waiting')]"/>
                 <filter string="Finished" name="finish" domain="[('state', '=', 'done')]"/>
                 <filter string="Available" name="available" domain="[('production_availability', '=', 'assigned')]"/>
                 <separator/>
@@ -383,7 +384,7 @@
                                 </div>
                                 <div class="o_kanban_manage_button_section">
                                     <h2>
-                                        <span t-attf-class="badge #{['pending'].indexOf(record.state.raw_value) > -1 ? 'badge-warning' :['progress'].indexOf(record.state.raw_value) > -1 ? 'badge-secondary' : ['ready'].indexOf(record.state.raw_value) > -1 ? 'badge-primary' : ['done'].indexOf(record.state.raw_value) > -1 ? 'badge-success' : 'badge-danger'}">
+                                        <span t-attf-class="badge #{['pending'].indexOf(record.state.raw_value) > -1 ? 'badge-warning' :['progress'].indexOf(record.state.raw_value) > -1 ? 'badge-secondary' : ['ready'].indexOf(record.state.raw_value) > -1 ? 'badge-primary' : ['done'].indexOf(record.state.raw_value) > -1 ? 'badge-success' : ['cancel'].indexOf(record.state.raw_value) > -1 ? 'badge-muted' : 'badge-danger'}">
                                             <t t-esc="record.state.value"/>
                                         </span>
                                     </h2>

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -230,7 +230,7 @@
                 <filter string="In Progress" name="progress" domain="[('state', '=', 'progress')]"/>
                 <filter string="Ready" name="ready" domain="[('state', '=', 'ready')]"/>
                 <filter string="Pending" name="pending" domain="[('state', '=', 'pending')]"/>
-                <filter string="Waiting" name="pending" domain="[('state', '=', 'waiting')]"/>
+                <filter string="Waiting" name="waiting" domain="[('state', '=', 'waiting')]"/>
                 <filter string="Finished" name="finish" domain="[('state', '=', 'done')]"/>
                 <filter string="Available" name="available" domain="[('production_availability', '=', 'assigned')]"/>
                 <separator/>


### PR DESCRIPTION
- The work order state changes based on the availability of the components
- So if all BOM components are ``available`` the state of the first WO is set to ``ready``
- The color of ``ready`` in the WO tree editable view will stay blue as long as ``done`` reserves the green color
- If one or multiple components are not available, the state of the first WO is set to ``waiting``
- The color of ``waiting`` in the WO tree editable view is set to orange
- By default ``To launch`` takes ``workorder_ready_count`` so it counts only ``ready`` WOs
- The user can always process the WO without restrictions even if the WO state is ``waiting``


Task ID: 2426773