### PR TITLE
[FIX] point_of_sale: translation issue in the ticket screen

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-27 14:12+0000\n"
-"PO-Revision-Date: 2020-11-27 14:12+0000\n"
+"POT-Creation-Date: 2021-01-26 09:03+0000\n"
+"PO-Revision-Date: 2021-01-26 09:03+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -444,6 +444,13 @@ msgid "All"
 msgstr ""
 
 #. module: point_of_sale
+#. openerp-web
+#: code:addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js:0
+#, python-format
+msgid "All Tickets"
+msgstr ""
+
+#. module: point_of_sale
 #: code:addons/point_of_sale/models/pos_config.py:0
 #, python-format
 msgid ""
@@ -770,6 +777,7 @@ msgstr ""
 
 #. module: point_of_sale
 #. openerp-web
+#: code:addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js:0
 #: code:addons/point_of_sale/static/src/xml/Screens/TicketScreen/TicketScreen.xml:0
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_payment__cardholder_name
 #, python-format
@@ -1280,6 +1288,7 @@ msgstr ""
 
 #. module: point_of_sale
 #. openerp-web
+#: code:addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js:0
 #: code:addons/point_of_sale/static/src/xml/Screens/OrderManagementScreen/OrderList.xml:0
 #: code:addons/point_of_sale/static/src/xml/Screens/PaymentScreen/PaymentScreen.xml:0
 #: code:addons/point_of_sale/static/src/xml/Screens/PaymentScreen/PaymentScreen.xml:0
@@ -1330,6 +1339,7 @@ msgstr ""
 
 #. module: point_of_sale
 #. openerp-web
+#: code:addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js:0
 #: code:addons/point_of_sale/static/src/xml/Screens/OrderManagementScreen/OrderList.xml:0
 #: code:addons/point_of_sale/static/src/xml/Screens/TicketScreen/TicketScreen.xml:0
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_order__date_order
@@ -2767,6 +2777,13 @@ msgid "Ok"
 msgstr ""
 
 #. module: point_of_sale
+#. openerp-web
+#: code:addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js:0
+#, python-format
+msgid "Ongoing"
+msgstr ""
+
+#. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_config__only_round_cash_method
 msgid "Only apply rounding on cash"
 msgstr ""
@@ -3076,6 +3093,7 @@ msgstr ""
 
 #. module: point_of_sale
 #. openerp-web
+#: code:addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js:0
 #: code:addons/point_of_sale/static/src/xml/Screens/PaymentScreen/PaymentScreen.xml:0
 #: code:addons/point_of_sale/static/src/xml/Screens/ProductScreen/ActionpadWidget.xml:0
 #: code:addons/point_of_sale/wizard/pos_payment.py:0
@@ -3839,6 +3857,13 @@ msgid "Ready to launch your <b>point of sale</b>?"
 msgstr ""
 
 #. module: point_of_sale
+#. openerp-web
+#: code:addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js:0
+#, python-format
+msgid "Receipt"
+msgstr ""
+
+#. module: point_of_sale
 #: code:addons/point_of_sale/models/pos_order.py:0
 #, python-format
 msgid "Receipt %s"
@@ -3856,6 +3881,7 @@ msgstr ""
 
 #. module: point_of_sale
 #. openerp-web
+#: code:addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js:0
 #: code:addons/point_of_sale/static/src/xml/Screens/TicketScreen/TicketScreen.xml:0
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_order__pos_reference
 #, python-format
@@ -4111,6 +4137,20 @@ msgstr ""
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_order_filter
 msgid "Search Sales Order"
+msgstr ""
+
+#. module: point_of_sale
+#. openerp-web
+#: code:addons/point_of_sale/static/src/xml/Screens/TicketScreen/TicketScreen.xml:0
+#, python-format
+msgid "Search Tickets..."
+msgstr ""
+
+#. module: point_of_sale
+#. openerp-web
+#: code:addons/point_of_sale/static/src/js/Misc/SearchBar.js:0
+#, python-format
+msgid "Select"
 msgstr ""
 
 #. module: point_of_sale

--- a/addons/point_of_sale/static/src/js/Misc/SearchBar.js
+++ b/addons/point_of_sale/static/src/js/Misc/SearchBar.js
@@ -37,7 +37,7 @@ odoo.define('point_of_sale.SearchBar', function (require) {
                 selectedFieldId: this.config.searchFields.length ? 0 : null,
                 showSearchFields: false,
                 showFilterOptions: false,
-                selectedFilter: this.config.filter.options[0] || 'Select',
+                selectedFilter: this.config.filter.options[0] || this.env._t('Select'),
             });
             useExternalListener(window, 'click', this._hideOptions);
         }

--- a/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
@@ -45,8 +45,9 @@ odoo.define('point_of_sale.TicketScreen', function (require) {
             return this.env.pos.get_order_list();
         }
         get filteredOrderList() {
+            const { AllTickets } = this.getOrderStates();
             const filterCheck = (order) => {
-                if (this.filter && this.filter !== 'All Tickets') {
+                if (this.filter && this.filter !== AllTickets) {
                     const screen = order.get_screen_data();
                     return this.filter === this.constants.screenToStatusMap[screen.name];
                 }
@@ -131,7 +132,8 @@ odoo.define('point_of_sale.TicketScreen', function (require) {
             };
         }
         get filterOptions() {
-            return ['All Tickets', 'Ongoing', 'Payment', 'Receipt'];
+            const { AllTickets, Ongoing, Payment, Receipt } = this.getOrderStates();
+            return [AllTickets, Ongoing, Payment, Receipt];
         }
         /**
          * An object with keys containing the search field names which map to functions.
@@ -158,14 +160,15 @@ odoo.define('point_of_sale.TicketScreen', function (require) {
          * @returns Record<string, (models.Order) => string>
          */
         get _searchFields() {
+            const { ReceiptNumber, Date, Customer, CardholderName } = this.getSearchFieldNames();
             var fields = {
-                'Receipt Number': (order) => order.name,
-                Date: (order) => moment(order.creation_date).format('YYYY-MM-DD hh:mm A'),
-                Customer: (order) => order.get_client_name(),
+                [ReceiptNumber]: (order) => order.name,
+                [Date]: (order) => moment(order.creation_date).format('YYYY-MM-DD hh:mm A'),
+                [Customer]: (order) => order.get_client_name(),
             };
 
             if (this.showCardholderName()) {
-                fields['Cardholder Name'] = (order) => order.get_cardholder_name();
+                fields[CardholderName] = (order) => order.get_cardholder_name();
             }
 
             return fields;
@@ -174,10 +177,11 @@ odoo.define('point_of_sale.TicketScreen', function (require) {
          * Maps the order screen params to order status.
          */
         get _screenToStatusMap() {
+            const { Ongoing, Payment, Receipt } = this.getOrderStates();
             return {
-                ProductScreen: 'Ongoing',
-                PaymentScreen: 'Payment',
-                ReceiptScreen: 'Receipt',
+                ProductScreen: Ongoing,
+                PaymentScreen: Payment,
+                ReceiptScreen: Receipt,
             };
         }
         _initializeSearchFieldConstants() {
@@ -186,6 +190,22 @@ odoo.define('point_of_sale.TicketScreen', function (require) {
                 searchFieldNames: Object.keys(this._searchFields),
                 screenToStatusMap: this._screenToStatusMap,
             });
+        }
+        getOrderStates() {
+            return {
+                AllTickets: this.env._t('All Tickets'),
+                Ongoing: this.env._t('Ongoing'),
+                Payment: this.env._t('Payment'),
+                Receipt: this.env._t('Receipt'),
+            };
+        }
+        getSearchFieldNames() {
+            return {
+                ReceiptNumber: this.env._t('Receipt Number'),
+                Date: this.env._t('Date'),
+                Customer: this.env._t('Customer'),
+                CardholderName: this.env._t('Cardholder Name'),
+            };
         }
     }
     TicketScreen.template = 'TicketScreen';

--- a/addons/point_of_sale/static/src/xml/Screens/TicketScreen/TicketScreen.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/TicketScreen/TicketScreen.xml
@@ -9,7 +9,8 @@
                         <button t-if="showNewTicketButton" class="highlight" t-on-click="createNewOrder">New Order</button>
                         <button class="discard" t-on-click="trigger('close-screen')">Discard</button>
                     </div>
-                    <SearchBar config="searchBarConfig" placeholder="'Search Tickets...'" />
+                    <t t-set="placeholder">Search Tickets...</t>
+                    <SearchBar config="searchBarConfig" placeholder="placeholder" />
                 </div>
                 <div class="orders">
                     <div class="header-row">

--- a/addons/pos_restaurant/i18n/pos_restaurant.pot
+++ b/addons/pos_restaurant/i18n/pos_restaurant.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-27 14:12+0000\n"
-"PO-Revision-Date: 2020-11-27 14:12+0000\n"
+"POT-Creation-Date: 2021-01-26 09:10+0000\n"
+"PO-Revision-Date: 2021-01-26 09:10+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -739,6 +739,13 @@ msgstr ""
 
 #. module: pos_restaurant
 #. openerp-web
+#: code:addons/pos_restaurant/static/src/js/Screens/TicketScreen.js:0
+#, python-format
+msgid "Open"
+msgstr ""
+
+#. module: pos_restaurant
+#. openerp-web
 #: code:addons/pos_restaurant/static/src/xml/Screens/FloorScreen/EditBar.xml:0
 #: code:addons/pos_restaurant/static/src/xml/Screens/FloorScreen/EditBar.xml:0
 #: code:addons/pos_restaurant/static/src/xml/Screens/FloorScreen/EditBar.xml:0
@@ -1219,6 +1226,13 @@ msgstr ""
 #: code:addons/pos_restaurant/static/src/xml/TipReceipt.xml:0
 #, python-format
 msgid "Tip:"
+msgstr ""
+
+#. module: pos_restaurant
+#. openerp-web
+#: code:addons/pos_restaurant/static/src/js/Screens/TicketScreen.js:0
+#, python-format
+msgid "Tipping"
 msgstr ""
 
 #. module: pos_restaurant

--- a/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
@@ -20,17 +20,19 @@ odoo.define('pos_restaurant.TicketScreen', function (require) {
                 }
             }
             get filterOptions() {
+                const { Payment, Open, Tipping } = this.getOrderStates();
                 var filterOptions = super.filterOptions;
                 if (this.env.pos.config.set_tip_after_payment) {
-                    var idx = filterOptions.indexOf('Payment');
-                    filterOptions[idx] = 'Open';
+                    var idx = filterOptions.indexOf(Payment);
+                    filterOptions[idx] = Open;
                 }
-                return [...filterOptions, 'Tipping'];
+                return [...filterOptions, Tipping];
             }
             get _screenToStatusMap() {
+                const { Open, Tipping } = this.getOrderStates();
                 return Object.assign(super._screenToStatusMap, {
-                    PaymentScreen: this.env.pos.config.set_tip_after_payment ? 'Open' : super._screenToStatusMap.PaymentScreen,
-                    TipScreen: 'Tipping',
+                    PaymentScreen: this.env.pos.config.set_tip_after_payment ? Open : super._screenToStatusMap.PaymentScreen,
+                    TipScreen: Tipping,
                 });
             }
             getTable(order) {
@@ -114,6 +116,12 @@ odoo.define('pos_restaurant.TicketScreen', function (require) {
                     method: 'set_no_tip',
                     model: 'pos.order',
                     args: [serverId],
+                });
+            }
+            getOrderStates() {
+                return Object.assign(super.getOrderStates(), {
+                    Tipping: this.env._t('Tipping'),
+                    Open: this.env._t('Open'),
                 });
             }
         };


### PR DESCRIPTION
The terms in the search bar of the ticket screen are not translated.
This commit fixes this issue by passing the translated form of the
terms to the search bar component.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
