### PR TITLE
[FIX] stock_account: allow user to validate transfer

### DIFF
--- a/addons/stock_account/security/ir.model.access.csv
+++ b/addons/stock_account/security/ir.model.access.csv
@@ -3,3 +3,4 @@ access_account_account_stock_manager,account.account stock manager,account.model
 access_stock_picking_invoicing_payments,stock.picking,stock.model_stock_picking,account.group_account_invoice,1,1,1,0
 access_stock_move_invoicing_payments,stock.move,model_stock_move,account.group_account_invoice,1,1,1,0
 access_stock_valuation_layer,access_stock_valuation_layer,model_stock_valuation_layer,stock.group_stock_manager,1,1,1,0
+access_account_tag_stock_user,account.tag stock user,account.model_account_account_tag,stock.group_stock_user,1,0,0,0


### PR DESCRIPTION
- Create a [DEMO] user with user access to inventory
- Create an account tag for taxes
- Add that account tag to the purchase tax under Tax grid
- As 'Admin' user create and confirm a PO with that tax
- Let this transfer to be validated by [DEMO]

A permission error on account.tag will block [DEMO] from
validating the transfer

opw-2382794

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
