### PR TITLE
[FIX] gantt: Display gantt popover dates in user locale

### DIFF
--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -355,8 +355,8 @@
                         <div class="row no-gutters">
                             <div class="col">
                                 <ul class="pl-1 mb-0 list-unstyled">
-                                    <li><strong>Start Date: </strong> <t t-esc="userTimezoneStartDate.format('YYYY-MM-DD HH:mm:ss')"/></li>
-                                    <li><strong>Stop Date: </strong> <t t-esc="userTimezoneStopDate.format('YYYY-MM-DD HH:mm:ss')"/></li>
+                                    <li><strong>Start Date: </strong> <t t-esc="userTimezoneStartDate.format('L LTS')"/></li>
+                                    <li><strong>Stop Date: </strong> <t t-esc="userTimezoneStopDate.format('L LTS')"/></li>
                                     <li><strong>Workcenter: </strong> <t t-esc="workcenter_id[1]"/></li>
                                 </ul>
                             </div>
@@ -387,8 +387,8 @@
                         <div class="row no-gutters">
                             <div class="col">
                                 <ul class="pl-1 mb-0 list-unstyled">
-                                    <li><strong>Start Date: </strong> <t t-esc="userTimezoneStartDate.format('YYYY-MM-DD HH:mm:ss')"/></li>
-                                    <li><strong>Stop Date: </strong> <t t-esc="userTimezoneStopDate.format('YYYY-MM-DD HH:mm:ss')"/></li>
+                                    <li><strong>Start Date: </strong> <t t-esc="userTimezoneStartDate.format('L LTS')"/></li>
+                                    <li><strong>Stop Date: </strong> <t t-esc="userTimezoneStopDate.format('L LTS')"/></li>
                                     <li><strong>Workcenter: </strong> <t t-esc="workcenter_id[1]"/></li>
                                 </ul>
                             </div>


### PR DESCRIPTION
Issue

        - Install "Manufacturing" module
	- Go to settings and activate "Master Production Schedule"
        - Install Dutch language
        - Switch user language to Dutch
        - Go to Manufacturing -> Planning -> Planning by Production
        - Hover work order

        Dates are not displayed with user locale.

Cause

        Date are formated to "YYYY-MM-DD HH:mm:ss",
        regardless the locale.

Solution

        Format date instead with locale format letters (L, LL, LTS, ...)

Doc : https://momentjs.com/docs/#/parsing/string-format/
      Go to "Locale aware formats" section

opw-2430570