### PR TITLE
[FIX] stock: get rules from location (recursion)

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -534,7 +534,7 @@ class Product(models.Model):
             'route_ids': route_ids,
             'warehouse_id': location.get_warehouse()
         })
-        if not rule:
+        if not rule or rule in seen_rules:
             return seen_rules
         if rule.procure_method == 'make_to_stock' or rule.action not in ('pull_push', 'pull'):
             return seen_rules | rule


### PR DESCRIPTION
When getting the rules from a location, the server calls a recursion
method with an incomplete stop condition:
The method calls itself with the next rule that needs to be checked
and all previous rules already checked. However, nothing ensures that
the current rule is not among the already done ones. As a result, the
method may check the same rule indefinitely.

Here is an example of such a situation:
(Need mrp)
1. Enable multi-step routes
2. Create a product P
	- Enable the Manufacture route
3. Create a warehouse WH02 (let WH be the default one)
4. Edit route "Manufacture":
	- First rule:
		- Action: Pull From
		- Op. Type: SF Manufacturing
		- Source: WH/Stock
		- Dest.: WH/Stock
		- Supp. Method: Trigger Another Rule
	- Second rule:
		- Action: Manufacture
		- Op. Type: WH02: Manufacturing
		- Dest.: WH02/Stock
5. Go to P-product's reordering rule
6. Click on Create

Error: A RecursionError is raised.

This fix improves the stop condition: the recursion is stopped if the
current rule is already checked.

OPW-2440384