### PR TITLE
[IMP] crm: tone down action buttons

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -6,16 +6,16 @@
             <field name="arch" type="xml">
                 <form class="o_lead_opportunity_form" js_class="crm_form">
                     <header>
-                        <button name="action_set_won_rainbowman" string="Mark Won"
+                        <button name="action_set_won_rainbowman" string="Won"
                             type="object" class="oe_highlight"
                             attrs="{'invisible': ['|','|', ('active','=',False), ('probability', '=', 100), ('type', '=', 'lead')]}"/>
-                        <button name="%(crm.crm_lead_lost_action)d" string="Mark Lost"
-                            type="action" class="oe_highlight" context="{'default_lead_id': active_id}" attrs="{'invisible': ['|', ('type', '=', 'lead'),('active', '=', False),('probability', '&lt;', 100)]}"/>
+                        <button name="%(crm.crm_lead_lost_action)d" string="Lost"
+                            type="action" context="{'default_lead_id': active_id}" attrs="{'invisible': ['|', ('type', '=', 'lead'),('active', '=', False),('probability', '&lt;', 100)]}"/>
                         <button name="%(crm.action_crm_lead2opportunity_partner)d" string="Convert to Opportunity" type="action" help="Convert to Opportunity"
                             class="oe_highlight" attrs="{'invisible': ['|', ('type', '=', 'opportunity'), ('active', '=', False)]}"/>
                         <button name="toggle_active" string="Restore" type="object"
                             attrs="{'invisible': ['|', ('probability', '&gt;', 0), ('active', '=', True)]}"/>
-                        <button name="action_set_lost" string="Mark as Lost" type="object"
+                        <button name="action_set_lost" string="Lost" type="object"
                             attrs="{'invisible': ['|', ('type', '=', 'opportunity'), '&amp;', ('probability', '=', 0), ('active', '=', False)]}"/>
                         <field name="stage_id" widget="statusbar"
                             options="{'clickable': '1', 'fold_field': 'fold'}"

--- a/addons/sale_crm/views/crm_lead_views.xml
+++ b/addons/sale_crm/views/crm_lead_views.xml
@@ -10,6 +10,9 @@
                     <button string="New Quotation" name="action_sale_quotations_new" type="object" class="oe_highlight"
                         attrs="{'invisible': ['|', ('type', '=', 'lead'), '&amp;', ('probability', '=', 0), ('active', '=', False)]}"/>
                 </xpath>
+                <button name="action_set_won_rainbowman" position="attributes">
+                    <attribute name="class" remove="oe_highlight"/>
+                </button>
                 <button name="action_schedule_meeting" position="after">
                     <button class="oe_stat_button" type="object"
                         name="action_view_sale_quotation" icon="fa-pencil-square-o" attrs="{'invisible': [('type', '=', 'lead')]}">


### PR DESCRIPTION
Primary action buttons should have a meaning. If they're all
primary, none are.All in all, they should suggest the next logical
flow spec to the user. In this case we consider that it is:
  -> The creation of a new commercial document if those apps are installed
  -> The winning of the deal (as losing would stop the flow)

What's more, this copy is pretty long, especially in other
languages ("Marquer Comme Gagné") so we try to make it shorter

in this commit we redesigned the buttons "Mark Won" and "Mark Lost"
to "Mark" and "Lost", also the highlight class for the buttons are
removed.

task-id: 2247355



