### PR TITLE
[FIX] event: rename groupby filters

### DIFF
--- a/addons/event/views/event_views.xml
+++ b/addons/event/views/event_views.xml
@@ -444,9 +444,9 @@
                         domain="[('activity_ids.date_deadline', '&gt;', context_today().strftime('%Y-%m-%d'))]"/>
                     <group expand="0" string="Group By">
                         <filter string="Responsible" name="responsible" context="{'group_by': 'user_id'}"/>
-                        <filter string="Template" name="event_type_id" context="{'group_by': 'event_type_id'}"/>
-                        <filter string="Stage" name="stage_id" context="{'group_by': 'stage_id'}"/>
-                        <filter string="Start Date" name="date_begin" domain="[]" context="{'group_by': 'date_begin'}"/>
+                        <filter string="Template" name="eventtype" context="{'group_by': 'event_type_id'}"/>
+                        <filter string="Stage" name="stage" context="{'group_by': 'stage_id'}"/>
+                        <filter string="Start Date" name="datebegin" domain="[]" context="{'group_by': 'date_begin'}"/>
                     </group>
                 </search>
             </field>


### PR DESCRIPTION
Since the filter names are equal to the field names, passing in a context with i.e. `{'search_default_event_type_id': 3}` activates both the domain and the groupby.

Thus, I rename the filters.

@Tecnativa TT27664




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
