### PR TITLE
[IMP] point_of_sale : Remove confirm text if cashier doesnt confirm the exit

### DIFF
--- a/addons/point_of_sale/static/src/js/chrome.js
+++ b/addons/point_of_sale/static/src/js/chrome.js
@@ -834,6 +834,9 @@ var Chrome = PosBaseWidget.extend(AbstractAction.prototype, {
                         },2000);
                     } else {
                         clearTimeout(this.confirmed);
+                        this.$el.removeClass('confirm');
+                        this.$el.text(_t('Close'));
+                        this.confirmed = false;
                         this.gui.close();
                     }
                 },


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Step to reproduce : 
- in a point of sale, make some orders, with the network connexion lost
- click on "close"
- when odoo asks if you really want to quit, click on "Cancel". (ref : https://github.com/odoo/odoo/blob/12.0/addons/point_of_sale/static/src/js/gui.js#L335)

**Current behavior before PR:**
- the button stay at the "confirm" state. And the next time, the question will not be asked.

**Desired behavior after PR is merged:**
- the button reset to the "close" state, and the next time, the question will be asked.


CC : @Yenthe666 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
