### PR TITLE
[IMP] hr_contract: add employee type

### DIFF
--- a/addons/hr/models/hr_employee_base.py
+++ b/addons/hr/models/hr_employee_base.py
@@ -53,6 +53,14 @@ class HrEmployeeBase(models.AbstractModel):
         ('presence_absent', 'Absent'),
         ('presence_to_define', 'To define'),
         ('presence_undetermined', 'Undetermined')], compute='_compute_presence_icon')
+    employee_type = fields.Selection([
+        ('employee', 'Employee'),
+        ('student', 'Student'),
+        ('trainee', 'Trainee'),
+        ('contractor', 'Contractor'),
+        ('freelance', 'Freelancer'),
+        ], string='Employee Type', default='employee', required=True,
+        help="The employee type. Although the primary purpose may seem to categorize employees, this field has also an impact in the Contract History. Only Employee type is supposed to be under contract and will have a Contract History.")
 
     @api.depends('user_id.im_status')
     def _compute_presence_state(self):

--- a/addons/hr/models/hr_employee_public.py
+++ b/addons/hr/models/hr_employee_public.py
@@ -30,6 +30,7 @@ class HrEmployeePublic(models.Model):
     resource_calendar_id = fields.Many2one(readonly=True)
     tz = fields.Selection(readonly=True)
     color = fields.Integer(readonly=True)
+    employee_type = fields.Selection(readonly=True)
 
     # hr.employee.public specific fields
     child_ids = fields.One2many('hr.employee.public', 'parent_id', string='Direct subordinates', readonly=True)

--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -65,6 +65,7 @@ class User(models.Model):
     hr_presence_state = fields.Selection(related='employee_id.hr_presence_state')
     last_activity = fields.Date(related='employee_id.last_activity')
     last_activity_time = fields.Char(related='employee_id.last_activity_time')
+    employee_type = fields.Selection(related='employee_id.employee_type', readonly=False, related_sudo=False)
 
     can_edit = fields.Boolean(compute='_compute_can_edit')
 
@@ -143,6 +144,7 @@ class User(models.Model):
             'study_field',
             'study_school',
             'private_lang',
+            'employee_type',
         ]
 
         init_res = super(User, self).__init__(pool, cr)

--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -60,6 +60,7 @@
                                 </group>
                                 <group>
                                     <field name="department_id"/>
+                                    <field name="employee_type"/>
                                     <field name="company_id" groups="base.group_multi_company"/>
                                     <field name="parent_id"/>
                                     <field name="coach_id"/>

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -178,6 +178,7 @@
                             <page name="hr_settings" string="HR Settings" groups="hr.group_hr_user">
                                 <group>
                                     <group string='Status' name="active_group">
+                                        <field name="employee_type"/>
                                         <field name="user_id" string="Related User" domain="[('share', '=', False)]"/>
                                     </group>
                                     <group string="Attendance" name="identification_group">

--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -176,7 +176,9 @@
                     </page>
                      <page name="hr_settings" string="HR Settings">
                         <group>
-                            <group string='Status' name="active_group" invisible="1"></group>
+                            <group string='Status' name="active_group">
+                                <field name="employee_type" attrs="{'readonly': [('can_edit', '=', False)]}"/>
+                            </group>
                             <group string="Attendance" name="identification_group">
                                 <field name="pin" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                                 <field name="barcode" attrs="{'readonly': [('can_edit', '=', False)]}"/>

--- a/addons/hr_contract/report/hr_contract_history.py
+++ b/addons/hr_contract/report/hr_contract_history.py
@@ -88,9 +88,10 @@ class ContractHistory(models.Model):
             FROM       hr_contract AS contract
             INNER JOIN contract_information ON contract.id = contract_information.id
             RIGHT JOIN hr_employee AS employee
-                ON contract_information.employee_id = employee.id
+                ON  contract_information.employee_id = employee.id
                 AND contract.company_id = employee.company_id
-            WHERE      (employee.active = true OR contract.state='draft')
+            WHERE   employee.employee_type IN ('employee', 'student')
+            AND     (employee.active = true OR contract.state='draft')
         )""" % (self._table, self._get_fields()))
 
     @api.depends('employee_id.contract_ids')

--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -13,7 +13,8 @@
                             class="oe_stat_button"
                             icon="fa-book"
                             type="object"
-                            groups="hr_contract.group_hr_contract_manager">
+                            groups="hr_contract.group_hr_contract_manager"
+                            attrs="{'invisible' : [('employee_type', 'not in', ['employee', 'student'])]}">
                             <div attrs="{'invisible' : [('first_contract_date', '=', False)]}" class="o_stat_info">
                                 <span class="o_stat_text text-success" attrs="{'invisible' : [('contract_warning', '=', True)]}" title="In Contract Since"> In Contract Since</span>
                                 <span class="o_stat_value text-success" attrs="{'invisible' : [('contract_warning', '=', True)]}">
@@ -37,7 +38,9 @@
                         </button>
                     </div>
                     <xpath expr="//field[@name='user_id']" position="before">
-                        <field name="first_contract_date" attrs="{'invisible' : [('first_contract_date', '=', False)]}" readonly="1"/>
+                        <field name="first_contract_date"
+                               attrs="{'invisible' : ['|', ('employee_type', 'not in', ['employee', 'student']), ('first_contract_date', '=', False)]}"
+                               readonly="1"/>
                     </xpath>
                     <xpath expr="//field[@name='bank_account_id']" position="replace">
                         <field name="bank_account_id" context="{'display_partner':True}" attrs="{'invisible' : [('address_home_id', '=', False)]}"/>


### PR DESCRIPTION
Prior to this commit:

* All employees were treated the same way regarding the contractual point of vue.

From this commit on:

* Three employee types will be created:
 - Employee, which is supposed to be under contract
 - Student & Contractor which are both not supposed to have an employee contract (but are still use the employee as working for the company)

* Employee view and Contract History will take this consideration into account.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
