### PR TITLE
[IMP] Refactor google_account, google_calendar method of getting cred…

### DIFF
--- a/addons/google_account/models/google_service.py
+++ b/addons/google_account/models/google_service.py
@@ -23,7 +23,7 @@ class GoogleService(models.AbstractModel):
     _name = 'google.service'
     _description = 'Google Service'
 
-    def get_client_credentials(self, service):
+    def _get_client_credentials(self, service):
         get_param = self.env['ir.config_parameter'].sudo().get_param
         return {
             "client_id": get_param('google_%s_client_id' % service),
@@ -39,7 +39,7 @@ class GoogleService(models.AbstractModel):
         """
         Parameters = self.env['ir.config_parameter'].sudo()
         redirect_uri = Parameters.get_param('google_redirect_uri')
-        credentials = self.get_client_credentials(service)
+        credentials = self._get_client_credentials(service)
         client_id = credentials["client_id"]
         client_secret = credentials["client_secret"]
 
@@ -65,7 +65,7 @@ class GoogleService(models.AbstractModel):
     @api.model
     def _get_google_token_uri(self, service, scope):
         get_param = self.env['ir.config_parameter'].sudo().get_param
-        credentials = self.get_client_credentials(service)
+        credentials = self._get_client_credentials(service)
         encoded_params = urls.url_encode({
             'scope': scope,
             'redirect_uri': get_param('google_redirect_uri'),
@@ -86,7 +86,7 @@ class GoogleService(models.AbstractModel):
         }
 
         get_param = self.env['ir.config_parameter'].sudo().get_param
-        credentials = self.get_client_credentials(service)
+        credentials = self._get_client_credentials(service)
         base_url = get_param('web.base.url', default='http://www.odoo.com?NoBaseUrl')
 
         encoded_params = urls.url_encode({
@@ -107,7 +107,7 @@ class GoogleService(models.AbstractModel):
         """
         get_param = self.env['ir.config_parameter'].sudo().get_param
         base_url = get_param('web.base.url', default='http://www.odoo.com?NoBaseUrl')
-        credentials = self.get_client_credentials(service)
+        credentials = self._get_client_credentials(service)
 
         headers = {"content-type": "application/x-www-form-urlencoded"}
         data = {

--- a/addons/google_calendar/controllers/main.py
+++ b/addons/google_calendar/controllers/main.py
@@ -21,7 +21,7 @@ class GoogleCalendarController(http.Controller):
             GoogleCal = GoogleCalendarService(request.env['google.service'])
 
             # Checking that admin have already configured Google API for google synchronization !
-            client_id = request.env['ir.config_parameter'].sudo().get_param('google_calendar_client_id')
+            client_id = request.env["google.service"].get_client_credentials("calendar")
 
             if not client_id or client_id == '':
                 action_id = ''

--- a/addons/google_calendar/controllers/main.py
+++ b/addons/google_calendar/controllers/main.py
@@ -21,7 +21,7 @@ class GoogleCalendarController(http.Controller):
             GoogleCal = GoogleCalendarService(request.env['google.service'])
 
             # Checking that admin have already configured Google API for google synchronization !
-            client_id = request.env["google.service"].get_client_credentials("calendar")
+            client_id = request.env["google.service"]._get_client_credentials("calendar")
 
             if not client_id or client_id == '':
                 action_id = ''

--- a/addons/google_calendar/models/res_users.py
+++ b/addons/google_calendar/models/res_users.py
@@ -46,9 +46,9 @@ class User(models.Model):
     def _refresh_google_calendar_token(self):
         # LUL TODO similar code exists in google_drive. Should be factorized in google_account
         self.ensure_one()
-        get_param = self.env['ir.config_parameter'].sudo().get_param
-        client_id = get_param('google_calendar_client_id')
-        client_secret = get_param('google_calendar_client_secret')
+        credentials = self.env["google.service"].get_client_credentials("calendar")
+        client_id = credentials["client_id"]
+        client_secret = credentials["client_secret"]
 
         if not client_id or not client_secret:
             raise UserError(_("The account for the Google Calendar service is not configured."))

--- a/addons/google_calendar/models/res_users.py
+++ b/addons/google_calendar/models/res_users.py
@@ -46,7 +46,7 @@ class User(models.Model):
     def _refresh_google_calendar_token(self):
         # LUL TODO similar code exists in google_drive. Should be factorized in google_account
         self.ensure_one()
-        credentials = self.env["google.service"].get_client_credentials("calendar")
+        credentials = self.env["google.service"]._get_client_credentials("calendar")
         client_id = credentials["client_id"]
         client_secret = credentials["client_secret"]
 

--- a/doc/cla/individual/kevinkhao.md
+++ b/doc/cla/individual/kevinkhao.md
@@ -1,0 +1,11 @@
+France, 2021-01-21
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Kevin Khao kevinkhao@gmail.com https://github.com/kevinkhao


### PR DESCRIPTION
…entials

Description of the issue/feature this PR addresses:
For google_calendar and google_account, every time we need google_X_client_id and google_X_client_secret, where X is the service, the get_param method is called.

Current behavior before PR:
It is hard to extend custom methods for getting credentials for Google Calendar service, as it requires replacing a lot of redundant code.

Desired behavior after PR is merged:
It is easy to implement a custom credentials fetching method.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
