### PR TITLE
[13.0] Human Resources: hr company search employee by name

### DIFF
--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -199,7 +199,7 @@ class User(models.Model):
 
     def _search_company_employee(self, operator, value):
         employees = self.env['hr.employee'].search([
-            ('name', operator, value),
+            ('id', operator, value),
             '|',
             ('company_id', '=', self.env.company.id),
             ('company_id', '=', False)

--- a/doc/cla/corporate/alphatechx.md
+++ b/doc/cla/corporate/alphatechx.md
@@ -1,0 +1,15 @@
+China, Jan.22.2021
+
+Alphatechx agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+followcat followcat@gmail.com https://github.com/followcat
+
+List of contributors:
+
+followcat followcat@gmail.com https://github.com/followcat


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Into odoo shell, use res.users to search some field in hr module inherit 'res.users', like department_id:
`self.env['res.users'].search([('department_id', 'ilike', 'IT')])` will get nothing.
Because of these fileds related to employee_id, and employee_id is a not stroe field,
it use method _search_company_employee to do search work.
When the related field get search results from _search_related, employee_id filter with 'id' but not 'name'.

Current behavior before PR:
There's no record as result..

Desired behavior after PR is merged:
Able to use related field search like `self.env['res.users'].search([('department_id', 'ilike', 'IT')])`.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
