### PR TITLE
[MERGE] crm: fix randomly failing tests about query counters and assign domain

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -12,41 +12,50 @@ from odoo.addons.phone_validation.tools import phone_validation
 from odoo.exceptions import UserError, AccessError
 from odoo.osv import expression
 from odoo.tools.translate import _
-from odoo.tools import email_re, email_split, safe_eval
+from odoo.tools import email_re, email_split
 
 from . import crm_stage
 
 _logger = logging.getLogger(__name__)
 
 CRM_LEAD_FIELDS_TO_MERGE = [
-    'name',
-    'partner_id',
+    # UTM mixin
     'campaign_id',
-    'company_id',
-    'country_id',
-    'team_id',
-    'state_id',
-    'stage_id',
     'medium_id',
     'source_id',
+    # Mail mixin
+    'email_cc',
+    # description
+    'name',
     'user_id',
-    'title',
-    'city',
-    'contact_name',
-    'description',
-    'mobile',
-    'partner_name',
-    'phone',
-    'probability',
+    'company_id',
+    'team_id',
+    # pipeline
+    'stage_id',
+    # revenues
     'expected_revenue',
+    # dates
+    'create_date',
+    'date_action_last',
+    # partner / contact
+    'partner_id',
+    'title',
+    'partner_name',
+    'contact_name',
+    'email_from',
+    'mobile',
+    'phone',
+    'website',
+    # address
     'street',
     'street2',
     'zip',
-    'create_date',
-    'date_action_last',
-    'email_from',
-    'email_cc',
-    'website']
+    'city',
+    'state_id',
+    'country_id',
+    # probability
+    'probability',
+]
 
 # Subset of partner fields: sync any of those
 PARTNER_FIELDS_TO_SYNC = [
@@ -99,6 +108,10 @@ class Lead(models.Model):
         help='UX: Limit to lead company or all if no company')
     user_email = fields.Char('User Email', related='user_id.email', readonly=True)
     user_login = fields.Char('User Login', related='user_id.login', readonly=True)
+    team_id = fields.Many2one(
+        'crm.team', string='Sales Team', check_company=True, index=True, tracking=True,
+        domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]",
+        compute='_compute_team_id', readonly=False, store=True)
     company_id = fields.Many2one(
         'res.company', string='Company', index=True,
         compute='_compute_company_id', readonly=False, store=True)
@@ -109,13 +122,10 @@ class Lead(models.Model):
         ('lead', 'Lead'), ('opportunity', 'Opportunity')],
         index=True, required=True, tracking=15,
         default=lambda self: 'lead' if self.env['res.users'].has_group('crm.group_use_lead') else 'opportunity')
+    # Pipeline management
     priority = fields.Selection(
         crm_stage.AVAILABLE_PRIORITIES, string='Priority', index=True,
         default=crm_stage.AVAILABLE_PRIORITIES[0][0])
-    team_id = fields.Many2one(
-        'crm.team', string='Sales Team', check_company=True, index=True, tracking=True,
-        domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]",
-        compute='_compute_team_id', readonly=False, store=True)
     stage_id = fields.Many2one(
         'crm.stage', string='Stage', index=True, tracking=True,
         compute='_compute_stage_id', readonly=False, store=True,
@@ -134,7 +144,7 @@ class Lead(models.Model):
         'crm.tag', 'crm_tag_rel', 'lead_id', 'tag_id', string='Tags',
         help="Classify and analyze your lead/opportunity categories like: Training, Service")
     color = fields.Integer('Color Index', default=0)
-    # Opportunity specific
+    # Revenues
     expected_revenue = fields.Monetary('Expected Revenue', currency_field='company_currency', tracking=True)
     prorated_revenue = fields.Monetary('Prorated Revenue', currency_field='company_currency', store=True, compute="_compute_prorated_revenue")
     recurring_revenue = fields.Monetary('Recurring Revenues', currency_field='company_currency', groups="crm.group_use_recurring_revenues")
@@ -205,11 +215,13 @@ class Lead(models.Model):
         compute='_compute_probabilities', readonly=False, store=True)
     automated_probability = fields.Float('Automated Probability', compute='_compute_probabilities', readonly=True, store=True)
     is_automated_probability = fields.Boolean('Is automated probability?', compute="_compute_is_automated_probability")
-    # External records
-    meeting_count = fields.Integer('# Meetings', compute='_compute_meeting_count')
+    # Won/Lost
     lost_reason = fields.Many2one(
         'crm.lost.reason', string='Lost Reason',
         index=True, ondelete='restrict', tracking=True)
+    # Statistics
+    meeting_count = fields.Integer('# Meetings', compute='_compute_meeting_count')
+    # UX
     ribbon_message = fields.Char('Ribbon message', compute='_compute_ribbon_message')
 
     _sql_constraints = [
@@ -931,15 +943,7 @@ class Lead(models.Model):
     # MERGE AND CONVERT LEADS / OPPORTUNITIES
     # ------------------------------------------------------------
 
-    def _merge_get_result_type(self):
-        """ Define the type of the result of the merge.  If at least one of the
-        element to merge is an opp, the resulting new element will be an opp.
-        Otherwise it will be a lead. """
-        if any(record.type == 'opportunity' for record in self):
-            return 'opportunity'
-        return 'lead'
-
-    def _merge_data(self, fields):
+    def _merge_data(self, fnames=None):
         """ Prepare lead/opp data into a dictionary for merging. Different types
             of fields are processed in different ways:
                 - text: all the values are concatenated
@@ -950,38 +954,37 @@ class Lead(models.Model):
             :param fields: list of fields to process
             :return dict data: contains the merged values of the new opportunity
         """
+        if fnames is None:
+            fnames = self._merge_get_fields()
+        fcallables = self._merge_get_fields_specific()
+
         # helpers
         def _get_first_not_null(attr, opportunities):
+            value = False
             for opp in opportunities:
-                val = opp[attr]
-                if val:
-                    return val
-            return False
+                if opp[attr]:
+                    value = opp[attr].id if isinstance(opp[attr], models.BaseModel) else opp[attr]
+                    break
+            return value
 
-        def _get_first_not_null_id(attr, opportunities):
-            res = _get_first_not_null(attr, opportunities)
-            return res.id if res else False
-
-        # process the fields' values
+        # process the field's values
         data = {}
-        for field_name in fields:
+        for field_name in fnames:
             field = self._fields.get(field_name)
             if field is None:
                 continue
-            if field.type in ('many2many', 'one2many'):
-                continue
-            elif field.type == 'many2one':
-                data[field_name] = _get_first_not_null_id(field_name, self)  # take the first not null
-            elif field.type == 'text':
-                data[field_name] = '\n\n'.join(it for it in self.mapped(field_name) if it)
-            else:
-                data[field_name] = _get_first_not_null(field_name, self)
 
-        # define the resulting type ('lead' or 'opportunity')
-        data['type'] = self._merge_get_result_type()
+            fcallable = fcallables.get(field_name)
+            if fcallable and callable(fcallable):
+                data[field_name] = fcallable(field_name, self)
+            elif not fcallable and field.type in ('many2many', 'one2many'):
+                continue
+            else:
+                data[field_name] = _get_first_not_null(field_name, self)  # take the first not null
+
         return data
 
-    def _merge_notify_get_merged_fields_message(self, fields):
+    def _merge_notify_get_merged_fields_message(self):
         """ Generate the message body with the changed values
 
         :param fields : list of fields to track
@@ -992,7 +995,7 @@ class Lead(models.Model):
             title = "%s : %s\n" % (_('Merged opportunity') if lead.type == 'opportunity' else _('Merged lead'), lead.name)
             body = [title]
             _fields = self.env['ir.model.fields'].search([
-                ('name', 'in', fields or []),
+                ('name', 'in', self._merge_get_fields()),
                 ('model_id.model', '=', lead._name),
             ])
             for field in _fields:
@@ -1022,12 +1025,10 @@ class Lead(models.Model):
         """
         # TODO JEM: mail template should be used instead of fix body, subject text
         self.ensure_one()
-        # mail message's subject
-        result_type = opportunities._merge_get_result_type()
-        merge_message = _('Merged leads') if result_type == 'lead' else _('Merged opportunities')
+        merge_message = _('Merged leads') if self.type == 'lead' else _('Merged opportunities')
         subject = merge_message + ": " + ", ".join(opportunities.mapped('name'))
         # message bodies
-        message_bodies = opportunities._merge_notify_get_merged_fields_message(list(CRM_LEAD_FIELDS_TO_MERGE))
+        message_bodies = opportunities._merge_notify_get_merged_fields_message()
         message_body = "\n\n".join(message_bodies)
         return self.message_post(body=message_body, subject=subject)
 
@@ -1084,7 +1085,6 @@ class Lead(models.Model):
           include `self` which is the target crm.lead being the result of the merge.
         """
         self.ensure_one()
-        self._merge_notify(opportunities)
         self._merge_opportunity_history(opportunities)
         self._merge_opportunity_attachments(opportunities)
 
@@ -1122,7 +1122,7 @@ class Lead(models.Model):
 
         # merge all the sorted opportunity. This means the value of
         # the first (head opp) will be a priority.
-        merged_data = opportunities._merge_data(list(CRM_LEAD_FIELDS_TO_MERGE))
+        merged_data = opportunities._merge_data(self._merge_get_fields())
 
         # force value for saleperson and Sales Team
         if user_id:
@@ -1130,6 +1130,8 @@ class Lead(models.Model):
         if team_id:
             merged_data['team_id'] = team_id
 
+        # log merge message
+        opportunities_head._merge_notify(opportunities_tail)
         # merge other data (mail.message, attachments, ...) from tail into head
         opportunities_head._merge_dependences(opportunities_tail)
 
@@ -1148,6 +1150,15 @@ class Lead(models.Model):
             opportunities_tail.sudo().unlink()
 
         return opportunities_head
+
+    def _merge_get_fields_specific(self):
+        return {
+            'description': lambda fname, leads: '\n\n'.join(desc for desc in leads.mapped('description') if desc),
+            'type': lambda fname, leads: 'opportunity' if any(lead.type == 'opportunity' for lead in leads) else 'lead',
+        }
+
+    def _merge_get_fields(self):
+        return list(CRM_LEAD_FIELDS_TO_MERGE) + list(self._merge_get_fields_specific().keys())
 
     def _convert_opportunity_data(self, customer, team_id=False):
         """ Extract the data from a lead to create the opportunity

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1155,6 +1155,7 @@ class Lead(models.Model):
         return {
             'description': lambda fname, leads: '\n\n'.join(desc for desc in leads.mapped('description') if desc),
             'type': lambda fname, leads: 'opportunity' if any(lead.type == 'opportunity' for lead in leads) else 'lead',
+            'priority': lambda fname, leads: max(leads.mapped('priority')) if leads else False,
         }
 
     def _merge_get_fields(self):

--- a/addons/crm/tests/__init__.py
+++ b/addons/crm/tests/__init__.py
@@ -10,3 +10,4 @@ from . import test_crm_lead_merge
 from . import test_crm_activity
 from . import test_crm_ui
 from . import test_crm_pls
+from . import test_performances

--- a/addons/crm/tests/common.py
+++ b/addons/crm/tests/common.py
@@ -349,7 +349,8 @@ class TestCrmCommon(TestSalesCommon, MailCase):
             return '\n\n'.join(value for value in values if value)
 
         def _get_priority():
-            return original_opp_values['priority']
+            values = [_find_value(lead, 'priority') for lead in leads]
+            return max(values)
 
         try:
             # merge process will modify opportunity

--- a/addons/crm/tests/common.py
+++ b/addons/crm/tests/common.py
@@ -421,7 +421,8 @@ class TestLeadConvertCommon(TestCrmCommon):
         if member.crm_team_id.assignment_domain:
             self.assertEqual(
                 member_leads.filtered_domain(literal_eval(member.crm_team_id.assignment_domain)),
-                member_leads
+                member_leads,
+                'Assign domain not matching: %s' % member.crm_team_id.assignment_domain
             )
 
 class TestLeadConvertMassCommon(TestLeadConvertCommon):

--- a/addons/crm/tests/common.py
+++ b/addons/crm/tests/common.py
@@ -2,13 +2,15 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from ast import literal_eval
+from contextlib import contextmanager
 from unittest.mock import patch
 
+from odoo.addons.crm.models.crm_lead import CRM_LEAD_FIELDS_TO_MERGE
 from odoo.addons.mail.tests.common import MailCase, mail_new_test_user
 from odoo.addons.phone_validation.tools import phone_validation
 from odoo.addons.sales_team.tests.common import TestSalesCommon
 from odoo.fields import Datetime
-from odoo import tools
+from odoo import models, tools
 
 INCOMING_EMAIL = """Return-Path: {return_path}
 X-Original-To: {to}
@@ -43,6 +45,14 @@ Somebody."""
 
 
 class TestCrmCommon(TestSalesCommon, MailCase):
+
+    FIELDS_FIRST_SET = [
+        'name', 'partner_id', 'campaign_id', 'company_id', 'country_id',
+        'team_id', 'state_id', 'stage_id', 'medium_id', 'source_id', 'user_id',
+        'title', 'city', 'contact_name', 'description', 'mobile', 'partner_name',
+        'phone', 'probability', 'expected_revenue', 'street', 'street2', 'zip',
+        'create_date', 'date_action_last', 'email_from', 'email_cc', 'website'
+    ]
 
     @classmethod
     def setUpClass(cls):
@@ -299,6 +309,71 @@ class TestCrmCommon(TestSalesCommon, MailCase):
         new_leads.flush()  # compute notably probability
         return new_leads
 
+    @contextmanager
+    def assertLeadMerged(self, opportunity, leads, **expected):
+        """ Assert result of lead _merge_opportunity process. This is done using
+        a context manager in order to save original opportunity (master lead)
+        values. Indeed those will be modified during merge process. We have to
+        ensure final values are correct taking into account all leads values
+        before merging them.
+
+        :param opportunity: final opportunity
+        :param leads: merged leads (including opportunity)
+        """
+        self.assertIn(opportunity, leads)
+
+        # save opportunity value before being modified by merge process
+        fields_all = self.FIELDS_FIRST_SET + ['type', 'priority']
+        # ensure tests are synchronized with crm code
+        self.assertTrue(all(field in fields_all for field in CRM_LEAD_FIELDS_TO_MERGE))
+        original_opp_values = dict(
+            (fname, opportunity[fname])
+            for fname in fields_all
+        )
+
+        def _find_value(lead, fname):
+            if lead == opportunity:
+                return original_opp_values[fname]
+            return lead[fname]
+
+        def _first_set(fname):
+            values = [_find_value(lead, fname) for lead in leads]
+            return next((value for value in values if value), False)
+
+        def _get_type():
+            values = [_find_value(lead, 'type') for lead in leads]
+            return 'opportunity' if 'opportunity' in values else 'lead'
+
+        def _get_description():
+            values = [_find_value(lead, 'description') for lead in leads]
+            return '\n\n'.join(value for value in values if value)
+
+        def _get_priority():
+            return original_opp_values['priority']
+
+        try:
+            # merge process will modify opportunity
+            yield
+        finally:
+            # support specific values caller may want to check in addition to generic tests
+            for fname, expected in expected.items():
+                self.assertEqual(opportunity[fname], expected)
+
+            # classic fields: first not void wins
+            for fname in fields_all:
+                opp_value = opportunity[fname]
+                if fname == 'description':
+                    self.assertEqual(opp_value, _get_description())
+                elif fname == 'type':
+                    self.assertEqual(opp_value, _get_type())
+                elif fname == 'priority':
+                    self.assertEqual(opp_value, _get_priority())
+                else:
+                    self.assertEqual(
+                        opp_value if opp_value or not isinstance(opp_value, models.BaseModel) else False,
+                        _first_set(fname)
+                    )
+
 
 class TestLeadConvertCommon(TestCrmCommon):
 
@@ -454,6 +529,7 @@ class TestLeadConvertMassCommon(TestLeadConvertCommon):
         cls.lead_w_partner = cls.env['crm.lead'].create({
             'name': 'New1',
             'type': 'lead',
+            'priority': '0',
             'probability': 10,
             'user_id': cls.user_sales_manager.id,
             'stage_id': False,
@@ -481,6 +557,7 @@ class TestLeadConvertMassCommon(TestLeadConvertCommon):
         cls.lead_w_email = cls.env['crm.lead'].create({
             'name': 'LeadEmailAsContact',
             'type': 'lead',
+            'priority': '2',
             'probability': 15,
             'email_from': 'contact.email@test.example.com',
             'user_id': cls.user_sales_salesman.id,

--- a/addons/crm/tests/common.py
+++ b/addons/crm/tests/common.py
@@ -49,7 +49,7 @@ class TestCrmCommon(TestSalesCommon, MailCase):
     FIELDS_FIRST_SET = [
         'name', 'partner_id', 'campaign_id', 'company_id', 'country_id',
         'team_id', 'state_id', 'stage_id', 'medium_id', 'source_id', 'user_id',
-        'title', 'city', 'contact_name', 'description', 'mobile', 'partner_name',
+        'title', 'city', 'contact_name', 'mobile', 'partner_name',
         'phone', 'probability', 'expected_revenue', 'street', 'street2', 'zip',
         'create_date', 'date_action_last', 'email_from', 'email_cc', 'website'
     ]
@@ -323,9 +323,9 @@ class TestCrmCommon(TestSalesCommon, MailCase):
         self.assertIn(opportunity, leads)
 
         # save opportunity value before being modified by merge process
-        fields_all = self.FIELDS_FIRST_SET + ['type', 'priority']
+        fields_all = self.FIELDS_FIRST_SET + ['description', 'type', 'priority']
         # ensure tests are synchronized with crm code
-        self.assertTrue(all(field in fields_all for field in CRM_LEAD_FIELDS_TO_MERGE))
+        self.assertTrue(all(field in fields_all for field in CRM_LEAD_FIELDS_TO_MERGE + list(self.env['crm.lead']._merge_get_fields_specific().keys())))
         original_opp_values = dict(
             (fname, opportunity[fname])
             for fname in fields_all
@@ -359,7 +359,7 @@ class TestCrmCommon(TestSalesCommon, MailCase):
             for fname, expected in expected.items():
                 self.assertEqual(opportunity[fname], expected)
 
-            # classic fields: first not void wins
+            # classic fields: first not void wins or specific computation
             for fname in fields_all:
                 opp_value = opportunity[fname]
                 if fname == 'description':

--- a/addons/crm/tests/test_crm_lead_convert_mass.py
+++ b/addons/crm/tests/test_crm_lead_convert_mass.py
@@ -24,7 +24,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         with self.assertQueryCount(user_sales_manager=0):
             test_leads = self.env['crm.lead'].browse(test_leads.ids)
 
-        with self.assertQueryCount(user_sales_manager=254):  # crm only: 252
+        with self.assertQueryCount(user_sales_manager=255):  # crm only: 252
             test_leads._handle_salesmen_assignment(user_ids=user_ids, team_id=False)
 
         self.assertEqual(test_leads.team_id, self.sales_team_convert | self.sales_team_1)
@@ -42,7 +42,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         with self.assertQueryCount(user_sales_manager=0):
             test_leads = self.env['crm.lead'].browse(test_leads.ids)
 
-        with self.assertQueryCount(user_sales_manager=220):  # crm only: 218
+        with self.assertQueryCount(user_sales_manager=223):  # crm only: 218
             test_leads._handle_salesmen_assignment(user_ids=user_ids, team_id=team_id)
 
         self.assertEqual(test_leads.team_id, self.sales_team_convert)

--- a/addons/crm/tests/test_crm_lead_merge.py
+++ b/addons/crm/tests/test_crm_lead_merge.py
@@ -158,5 +158,5 @@ class TestLeadMerge(TestLeadConvertMassCommon):
         with self.assertLeadMerged(self.lead_1, leads,
                                    name='Nibbler Spacecraft Request',
                                    partner_id=self.contact_company_1,
-                                   priority='0'):
+                                   priority='2'):
             leads._merge_opportunity(auto_unlink=False, max_length=None)

--- a/addons/crm/tests/test_crm_lead_merge.py
+++ b/addons/crm/tests/test_crm_lead_merge.py
@@ -157,5 +157,6 @@ class TestLeadMerge(TestLeadConvertMassCommon):
         leads = self.env['crm.lead'].browse(self.leads.ids)._sort_by_confidence_level(reverse=True)
         with self.assertLeadMerged(self.lead_1, leads,
                                    name='Nibbler Spacecraft Request',
-                                   partner_id=self.contact_company_1):
+                                   partner_id=self.contact_company_1,
+                                   priority='0'):
             leads._merge_opportunity(auto_unlink=False, max_length=None)

--- a/addons/crm/tests/test_crm_lead_merge.py
+++ b/addons/crm/tests/test_crm_lead_merge.py
@@ -141,3 +141,21 @@ class TestLeadMerge(TestLeadConvertMassCommon):
         # self.assertEqual(merge_opportunity.team_id, self.sales_team_1)
         # TDE FIXME: BUT team_id is computed after checking stage, based on wizard's team_id
         self.assertEqual(merge_opportunity.stage_id, self.stage_team_convert_1)
+
+    @users('user_sales_manager')
+    def test_merge_method(self):
+        """ In case of mix, opportunities are on top, and result is an opportunity
+
+        lead_1 -------------------opp----seq=1
+        lead_w_partner_company ---opp----seq=1 (ID greater)
+        lead_w_contact -----------lead---seq=30
+        lead_w_email -------------lead---seq=3
+        lead_w_partner -----------lead---seq=False
+        """
+        # ensure initial data
+        (self.lead_w_partner_company | self.lead_1).write({'type': 'opportunity'})
+        leads = self.env['crm.lead'].browse(self.leads.ids)._sort_by_confidence_level(reverse=True)
+        with self.assertLeadMerged(self.lead_1, leads,
+                                   name='Nibbler Spacecraft Request',
+                                   partner_id=self.contact_company_1):
+            leads._merge_opportunity(auto_unlink=False, max_length=None)

--- a/addons/website_crm/models/crm_lead.py
+++ b/addons/website_crm/models/crm_lead.py
@@ -37,11 +37,11 @@ class Lead(models.Model):
             action['context'] = {'search_default_group_by_page': '1'}
         return action
 
-    def _merge_data(self, fields):
-        merged_data = super(Lead, self)._merge_data(fields)
+    def _merge_get_fields_specific(self):
+        fields_info = super(Lead, self)._merge_get_fields_specific()
         # add all the visitors from all lead to merge
-        merged_data['visitor_ids'] = [(6, 0, self.visitor_ids.ids)]
-        return merged_data
+        fields_info['visitor_ids'] = lambda fname, leads: [(6, 0, leads.visitor_ids.ids)]
+        return fields_info
 
     def website_form_input_filter(self, request, values):
         values['medium_id'] = values.get('medium_id') or \

--- a/addons/website_crm_partner_assign/models/crm_lead.py
+++ b/addons/website_crm_partner_assign/models/crm_lead.py
@@ -26,10 +26,6 @@ class CrmLead(models.Model):
         copy=True, readonly=False, store=True,
         help="Last date this case was forwarded/assigned to a partner")
 
-    def _merge_data(self, fields):
-        fields += ['partner_latitude', 'partner_longitude', 'partner_assigned_id', 'date_partner_assign']
-        return super(CrmLead, self)._merge_data(fields)
-
     @api.depends("partner_assigned_id")
     def _compute_date_partner_assign(self):
         for lead in self:
@@ -37,6 +33,11 @@ class CrmLead(models.Model):
                 lead.date_partner_assign = False
             else:
                 lead.date_partner_assign = fields.Date.context_today(lead)
+
+    def _merge_get_fields(self):
+        fields_list = super(CrmLead, self)._merge_get_fields()
+        fields_list += ['partner_latitude', 'partner_longitude', 'partner_assigned_id', 'date_partner_assign']
+        return fields_list
 
     def assign_salesman_of_assigned_partner(self):
         salesmans_leads = {}


### PR DESCRIPTION
PURPOSE

Fix recently added lead assignment tests, notably about query counters
and random behavior of lead merge.

SPECIFICATIONS

Split performance tests from unit tests. Performance tests should be
reproducible. Currently there are too much varying query counters.

Fix lead merge process done during assign. As duplicate leads are merged
final opportunity could not fit team domain anymore. This is a side effect
of lead deduplication. In this case this is linked to priority field that is set
to the value of the "final" opportunity, whatever the value of other leads
merged into it. We think that priority is a field that should be managed
more carefully. We choose to set it as the highest value found in leads
merged.

LINKS

Task ID-2446759 (lead merge priority field management)
Task ID-2446883 (query counters fix) 
PR odoo/odoo#65016