### PR TITLE
[FIX] website: add tests for TODO-64446

### DIFF
--- a/addons/website/models/ir_module_module.py
+++ b/addons/website/models/ir_module_module.py
@@ -411,3 +411,14 @@ class IrModuleModule(models.Model):
                         'res_model': self._name,
                         'res_id': theme.id,
                     })
+
+    def _check(self):
+        super()._check()
+        View = self.env['ir.ui.view']
+        website_views_to_adapt = getattr(self.pool, 'website_views_to_adapt', [])
+        for module in self:
+            if website_views_to_adapt and module.name == 'website':
+                for view_replay in website_views_to_adapt:
+                    cow_view = View.browse(view_replay[0])
+                    View._load_records_write_on_cow(cow_view, view_replay[1], view_replay[2])
+                self.pool.website_views_to_adapt.clear()

--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -131,6 +131,14 @@ class View(models.Model):
 
         return True
 
+    def _load_records_write_on_cow(self, cow_view, inherit_id, values):
+        inherit_id = self.search([
+            ('key', '=', self.browse(inherit_id).key),
+            ('website_id', 'in', (False, cow_view.website_id.id)),
+        ], order='website_id', limit=1).id
+        values['inherit_id'] = inherit_id
+        cow_view.with_context(no_cow=True).write(values)
+
     def _create_all_specific_views(self, processed_modules):
         """ When creating a generic child view, we should
             also create that view under specific view trees (COW'd).

--- a/addons/website/tests/__init__.py
+++ b/addons/website/tests/__init__.py
@@ -14,7 +14,7 @@ from . import test_res_users
 from . import test_theme
 from . import test_ui
 from . import test_views
-from . import test_website_favicon
+from . import test_views_inherit_module_update
 from . import test_website_reset_password
 from . import test_website_visitor
 from . import test_controllers

--- a/addons/website/tests/test_views.py
+++ b/addons/website/tests/test_views.py
@@ -773,6 +773,7 @@ class TestCowViewSaving(common.TransactionCase):
         View._create_all_specific_views(['_website_sale_comparison'])
 
         specific_view = Website.with_context(load_all_views=True, website_id=1).viewref('_website_sale.product')
+        self.assertEqual(self.base_view.key, specific_view.key, "Ensure it is equal as it should be for the rest of the test so we test the expected behaviors")
         specific_view_arch = specific_view.read_combined(['arch'])['arch']
         self.assertEqual(specific_view.website_id.id, 1, "Ensure we got specific view to perform the checks against")
         self.assertEqual(specific_view_arch, '<p>COMPARE</p>', "When a module creates an inherited view (on a generic tree), it should also create that view in the specific COW'd tree.")
@@ -785,20 +786,33 @@ class TestCowViewSaving(common.TransactionCase):
         self.assertEqual(specific_view_arch, '<p>COMPARE EDITED</p>', "When a module updates an inherited view (on a generic tree), it should also update the copies of that view (COW).")
 
         # Test fields that should not be COW'd
-        random_view_id = View.search([], limit=1).id
+        random_views = View.search([('key', '!=', None)], limit=2)
         View._load_records([dict(xml_id='_website_sale_comparison.product_add_to_compare', values={
             'website_id': None,
-            'inherit_id': random_view_id,
+            'inherit_id': random_views[0].id,
         })])
 
         w1_specific_child_view = Website.with_context(load_all_views=True, website_id=1).viewref('_website_sale_comparison.product_add_to_compare')
         generic_child_view = Website.with_context(load_all_views=True).viewref('_website_sale_comparison.product_add_to_compare')
         self.assertEqual(w1_specific_child_view.website_id.id, 1, "website_id is a prohibited field when COWing views during _load_records")
-        self.assertEqual(w1_specific_child_view.inherit_id.id != random_view_id, True, "inherit_id is a prohibited field when COWing views during _load_records")
-        self.assertEqual(generic_child_view.inherit_id.id, random_view_id, "prohibited fields only concerned write on COW'd view. Generic should still considere these fields")
+        self.assertEqual(generic_child_view.inherit_id, random_views[0], "prohibited fields only concerned write on COW'd view. Generic should still considere these fields")
+        self.assertEqual(w1_specific_child_view.inherit_id, random_views[0], "inherit_id update should be repliacated on cow views during _load_records")
 
         # Set back the generic view as parent for the rest of the test
         generic_child_view.inherit_id = self.base_view
+        w1_specific_child_view.inherit_id = specific_view
+
+        # Don't update inherit_id if it was anually updated
+        w1_specific_child_view.inherit_id = random_views[1].id
+        View._load_records([dict(xml_id='_website_sale_comparison.product_add_to_compare', values={
+            'inherit_id': random_views[0].id,
+        })])
+        self.assertEqual(w1_specific_child_view.inherit_id, random_views[1],
+                         "inherit_id update should not be repliacated on cow views during _load_records if it was manually updated before")
+
+        # Set back the generic view as parent for the rest of the test
+        generic_child_view.inherit_id = self.base_view
+        w1_specific_child_view.inherit_id = specific_view
 
         # Don't update fields from COW'd view if these fields have been modified from original view
         new_website = Website.create({'name': 'New Website'})
@@ -985,6 +999,67 @@ class TestCowViewSaving(common.TransactionCase):
         specific_view.invalidate_cache(['arch_db', 'arch'])
         self.assertEqual(specific_view.with_context(lang='en_US').arch, '<div>hi</div>',
             "loading module translation copy translation from base to specific view")
+
+    def test_specific_view_module_update_inherit_change(self):
+        """ During a module update, if inherit_id is changed, we need to
+        replicate the change for cow views. """
+        # If D.inherit_id becomes B instead of A, after module update, we expect:
+        # CASE 1
+        #   A    A'   B                      A    A'   B
+        #   |    |                 =>                 / \
+        #   D    D'                                  D   D'
+        #
+        # CASE 2
+        #   A    A'   B    B'               A    A'   B   B'
+        #   |    |                 =>                 |   |
+        #   D    D'                                   D   D'
+        #
+        # CASE 3
+        #     A    B                        A    B
+        #    / \                   =>           / \
+        #   D   D'                             D   D'
+        #
+        # CASE 4
+        #     A    B    B'                  A    B   B'
+        #    / \                   =>            |   |
+        #   D   D'                               D   D'
+
+        # 1. Setup following view trees
+        #   A    A'   B
+        #   |    |
+        #   D    D'
+        View = self.env['ir.ui.view']
+        Website = self.env['website']
+        self.env['ir.model.data'].create({
+            'module': 'website',
+            'name': self.inherit_view.key.replace('website.', ''),
+            'model': self.inherit_view._name,
+            'res_id': self.inherit_view.id,
+        })
+        base_view_2 = self.base_view.copy({'key': 'website.base_view2', 'arch': '<div>base2 content</div>'})
+        self.base_view.with_context(website_id=1).write({'arch': '<div>website 1 content</div>'})
+        specific_view = Website.with_context(load_all_views=True, website_id=1).viewref(self.base_view.key)
+        specific_view.inherit_children_ids.with_context(website_id=1).write({'arch': '<div position="inside">, extended content website 1</div>'})
+        specific_child_view = Website.with_context(load_all_views=True, website_id=1).viewref(self.inherit_view.key)
+        # 2. Ensure view trees are as expected
+        self.assertEqual(self.base_view.inherit_children_ids, self.inherit_view, "D should be under A")
+        self.assertEqual(specific_view.inherit_children_ids, specific_child_view, "D' should be under A'")
+        self.assertFalse(base_view_2.inherit_children_ids, "B should have no child")
+
+        # 3. Simulate module update, D.inherit_id is now B instead of A
+        View._load_records([dict(xml_id=self.inherit_view.key, values={
+            'inherit_id': base_view_2.id,
+        })])
+
+        # 4. Ensure view trees is now
+        #   A    A'   B
+        #            / \
+        #           D   D'
+        self.assertTrue(len(self.base_view.inherit_children_ids) == len(specific_view.inherit_children_ids) == 0,
+                        "Child views should now be under view B")
+        self.assertEqual(len(base_view_2.inherit_children_ids), 2, "D and D' should be under B")
+        self.assertTrue(self.inherit_view in base_view_2.inherit_children_ids, "D should be under B")
+        self.assertTrue(specific_child_view in base_view_2.inherit_children_ids, "D' should be under B")
 
 
 @tagged('-at_install', 'post_install')

--- a/addons/website/tests/test_views_inherit_module_update.py
+++ b/addons/website/tests/test_views_inherit_module_update.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import standalone
+
+"""
+This test ensure `inherit_id` update is correctly replicated on cow views.
+The view receiving the `inherit_id` update is either:
+1. in a module loaded before `website`. In that case, `website` code is not
+   loaded yet, so we store the updates to replay the changes on the cow views
+   once `website` module is loaded (see `_check()`). This test is testing that
+   part.
+2. in a module loaded after `website`. In that case, the `inherit_id` update is
+   directly replicated on the cow views. That behavior is tested with
+   `test_module_new_inherit_view_on_parent_already_forked` and
+   `test_specific_view_module_update_inherit_change` in `website` module.
+"""
+
+
+@standalone('cow_views_inherit')
+def test_01_cow_views_inherit_on_module_update(env):
+    #     A    B                        A    B
+    #    / \                   =>           / \
+    #   D   D'                             D   D'
+
+    # 1. Setup hierarchy as comment above
+    View = env['ir.ui.view']
+    View.with_context(_force_unlink=True, active_test=False).search([('website_id', '=', 1)]).unlink()
+    child_view = env.ref('portal.footer_language_selector')
+    parent_view = env.ref('portal.portal_back_in_edit_mode')
+    # Change `inherit_id` so the module update will set it back to the XML value
+    child_view.write({'inherit_id': parent_view.id, 'arch': child_view.arch_db.replace('o_footer_copyright_name', 'text-center')})
+    # Trigger COW on view
+    child_view.with_context(website_id=1).write({'name': 'COW Website 1'})
+    child_cow_view = child_view._get_specific_views()
+
+    # 2. Ensure setup is as expected
+    assert child_cow_view.inherit_id == parent_view, "Ensure test is setup as expected."
+
+    # 3. Upgrade the module
+    test_website_module = env['ir.module.module'].search([('name', '=', 'portal')])
+    test_website_module.button_immediate_upgrade()
+    env.reset()     # clear the set of environments
+    env = env()     # get an environment that refers to the new registry
+
+    # 4. Ensure cow view also got its inherit_id updated
+    expected_parent_view = env.ref('portal.frontend_layout')  # XML data
+    assert child_view.inherit_id == expected_parent_view, "Generic view security check."
+    assert child_cow_view.inherit_id == expected_parent_view, "COW view should also have received the `inherit_id` update."
+
+
+@standalone('cow_views_inherit')
+def test_02_cow_views_inherit_on_module_update(env):
+    #     A    B    B'                  A    B   B'
+    #    / \                   =>            |   |
+    #   D   D'                               D   D'
+
+    # 1. Setup hierarchy as comment above
+    View = env['ir.ui.view']
+    View.with_context(_force_unlink=True, active_test=False).search([('website_id', '=', 1)]).unlink()
+    view_D = env.ref('portal.my_account_link')
+    view_A = env.ref('portal.message_thread')
+    # Change `inherit_id` so the module update will set it back to the XML value
+    view_D.write({'inherit_id': view_A.id, 'arch_db': view_D.arch_db.replace('o_logout_divider', 'discussion')})
+    # Trigger COW on view
+    view_B = env.ref('portal.user_dropdown')  # XML data
+    view_D.with_context(website_id=1).write({'name': 'D Website 1'})
+    view_B.with_context(website_id=1).write({'name': 'B Website 1'})
+    view_Dcow = view_D._get_specific_views()
+
+    # 2. Ensure setup is as expected
+    view_Bcow = view_B._get_specific_views()
+    assert view_Dcow.inherit_id == view_A, "Ensure test is setup as expected."
+    assert len(view_Bcow) == len(view_Dcow) == 1, "Ensure test is setup as expected (2)."
+    assert view_B != view_Bcow, "Security check to ensure `_get_specific_views` return what it should."
+
+    # 3. Upgrade the module
+    test_website_module = env['ir.module.module'].search([('name', '=', 'portal')])
+    test_website_module.button_immediate_upgrade()
+    env.reset()     # clear the set of environments
+    env = env()     # get an environment that refers to the new registry
+
+    # 4. Ensure cow view also got its inherit_id updated
+    assert view_D.inherit_id == view_B, "Generic view security check."
+    assert view_Dcow.inherit_id == view_Bcow, "COW view should also have received the `inherit_id` update."

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1826,14 +1826,31 @@ actual arch.
             noupdate behavior on views having an ir.model.data.
         """
         if self.type == 'qweb':
-            # Update also specific views
             for cow_view in self._get_specific_views():
                 authorized_vals = {}
                 for key in values:
-                    if cow_view[key] == self[key]:
+                    if key != 'inherit_id' and cow_view[key] == self[key]:
                         authorized_vals[key] = values[key]
-                cow_view.write(authorized_vals)
+                # if inherit_id update, replicate change on cow view but
+                # only if that cow view inherit_id wasn't manually changed
+                inherit_id = values.get('inherit_id')
+                if inherit_id and self.inherit_id.id != inherit_id and \
+                   cow_view.inherit_id.key == self.inherit_id.key:
+                    self._load_records_write_on_cow(cow_view, inherit_id, authorized_vals)
+                else:
+                    cow_view.with_context(no_cow=True).write(authorized_vals)
         super(View, self)._load_records_write(values)
+
+    def _load_records_write_on_cow(self, cow_view, inherit_id, values):
+        # for modules updated before `website`, we need to
+        # store the change to replay later on cow views
+        if not hasattr(self.pool, 'website_views_to_adapt'):
+            self.pool.website_views_to_adapt = []
+        self.pool.website_views_to_adapt.append((
+            cow_view.id,
+            inherit_id,
+            values,
+        ))
 
 
 class ResetViewArchWizard(models.TransientModel):


### PR DESCRIPTION
As `standalone` tests were introduced in 14.0 (see 0453566), this commit
adds tests to ensure the `inherit_id` of COW views are correctly updated on
module updates.
This test could not be rewritten in a regular test and merged in 12.0 as module
operation in tests try to be avoided (see 5e7e7b0).

See TODO-64446 for more information about the original fix.