### PR TITLE
[FIX] website: handle RequestUID case in slug  - _slug_matching

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -255,7 +255,7 @@ class ModelConverter(ModelConverter):
             # limited support for negative IDs due to our slug pattern, assume abs() if not found
             if not env[self.model].browse(record_id).exists():
                 record_id = abs(record_id)
-        return env[self.model].browse(record_id)
+        return env[self.model].with_context(_converter_value=value).browse(record_id)
 
 
 class IrHttp(models.AbstractModel):

--- a/addons/test_website/__init__.py
+++ b/addons/test_website/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import controllers
+from . import models

--- a/addons/test_website/__manifest__.py
+++ b/addons/test_website/__manifest__.py
@@ -18,6 +18,7 @@ models which only purpose is to run tests.""",
     'data': [
         'views/templates.xml',
         'data/test_website_data.xml',
+        'security/ir.model.access.csv',
     ],
     'installable': True,
     'application': False,

--- a/addons/test_website/controllers/main.py
+++ b/addons/test_website/controllers/main.py
@@ -127,7 +127,10 @@ class WebsiteTest(Home):
         return 'Basic Controller Content'
 
     # Test Redirects
-
     @http.route(['/test_website/country/<model("res.country"):country>'], type='http', auth="public", website=True, sitemap=False)
     def test_model_converter_country(self, country, **kw):
         return request.render('test_website.test_redirect_view', {'country': country})
+
+    @http.route(['/test_website/200/<model("test.model"):rec>'], type='http', auth="public", website=True, sitemap=False)
+    def test_model_converter_seoname(self, rec, **kw):
+        return request.make_response('ok')

--- a/addons/test_website/data/test_website_data.xml
+++ b/addons/test_website/data/test_website_data.xml
@@ -2,6 +2,15 @@
 <odoo>
     <data noupdate="1">
 
+        <record id="test_model_publish" model="ir.rule">
+            <field name="name">Public user: read only website published</field>
+            <field name="model_id" ref="test_website.model_test_model"/>
+            <field name="groups" eval="[(4, ref('base.group_public'))]"/>
+            <field name="domain_force">[('website_published','=', True)]</field>
+            <field name="perm_read" eval="True"/>
+        </record>
+
+
         <!-- RECORDS FOR RESET VIEWS TESTS -->
         <record id="test_view" model="ir.ui.view">
             <field name="name">Test View</field>

--- a/addons/test_website/models/__init__.py
+++ b/addons/test_website/models/__init__.py
@@ -1,0 +1,1 @@
+from . import model

--- a/addons/test_website/models/model.py
+++ b/addons/test_website/models/model.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class TestModel(models.Model):
+    """ Add website option in server actions. """
+
+    _name = 'test.model'
+    _inherit = ['website.seo.metadata', 'website.published.mixin']
+    _description = 'Website Model Test'
+
+    name = fields.Char(required=1)

--- a/addons/test_website/security/ir.model.access.csv
+++ b/addons/test_website/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_test_model,access_test_model,model_test_model,,1,0,0,0

--- a/addons/test_website/tests/test_redirect.py
+++ b/addons/test_website/tests/test_redirect.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
+import odoo
 from odoo.tests import HttpCase, tagged
+from odoo.tests.common import HOST
+from odoo.tools import mute_logger
 from odoo.addons.http_routing.models.ir_http import slug
+
+from unittest.mock import patch
 
 
 @tagged('-at_install', 'post_install')
@@ -18,28 +22,32 @@ class TestRedirect(HttpCase):
             'email': 'portal_user@mail.com',
             'groups_id': [(6, 0, [self.env.ref('base.group_portal').id])]
         })
-        self.redirect = self.env['website.rewrite'].create({
+
+        self.base_url = "http://%s:%s" % (HOST, odoo.tools.config['http_port'])
+
+    def test_01_redirect_308_model_converter(self):
+
+        self.env['website.rewrite'].create({
             'name': 'Test Website Redirect',
             'redirect_type': '308',
             'url_from': '/test_website/country/<model("res.country"):country>',
             'url_to': '/redirected/country/<model("res.country"):country>',
         })
-        self.country_ad = self.env.ref('base.ad')
+        country_ad = self.env.ref('base.ad')
 
-    def test_01_redirect_308_model_converter(self):
         """ Ensure 308 redirect with model converter works fine, including:
                 - Correct & working redirect as public user
                 - Correct & working redirect as logged in user
                 - Correct replace of url_for() URLs in DOM
         """
-        url = '/test_website/country/' + slug(self.country_ad)
+        url = '/test_website/country/' + slug(country_ad)
         redirect_url = url.replace('test_website', 'redirected')
 
         # [Public User] Open the original url and check redirect OK
         r = self.url_open(url)
         self.assertEqual(r.status_code, 200)
         self.assertTrue(r.url.endswith(redirect_url), "Ensure URL got redirected")
-        self.assertTrue(self.country_ad.name in r.text, "Ensure the controller returned the expected value")
+        self.assertTrue(country_ad.name in r.text, "Ensure the controller returned the expected value")
         self.assertTrue(redirect_url in r.text, "Ensure the url_for has replaced the href URL in the DOM")
 
         # [Logged In User] Open the original url and check redirect OK
@@ -48,10 +56,107 @@ class TestRedirect(HttpCase):
         self.assertEqual(r.status_code, 200)
         self.assertTrue(r.url.endswith(redirect_url), "Ensure URL got redirected (2)")
         self.assertTrue('Logged In' in r.text, "Ensure logged in")
-        self.assertTrue(self.country_ad.name in r.text, "Ensure the controller returned the expected value (2)")
+        self.assertTrue(country_ad.name in r.text, "Ensure the controller returned the expected value (2)")
         self.assertTrue(redirect_url in r.text, "Ensure the url_for has replaced the href URL in the DOM")
 
-    def test_02_redirect_308_model_converter_record_not_exist(self):
-        # Accessing a 308 route should not crash if the Model Converter record doesn't exist
-        r = self.url_open('/test_website/country/whatever-10000')
-        self.assertEqual(r.status_code, 404)
+    @mute_logger('odoo.addons.http_routing.models.ir_http')  # mute 403 warning
+    def test_02_redirect_308_RequestUID(self):
+        self.env['website.rewrite'].create({
+            'name': 'Test Website Redirect',
+            'redirect_type': '308',
+            'url_from': '/test_website/200/<model("test.model"):rec>',
+            'url_to': '/test_website/308/<model("test.model"):rec>',
+        })
+
+        rec_published = self.env['test.model'].create({'name': 'name', 'website_published': True})
+        rec_unpublished = self.env['test.model'].create({'name': 'name', 'website_published': False})
+
+        WebsiteHttp = odoo.addons.website.models.ir_http.Http
+
+        def _get_error_html(env, code, value):
+            return str(code).split('_')[-1], "CUSTOM %s" % code
+
+        with patch.object(WebsiteHttp, '_get_error_html', _get_error_html):
+            # Patch will avoid to display real 404 page and regenerate assets each time and unlink old one.
+            # And it allow to be sur that exception id handled by handle_exception and return a "managed error" page.
+
+            # published
+            resp = self.url_open("/test_website/200/name-%s" % rec_published.id, allow_redirects=False)
+            self.assertEqual(resp.status_code, 308)
+            self.assertEqual(resp.headers.get('Location'), self.base_url + "/test_website/308/name-%s" % rec_published.id)
+
+            resp = self.url_open("/test_website/308/name-%s" % rec_published.id, allow_redirects=False)
+            self.assertEqual(resp.status_code, 200)
+
+            resp = self.url_open("/test_website/200/xx-%s" % rec_published.id, allow_redirects=False)
+            self.assertEqual(resp.status_code, 308)
+            self.assertEqual(resp.headers.get('Location'), self.base_url + "/test_website/308/xx-%s" % rec_published.id)
+
+            resp = self.url_open("/test_website/308/xx-%s" % rec_published.id, allow_redirects=False)
+            self.assertEqual(resp.status_code, 301)
+            self.assertEqual(resp.headers.get('Location'), self.base_url + "/test_website/308/name-%s" % rec_published.id)
+
+            resp = self.url_open("/test_website/200/xx-%s" % rec_published.id, allow_redirects=True)
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.url, self.base_url + "/test_website/308/name-%s" % rec_published.id)
+
+            # unexisting
+            resp = self.url_open("/test_website/200/name-100", allow_redirects=False)
+            self.assertEqual(resp.status_code, 308)
+            self.assertEqual(resp.headers.get('Location'), self.base_url + "/test_website/308/name-100")
+
+            resp = self.url_open("/test_website/308/name-100", allow_redirects=False)
+            self.assertEqual(resp.status_code, 404)
+            self.assertEqual(resp.text, "CUSTOM 404")
+
+            resp = self.url_open("/test_website/200/xx-100", allow_redirects=False)
+            self.assertEqual(resp.status_code, 308)
+            self.assertEqual(resp.headers.get('Location'), self.base_url + "/test_website/308/xx-100")
+
+            resp = self.url_open("/test_website/308/xx-100", allow_redirects=False)
+            self.assertEqual(resp.status_code, 404)
+            self.assertEqual(resp.text, "CUSTOM 404")
+
+            # unpublish
+            resp = self.url_open("/test_website/200/name-%s" % rec_unpublished.id, allow_redirects=False)
+            self.assertEqual(resp.status_code, 308)
+            self.assertEqual(resp.headers.get('Location'), self.base_url + "/test_website/308/name-%s" % rec_unpublished.id)
+
+            resp = self.url_open("/test_website/308/name-%s" % rec_unpublished.id, allow_redirects=False)
+            self.assertEqual(resp.status_code, 403)
+            self.assertEqual(resp.text, "CUSTOM 403")
+
+            resp = self.url_open("/test_website/200/xx-%s" % rec_unpublished.id, allow_redirects=False)
+            self.assertEqual(resp.status_code, 308)
+            self.assertEqual(resp.headers.get('Location'), self.base_url + "/test_website/308/xx-%s" % rec_unpublished.id)
+
+            resp = self.url_open("/test_website/308/xx-%s" % rec_unpublished.id, allow_redirects=False)
+            self.assertEqual(resp.status_code, 403)
+            self.assertEqual(resp.text, "CUSTOM 403")
+
+            # with seo_name as slug
+            rec_published.seo_name = "seo_name"
+            rec_unpublished.seo_name = "seo_name"
+
+            resp = self.url_open("/test_website/200/seo-name-%s" % rec_published.id, allow_redirects=False)
+            self.assertEqual(resp.status_code, 308)
+            self.assertEqual(resp.headers.get('Location'), self.base_url + "/test_website/308/seo-name-%s" % rec_published.id)
+
+            resp = self.url_open("/test_website/308/seo-name-%s" % rec_published.id, allow_redirects=False)
+            self.assertEqual(resp.status_code, 200)
+
+            resp = self.url_open("/test_website/200/xx-%s" % rec_unpublished.id, allow_redirects=False)
+            self.assertEqual(resp.status_code, 308)
+            self.assertEqual(resp.headers.get('Location'), self.base_url + "/test_website/308/xx-%s" % rec_unpublished.id)
+
+            resp = self.url_open("/test_website/308/xx-%s" % rec_unpublished.id, allow_redirects=False)
+            self.assertEqual(resp.status_code, 403)
+            self.assertEqual(resp.text, "CUSTOM 403")
+
+            resp = self.url_open("/test_website/200/xx-100", allow_redirects=False)
+            self.assertEqual(resp.status_code, 308)
+            self.assertEqual(resp.headers.get('Location'), self.base_url + "/test_website/308/xx-100")
+
+            resp = self.url_open("/test_website/308/xx-100", allow_redirects=False)
+            self.assertEqual(resp.status_code, 404)
+            self.assertEqual(resp.text, "CUSTOM 404")

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -19,7 +19,6 @@ from odoo import registry, SUPERUSER_ID
 from odoo.http import request
 from odoo.tools.safe_eval import safe_eval
 from odoo.osv.expression import FALSE_DOMAIN
-
 from odoo.addons.http_routing.models.ir_http import ModelConverter, _guess_mimetype
 from odoo.addons.portal.controllers.portal import _build_url_w_params
 
@@ -75,7 +74,7 @@ class Http(models.AbstractModel):
     def _slug_matching(cls, adapter, endpoint, **kw):
         for arg in kw:
             if isinstance(kw[arg], models.BaseModel):
-                kw[arg] = kw[arg].sudo()
+                kw[arg] = kw[arg].with_context(slug_matching=True)
         qs = request.httprequest.query_string.decode('utf-8')
         try:
             return adapter.build(endpoint, kw) + (qs and '?%s' % qs or '')
@@ -422,6 +421,11 @@ class Http(models.AbstractModel):
 
 
 class ModelConverter(ModelConverter):
+
+    def to_url(self, value):
+        if value.env.context.get('slug_matching'):
+            return value.env.context.get('_converter_value', str(value.id))
+        return super().to_url(value)
 
     def generate(self, uid, dom=None, args=None):
         Model = request.env[self.model].with_user(uid)


### PR DESCRIPTION
[FIX] website: handle RequestUID case in slug 

Before this commit, a 308 on a route with a modelconverter for a model
that have a seo_name field will crash with an exception:
Cannot iterate on RequestUID

Another simplest solution was to use a with_user(SUPERUSER_ID) but in this case
it bypass the security set and display the name of the record even if not yet
published.

How to reproduce:

Create a 308 from /shop/<product> to /mag/<product>
Unpublish product 10
Try to access /shop/product-10

You have an unmanaged '500 internal error"
because slug_matching -> build -> to_url -> slug with a record with Requestuid
as env._uid.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
