### PR TITLE
[FIX] stock_account: correct forecast report total amount and currency

### DIFF
--- a/addons/stock_account/models/stock_quant.py
+++ b/addons/stock_account/models/stock_quant.py
@@ -20,8 +20,8 @@ class StockQuant(models.Model):
         average cost is the same for all location and the valuation field is
         a estimation more than a real value).
         """
-        self.currency_id = self.env.company.currency_id
         for quant in self:
+            quant.currency_id = quant.company_id.currency_id
             # If the user didn't enter a location yet while enconding a quant.
             if not quant.location_id:
                 quant.value = 0
@@ -36,10 +36,10 @@ class StockQuant(models.Model):
                 if float_is_zero(quantity, precision_rounding=quant.product_id.uom_id.rounding):
                     quant.value = 0.0
                     continue
-                average_cost = quant.product_id.value_svl / quantity
+                average_cost = quant.product_id.with_company(quant.company_id).value_svl / quantity
                 quant.value = quant.quantity * average_cost
             else:
-                quant.value = quant.quantity * quant.product_id.standard_price
+                quant.value = quant.quantity * quant.product_id.with_company(quant.company_id).standard_price
 
     @api.model
     def read_group(self, domain, fields, groupby, offset=0, limit=None, orderby=False, lazy=True):


### PR DESCRIPTION
Steps:
- Go to Settings > Companies > Manage Companies
- Create a company (1) with a different currency than the one you're in
- Go to inventory > Products > Products > Create a product (2)
  - Storable Product
  - Cost: 10
- Click Update Quantity
- Create a new quantity line with 1 in On Hand Quantity
- Switch to company (1)
- Go to Inventory > Products > Products > Edit product (2)
  - Storable Product
  - Cost: 15
- Click Update Quantity
- Create a new quantity line with 1 in On Hand Quantity
- Go back to the product
- Click the "Forecasted" smart button

Bug:
Traceback here:
https://github.com/odoo/odoo/blob/47bfdf0592a5dd93870ca1a9da326351d70087bb/addons/stock_account/report/report_stock_forecasted.py#L17
ValueError: Expected singleton: res.currency(2, 1)

Explanation:
The amount is the sum of the `stock.valuation.layer`s of a product
across all companies and these companies may have different currencies.

This commit scopes the computation of the amount inside the company of
the current warehouse.

Also the `stock.quant` values displayed in the "On Hand" report are not
correct for the other companies when displaying their data by selecting
all the checkboxes in the global company dropdown.
This commit also fixes the amounts in the On Hand view by using the
standard price per company and attributing the correct currency to the
`stock.quant`.

opw:2444593