### PR TITLE
[IMP] website_mass_mailing: convert newsletter popup in popup

### DIFF
--- a/addons/website_mass_mailing/static/src/js/website_mass_mailing.editor.js
+++ b/addons/website_mass_mailing/static/src/js/website_mass_mailing.editor.js
@@ -12,27 +12,27 @@ var _t = core._t;
 
 const mailingListSubscribe = {
 
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
     /**
-     * show warning popup, if mailing list is not exists in the database
-     * @public
+     * Shows a warning popup, if mailing list is not exists in the database.
+     *
+     * @private
      */
-    showWarning() {
-        const text =  _t('No mailing list exists in the database, Do you want to create a new mailing list!');
+     _showWarning() {
+        const text = _t("No mailing list exists in the database, Do you want to create a new mailing list!");
         Dialog.confirm(this, text, {
             title: _t("Warning!"),
             confirm_callback: () => {
                 window.location.href = '/web#action=mass_mailing.action_view_mass_mailing_lists';
             },
             cancel_callback: () => {
-                this.getParent()._onRemoveClick($.Event( "click" ));
+                this.getParent()._onRemoveClick($.Event("click"));
             },
         });
     },
-
-    //--------------------------------------------------------------------------
-    // Private
-    //--------------------------------------------------------------------------
-
     /**
      * @private
      */
@@ -55,7 +55,7 @@ const mailingListSubscribe = {
             }
         }
     },
-}
+};
 
 options.registry.mailing_list_subscribe = options.Class.extend(mailingListSubscribe, {
 
@@ -80,7 +80,7 @@ options.registry.mailing_list_subscribe = options.Class.extend(mailingListSubscr
         if (mailingListID) {
             this.$target.attr("data-list-id", mailingListID);
         } else {
-            this.showWarning();
+            this._showWarning();
         }
     },
 
@@ -89,14 +89,12 @@ options.registry.mailing_list_subscribe = options.Class.extend(mailingListSubscr
     //--------------------------------------------------------------------------
 
     /**
-     * @private
      * @override
      */
     async _renderCustomXML(uiFragment) {
         await this._renderMailingListButtons(uiFragment);
     },
     /**
-     * @private
      * @override
      */
     _computeWidgetState(methodName, params) {
@@ -203,7 +201,7 @@ options.registry.newsletterPopup = options.registry.SnippetPopup.extend(mailingL
         if (mailingListID) {
             this.$target.attr("data-list-id", mailingListID);
         } else {
-            this.showWarning();
+            this._showWarning();
         }
     },
 
@@ -212,14 +210,12 @@ options.registry.newsletterPopup = options.registry.SnippetPopup.extend(mailingL
     //--------------------------------------------------------------------------
 
     /**
-     * @private
      * @override
      */
     async _renderCustomXML(uiFragment) {
         await this._renderMailingListButtons(uiFragment);
     },
     /**
-     * @private
      * @override
      */
     _computeWidgetState(methodName, params) {

--- a/addons/website_mass_mailing/static/src/js/website_mass_mailing.js
+++ b/addons/website_mass_mailing/static/src/js/website_mass_mailing.js
@@ -183,8 +183,10 @@ popup.include({
      * @override
      */
     _showPopup: function () {
-        if (this.$target.data('is_subscriber')) return;
-        this._super(this, ...arguments);
+        if (this.$target.data('is_subscriber')) {
+            return;
+        }
+        this._super(...arguments);
     },
 });
 });

--- a/addons/website_mass_mailing/static/tests/tours/newsletter_popup.js
+++ b/addons/website_mass_mailing/static/tests/tours/newsletter_popup.js
@@ -13,10 +13,6 @@ tour.register('newsletter_popup_edition', {
         name: 'Newsletter Popup',
     }),
     {
-        content: "Confirm newsletter choice",
-        trigger: '.modal-footer .btn-primary',
-    },
-    {
         content: "Check the modal is opened for edition",
         trigger: '.o_newsletter_popup .modal:visible',
         in_modal: false,

--- a/addons/website_mass_mailing/views/snippets_templates.xml
+++ b/addons/website_mass_mailing/views/snippets_templates.xml
@@ -51,18 +51,35 @@
 </template>
 
 <template id="s_newsletter_subscribe_popup" name="Newsletter Popup">
-    <div class="o_newsletter_popup o_snippet_invisible" data-list-id="0"/>
+    <div class="s_popup o_newsletter_popup o_snippet_invisible" data-list-id="0" data-name="Newsletter Popup" data-vcss="001" data-invisible="1">
+        <div class="modal fade d-none s_popup_middle o_newsletter_modal"
+            style="background-color: var(--black-50) !important;"
+            data-show-after="5000"
+            data-display="afterDelay"
+            data-consents-duration="7"
+            data-focus="false"
+            data-backdrop="false"
+            tabindex="-1"
+            role="dialog">
+            <div class="modal-dialog d-flex">
+                <div class="modal-content oe_structure">
+                    <div class="s_popup_close js_close_popup o_we_no_overlay o_not_editable" aria-label="Close">×</div>
+                    <div class="o_newsletter_content"/>
+                </div>
+            </div>
+        </div>
+    </div>
 </template>
 
 <template id="s_newsletter_subscribe_popup_content" name="Newsletter Popup Content">
-    <section class="s_text_block oe_img_bg o_bg_img_center pt88 pb64" data-snippet="s_text_block"
+    <section class="s_text_block oe_img_bg o_bg_img_center o_cc o_cc1 pt88 pb64" data-snippet="s_text_block"
              style="background-image: url('/web/image/website.s_cover_default_image'); background-position: 0 100%;">
         <div class="container s_allow_columns">
             <h1 style="text-align: center;">Always <b>First</b>.</h1>
             <p style="text-align: center;">Be the first to find out all the latest news,<br/> products, and trends.</p>
         </div>
     </section>
-    <section class="s_text_block" data-snippet="s_text_block">
+    <section class="s_text_block o_cc o_cc1" data-snippet="s_text_block">
         <div class="container">
             <div class="row s_nb_column_fixed no-gutters">
                 <div class="col-lg-8 offset-lg-2 pt32 pb32">
@@ -80,7 +97,7 @@
         <div data-js="mailing_list_subscribe"
             t-att-data-selector="selector"
             t-attf-data-exclude=".o_newsletter_modal #{selector}">
-            <we-button data-select_mailing_list="" data-no-preview="true">Change Newsletter</we-button>
+            <we-select class="o_we_inline" string="Change Newsletter" data-name="mailing_list" data-no-preview="true"></we-select>
         </div>
         <div data-js="recaptchaSubscribe"
             t-att-data-selector="selector">
@@ -88,9 +105,8 @@
             <we-checkbox t-if="recaptcha_public_key" string="Show reCaptcha Policy" data-toggle-recaptcha-legal="" data-no-preview="true"/>
         </div>
         <div t-att-data-selector="selector" data-drop-near="p, h1, h2, h3, blockquote, .card"/>
-        <div data-js="newsletter_popup"
-            data-selector=".o_newsletter_popup">
-            <we-button data-select_mailing_list="" data-no-preview="true">Change Newsletter</we-button>
+        <div data-js="newsletterPopup" data-selector=".o_newsletter_popup">
+            <we-select class="o_we_inline" string="Change Newsletter" data-name="mailing_list" data-no-preview="true"></we-select>
         </div>
     </xpath>
     <xpath expr="//div[@data-js='anchor']" position="attributes">

--- a/addons/website_mass_mailing/views/snippets_templates.xml
+++ b/addons/website_mass_mailing/views/snippets_templates.xml
@@ -54,13 +54,8 @@
     <div class="s_popup o_newsletter_popup o_snippet_invisible" data-list-id="0" data-name="Newsletter Popup" data-vcss="001" data-invisible="1">
         <div class="modal fade d-none s_popup_middle o_newsletter_modal"
             style="background-color: var(--black-50) !important;"
-            data-show-after="5000"
-            data-display="afterDelay"
-            data-consents-duration="7"
-            data-focus="false"
-            data-backdrop="false"
-            tabindex="-1"
-            role="dialog">
+            data-show-after="5000" data-display="afterDelay" data-consents-duration="7"
+            data-focus="false" data-backdrop="false" tabindex="-1" role="dialog">
             <div class="modal-dialog d-flex">
                 <div class="modal-content oe_structure">
                     <div class="s_popup_close js_close_popup o_we_no_overlay o_not_editable" aria-label="Close">×</div>


### PR DESCRIPTION
purpose: replace mailing list popup by a select in the left panel button and make the newsletter popup use the same structure as the popup snippet.

we replaced the button of "Change newsletter" by a select button of the mailing list in the left panel, now are we able to change the newsletter mailing list without open a popup modal.

we have added all options of the popup to the newsletter popup like size, position, delay, etc. The newsletter popup used the exact same structure as the s_popup snippet and only filled the popup content using the public widget.
we didn't change the current flow of the newsletter just we have added popup options in the newsletter. the newsletter works the same as popup snippet. newsletter popup does not open once the user has subscribed to the mailing list
otherwise it's working like popup options of the delay configuration.

task-2246975

closes https://github.com/odoo/odoo/pull/64923

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
