### PR TITLE
[FIX] calendar: correct 'Date' filter behavior

### DIFF
--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -280,7 +280,7 @@
                 <field name="show_as"/>
                 <filter string="My Meetings" help="My Meetings" name="mymeetings" domain="[('partner_ids.user_ids', 'in', [uid])]"/>
                 <separator/>
-                <filter string="Date" name="filter_start_date" date="start_date"/>
+                <filter string="Date" name="filter_start_date" date="start"/>
                 <separator/>
                 <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
                 <group expand="0" string="Group By">


### PR DESCRIPTION
Issue

	- Install calendar
	- Go to calendar and set 'week' view
	- Go to first week of the year
	- Add a 'Full Day' event
	- Add an event of 'few hours'
	- Click on filters -> Date -> Q1

	Only 'Full Day' events remains displayed.

Cause

	'start_date' is used to in the 'Date' filter
	and this field is set only on 'Full Day' events.

Solution

	Use 'start' field instead since always set.

opw-2439460