### PR TITLE
[FIX] hr_attendance: user can see other users attendances

### DIFF
--- a/addons/hr_attendance/security/hr_attendance_security.xml
+++ b/addons/hr_attendance/security/hr_attendance_security.xml
@@ -59,10 +59,10 @@
         </record>
 
         <record id="hr_attendance_rule_attendance_employee" model="ir.rule">
-            <field name="name">user: modify own attendance only</field>
+            <field name="name">user: read and modify own attendance only</field>
             <field name="model_id" ref="model_hr_attendance"/>
             <field name="domain_force">[('employee_id.user_id','=',user.id)]</field>
-            <field name="perm_read" eval="0"/>
+            <field name="perm_read" eval="1"/>
             <field name="perm_write" eval="1"/>
             <field name="perm_create" eval="1"/>
             <field name="perm_unlink" eval="0"/>

--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -152,7 +152,7 @@
         <field name="name">Attendances</field>
         <field name="res_model">hr.attendance</field>
         <field name="view_mode">tree,form</field>
-        <field name="context">{'search_default_employee_id': active_id, 'default_employee_id': active_id, 'create': False}</field>
+        <field name="context">{'create': False}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_empty_folder">
                 No attendance records to display

--- a/addons/hr_attendance/views/hr_employee_view.xml
+++ b/addons/hr_attendance/views/hr_employee_view.xml
@@ -21,7 +21,8 @@
                         '|', ('attendance_state', '=', False),
                         '&amp;',
                             ('hr_presence_state', '=', 'present'),
-                            ('attendance_state', '=', 'checked_out')]}">
+                            ('attendance_state', '=', 'checked_out')]}"
+                    context="{'search_default_employee_id': id}">
                     <div role="img" id="oe_hr_attendance_status" class="fa fa-fw fa-circle o_button_icon oe_hr_attendance_status_green" attrs="{'invisible': [('attendance_state', '=', 'checked_out')]}" aria-label="Available" title="Available"/>
                     <div role="img" id="oe_hr_attendance_status" class="fa fa-fw fa-circle o_button_icon oe_hr_attendance_status_red" attrs="{'invisible': [('attendance_state', '=', 'checked_in')]}" aria-label="Not available" title="Not available"/>
                     <div class="o_stat_info" attrs="{'invisible': ['|', ('last_check_in', '=', False), ('last_check_out', '!=', False)]}">
@@ -40,7 +41,7 @@
                         class="oe_stat_button"
                         icon="fa-clock-o"
                         type="action"
-                        context="{'search_default_employee_id': active_id, 'search_default_check_in_filter': '1'}"
+                        context="{'search_default_employee_id': id, 'search_default_check_in_filter': '1'}"
                         groups="base.group_user"
                         help="Worked hours last month">
                     <div class="o_field_widget o_stat_info">
@@ -90,7 +91,7 @@
             </xpath>
             <xpath expr="//div[@name='button_box']" position="inside">
                 <field name="employee_ids" invisible="1"/>
-                <button name="%(hr_attendance_action)d"
+                <button name="%(hr_attendance_action_employee)d"
                         class="oe_stat_button"
                         icon="fa-calendar"
                         type="action"


### PR DESCRIPTION
Steps:
- As admin, go to Settings > Users & Companies > Users
- Edit Mark Demo (demo)
- In Human Resources > Attendances, select Manual Attendance or blank
- As demo, go to My Profile
- Click the smart button showing the hours worked for the last month
- Remove all filters

Bug:
The demo user, who hasn't the rights to see the other employees
attendances, can see them.

Explanation:
Every user must have the right to read attendances in order to see their
own attendances. Not giving the users the read rights in the security
record rule prevents the record rule from being applied when reading
attendances. This makes the read access rights the only rule and allows
everyone to see the attendances of the others.

This commit also fixes the default selected employee when going to the
attendances tree view on these paths:
- User
- Employee
- User > Employee

In fact, sometime, `active_id` is the ÌD of the user and not of the
employee. This leads to incorrect results since another employee's
attendances are shown.

Finally, this commit prevents users from creating attendances from other
apps since only attendance officers and above can have access to the
creation form within the Attendances app.

opw:2440117