### PR TITLE
[FIX] web_editor: save custom snippets per website

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4706,6 +4706,10 @@ registry.SnippetSave = SnippetOptionWidget.extend({
                             key: snippetKey,
                             onSuccess: url => thumbnailURL = url,
                         });
+                        let context;
+                        this.trigger_up('context_get', {
+                            callback: ctx => context = ctx,
+                        });
                         this.trigger_up('request_save', {
                             reloadEditor: true,
                             onSuccess: async () => {
@@ -4725,6 +4729,7 @@ registry.SnippetSave = SnippetOptionWidget.extend({
                                         'template_key': this.options.snippets,
                                         'snippet_key': snippetKey,
                                         'thumbnail_url': thumbnailURL,
+                                        'context': context,
                                     },
                                 });
                             },


### PR DESCRIPTION
Before this commit the custom snippets were saved across websites
because the RPC mechanism used by the save & reload does not include the
context by default.

After this commit the custom snippets are saved for the specific website
as initially intended.
No migration is needed: already created snippets that have been created
across all sites will have the correct lifecycle because of the
copy-on-update/copy-on-write.

Related to task-2374802

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
