### PR TITLE
[FIX] google_calendar: let Google send emails

### DIFF
--- a/addons/google_calendar/models/__init__.py
+++ b/addons/google_calendar/models/__init__.py
@@ -6,3 +6,4 @@ from . import google_sync
 from . import calendar
 from . import calendar_recurrence_rule
 from . import res_users
+from . import calendar_attendee

--- a/addons/google_calendar/models/calendar_attendee.py
+++ b/addons/google_calendar/models/calendar_attendee.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+from odoo.addons.google_calendar.models.google_sync import google_calendar_token
+
+class Attendee(models.Model):
+    _name = 'calendar.attendee'
+    _inherit = 'calendar.attendee'
+
+    def _send_mail_to_attendees(self, template_xmlid, force_send=False, ignore_recurrence=False):
+        """ Override
+        If not synced with Google, let Odoo in charge of sending emails
+        Otherwise, nothing to do: Google will send them
+        """
+        with google_calendar_token(self.env.user.sudo()) as token:
+            if not token:
+                super()._send_mail_to_attendees(template_xmlid, force_send, ignore_recurrence)


### PR DESCRIPTION
When synced with Google, if a user adds an event to Odoo Calendar, both
Google and Odoo will send an invitation to attendees.

To reproduce the error:
(Need mailcatcher)
1. Sync Odoo Calendar with Google Calendar
2. Create an event in Odoo Calendar
	- Add at least one attendee who has an email address
3. Save

Error: Odoo's server sends an email. When synced, it should not, it
should let Google in charge of emails sending.

(Similar to #62383)

OPW-2440485