### PR TITLE
[IMP] {account, base_setup, mail}: make alias domain company dependent

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -42,7 +42,7 @@ class AccountJournal(models.Model):
         return self.__get_bank_statements_available_sources()
 
     def _default_alias_domain(self):
-        return self.env["ir.config_parameter"].sudo().get_param("mail.catchall.domain")
+        return self.env.company.alias_domain
 
     def _default_invoice_reference_model(self):
         """Get the invoice reference model according to the company's country."""

--- a/addons/account/tests/test_account_incoming_supplier_invoice.py
+++ b/addons/account/tests/test_account_incoming_supplier_invoice.py
@@ -12,7 +12,7 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon):
     def setUpClass(cls, chart_template_ref=None):
         super().setUpClass(chart_template_ref=chart_template_ref)
 
-        cls.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id = %s', ('test-company.odoo.com', cls.env.company.id))
+        cls.env.company.write({'alias_domain': 'test-company.odoo.com'})
 
         cls.internal_user = cls.env['res.users'].create({
             'name': 'Internal User',

--- a/addons/account/tests/test_account_incoming_supplier_invoice.py
+++ b/addons/account/tests/test_account_incoming_supplier_invoice.py
@@ -12,7 +12,7 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon):
     def setUpClass(cls, chart_template_ref=None):
         super().setUpClass(chart_template_ref=chart_template_ref)
 
-        cls.env.company.write({'alias_domain': 'test-company.odoo.com'})
+        cls.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id = %s', ('test-company.odoo.com', cls.env.company.id))
 
         cls.internal_user = cls.env['res.users'].create({
             'name': 'Internal User',

--- a/addons/account/tests/test_account_incoming_supplier_invoice.py
+++ b/addons/account/tests/test_account_incoming_supplier_invoice.py
@@ -12,7 +12,7 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon):
     def setUpClass(cls, chart_template_ref=None):
         super().setUpClass(chart_template_ref=chart_template_ref)
 
-        cls.env['ir.config_parameter'].sudo().set_param('mail.catchall.domain', 'test-company.odoo.com')
+        cls.env.company.write({'alias_domain': 'test-company.odoo.com'})
 
         cls.internal_user = cls.env['res.users'].create({
             'name': 'Internal User',

--- a/addons/base_setup/models/__init__.py
+++ b/addons/base_setup/models/__init__.py
@@ -2,5 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import ir_http
+from . import res_company
 from . import res_config_settings
 from . import res_users

--- a/addons/base_setup/models/res_company.py
+++ b/addons/base_setup/models/res_company.py
@@ -1,0 +1,8 @@
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    external_email_server_default = fields.Boolean(
+        "External Email Servers")

--- a/addons/base_setup/models/res_config_settings.py
+++ b/addons/base_setup/models/res_config_settings.py
@@ -16,7 +16,7 @@ class ResConfigSettings(models.TransientModel):
         config_parameter='base_setup.default_user_rights')
     external_email_server_default = fields.Boolean(
         "Custom Email Servers",
-        config_parameter='base_setup.default_external_email_server')
+        default=lambda self: self.env.company.external_email_server_default)
     module_base_import = fields.Boolean("Allow users to import data from CSV/XLS/XLSX/ODS files")
     module_google_calendar = fields.Boolean(
         string='Allow the users to synchronize their calendar  with Google Calendar')
@@ -123,3 +123,7 @@ class ResConfigSettings(models.TransientModel):
 
         for record in self:
             record.company_informations = informations
+
+    def set_values(self):
+        super(ResConfigSettings, self).set_values()
+        self.env.company.write({'external_email_server_default': self.external_email_server_default})

--- a/addons/crm/tests/test_crm_lead_notification.py
+++ b/addons/crm/tests/test_crm_lead_notification.py
@@ -49,7 +49,8 @@ class NewLeadNotification(TestCrmCommon):
 
         crm_team_model = self.env['ir.model'].search([('model', '=', 'crm.team')])
         crm_lead_model = self.env['ir.model'].search([('model', '=', 'crm.lead')])
-        self.env["ir.config_parameter"].sudo().set_param("mail.catchall.domain", 'aqualung.com')
+        company0.write({'alias_domain': 'aqualung.com'})
+        company1.write({'alias_domain': 'aqualung.com'})
 
         crm_team0 = self.env['crm.team'].create({
             'name': 'crm team 0',

--- a/addons/crm/tests/test_crm_lead_notification.py
+++ b/addons/crm/tests/test_crm_lead_notification.py
@@ -49,8 +49,7 @@ class NewLeadNotification(TestCrmCommon):
 
         crm_team_model = self.env['ir.model'].search([('model', '=', 'crm.team')])
         crm_lead_model = self.env['ir.model'].search([('model', '=', 'crm.lead')])
-        company0.write({'alias_domain': 'aqualung.com'})
-        company1.write({'alias_domain': 'aqualung.com'})
+        self.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id IN %s', ['aqualung.com', tuple((company0 + company1).ids)])
 
         crm_team0 = self.env['crm.team'].create({
             'name': 'crm team 0',

--- a/addons/crm/tests/test_crm_lead_notification.py
+++ b/addons/crm/tests/test_crm_lead_notification.py
@@ -49,7 +49,8 @@ class NewLeadNotification(TestCrmCommon):
 
         crm_team_model = self.env['ir.model'].search([('model', '=', 'crm.team')])
         crm_lead_model = self.env['ir.model'].search([('model', '=', 'crm.lead')])
-        self.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id IN %s', ['aqualung.com', tuple((company0 + company1).ids)])
+        company0.write({'alias_domain': 'aqualung.com'})
+        company1.write({'alias_domain': 'aqualung.com'})
 
         crm_team0 = self.env['crm.team'].create({
             'name': 'crm team 0',

--- a/addons/mail/models/mail_alias.py
+++ b/addons/mail/models/mail_alias.py
@@ -34,7 +34,7 @@ class Alias(models.Model):
     _order = 'alias_model_id, alias_name'
 
     def _default_alias_domain(self):
-        return self.env["ir.config_parameter"].sudo().get_param("mail.catchall.domain")
+        return self.env.company.alias_domain
 
     alias_name = fields.Char('Alias Name', copy=False, help="The name of the email alias, e.g. 'jobs' if you want to catch emails for <jobs@example.odoo.com>")
     alias_model_id = fields.Many2one('ir.model', 'Aliased Model', required=True, ondelete="cascade",
@@ -171,7 +171,7 @@ class Alias(models.Model):
 
         catchall_alias = self.env['ir.config_parameter'].sudo().get_param('mail.catchall.alias')
         bounce_alias = self.env['ir.config_parameter'].sudo().get_param('mail.bounce.alias')
-        alias_domain = self.env["ir.config_parameter"].sudo().get_param("mail.catchall.domain")
+        alias_domain = self.env.company.alias_domain
 
         # matches catchall or bounce alias
         for sanitized_name in sanitized_names:

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -351,7 +351,7 @@ class MailMail(models.Model):
                 headers = {}
                 ICP = self.env['ir.config_parameter'].sudo()
                 bounce_alias = ICP.get_param("mail.bounce.alias")
-                catchall_domain = ICP.get_param("mail.catchall.domain")
+                catchall_domain = self.env.company.alias_domain
                 if bounce_alias and catchall_domain:
                     headers['Return-Path'] = '%s@%s' % (bounce_alias, catchall_domain)
                 if mail.headers:

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -347,7 +347,7 @@ class MailThread(models.AbstractModel):
         that adds alias information. """
         model = self._context.get('empty_list_help_model')
         res_id = self._context.get('empty_list_help_id')
-        catchall_domain = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain")
+        catchall_domain = self.env.company.alias_domain
         document_name = self._context.get('empty_list_help_document_name', _('document'))
         nothing_here = not help
         alias = None
@@ -1527,7 +1527,7 @@ class MailThread(models.AbstractModel):
         """
         # find normalized emails and exclude aliases (to avoid subscribing alias emails to records)
         normalized_email = tools.email_normalize(email)
-        catchall_domain = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain")
+        catchall_domain = self.env.company.alias_domain
         if normalized_email and catchall_domain:
             left_part = normalized_email.split('@')[0] if normalized_email.split('@')[1] == catchall_domain.lower() else False
             if left_part:
@@ -1584,7 +1584,7 @@ class MailThread(models.AbstractModel):
             followers = records.mapped('message_partner_ids')
         else:
             followers = self.env['res.partner']
-        catchall_domain = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain")
+        catchall_domain = self.env.company.alias_domain
 
         # first, build a normalized email list and remove those linked to aliases to avoid adding aliases as partners
         normalized_emails = [tools.email_normalize(contact) for contact in emails if tools.email_normalize(contact)]

--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -122,7 +122,7 @@ class BaseModel(models.AbstractModel):
         res_ids = _records.ids if _records and model else []
         _res_ids = res_ids or [False]  # always have a default value located in False
 
-        alias_domain = self.env['ir.config_parameter'].sudo().get_param("mail.catchall.domain")
+        alias_domain = self.env.company.alias_domain
         result = dict.fromkeys(_res_ids, False)
         result_email = dict()
         doc_names = doc_names if doc_names else dict()

--- a/addons/mail/models/res_company.py
+++ b/addons/mail/models/res_company.py
@@ -16,11 +16,14 @@ class Company(models.Model):
     def _compute_catchall(self):
         ConfigParameter = self.env['ir.config_parameter'].sudo()
         alias = ConfigParameter.get_param('mail.catchall.alias')
-        domain = ConfigParameter.get_param('mail.catchall.domain')
-        if alias and domain:
+        if alias:
             for company in self:
-                company.catchall_email = '%s@%s' % (alias, domain)
-                company.catchall_formatted = tools.formataddr((company.name, company.catchall_email))
+                if company.alias_domain:
+                    company.catchall_email = '%s@%s' % (alias, company.alias_domain)
+                    company.catchall_formatted = tools.formataddr((company.name, company.catchall_email))
+                else:
+                    company.catchall_email = ''
+                    company.catchall_formatted = ''
         else:
             for company in self:
                 company.catchall_email = ''

--- a/addons/mail/models/res_config_settings.py
+++ b/addons/mail/models/res_config_settings.py
@@ -13,7 +13,7 @@ class ResConfigSettings(models.TransientModel):
 
     fail_counter = fields.Integer('Fail Mail', readonly=True)
     alias_domain = fields.Char('Alias Domain', help="If you have setup a catch-all email domain redirected to "
-                               "the Odoo server, enter the domain name here.", config_parameter='mail.catchall.domain')
+                               "the Odoo server, enter the domain name here.", default=lambda self: self.env.company.alias_domain)
     restrict_template_rendering = fields.Boolean(
         'Restrict Template Rendering',
         config_parameter='mail.restrict.template.rendering',
@@ -36,4 +36,5 @@ class ResConfigSettings(models.TransientModel):
 
     def set_values(self):
         super(ResConfigSettings, self).set_values()
-        self.env['ir.config_parameter'].set_param("mail.catchall.domain", self.alias_domain or '')
+        if self.alias_domain and self.alias_domain != self.env.company.alias_domain:
+            self.env.company.write({'alias_domain': self.alias_domain})

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -102,7 +102,7 @@ class MockEmail(common.BaseCase):
         cls.alias_bounce = 'bounce.test'
         cls.default_from = 'notifications'
         cls.env['ir.config_parameter'].set_param('mail.bounce.alias', cls.alias_bounce)
-        cls.env.company.write({'alias_domain': cls.alias_domain})
+        cls.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id = %s', (cls.alias_domain, cls.env.company.id))
         cls.env['ir.config_parameter'].set_param('mail.catchall.alias', cls.alias_catchall)
         cls.env['ir.config_parameter'].set_param('mail.default.from', cls.default_from)
         cls.mailer_daemon_email = formataddr(('MAILER-DAEMON', '%s@%s' % (cls.alias_bounce, cls.alias_domain)))

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -102,7 +102,7 @@ class MockEmail(common.BaseCase):
         cls.alias_bounce = 'bounce.test'
         cls.default_from = 'notifications'
         cls.env['ir.config_parameter'].set_param('mail.bounce.alias', cls.alias_bounce)
-        cls.env['ir.config_parameter'].set_param('mail.catchall.domain', cls.alias_domain)
+        cls.env.company.write({'alias_domain': cls.alias_domain})
         cls.env['ir.config_parameter'].set_param('mail.catchall.alias', cls.alias_catchall)
         cls.env['ir.config_parameter'].set_param('mail.default.from', cls.default_from)
         cls.mailer_daemon_email = formataddr(('MAILER-DAEMON', '%s@%s' % (cls.alias_bounce, cls.alias_domain)))

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -102,7 +102,7 @@ class MockEmail(common.BaseCase):
         cls.alias_bounce = 'bounce.test'
         cls.default_from = 'notifications'
         cls.env['ir.config_parameter'].set_param('mail.bounce.alias', cls.alias_bounce)
-        cls.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id = %s', (cls.alias_domain, cls.env.company.id))
+        cls.env.company.write({'alias_domain': cls.alias_domain})
         cls.env['ir.config_parameter'].set_param('mail.catchall.alias', cls.alias_catchall)
         cls.env['ir.config_parameter'].set_param('mail.default.from', cls.default_from)
         cls.mailer_daemon_email = formataddr(('MAILER-DAEMON', '%s@%s' % (cls.alias_bounce, cls.alias_domain)))

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -655,7 +655,7 @@ class TestMailgateway(TestMailCommon):
     @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
     def test_message_route_alias_no_domain(self):
         """ Incoming email: write to alias even if no domain set: considered as valid alias """
-        self.env.company.write({'alias_domain': ''})
+        self.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id = %s', ('', self.env.company.id))
 
         new_record = self.format_and_process(MAIL_TEMPLATE, self.partner_1.email_formatted, 'groups@another.domain.com', subject='Test Subject')
         # Test: one group created

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -655,7 +655,7 @@ class TestMailgateway(TestMailCommon):
     @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
     def test_message_route_alias_no_domain(self):
         """ Incoming email: write to alias even if no domain set: considered as valid alias """
-        self.env['ir.config_parameter'].set_param('mail.catchall.domain', '')
+        self.env.company.write({'alias_domain': ''})
 
         new_record = self.format_and_process(MAIL_TEMPLATE, self.partner_1.email_formatted, 'groups@another.domain.com', subject='Test Subject')
         # Test: one group created

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -655,7 +655,7 @@ class TestMailgateway(TestMailCommon):
     @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
     def test_message_route_alias_no_domain(self):
         """ Incoming email: write to alias even if no domain set: considered as valid alias """
-        self.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id = %s', ('', self.env.company.id))
+        self.env.company.write({'alias_domain': ''})
 
         new_record = self.format_and_process(MAIL_TEMPLATE, self.partner_1.email_formatted, 'groups@another.domain.com', subject='Test Subject')
         # Test: one group created

--- a/addons/test_mail/tests/test_mail_message.py
+++ b/addons/test_mail/tests/test_mail_message.py
@@ -80,7 +80,7 @@ class TestMessageValues(TestMailCommon):
         self.assertEqual(msg.email_from, formataddr((self.user_employee.name, self.user_employee.email)))
 
         # no alias domain -> author
-        self.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id = %s', ('', self.env.company.id))
+        self.env.company.write({'alias_domain': ''})
 
         msg = self.Message.create({})
         self.assertIn('-private', msg.message_id.split('@')[0], 'mail_message: message_id for a void message should be a "private" one')
@@ -88,7 +88,7 @@ class TestMessageValues(TestMailCommon):
         self.assertEqual(msg.email_from, formataddr((self.user_employee.name, self.user_employee.email)))
 
         # no alias catchall, no alias -> author
-        self.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id = %s', (self.alias_domain, self.env.company.id))
+        self.env.company.write({'alias_domain': self.alias_domain})
         self.env['ir.config_parameter'].search([('key', '=', 'mail.catchall.alias')]).unlink()
 
         msg = self.Message.create({})
@@ -109,7 +109,7 @@ class TestMessageValues(TestMailCommon):
         self.assertEqual(msg.email_from, formataddr((self.user_employee.name, self.user_employee.email)))
 
         # no alias domain -> author
-        self.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id = %s', ('', self.env.company.id))
+        self.env.company.write({'alias_domain': ''})
 
         msg = self.Message.create({
             'model': 'mail.test.container',
@@ -120,7 +120,7 @@ class TestMessageValues(TestMailCommon):
         self.assertEqual(msg.email_from, formataddr((self.user_employee.name, self.user_employee.email)))
 
         # no catchall -> don't care, alias
-        self.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id = %s', (self.alias_domain, self.env.company.id))
+        self.env.company.write({'alias_domain': self.alias_domain})
         self.env['ir.config_parameter'].search([('key', '=', 'mail.catchall.alias')]).unlink()
 
         msg = self.Message.create({
@@ -344,7 +344,7 @@ class TestMessageAccess(TestMailCommon):
 
     def test_mail_message_access_create_reply(self):
         # TDE FIXME: should it really work ? not sure - catchall makes crash (aka, post will crash also)
-        self.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id = %s', ('', self.env.company.id))
+        self.env.company.alias_domain = ''
         self.message.write({'partner_ids': [(4, self.user_employee.partner_id.id)]})
         self.env['mail.message'].with_user(self.user_employee).create({'model': 'mail.channel', 'res_id': self.group_private.id, 'body': 'Test', 'parent_id': self.message.id})
 

--- a/addons/test_mail/tests/test_mail_message.py
+++ b/addons/test_mail/tests/test_mail_message.py
@@ -80,7 +80,7 @@ class TestMessageValues(TestMailCommon):
         self.assertEqual(msg.email_from, formataddr((self.user_employee.name, self.user_employee.email)))
 
         # no alias domain -> author
-        self.env.company.write({'alias_domain': ''})
+        self.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id = %s', ('', self.env.company.id))
 
         msg = self.Message.create({})
         self.assertIn('-private', msg.message_id.split('@')[0], 'mail_message: message_id for a void message should be a "private" one')
@@ -88,7 +88,7 @@ class TestMessageValues(TestMailCommon):
         self.assertEqual(msg.email_from, formataddr((self.user_employee.name, self.user_employee.email)))
 
         # no alias catchall, no alias -> author
-        self.env.company.write({'alias_domain': self.alias_domain})
+        self.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id = %s', (self.alias_domain, self.env.company.id))
         self.env['ir.config_parameter'].search([('key', '=', 'mail.catchall.alias')]).unlink()
 
         msg = self.Message.create({})
@@ -109,7 +109,7 @@ class TestMessageValues(TestMailCommon):
         self.assertEqual(msg.email_from, formataddr((self.user_employee.name, self.user_employee.email)))
 
         # no alias domain -> author
-        self.env.company.write({'alias_domain': ''})
+        self.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id = %s', ('', self.env.company.id))
 
         msg = self.Message.create({
             'model': 'mail.test.container',
@@ -120,7 +120,7 @@ class TestMessageValues(TestMailCommon):
         self.assertEqual(msg.email_from, formataddr((self.user_employee.name, self.user_employee.email)))
 
         # no catchall -> don't care, alias
-        self.env.company.write({'alias_domain': self.alias_domain})
+        self.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id = %s', (self.alias_domain, self.env.company.id))
         self.env['ir.config_parameter'].search([('key', '=', 'mail.catchall.alias')]).unlink()
 
         msg = self.Message.create({
@@ -344,7 +344,7 @@ class TestMessageAccess(TestMailCommon):
 
     def test_mail_message_access_create_reply(self):
         # TDE FIXME: should it really work ? not sure - catchall makes crash (aka, post will crash also)
-        self.env.company.alias_domain = ''
+        self.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id = %s', ('', self.env.company.id))
         self.message.write({'partner_ids': [(4, self.user_employee.partner_id.id)]})
         self.env['mail.message'].with_user(self.user_employee).create({'model': 'mail.channel', 'res_id': self.group_private.id, 'body': 'Test', 'parent_id': self.message.id})
 

--- a/addons/test_mail/tests/test_mail_message.py
+++ b/addons/test_mail/tests/test_mail_message.py
@@ -80,7 +80,7 @@ class TestMessageValues(TestMailCommon):
         self.assertEqual(msg.email_from, formataddr((self.user_employee.name, self.user_employee.email)))
 
         # no alias domain -> author
-        self.env['ir.config_parameter'].search([('key', '=', 'mail.catchall.domain')]).unlink()
+        self.env.company.write({'alias_domain': ''})
 
         msg = self.Message.create({})
         self.assertIn('-private', msg.message_id.split('@')[0], 'mail_message: message_id for a void message should be a "private" one')
@@ -88,7 +88,7 @@ class TestMessageValues(TestMailCommon):
         self.assertEqual(msg.email_from, formataddr((self.user_employee.name, self.user_employee.email)))
 
         # no alias catchall, no alias -> author
-        self.env['ir.config_parameter'].set_param('mail.catchall.domain', self.alias_domain)
+        self.env.company.write({'alias_domain': self.alias_domain})
         self.env['ir.config_parameter'].search([('key', '=', 'mail.catchall.alias')]).unlink()
 
         msg = self.Message.create({})
@@ -109,7 +109,7 @@ class TestMessageValues(TestMailCommon):
         self.assertEqual(msg.email_from, formataddr((self.user_employee.name, self.user_employee.email)))
 
         # no alias domain -> author
-        self.env['ir.config_parameter'].search([('key', '=', 'mail.catchall.domain')]).unlink()
+        self.env.company.write({'alias_domain': ''})
 
         msg = self.Message.create({
             'model': 'mail.test.container',
@@ -120,7 +120,7 @@ class TestMessageValues(TestMailCommon):
         self.assertEqual(msg.email_from, formataddr((self.user_employee.name, self.user_employee.email)))
 
         # no catchall -> don't care, alias
-        self.env['ir.config_parameter'].set_param('mail.catchall.domain', self.alias_domain)
+        self.env.company.write({'alias_domain': self.alias_domain})
         self.env['ir.config_parameter'].search([('key', '=', 'mail.catchall.alias')]).unlink()
 
         msg = self.Message.create({
@@ -344,7 +344,7 @@ class TestMessageAccess(TestMailCommon):
 
     def test_mail_message_access_create_reply(self):
         # TDE FIXME: should it really work ? not sure - catchall makes crash (aka, post will crash also)
-        self.env['ir.config_parameter'].set_param('mail.catchall.domain', False)
+        self.env.company.alias_domain = ''
         self.message.write({'partner_ids': [(4, self.user_employee.partner_id.id)]})
         self.env['mail.message'].with_user(self.user_employee).create({'model': 'mail.channel', 'res_id': self.group_private.id, 'body': 'Test', 'parent_id': self.message.id})
 

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -455,7 +455,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         })
 
         # setup mail gateway
-        self.env['ir.config_parameter'].sudo().set_param('mail.catchall.domain', 'example.com')
+        self.env.company.write({'alias_domain': 'example.com'})
         self.env['ir.config_parameter'].sudo().set_param('mail.catchall.alias', 'test-catchall')
         self.env['ir.config_parameter'].sudo().set_param('mail.bounce.alias', 'test-bounce')
 

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -455,7 +455,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         })
 
         # setup mail gateway
-        self.env.company.write({'alias_domain': 'example.com'})
+        self.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id = %s', ('example.com', self.env.company.id))
         self.env['ir.config_parameter'].sudo().set_param('mail.catchall.alias', 'test-catchall')
         self.env['ir.config_parameter'].sudo().set_param('mail.bounce.alias', 'test-bounce')
 

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -455,7 +455,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         })
 
         # setup mail gateway
-        self.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id = %s', ('example.com', self.env.company.id))
+        self.env.company.write({'alias_domain': 'example.com'})
         self.env['ir.config_parameter'].sudo().set_param('mail.catchall.alias', 'test-catchall')
         self.env['ir.config_parameter'].sudo().set_param('mail.bounce.alias', 'test-bounce')
 

--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -425,7 +425,7 @@ class IrMailServer(models.Model):
         '''
         get_param = self.env['ir.config_parameter'].sudo().get_param
         postmaster = get_param('mail.bounce.alias', default='postmaster-odoo')
-        domain = get_param('mail.catchall.domain')
+        domain = self.env.company.alias_domain
         if postmaster and domain:
             return '%s@%s' % (postmaster, domain)
 
@@ -443,7 +443,7 @@ class IrMailServer(models.Model):
             ``--email-from`` CLI/config parameter.
         """
         get_param = self.env['ir.config_parameter'].sudo().get_param
-        domain = get_param('mail.catchall.domain')
+        domain = self.env.company.alias_domain
         email_from = get_param("mail.default.from")
         if email_from and domain:
             return "%s@%s" % (email_from, domain)

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -96,6 +96,7 @@ class Company(models.Model):
     secondary_color = fields.Char()
     layout_background = fields.Selection([('Blank', 'Blank'), ('Geometric', 'Geometric'), ('Custom', 'Custom')], default="Blank", required=True)
     layout_background_image = fields.Binary("Background Image")
+    alias_domain = fields.Char(string="Alias Domain")
     _sql_constraints = [
         ('name_uniq', 'unique (name)', 'The company name must be unique !')
     ]

--- a/odoo/addons/base/tests/common.py
+++ b/odoo/addons/base/tests/common.py
@@ -299,7 +299,7 @@ class MockSmtplibCase:
 
     @classmethod
     def _init_mail_servers(cls):
-        cls.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id = %s', ('test.com', cls.env.company.id))
+        cls.env.company.alias_domain = 'test.com'
         cls.env['ir.config_parameter'].sudo().set_param('mail.default.from', 'notifications')
         cls.env['ir.config_parameter'].sudo().set_param('mail.bounce.alias', 'bounce')
 

--- a/odoo/addons/base/tests/common.py
+++ b/odoo/addons/base/tests/common.py
@@ -299,7 +299,7 @@ class MockSmtplibCase:
 
     @classmethod
     def _init_mail_servers(cls):
-        cls.env['ir.config_parameter'].sudo().set_param('mail.catchall.domain', 'test.com')
+        cls.env.company.alias_domain = 'test.com'
         cls.env['ir.config_parameter'].sudo().set_param('mail.default.from', 'notifications')
         cls.env['ir.config_parameter'].sudo().set_param('mail.bounce.alias', 'bounce')
 

--- a/odoo/addons/base/tests/common.py
+++ b/odoo/addons/base/tests/common.py
@@ -299,7 +299,7 @@ class MockSmtplibCase:
 
     @classmethod
     def _init_mail_servers(cls):
-        cls.env.company.alias_domain = 'test.com'
+        cls.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id = %s', ('test.com', cls.env.company.id))
         cls.env['ir.config_parameter'].sudo().set_param('mail.default.from', 'notifications')
         cls.env['ir.config_parameter'].sudo().set_param('mail.bounce.alias', 'bounce')
 

--- a/odoo/addons/base/tests/test_ir_mail_server.py
+++ b/odoo/addons/base/tests/test_ir_mail_server.py
@@ -98,7 +98,7 @@ class TestIrMailServer(TransactionCase, MockSmtplibCase):
         # remove the notifications email to simulate a mis-configured Odoo database
         # so we do not have the choice, we have to spoof the FROM
         # (otherwise we can not send the email)
-        self.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id = %s', ('', self.env.company.id))
+        self.env.company.alias_domain = False
         with mute_logger('odoo.addons.base.models.ir_mail_server'):
             mail_server, mail_from = self.env['ir.mail_server']._find_mail_server(email_from='test@unknown_domain.com')
             self.assertEqual(mail_server.from_filter, False, 'No notifications email set, must be forced to spoof the FROM')
@@ -184,7 +184,7 @@ class TestIrMailServer(TransactionCase, MockSmtplibCase):
         )
 
         # Test that the mail from / recipient envelop are encoded using IDNA
-        self.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id = %s', ('ééééééé.com', self.env.company.id))
+        self.env.company.alias_domain = 'ééééééé.com'
         with self.mock_smtplib_connection():
             message = self._build_email(mail_from='test@ééééééé.com')
             IrMailServer.send_email(message)

--- a/odoo/addons/base/tests/test_ir_mail_server.py
+++ b/odoo/addons/base/tests/test_ir_mail_server.py
@@ -98,7 +98,7 @@ class TestIrMailServer(TransactionCase, MockSmtplibCase):
         # remove the notifications email to simulate a mis-configured Odoo database
         # so we do not have the choice, we have to spoof the FROM
         # (otherwise we can not send the email)
-        self.env.company.alias_domain = False
+        self.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id = %s', ('', self.env.company.id))
         with mute_logger('odoo.addons.base.models.ir_mail_server'):
             mail_server, mail_from = self.env['ir.mail_server']._find_mail_server(email_from='test@unknown_domain.com')
             self.assertEqual(mail_server.from_filter, False, 'No notifications email set, must be forced to spoof the FROM')
@@ -184,7 +184,7 @@ class TestIrMailServer(TransactionCase, MockSmtplibCase):
         )
 
         # Test that the mail from / recipient envelop are encoded using IDNA
-        self.env.company.alias_domain = 'ééééééé.com'
+        self.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id = %s', ('ééééééé.com', self.env.company.id))
         with self.mock_smtplib_connection():
             message = self._build_email(mail_from='test@ééééééé.com')
             IrMailServer.send_email(message)

--- a/odoo/addons/base/tests/test_ir_mail_server.py
+++ b/odoo/addons/base/tests/test_ir_mail_server.py
@@ -98,7 +98,7 @@ class TestIrMailServer(TransactionCase, MockSmtplibCase):
         # remove the notifications email to simulate a mis-configured Odoo database
         # so we do not have the choice, we have to spoof the FROM
         # (otherwise we can not send the email)
-        self.env['ir.config_parameter'].sudo().set_param('mail.catchall.domain', False)
+        self.env.company.alias_domain = False
         with mute_logger('odoo.addons.base.models.ir_mail_server'):
             mail_server, mail_from = self.env['ir.mail_server']._find_mail_server(email_from='test@unknown_domain.com')
             self.assertEqual(mail_server.from_filter, False, 'No notifications email set, must be forced to spoof the FROM')
@@ -184,7 +184,7 @@ class TestIrMailServer(TransactionCase, MockSmtplibCase):
         )
 
         # Test that the mail from / recipient envelop are encoded using IDNA
-        self.env['ir.config_parameter'].sudo().set_param('mail.catchall.domain', 'ééééééé.com')
+        self.env.company.alias_domain = 'ééééééé.com'
         with self.mock_smtplib_connection():
             message = self._build_email(mail_from='test@ééééééé.com')
             IrMailServer.send_email(message)

--- a/odoo/addons/base/tests/test_mail.py
+++ b/odoo/addons/base/tests/test_mail.py
@@ -474,7 +474,7 @@ class EmailConfigCase(TransactionCase):
         """Email from setting is respected."""
         # ICP setting is more important
         ICP = self.env["ir.config_parameter"].sudo()
-        self.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id = %s', ('example.org', self.env.company.id))
+        self.env.company.write({"alias_domain": "example.org"})
         ICP.set_param("mail.default.from", "icp")
         message = self.env["ir.mail_server"].build_email(
             False, "recipient@example.com", "Subject",

--- a/odoo/addons/base/tests/test_mail.py
+++ b/odoo/addons/base/tests/test_mail.py
@@ -474,7 +474,7 @@ class EmailConfigCase(TransactionCase):
         """Email from setting is respected."""
         # ICP setting is more important
         ICP = self.env["ir.config_parameter"].sudo()
-        ICP.set_param("mail.catchall.domain", "example.org")
+        self.env.company.write({"alias_domain": "example.org"})
         ICP.set_param("mail.default.from", "icp")
         message = self.env["ir.mail_server"].build_email(
             False, "recipient@example.com", "Subject",

--- a/odoo/addons/base/tests/test_mail.py
+++ b/odoo/addons/base/tests/test_mail.py
@@ -474,7 +474,7 @@ class EmailConfigCase(TransactionCase):
         """Email from setting is respected."""
         # ICP setting is more important
         ICP = self.env["ir.config_parameter"].sudo()
-        self.env.company.write({"alias_domain": "example.org"})
+        self.env.cr.execute('UPDATE res_company SET alias_domain = %s WHERE id = %s', ('example.org', self.env.company.id))
         ICP.set_param("mail.default.from", "icp")
         message = self.env["ir.mail_server"].build_email(
             False, "recipient@example.com", "Subject",


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Alias domain company dependent
* Useful for eCommerce companies who would like to manage multiple stores using Odoo multi website feature in a single business application.

Current behavior before PR:
Odoo supports only one email alias domain per database.

Desired behavior after PR is merged:
Video demonstrating the feature:
https://drive.google.com/file/d/10a2LRQ7L44m-YI2ViIXHGmsMMmg3boCT/view?usp=sharing



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
