### PR TITLE
[IMP] product,sale,stock: find variant to archive directly

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -365,6 +365,9 @@ class ProductProduct(models.Model):
         self.clear_caches()
         return res
 
+    def _filter_to_unlink(self, check_access=True):
+        return self
+
     def _unlink_or_archive(self, check_access=True):
         """Unlink or archive products.
         Try in batch as much as possible because it is much faster.
@@ -382,6 +385,10 @@ class ProductProduct(models.Model):
             self.check_access_rights('write')
             self.check_access_rule('write')
             self = self.sudo()
+            to_unlink = self._filter_to_unlink()
+            to_archive = self - to_unlink
+            to_archive.write({'active': False})
+            self = to_unlink
 
         try:
             with self.env.cr.savepoint(), tools.mute_logger('odoo.sql_db'):

--- a/addons/sale/models/product_product.py
+++ b/addons/sale/models/product_product.py
@@ -56,6 +56,12 @@ class ProductProduct(models.Model):
         self.ensure_one()
         return self.product_tmpl_id._get_combination_info(self.product_template_attribute_value_ids, self.id, add_qty, pricelist, parent_combination)
 
+    def _filter_to_unlink(self):
+        domain = [('product_id', 'in', self.ids)]
+        lines = self.env['sale.order.line'].read_group(domain, ['product_id'], ['product_id'])
+        linked_product_ids = [group['product_id'][0] for group in lines]
+        return super(ProductProduct, self - self.browse(linked_product_ids))._filter_to_unlink()
+
 
 class ProductAttribute(models.Model):
     _inherit = "product.attribute"

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -548,6 +548,13 @@ class Product(models.Model):
                 raise UserError(msg)
         return res
 
+    def _filter_to_unlink(self):
+        domain = [('product_id', 'in', self.ids)]
+        lines = self.env['stock.production.lot'].read_group(domain, ['product_id'], ['product_id'])
+        linked_product_ids = [group['product_id'][0] for group in lines]
+        return super(Product, self - self.browse(linked_product_ids))._filter_to_unlink()
+
+
 class ProductTemplate(models.Model):
     _inherit = 'product.template'
     _check_company_auto = True


### PR DESCRIPTION
BEFORE: Odoo tries to unlink and then checks for exceptions

AFTER: allow to filter products before starting recursion

WHY: this speeds up updating attributes in product.template

---

opw-2440417

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
