### PR TITLE
[FIX] website_sale: Payment terms in multi companies

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -200,9 +200,12 @@ class Website(models.Model):
 
     @api.model
     def sale_get_payment_term(self, partner):
+        pt = self.env.ref('account.account_payment_term_immediate', False).sudo()
+        if pt:
+            pt = (not pt.company_id.id or self.company_id.id == pt.company_id.id) and pt
         return (
             partner.property_payment_term_id or
-            self.env.ref('account.account_payment_term_immediate', False) or
+            pt or
             self.env['account.payment.term'].sudo().search([('company_id', '=', self.company_id.id)], limit=1)
         ).id
 


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider two companies C1, C2 and a website W1 in C1
- Set C2 on the payment term Immediate payment
- Go to the shop
- Add a product in the cart

Bug:

A traceback was raised because Immediate was not in company C1

opw:2431705