### PR TITLE
[FIX] mrp: fix quantity edition in Produce wizard

### DIFF
--- a/addons/mrp/models/mrp_abstract_workorder.py
+++ b/addons/mrp/models/mrp_abstract_workorder.py
@@ -162,12 +162,6 @@ class MrpAbstractWorkorder(models.AbstractModel):
                 if float_compare(qty_todo, 0.0, precision_rounding=rounding) > 0:
                     for values in self._generate_lines_values(move, qty_todo):
                         line_values['to_create'].append(values)
-        # wo lines without move_id should also be deleted
-        for wo_line in self._workorder_line_ids().filtered(lambda w: not w.move_id and (not w.finished_workorder_id or w.product_id != w.finished_workorder_id.product_id)):
-            if not line_values['to_delete']:
-                line_values['to_delete'] = wo_line
-            elif wo_line not in line_values['to_delete']:
-                line_values['to_delete'] |= wo_line
         return line_values
 
     @api.model


### PR DESCRIPTION
- Create a Product and a BOM for it (i.e. Product X)
- Go to Manufactoring > Operations > Manufacturing Orders and create a MO for Product X
- Mark as Todo and click on Produce
- On Produce Wizard, add a Component line with any Product and edit Quantity to produce
An AttributeError is raised: "'mrp.product.produce.line' object has no attribute 'finished_workorder_line_id'"

"_workorder_line_ids" method can either return "mrp.workorder.line" records or "mrp.product.produce.line"
and "finished_workorder_line_id" does not exist in "mrp.product.produce.line" model.

opw-2439172

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
