### PR TITLE
[FIX] web_editor: fix weird behaviour when changing text-color 3 times

### DIFF
--- a/addons/web_editor/static/src/js/editor/summernote.js
+++ b/addons/web_editor/static/src/js/editor/summernote.js
@@ -2080,7 +2080,8 @@ $.summernote.pluginEvents.applyFont = function (event, editor, layoutInfo, color
       ancestor = dom.ancestor(endPoint.node, dom.isFont) || endPoint.node;
       dom.splitTree(ancestor, endPoint);
     }
-    if (startPoint.offset && startPoint.offset !== dom.nodeLength(startPoint.node)) {
+    if (startPoint.offset && startPoint.offset !== dom.nodeLength(startPoint.node) ||
+        (dom.isText(startPoint.node) && startPoint.node !== startPoint.node.parentNode.childNodes[0])) {
       ancestor = dom.ancestor(startPoint.node, dom.isFont) || startPoint.node;
       node = dom.splitTree(ancestor, startPoint);
       if (endPoint.node === startPoint.node) {


### PR DESCRIPTION
Before this commit:
- select text, color it in red
- partially select red text with selection start inside the red
- choose green color
- choose red color again
- choose green color again
=> the unselected start of the red text is now green

This is caused by the fact that when determining whether to split the
DOM in two at the selection start, the code checks if the start of the
selection is at the start of a node, however this approach is only valid
if the node in question is the first text node of the element. When the
text node is not the first one, we still need to wrap it with a copy of
the parent element individually so that we can manipulate it separately
from the the earlier text nodes in that same element.

This commit adds a check that the node is also the first text node in
the element, and if not, splits the DOM tree as if it wasn't, allowing
style to be applied to both sides of the splitting point independently.