### PR TITLE
[FIX] mass_mailing: disable the ability to save custom snippets

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_snippets.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_snippets.js
@@ -139,4 +139,15 @@ options.registry.BackgroundImage = options.registry.BackgroundImage.extend({
     }
 });
 
+// TODO remove in master when removing the XML div. The option has been disabled
+// in 14.0 because of tricky problems to resolve that require refactoring:
+// the ability to clean snippet without saving and reloading the page.
+options.registry.SnippetSave.include({
+
+    async saveSnippet(previewMode, widgetValue, params) {},
+
+    async _computeVisibility() {
+        return false;
+    },
+});
 });

--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -851,8 +851,11 @@
         data-drop-near="[data-oe-field='body_html']:not(:has(.o_layout)) > *, .oe_structure > *"
         data-drop-in="[data-oe-field='body_html']:not(:has(.o_layout)), .oe_structure"/>
 
-    <div data-js="SnippetSave"
-        t-att-data-selector="mailing_content_selector">
+    <!-- TODO remove in master, the option has been disabled in 14.0 because -->
+    <!-- of tricky problems to resolve that require refactoring -->
+    <div t-if="False"
+         data-js="SnippetSave"
+         t-att-data-selector="mailing_content_selector">
         <we-button class="fa fa-fw fa-save"
                    title="Save the block to use it elsewhere"
                    data-save-snippet=""


### PR DESCRIPTION
Before this commit saving a custom snippet inside an email template
produced a "cross origin" error related to the combination of the save &
reload mechanism with the fact that the email template editor is inside
an iframe.

After this commit saving a custom snippet inside an email template is
not available anymore.
Given that fixing the reload problem would be only temporary -while
quite complex-, it has been decided to disable the feature until the
editor allows for cleaning snippets without saving them.

Decided during task-2374802

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
