### PR TITLE
[IMP] hr: Make employee lang editable on employee + my profile

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -43,6 +43,7 @@ class HrEmployeePrivate(models.Model):
         compute='_compute_is_address_home_a_company',
     )
     private_email = fields.Char(related='address_home_id.email', string="Private Email", groups="hr.group_hr_user")
+    lang = fields.Selection(related='address_home_id.lang', string="Lang", groups="hr.group_hr_user", readonly=False)
     country_id = fields.Many2one(
         'res.country', 'Nationality (Country)', groups="hr.group_hr_user", tracking=True)
     gender = fields.Selection([

--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -35,6 +35,7 @@ class User(models.Model):
     private_country_id = fields.Many2one(related='address_home_id.country_id', string="Private Country", readonly=False, related_sudo=False)
     is_address_home_a_company = fields.Boolean(related='employee_id.is_address_home_a_company', readonly=False, related_sudo=False)
     private_email = fields.Char(related='address_home_id.email', string="Private Email", readonly=False)
+    private_lang = fields.Selection(related='address_home_id.lang', string="Employee Lang", readonly=False)
     km_home_work = fields.Integer(related='employee_id.km_home_work', readonly=False, related_sudo=False)
     # res.users already have a field bank_account_id and country_id from the res.partner inheritance: don't redefine them
     employee_bank_account_id = fields.Many2one(related='employee_id.bank_account_id', string="Employee's Bank Account Number", related_sudo=False, readonly=False)
@@ -141,6 +142,7 @@ class User(models.Model):
             'certificate',
             'study_field',
             'study_school',
+            'private_lang',
         ]
 
         init_res = super(User, self).__init__(pool, cr)

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -133,6 +133,7 @@
                                             options='{"always_reload": True, "highlight_first_line": True}'/>
                                         <field name="private_email" string="Email"/>
                                         <field name="phone" class="o_force_ltr" groups="hr.group_hr_user" string="Phone"/>
+                                        <field name="lang" string="Language"/>
                                         <field name="bank_account_id" context="{'default_partner_id': address_home_id}"/>
                                         <label for="km_home_work"/>
                                         <div class="o_row" name="div_km_home_work">

--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -137,6 +137,7 @@
 
                                 <field name="private_email" string="Email" attrs="{'readonly': [('can_edit', '=', False)], 'invisible': [('address_home_id', '=', False)]}"/>
                                 <field name="employee_phone" string="Phone" class="o_force_ltr" attrs="{'readonly': [('can_edit', '=', False)], 'invisible': [('address_home_id', '=', False)]}" options="{'enable_sms': false}"/>
+                                <field name="private_lang" string="Language" attrs="{'readonly': [('can_edit', '=', False)], 'invisible': [('address_home_id', '=', False)]}"/>
                                 <field name="employee_bank_account_id" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                                 <field name="km_home_work" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                             </group>


### PR DESCRIPTION
The field is defined on the private address (address_home_id) of the
employee.

It would be more convenient to allow the configuration directly on the
employee view and to allow the employee to change it by himself.

TaskID: 2410407

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
