### PR TITLE
[FIX] account_check_printing: checks to print does not update

### DIFF
--- a/addons/account_check_printing/models/account_journal.py
+++ b/addons/account_check_printing/models/account_journal.py
@@ -112,7 +112,8 @@ class AccountJournal(models.Model):
         domain_checks_to_print = [
             ('journal_id', '=', self.id),
             ('payment_method_id.code', '=', 'check_printing'),
-            ('state', '=', 'posted')
+            ('state', '=', 'posted'),
+            ('is_move_sent','=', False),
         ]
         return dict(
             super(AccountJournal, self).get_journal_dashboard_datas(),

--- a/addons/account_check_printing/views/account_payment_views.xml
+++ b/addons/account_check_printing/views/account_payment_views.xml
@@ -30,7 +30,7 @@
             <field name="arch" type="xml">
                 <xpath expr="//filter[@name='activities_overdue']" position="before">
                     <separator/>
-                    <filter name="checks_to_send" string="Checks to Print" domain="[('payment_method_id.code', '=', 'check_printing'), ('state', '=', 'posted')]"/>
+                    <filter name="checks_to_send" string="Checks to Print" domain="[('payment_method_id.code', '=', 'check_printing'), ('state', '=', 'posted'), ('is_move_sent', '=', False)]"/>
                     <separator/>
                 </xpath>
             </field>


### PR DESCRIPTION
1. Go to Settings > Accounting and set a Check layout
2. Go to Accounting > Vendors > Payments
3. Create 2 payments to Vendors, and Confirm (but do not print).
  - Payment Type: Send money
  - Partner Type: Vendor
  - fill in any Amount
  - Payment Method: Checks

4. Go to the accounting dashboard, click on "2 checks to print"
5. Select both payments and print the checks from the Actions menu
6. Refresh the page.

Both payments still show up with the "Checks to print" search filter
enabled. They also shows up in Accounting dashboard as checks to print

opw-2427523

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
