### PR TITLE
[FIX] point_of_sale: change pricelist remove price extra (variant)

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -2955,7 +2955,7 @@ exports.Order = Backbone.Model.extend({
             return ! line.price_manually_set;
         });
         _.each(lines_to_recompute, function (line) {
-            line.set_unit_price(line.product.get_price(self.pricelist, line.get_quantity()));
+            line.set_unit_price(line.product.get_price(self.pricelist, line.get_quantity()) + line.get_price_extra());
             self.fix_tax_included_price(line);
         });
         this.trigger('change');


### PR DESCRIPTION
Create a product with variants attributes that NEVER create variants.
Configure Variants to add some extra-prices to some variants.
In POS settings activate "Product Configurator" and
"Advanced Pricelists", add the public pricelist and one that applies 5% to
the product.

Open a session and select the product created (say price = 1$)
Select the attributes, the extra-price is added to the product (say the
total price now is 2$).
Change pricelist from public to 5% and the order line will show our
product = 0.95, not taking the extra-prices into account (so not 1.9,
i.e. 5% of the 2$ that were formerly displayed)

opw-2439445

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
