### PR TITLE
[FIX] base: allow space in SMTP login username

### DIFF
--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -236,8 +236,9 @@ class IrMailServer(models.Model):
         if smtp_user:
             # Attempt authentication - will raise if AUTH service not supported
             local, at, domain = smtp_user.rpartition('@')
-            domain = idna.encode(domain).decode('ascii')
-            connection.login(f"{local}{at}{domain}", smtp_password or '')
+            if at:
+                smtp_user = local + at + idna.encode(domain).decode('ascii')
+            connection.login(smtp_user, smtp_password or '')
 
         # Some methods of SMTP don't check whether EHLO/HELO was sent.
         # Anyway, as it may have been sent by login(), all subsequent usages should consider this command as sent.


### PR DESCRIPTION
Configure an email server and create a login account with a space like
"foo bar". In odoo configure an Outgoing mail server using that account,
there is an error because the username is misconsidered invalid.

The errors resides in the IDNA implementation of Odoo, we try to split
the username to get a login and a domain in order to encode the domain
using the ponycode algorithm. In case the username was not an email
adress but just a single name, the single name was mistaken for a
domain. As domain cannot have spaces, an error was thrown.

opw-2419024
