### PR TITLE
[FIX] google_calendar: enable the event deletion

### DIFF
--- a/addons/google_calendar/i18n/google_calendar.pot
+++ b/addons/google_calendar/i18n/google_calendar.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 14.0\n"
+"Project-Id-Version: Odoo Server 14.0+e\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-11-27 11:24+0000\n"
-"PO-Revision-Date: 2020-11-27 11:24+0000\n"
+"PO-Revision-Date: 2021-01-22 08:05+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -362,14 +362,6 @@ msgstr ""
 #. module: google_calendar
 #: model:ir.model,name:google_calendar.model_res_users
 msgid "Users"
-msgstr ""
-
-#. module: google_calendar
-#: code:addons/google_calendar/models/google_sync.py:0
-#, python-format
-msgid ""
-"You cannot delete a record synchronized with Google Calendar, archive it "
-"instead."
 msgstr ""
 
 #. module: google_calendar

--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -104,7 +104,11 @@ class GoogleSync(models.AbstractModel):
             synced.write({self._active_name: False})
             self = self - synced
         elif synced:
-            raise UserError(_("You cannot delete a record synchronized with Google Calendar, archive it instead."))
+            # Since we can not delete such an event (see method comment), we archive it.
+            # Notice that archiving an event will delete the associated event on Google.
+            # Then, since it has been deleted on Google, the event is also deleted on Odoo DB (_sync_google2odoo).
+            self.action_archive()
+            return True
         return super().unlink()
 
     @api.model


### PR DESCRIPTION
When using the Calender synced with Google, if the user tries to delete
an event, an error message is displayed: he has to archive it instead.

To reproduce the error:
1. Sync Odoo Calendar with Gogle Calendar
2. Add an event
3. Click on it > Delete

Error: UserError message: "You cannot delete a record synchronized with
Google Calendar, archive it instead"

To make the flow simpler and faster, when clicking on "Delete", the
server will archive the event. When archiving an event, the server
deletes the corresponding event on Google Calendar. As a result, the
next time the user loads his Odoo Calendar, the sync Google->Odoo will
delete the archived event.

OPW-2440339