### PR TITLE
[FIX] purchase_product_matrix,sale_product_matrix: not lose warn msg

### DIFF
--- a/addons/purchase_product_matrix/models/purchase.py
+++ b/addons/purchase_product_matrix/models/purchase.py
@@ -98,10 +98,12 @@ class PurchaseOrder(models.Model):
                         product_no_variant_attribute_value_ids=no_variant_attribute_values.ids)
                     ))
             if new_lines:
+                res = False
                 self.update(dict(order_line=new_lines))
                 for line in self.order_line.filtered(lambda line: line.product_template_id == product_template):
-                    line._product_id_change()
+                    res = line._product_id_change() or res
                     line._onchange_quantity()
+                return res
 
     def _get_matrix(self, product_template):
         def has_ptavs(line, sorted_attr_ids):

--- a/addons/sale_product_matrix/models/sale_order.py
+++ b/addons/sale_product_matrix/models/sale_order.py
@@ -106,12 +106,13 @@ class SaleOrder(models.Model):
                         product_no_variant_attribute_value_ids=no_variant_attribute_values.ids)
                     ))
             if new_lines:
+                res = False
                 self.update(dict(order_line=new_lines))
                 for line in self.order_line.filtered(lambda line: line.product_template_id == product_template):
-                    line.product_id_change()
+                    res = line.product_id_change() or res
                     line._onchange_discount()
                     line._onchange_product_id_set_customer_lead()
-                    
+                return res
 
     def _get_matrix(self, product_template):
         """Return the matrix of the given product, updated with current SOLines quantities.


### PR DESCRIPTION
Set up a DEMO product with
- warning message on sale
- variant
- Order Grid Entry as Sales Variant Selection

Create SO, configure this product

Warning message doesn't display

opw-2442352

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
