### PR TITLE
[FIX] website_sale: fix salesperson assignment from website

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -206,7 +206,13 @@ class Website(models.Model):
     def _prepare_sale_order_values(self, partner, pricelist):
         self.ensure_one()
         affiliate_id = request.session.get('affiliate_id')
-        salesperson_id = affiliate_id if self.env['res.users'].sudo().browse(affiliate_id).exists() else request.website.salesperson_id.id
+        salesperson_id = False
+        if self.env['res.users'].sudo().browse(affiliate_id).exists():
+            salesperson_id = affiliate_id
+        if not salesperson_id and partner.user_id:
+            salesperson_id = partner.user_id.id
+        if not salesperson_id:
+            salesperson_id = request.website.salesperson_id.id
         addr = partner.address_get(['delivery'])
         if not request.website.is_public_user():
             last_sale_order = self.env['sale.order'].sudo().search([('partner_id', '=', partner.id)], limit=1, order="date_order desc, id desc")


### PR DESCRIPTION
1. Configure the website (Website / Configuration / Settings): Orders
Followup / Salesperson: Joel Willis
2. Configure the contact Marc Demo: Sales & Purchases / Salesperson:
Frances Pierce
3. Connect As Marc Demo
4. Go to the shop
5. Add anything to the cart
6. Connect as Admin
7. Go to Sales / Quotations, remove all filters
8. The most recent quotation (Marc Demo's cart) is assigned to
salesperson Joel Willis, instead of Frances Pierce

This commit will change how salesman assignment is done. In order will
be checked:
1) Affiliate id
2) Salesperson specified on partner id
3) Salesperson specified on website config

opw-2255678

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
