### PR TITLE
[FIX] sale_coupon:  promo_applicability on next order

### DIFF
--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -314,7 +314,7 @@ class SaleOrder(models.Model):
             error_status = program._check_promo_code(order, False)
             if not error_status.get('error'):
                 if program.promo_applicability == 'on_next_order':
-                    order._create_reward_coupon(program)
+                    order.state != 'cancel' and order._create_reward_coupon(program)
                 elif program.discount_line_product_id.id not in self.order_line.mapped('product_id').ids:
                     self.write({'order_line': [(0, False, value) for value in self._get_reward_line_values(program)]})
                 order.no_code_promo_program_ids |= program


### PR DESCRIPTION
Steps to reproduce the bug:

- Create a promotion program PP
- Set 50 in minimal amount
- Set promo_applicability = on_next_order
- Set reward_type = discount
- Set discount_type = discount
- Create a new sale order SO with a product with price 100€
- Cancel the SO

Bug:

A coupon C had been created

PS: When reset to draft and confirm SO, C became valid

Closes #64361

opw:2431740