### PR TITLE
[mail] Chatter Search

### DIFF
--- a/addons/mail/static/src/components/chatter/chatter.js
+++ b/addons/mail/static/src/components/chatter/chatter.js
@@ -24,6 +24,10 @@ export class Chatter extends Component {
          */
         this._scrollPanelRef = useRef('scrollPanel');
         /**
+         * Reference of the search box. Useful to focus it.
+         */
+        this._searchBoxRef = useRef('searchBox');
+        /**
          * Reference of the message list. Useful to trigger the scroll event on it.
          */
         this._threadRef = useRef('thread');
@@ -80,6 +84,10 @@ export class Chatter extends Component {
             const composer = this._composerRef.comp;
             if (composer) {
                 composer.focus();
+            }
+            const searchBox = this._searchBoxRef.comp;
+            if (searchBox) {
+                searchBox.focus();
             }
         }
     }

--- a/addons/mail/static/src/components/chatter/chatter.scss
+++ b/addons/mail/static/src/components/chatter/chatter.scss
@@ -19,6 +19,15 @@
     }
 }
 
+.o_Chatter_searchBox {
+    border-bottom: $border-width solid;
+
+    &.o-bordered {
+        border-left: $border-width solid;
+        border-right: $border-width solid;
+    }
+}
+
 .o_Chatter_scrollPanel {
     overflow-y: auto;
 }
@@ -33,6 +42,15 @@
 }
 
 .o_Chatter_composer {
+    border-bottom-color: $border-color;
+
+    &.o-bordered {
+        border-left-color: $border-color;
+        border-right-color: $border-color;
+    }
+}
+
+.o_Chatter_searchBox {
     border-bottom-color: $border-color;
 
     &.o-bordered {

--- a/addons/mail/static/src/components/chatter/chatter.xml
+++ b/addons/mail/static/src/components/chatter/chatter.xml
@@ -23,6 +23,14 @@
                             t-ref="composer"
                         />
                     </t>
+                    <t t-if="chatter.isSearchBoxVisible">
+                        <ChatterSearchBox
+                            class="o_Chatter_searchBox"
+                            t-att-class="{ 'o-bordered': chatter.hasExternalBorder }"
+                            threadLocalId="chatter.thread.localId"
+                            t-ref="searchBox"
+                        />
+                    </t>
                 </div>
                 <div class="o_Chatter_scrollPanel" t-on-scroll="_onScrollPanelScroll" t-ref="scrollPanel">
                     <t t-if="chatter.isAttachmentBoxVisible">

--- a/addons/mail/static/src/components/chatter/tests/chatter_tests.js
+++ b/addons/mail/static/src/components/chatter/tests/chatter_tests.js
@@ -542,7 +542,7 @@ QUnit.test('search message with "Enter" keyboard shortcut', async function (asse
         });
     }
     await this.start();
-    const chatter = this.env.models['mail.chatter'].create({
+    const chatter = this.messaging.models['mail.chatter'].create({
         threadId: 100,
         threadModel: 'res.partner',
     });

--- a/addons/mail/static/src/components/chatter/tests/chatter_tests.js
+++ b/addons/mail/static/src/components/chatter/tests/chatter_tests.js
@@ -46,7 +46,7 @@ QUnit.module('chatter_tests.js', {
 });
 
 QUnit.test('base rendering when chatter has no attachment', async function (assert) {
-    assert.expect(6);
+    assert.expect(7);
 
     this.data['res.partner'].records.push({ id: 100 });
     for (let i = 0; i < 60; i++) {
@@ -71,6 +71,11 @@ QUnit.test('base rendering when chatter has no attachment', async function (asse
         document.querySelectorAll(`.o_ChatterTopbar`).length,
         1,
         "should have a chatter topbar"
+    );
+    assert.strictEqual(
+        document.querySelectorAll(`.o_ChatterTopbar_buttonSearch`).length,
+        1,
+        "should have a search box in the chatter"
     );
     assert.strictEqual(
         document.querySelectorAll(`.o_Chatter_attachmentBox`).length,
@@ -98,7 +103,7 @@ QUnit.test('base rendering when chatter has no attachment', async function (asse
 });
 
 QUnit.test('base rendering when chatter has no record', async function (assert) {
-    assert.expect(8);
+    assert.expect(9);
 
     await this.start();
     const chatter = this.messaging.models['mail.chatter'].create({
@@ -114,6 +119,11 @@ QUnit.test('base rendering when chatter has no record', async function (assert) 
         document.querySelectorAll(`.o_ChatterTopbar`).length,
         1,
         "should have a chatter topbar"
+    );
+    assert.strictEqual(
+        document.querySelectorAll(`.o_ChatterTopbar_buttonSearch`).length,
+        1,
+        "should have a search box in the chatter"
     );
     assert.strictEqual(
         document.querySelectorAll(`.o_Chatter_attachmentBox`).length,
@@ -517,6 +527,72 @@ QUnit.test('do not post message with "Enter" keyboard shortcut', async function 
         document.body,
         '.o_Message',
         "should still not have any message in mailing channel after pressing 'Enter' in text input of composer"
+    );
+});
+
+QUnit.test('search message with "Enter" keyboard shortcut', async function (assert) {
+    assert.expect(7);
+
+    this.data['res.partner'].records.push({ id: 100 });
+    for (let i = 0; i < 10; i++) {
+        this.data['mail.message'].records.push({
+            body: "test" + i,
+            model: 'res.partner',
+            res_id: 100,
+        });
+    }
+    await this.start();
+    const chatter = this.env.models['mail.chatter'].create({
+        threadId: 100,
+        threadModel: 'res.partner',
+    });
+    await this.createChatterComponent({ chatter });
+    assert.strictEqual(
+        document.querySelectorAll(`.o_Message`).length,
+        10,
+        "should have 10 messages of thread"
+    );
+    assert.strictEqual(
+        document.querySelectorAll(`.o_ChatterTopbar_buttonSearch`).length,
+        1,
+        "should have a search button in the chatter"
+    );
+
+    await afterNextRender(() =>
+        document.querySelector(`.o_ChatterTopbar_buttonSearch`).click()
+    );
+    assert.hasClass(
+        document.querySelector('.o_ChatterTopbar_buttonSearch'),
+        'o-active',
+        "search button should be active"
+    );
+    assert.strictEqual(
+        document.querySelectorAll(`.o_ChatterSearchBox`).length,
+        1,
+        "should have a search box"
+    );
+
+    document.querySelector('.o_ChatterSearchBox_textInput').focus();
+    document.execCommand('insertText', false, "Test1");
+
+    await afterNextRender(() => {
+        const kevt = new window.KeyboardEvent('keydown', { key: "Enter" });
+        document.querySelector('.o_ChatterSearchBox_textInput').dispatchEvent(kevt);
+    });
+    assert.strictEqual(
+        document.querySelector('.o_ChatterSearchBox_searchCount').textContent,
+        '1 Results',
+        "should display a filtered messages count"
+    );
+    assert.strictEqual(
+        document.querySelectorAll(`.o_Message`).length,
+        1,
+        "should have single filtered message of thread"
+    );
+    assert.containsOnce(
+        document.querySelector(`.o_Message_content`),
+        '.highlighter',
+        "should have a body with highlighter"
     );
 });
 

--- a/addons/mail/static/src/components/chatter_search_box/chatter_search_box.js
+++ b/addons/mail/static/src/components/chatter_search_box/chatter_search_box.js
@@ -1,0 +1,97 @@
+/** @odoo-module **/
+
+import { registerMessagingComponent } from '@mail/utils/messaging_component';
+import { useUpdate } from '@mail/component_hooks/use_update/use_update';
+
+const { Component } = owl;
+const { useRef } = owl.hooks;
+
+class ChatterSearchBox extends Component {
+
+    /**
+     * @override
+     */
+    constructor(...args) {
+        super(...args);
+        /**
+         * Updates the text input content when search box is mounted
+         * as input content can't be changed from the DOM.
+         */
+        useUpdate({ func: () => this._update() });
+        /**
+         * Reference of the input. Useful to set content.
+         */
+        this._inputRef = useRef('input');
+    }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    /**
+     * @returns {mail.thread|undefined}
+     */
+    get thread() {
+        return this.messaging && this.messaging.models['mail.thread'].get(this.props.threadLocalId);
+    }
+
+    focus() {
+        this._inputRef.el.focus();
+    }
+
+    /**
+     * Saves the text input state in store
+     */
+    saveStateInStore() {
+        this.thread.update({ searchedText: this._inputRef.el.value });
+    }
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * Updates the content
+     *
+     * @private
+     */
+    _update() {
+        if (!this.thread) {
+            return;
+        }
+        this._inputRef.el.value = this.thread.searchedText;
+    }
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    /**
+     * @private
+     */
+    _onFocusout() {
+        this.saveStateInStore();
+    }
+    /**
+     * @private
+     * @param {KeyboardEvent} ev
+     */
+    _onKeydown(ev) {
+        if (ev.key === 'Enter') {
+            this.saveStateInStore();
+            if (!this._inputRef.el.value) {
+                return;
+            }
+        }
+    }
+
+}
+
+Object.assign(ChatterSearchBox, {
+    props: {
+        threadLocalId: String,
+    },
+    template: 'mail.ChatterSearchBox',
+});
+
+registerMessagingComponent(ChatterSearchBox);

--- a/addons/mail/static/src/components/chatter_search_box/chatter_search_box.scss
+++ b/addons/mail/static/src/components/chatter_search_box/chatter_search_box.scss
@@ -1,0 +1,34 @@
+// ------------------------------------------------------------------
+// Layout
+// ------------------------------------------------------------------
+
+.o_ChatterSearchBox {
+    padding: 10px;
+}
+
+.o_ChatterSearchBox_loadingIcon {
+    margin-right: 5px;
+}
+
+.o_ChatterSearchBox_searchCount {
+    margin-top: 8px;
+}
+
+.o_ChatterSearchBox_textInput {
+    border: $border-width solid;
+    height: 38px;
+    padding: 10px;
+}
+
+// ------------------------------------------------------------------
+// Style
+// ------------------------------------------------------------------
+
+.o_ChatterSearchBox {
+    background-color: gray('100');
+}
+
+.o_ChatterSearchBox_textInput {
+    border-color: $border-color;
+    border-radius: $o-mail-rounded-rectangle-border-radius-lg;
+}

--- a/addons/mail/static/src/components/chatter_search_box/chatter_search_box.xml
+++ b/addons/mail/static/src/components/chatter_search_box/chatter_search_box.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="mail.ChatterSearchBox" owl="1">
+        <div class="o_ChatterSearchBox">
+            <t t-if="thread">
+                <input type="text" class="o_ChatterSearchBox_textInput" placeholder="Search..." t-on-focusout="_onFocusout" t-on-keydown="_onKeydown" t-ref="input"/>
+                <t t-if="thread.cache and thread.searchedText">
+                    <div class="o_ChatterSearchBox_searchCount">
+                        <t t-if="thread.cache.isSearchingMessages">
+                            <span><i class="o_ChatterSearchBox_loadingIcon fa fa-spinner fa-spin" title="Searching..." role="img"/>Searching...</span>
+                        </t>
+                        <t t-else="">
+                            <span><t t-esc="thread.cache.filteredMessages.length"/> Results</span>
+                        </t>
+                    </div>
+                </t>
+            </t>
+        </div>
+    </t>
+
+</templates>

--- a/addons/mail/static/src/components/chatter_topbar/chatter_topbar.js
+++ b/addons/mail/static/src/components/chatter_topbar/chatter_topbar.js
@@ -47,6 +47,9 @@ export class ChatterTopbar extends Component {
         if (!this.chatter.composer) {
             return;
         }
+        if (this.chatter.isSearchBoxVisible) {
+            this.chatter.update({ isSearchBoxVisible: false });
+        }
         if (this.chatter.isComposerVisible && this.chatter.composer.isLog) {
             this.chatter.update({ isComposerVisible: false });
         } else {
@@ -86,9 +89,27 @@ export class ChatterTopbar extends Component {
      * @private
      * @param {MouseEvent} ev
      */
+    _onClickSearch(ev) {
+        if (this.chatter.isComposerVisible) {
+            this.chatter.update({ isComposerVisible: false });
+        }
+        if (this.chatter.isSearchBoxVisible) {
+            this.chatter.update({ isSearchBoxVisible: false });
+        } else {
+            this.chatter.showSearchBox();
+        }
+    }
+
+    /**
+     * @private
+     * @param {MouseEvent} ev
+     */
     _onClickSendMessage(ev) {
         if (!this.chatter.composer) {
             return;
+        }
+        if (this.chatter.isSearchBoxVisible) {
+            this.chatter.update({ isSearchBoxVisible: false });
         }
         if (this.chatter.isComposerVisible && !this.chatter.composer.isLog) {
             this.chatter.update({ isComposerVisible: false });

--- a/addons/mail/static/src/components/chatter_topbar/chatter_topbar.scss
+++ b/addons/mail/static/src/components/chatter_topbar/chatter_topbar.scss
@@ -103,3 +103,7 @@
         color: $white;
     }
 }
+
+.o_ChatterTopbar_buttonSearch.o-active {
+    border-left-color: $border-color;
+}

--- a/addons/mail/static/src/components/chatter_topbar/chatter_topbar.xml
+++ b/addons/mail/static/src/components/chatter_topbar/chatter_topbar.xml
@@ -4,7 +4,7 @@
     <t t-name="mail.ChatterTopbar" owl="1">
         <div class="o_ChatterTopbar">
             <t t-if="chatter">
-                <div class="o_ChatterTopbar_actions" t-att-class="{'o-has-active-button': chatter.isComposerVisible }">
+                <div class="o_ChatterTopbar_actions" t-att-class="{'o-has-active-button': chatter.isComposerVisible or chatter.isSearchBoxVisible }">
                     <t t-if="chatter.threadView">
                         <button class="btn btn-link o_ChatterTopbar_button o_ChatterTopbar_buttonSendMessage"
                             type="button"
@@ -41,6 +41,18 @@
                     </t>
                     <div class="o-autogrow"/>
                         <div class="o_ChatterTopbar_rightSection">
+                            <t t-if="chatter.threadView">
+                                <button class="btn btn-link o_ChatterTopbar_button o_ChatterTopbar_buttonSearch"
+                                    t-att-class="{
+                                        'o-active': chatter.isSearchBoxVisible,
+                                        'o-bordered': chatter.hasExternalBorder,
+                                    }"
+                                    t-att-disabled="chatter.isDisabled"
+                                    t-on-click="_onClickSearch"
+                                >
+                                    <i class="fa fa-search"/>
+                                </button>
+                            </t>
                             <button class="btn btn-link o_ChatterTopbar_button o_ChatterTopbar_buttonAttachments" type="button" t-att-disabled="chatter.isDisabled" t-on-click="_onClickAttachments">
                                 <i class="fa fa-paperclip"/>
                                 <t t-if="chatter.isDisabled or !chatter.isShowingAttachmentsLoading">

--- a/addons/mail/static/src/components/chatter_topbar/tests/chatter_topbar_tests.js
+++ b/addons/mail/static/src/components/chatter_topbar/tests/chatter_topbar_tests.js
@@ -435,7 +435,7 @@ QUnit.test('search box state conserved when clicking on another topbar button', 
 
     this.data['res.partner'].records.push({ id: 100 });
     await this.start();
-    const chatter = this.env.models['mail.chatter'].create({
+    const chatter = this.messaging.models['mail.chatter'].create({
         threadId: 100,
         threadModel: 'res.partner',
     });
@@ -695,7 +695,7 @@ QUnit.test('search message toggling', async function (assert) {
 
     this.data['res.partner'].records.push({ id: 100 });
     await this.start();
-    const chatter = this.env.models['mail.chatter'].create({
+    const chatter = this.messaging.models['mail.chatter'].create({
         threadId: 100,
         threadModel: 'res.partner',
     });

--- a/addons/mail/static/src/components/chatter_topbar/tests/chatter_topbar_tests.js
+++ b/addons/mail/static/src/components/chatter_topbar/tests/chatter_topbar_tests.js
@@ -40,7 +40,7 @@ QUnit.module('chatter_topbar_tests.js', {
 });
 
 QUnit.test('base rendering', async function (assert) {
-    assert.expect(8);
+    assert.expect(9);
 
     this.data['res.partner'].records.push({ id: 100 });
     await this.start();
@@ -71,6 +71,11 @@ QUnit.test('base rendering', async function (assert) {
         "should have a schedule activity button in chatter menu"
     );
     assert.strictEqual(
+        document.querySelectorAll(`.o_ChatterTopbar_buttonSearch`).length,
+        1,
+        "should have a search button in chatter menu"
+    );
+    assert.strictEqual(
         document.querySelectorAll(`.o_ChatterTopbar_buttonAttachments`).length,
         1,
         "should have an attachments button in chatter menu"
@@ -93,7 +98,7 @@ QUnit.test('base rendering', async function (assert) {
 });
 
 QUnit.test('base disabled rendering', async function (assert) {
-    assert.expect(8);
+    assert.expect(9);
 
     await this.start();
     const chatter = this.messaging.models['mail.chatter'].create({
@@ -116,6 +121,10 @@ QUnit.test('base disabled rendering', async function (assert) {
     assert.ok(
         document.querySelector(`.o_ChatterTopbar_buttonScheduleActivity`).disabled,
         "schedule activity should be disabled"
+    );
+    assert.ok(
+        document.querySelector(`.o_ChatterTopbar_buttonSearch`).disabled,
+        "search button should be disabled"
     );
     assert.ok(
         document.querySelector(`.o_ChatterTopbar_buttonAttachments`).disabled,
@@ -421,6 +430,51 @@ QUnit.test('composer state conserved when clicking on another topbar button', as
     );
 });
 
+QUnit.test('search box state conserved when clicking on another topbar button', async function (assert) {
+    assert.expect(5);
+
+    this.data['res.partner'].records.push({ id: 100 });
+    await this.start();
+    const chatter = this.env.models['mail.chatter'].create({
+        threadId: 100,
+        threadModel: 'res.partner',
+    });
+    await this.createChatterTopbarComponent(chatter);
+
+    assert.containsOnce(
+        document.body,
+        `.o_ChatterTopbar`,
+        "should have a chatter topbar"
+    );
+    assert.containsOnce(
+        document.body,
+        `.o_ChatterTopbar_buttonSearch`,
+        "should have a search button in chatter menu"
+    );
+    assert.containsOnce(
+        document.body,
+        `.o_ChatterTopbar_buttonAttachments`,
+        "should have an attachments button in chatter menu"
+    );
+
+    await afterNextRender(() => {
+        document.querySelector(`.o_ChatterTopbar_buttonSearch`).click();
+    });
+    assert.containsOnce(
+        document.body,
+        `.o_ChatterTopbar_buttonSearch.o-active`,
+        "search button should now be active"
+    );
+
+    document.querySelector(`.o_ChatterTopbar_buttonAttachments`).click();
+    await nextAnimationFrame();
+    assert.containsOnce(
+        document.body,
+        `.o_ChatterTopbar_buttonSearch.o-active`,
+        "search button should still be active"
+    );
+});
+
 QUnit.test('rendering with multiple partner followers', async function (assert) {
     assert.expect(7);
 
@@ -633,6 +687,46 @@ QUnit.test('send message toggling', async function (assert) {
         document.querySelector('.o_ChatterTopbar_buttonSendMessage'),
         'o-active',
         "'Send Message' button should not be active"
+    );
+});
+
+QUnit.test('search message toggling', async function (assert) {
+    assert.expect(4);
+
+    this.data['res.partner'].records.push({ id: 100 });
+    await this.start();
+    const chatter = this.env.models['mail.chatter'].create({
+        threadId: 100,
+        threadModel: 'res.partner',
+    });
+    await this.createChatterTopbarComponent(chatter);
+    assert.containsOnce(
+        document.body,
+        '.o_ChatterTopbar_buttonSearch',
+        "should have a search button"
+    );
+    assert.doesNotHaveClass(
+        document.querySelector('.o_ChatterTopbar_buttonSearch'),
+        'o-active',
+        "search button should not be active"
+    );
+
+    await afterNextRender(() =>
+        document.querySelector(`.o_ChatterTopbar_buttonSearch`).click()
+    );
+    assert.hasClass(
+        document.querySelector('.o_ChatterTopbar_buttonSearch'),
+        'o-active',
+        "search button should be active"
+    );
+
+    await afterNextRender(() =>
+        document.querySelector(`.o_ChatterTopbar_buttonSearch`).click()
+    );
+    assert.doesNotHaveClass(
+        document.querySelector('.o_ChatterTopbar_buttonSearch'),
+        'o-active',
+        "search button should not be active"
     );
 });
 

--- a/addons/mail/static/src/components/message/message.js
+++ b/addons/mail/static/src/components/message/message.js
@@ -29,6 +29,7 @@ export class Message extends Component {
             isClicked: false,
         });
         useUpdate({ func: () => this._update() });
+        this._authorHighlighterRef = useRef('_authorHighlighterRef');
         /**
          * The intent of the reply button depends on the last rendered state.
          */
@@ -43,6 +44,7 @@ export class Message extends Component {
          * replace prettyBody with new value in JS (which is faster than t-raw).
          */
         this._prettyBodyRef = useRef('prettyBody');
+        this._prettyBodyHighlighterRef = useRef('prettyBodyHighlighter');
         /**
          * Reference to the content of the message.
          */
@@ -56,6 +58,7 @@ export class Message extends Component {
          * regular time.
          */
         this._intervalId = undefined;
+        this._subjectHighlighterRef = useRef('subjectHighlighterRef');
         this._constructor();
     }
 
@@ -394,9 +397,19 @@ export class Message extends Component {
         if (!this.message) {
             return;
         }
+        if (this._authorHighlighterRef.el) {
+            this._authorHighlighterRef.el.innerHTML = this.message.filterOn.author;
+        }
+        if (this._prettyBodyHighlighterRef.el) {
+            this._prettyBodyHighlighterRef.el.innerHTML = this.message.filterOn.body;
+            this._lastPrettyBody = this.message.filteredMessageBody;
+        }
         if (this._prettyBodyRef.el && this.message.prettyBody !== this._lastPrettyBody) {
             this._prettyBodyRef.el.innerHTML = this.message.prettyBody;
             this._lastPrettyBody = this.message.prettyBody;
+        }
+        if (this._subjectHighlighterRef.el) {
+            this._subjectHighlighterRef.el.innerHTML = this.message.filterOn.subject;
         }
         // Remove all readmore before if any before reinsert them with _insertReadMoreLess.
         // This is needed because _insertReadMoreLess is working with direct DOM mutations
@@ -538,6 +551,7 @@ Object.assign(Message, {
     defaultProps: {
         hasMarkAsReadIcon: false,
         hasReplyIcon: false,
+        isFiltered: false,
         isSquashed: false,
     },
     props: {
@@ -548,6 +562,7 @@ Object.assign(Message, {
         },
         hasMarkAsReadIcon: Boolean,
         hasReplyIcon: Boolean,
+        isFiltered: Boolean,
         isSquashed: Boolean,
         messageLocalId: String,
         threadViewLocalId: {

--- a/addons/mail/static/src/components/message/message.scss
+++ b/addons/mail/static/src/components/message/message.scss
@@ -333,6 +333,10 @@
     }
 }
 
+.o_Message .highlighter {
+    background-color: yellow;
+}
+
 .o_Message_sidebarCommands {
     display: none;
 }

--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -59,12 +59,28 @@
                         </t>
                     </t>
                 </div>
+                <t t-set="isFiltered" t-value="props.isFiltered and message.isFiltered"/>
+                <t t-if="isFiltered and message.filterOn">
+                    <t t-set="isFilterOnAuthor" t-value="message.filterOn.author"/>
+                    <t t-set="isFilterOnBody" t-value="message.filterOn.body"/>
+                    <t t-set="isFilterOnSubject" t-value="message.filterOn.subject"/>
+                </t>
+                <t t-else="">
+                    <t t-set="isFilterOnAuthor" t-value="false"/>
+                    <t t-set="isFilterOnBody" t-value="false"/>
+                    <t t-set="isFilterOnSubject" t-value="false"/>
+                </t>
                 <div class="o_Message_core">
                     <t t-if="!props.isSquashed">
                         <div class="o_Message_header">
                             <t t-if="message.author">
                                 <div class="o_Message_authorName o_Message_authorRedirect o_redirect text-truncate" t-on-click="_onClickAuthorName" title="Open profile">
-                                    <t t-esc="message.author.nameOrDisplayName"/>
+                                    <t t-if="isFilterOnAuthor">
+                                        <div t-ref="_authorHighlighterRef"/>
+                                    </t>
+                                    <t t-else="">
+                                        <t t-esc="message.author.nameOrDisplayName"/>
+                                    </t>
                                 </div>
                             </t>
                             <t t-elif="message.email_from">
@@ -146,9 +162,14 @@
                         </div>
                     </t>
                     <div class="o_Message_content" t-ref="content">
-                        <div class="o_Message_prettyBody" t-ref="prettyBody"/><!-- message.prettyBody is inserted here from _update() -->
-                        <t t-if="message.subtype_description and !message.isBodyEqualSubtypeDescription">
-                            <p t-esc="message.subtype_description"/>
+                        <t t-if="isFilterOnBody">
+                            <div class="o_Message_prettyBody_highlighter" t-ref="prettyBodyHighlighter"/>
+                        </t>
+                        <t t-else="">
+                            <div class="o_Message_prettyBody" t-ref="prettyBody"/><!-- message.prettyBody is inserted here from _update() -->
+                            <t t-if="message.subtype_description and !message.isBodyEqualSubtypeDescription">
+                                <p t-esc="message.subtype_description"/>
+                            </t>
                         </t>
                         <t t-if="trackingValues.length > 0">
                             <ul class="o_Message_trackingValues">
@@ -170,7 +191,12 @@
                         </t>
                     </div>
                     <t t-if="message.subject and !message.isSubjectSimilarToOriginThreadName">
-                        <p class="o_Message_subject mb-0">Subject: <t t-esc="message.subject"/></p>
+                        <t t-if="isFilterOnSubject">
+                            <p class="o_Message_subject mb-0" t-ref="subjectHighlighterRef"/>
+                        </t>
+                        <t t-else="">
+                            <p class="o_Message_subject mb-0">Subject: <t t-esc="message.subject"/></p>
+                        </t>
                     </t>
                     <t t-if="message.attachments and message.attachments.length > 0">
                         <div class="o_Message_footer">

--- a/addons/mail/static/src/components/message_list/message_list.js
+++ b/addons/mail/static/src/components/message_list/message_list.js
@@ -44,6 +44,7 @@ export class MessageList extends Component {
             const threadCache = threadView && threadView.threadCache;
             return {
                 componentHintList: threadView ? [...threadView.componentHintList] : [],
+                filteredMessages: threadCache ? [...threadCache.filteredMessages] : [],
                 hasAutoScrollOnMessageReceived: threadView && threadView.hasAutoScrollOnMessageReceived,
                 hasScrollAdjust: this.props.hasScrollAdjust,
                 order: this.props.order,
@@ -237,12 +238,15 @@ export class MessageList extends Component {
     /**
      * @returns {mail.message[]}
      */
-    get orderedMessages() {
+    get messages() {
         const threadCache = this.threadView.threadCache;
+        const messages = this.threadView.hasVisibleSearchBox && threadCache.filteredMessages.length > 0
+                       ? threadCache.filteredMessages
+                       : threadCache.orderedMessages;
         if (this.props.order === 'desc') {
-            return [...threadCache.orderedMessages].reverse();
+            return [...messages].reverse();
         }
-        return threadCache.orderedMessages;
+        return messages;
     }
 
     /**
@@ -254,6 +258,20 @@ export class MessageList extends Component {
         }
         this._isLastScrollProgrammatic = true;
         this._getScrollableElement().scrollTop = value;
+    }
+
+    /**
+     * @param {mail.message} message
+     * @returns {boolean}
+     */
+    shouldMessageBeFiltered(message) {
+        const threadCache = this.threadView.threadCache;
+        if (threadCache.filteredMessages.includes(message)) {
+            message.update({ 'isFiltered': true });
+        } else {
+            message.update({ 'isFiltered': false });
+        }
+        return message.isFiltered;
     }
 
     /**

--- a/addons/mail/static/src/components/message_list/message_list.xml
+++ b/addons/mail/static/src/components/message_list/message_list.xml
@@ -41,13 +41,13 @@
                         </button>
                     </div>
                 </t>
-                <t t-elif="props.order === 'asc' and orderedMessages.length > 0">
+                <t t-elif="props.order === 'asc' and messages.length > 0">
                     <t t-call="mail.MessageList.loadMore"/>
                 </t>
                 <!-- MESSAGES -->
                 <t t-set="current_day" t-value="0"/>
                 <t t-set="prev_message" t-value="0"/>
-                <t t-foreach="orderedMessages" t-as="message" t-key="message.localId">
+                <t t-foreach="messages" t-as="message" t-key="message.localId">
                     <t t-if="message === threadView.thread.messageAfterNewMessageSeparator">
                         <div class="o_MessageList_separator o_MessageList_separatorNewMessages o_MessageList_item" t-att-class="{ 'o-disable-animation': messaging.disableAnimation }" t-transition="fade">
                             <hr class="o_MessageList_separatorLine o_MessageList_separatorLineNewMessages"/><span class="o_MessageList_separatorLabel o_MessageList_separatorLabelNewMessages">New messages</span>
@@ -65,10 +65,17 @@
                         <t t-else="">
                             <t t-set="isMessageSquashed" t-value="shouldMessageBeSquashed(prev_message, message)"/>
                         </t>
+                        <t t-if="threadView.hasVisibleSearchBox">
+                            <t t-set="isMessageFiltered" t-value="shouldMessageBeFiltered(message)"/>
+                        </t>
+                        <t t-else="">
+                            <t t-set="isMessageFiltered" t-value="false"/>
+                        </t>
                         <Message
                             class="o_MessageList_item o_MessageList_message"
                             hasMarkAsReadIcon="props.haveMessagesMarkAsReadIcon"
                             hasReplyIcon="props.haveMessagesReplyIcon"
+                            isFiltered="isMessageFiltered"
                             isSquashed="isMessageSquashed"
                             messageLocalId="message.localId"
                             threadViewLocalId="threadView.localId"
@@ -78,7 +85,7 @@
                     </t>
                 </t>
                 <!-- LOADING (if order desc)-->
-                <t t-if="!threadView.threadCache.hasLoadingFailed and props.order === 'desc' and orderedMessages.length > 0">
+                <t t-if="!threadView.threadCache.hasLoadingFailed and props.order === 'desc' and messages.length > 0">
                     <t t-call="mail.MessageList.loadMore"/>
                 </t>
             </t>

--- a/addons/mail/static/src/models/chatter/chatter.js
+++ b/addons/mail/static/src/models/chatter/chatter.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { registerNewModel } from '@mail/model/model_core';
-import { attr, many2one, one2one } from '@mail/model/model_field';
+import { attr, many2one, many2many, one2one } from '@mail/model/model_field';
 import { create, insert, link, unlink, update } from '@mail/model/model_field_command';
 import { OnChange } from '@mail/model/model_onchange';
 
@@ -72,6 +72,11 @@ function factory(dependencies) {
         showLogNote() {
             this.update({ isComposerVisible: true });
             this.thread.composer.update({ isLog: true });
+            this.focus();
+        }
+
+        showSearchBox() {
+            this.update({ isSearchBoxVisible: true });
             this.focus();
         }
 
@@ -278,6 +283,12 @@ function factory(dependencies) {
         isDoFocus: attr({
             default: false,
         }),
+        /**
+         * Determiners whether the search box is currently visible.
+         */
+        isSearchBoxVisible: attr({
+            default: false,
+        }),
         isShowingAttachmentsLoading: attr({
             default: false,
         }),
@@ -304,6 +315,7 @@ function factory(dependencies) {
          */
         threadViewer: one2one('mail.thread_viewer', {
             compute: '_computeThreadViewer',
+            inverse: 'chatter',
             isCausal: true,
             readonly: true,
             required: true,

--- a/addons/mail/static/src/models/message/message.js
+++ b/addons/mail/static/src/models/message/message.js
@@ -359,6 +359,40 @@ function factory(dependencies) {
 
         /**
          * @private
+         * @returns {Object}
+         */
+        _computeMessagefilterOn() {
+            if (!this.isFiltered) {
+                return;
+            }
+            const filterBy = {};
+            const body = this.body ? this.body : this.subtype_description;
+            const searchRegExp = new RegExp(this.originThread.searchedText, 'gi');
+
+            if (body.match(searchRegExp)) {
+                filterBy.body = body.replace(searchRegExp, (match) => {
+                    return `<span class="highlighter">${match}</span>`;
+                });
+            }
+            if (this.author && this.author.nameOrDisplayName.match(searchRegExp)) {
+                filterBy.author = this.author.nameOrDisplayName.replace(searchRegExp, (match) => {
+                    return `<span class="highlighter">${match}</span>`;
+                });
+            }
+            if (this.subject && !this.isSubjectSimilarToOriginThreadName) {
+                const subject = this.env._t("Subject: ") + this.subject;
+                if (subject.match(searchRegExp)) {
+                    filterBy.subject = subject.replace(searchRegExp, (match) => {
+                        return `<span class="highlighter">${match}</span>`;
+                    });
+                }
+            }
+
+            return filterBy;
+        }
+
+        /**
+         * @private
          * @returns {boolean}
          */
         _computeIsSubjectSimilarToOriginThreadName() {
@@ -477,6 +511,10 @@ function factory(dependencies) {
         failureNotifications: one2many('mail.notification', {
             compute: '_computeFailureNotifications',
         }),
+        filterOn: attr({
+            default: {},
+            compute: '_computeMessagefilterOn',
+        }),
         id: attr({
             required: true,
         }),
@@ -515,6 +553,13 @@ function factory(dependencies) {
          */
         isEmpty: attr({
             compute: '_computeIsEmpty',
+        }),
+        /**
+         * Determine whether the message is filtered or not. Useful to make
+         * body with highlighted keyword.
+         */
+        isFiltered: attr({
+            default: false,
         }),
         /**
          * States whether `originThread.name` and `subject` contain similar

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -1953,6 +1953,9 @@ function factory(dependencies) {
          */
         pendingSeenMessageId: attr(),
         public: attr(),
+        searchedText: attr({
+            default: "",
+        }),
         /**
          * Determine the last fold state known by the server, which is the fold
          * state displayed after initialization or when the last pending

--- a/addons/mail/static/src/models/thread_view/thread_view.js
+++ b/addons/mail/static/src/models/thread_view/thread_view.js
@@ -258,6 +258,9 @@ function factory(dependencies) {
         composer: many2one('mail.composer', {
             related: 'thread.composer',
         }),
+        filteredMessages: many2many('mail.message', {
+            related: 'threadCache.filteredMessages',
+        }),
         hasComposerFocus: attr({
             related: 'composer.hasFocus',
         }),
@@ -266,6 +269,12 @@ function factory(dependencies) {
          */
         hasTopbar: attr({
             related: 'threadViewer.hasTopbar',
+        }),
+        /**
+         * Determines whether this thread view has a search box.
+         */
+        hasVisibleSearchBox: attr({
+            related: 'threadViewer.hasVisibleSearchBox',
         }),
         /**
          * States whether `this.threadCache` is currently loading messages.

--- a/addons/mail/static/src/models/thread_view/thread_viewer.js
+++ b/addons/mail/static/src/models/thread_view/thread_viewer.js
@@ -78,6 +78,12 @@ function factory(dependencies) {
 
     ThreadViewer.fields = {
         /**
+         * States the `mail.chatter` managing `this`.
+         */
+        chatter: one2one('mail.chatter', {
+            inverse: 'threadViewer',
+        }),
+        /**
          * Determines whether `this.thread` should be displayed.
          */
         hasThreadView: attr({
@@ -88,6 +94,12 @@ function factory(dependencies) {
          */
         hasTopbar: attr({
             default: false,
+        }),
+        /**
+         * Determines whether this thread viewer has a search box.
+         */
+        hasVisibleSearchBox: attr({
+            related: 'chatter.isSearchBoxVisible',
         }),
         /**
          * Determines the selected `mail.message`.


### PR DESCRIPTION
**PURPOSE**

Ease the way users navigate in the chatter. Get rid of the boring
scroll down/Load More/scroll down in case you're looking for when
X or Y happened.

**SPECIFICATION**

- A search icon only be visible when having messages in the chatter
- Search is made on 'Enter' and display spinner in case it takes time
- Highlighted the searched word on filtered messages.
- If re-click on the search icon, re-show the last query and ready to be
  re-launched.

Task-2359037




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
