### PR TITLE
[FIX] sale_management: uom not displayed to the customer

### DIFF
--- a/addons/sale_management/views/sale_portal_templates.xml
+++ b/addons/sale_management/views/sale_portal_templates.xml
@@ -101,7 +101,7 @@
             </t>
             <t t-else="">
                 <span t-field="line.product_uom_qty"/>
-                <span t-field="line.product_uom" groups="uom.group_uom"/>
+                <span t-field="line.product_uom"/>
             </t>
         </xpath>
 


### PR DESCRIPTION
The uom must be displayed to the customer in any case.
Otherwise portal user couldn't sign their online quote if
they couldn't read the uom (ex: a contract of one year or one day)

Fine tuning of https://github.com/odoo/odoo/commit/342dd5ffb8281cb5c37fea4fb96db2b570c30122

opw:2411108