### PR TITLE
[FIX] stock: automatic orderpoint creation

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -343,7 +343,7 @@ class StockWarehouseOrderpoint(models.Model):
         orderpoint_values_list = []
         for (product, warehouse), product_qty in to_refill.items():
             lot_stock_id = lot_stock_id_by_warehouse[warehouse]
-            orderpoint = self.filtered(lambda o: o.product_id == product and o.location_id == lot_stock_id)
+            orderpoint = orderpoints.filtered(lambda o: o.product_id.id == product and o.location_id.id == lot_stock_id)
             if orderpoint:
                 orderpoint[0].qty_forecast += product_qty
             else:
@@ -353,7 +353,7 @@ class StockWarehouseOrderpoint(models.Model):
                     'warehouse_id': warehouse,
                     'company_id': self.env['stock.warehouse'].browse(warehouse).company_id.id,
                 })
-            orderpoint_values_list.append(orderpoint_values)
+                orderpoint_values_list.append(orderpoint_values)
 
         orderpoints = self.env['stock.warehouse.orderpoint'].with_user(SUPERUSER_ID).create(orderpoint_values_list)
         for orderpoint in orderpoints:


### PR DESCRIPTION
When checking the replenishments, it sometimes creates a new reordering
rule for a product while another already exists.

To reproduce the error:
(Need purchase,sale_management)
1. Create a product P
	- Must be storable
	- In Purchase tab, add a vendor
2. Create a reordering rule for P
	- Trigger: Manual
	- Min: 0
	- Max: 0
3. Create+Confirm a SO with P
4. Go to Inventory > Operations > Replenishment
5. On P-product's line, click on "Order Once"
6. Confirm the generated RfQ
7. Repeat 3-4

Error: There are now two lines for P-product. A second reordering rule
has been automatically created but the first one does already the job.

OPW-2431780