### PR TITLE
[FIX] mass_mailing: fix the mailing tour (rename the targeted button)

### DIFF
--- a/addons/mass_mailing/static/src/js/tours/mass_mailing_tour.js
+++ b/addons/mass_mailing/static/src/js/tours/mass_mailing_tour.js
@@ -12,7 +12,7 @@ odoo.define('mass_mailing.mass_mailing_tour', function (require) {
     }, [tour.stepUtils.showAppsMenuItem(), {
         trigger: '.o_app[data-menu-xmlid="mass_mailing.mass_mailing_menu_root"]',
         content: _t("Let's try the Email Marketing app."),
-        width: 210,
+        width: 225,
         position: 'bottom',
         edition: 'enterprise',
     }, {
@@ -69,7 +69,7 @@ odoo.define('mass_mailing.mass_mailing_tour', function (require) {
         content: _t("Check the email address and click send."),
         position: 'bottom',
     }, {
-        trigger: 'button[name="action_put_in_queue"]',
+        trigger: 'button[name="action_launch"]',
         content: _t("Ready for take-off!"),
         position: 'bottom',
     }, {


### PR DESCRIPTION
Bug
===
Since e598e74648576e8812592583fa1a9dec65ead0d2 the action button "Launch"
in the mailing form view was renamed. Therefor, the mass mailing tour is
broken and need to be updated.

Task 2446835