### PR TITLE
[FIX] crm: fix rainbowman nondeterministic tour issue

### DIFF
--- a/addons/crm/static/tests/tours/crm_rainbowman.js
+++ b/addons/crm/static/tests/tours/crm_rainbowman.js
@@ -48,6 +48,9 @@ odoo.define('crm.tour_crm_rainbowman', function (require) {
             trigger: "button.o_kanban_add",
             content: "create lead",
         }, {
+            trigger: ".o_kanban_record .o_kanban_record_title:contains('Test Lead 2')",
+            run: function () {} // wait for the record to be properly created
+        }, {
             // move first test back to new stage to be able to test rainbowman a second time
             trigger: ".o_kanban_record .o_kanban_record_title:contains('Test Lead 1')",
             content: "move back to new stage",


### PR DESCRIPTION
This commit fixes a nondeterministic issue during the rainbowman tour.

We make sure that the record is properly created and the kanban reloaded before
moving on to the next step, ensuring that the tour completes without race
conditions.

Task-2426257

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
