### PR TITLE
discard unchanged record in editable list

### DIFF
--- a/addons/account/static/tests/section_and_note_tests.js
+++ b/addons/account/static/tests/section_and_note_tests.js
@@ -89,6 +89,8 @@ QUnit.module('section_and_note', {
         // editing section should be input
         $tr1 = form.$('tr.o_data_row:eq(1)');
         await testUtils.dom.click($tr1.find('td.o_data_cell'));
+        await testUtils.nextTick();
+        $tr1 = form.$('tr.o_data_row:eq(1)');
         assert.containsOnce($tr1, 'td.o_data_cell input[name="name"]',
             "editing section should be input");
 

--- a/addons/sale_product_configurator/static/src/js/product_configurator_widget.js
+++ b/addons/sale_product_configurator/static/src/js/product_configurator_widget.js
@@ -101,13 +101,13 @@ ProductConfiguratorWidget.include({
                 allowWarning: true,
                 onSuccess: function () {
                     // Leave edit mode of one2many list.
-                    unselectRow();
+                    unselectRow({ forceCreate: true });
                 }
             });
         } else if (!self._isConfigurableLine() && self._isConfigurableProduct()) {
             // Leave edit mode of current line if line was configured
             // only through the product configurator.
-            unselectRow();
+            unselectRow({ forceCreate: true });
         }
     },
 

--- a/addons/sale_product_matrix/static/tests/tours/sale_product_matrix_tour.js
+++ b/addons/sale_product_matrix/static/tests/tours/sale_product_matrix_tour.js
@@ -69,7 +69,7 @@ tour.register('sale_matrix_tour', {
     run: 'click' // apply the matrix
 }, {
     trigger: ".o_form_editable .o_field_many2one[name='partner_id'] input",
-    extra_trigger: ".o_sale_order",
+    extra_trigger: '.o_field_cell.o_data_cell.o_list_number:contains("1.00")',
     run: 'text Agrolait'
 }, {
     trigger: ".ui-menu-item > a",

--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -1742,8 +1742,16 @@ var FieldX2Many = AbstractField.extend(WidgetAdapterMixin, {
         var self = this;
         ev.stopPropagation();
         this.renderer.commitChanges(ev.data.recordID).then(function () {
+            const record = self.renderer._getRecord(ev.data.recordID);
             self.trigger_up('mutexify', {
                 action: function () {
+                    if (!ev.data.forceCreate && !record.isDirty()) {
+                        return self.trigger_up('discard_changes', {
+                            recordID: ev.data.recordID,
+                            onSuccess: ev.data.onSuccess,
+                            onFailure: ev.data.onFailure,
+                        });
+                    }
                     return self._saveLine(ev.data.recordID)
                         .then(ev.data.onSuccess)
                         .guardedCatch(ev.data.onFailure);

--- a/addons/web/static/src/js/views/list/list_controller.js
+++ b/addons/web/static/src/js/views/list/list_controller.js
@@ -909,6 +909,11 @@ var ListController = BasicController.extend({
      * @param {OdooEvent} ev
      */
     _onSaveLine: function (ev) {
+        if (!this.isDirty(ev.data.recordID)) {
+            this.updateButtons('readonly');
+            this._abandonRecord(ev.data.recordID);
+            return ev.data.onSuccess();
+        }
         this.saveRecord(ev.data.recordID)
             .then(ev.data.onSuccess)
             .guardedCatch(ev.data.onFailure);

--- a/addons/web/static/src/js/views/list/list_editable_renderer.js
+++ b/addons/web/static/src/js/views/list/list_editable_renderer.js
@@ -492,26 +492,11 @@ ListRenderer.include({
 
         toggleWidgets(true);
         return new Promise((resolve, reject) => {
-            const record = this._getRecord(recordID);
-            this.commitChanges(recordID).then(() => {
-                if ((!options || !options.forceCreate) && !record.isDirty()) {
-                    this.trigger_up('mutexify', {
-                        action: () => {
-                            return this.trigger_up('discard_changes', {
-                                recordID: recordID,
-                                onSuccess: resolve,
-                                onFailure: reject,
-                            });
-                        },
-                    });
-                } else {
-                    this.trigger_up('save_line', {
-                        recordID: recordID,
-                        onSuccess: resolve,
-                        onFailure: reject,
-                        forceCreate: options && options.forceCreate,
-                    });
-                }
+            this.trigger_up('save_line', {
+                recordID: recordID,
+                onSuccess: resolve,
+                onFailure: reject,
+                forceCreate: options && options.forceCreate,
             });
         }).then(selectNextRow => {
             this._enableRecordSelectors();

--- a/addons/web/static/tests/fields/relational_fields/field_many2one_tests.js
+++ b/addons/web/static/tests/fields/relational_fields/field_many2one_tests.js
@@ -2872,6 +2872,7 @@ QUnit.module('fields', {}, function () {
                 arch: '<form>' +
                     '<field name="p">' +
                     '<tree editable="bottom">' +
+                    '<field name="foo"/>' +
                     '<field name="trululu"/>' +
                     '</tree>' +
                     '</field>' +
@@ -2900,6 +2901,8 @@ QUnit.module('fields', {}, function () {
             domain = [['id', 'in', [10]]]; // domain for subrecord 1
             await testUtils.dom.click(form.$('.o_field_x2many_list_row_add a'));
             await testUtils.dom.click(form.$('.o_field_widget[name=trululu] input'));
+            // add some value to foo field to make record dirty
+            await testUtils.fields.editInput(form.$('tr.o_selected_row input[name="foo"]'), 'new value');
 
             // add a second row with another domain for the m2o
             domain = [['id', 'in', [5]]]; // domain for subrecord 2
@@ -2908,7 +2911,7 @@ QUnit.module('fields', {}, function () {
 
             // check again the first row to ensure that the domain hasn't change
             domain = [['id', 'in', [10]]]; // domain for subrecord 1 should have been kept
-            await testUtils.dom.click(form.$('.o_data_row:first .o_data_cell'));
+            await testUtils.dom.click(form.$('.o_data_row:first .o_data_cell:eq(1)'));
             await testUtils.dom.click(form.$('.o_field_widget[name=trululu] input'));
 
             form.destroy();

--- a/addons/web/static/tests/fields/relational_fields/field_one2many_tests.js
+++ b/addons/web/static/tests/fields/relational_fields/field_one2many_tests.js
@@ -2660,9 +2660,10 @@ QUnit.module('fields', {}, function () {
                 res_id: 1,
             });
 
-            // add a record, then click in form view to confirm it
+            // add a record, add value to turtle_foo then click in form view to confirm it
             await testUtils.form.clickEdit(form);
             await testUtils.dom.click(form.$('.o_field_x2many_list_row_add a'));
+            await testUtils.fields.editInput(form.$('input[name="turtle_foo"]'), 'nora');
             await testUtils.dom.click(form.$el);
 
             assert.strictEqual(form.$('.o_field_widget[name=turtles] .o_pager').text().trim(), '1-4 / 5',
@@ -2862,11 +2863,12 @@ QUnit.module('fields', {}, function () {
                 res_id: 1,
             });
 
-            // edit mode, then click on Add an item 2 times
+            // edit mode, then click on Add an item, enter value in turtle_foo and Add an item again
             assert.containsOnce(form, 'tr.o_data_row',
                 "should have 1 data rows");
             await testUtils.form.clickEdit(form);
             await testUtils.dom.click(form.$('.o_field_x2many_list_row_add a'));
+            await testUtils.fields.editInput(form.$('input[name="turtle_foo"]'), 'nora');
             await testUtils.dom.click(form.$('.o_field_x2many_list_row_add a'));
             assert.containsN(form, 'tr.o_data_row', 3,
                 "should have 3 data rows");
@@ -2997,7 +2999,8 @@ QUnit.module('fields', {}, function () {
             // the record currently being added should not count in the pager
             assert.containsNone(form, '.o_field_widget[name=turtles] .o_pager');
 
-            // unselect the row
+            // enter value in turtle_foo field and click outside to unselect the row
+            await testUtils.fields.editInput(form.$('input[name="turtle_foo"]'), 'nora');
             await testUtils.dom.click(form.$el);
             assert.containsNone(form, '.o_selected_row');
             assert.containsNone(form, '.o_field_widget[name=turtles] .o_pager');
@@ -3138,8 +3141,11 @@ QUnit.module('fields', {}, function () {
             // add 4 records (to have more records than the limit)
             await testUtils.form.clickEdit(form);
             await testUtils.dom.click(form.$('.o_field_x2many_list_row_add a'));
+            await testUtils.fields.editInput(form.$('input[name="turtle_foo"]'), 'nora');
             await testUtils.dom.click(form.$('.o_field_x2many_list_row_add a'));
+            await testUtils.fields.editInput(form.$('input[name="turtle_foo"]'), 'nora');
             await testUtils.dom.click(form.$('.o_field_x2many_list_row_add a'));
+            await testUtils.fields.editInput(form.$('input[name="turtle_foo"]'), 'nora');
             await testUtils.dom.click(form.$('.o_field_x2many_list_row_add a'));
 
             assert.containsN(form, 'tr.o_data_row', 5);
@@ -8060,9 +8066,12 @@ QUnit.module('fields', {}, function () {
             assert.strictEqual($('.o_data_cell').text(), "");
 
             // click add pizza
-            // save the modal
+            // press enter to save the record
             // check it's pizza
             await testUtils.dom.click(form.$('.o_field_x2many_list_row_add a:eq(1)'));
+            await testUtils.nextTick();
+            const $input = form.$('.o_field_widget[name="p"] .o_selected_row .o_field_widget[name="display_name"]');
+            await testUtils.fields.triggerKeydown($input, 'enter');
             // click add pasta
             await testUtils.dom.click(form.$('.o_field_x2many_list_row_add a:eq(2)'));
             await testUtils.form.clickSave(form);
@@ -8284,7 +8293,8 @@ QUnit.module('fields', {}, function () {
             await testUtils.form.clickEdit(form);
             await testUtils.dom.click(form.$('.o_data_row:eq(1)'));
             await testUtils.dom.click($('.modal .o_field_x2many_list_row_add a'));
-            $('.modal input[name="display_name"]').val('michelangelo').change();
+            await testUtils.fields.editInput($('.modal input[name="display_name"]'), 'michelangelo');
+            // $('.modal input[name="display_name"]').val('michelangelo').change();
             await testUtils.dom.click($('.modal .btn-primary'));
             // open first partner so changes from previous action are applied
             await testUtils.dom.click(form.$('.o_data_row:eq(0)'));

--- a/addons/web/static/tests/fields/relational_fields_tests.js
+++ b/addons/web/static/tests/fields/relational_fields_tests.js
@@ -531,7 +531,7 @@ QUnit.module('relational_fields', {
     });
 
     QUnit.test('one2many, onchange, edition and multipage...', async function (assert) {
-        assert.expect(7);
+        assert.expect(8);
 
         this.data.partner.onchanges = {
             turtles: function (obj) {
@@ -562,6 +562,7 @@ QUnit.module('relational_fields', {
             },
         });
         await testUtils.dom.click(form.$('.o_field_x2many_list_row_add a'));
+        await testUtils.fields.editInput(form.$('input[name="turtle_foo"]'), 'nora');
         await testUtils.dom.click(form.$('.o_field_x2many_list_row_add a'));
 
         assert.verifySteps([
@@ -569,6 +570,7 @@ QUnit.module('relational_fields', {
             'read turtle',
             'onchange turtle',
             'onchange partner',
+            "onchange partner",
             'onchange turtle',
             'onchange partner',
         ]);

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -5108,7 +5108,7 @@ QUnit.module('Views', {
             model: 'foo',
             data: this.data,
             arch: '<tree string="Phonecalls" editable="top">' +
-                    '<field name="date"/>' +
+                    '<field name="foo"/>' +
                 '</tree>',
             mockRPC: function (route, args) {
                 if (args.method === 'create') {
@@ -5119,16 +5119,19 @@ QUnit.module('Views', {
         });
 
         await testUtils.dom.click(list.$buttons.find('.o_list_button_add'));
+        await testUtils.fields.editInput(list.$('tr.o_selected_row input[name="foo"]'), 'new value');
         await testUtils.dom.click(list.$('.o_list_view'));
 
         assert.strictEqual(createCount, 1, "should have created a record");
 
         await testUtils.dom.click(list.$buttons.find('.o_list_button_add'));
+        await testUtils.fields.editInput(list.$('tr.o_selected_row input[name="foo"]'), 'new value');
         await testUtils.dom.click(list.$('tfoot'));
 
         assert.strictEqual(createCount, 2, "should have created a record");
 
         await testUtils.dom.click(list.$buttons.find('.o_list_button_add'));
+        await testUtils.fields.editInput(list.$('tr.o_selected_row input[name="foo"]'), 'new value');
         await testUtils.dom.click(list.$('tbody tr').last());
 
         assert.strictEqual(createCount, 3, "should have created a record");
@@ -6277,6 +6280,7 @@ QUnit.module('Views', {
 
         // Press 'Tab' -> should go to next line
         await testUtils.fields.triggerKeydown(form.$('.o_field_widget[name=o2m] .o_selected_row input'), 'tab');
+        await testUtils.owlCompatibilityExtraNextTick();
         assert.hasClass(form.$('.o_field_widget[name=o2m] .o_data_row:nth(1)'),'o_selected_row',
             "second row should be in edition");
 
@@ -7183,12 +7187,12 @@ QUnit.module('Views', {
         list.destroy();
     });
 
-    QUnit.test('list with handle widget, create, move and discard', async function (assert) {
+    QUnit.test('list with handle widget, create and move should keep empty lines at last', async function (assert) {
         // When there are less than 4 records in the table, empty lines are added
         // to have at least 4 rows. This test ensures that the empty line added
         // when a new record is discarded is correctly added on the bottom of
         // the list, even if the discarded record wasn't.
-        assert.expect(11);
+        assert.expect(8);
 
         const list = await createView({
             View: ListView,
@@ -7216,11 +7220,8 @@ QUnit.module('Views', {
             list.$('tbody tr.o_data_row').eq(1),
             { position: 'bottom' }
         );
-        assert.containsN(list, '.o_data_row', 2);
-        assert.hasClass(list.$('.o_data_row:first'), 'o_selected_row');
-        assert.doesNotHaveClass(list.$('.o_data_row:nth(1)'), 'o_selected_row');
 
-        await testUtils.dom.click(list.$('.o_list_button_discard'));
+        // Drag and drop will discard record as well
         assert.containsOnce(list, '.o_data_row');
         assert.hasClass(list.$('tbody tr:first'), 'o_data_row');
         assert.containsN(list, 'tbody tr', 4);
@@ -7521,14 +7522,15 @@ QUnit.module('Views', {
         list.destroy();
     });
 
-    QUnit.test('editable list view: mouseup somewhere else with required fields', async function (assert) {
-        assert.expect(2);
+    QUnit.test('editable list view: non dirty record with required fields', async function (assert) {
+        assert.expect(10);
 
         const list = await createView({
             arch: `
-            <tree editable="top">
-                <field name="foo" required="1"/>
-            </tree>`,
+        <tree editable="top">
+            <field name="foo" required="1"/>
+            <field name="int_field"/>
+        </tree>`,
             data: this.data,
             model: 'foo',
             View: ListView,
@@ -7536,10 +7538,38 @@ QUnit.module('Views', {
 
         await testUtils.dom.click($('.o_list_button_add'));
         assert.containsOnce(list, '.o_selected_row');
-
         // do not change anything and then click outside should discard record
         await testUtils.dom.click('body');
         assert.containsNone(list, '.o_selected_row');
+
+        await testUtils.dom.click($('.o_list_button_add'));
+        assert.containsOnce(list, '.o_selected_row');
+        // do not change anything and then click save button should not allow to discard record
+        await testUtils.dom.click($('.o_list_button_save'));
+        assert.containsOnce(list, '.o_selected_row');
+
+        // selecting some other row should discard non dirty record
+        assert.strictEqual(list.$('.o_selected_row').data('id'), 'foo_7',
+            "foo_7 record should be currently selected");
+        await testUtils.dom.click(list.$('.o_data_row:eq(1) .o_data_cell:eq(0)'));
+        assert.strictEqual(list.$('.o_selected_row').data('id'), 'foo_2',
+            "foo_2 record should be currently selected");
+
+        // click somewhere else to discard currently selected row
+        await testUtils.dom.click('body');
+        await testUtils.dom.click($('.o_list_button_add'));
+        assert.containsOnce(list, '.o_selected_row');
+        // do not change anything and press Enter key should not allow to discard record
+        await testUtils.fields.triggerKeydown(list.$('tr.o_selected_row input.o_field_widget[name="foo"]'), 'enter');
+        assert.containsOnce(list, '.o_selected_row');
+
+        // discard row and create new record and keep required field empty and click anywhere
+        await testUtils.dom.click(list.$buttons.find('.o_list_button_discard'));
+        await testUtils.dom.click($('.o_list_button_add'));
+        assert.containsOnce(list, '.o_selected_row', "row should be selected");
+        await testUtils.fields.editInput(list.$('.o_selected_row .o_field_widget[name=int_field]'), 123);
+        await testUtils.dom.click('body');
+        assert.containsOnce(list, '.o_selected_row', "row should still be selected");
 
         list.destroy();
     });
@@ -8500,6 +8530,7 @@ QUnit.module('Views', {
         await testUtils.dom.click(form.$('.o_field_x2many_list_row_add > a'));
         assert.containsOnce(form, '.o_data_row');
         assert.hasClass(form.$('.o_data_row'), 'o_selected_row');
+        await testUtils.fields.editInput(form.$('.o_field_x2many[name="o2m"] .o_selected_row input[name="display_name"]'), 'new value');
 
         // click outside to unselect the row
         await testUtils.dom.click(document.body);
@@ -10384,6 +10415,7 @@ QUnit.module('Views', {
 
         await testUtils.dom.click(list.$('.o_group_header:first')); // open group
         await testUtils.dom.click(list.$('.o_group_field_row_add a')); // add a new row
+        await testUtils.fields.editInput(list.$('input[name="foo"]'), 'xyz'); // make record dirty
         await testUtils.dom.click($('body')); // unselect row
         assert.verifySteps(['1']);
         assert.strictEqual(list.$('.o_data_row .o_data_cell:eq(1)').text(), 'Low',

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -7521,6 +7521,29 @@ QUnit.module('Views', {
         list.destroy();
     });
 
+    QUnit.test('editable list view: mouseup somewhere else with required fields', async function (assert) {
+        assert.expect(2);
+
+        const list = await createView({
+            arch: `
+            <tree editable="top">
+                <field name="foo" required="1"/>
+            </tree>`,
+            data: this.data,
+            model: 'foo',
+            View: ListView,
+        });
+
+        await testUtils.dom.click($('.o_list_button_add'));
+        assert.containsOnce(list, '.o_selected_row');
+
+        // do not change anything and then click outside should discard record
+        await testUtils.dom.click('body');
+        assert.containsNone(list, '.o_selected_row');
+
+        list.destroy();
+    });
+
     QUnit.test('editable list view: multi edition', async function (assert) {
         assert.expect(26);
 

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -7220,7 +7220,6 @@ QUnit.module('Views', {
             list.$('tbody tr.o_data_row').eq(1),
             { position: 'bottom' }
         );
-
         // Drag and drop will discard record as well
         assert.containsOnce(list, '.o_data_row');
         assert.hasClass(list.$('tbody tr:first'), 'o_data_row');
@@ -7527,10 +7526,10 @@ QUnit.module('Views', {
 
         const list = await createView({
             arch: `
-        <tree editable="top">
-            <field name="foo" required="1"/>
-            <field name="int_field"/>
-        </tree>`,
+            <tree editable="top">
+                <field name="foo" required="1"/>
+                <field name="int_field"/>
+            </tree>`,
             data: this.data,
             model: 'foo',
             View: ListView,


### PR DESCRIPTION
PURPOSE
When leaving the formview of a new unchanged record (i.e. the user did not change anything in the record), it is simply discarded, this is good and expected, nevertheless, this is not the case on the editable listview.
Steps:
    1. Go to an editable listview
    2. Click create
    3. Click outside of the listview
    4. Instead of discarding the new unchanged record (since there is nothing to save), the client expects the user to set the record required fields.

SPEC
When 'leaving' a new unchanged listview record, the record should simply be discarded.

TASK 2444153



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
