### PR TITLE
[FIX] web_editor: restore website header once page content is removed

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -348,6 +348,11 @@ var SnippetEditor = Widget.extend({
         this.destroy();
         $parent.trigger('content_changed');
 
+        // TODO Page content changed, some elements may need to be adapted
+        // according to it. While waiting for a better way to handle that this
+        // window trigger will handle most cases.
+        $(window).trigger('resize');
+
         function isEmptyAndRemovable($el, editor) {
             editor = editor || $el.data('snippet-editor');
             return $el.children().length === 0 && $el.text().trim() === ''


### PR DESCRIPTION
The affixed header was not reappearing if page content was removed and
the page thus indirectly scrolled.

task-2446020
