### PR TITLE
[FIX] web: call read_progress_bar asynchronously

### DIFF
--- a/addons/web/static/src/js/views/kanban/kanban_column.js
+++ b/addons/web/static/src/js/views/kanban/kanban_column.js
@@ -173,6 +173,10 @@ var KanbanColumn = Widget.extend({
 
         return $.when.apply($, defs);
     },
+    updateProgressBar: function(data){
+        this.progressBar = new KanbanColumnProgressBar(this, this.barOptions, data);
+        this.progressBar.appendTo(this.$header);
+    },
     /**
      * Called when a record has been quick created, as a new column is rendered
      * and appended into a fragment, before replacing the old column in the DOM.

--- a/addons/web/static/src/js/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/js/views/kanban/kanban_controller.js
@@ -30,6 +30,7 @@ var KanbanController = BasicController.extend({
         kanban_column_resequence: '_onColumnResequence',
         kanban_load_more: '_onLoadMore',
         kanban_load_records: '_onLoadColumnRecords',
+        kanban_load_progress_bar: '_onLoadProgressBar',
         column_toggle_fold: '_onToggleColumn',
         kanban_column_records_toggle_active: '_onToggleActiveRecords',
     }),
@@ -335,6 +336,16 @@ var KanbanController = BasicController.extend({
                     self.reload();
                 }
             });
+    },
+    /**
+     * Loads progress bar info for columns
+     *
+     * @private
+     * @param {OdooEvent} event
+     */
+    _onLoadProgressBar: function (event) {
+        console.log('_onLoadProgressBar');
+        this.renderer._renderGroupedProgressBar(event.data);
     },
     /**
      * Loads the record of a given column (used in mobile, as the columns are

--- a/addons/web/static/src/js/views/kanban/kanban_model.js
+++ b/addons/web/static/src/js/views/kanban/kanban_model.js
@@ -344,13 +344,29 @@ var KanbanModel = BasicModel.extend({
                 progress_bar: list.progressBar,
                 context: list.context,
             },
+        }, {
+            shadow: true,
         });
-        return $.when(groupsDef, progressBarDef).then(function (a, data) {
+        $.when(groupsDef, progressBarDef).then(function (a, data) {
+            var groups = [];
             _.each(list.data, function (groupID) {
                 var group = self.localData[groupID];
                 group.progressBarValues = _.extend({
                     counts: data[group.value] || {},
                 }, list.progressBar);
+                groups.push(group);
+            });
+            self.trigger_up('kanban_load_progress_bar', groups);
+        });
+        return groupsDef.then(function(){
+            _.each(list.data, function (groupID) {
+                var group = self.localData[groupID];
+                // temporarly fill it with empty values
+                if (!group.progressBarValues){
+                    group.progressBarValues = _.extend({
+                        counts: {},
+                    }, list.progressBar);
+                }
             });
             return list;
         });

--- a/addons/web/static/src/js/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/js/views/kanban/kanban_renderer.js
@@ -283,6 +283,20 @@ var KanbanRenderer = BasicRenderer.extend({
             $ghost.appendTo(fragment);
         }
     },
+    _renderGroupedProgressBar: function (data) {
+        var self = this;
+        var KanbanColumn = this.config.KanbanColumn;
+        var data_by_id = {};
+        _.each(data, function(d){
+            data_by_id[d.id] = d;
+        });
+        _.each(this.widgets, function(w){
+            if (w instanceof KanbanColumn) {
+                var d = data_by_id[w.data.id];
+                w.updateProgressBar(d);
+            }
+        });
+    },
     /**
      * Renders an grouped kanban view in a fragment.
      *


### PR DESCRIPTION
The method works very slowly with not stored field like activity_state. As
workaround, don't block UI and update progress bar once it's loaded

---

opw-2346901

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
