### PR TITLE
[FIX] point_of_sale: picking not validated for kits

### DIFF
--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -94,63 +94,62 @@ class StockPicking(models.Model):
             )
             confirmed_moves = current_move._action_confirm()
             for move in confirmed_moves:
-                if first_line.product_id == move.product_id:
-                    if first_line.product_id.tracking != 'none':
-                        if self.picking_type_id.use_existing_lots or self.picking_type_id.use_create_lots:
-                            for line in order_lines:
-                                sum_of_lots = 0
-                                for lot in line.pack_lot_ids.filtered(lambda l: l.lot_name):
-                                    if line.product_id.tracking == 'serial':
-                                        qty = 1
-                                    else:
-                                        qty = abs(line.qty)
-                                    ml_vals = move._prepare_move_line_vals()
-                                    ml_vals.update({'qty_done':qty})
-                                    if self.picking_type_id.use_existing_lots:
-                                        existing_lot = self.env['stock.production.lot'].search([
-                                            ('company_id', '=', self.company_id.id),
-                                            ('product_id', '=', line.product_id.id),
-                                            ('name', '=', lot.lot_name)
-                                        ])
-                                        if not existing_lot and self.picking_type_id.use_create_lots:
-                                            existing_lot = self.env['stock.production.lot'].create({
-                                                'company_id': self.company_id.id,
-                                                'product_id': line.product_id.id,
-                                                'name': lot.lot_name,
-                                            })
-                                        ml_vals.update({
-                                            'lot_id': existing_lot.id,
-                                        })
-                                    else:
-                                        ml_vals.update({
-                                            'lot_name': lot.lot_name,
-                                        })
-                                    self.env['stock.move.line'].create(ml_vals)
-                                    sum_of_lots += qty
-                                if abs(line.qty) != sum_of_lots:
-                                    difference_qty = abs(line.qty) - sum_of_lots
-                                    ml_vals = current_move._prepare_move_line_vals()
-                                    if line.product_id.tracking == 'serial':
-                                        ml_vals.update({'qty_done': 1})
-                                        for i in range(int(difference_qty)):
-                                            self.env['stock.move.line'].create(ml_vals)
-                                    else:
-                                        ml_vals.update({'qty_done': difference_qty})
-                                        self.env['stock.move.line'].create(ml_vals)
-                        else:
-                            move._action_assign()
+                if first_line.product_id == move.product_id and first_line.product_id.tracking != 'none':
+                    if self.picking_type_id.use_existing_lots or self.picking_type_id.use_create_lots:
+                        for line in order_lines:
                             sum_of_lots = 0
-                            for move_line in move.move_line_ids:
-                                move_line.qty_done = move_line.product_uom_qty
-                                sum_of_lots += move_line.product_uom_qty
-                            if float_compare(move.product_uom_qty, move.quantity_done, precision_rounding=move.product_uom.rounding) > 0:
-                                remaining_qty = move.product_uom_qty - move.quantity_done
+                            for lot in line.pack_lot_ids.filtered(lambda l: l.lot_name):
+                                if line.product_id.tracking == 'serial':
+                                    qty = 1
+                                else:
+                                    qty = abs(line.qty)
                                 ml_vals = move._prepare_move_line_vals()
-                                ml_vals.update({'qty_done':remaining_qty})
+                                ml_vals.update({'qty_done':qty})
+                                if self.picking_type_id.use_existing_lots:
+                                    existing_lot = self.env['stock.production.lot'].search([
+                                        ('company_id', '=', self.company_id.id),
+                                        ('product_id', '=', line.product_id.id),
+                                        ('name', '=', lot.lot_name)
+                                    ])
+                                    if not existing_lot and self.picking_type_id.use_create_lots:
+                                        existing_lot = self.env['stock.production.lot'].create({
+                                            'company_id': self.company_id.id,
+                                            'product_id': line.product_id.id,
+                                            'name': lot.lot_name,
+                                        })
+                                    ml_vals.update({
+                                        'lot_id': existing_lot.id,
+                                    })
+                                else:
+                                    ml_vals.update({
+                                        'lot_name': lot.lot_name,
+                                    })
                                 self.env['stock.move.line'].create(ml_vals)
-
+                                sum_of_lots += qty
+                            if abs(line.qty) != sum_of_lots:
+                                difference_qty = abs(line.qty) - sum_of_lots
+                                ml_vals = current_move._prepare_move_line_vals()
+                                if line.product_id.tracking == 'serial':
+                                    ml_vals.update({'qty_done': 1})
+                                    for i in range(int(difference_qty)):
+                                        self.env['stock.move.line'].create(ml_vals)
+                                else:
+                                    ml_vals.update({'qty_done': difference_qty})
+                                    self.env['stock.move.line'].create(ml_vals)
                     else:
-                        move.quantity_done = move.product_uom_qty
+                        move._action_assign()
+                        sum_of_lots = 0
+                        for move_line in move.move_line_ids:
+                            move_line.qty_done = move_line.product_uom_qty
+                            sum_of_lots += move_line.product_uom_qty
+                        if float_compare(move.product_uom_qty, move.quantity_done, precision_rounding=move.product_uom.rounding) > 0:
+                            remaining_qty = move.product_uom_qty - move.quantity_done
+                            ml_vals = move._prepare_move_line_vals()
+                            ml_vals.update({'qty_done':remaining_qty})
+                            self.env['stock.move.line'].create(ml_vals)
+
+                else:
+                    move.quantity_done = move.product_uom_qty
 
     def _send_confirmation_email(self):
         # Avoid sending Mail/SMS for POS deliveries


### PR DESCRIPTION
When you are selling a kit in point_of_sale, the associated picking is
not validated. Because no quantity done is set on its component move
lines.

This has been caused by modifications made in following commit: https://github.com/odoo/odoo/commit/f9dd1d88d0d24914028464cc12b69ff0878346f8

OPW-2426992

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
