### PR TITLE
[FIX] coupon: printed coupon not properly displayed

### DIFF
--- a/addons/coupon/report/coupon_report_templates.xml
+++ b/addons/coupon/report/coupon_report_templates.xml
@@ -50,7 +50,7 @@
                                     Use this promo code before
                                     <span t-field="o.expiration_date" t-options='{"format": "yyyy-MM-d"}'/>
                                 </h4>
-                                <h2 class="mt32">
+                                <h2 class="mt32" style="margin-top: 32px">
                                     <strong class="bg-light" t-esc="o.code" style="padding: 20px 10px;"></strong>
                                 </h2>
                                 <h4 t-if="o.program_id.rule_min_quantity > 1">


### PR DESCRIPTION
Generate a coupon code, print it

opw-2444242

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
