### PR TITLE
[FIX] mrp,stock: use correct qty to backorder in MO simplified view

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1451,15 +1451,17 @@ class MrpProduction(models.Model):
         if self.env.context.get('mo_ids_to_backorder'):
             productions_to_backorder = self.browse(self.env.context['mo_ids_to_backorder'])
             productions_not_to_backorder = self - productions_to_backorder
+            close_mo = False
         else:
             productions_not_to_backorder = self
             productions_to_backorder = self.env['mrp.production']
+            close_mo = True
 
         self.workorder_ids.button_finish()
 
+        backorders = productions_to_backorder._generate_backorder_productions(close_mo=close_mo)
         productions_not_to_backorder._post_inventory(cancel_backorder=True)
         productions_to_backorder._post_inventory(cancel_backorder=False)
-        backorders = productions_to_backorder._generate_backorder_productions()
 
         # if completed products make other confirmed/partially_available moves available, assign them
         done_move_finished_ids = (productions_to_backorder.move_finished_ids | productions_not_to_backorder.move_finished_ids).filtered(lambda m: m.state == 'done')

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -1824,3 +1824,42 @@ class TestMrpOrder(TestMrpCommon):
         tuesday = date_planned + timedelta(days=1)
         self.assertEqual(mo.workorder_ids[1].date_planned_start, tuesday.replace(hour=1))
         self.assertEqual(mo.workorder_ids[1].date_planned_finished, tuesday.replace(hour=2))
+
+    def test_backorder_with_overconsumption(self):
+        """ Check that the components of the backorder have the correct quantities
+        when there is overconsumption in the initial MO
+        """
+        mo, _, _, _, _ = self.generate_mo(qty_final=30, qty_base_1=2, qty_base_2=3)
+        mo.action_confirm()
+        mo.qty_producing = 10
+        mo.move_raw_ids[0].quantity_done = 90
+        mo.move_raw_ids[1].quantity_done = 70
+        action = mo.button_mark_done()
+        backorder = Form(self.env['mrp.production.backorder'].with_context(**action['context']))
+        backorder.save().action_backorder()
+        mo_backorder = mo.procurement_group_id.mrp_production_ids[-1]
+
+        # Check quantities of the original MO
+        self.assertEqual(mo.product_uom_qty, 10.0)
+        self.assertEqual(mo.qty_produced, 10.0)
+        move_prod_1 = self.env['stock.move'].search([
+            ('product_id', '=', mo.bom_id.bom_line_ids[0].product_id.id),
+            ('raw_material_production_id', '=', mo.id)])
+        move_prod_2 = self.env['stock.move'].search([
+            ('product_id', '=', mo.bom_id.bom_line_ids[1].product_id.id),
+            ('raw_material_production_id', '=', mo.id)])
+        self.assertEqual(sum(move_prod_1.mapped('quantity_done')), 90.0)
+        self.assertEqual(sum(move_prod_1.mapped('product_uom_qty')), 90.0)
+        self.assertEqual(sum(move_prod_2.mapped('quantity_done')), 70.0)
+        self.assertEqual(sum(move_prod_2.mapped('product_uom_qty')), 70.0)
+
+        # Check quantities of the backorder MO
+        self.assertEqual(mo_backorder.product_uom_qty, 20.0)
+        move_prod_1_bo = self.env['stock.move'].search([
+            ('product_id', '=', mo.bom_id.bom_line_ids[0].product_id.id),
+            ('raw_material_production_id', '=', mo_backorder.id)])
+        move_prod_2_bo = self.env['stock.move'].search([
+            ('product_id', '=', mo.bom_id.bom_line_ids[1].product_id.id),
+            ('raw_material_production_id', '=', mo_backorder.id)])
+        self.assertEqual(sum(move_prod_1_bo.mapped('product_uom_qty')), 60.0)
+        self.assertEqual(sum(move_prod_2_bo.mapped('product_uom_qty')), 40.0)


### PR DESCRIPTION
The problem arises when a user creates a backorder for a MO after registering over-consumption of some components through the simplified view.
The quantities of the components of the new backordered MO are then wrong.
Components that were over consumed in the first MO will have smaller quantities in the new MO, the difference being the amount over consumed.
This problem does not appear in the case of the Tablet View where a proper recalculation of quantities is done.
This commit fixes the problem reusing the code of the Tablet View to calculate the quantities.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
