### PR TITLE
[FIX] sale_timesheet: review views inherited from project.task model

### DIFF
--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -134,7 +134,8 @@
         <record id="project_task_view_form_inherit_sale_timesheet" model="ir.ui.view">
             <field name="name">project.task.form.inherit.timesheet</field>
             <field name="model">project.task</field>
-            <field name="inherit_id" ref="hr_timesheet.view_task_form2_inherited"/>
+            <field name="inherit_id" ref="project.view_task_form2"/>
+            <field name="groups_id" eval="[(6,0, (ref('hr_timesheet.group_hr_timesheet_user'),))]"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='timesheet_ids']/tree" position="attributes">
                     <attribute name="decoration-muted">timesheet_invoice_id != False</attribute>
@@ -156,20 +157,6 @@
                 <xpath expr="//field[@name='timesheet_ids']/tree" position="inside">
                     <field name="non_allow_billable" attrs="{'column_invisible': ['|', '&amp;', '&amp;', '|', ('parent.bill_type', '!=', 'customer_project'), ('parent.pricing_type', '!=', 'employee_rate'), ('parent.timesheet_product_id', '=', False), ('parent.sale_line_id', '=', False), '&amp;', ('parent.bill_type', '=', 'customer_project'), ('parent.pricing_type', '=', 'employee_rate')]}" invisible="1"/>
                 </xpath>
-            </field>
-        </record>
-
-        <record id="view_task_form2_inherit_sale_timesheet" model="ir.ui.view">
-            <field name="name">view.task.form2.inherit</field>
-            <field name="model">project.task</field>
-            <field name="inherit_id" ref="project.view_task_form2"/>
-            <field name="arch" type="xml">
-                <xpath expr="//field[@name='sale_line_id']" position="attributes">
-                    <attribute name="context">{'with_remaining_hours': True}</attribute>
-                    <attribute name="attrs">
-                        {'invisible': ['|', ('allow_billable', '=', False), ('partner_id', '=', False)]}
-                    </attribute>
-                </xpath>
                 <xpath expr="//field[@name='remaining_hours']" position="after">
                     <field name="remaining_hours_available" invisible="1"/>
                     <span id="remaining_hours_so_label" attrs="{'invisible': ['|', '|', '|', '|', ('allow_billable', '=', False), ('sale_order_id', '=', False), ('partner_id', '=', False), ('sale_line_id', '=', False), ('remaining_hours_available', '=', False)]}">
@@ -183,6 +170,20 @@
                                attrs="{'invisible': ['|', ('encode_uom_in_days', '=', False), ('remaining_hours_so', '&gt;=', 0)]}"/>
                     </span>
                     <field name="remaining_hours_so" nolabel="1" widget="timesheet_uom" attrs="{'invisible': ['|', '|', '|', '|', ('allow_billable', '=', False), ('sale_order_id', '=', False), ('partner_id', '=', False), ('sale_line_id', '=', False), ('remaining_hours_available', '=', False)]}"></field>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="view_task_form2_inherit_sale_timesheet" model="ir.ui.view">
+            <field name="name">view.task.form2.inherit</field>
+            <field name="model">project.task</field>
+            <field name="inherit_id" ref="project.view_task_form2"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='sale_line_id']" position="attributes">
+                    <attribute name="context">{'with_remaining_hours': True}</attribute>
+                    <attribute name="attrs">
+                        {'invisible': ['|', ('allow_billable', '=', False), ('partner_id', '=', False)]}
+                    </attribute>
                 </xpath>
                 <xpath expr="//field[@name='sale_order_id']" position="attributes">
                     <attribute name="invisible">1</attribute>


### PR DESCRIPTION
Before this commit, when the user with no access right to Timesheet App
wants to see the tasks in a project and sale_timesheet module is
installed, the user has a traceback saying remaining_hours field is not
find in the parent view of
`sale_timesheet.view_task_form2_inherit_sale_timesheet`.

This traceback is raised because the
`hr_timesheet.view_task_form2_inherited` is not used if the user has no
access right to Timesheet App and then remaining_hours field is not
defined for this user because this field is appeared in the view in
hr_timesheet module.

This commit revises the views inherited from the project.task model to
give the user without access rights in Timesheet the possibility to see
the tasks in any project he can see.

opw-2429662

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
