### PR TITLE
[FIX] hr_holidays: Time Off or Allocations to approve not visible

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -649,7 +649,7 @@
             'search_default_my_team_leaves':1,
             'search_default_approve':1}
         </field>
-        <field name="domain">[('employee_id.leave_manager_id', '=', uid)]</field>
+        <field name="domain">['|', '|', '&amp;', ('employee_id.leave_manager_id', '=', uid), ('holiday_status_id.validation_type', '=', 'manager'), '&amp;', ('holiday_status_id.responsible_id', '=', uid), ('holiday_status_id.validation_type', '=', 'hr'), '&amp;', '|', ('holiday_status_id.responsible_id', '=', uid), ('holiday_status_id.responsible_id', '=', uid), ('holiday_status_id.validation_type', '=', 'both')]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Create a new time off request


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider employees E1, E2
- Let's consider a time off type TOT with validation_type = hr and E2 as responsible_id
- Create an TOT leave L for E1
- Log with E2
- Go to Time Off module > Managers > To Approve > Time Off

Bug:

L didn't appear in the result

opw:2422504