### PR TITLE
[FIX] web: Show scroll in report view search filter

### DIFF
--- a/addons/web/static/src/scss/dropdown_menu.scss
+++ b/addons/web/static/src/scss/dropdown_menu.scss
@@ -4,8 +4,6 @@
     }
 
     min-width: 150px;
-    max-height: calc(100vh - 140px); // FIXME
-    overflow: auto;
 
     .o_menu_item {
         position: relative;
@@ -18,6 +16,11 @@
             }
         }
     }
+}
+
+.o_dropdown_menu, .dropdown-menu {
+    max-height: calc(100vh - 140px); // FIXME
+    overflow: auto;
 }
 
 .dropdown-item {


### PR DESCRIPTION
Issue

	- Install "Accounting" module
	- Ensure there is more then 20 journals ( or
	  must do a zoom-in on the browser)
	- Go to Accounting -> Reporting -> Profit and Loss
	- Click on "Journals" filter

	Not all journals are displayed.

Cause

	No scroll or max-height set on dropdown.

Solution

	Set a max-height and an overflow:auto on the filter menu
	if it's a dropdown-menu.

opw-2430101