### PR TITLE
[IMP] *: adds generic user avatar with images

### DIFF
--- a/addons/calendar/static/tests/calendar_tests.js
+++ b/addons/calendar/static/tests/calendar_tests.js
@@ -79,7 +79,7 @@ QUnit.module('calendar', {
             "should have img tag");
         assert.hasAttrValue(form.$('.o_field_many2manytags.avatar.o_field_widget .badge:first img'),
             'data-src',
-            '/web/image/partner/1/image_128',
+            '/web/avatar/partner/1/image_128',
             "should have correct avatar image");
 
         form.destroy();

--- a/addons/hr/static/tests/many2one_avatar_employee_tests.js
+++ b/addons/hr/static/tests/many2one_avatar_employee_tests.js
@@ -155,10 +155,10 @@ QUnit.module('hr', {}, function () {
 
         assert.strictEqual(kanban.$('.o_kanban_record').text().trim(), '');
         assert.containsN(kanban, '.o_m2o_avatar', 4);
-        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(0)').data('src'), '/web/image/hr.employee.public/11/image_128');
-        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(1)').data('src'), '/web/image/hr.employee.public/7/image_128');
-        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(2)').data('src'), '/web/image/hr.employee.public/11/image_128');
-        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(3)').data('src'), '/web/image/hr.employee.public/23/image_128');
+        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(0)').data('src'), '/web/avatar/hr.employee.public/11/image_128');
+        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(1)').data('src'), '/web/avatar/hr.employee.public/7/image_128');
+        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(2)').data('src'), '/web/avatar/hr.employee.public/11/image_128');
+        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(3)').data('src'), '/web/avatar/hr.employee.public/23/image_128');
 
         kanban.destroy();
     });

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -73,7 +73,7 @@
                             </button>
                         </div>
                         <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
-                        <field name="image_1920" widget='image' class="oe_avatar" options='{"zoom": true, "preview_image":"image_128"}'/>
+                        <field name="image_1920" widget='image' class="oe_avatar" options='{"zoom": true, "preview_image":"image_128", "placeholder":"/base/static/img/avatar_grey.png"}'/>
                         <div class="oe_title">
                             <h1 class="d-flex">
                                 <field name="name" placeholder="Employee's Name" required="True"/>

--- a/addons/hr_org_chart/static/src/xml/hr_org_chart.xml
+++ b/addons/hr_org_chart/static/src/xml/hr_org_chart.xml
@@ -10,13 +10,13 @@
                 use bg-images to get a clean and centred images -->
             <a t-if="! is_self"
                 class="o_media_object rounded-circle o_employee_redirect"
-                t-att-style="'background-image:url(\'/web/image/hr.employee.public/' + employee.id + '/image_1024/\')'"
+                t-att-style="'background-image:url(\'/web/avatar/hr.employee.public/' + employee.id + '/image_1024/\')'"
                 t-att-alt="employee.name"
                 t-att-data-employee-id="employee.id"
                 t-att-href="employee.link"/>
             <div t-if="is_self"
                 class="o_media_object rounded-circle"
-                t-att-style="'background-image:url(\'/web/image/hr.employee.public/' + employee.id + '/image_1024/\')'"/>
+                t-att-style="'background-image:url(\'/web/avatar/hr.employee.public/' + employee.id + '/image_1024/\')'"/>
         </div>
 
         <div class="media-body">
@@ -151,7 +151,7 @@
 
 <t t-name="hr_orgchart_emp_popover_title">
     <div>
-        <span t-att-style='"background-image:url(\"/web/image/hr.employee.public/" + employee.id + "/image_1024/\")"'/>
+        <span t-att-style='"background-image:url(\"/web/avatar/hr.employee.public/" + employee.id + "/image_1024/\")"'/>
         <a href="#" class="float-right o_employee_redirect" t-att-data-employee-id="employee.id"><i class="fa fa-external-link" role="img" aria-label='Redirect' title="Redirect"></i></a>
         <b><t t-esc="employee.name"/></b>
     </div>

--- a/addons/hr_recruitment/data/mail_template_data.xml
+++ b/addons/hr_recruitment/data/mail_template_data.xml
@@ -88,7 +88,7 @@
                     <table>
                         <tr>
                             <td width="75">
-                                <img src="/web/image/res.users/${object.user_id.id}/image_128" alt="Avatar" style="vertical-align:baseline; width: 64px; height: 64px; object-fit: cover;" />
+                                <img src="/web/avatar/res.users/${object.user_id.id}/image_128" alt="Avatar" style="vertical-align:baseline; width: 64px; height: 64px; object-fit: cover;" />
                             </td>
                             <td>
                                 <strong>${object.user_id.name}</strong><br/>
@@ -189,7 +189,7 @@
                     <table>
                         <tr>
                             <td width="75">
-                                <img src="/web/image/res.users/${object.user_id.id}/image_128" alt="Avatar" style="vertical-align:baseline; width: 64px; height: 64px; object-fit: cover;" />
+                                <img src="/web/avatar/res.users/${object.user_id.id}/image_128" alt="Avatar" style="vertical-align:baseline; width: 64px; height: 64px; object-fit: cover;" />
                             </td>
                             <td>
                                 <strong>${object.user_id.name}</strong><br/>

--- a/addons/im_livechat/static/src/legacy/public_livechat.js
+++ b/addons/im_livechat/static/src/legacy/public_livechat.js
@@ -1631,7 +1631,7 @@ var AbstractMessage = Class.extend({
      */
     getAvatarSource: function () {
         if (this.hasAuthor()) {
-            return '/web/image/res.partner/' + this.getAuthorID() + '/image_128';
+            return '/web/avatar/res.partner/' + this.getAuthorID() + '/image_128';
         }
     },
     /**

--- a/addons/lunch/controllers/main.py
+++ b/addons/lunch/controllers/main.py
@@ -91,7 +91,7 @@ class LunchController(http.Controller):
 
         res.update({
             'username': user.sudo().name,
-            'userimage': '/web/image?model=res.users&id=%s&field=image_128' % user.id,
+            'userimage': '/web/avatar/res.users/%s/image_128' % user.id,
             'wallet': request.env['lunch.cashmove'].get_wallet_balance(user, False),
             'is_manager': is_manager,
             'locations': request.env['lunch.location'].search_read([], ['name']),

--- a/addons/mail/static/src/components/activity/activity.js
+++ b/addons/mail/static/src/components/activity/activity.js
@@ -68,6 +68,13 @@ class Activity extends Component {
     /**
      * @returns {string}
      */
+    get avatarUrl() {
+        return `/web/avatar/res.users/${this.activity.assignee.id}/image_128`
+    }
+
+    /**
+     * @returns {string}
+     */
     get delayLabel() {
         const today = moment().startOf('day');
         const momentDeadlineDate = moment(auto_str_to_date(this.activity.dateDeadline));

--- a/addons/mail/static/src/components/activity/activity.scss
+++ b/addons/mail/static/src/components/activity/activity.scss
@@ -24,9 +24,13 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 25px;
-    height: 25px;
+    width: 20px;
+    height: 20px;
     border-width: 2px;
+}
+
+.o_Activity_icon {
+    font-size: 9px;
 }
 
 .o_Activity_info {

--- a/addons/mail/static/src/components/activity/activity.xml
+++ b/addons/mail/static/src/components/activity/activity.xml
@@ -7,7 +7,7 @@
                 <div class="o_Activity_sidebar">
                     <div class="o_Activity_user">
                         <t t-if="activity.assignee">
-                            <img class="o_Activity_userAvatar" t-attf-src="/web/image/res.users/{{ activity.assignee.id }}/image_128" t-att-alt="activity.assignee.nameOrDisplayName"/>
+                            <img class="o_Activity_userAvatar" t-attf-src="{{avatarUrl}}" t-att-alt="activity.assignee.nameOrDisplayName"/>
                         </t>
                         <div class="o_Activity_iconContainer"
                             t-att-class="{
@@ -65,7 +65,7 @@
                                     <dt>Created</dt>
                                     <dd class="o_Activity_detailsCreation">
                                         <t t-esc="formattedCreateDatetime"/>
-                                        <img class="o_Activity_detailsUserAvatar o_Activity_detailsCreatorAvatar" t-attf-src="/web/image/res.users/{{ activity.creator.id }}/image_128" t-att-title="activity.creator.nameOrDisplayName" t-att-alt="activity.creator.nameOrDisplayName"/>
+                                        <img class="o_Activity_detailsUserAvatar o_Activity_detailsCreatorAvatar" t-attf-src="/web/avatar/res.users/{{ activity.creator.id }}/image_128" t-att-title="activity.creator.nameOrDisplayName" t-att-alt="activity.creator.nameOrDisplayName"/>
                                         <span class="o_Activity_detailsCreator">
                                             <t t-esc="activity.creator.nameOrDisplayName"/>
                                         </span>
@@ -74,7 +74,7 @@
                                 <t t-if="activity.assignee">
                                     <dt>Assigned to</dt>
                                     <dd class="o_Activity_detailsAssignation">
-                                        <img class="o_Activity_detailsUserAvatar o_Activity_detailsAssignationUserAvatar" t-attf-src="/web/image/res.users/{{ activity.assignee.id }}/image_128" t-att-title="activity.assignee.nameOrDisplayName" t-att-alt="activity.assignee.nameOrDisplayName"/>
+                                        <img class="o_Activity_detailsUserAvatar o_Activity_detailsAssignationUserAvatar" t-attf-src="/web/avatar/res.users/{{ activity.assignee.id }}/image_128" t-att-title="activity.assignee.nameOrDisplayName" t-att-alt="activity.assignee.nameOrDisplayName"/>
                                         <t t-esc="activity.assignee.nameOrDisplayName"/>
                                     </dd>
                                 </t>

--- a/addons/mail/static/src/components/composer/composer.js
+++ b/addons/mail/static/src/components/composer/composer.js
@@ -123,11 +123,7 @@ class Composer extends Component {
      */
     get currentPartnerAvatar() {
         const avatar = this.env.messaging.currentUser
-            ? this.env.session.url('/web/image', {
-                    field: 'image_128',
-                    id: this.env.messaging.currentUser.id,
-                    model: 'res.users',
-                })
+            ? this.env.session.url(`/web/avatar/res.users/${this.env.messaging.currentUser.id}/image_128`)
             : '/web/static/src/img/user_menu_avatar.png';
         return avatar;
     }

--- a/addons/mail/static/src/components/discuss/tests/discuss_tests.js
+++ b/addons/mail/static/src/components/discuss/tests/discuss_tests.js
@@ -1323,7 +1323,7 @@ QUnit.test('basic rendering of message', async function (assert) {
     );
     assert.strictEqual(
         message.querySelector(`:scope .o_Message_authorAvatar`).dataset.src,
-        "/web/image/res.partner/11/image_128",
+        "/web/avatar/res.partner/11/image_128",
         "should have url of message in author avatar sidebar"
     );
     assert.strictEqual(

--- a/addons/mail/static/src/components/follower/follower.xml
+++ b/addons/mail/static/src/components/follower/follower.xml
@@ -5,7 +5,7 @@
         <div class="o_Follower">
             <t t-if="follower">
                 <a class="o_Follower_details" t-att-class="{ 'o-inactive': !follower.isActive }" href="#" t-on-click="_onClickDetails">
-                    <img class="o_Follower_avatar" t-att-src="follower.partner.avatarUrl" alt="Avatar"/>
+                    <img class="o_Follower_avatar" t-attf-src="/web/avatar/{{ follower.resModel }}/{{ follower.resId }}/image_128" alt="Avatar"/>
                     <span class="o_Follower_name" t-esc="follower.name"/>
                 </a>
                 <t t-if="follower.isEditable">

--- a/addons/mail/static/src/components/message/message_tests.js
+++ b/addons/mail/static/src/components/message/message_tests.js
@@ -88,7 +88,7 @@ QUnit.test('basic rendering', async function (assert) {
     );
     assert.strictEqual(
         messageEl.querySelector(`:scope .o_Message_authorAvatar`).dataset.src,
-        '/web/image/res.partner/7/image_128',
+        '/web/avatar/res.partner/7/image_128',
         "message author avatar should GET image of the related partner"
     );
     assert.strictEqual(

--- a/addons/mail/static/src/js/views/activity/activity_record.js
+++ b/addons/mail/static/src/js/views/activity/activity_record.js
@@ -57,6 +57,37 @@ var ActivityRecord = KanbanRecord.extend({
             widget: this,
         };
     },
+        /**
+     * @private
+     * @param {string} model the name of the model
+     * @param {string} field the name of the field
+     * @param {integer} id the id of the resource
+     * @param {string} placeholder
+     * @returns {string} the url of the image
+     */
+    _getImageURL: function (model, field, id, placeholder) {
+        id = (_.isArray(id) ? id[0] : id) || null;
+        var isCurrentRecord = this.modelName === model && this.recordData.id === id;
+        var url;
+        if (isCurrentRecord && this.record[field] && this.record[field].raw_value && !utils.is_bin_size(this.record[field].raw_value)) {
+            // Use magic-word technique for detecting image type
+            url = 'data:image/' + this.file_type_magic_word[this.record[field].raw_value[0]] + ';base64,' + this.record[field].raw_value;
+        } else {
+            var session = this.getSession();
+            var params = {
+                model: model,
+                field: field,
+                id: id
+            };
+            if (isCurrentRecord) {
+                params.unique = this.record.__last_update && this.record.__last_update.value.replace(/[^0-9]/g, '');
+            }
+            url = params.unique ?
+                session.url(`/web/avatar/${model}/${id}/${field}?unique=${params.unique}`) :
+                session.url(`/web/avatar/${model}/${id}/${field}`)
+        }
+        return url;
+    },
 });
 return ActivityRecord;
 });

--- a/addons/mail/static/src/models/partner/partner.js
+++ b/addons/mail/static/src/models/partner/partner.js
@@ -374,7 +374,7 @@ function factory(dependencies) {
             if (this === this.env.messaging.partnerRoot) {
                 return '/mail/static/src/img/odoobot.png';
             }
-            return `/web/image/res.partner/${this.id}/image_128`;
+            return `/web/avatar/res.partner/${this.id}/image_128`;
         }
 
         /**

--- a/addons/mail/static/tests/many2one_avatar_user_tests.js
+++ b/addons/mail/static/tests/many2one_avatar_user_tests.js
@@ -112,10 +112,10 @@ QUnit.module('mail', {}, function () {
 
         assert.strictEqual(kanban.$('.o_kanban_record').text().trim(), '');
         assert.containsN(kanban, '.o_m2o_avatar', 4);
-        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(0)').data('src'), '/web/image/res.users/11/image_128');
-        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(1)').data('src'), '/web/image/res.users/7/image_128');
-        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(2)').data('src'), '/web/image/res.users/11/image_128');
-        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(3)').data('src'), '/web/image/res.users/23/image_128');
+        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(0)').data('src'), '/web/avatar/res.users/11/image_128');
+        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(1)').data('src'), '/web/avatar/res.users/7/image_128');
+        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(2)').data('src'), '/web/avatar/res.users/11/image_128');
+        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(3)').data('src'), '/web/avatar/res.users/23/image_128');
 
         kanban.destroy();
     });

--- a/addons/portal/static/src/xml/portal_chatter.xml
+++ b/addons/portal/static/src/xml/portal_chatter.xml
@@ -32,7 +32,7 @@
                     Oops! Something went wrong. Try to reload the page and log in.
                 </div>
                 <div class="media">
-                    <img alt="Avatar" class="o_portal_chatter_avatar" t-attf-src="/web/image/res.partner/#{widget.options['partner_id']}/image_128/50x50"
+                    <img alt="Avatar" class="o_portal_chatter_avatar" t-attf-src="/web/avatar/res.partner/#{widget.options['partner_id']}/image_128/"
                          t-if="!widget.options['is_user_public'] or !widget.options['token']"/>
                     <div class="media-body">
                         <div class="o_portal_chatter_composer_input">

--- a/addons/purchase/views/portal_templates.xml
+++ b/addons/purchase/views/portal_templates.xml
@@ -103,8 +103,8 @@
                   </div>
                   <div class="row flex-nowrap">
                     <div class="col flex-grow-0 pr-2">
-                      <img class="rounded-circle mr4 float-left o_portal_contact_img" t-if="purchase_order.user_id.image_1024" t-att-src="image_data_uri(purchase_order.user_id.image_1024)" alt="Contact"/>
-                      <img class="rounded-circle mr4 float-left o_portal_contact_img" t-if="not purchase_order.user_id.image_1024" src="/web/static/src/img/placeholder.png" alt="Contact"/>
+                      <img class="rounded-circle mr4 float-left o_portal_contact_img" t-if="purchase_order.user_id.id" t-att-src="'/web/avatar/res.users/%s/image_1024' % purchase_order.user_id.id" alt="Contact"/>
+                      <img class="rounded-circle mr4 float-left o_portal_contact_img" t-if="not purchase_order.user_id.id" src="/web/static/src/img/placeholder.png" alt="Contact"/>
                     </div>
                     <div class="col pl-0" style="min-width: 150px">
                       <span t-field="purchase_order.user_id" t-options='{"widget": "contact", "fields": ["name", "phone"], "no_marker": True}'/>

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -180,8 +180,8 @@
                                 <div class="small mb-1"><strong class="text-muted">Salesperson</strong></div>
                                 <div class="row flex-nowrap">
                                     <div class="col flex-grow-0 pr-2">
-                                        <img class="rounded-circle mr4 float-left o_portal_contact_img" t-if="sale_order.user_id.image_1024" t-att-src="image_data_uri(sale_order.user_id.image_1024)" alt="Contact"/>
-                                        <img class="rounded-circle mr4 float-left o_portal_contact_img" t-if="not sale_order.user_id.image_1024" src="/web/static/src/img/placeholder.png" alt="Contact"/>
+                                        <img class="rounded-circle mr4 float-left o_portal_contact_img" t-if="sale_order.user_id.id" t-att-src="'/web/avatar/res.users/%s/image_1024' % sale_order.user_id.id" alt="Contact"/>
+                                        <img class="rounded-circle mr4 float-left o_portal_contact_img" t-if="not sale_order.user_id.id" src="/web/static/src/img/placeholder.png" alt="Contact"/>
                                     </div>
                                     <div class="col pl-0" style="min-width: 150px">
                                         <span t-field="sale_order.user_id" t-options='{"widget": "contact", "fields": ["name", "phone"], "no_marker": True}'/>

--- a/addons/web/static/src/js/chrome/user_menu.js
+++ b/addons/web/static/src/js/chrome/user_menu.js
@@ -44,11 +44,7 @@ var UserMenu = Widget.extend({
                 topbar_name = _.str.sprintf("%s (%s)", topbar_name, session.db);
             }
             self.$('.oe_topbar_name').text(topbar_name);
-            var avatar_src = session.url('/web/image', {
-                model:'res.users',
-                field: 'image_128',
-                id: session.uid,
-            });
+            var avatar_src = session.url(`/web/avatar/res.users/${session.uid}/image_128`);
             $avatar.attr('src', avatar_src);
         });
     },

--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -1940,7 +1940,6 @@ var FieldBinaryImage = AbstractFieldBinary.extend({
     fieldDependencies: _.extend({}, AbstractFieldBinary.prototype.fieldDependencies, {
         __last_update: {type: 'datetime'},
     }),
-
     template: 'FieldBinaryImage',
     placeholder: "/web/static/src/img/placeholder.png",
     events: _.extend({}, AbstractFieldBinary.prototype.events, {
@@ -1979,7 +1978,7 @@ var FieldBinaryImage = AbstractFieldBinary.extend({
     },
     _render: function () {
         var self = this;
-        var url = this.placeholder;
+        var url = this.attrs.options.placeholder || this.recordData.default_partner_image || this.placeholder;
         if (this.value) {
             if (!utils.is_bin_size(this.value)) {
                 // Use magic-word technique for detecting image type

--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -1034,7 +1034,7 @@ const Many2OneAvatar = FieldMany2One.extend({
         this.$el.empty();
         if (this.value) {
             this.$el.html(qweb.render(this._template, {
-                url: `/web/image/${this.field.relation}/${this.value.res_id}/image_128`,
+                url: `/web/avatar/${this.field.relation}/${this.value.res_id}/image_128`,
                 value: this.m2o_value,
             }));
         }

--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -1307,7 +1307,7 @@
 </t>
 <t t-name="FieldMany2ManyTagAvatar" t-extend="FieldMany2ManyTag">
     <t t-jquery="span:first" t-operation="prepend">
-        <img t-attf-src="/web/image/#{avatarModel}/#{el.id}/#{avatarField}" class="rounded-circle"/>
+        <img t-attf-src="/web/avatar/#{avatarModel}/#{el.id}/#{avatarField}" class="rounded-circle"/>
     </t>
 </t>
 <t t-name="FieldMany2ManyTag.colorpicker">

--- a/addons/web/static/src/xml/web_calendar.xml
+++ b/addons/web/static/src/xml/web_calendar.xml
@@ -78,7 +78,7 @@
                                 <i class="fa fa-check position-relative"/>
                             </span>
                             <i t-if="filter.value == 'all'" class="o_cw_filter_avatar fa fa-users fa-fw  flex-shrink-0 mr-1" role="img" aria-label="Avatar" title="Avatar"/>
-                            <img t-elif="widget.avatar_field and filter.value" t-attf-src="/web/image/#{widget.avatar_model}/#{filter.value}/#{widget.avatar_field}" class="o_cw_filter_avatar flex-shrink-0 mr-1" alt="Avatar"/>
+                            <img t-elif="widget.avatar_field and filter.value" t-attf-src="/web/avatar/#{widget.avatar_model}/#{filter.value}/#{widget.avatar_field}" class="o_cw_filter_avatar flex-shrink-0 mr-1" alt="Avatar"/>
                             <span class="o_cw_filter_title text-truncate flex-grow" t-esc="filter.label" t-attf-title="#{ ['all', false].includes(filter.value) or !widget.avatar_field ? filter.label : '' }"/>
                         </label>
 

--- a/addons/web/static/tests/fields/relational_fields/field_many2one_tests.js
+++ b/addons/web/static/tests/fields/relational_fields/field_many2one_tests.js
@@ -3563,7 +3563,7 @@ QUnit.module('fields', {}, function () {
 
             assert.hasClass(form.$('.o_form_view'), 'o_form_readonly');
             assert.strictEqual(form.$('.o_field_widget[name=user_id]').text().trim(), 'Aline');
-            assert.containsOnce(form, 'img.o_m2o_avatar[data-src="/web/image/user/17/image_128"]');
+            assert.containsOnce(form, 'img.o_m2o_avatar[data-src="/web/avatar/user/17/image_128"]');
 
             await testUtils.form.clickEdit(form);
 
@@ -3578,7 +3578,7 @@ QUnit.module('fields', {}, function () {
 
             assert.hasClass(form.$('.o_form_view'), 'o_form_readonly');
             assert.strictEqual(form.$('.o_field_widget[name=user_id]').text().trim(), 'Christine');
-            assert.containsOnce(form, 'img.o_m2o_avatar[data-src="/web/image/user/19/image_128"]');
+            assert.containsOnce(form, 'img.o_m2o_avatar[data-src="/web/avatar/user/19/image_128"]');
 
             form.destroy();
         });
@@ -3610,12 +3610,12 @@ QUnit.module('fields', {}, function () {
 
             assert.hasClass(form.$('.o_form_view'), 'o_form_editable');
             assert.strictEqual(form.$('.o_field_widget[name=user_id]').text().trim(), 'Aline');
-            assert.containsOnce(form, 'img.o_m2o_avatar[data-src="/web/image/user/17/image_128"]');
+            assert.containsOnce(form, 'img.o_m2o_avatar[data-src="/web/avatar/user/17/image_128"]');
 
             await testUtils.fields.editInput(form.$('.o_field_widget[name=int_field]'), 1);
 
             assert.strictEqual(form.$('.o_field_widget[name=user_id]').text().trim(), 'Christine');
-            assert.containsOnce(form, 'img.o_m2o_avatar[data-src="/web/image/user/19/image_128"]');
+            assert.containsOnce(form, 'img.o_m2o_avatar[data-src="/web/avatar/user/19/image_128"]');
 
             await testUtils.fields.editInput(form.$('.o_field_widget[name=int_field]'), 2);
 
@@ -3642,9 +3642,9 @@ QUnit.module('fields', {}, function () {
             });
 
             assert.strictEqual(list.$('.o_data_cell span').text(), 'AlineChristineAline');
-            assert.containsOnce(list.$('.o_data_cell:nth(0)'), 'img.o_m2o_avatar[data-src="/web/image/user/17/image_128"]');
-            assert.containsOnce(list.$('.o_data_cell:nth(1)'), 'img.o_m2o_avatar[data-src="/web/image/user/19/image_128"]');
-            assert.containsOnce(list.$('.o_data_cell:nth(2)'), 'img.o_m2o_avatar[data-src="/web/image/user/17/image_128"]');
+            assert.containsOnce(list.$('.o_data_cell:nth(0)'), 'img.o_m2o_avatar[data-src="/web/avatar/user/17/image_128"]');
+            assert.containsOnce(list.$('.o_data_cell:nth(1)'), 'img.o_m2o_avatar[data-src="/web/avatar/user/19/image_128"]');
+            assert.containsOnce(list.$('.o_data_cell:nth(2)'), 'img.o_m2o_avatar[data-src="/web/avatar/user/17/image_128"]');
             assert.containsNone(list.$('.o_data_cell:nth(3)'), 'img.o_m2o_avatar');
 
             list.destroy();

--- a/addons/web/static/tests/fields/relational_fields_tests.js
+++ b/addons/web/static/tests/fields/relational_fields_tests.js
@@ -2007,7 +2007,7 @@ QUnit.module('relational_fields', {
         });
 
         assert.containsN(form, '.o_field_many2manytags.avatar.o_field_widget .badge', 2, "should have 2 records");
-        assert.strictEqual(form.$('.o_field_many2manytags.avatar.o_field_widget .badge:first img').data('src'), '/web/image/partner/2/image_128',
+        assert.strictEqual(form.$('.o_field_many2manytags.avatar.o_field_widget .badge:first img').data('src'), '/web/avatar/partner/2/image_128',
             "should have correct avatar image");
 
         form.destroy();

--- a/addons/website_blog/static/src/js/website_blog.editor.js
+++ b/addons/website_blog/static/src/js/website_blog.editor.js
@@ -168,7 +168,7 @@ options.registry.many2one.include({
                 var $img = $(this).find('img');
                 var css = window.getComputedStyle($img[0]);
                 $img.css({ width: css.width, height: css.height });
-                $img.attr('src', '/web/image/res.partner/'+self.ID+'/image_1024');
+                $img.attr('src', '/web/avatar/res.partner/'+self.ID+'/image_1024');
             });
             setTimeout(function () { $nodes.removeClass('o_dirty'); },0);
         }

--- a/addons/website_livechat/views/website_visitor_views.xml
+++ b/addons/website_livechat/views/website_visitor_views.xml
@@ -41,7 +41,7 @@
                     Speaking With
                     <div name="livechat_operator_id"
                          class="o_field_many2one_avatar o_field_widget font-weight-bold float-right d-inline-block">
-                        <img t-attf-src="/web/image/res.partner/#{record.livechat_operator_id.raw_value}/image_128"
+                        <img t-attf-src="/web/avatar/res.partner/#{record.livechat_operator_id.raw_value}/image_128"
                              alt="Operator Avatar" class="o_m2o_avatar"/>
                         <field name="livechat_operator_name"/>
                     </div>
@@ -60,7 +60,7 @@
                 <div class="col mx-2">
                     <div t-if="record.livechat_operator_id.raw_value"
                          class="o_field_many2one_avatar o_field_widget font-weight-bold" name="livechat_operator_id">
-                        <img t-attf-src="/web/image/res.partner/#{record.livechat_operator_id.raw_value}/image_128"
+                        <img t-attf-src="/web/avatar/res.partner/#{record.livechat_operator_id.raw_value}/image_128"
                              alt="Operator Avatar" class="o_m2o_avatar"/>
                         <field name="livechat_operator_name"/>
                     </div>

--- a/odoo/addons/base/controllers/__init__.py
+++ b/odoo/addons/base/controllers/__init__.py
@@ -1,1 +1,2 @@
 from . import rpc
+from . import avatar

--- a/odoo/addons/base/controllers/avatar.py
+++ b/odoo/addons/base/controllers/avatar.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from hashlib import sha1
+
+from odoo.http import Controller, request, route, Response, local_redirect
+from odoo import tools
+
+class Avatar(Controller):
+    @route([
+        '/web/avatar/<string:res_model>/<int:user_id>',
+        '/web/avatar/<string:res_model>/<int:user_id>/<string:field>'
+    ], auth='public', methods=['GET'])
+    def get_avatar(self, res_model='res.users', user_id=1, field='image_128', **kwargs):
+        """
+        Returns a custom avatar based on the user's data
+            res_model: corresponding model
+            user_id: user id
+            field: image field
+        """
+        if res_model not in ['res.users', 'res.partner', 'hr.employee', 'hr.employee.public']:
+            return local_redirect(f'/web/image?model={res_model}&id={user_id}&field={field}')
+        user = request.env[res_model].sudo().browse(user_id).exists()
+        if not user:
+            return request.not_found()
+        if user[field]:
+            return local_redirect(f'/web/image?model={res_model}&id={user_id}&field={field}')
+        avatar = _generate_avatar_svg(user.name)
+        return Response(avatar, mimetype='image/svg+xml')
+
+def _encode_name(name):
+    return sha1(name.encode('utf-8'))
+
+def _generate_avatar_svg(name):
+    base = _encode_name(name)
+    initials = tools.html_escape(_generate_initials(name))
+    bgcolor = tools.html_escape(_generate_bgcolor(base))
+    if initials:
+        return (
+            "<?xml version='1.0' encoding='UTF-8' ?>"
+            "<svg height='180' width='180' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'>"
+            f"<rect fill='{bgcolor}' height='180' width='180'/>"
+            f"<text fill='#ffffff' font-size='96' text-anchor='middle' x='90' y='125' font-family='sans-serif'>{initials}</text>"
+            "</svg>"
+        )
+    else:
+        return _generate_default_avatar()
+
+def _generate_default_avatar(bgcolor='hsl(230, 0%, 90%)'):
+    return (
+        "<?xml version='1.0' encoding='UTF-8' ?>"
+        "<svg height='180' width='180' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'>"
+        f"<rect fill='{tools.html_escape(bgcolor)}' height='180' width='180'/>"
+        "<text fill='#ffffff' font-size='120' text-anchor='middle' x='90' y='155' font-family='sans-serif'>&#x1F464;</text>"
+        "</svg>"
+    )
+
+def _generate_initials(name):
+    return name[0].upper() if name else ''
+
+def _generate_bgcolor(name):
+    if name:
+        base = name.hexdigest()[0:6]
+        hue = _get_hue(base[0:2])
+        sat = _get_sat(base[2:4])
+        lig = _get_lig(base[4:6])
+        return f'hsl({hue}, {sat}%, {lig}%)'
+    return 'hsl(180, 50%, 50%)'
+
+def _get_hue(value):
+    hue_max = 360
+    hue_dec = int(value, 16)
+    return hue_dec * hue_max / 255
+
+def _get_sat(value):
+    sat_min = 40
+    sat_max = 70
+    sat_dec = int(value, 16)
+    return sat_dec * ((sat_max - sat_min) / 255) + sat_min
+
+def _get_lig(value):
+    return 45

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -325,7 +325,7 @@ class Users(models.Model):
                                  compute='_compute_accesses_count', compute_sudo=True)
     groups_count = fields.Integer('# Groups', help='Number of groups that apply to the current user',
                                   compute='_compute_accesses_count', compute_sudo=True)
-    image_1920 = fields.Image(related='partner_id.image_1920', inherited=True, readonly=False, default=_get_default_image)
+    image_1920 = fields.Image(related='partner_id.image_1920', inherited=True, readonly=False)
 
     _sql_constraints = [
         ('login_key', 'UNIQUE (login)',  'You can not have two users with the same login !')

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -151,6 +151,7 @@
                 <sheet>
                     <div class="oe_button_box" name="button_box"/>
                     <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                    <field name="default_partner_image" invisible="1"/>
                     <field name="image_1920" widget='image' class="oe_avatar" options='{"preview_image": "image_128"}'/>
                     <div class="oe_title">
                         <field name="is_company" invisible="1"/>
@@ -461,11 +462,11 @@
                                     <t t-if="record.type.raw_value === 'delivery'" t-set="placeholder" t-value="'/base/static/img/truck.png'"/>
                                     <t t-elif="record.type.raw_value === 'invoice'" t-set="placeholder" t-value="'/base/static/img/money.png'"/>
                                     <t t-else="" t-set="placeholder" t-value="'/base/static/img/avatar_grey.png'"/>
-                                    <div class="o_kanban_image_fill_left d-none d-md-block" t-attf-style="background-image:url('#{kanban_image('res.partner', 'image_128', record.id.raw_value,  placeholder)}')">
-                                        <img class="o_kanban_image_inner_pic" t-if="record.parent_id.raw_value" t-att-alt="record.parent_id.value" t-att-src="kanban_image('res.partner', 'image_128', record.parent_id.raw_value)"/>
+                                    <div class="o_kanban_image_fill_left d-none d-md-block" t-attf-style="background-image:url('#{kanban_image('res.partner', 'image_128', record.id.raw_value, placeholder)}')">
+                                        <img class="o_kanban_image_inner_pic" t-if="record.parent_id.raw_value" t-att-alt="record.parent_id.value" t-att-src="kanban_image('res.partner', 'image_128', record.parent_id.raw_value, '/base/static/img/company_image.png')"/>
                                     </div>
-                                    <div class="o_kanban_image d-md-none" t-attf-style="background-image:url('#{kanban_image('res.partner', 'image_128', record.id.raw_value,  placeholder)}')">
-                                        <img class="o_kanban_image_inner_pic" t-if="record.parent_id.raw_value" t-att-alt="record.parent_id.value" t-att-src="kanban_image('res.partner', 'image_128', record.parent_id.raw_value)"/>
+                                    <div class="o_kanban_image d-md-none" t-attf-style="background-image:url('#{kanban_image('res.partner', 'image_128', record.id.raw_value, placeholder)}')">
+                                        <img class="o_kanban_image_inner_pic" t-if="record.parent_id.raw_value" t-att-alt="record.parent_id.value" t-att-src="kanban_image('res.partner', 'image_128', record.parent_id.raw_value, '/base/static/img/company_image.png')"/>
                                     </div>
                                 </t>
                                 <t t-else="">

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -212,7 +212,7 @@
                             <field name="partner_id" required="0" readonly="1"/>
                           </div>
                         </div>
-                        <field name="image_1920" widget='image' class="oe_avatar" options='{"preview_image": "image_128"}'/>
+                        <field name="image_1920" widget='image' class="oe_avatar" options='{"preview_image": "image_128", "placeholder":"/base/static/img/avatar_grey.png"}'/>
                         <div class="oe_title">
                             <label for="name"/>
                             <h1><field name="name" placeholder="e.g. John Doe" required="1"/></h1>
@@ -288,11 +288,12 @@
                     <field name="lang"/>
                     <field name="active"/>
                     <field name="login_date"/>
+                    <field name="image_128"/>
                     <templates>
                         <t t-name="kanban-box">
                             <div t-attf-class="oe_kanban_global_click">
                                 <div class="o_kanban_image">
-                                    <img alt="Avatar" t-att-src="kanban_image('res.users', 'image_128', record.id.raw_value)"/>
+                                    <img alt="Avatar" t-att-src="kanban_image('res.users', 'image_128', record.id.raw_value, '/base/static/img/avatar_grey.png')"/>
                                 </div>
                                 <div class="oe_kanban_details">
                                     <ul>

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -658,8 +658,6 @@ class TransactionCase(BaseCase):
         self.cr.execute('SAVEPOINT test_%d' % self._savepoint_id)
         self.addCleanup(self.cr.execute, 'ROLLBACK TO SAVEPOINT test_%d' % self._savepoint_id)
 
-        self.patch(self.registry['res.partner'], '_get_gravatar_image', lambda *a: False)
-
 
 class SavepointCase(TransactionCase):
     @classmethod


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
It is currently quite difficult to differentiate users. Most of the time, people don't take the time to upload an actual avatar so everybody looks the same. This PR generates a custom avatar with the users initials and random color to differentiate them.

Current behavior before PR:
Avatar had only random colors and was being saved in database, being inneficient.

Desired behavior after PR is merged:
An avatar API generates an image with the user's initials and random color if the user did not upload any picture.

Task: 2404630

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
