### PR TITLE
[FIX] sale_management: uom not displayed to the customer

### DIFF
--- a/addons/sale/report/sale_report_templates.xml
+++ b/addons/sale/report/sale_report_templates.xml
@@ -94,7 +94,7 @@
                                 <td name="td_name"><span t-field="line.name"/></td>
                                 <td name="td_quantity" class="text-right">
                                     <span t-field="line.product_uom_qty"/>
-                                    <span t-field="line.product_uom" groups="uom.group_uom"/>
+                                    <span t-field="line.product_uom"/>
                                 </td>
                                 <td name="td_priceunit" class="text-right">
                                     <span t-field="line.price_unit"/>


### PR DESCRIPTION
The uom must be displayed to the customer in any case.
Otherwise a customer couldn't know the modalities of a contract
(ex: a contract of one year or one day)

Fine tuning of 342dd5f

opw:2411108