### PR TITLE
[IMP] web_editor: select siblings when block is removed

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -310,7 +310,13 @@ var SnippetEditor = Widget.extend({
             });
         });
 
-        this.trigger_up('go_to_parent', {$snippet: this.$target});
+        const parent = this.$target[0].parentElement;
+        const nextSibling = this.$target[0].nextElementSibling;
+        const previousSibling = this.$target[0].previousElementSibling;
+        this.trigger_up('activate_snippet', {
+            $snippet: $(previousSibling || nextSibling || parent)
+        });
+
         var $parent = this.$target.parent();
         this.$target.find('*').addBack().tooltip('dispose');
         this.$target.remove();
@@ -643,7 +649,7 @@ var SnippetEditor = Widget.extend({
             }
         }
 
-        this.trigger_up('go_to_parent', {$snippet: this.$target});
+        this.trigger_up('activate_snippet', {$snippet: this.$target.parent()});
         this.trigger_up('activate_insertion_zones', {
             $selectorSiblings: $selectorSiblings,
             $selectorChildren: $selectorChildren,
@@ -897,7 +903,6 @@ var SnippetsMenu = Widget.extend({
         'deactivate_snippet': '_onDeactivateSnippet',
         'drag_and_drop_stop': '_onDragAndDropStop',
         'get_snippet_versions': '_onGetSnippetVersions',
-        'go_to_parent': '_onGoToParent',
         'remove_snippet': '_onRemoveSnippet',
         'snippet_edition_request': '_onSnippetEditionRequest',
         'snippet_editor_destroyed': '_onSnippetEditorDestroyed',
@@ -2250,17 +2255,6 @@ var SnippetsMenu = Widget.extend({
     _onDragAndDropStop: async function (ev) {
         await this._destroyEditors();
         await this._activateSnippet(ev.data.$snippet);
-    },
-    /**
-     * Called when a snippet editor asked to disable itself and to enable its
-     * parent instead.
-     *
-     * @private
-     * @param {OdooEvent} ev
-     */
-    _onGoToParent: function (ev) {
-        ev.stopPropagation();
-        this._activateSnippet(ev.data.$snippet.parent());
     },
     /**
      * @private


### PR DESCRIPTION
CONTEXT: Within a container, delete a block which has a sibling.

The actual behaviour is to select the container after deletion.

The goal of this PR is to select the previous sibling (if exists),
or next one. Otherwise the parent element will be selected (default behaviour).

task-2431506

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
