### PR TITLE
[FIX] crm: add filter for overdue opportunities

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -695,6 +695,7 @@
                     <filter string="Won" name="won" domain="['&amp;', ('active', '=', True), ('stage_id.is_won', '=', True)]"/>
                     <filter string="Lost" name="lost" domain="['&amp;', ('active', '=', False), ('probability', '=', 0)]"/>
                     <separator/>
+                    <filter invisible="1" string="Overdue Opportunities" name="overdue_opp" domain="[('date_deadline', '&lt;', context_today().strftime('%Y-%m-%d'))]"/>
                     <filter invisible="1" string="Late Activities" name="activities_overdue"
                         domain="[('activity_ids.date_deadline', '&lt;', context_today().strftime('%Y-%m-%d'))]"
                         help="Show all opportunities for which the next action date is before today"/>


### PR DESCRIPTION
In the overview of team pipelines in CRM application,
the count displayed for the overdue opportunities is
correct but clicking on the count doesn't filter the
overdue opportunities and gives a list of all the
opportunities.

problem link:- [https://github.com/odoo/odoo/commit/1da63f0ab0fb4212bee46f960c6bbe8ca9251cac](https://github.com/odoo/odoo/commit/1da63f0ab0fb4212bee46f960c6bbe8ca9251cac)
in this commit for the overdue opportunity only context is add for overdue opportunity
there is no filter created in search view.

After this commit, You land on the kanban view with a
filter "Overdue Opportunities". The count matches what
you see and you know which ones are overdue.

**TaskID : 2323612**

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
