### PR TITLE
[FIX] mrp: use bom quantity in bom report

### DIFF
--- a/addons/mrp/report/mrp_report_bom_structure.py
+++ b/addons/mrp/report/mrp_report_bom_structure.py
@@ -69,7 +69,7 @@ class ReportBomStructure(models.AbstractModel):
     def _get_report_data(self, bom_id, searchQty=0, searchVariant=False):
         lines = {}
         bom = self.env['mrp.bom'].browse(bom_id)
-        bom_quantity = searchQty or bom.product_qty
+        bom_quantity = searchQty or bom.product_qty or 1
         bom_product_variants = {}
         bom_uom_name = ''
 

--- a/addons/mrp/static/src/js/mrp_bom_report.js
+++ b/addons/mrp/static/src/js/mrp_bom_report.js
@@ -19,7 +19,7 @@ var MrpBomReport = stock_report_generic.extend({
         var self = this;
         var args = [
             this.given_context.active_id,
-            this.given_context.searchQty || 1,
+            this.given_context.searchQty || false,
             this.given_context.searchVariant,
         ];
         return this._rpc({


### PR DESCRIPTION
This commit makes it so when the bom structure report (Structure & Cost
smartbutton) is opened the product quantity defaults to the BoM's
`product_qty` amount rather than 1.

Steps to reproduce:
- Create/open a BoM
- Set `product_qty` to any value greater than 1
- Click on "Structure & Cost" button.

Expected result: product quantities scaled to the `product_qty`
Actual result: product quantities scaled to Quantity = 1

Task: 2429885


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
