### PR TITLE
[FIX] website_crm_partner_assign: fix opportunities portal page witho…

### DIFF
--- a/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
+++ b/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
@@ -532,7 +532,9 @@
                         <div class="col-lg-5 mb-4 mb-lg-0">
                             <div class="border-bottom d-flex justify-content-between py-2 mb-3 align-items-center">
                                 <h5 class="mb-0">
-                                    <span class="text-nowrap" t-esc="opportunity.planned_revenue" t-options="{'widget': 'monetary', 'display_currency': opportunity.company_currency}"/> at
+                                    <span t-if="opportunity.company_currency" class="text-nowrap" t-esc="opportunity.planned_revenue" t-options="{'widget': 'monetary', 'display_currency': opportunity.company_currency}"/>
+                                    <span t-else="" class="text-nowrap" t-esc="opportunity.planned_revenue"/>
+                                    <span> at </span>
                                     <span class="badge badge-info badge-pill"><span t-field="opportunity.probability"/>%</span>
                                 </h5>
                                 <button type="button" data-toggle="modal" data-target=".modal_edit_opp" class="btn btn-link btn-sm"><i class="fa fa-pencil mr-1"/>Edit</button>


### PR DESCRIPTION
…ut currency

Follow-up of 13a4544707053295565c33580526f6a8a16f556b

Where we fixed the portal *list* of opportunities but did not notice that the
associated *form* also had the same issue.

To recap the issue:

When you remove the 'company_id' on a crm.lead, you also remove the computed
'company_currency'.
When trying to view this kind of leads in the website_crm_partner_assign portal
form page, it would raise an error while trying to display the planned_revenue
in the missing currency.

Now, we display the number without any currency sign, which is a "best effort"
solution, just the same as on the crm.lead form view.
So it will look like "9000 at 47%" instead of "$9000 at 47%".

Task-2444539

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
