### PR TITLE
[FIX] stock: reserved quantity readonly

### DIFF
--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -37,7 +37,7 @@
                         <group>
                             <label for="product_uom_qty" string="Quantity Reserved" attrs="{'invisible': [('state', '=', 'done')]}"/>
                             <div class="o_row" attrs="{'invisible': [('state', '=', 'done')]}">
-                                <field name="product_uom_qty"/>
+                                <field name="product_uom_qty" readonly="1"/>
                                 <field name="product_uom_id" options="{'no_create': True}" string="Unit of Measure" groups="uom.group_uom"/>
                             </div>
                             <label for="qty_done" string="Quantity Done"/>


### PR DESCRIPTION
Force the quantity reserved on stock move line to be readonly to avoid
de-synchronisation with the reserved quantity on the quants.

Back-port of 08394c89407fba69b78ba1f82846501efd5c9c87

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
