### PR TITLE
[REV] web_editor, *: remove JW empty assets

### DIFF
--- a/addons/mass_mailing/views/assets.xml
+++ b/addons/mass_mailing/views/assets.xml
@@ -5,7 +5,6 @@
             <link rel="stylesheet" type="text/scss" href="/mass_mailing/static/src/scss/mass_mailing.scss"/>
             <link rel="stylesheet" type="text/scss" href="/mass_mailing/static/src/scss/mass_mailing_mobile.scss"/>
             <link rel="stylesheet" href="/mass_mailing/static/src/css/email_template.css"/>
-            <link rel="stylesheet" type="text/scss" href="/mass_mailing/static/src/scss/mass_mailing.ui.jw.scss"/>
 
             <script type="text/javascript" src="/mass_mailing/static/src/js/mass_mailing.js"></script>
             <script type="text/javascript" src="/mass_mailing/static/src/js/mass_mailing_widget.js"></script>
@@ -24,13 +23,10 @@
     <template id="assets_mail_themes_edition"> <!-- maybe to remove and convert into a field dumy with attr invisible if the template is not selected -->
         <t t-call="web._assets_helpers"/>
         <link rel="stylesheet" type="text/scss" href="/mass_mailing/static/src/scss/mass_mailing.ui.scss"/>
-        <link rel="stylesheet" type="text/scss" href="/mass_mailing/static/src/scss/mass_mailing.ui.shadow.scss"/>
         <link rel="stylesheet" type="text/scss" href="/web/static/src/scss/webclient.scss"/>
     </template>
 
     <template id="iframe_css_assets_edit" groups="base.group_user">
-        <t t-call-assets="web.assets_common" t-js="false"/>
-        <t t-call-assets="web_editor.assets_wysiwyg" t-js="false"/>
         <t t-call-assets="mass_mailing.assets_mail_themes" t-js="false"/>
         <t t-call-assets="mass_mailing.assets_mail_themes_edition" t-js="false"/>
     </template>

--- a/addons/web_editor/static/lib/summernote/src/js/enable_summernote.js
+++ b/addons/web_editor/static/lib/summernote/src/js/enable_summernote.js
@@ -1,1 +1,0 @@
-odoo.__enable_summernote__ = true;

--- a/addons/web_editor/views/editor.xml
+++ b/addons/web_editor/views/editor.xml
@@ -11,7 +11,7 @@
     <t t-call-assets="web_editor.assets_wysiwyg"/>
 </template>
 
-<template id="web_editor.assets_wysiwyg" name="Wysiwyg Editor Assets">
+<template id="assets_wysiwyg" name="Wysiwyg Editor Assets">
     <!-- lib -->
 
     <t t-call-assets="web_editor.assets_summernote"/>
@@ -41,7 +41,6 @@
     <script type="text/javascript" src="/web_editor/static/src/js/editor/rte.js"/>
     <script type="text/javascript" src="/web_editor/static/src/js/editor/rte.summernote.js"/>
     <script type="text/javascript" src="/web_editor/static/src/js/editor/image_processing.js"/>
-    <script type="text/javascript" src="/web_editor/static/src/js/editor/custom_colors.js"/>
 
     <!-- widgets & plugins -->
 
@@ -58,16 +57,13 @@
     <script type="text/javascript" src="/web_editor/static/src/js/editor/snippets.options.js"/>
 
     <!-- Launcher -->
-    <script type="text/javascript" src="/web_editor/static/lib/jabberwock/jabberwock.js"/>
-    <link rel="stylesheet" type="text/css" href="/web_editor/static/lib/jabberwock/jabberwock.css"/>
-    <script type="text/javascript" src="/web_editor/static/src/js/wysiwyg/wysiwyg_translate_attributes.js"/>
+
     <script type="text/javascript" src="/web_editor/static/src/js/wysiwyg/wysiwyg.js"/>
     <script type="text/javascript" src="/web_editor/static/src/js/wysiwyg/wysiwyg_snippets.js"/>
     <script type="text/javascript" src="/web_editor/static/src/js/wysiwyg/wysiwyg_iframe.js"/>
 </template>
 
 <template id="assets_summernote" name="Summernote">
-    <script type="text/javascript" src="/web_editor/static/lib/summernote/src/js/enable_summernote.js"/>
     <script type="text/javascript">
         (function () {
             "use strict";
@@ -76,7 +72,6 @@
             var uniqId = 0;
             odoo.__define__ = window.define;
             window.define = function (id) {
-                if (!odoo.__enable_summernote__) return;
                 var args = Array.prototype.slice.call(arguments);
                 var factorie = args.pop();
                 var id = args[0];
@@ -116,7 +111,6 @@
         window.define = odoo.__define__;
         delete odoo.__define__;
         delete odoo.website_next_define;
-        delete odoo.__enable_summernote__;
     </script>
     <link rel="stylesheet" type="text/css" href="/web_editor/static/lib/summernote/src/css/summernote.css"/>
 </template>
@@ -161,7 +155,6 @@
         <link rel="stylesheet" type="text/scss" href="/web_editor/static/src/scss/web_editor.backend.scss"/>
     </xpath>
     <xpath expr="script[last()]" position="after">
-        <script type="text/javascript" src="/web_editor/static/src/js/frontend/loader.js" />
         <script type="text/javascript" src="/web_editor/static/src/js/backend/field_html.js" />
         <script type="text/javascript" src="/web_editor/static/src/js/backend/convert_inline.js" />
     </xpath>
@@ -195,23 +188,16 @@
             odoo.define('web_editor.wysiwyg.root.test', function (require) {
                 'use strict';
                 var WysiwygRoot = require('web_editor.wysiwyg.root');
-                if (WysiwygRoot) {
-                    WysiwygRoot.include({
-                        assetLibs: null // We need to add the asset because tests performed overwrites (Dialog, Unbreakable...)
-                    });
-                }
+                WysiwygRoot.include({
+                    assetLibs: null // We need to add the asset because tests performed overwrites (Dialog, Unbreakable...)
+                });
             });
         </script>
-        <t t-call="web_editor.assets_wysiwyg"/>
+        <t t-call="web_editor.compiled_assets_wysiwyg"/>
 
         <script type="text/javascript" src="/web_editor/static/tests/test_utils.js"/>
         <script type="text/javascript" src="/web_editor/static/tests/field_html_tests.js"/>
     </xpath>
-</template>
-
-<template id="assets_edit_html_field" name="Wysiwyg Editor Assets for html field (style-inline)" groups="base.group_user,base.group_portal">
-    <t t-call-assets="web.assets_common" t-js="false"/>
-    <t t-call-assets="web_editor.assets_wysiwyg" t-js="false"/>
 </template>
 
 <!--

--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 <template id="snippets" groups="base.group_user">
-    <form class="o_we_website_top_actions d-none">
-        <button type="button" class="btn btn-primary" name="save" data-action="save" accesskey="s">Save</button>
-        <button type="button" class="btn btn-secondary" name="cancel" data-action="cancel" accesskey="j">Discard</button>
-        <button type="button" class="btn btn-secondary" name="mobile" data-action="mobile">Mobile preview</button>
-    </form>
     <div id="snippets_menu">
         <button type="button" tabindex="1" class="o_we_add_snippet_btn active text-uppercase" accesskey="1">
             <span>Blocks</span>

--- a/addons/website/views/assets.xml
+++ b/addons/website/views/assets.xml
@@ -119,7 +119,6 @@
     <link rel="stylesheet" type="text/scss" href="/website/static/src/scss/website.edit_mode.scss"/>
 
     <script type="text/javascript" src="/website/static/src/js/editor/editor.js"/>
-    <script type="text/javascript" src="/website/static/src/js/editor/mega_menu.js"/>
     <script type="text/javascript" src="/website/static/src/js/editor/snippets.editor.js"/>
     <script type="text/javascript" src="/website/static/src/js/editor/rte.summernote.js"/>
     <script type="text/javascript" src="/website/static/src/js/editor/snippets.options.js"/>


### PR DESCRIPTION
*: mass_mailing, website

The revert of Jabberwock at [1] was made reverting all the commits
that happened during and after the Jabberwock merge. This missed a
preparation commit [2] which added empty asset files a few days earlier.
This reverts that commit.

[1]: https://github.com/odoo/odoo/commit/e5572c317a7775a58675ed73efc89b5c9f6c0c39
[2]: https://github.com/odoo/odoo/commit/55f10ac9a0bb574a893e84c3ee6237e1d439750b
