### PR TITLE
[IMP] l10n_ar: original amount in VAT Book

### DIFF
--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -187,13 +187,10 @@ class AccountMove(models.Model):
             })
         return super()._reverse_moves(default_values_list=default_values_list, cancel=cancel)
 
-    def _l10n_ar_get_amounts(self, company_currency=False):
+    def _l10n_ar_get_amounts(self):
         """ Method used to prepare data to present amounts and taxes related amounts when creating an
         electronic invoice for argentinian and the txt files for digital VAT books. Only take into account the argentinian taxes """
         self.ensure_one()
-        amount_field = company_currency and 'balance' or 'price_subtotal'
-        # if we use balance we need to correct sign (on price_subtotal is positive for refunds and invoices)
-        sign = -1 if (company_currency and self.is_inbound()) else 1
         tax_lines = self.line_ids.filtered('tax_line_id')
         vat_taxes = tax_lines.filtered(lambda r: r.tax_line_id.tax_group_id.l10n_ar_vat_afip_code)
 
@@ -203,42 +200,39 @@ class AccountMove(models.Model):
                 vat_taxable |= line
 
         profits_tax_group = self.env.ref('l10n_ar.tax_group_percepcion_ganancias')
-        return {'vat_amount': sign * sum(vat_taxes.mapped(amount_field)),
+        return {'vat_amount': sum(vat_taxes.mapped('price_subtotal')),
                 # For invoices of letter C should not pass VAT
-                'vat_taxable_amount': sign * sum(vat_taxable.mapped(amount_field)) if self.l10n_latam_document_type_id.l10n_ar_letter != 'C' else self.amount_untaxed,
-                'vat_exempt_base_amount': sign * sum(self.invoice_line_ids.filtered(lambda x: x.tax_ids.filtered(lambda y: y.tax_group_id.l10n_ar_vat_afip_code == '2')).mapped(amount_field)),
-                'vat_untaxed_base_amount': sign * sum(self.invoice_line_ids.filtered(lambda x: x.tax_ids.filtered(lambda y: y.tax_group_id.l10n_ar_vat_afip_code == '1')).mapped(amount_field)),
+                'vat_taxable_amount': sum(vat_taxable.mapped('price_subtotal')) if self.l10n_latam_document_type_id.l10n_ar_letter != 'C' else self.amount_untaxed,
+                'vat_exempt_base_amount': sum(self.invoice_line_ids.filtered(lambda x: x.tax_ids.filtered(lambda y: y.tax_group_id.l10n_ar_vat_afip_code == '2')).mapped('price_subtotal')),
+                'vat_untaxed_base_amount': sum(self.invoice_line_ids.filtered(lambda x: x.tax_ids.filtered(lambda y: y.tax_group_id.l10n_ar_vat_afip_code == '1')).mapped('price_subtotal')),
                 # used on FE
-                'not_vat_taxes_amount': sign * sum((tax_lines - vat_taxes).mapped(amount_field)),
+                'not_vat_taxes_amount': sum((tax_lines - vat_taxes).mapped('price_subtotal')),
                 # used on BFE + TXT
-                'iibb_perc_amount': sign * sum(tax_lines.filtered(lambda r: r.tax_line_id.tax_group_id.l10n_ar_tribute_afip_code == '07').mapped(amount_field)),
-                'mun_perc_amount': sign * sum(tax_lines.filtered(lambda r: r.tax_line_id.tax_group_id.l10n_ar_tribute_afip_code == '08').mapped(amount_field)),
-                'intern_tax_amount': sign * sum(tax_lines.filtered(lambda r: r.tax_line_id.tax_group_id.l10n_ar_tribute_afip_code == '04').mapped(amount_field)),
-                'other_taxes_amount': sign * sum(tax_lines.filtered(lambda r: r.tax_line_id.tax_group_id.l10n_ar_tribute_afip_code == '99').mapped(amount_field)),
-                'profits_perc_amount': sign * sum(tax_lines.filtered(lambda r: r.tax_line_id.tax_group_id == profits_tax_group).mapped(amount_field)),
-                'vat_perc_amount': sign * sum(tax_lines.filtered(lambda r: r.tax_line_id.tax_group_id.l10n_ar_tribute_afip_code == '06').mapped(amount_field)),
-                'other_perc_amount': sign * sum(tax_lines.filtered(lambda r: r.tax_line_id.tax_group_id.l10n_ar_tribute_afip_code == '09' and r.tax_line_id.tax_group_id != profits_tax_group).mapped(amount_field)),
+                'iibb_perc_amount': sum(tax_lines.filtered(lambda r: r.tax_line_id.tax_group_id.l10n_ar_tribute_afip_code == '07').mapped('price_subtotal')),
+                'mun_perc_amount': sum(tax_lines.filtered(lambda r: r.tax_line_id.tax_group_id.l10n_ar_tribute_afip_code == '08').mapped('price_subtotal')),
+                'intern_tax_amount': sum(tax_lines.filtered(lambda r: r.tax_line_id.tax_group_id.l10n_ar_tribute_afip_code == '04').mapped('price_subtotal')),
+                'other_taxes_amount': sum(tax_lines.filtered(lambda r: r.tax_line_id.tax_group_id.l10n_ar_tribute_afip_code == '99').mapped('price_subtotal')),
+                'profits_perc_amount': sum(tax_lines.filtered(lambda r: r.tax_line_id.tax_group_id == profits_tax_group).mapped('price_subtotal')),
+                'vat_perc_amount': sum(tax_lines.filtered(lambda r: r.tax_line_id.tax_group_id.l10n_ar_tribute_afip_code == '06').mapped('price_subtotal')),
+                'other_perc_amount': sum(tax_lines.filtered(lambda r: r.tax_line_id.tax_group_id.l10n_ar_tribute_afip_code == '09' and r.tax_line_id.tax_group_id != profits_tax_group).mapped('price_subtotal')),
                 }
 
-    def _get_vat(self, company_currency=False):
+    def _get_vat(self):
         """ Applies on wsfe web service and in the VAT digital books """
-        amount_field = company_currency and 'balance' or 'price_subtotal'
-        # if we use balance we need to correct sign (on price_subtotal is positive for refunds and invoices)
-        sign = -1 if (company_currency and self.is_inbound()) else 1
         res = []
         vat_taxable = self.env['account.move.line']
         # get all invoice lines that are vat taxable
         for line in self.line_ids:
-            if any(tax.tax_group_id.l10n_ar_vat_afip_code and tax.tax_group_id.l10n_ar_vat_afip_code not in ['0', '1', '2'] for tax in line.tax_line_id) and line[amount_field]:
+            if any(tax.tax_group_id.l10n_ar_vat_afip_code and tax.tax_group_id.l10n_ar_vat_afip_code not in ['0', '1', '2'] for tax in line.tax_line_id) and line['price_subtotal']:
                 vat_taxable |= line
         for vat in vat_taxable:
-            base_imp = sum(self.invoice_line_ids.filtered(lambda x: x.tax_ids.filtered(lambda y: y.tax_group_id.l10n_ar_vat_afip_code == vat.tax_line_id.tax_group_id.l10n_ar_vat_afip_code)).mapped(amount_field))
+            base_imp = sum(self.invoice_line_ids.filtered(lambda x: x.tax_ids.filtered(lambda y: y.tax_group_id.l10n_ar_vat_afip_code == vat.tax_line_id.tax_group_id.l10n_ar_vat_afip_code)).mapped('price_subtotal'))
             res += [{'Id': vat.tax_line_id.tax_group_id.l10n_ar_vat_afip_code,
-                     'BaseImp': sign * base_imp,
-                     'Importe': sign * vat[amount_field]}]
+                     'BaseImp': base_imp,
+                     'Importe': vat['price_subtotal']}]
 
         # Report vat 0%
-        vat_base_0 = sign * sum(self.invoice_line_ids.filtered(lambda x: x.tax_ids.filtered(lambda y: y.tax_group_id.l10n_ar_vat_afip_code == '3')).mapped(amount_field))
+        vat_base_0 = sum(self.invoice_line_ids.filtered(lambda x: x.tax_ids.filtered(lambda y: y.tax_group_id.l10n_ar_vat_afip_code == '3')).mapped('price_subtotal'))
         if vat_base_0:
             res += [{'Id': '3', 'BaseImp': vat_base_0, 'Importe': 0.0}]
 


### PR DESCRIPTION
### task 452

**Description of the issue/feature this PR addresses:**

Since AFIP requires to keep the original amounts in the txt files
for the digital VAT Book, we deprecate the option
'company_currency = True' in the methods used to prepare the data.

**Current behavior before PR:**
If you have an invoice with a different currency than the one in your company, when you get the txt files to import in AFIP the values are translated to the company currency.

**Desired behavior after PR is merged:**
If you have an invoice with a different currency than the one in your company, when you get the txt files to import in AFIP it keeps the original amounts.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
