### PR TITLE
[FIX] http.py: exception handling parity in mono/multi db

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1437,7 +1437,10 @@ class Root(object):
                 except werkzeug.exceptions.HTTPException as e:
                     return request._handle_exception(e)
                 request.set_handler(func, arguments, "none")
-                result = request.dispatch()
+                try:
+                    result = request.dispatch()
+                except Exception as e:
+                    return request._handle_exception(e)
                 return result
 
             with request:


### PR DESCRIPTION
The mobile app's authentication bases its feedback to the user on the
error message returned by the server.
Sadly, in case of multi-databases, no error message are properly
returned when the user provides wrong credentials (presenting only an
empty Snackbar).

This difference of behaviour was introduced in the commit
07d5ea3 which goals was to give more power for JsonRequest's
error handling customization. To do so, the catching of the exception
(if one happens) was delegated to the caller instead of the JsonRequest
itself.

This change indirectly introduced a difference about the treatment of an
exception between mono and multi-database :
* mono-database was already catching the exception and handling it
properly (see in https://github.com/odoo/odoo/blob/f05f8ef647a4eaba49d8a20eb8068f1c7a702297/odoo/addons/base/models/ir_http.py#L235-L241).
* multi-databases didn't catch it.

This commit restores the parity between both use cases by applying the
same behaviour (as described in the commit 07d5ea3):

```python
ir_http.dispatch():
	try:
		request.dispatch()
	catch Exception as e:
		ir_http._handle_exception(e)

ir_http.handle_exception(e)
	request._handle_exception(e)
```

Steps to reproduce:

1. Open the mobile app;
2. Try to register an account with a wrong password with multiple
   databases;
3. The snackbar is empty and no error is shown => bug;

Task ID: 2287176