### PR TITLE
[IMP] hr_holidays: Support document on Time Off based on Time Off type

### DIFF
--- a/addons/hr_holidays/data/hr_holidays_data.xml
+++ b/addons/hr_holidays/data/hr_holidays_data.xml
@@ -22,6 +22,7 @@
             <field name="validity_start" eval="time.strftime('%Y-01-01')"/>
             <field name="leave_notif_subtype_id" ref="mt_leave_sick"/>
             <field name="responsible_id" ref="base.user_admin"/>
+            <field name="support_document">True</field>
         </record>
 
         <!-- Compensatory Days -->

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -192,8 +192,14 @@ class HolidaysRequest(models.Model):
     can_reset = fields.Boolean('Can reset', compute='_compute_can_reset')
     can_approve = fields.Boolean('Can Approve', compute='_compute_can_approve')
 
+    attachment_ids = fields.One2many('ir.attachment', 'res_id', string="Attachments")
+    # To display in form view
+    supported_attachment_ids = fields.Many2many(
+        'ir.attachment', string="Attach File", compute='_compute_supported_attachment_ids',
+        inverse='_inverse_supported_attachment_ids')
     # UX fields
     leave_type_request_unit = fields.Selection(related='holiday_status_id.request_unit', readonly=True)
+    leave_type_support_document = fields.Boolean(related="holiday_status_id.support_document")
     # Interface fields used when not using hour-based computation
     request_date_from = fields.Date('Request Start Date')
     request_date_to = fields.Date('Request End Date')
@@ -555,6 +561,15 @@ class HolidaysRequest(models.Model):
     def _compute_is_hatched(self):
         for holiday in self:
             holiday.is_hatched = holiday.state not in ['refuse', 'validate']
+
+    @api.depends('leave_type_support_document', 'attachment_ids')
+    def _compute_supported_attachment_ids(self):
+        for holiday in self:
+            holiday.supported_attachment_ids = holiday.attachment_ids
+
+    def _inverse_supported_attachment_ids(self):
+        for holiday in self:
+            holiday.attachment_ids = holiday.supported_attachment_ids
 
     @api.constrains('date_from', 'date_to', 'employee_id')
     def _check_date(self):

--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -105,6 +105,7 @@ class HolidaysType(models.Model):
     unpaid = fields.Boolean('Is Unpaid', default=False)
     leave_notif_subtype_id = fields.Many2one('mail.message.subtype', string='Time Off Notification Subtype', default=lambda self: self.env.ref('hr_holidays.mt_leave', raise_if_not_found=False))
     allocation_notif_subtype_id = fields.Many2one('mail.message.subtype', string='Allocation Notification Subtype', default=lambda self: self.env.ref('hr_holidays.mt_leave_allocation', raise_if_not_found=False))
+    support_document = fields.Boolean(string='Supporting Document')
 
     @api.constrains('validity_start', 'validity_stop')
     def _check_validity_dates(self):

--- a/addons/hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays/views/hr_leave_type_views.xml
@@ -56,6 +56,7 @@
                                 attrs="{
                                 'invisible': [('leave_validation_type', 'in', ['no_validation', 'manager']), '|', ('allocation_type', '=', 'no'), ('allocation_validation_type', '=', 'manager')],
                                 'required': ['|', ('leave_validation_type', 'in', ['hr', 'both']), '&amp;', ('allocation_type', 'in', ['fixed_allocation', 'fixed']), ('allocation_validation_type', 'in', ['hr', 'both'])]}"/>
+                            <field name="support_document"/>
                         </group>
                         <group name="leave_validation" string="Time Off Requests">
                             <field name="leave_validation_type" string="Approval" widget="radio"/>

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -329,6 +329,11 @@
                         </div>
                         <field name="name" attrs="{'readonly': [('state', 'not in', ('draft', 'confirm'))]}" widget="text"/>
                         <field name="user_id" invisible="1"/>
+                        <field name="leave_type_support_document" invisible="1"/>
+                        <label for="supported_attachment_ids" string="Supporting Documents"
+                            attrs="{'invisible': ['|', ('leave_type_support_document', '=', False), ('state', 'not in', ('draft', 'confirm', 'validate1'))]}"/>
+                        <field name="supported_attachment_ids" widget="many2many_binary" nolabel="1"
+                            attrs="{'invisible': ['|', ('leave_type_support_document', '=', False), ('state', 'not in', ('draft', 'confirm', 'validate1'))]}"/>
                     </group>
                     <group name="col_right">
                         <field name="department_id" groups="hr_holidays.group_hr_holidays_user" invisible="1"/>
@@ -338,7 +343,7 @@
             <div class="oe_chatter">
                 <field name="message_follower_ids"/>
                 <field name="activity_ids"/>
-                <field name="message_ids"/>
+                <field name="message_ids" options="{'post_refresh': 'always'}"/>
             </div>
             </form>
         </field>

--- a/addons/mail/static/src/components/attachment_delete_confirm_dialog/attachment_delete_confirm_dialog.js
+++ b/addons/mail/static/src/components/attachment_delete_confirm_dialog/attachment_delete_confirm_dialog.js
@@ -71,9 +71,9 @@ class AttachmentDeleteConfirmDialog extends Component {
     /**
      * @private
      */
-    _onClickOk() {
+    async _onClickOk() {
+        await this.attachment.remove();
         this._dialogRef.comp._close();
-        this.attachment.remove();
         this.trigger('o-attachment-removed', { attachmentLocalId: this.props.attachmentLocalId });
     }
 


### PR DESCRIPTION
Currently, it's possible to add supporting documents on the chatter of
the time off. But it's not easy to use and don't make really sense.
So we will add the possibility to add it more easily.

So in this commit,
 - Set default calendar view to 'month'
 - Added 'Supporting Document' on Time Off type sto support the
attachment based on types.
 - On new Time Off, if Time Off type has support document then allow
to upload the supporting document in form view.
 - The File is record on the chatter of the Time Off request.

TaskID: 2431478