### PR TITLE
[IMP] [website_]event[_exhibitor|_meet|_questions|_track]: even…

### DIFF
--- a/addons/website_event/views/event_event_views.xml
+++ b/addons/website_event/views/event_event_views.xml
@@ -23,10 +23,10 @@
                 <div name="event_menu_configuration" groups="base.group_no_one">
                     <label for="website_menu" string="Website Submenu"/>
                     <field name="website_menu"/>
-                    <label for="menu_register_cta" string="Register Button"/>
-                    <field name="menu_register_cta"/>
                     <label for="community_menu" string="Community" invisible="1"/>
-                    <field name="community_menu" invisible="1"/>
+                    <field name="community_menu" invisible="1" attrs="{'readonly': [('website_menu', '=', False)]}"/>
+                    <label for="menu_register_cta" string="Register Button"/>
+                    <field name="menu_register_cta" attrs="{'readonly': [('website_menu', '=', False)]}"/>
                 </div>
             </xpath>
         </field>

--- a/addons/website_event_exhibitor/views/event_event_views.xml
+++ b/addons/website_event_exhibitor/views/event_event_views.xml
@@ -15,9 +15,9 @@
                     <field name="sponsor_count" string="Sponsors" widget="statinfo"/>
                 </button>
             </field>
-            <xpath expr="//field[@name='website_menu']" position="after">
+            <xpath expr="//field[@name='website_track_proposal' or @name='website_menu'][last()]" position="after">
                 <label for="exhibitor_menu"/>
-                <field name="exhibitor_menu"/>
+                <field name="exhibitor_menu" attrs="{'readonly': [('website_menu', '=', False)]}"/>
             </xpath>
         </field>
     </record>

--- a/addons/website_event_meet/models/event_event.py
+++ b/addons/website_event_meet/models/event_event.py
@@ -14,16 +14,41 @@ class Event(models.Model):
         readonly=False, store=True,
         help="Let Visitors Create Rooms")
 
-    @api.depends("event_type_id", "website_menu", "community_menu")
+    @api.depends('event_type_id', 'website_menu')
     def _compute_community_menu(self):
         """ At type onchange: synchronize. At website_menu update: synchronize. """
         for event in self:
-            if event.event_type_id and event.event_type_id != event._origin.event_type_id:
+            # If we activate website_menu and there is event_type, take event type value, unless exhibitor menu is already activated.
+            if event.event_type_id and (event.event_type_id != event._origin.event_type_id) or (
+                    event.website_menu and not event.community_menu):
                 event.community_menu = event.event_type_id.community_menu
-            elif event.website_menu and (event.website_menu != event._origin.website_menu or not event.community_menu):
-                event.community_menu = True
-            elif not event.website_menu:
-                event.community_menu = False
+            # If no event type, or if there is event type but exhibitor_menu is already set when setting website_menu, simply take same value as website_menu
+            else:
+                event.community_menu = event.website_menu
+
+    @api.onchange('website_menu')
+    def _onchange_website_menu(self):
+        """use onchange to make sure that website_track has the correct value
+        when the user makes changes inside the form, what we want is that when
+        the user activates the website menu the website_track field to be set to
+        the value of the template, if the event is not linked
+        to a template, the value of website_track will be set to True.
+        When the menu is deactivated it should always be false"""
+        super(Event, self)._onchange_website_menu()
+        for event in self:
+            if event.website_menu and event.event_type_id:
+                event.community_menu = event.event_type_id.community_menu
+            else:
+                event.community_menu = event.website_menu
+
+    @api.onchange('event_type_id')
+    def _onchange_event_type(self):
+        """use onchange to make sure that website_track has the same value
+        as in the event type when the user makes changes inside the form"""
+        super(Event, self)._onchange_event_type()
+        for event in self:
+            if event.event_type_id:
+                event.community_menu = event.event_type_id.community_menu
 
     @api.depends("meeting_room_ids")
     def _compute_meeting_room_count(self):
@@ -50,3 +75,11 @@ class Event(models.Model):
                 event.meeting_room_allow_creation = True
             elif not event.community_menu or not event.meeting_room_allow_creation:
                 event.meeting_room_allow_creation = False
+
+    def toggle_website_menu(self, val):
+        super(Event, self).toggle_website_menu(val)
+        if val:
+            if self.event_type_id:
+                self.community_menu = self.event_type_id.community_menu
+            else:
+                self.community_menu = self.website_menu

--- a/addons/website_event_track/models/event_event.py
+++ b/addons/website_event_track/models/event_event.py
@@ -31,25 +31,52 @@ class Event(models.Model):
 
     @api.depends('event_type_id', 'website_menu')
     def _compute_website_track(self):
-        """ Propagate event_type configuration (only at change); otherwise propagate
-        website_menu updated value. Also force True is track_proposal changes. """
         for event in self:
-            if event.event_type_id and event.event_type_id != event._origin.event_type_id:
+            # If we activate website_menu and there is event_type, take event type value, unless exhibitor menu is already activated.
+            if event.event_type_id and (event.event_type_id != event._origin.event_type_id) or (
+                    event.website_menu and not event.website_track):
                 event.website_track = event.event_type_id.website_track
-            elif event.website_menu and (event.website_menu != event._origin.website_menu or not event.website_track):
-                event.website_track = True
-            elif not event.website_menu:
-                event.website_track = False
+            # If no event type, or if there is event type but exhibitor_menu is already set when setting website_menu, simply take same value as website_menu
+            else:
+                event.website_track = event.website_menu
 
-    @api.depends('event_type_id', 'website_track')
+    @api.depends('event_type_id', 'website_menu')
     def _compute_website_track_proposal(self):
-        """ Propagate event_type configuration (only at change); otherwise propagate
-        website_track updated value (both together True or False at update). """
         for event in self:
-            if event.event_type_id and event.event_type_id != event._origin.event_type_id:
+            # If we activate website_menu and there is event_type, take event type value, unless exhibitor menu is already activated.
+            if event.event_type_id and (event.event_type_id != event._origin.event_type_id) or (
+                    event.website_menu and not event.website_track_proposal):
                 event.website_track_proposal = event.event_type_id.website_track_proposal
-            elif event.website_track != event._origin.website_track or not event.website_track or not event.website_track_proposal:
-                event.website_track_proposal = event.website_track
+            # If no event type, or if there is event type but exhibitor_menu is already set when setting website_menu, simply take same value as website_menu
+            else:
+                event.website_track_proposal = event.website_menu
+
+    @api.onchange('website_menu')
+    def _onchange_website_menu(self):
+        """use onchange to make sure that website_track has the correct value
+        when the user makes changes inside the form, what we want is that when
+        the user activates the website menu the website_track field to be set to
+        the value of the template, if the event is not linked
+        to a template, the value of website_track will be set to True.
+        When the menu is deactivated it should always be false"""
+        super(Event, self)._onchange_website_menu()
+        for event in self:
+            if event.website_menu and event.event_type_id:
+                event.website_track = event.event_type_id.website_track
+                event.website_track_proposal = event.event_type_id.website_track_proposal
+            else:
+                event.website_track = event.website_menu
+                event.website_track_proposal = event.website_menu
+
+    @api.onchange('event_type_id')
+    def _onchange_event_type(self):
+        """use onchange to make sure that website_track has the same value
+        as in the event type when the user makes changes inside the form"""
+        super(Event, self)._onchange_event_type()
+        for event in self:
+            if event.event_type_id:
+                event.website_track = event.event_type_id.website_track
+                event.website_track_proposal = event.event_type_id.website_track_proposal
 
     @api.depends('track_ids.tag_ids', 'track_ids.tag_ids.color')
     def _compute_tracks_tag_ids(self):
@@ -59,6 +86,16 @@ class Event(models.Model):
     # ------------------------------------------------------------
     # WEBSITE MENU MANAGEMENT
     # ------------------------------------------------------------
+
+    def toggle_website_menu(self, val):
+        super(Event, self).toggle_website_menu(val)
+        if val:
+            if self.event_type_id:
+                self.website_track = self.event_type_id.website_track
+                self.website_track_proposal = self.event_type_id.website_track_proposal
+            else:
+                self.website_track = True
+                self.website_track_proposal = True
 
     def toggle_website_track(self, val):
         self.website_track = val

--- a/addons/website_event_track/views/event_event_views.xml
+++ b/addons/website_event_track/views/event_event_views.xml
@@ -17,10 +17,10 @@
                 </button>
             </xpath>
             <xpath expr="//field[@name='website_menu']" position="after">
-                <label for="website_track" string="Showcase Tracks"/>
-                <field name="website_track"/>
+                <label for="website_track" string="Showcase Tracks" />
+                <field name="website_track" attrs="{'readonly': [('website_menu', '=', False)]}"/>
                 <label for="website_track_proposal" string="Allow Track Proposals"/>
-                <field name="website_track_proposal"/>
+                <field name="website_track_proposal" attrs="{'readonly': [('website_menu', '=', False)]}"/>
             </xpath>
         </field>
     </record>

--- a/addons/website_event_track_quiz/models/event_event.py
+++ b/addons/website_event_track_quiz/models/event_event.py
@@ -7,13 +7,46 @@ from odoo import api, fields, models
 class Event(models.Model):
     _inherit = "event.event"
 
-    @api.depends("event_type_id", "website_menu", "community_menu")
+    @api.depends('event_type_id', 'website_menu')
     def _compute_community_menu(self):
         """ At type onchange: synchronize. At website_menu update: synchronize. """
         for event in self:
-            if event.event_type_id and event.event_type_id != event._origin.event_type_id:
+            # If we activate website_menu and there is event_type, take event type value, unless exhibitor menu is already activated.
+            if event.event_type_id and (event.event_type_id != event._origin.event_type_id) or (
+                    event.website_menu and not event.community_menu):
                 event.community_menu = event.event_type_id.community_menu
-            elif event.website_menu and (event.website_menu != event._origin.website_menu or not event.community_menu):
-                event.community_menu = True
-            elif not event.website_menu:
-                event.community_menu = False
+            # If no event type, or if there is event type but exhibitor_menu is already set when setting website_menu, simply take same value as website_menu
+            else:
+                event.community_menu = event.website_menu
+
+    @api.onchange('website_menu')
+    def _onchange_website_menu_community_menu(self):
+        """use onchange to make sure that website_track has the correct value
+        when the user makes changes inside the form, what we want is that when
+        the user activates the website menu the website_track field to be set to
+        the value of the template, if the event is not linked
+        to a template, the value of website_track will be set to True.
+        When the menu is deactivated it should always be false"""
+        super(Event, self)._onchange_website_menu()
+        for event in self:
+            if event.website_menu and event.event_type_id:
+                event.community_menu = event.event_type_id.community_menu
+            else:
+                event.community_menu = event.website_menu
+
+    @api.onchange('event_type_id')
+    def _onchange_event_type(self):
+        """use onchange to make sure that website_track has the same value
+        as in the event type when the user makes changes inside the form"""
+        super(Event, self)._onchange_event_type()
+        for event in self:
+            if event.event_type_id:
+                event.community_menu = event.event_type_id.community_menu
+
+    def toggle_website_menu(self, val):
+        super(Event, self).toggle_website_menu(val)
+        if val:
+            if self.event_type_id:
+                self.community_menu = self.event_type_id.community_menu
+            else:
+                self.community_menu = self.website_menu


### PR DESCRIPTION
…t template form revamp & menu items in event form fix

This commit revamps the event template form in order to give more
clarity to the user.
It also fixes the order of the fields in the event form to be exactly
the same as in the front-end, so that the user don't get confused.

In addition, the commit fixes a bug which happens after the installation
of the website_track and website_exhibitor modules
where the website menu fields
(which are only available in developer mode) are set to true
while on the front-end they don't appear.

Task-2341656

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
