### PR TITLE
[FIX] mass_mailing: fix the save snippet icon look-and-feel

### DIFF
--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -853,7 +853,7 @@
 
     <div data-js="SnippetSave"
         t-att-data-selector="mailing_content_selector">
-        <we-button class="fa fa-fw fa-save"
+        <we-button class="fa fa-fw fa-save o_we_link o_we_hover_warning"
                    title="Save the block to use it elsewhere"
                    data-save-snippet=""
                    data-no-preview="true"/>


### PR DESCRIPTION
Before this commit the save snippet icon has a wrong look-and-feel.

After this commit the save snippet icon has the same look-and-feel as
the duplicate and remove icons.

Split from task-2374802

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
