### PR TITLE
[FIX] purchase: convert standard price depending on the uom

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1033,7 +1033,7 @@ class PurchaseOrderLine(models.Model):
         # If not seller, use the standard price. It needs a proper currency conversion.
         if not seller:
             price_unit = self.env['account.tax']._fix_tax_included_price_company(
-                self.product_id.standard_price,
+                self.product_id.uom_id._compute_price(self.product_id.standard_price, self.product_id.uom_po_id),
                 self.product_id.supplier_taxes_id,
                 self.taxes_id,
                 self.company_id,


### PR DESCRIPTION
- Install purchase and stock;
- Activate Units of Measure (uom);
- Create a new storable product;
- Choose a different uom for: 'Unit of Measure' (e.g., Dozens) and
    'Purchase Unit of Measure' (e.g., Units);
- Update the Cost (e.g. $ 300.00 per Dozens)
- Create a PO;
- Add the product.

Before this commit, the price on the PO will be 300 and the unit of
measure will be 'Units'.

Now, the price will be adapted to the 'Purchase Unit of Measure', in
this example it will be $25.0 per Unit.

opw-2439506