### PR TITLE
[FIX] hr_holidays: Leaves in Multi companies

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -411,7 +411,7 @@ class HolidaysRequest(models.Model):
     @api.depends('number_of_days')
     def _compute_number_of_hours_display(self):
         for holiday in self:
-            calendar = holiday.employee_id.resource_calendar_id or self.env.user.company_id.resource_calendar_id
+            calendar = holiday.employee_id.sudo().resource_calendar_id or self.env.user.company_id.resource_calendar_id
             if holiday.date_from and holiday.date_to:
                 number_of_hours = calendar.get_work_hours_count(holiday.date_from, holiday.date_to)
                 holiday.number_of_hours_display = number_of_hours or (holiday.number_of_days * HOURS_PER_DAY)
@@ -511,7 +511,7 @@ class HolidaysRequest(models.Model):
                 elif leave.holiday_type == 'category':
                     target = leave.category_id.name
                 else:
-                    target = leave.employee_id.name
+                    target = leave.employee_id.sudo().name
                 if leave.leave_type_request_unit == 'hour':
                     res.append(
                         (leave.id,


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider 3 companies C1, C2, C3 where C1 and C2 are childs of C3
- Let's consider 3 employees E1, E2, E3 respectively in C1, C2, C3
- Create a user U with administrator access rights in Leaves and U is linked to E3
- Log as U in C3
- Create a Leave Type LT with no company
- Create a leave LT  LT1 for E1 and LT2 for E2
- Change your current company to C2
- Click on LT1

Bug:

An access right error was raised

opw:2431572