### PR TITLE
[FIX] account: missing renaming type -> move_type

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -624,11 +624,11 @@ class TestAccountReconciliationCommon(AccountTestInvoicingCommon):
             }
         ])
 
-    def _create_invoice(self, type='out_invoice', invoice_amount=50, currency_id=None, partner_id=None, date_invoice=None, payment_term_id=False, auto_validate=False):
+    def _create_invoice(self, move_type='out_invoice', invoice_amount=50, currency_id=None, partner_id=None, date_invoice=None, payment_term_id=False, auto_validate=False):
         date_invoice = date_invoice or time.strftime('%Y') + '-07-01'
 
         invoice_vals = {
-            'move_type': type,
+            'move_type': move_type,
             'partner_id': partner_id or self.partner_agrolait_id,
             'invoice_date': date_invoice,
             'date': date_invoice,
@@ -651,12 +651,12 @@ class TestAccountReconciliationCommon(AccountTestInvoicingCommon):
             invoice.action_post()
         return invoice
 
-    def create_invoice(self, type='out_invoice', invoice_amount=50, currency_id=None):
-        return self._create_invoice(type=type, invoice_amount=invoice_amount, currency_id=currency_id, auto_validate=True)
+    def create_invoice(self, move_type='out_invoice', invoice_amount=50, currency_id=None):
+        return self._create_invoice(move_type=move_type, invoice_amount=invoice_amount, currency_id=currency_id, auto_validate=True)
 
-    def create_invoice_partner(self, type='out_invoice', invoice_amount=50, currency_id=None, partner_id=False, payment_term_id=False):
+    def create_invoice_partner(self, move_type='out_invoice', invoice_amount=50, currency_id=None, partner_id=False, payment_term_id=False):
         return self._create_invoice(
-            type=type,
+            move_type=move_type,
             invoice_amount=invoice_amount,
             currency_id=currency_id,
             partner_id=partner_id,
@@ -684,14 +684,14 @@ class TestAccountReconciliationCommon(AccountTestInvoicingCommon):
 
     def make_customer_and_supplier_flows(self, invoice_currency_id, invoice_amount, bank_journal, amount, amount_currency, transaction_currency_id):
         #we create an invoice in given invoice_currency
-        invoice_record = self.create_invoice(type='out_invoice', invoice_amount=invoice_amount, currency_id=invoice_currency_id)
+        invoice_record = self.create_invoice(move_type='out_invoice', invoice_amount=invoice_amount, currency_id=invoice_currency_id)
         #we encode a payment on it, on the given bank_journal with amount, amount_currency and transaction_currency given
         line = invoice_record.line_ids.filtered(lambda line: line.account_id.user_type_id.type in ('receivable', 'payable'))
         bank_stmt = self.make_payment(invoice_record, bank_journal, amount=amount, amount_currency=amount_currency, currency_id=transaction_currency_id, reconcile_param=[{'id': line.id}])
         customer_move_lines = bank_stmt.line_ids.line_ids
 
         #we create a supplier bill in given invoice_currency
-        invoice_record = self.create_invoice(type='in_invoice', invoice_amount=invoice_amount, currency_id=invoice_currency_id)
+        invoice_record = self.create_invoice(move_type='in_invoice', invoice_amount=invoice_amount, currency_id=invoice_currency_id)
         #we encode a payment on it, on the given bank_journal with amount, amount_currency and transaction_currency given
         line = invoice_record.line_ids.filtered(lambda line: line.account_id.user_type_id.type in ('receivable', 'payable'))
         bank_stmt = self.make_payment(invoice_record, bank_journal, amount=-amount, amount_currency=-amount_currency, currency_id=transaction_currency_id, reconcile_param=[{'id': line.id}])

--- a/addons/account/tests/test_reconciliation.py
+++ b/addons/account/tests/test_reconciliation.py
@@ -711,7 +711,7 @@ class TestReconciliationExec(TestAccountReconciliationCommon):
             'company_id': self.company.id
         })
         inv1 = self.create_invoice(invoice_amount=800, currency_id=self.currency_usd_id)
-        inv2 = self.create_invoice(type="out_refund", invoice_amount=400, currency_id=self.currency_usd_id)
+        inv2 = self.create_invoice(move_type="out_refund", invoice_amount=400, currency_id=self.currency_usd_id)
 
         payment = self.env['account.payment'].create({
             'date': time.strftime('%Y') + '-07-15',
@@ -777,7 +777,7 @@ class TestReconciliationExec(TestAccountReconciliationCommon):
             'company_id': company.id
         })
         inv1 = self.create_invoice(invoice_amount=658, currency_id=self.currency_usd_id)
-        inv2 = self.create_invoice(type="out_refund", invoice_amount=225, currency_id=self.currency_usd_id)
+        inv2 = self.create_invoice(move_type="out_refund", invoice_amount=225, currency_id=self.currency_usd_id)
 
         payment = self.env['account.payment'].create({
             'payment_method_id': self.inbound_payment_method.id,
@@ -851,7 +851,7 @@ class TestReconciliationExec(TestAccountReconciliationCommon):
             'company_id': company.id
         })
         inv1 = self._create_invoice(invoice_amount=658, currency_id=self.currency_usd_id, date_invoice=time.strftime('%Y') + '-07-01', auto_validate=True)
-        inv2 = self._create_invoice(type="out_refund", invoice_amount=225, currency_id=self.currency_usd_id, date_invoice=time.strftime('%Y') + '-07-15', auto_validate=True)
+        inv2 = self._create_invoice(move_type="out_refund", invoice_amount=225, currency_id=self.currency_usd_id, date_invoice=time.strftime('%Y') + '-07-15', auto_validate=True)
 
         payment = self.env['account.payment'].create({
             'date': time.strftime('%Y') + '-07-15',
@@ -923,7 +923,7 @@ class TestReconciliationExec(TestAccountReconciliationCommon):
         })
 
         inv1 = self._create_invoice(invoice_amount=600, currency_id=self.currency_usd_id, date_invoice=time.strftime('%Y') + '-07-15', auto_validate=True)
-        inv2 = self._create_invoice(type="out_refund", invoice_amount=250, currency_id=self.currency_usd_id, date_invoice=time.strftime('%Y') + '-07-15', auto_validate=True)
+        inv2 = self._create_invoice(move_type="out_refund", invoice_amount=250, currency_id=self.currency_usd_id, date_invoice=time.strftime('%Y') + '-07-15', auto_validate=True)
 
         inv1_receivable = inv1.line_ids.filtered(lambda l: l.account_id.internal_type == 'receivable')
         inv2_receivable = inv2.line_ids.filtered(lambda l: l.account_id.internal_type == 'receivable')
@@ -981,7 +981,7 @@ class TestReconciliationExec(TestAccountReconciliationCommon):
             'company_id': company.id
         })
         inv1 = self._create_invoice(invoice_amount=600, currency_id=self.currency_usd_id, date_invoice=time.strftime('%Y') + '-07-15', auto_validate=True)
-        inv2 = self._create_invoice(type="out_refund", invoice_amount=250, currency_id=self.currency_usd_id, date_invoice=time.strftime('%Y') + '-07-15', auto_validate=True)
+        inv2 = self._create_invoice(move_type="out_refund", invoice_amount=250, currency_id=self.currency_usd_id, date_invoice=time.strftime('%Y') + '-07-15', auto_validate=True)
 
         inv1_receivable = inv1.line_ids.filtered(lambda l: l.account_id.internal_type == 'receivable')
         inv2_receivable = inv2.line_ids.filtered(lambda l: l.account_id.internal_type == 'receivable')
@@ -1051,7 +1051,7 @@ class TestReconciliationExec(TestAccountReconciliationCommon):
             'company_id': company.id
         })
         inv1 = self._create_invoice(invoice_amount=600, currency_id=foreign_1.id, date_invoice=time.strftime('%Y') + '-07-15', auto_validate=True)
-        inv2 = self._create_invoice(type="out_refund", invoice_amount=250, currency_id=foreign_1.id, date_invoice=time.strftime('%Y') + '-07-15', auto_validate=True)
+        inv2 = self._create_invoice(move_type="out_refund", invoice_amount=250, currency_id=foreign_1.id, date_invoice=time.strftime('%Y') + '-07-15', auto_validate=True)
 
         inv1_receivable = inv1.line_ids.filtered(lambda l: l.account_id.internal_type == 'receivable')
         inv2_receivable = inv2.line_ids.filtered(lambda l: l.account_id.internal_type == 'receivable')

--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -330,7 +330,7 @@ class Repair(models.Model):
             currency = repair.pricelist_id.currency_id
             company = repair.env.company
 
-            journal = repair.env['account.move'].with_context(type='out_invoice')._get_default_journal()
+            journal = repair.env['account.move'].with_context(move_type='out_invoice')._get_default_journal()
             if not journal:
                 raise UserError(_('Please define an accounting sales journal for the company %s (%s).') % (company.name, company.id))
 

--- a/addons/web/static/tests/core/py_utils_tests.js
+++ b/addons/web/static/tests/core/py_utils_tests.js
@@ -894,7 +894,7 @@ QUnit.module('core', function () {
         var result = pyUtils.eval('contexts', [{
             "__ref": "compound_context",
             "__contexts": [
-                {"__ref": "context", "__debug": "{'type':parent.move_type}",
+                {"__ref": "context", "__debug": "{'move_type':parent.move_type}",
                     "__id": "462b9dbed42f"}
             ],
             "__eval_context": {
@@ -902,7 +902,7 @@ QUnit.module('core', function () {
                 "__contexts": [{
                         "__ref": "compound_context",
                         "__contexts": [
-                            {"__ref": "context", "__debug": "{'type': move_type}",
+                            {"__ref": "context", "__debug": "{'move_type': move_type}",
                                 "__id": "16a04ed5a194"}
                         ],
                         "__eval_context": {
@@ -967,7 +967,7 @@ QUnit.module('core', function () {
             }
         }]);
 
-        assert.deepEqual(result, {type: 'out_invoice'});
+        assert.deepEqual(result, {move_type: 'out_invoice'});
     });
 
     QUnit.test('return-input-value', function (assert) {


### PR DESCRIPTION
Following https://github.com/odoo/odoo/commit/d675dbaa4c7174591e0e7c1a3caf3e76877312ce

Also updated tests to be more consistant.

Regex used to find problematic lines:
`\btype\b.*\b(out|in)_(invoice|refund)\b`



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
