### PR TITLE
[FIX] website: update python dailymotion regex

### DIFF
--- a/addons/website/tools.py
+++ b/addons/website/tools.py
@@ -22,7 +22,7 @@ def get_video_embed_code(video_url):
     # Regex for few of the widely used video hosting services
     ytRegex = r'^(?:(?:https?:)?\/\/)?(?:www\.)?(?:youtu\.be\/|youtube(-nocookie)?\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))((?:\w|-){11})(?:\S+)?$'
     vimeoRegex = r'\/\/(player.)?vimeo.com\/([a-z]*\/)*([0-9]{6,11})[?]?.*'
-    dmRegex = r'.+dailymotion.com\/(video|hub|embed)\/([^_]+)[^#]*(#video=([^_&]+))?'
+    dmRegex = r'.+dailymotion.com\/(video|hub|embed)\/([^_?]+)[^#]*(#video=([^_&]+))?'
     igRegex = r'(.*)instagram.com\/p\/(.[a-zA-Z0-9]*)'
     ykuRegex = r'(.*).youku\.com\/(v_show\/id_|embed\/)(.+)'
 


### PR DESCRIPTION
The regex was updated in JS with [1] but its python counterpart was
forgotten during forward-port.

[1]: https://github.com/odoo/odoo/pull/46898

