### PR TITLE
[ADD] l10n_ar: generic changes to use in qr code

### DIFF
--- a/addons/l10n_ar/__manifest__.py
+++ b/addons/l10n_ar/__manifest__.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Argentinian Accounting',
-    'version': "3.0",
+    'version': "3.1",
     'description': """
 Functional
 ----------

--- a/addons/l10n_ar/i18n/es.po
+++ b/addons/l10n_ar/i18n/es.po
@@ -207,16 +207,19 @@ msgid "AFIP Concept"
 msgstr "Concepto AFIP"
 
 #. module: l10n_ar
+#: model:ir.model.fields,field_description:l10n_ar.field_account_bank_statement_import_journal_creation__l10n_ar_afip_pos_partner_id
 #: model:ir.model.fields,field_description:l10n_ar.field_account_journal__l10n_ar_afip_pos_partner_id
 msgid "AFIP POS Address"
 msgstr "Dirección PdV AFIP"
 
 #. module: l10n_ar
+#: model:ir.model.fields,field_description:l10n_ar.field_account_bank_statement_import_journal_creation__l10n_ar_afip_pos_number
 #: model:ir.model.fields,field_description:l10n_ar.field_account_journal__l10n_ar_afip_pos_number
 msgid "AFIP POS Number"
 msgstr "Número PdV AFIP"
 
 #. module: l10n_ar
+#: model:ir.model.fields,field_description:l10n_ar.field_account_bank_statement_import_journal_creation__l10n_ar_afip_pos_system
 #: model:ir.model.fields,field_description:l10n_ar.field_account_journal__l10n_ar_afip_pos_system
 msgid "AFIP POS System"
 msgstr "Sistema PdV AFIP"
@@ -1042,6 +1045,7 @@ msgid "Sequence"
 msgstr "Secuencia"
 
 #. module: l10n_ar
+#: model:ir.model.fields,field_description:l10n_ar.field_account_bank_statement_import_journal_creation__l10n_ar_sequence_ids
 #: model:ir.model.fields,field_description:l10n_ar.field_account_journal__l10n_ar_sequence_ids
 msgid "Sequences"
 msgstr "Secuencias"
@@ -1168,12 +1172,14 @@ msgstr ""
 "Este campo es requerido para poder imprimir las facturas correctamente"
 
 #. module: l10n_ar
+#: model:ir.model.fields,help:l10n_ar.field_account_bank_statement_import_journal_creation__l10n_ar_afip_pos_partner_id
 #: model:ir.model.fields,help:l10n_ar.field_account_journal__l10n_ar_afip_pos_partner_id
 msgid "This is the address used for invoice reports of this POS"
 msgstr ""
 "Esta dirección es la usada para los reportes de facturación de este PdV"
 
 #. module: l10n_ar
+#: model:ir.model.fields,help:l10n_ar.field_account_bank_statement_import_journal_creation__l10n_ar_afip_pos_number
 #: model:ir.model.fields,help:l10n_ar.field_account_journal__l10n_ar_afip_pos_number
 msgid ""
 "This is the point of sale number assigned by AFIP in order to generate "
@@ -1193,9 +1199,30 @@ msgid "Type of gross income: exempt, local, multilateral"
 msgstr "Tipo de ingreso bruto: exento, local, multilateral"
 
 #. module: l10n_ar
+#: model:ir.model.fields,field_description:l10n_ar.field_account_bank_statement_import_journal_creation__l10n_ar_share_sequences
 #: model:ir.model.fields,field_description:l10n_ar.field_account_journal__l10n_ar_share_sequences
 msgid "Unified Book"
 msgstr "Libro Unificado"
+
+#. module: l10n_ar
+#: model:product.product,uom_name:l10n_ar.product_product_arancel
+#: model:product.product,uom_name:l10n_ar.product_product_cero
+#: model:product.product,uom_name:l10n_ar.product_product_exento
+#: model:product.product,uom_name:l10n_ar.product_product_no_gravado
+#: model:product.product,uom_name:l10n_ar.product_product_quote_despacho
+#: model:product.product,uom_name:l10n_ar.product_product_servicio_de_guarda
+#: model:product.product,uom_name:l10n_ar.product_product_tasa_estadistica
+#: model:product.product,uom_name:l10n_ar.product_product_telefonia
+#: model:product.template,uom_name:l10n_ar.product_product_arancel_product_template
+#: model:product.template,uom_name:l10n_ar.product_product_cero_product_template
+#: model:product.template,uom_name:l10n_ar.product_product_exento_product_template
+#: model:product.template,uom_name:l10n_ar.product_product_no_gravado_product_template
+#: model:product.template,uom_name:l10n_ar.product_product_quote_despacho_product_template
+#: model:product.template,uom_name:l10n_ar.product_product_servicio_de_guarda_product_template
+#: model:product.template,uom_name:l10n_ar.product_product_tasa_estadistica_product_template
+#: model:product.template,uom_name:l10n_ar.product_product_telefonia_product_template
+msgid "Units"
+msgstr "Unidades"
 
 #. module: l10n_ar
 #: model:ir.model.fields.selection,name:l10n_ar.selection__account_tax_group__l10n_ar_vat_afip_code__1
@@ -1214,6 +1241,7 @@ msgid "UpApP"
 msgstr ""
 
 #. module: l10n_ar
+#: model:ir.model.fields,help:l10n_ar.field_account_bank_statement_import_journal_creation__l10n_ar_share_sequences
 #: model:ir.model.fields,help:l10n_ar.field_account_journal__l10n_ar_share_sequences
 msgid "Use same sequence for documents with the same letter"
 msgstr "Usar la misma secuencia para documentos con misma letra"
@@ -1284,6 +1312,12 @@ msgstr "IVA No Gravado"
 #, python-format
 msgid "Warning"
 msgstr "Alerta"
+
+#. module: l10n_ar
+#: code:addons/l10n_ar/models/res_partner.py:0
+#, python-format
+msgid "We were not able to sanitize the identification number"
+msgstr "No pudimos limpiar el número de identificación"
 
 #. module: l10n_ar
 #: model_terms:ir.ui.view,arch_db:l10n_ar.view_account_invoice_report_search_inherit

--- a/addons/l10n_ar/i18n/l10n_ar.pot
+++ b/addons/l10n_ar/i18n/l10n_ar.pot
@@ -203,16 +203,19 @@ msgid "AFIP Concept"
 msgstr ""
 
 #. module: l10n_ar
+#: model:ir.model.fields,field_description:l10n_ar.field_account_bank_statement_import_journal_creation__l10n_ar_afip_pos_partner_id
 #: model:ir.model.fields,field_description:l10n_ar.field_account_journal__l10n_ar_afip_pos_partner_id
 msgid "AFIP POS Address"
 msgstr ""
 
 #. module: l10n_ar
+#: model:ir.model.fields,field_description:l10n_ar.field_account_bank_statement_import_journal_creation__l10n_ar_afip_pos_number
 #: model:ir.model.fields,field_description:l10n_ar.field_account_journal__l10n_ar_afip_pos_number
 msgid "AFIP POS Number"
 msgstr ""
 
 #. module: l10n_ar
+#: model:ir.model.fields,field_description:l10n_ar.field_account_bank_statement_import_journal_creation__l10n_ar_afip_pos_system
 #: model:ir.model.fields,field_description:l10n_ar.field_account_journal__l10n_ar_afip_pos_system
 msgid "AFIP POS System"
 msgstr ""
@@ -1007,6 +1010,7 @@ msgid "Sequence"
 msgstr ""
 
 #. module: l10n_ar
+#: model:ir.model.fields,field_description:l10n_ar.field_account_bank_statement_import_journal_creation__l10n_ar_sequence_ids
 #: model:ir.model.fields,field_description:l10n_ar.field_account_journal__l10n_ar_sequence_ids
 msgid "Sequences"
 msgstr ""
@@ -1120,11 +1124,13 @@ msgid "This field is required in order to print the invoice report properly"
 msgstr ""
 
 #. module: l10n_ar
+#: model:ir.model.fields,help:l10n_ar.field_account_bank_statement_import_journal_creation__l10n_ar_afip_pos_partner_id
 #: model:ir.model.fields,help:l10n_ar.field_account_journal__l10n_ar_afip_pos_partner_id
 msgid "This is the address used for invoice reports of this POS"
 msgstr ""
 
 #. module: l10n_ar
+#: model:ir.model.fields,help:l10n_ar.field_account_bank_statement_import_journal_creation__l10n_ar_afip_pos_number
 #: model:ir.model.fields,help:l10n_ar.field_account_journal__l10n_ar_afip_pos_number
 msgid ""
 "This is the point of sale number assigned by AFIP in order to generate "
@@ -1143,8 +1149,29 @@ msgid "Type of gross income: exempt, local, multilateral"
 msgstr ""
 
 #. module: l10n_ar
+#: model:ir.model.fields,field_description:l10n_ar.field_account_bank_statement_import_journal_creation__l10n_ar_share_sequences
 #: model:ir.model.fields,field_description:l10n_ar.field_account_journal__l10n_ar_share_sequences
 msgid "Unified Book"
+msgstr ""
+
+#. module: l10n_ar
+#: model:product.product,uom_name:l10n_ar.product_product_arancel
+#: model:product.product,uom_name:l10n_ar.product_product_cero
+#: model:product.product,uom_name:l10n_ar.product_product_exento
+#: model:product.product,uom_name:l10n_ar.product_product_no_gravado
+#: model:product.product,uom_name:l10n_ar.product_product_quote_despacho
+#: model:product.product,uom_name:l10n_ar.product_product_servicio_de_guarda
+#: model:product.product,uom_name:l10n_ar.product_product_tasa_estadistica
+#: model:product.product,uom_name:l10n_ar.product_product_telefonia
+#: model:product.template,uom_name:l10n_ar.product_product_arancel_product_template
+#: model:product.template,uom_name:l10n_ar.product_product_cero_product_template
+#: model:product.template,uom_name:l10n_ar.product_product_exento_product_template
+#: model:product.template,uom_name:l10n_ar.product_product_no_gravado_product_template
+#: model:product.template,uom_name:l10n_ar.product_product_quote_despacho_product_template
+#: model:product.template,uom_name:l10n_ar.product_product_servicio_de_guarda_product_template
+#: model:product.template,uom_name:l10n_ar.product_product_tasa_estadistica_product_template
+#: model:product.template,uom_name:l10n_ar.product_product_telefonia_product_template
+msgid "Units"
 msgstr ""
 
 #. module: l10n_ar
@@ -1164,6 +1191,7 @@ msgid "UpApP"
 msgstr ""
 
 #. module: l10n_ar
+#: model:ir.model.fields,help:l10n_ar.field_account_bank_statement_import_journal_creation__l10n_ar_share_sequences
 #: model:ir.model.fields,help:l10n_ar.field_account_journal__l10n_ar_share_sequences
 msgid "Use same sequence for documents with the same letter"
 msgstr ""
@@ -1233,6 +1261,12 @@ msgstr ""
 #: code:addons/l10n_ar/models/account_fiscal_position.py:0
 #, python-format
 msgid "Warning"
+msgstr ""
+
+#. module: l10n_ar
+#: code:addons/l10n_ar/models/res_partner.py:0
+#, python-format
+msgid "We were not able to sanitize the identification number"
 msgstr ""
 
 #. module: l10n_ar

--- a/addons/l10n_ar/models/res_partner.py
+++ b/addons/l10n_ar/models/res_partner.py
@@ -2,6 +2,7 @@
 from odoo import fields, models, api, _
 from odoo.exceptions import UserError, ValidationError
 import stdnum.ar
+import re
 import logging
 
 _logger = logging.getLogger(__name__)
@@ -110,3 +111,14 @@ class ResPartner(models.Model):
                 raise ValidationError(_('Only numbers allowed for "%s"') % rec.l10n_latam_identification_type_id.name)
             except Exception as error:
                 raise ValidationError(repr(error))
+
+    @api.model
+    def _get_id_number_sanitize(self):
+        """ Sanitize the identification number. Return the digits/integer value of the identification number """
+        if self.l10n_latam_identification_type_id.l10n_ar_afip_code in ['80', '86']:
+            # Compact is the number clean up, remove all separators leave only digits
+            res = int(stdnum.ar.cuit.compact(self.vat))
+        else:
+            id_number = re.sub('[^0-9]', '', self.vat)
+            res = int(id_number)
+        return res

--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -87,7 +87,7 @@
 
             <t t-set="custom_footer">
                 <div class="row">
-                    <div name="footer_left_column" class="col-8 text-center">
+                    <div name="footer_left_column" class="col-8 text-left">
                     </div>
                     <div name="footer_right_column" class="col-4 text-right">
                         <div name="pager" t-if="report_type == 'pdf'">
@@ -260,7 +260,7 @@
 
             <t t-set="custom_footer">
                 <div class="row">
-                    <div name="footer_left_column" class="col-8 text-center">
+                    <div name="footer_left_column" class="col-8 text-left">
                     </div>
                     <div name="footer_right_column" class="col-4 text-right">
                         <div name="pager" t-if="report_type == 'pdf'">


### PR DESCRIPTION
AFIP give us new resolution 4291 that request to print QR code in printed version of electronic invoices. For that we update the xml report footer and add some generic method to sanitize the identification number we are sending, the sanitize method is added here in order to be re used for other functionalities.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
