### PR TITLE
   [FIX] website: Error message on website if dynamic snippet category deleted

### DIFF
--- a/addons/website/static/src/snippets/s_dynamic_snippet/000.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/000.js
@@ -94,14 +94,14 @@ const DynamicSnippet = publicWidget.Widget.extend({
      * domain if needed.
      * @private
      */
-    _getSearchDomain: async function () {
+    _getSearchDomain: function () {
         return [];
     },
     /**
      * Fetches the data.
      * @private
      */
-    _fetchData: async function () {
+    _fetchData: function () {
         if (this._isConfigComplete()) {
             return this._rpc(
                 {
@@ -110,7 +110,7 @@ const DynamicSnippet = publicWidget.Widget.extend({
                         'filter_id': parseInt(this.$el.get(0).dataset.filterId),
                         'template_key': this.$el.get(0).dataset.templateKey,
                         'limit': parseInt(this.$el.get(0).dataset.numberOfRecords),
-                        'search_domain': await this._getSearchDomain()
+                        'search_domain': this._getSearchDomain()
                     },
                 })
                 .then(

--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.js
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.js
@@ -14,18 +14,6 @@ const DynamicSnippetProducts = DynamicSnippetCarousel.extend({
     //--------------------------------------------------------------------------
 
     /**
-     * Check product category exist.
-     * @private
-     * @returns {Promise}
-     */
-    _checkCategoryExist: async function (productCategoryId) {
-        return this._rpc({
-            model: 'product.public.category',
-            method: 'search_count',
-            args: [[['id', '=', productCategoryId]]],
-        }).then(nb => nb > 0);
-    },
-    /**
      * Method to be overridden in child components if additional configuration elements
      * are required in order to fetch data.
      * @override
@@ -40,15 +28,9 @@ const DynamicSnippetProducts = DynamicSnippetCarousel.extend({
      * @override
      * @private
      */
-    _getSearchDomain: async function () {
-        const searchDomain = await this._super.apply(this, arguments);
-        const productCategoryId = parseInt(this.$el.get(0).dataset.productCategoryId);
-        const categoryExist = await this._checkCategoryExist(productCategoryId);
-        if (categoryExist) {
-            searchDomain.push(['public_categ_ids', 'child_of', productCategoryId]);
-        } else {
-            searchDomain.push([0, '=', 1]);
-        }
+    _getSearchDomain: function () {
+        const searchDomain = this._super.apply(this, arguments);
+        searchDomain.push(['public_categ_ids', 'child_of', parseInt(this.$el.get(0).dataset.productCategoryId)]);
         return searchDomain;
     },
 


### PR DESCRIPTION
Issue
  
      - Install "Ecommerce" app
      - Go to 'Shop' page and edit it
      - Add a "Dynamic Products" block
      - Click on it to edit it :
      -  Select any template
      -  Select `Desks` as product category
      -  Save
      - Go to "Website -> Configuration -> eCommerce Categories"
      - Delete the "Desks" category
      - Go back to Shop page
      
      Error : "Record does not exist or has been deleted".

Cause
    
      The search domain is looking for child categories of dataset.productCategoryId
      (who does not exist anymore in the above case).
      `child_of` do a browse() to fetch the records, and therefore generate
      an error if category not found.
        
Solution
      
      Log warning message if unexptected domain and return empty records set instead.
        
opw-2440917