### PR TITLE
[MERGE] generic improvements from UserTesting in Project App

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -571,7 +571,7 @@ class Task(models.Model):
     priority = fields.Selection([
         ('0', 'Normal'),
         ('1', 'Important'),
-    ], default='0', index=True, string="Priority")
+    ], default='0', index=True, string="Starred")
     sequence = fields.Integer(string='Sequence', index=True, default=10,
         help="Gives the sequence order when displaying a list of tasks.")
     stage_id = fields.Many2one('project.task.type', string='Stage', compute='_compute_stage_id',

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -248,7 +248,7 @@
             <field name="arch" type="xml">
                 <form string="Project" delete="0">
                     <header>
-                        <button name="%(portal.portal_share_action)d" string="Share" type="action" class="oe_highlight oe_read_only"/>
+                        <button name="%(portal.portal_share_action)d" string="Share" type="action" class="oe_highlight oe_read_only" groups="project.group_project_manager"/>
                     </header>
                 <sheet string="Project">
                     <div class="oe_button_box" name="button_box" groups="base.group_user">

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -692,6 +692,8 @@
                             <field name="project_id" required="1" domain="[('active', '=', True), ('company_id', '=', company_id)]"/>
                             <field name="user_id"
                                 class="o_task_user_field"
+                                options="{'no_open': True}"
+                                widget="many2one_avatar_user"
                                 domain="[('share', '=', False)]"/>
                             <field
                                 name="parent_id"

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -36,7 +36,7 @@
                         type="object" name="action_view_so" icon="fa-dollar"
                         attrs="{'invisible': [('sale_order_id', '=', False)]}"
                         string="Sales Order"
-                        groups="sales_team.group_sale_salesman"/>
+                        groups="sales_team.group_sale_salesman_all_leads"/>
             </div>
             <xpath expr="//field[@name='partner_id']" position="attributes">
                 <attribute name="options">{'always_reload': True}</attribute>

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="hr_timesheet.project_invoice_form"/>
         <field name="arch" type="xml">
             <div class="oe_button_box" position="inside">
-                <button string="Project Overview" class="oe_stat_button" type="object" name="action_view_timesheet" icon="fa-puzzle-piece" attrs="{'invisible': [('allow_billable', '=', False)]}"/>
+                <button string="Project Overview" class="oe_stat_button" type="object" name="action_view_timesheet" icon="fa-puzzle-piece" attrs="{'invisible': [('allow_billable', '=', False)]}" groups="project.group_project_manager"/>
                 <button class="d-none d-md-inline oe_stat_button"
                         type="object" name="action_view_so" icon="fa-dollar"
                         attrs="{'invisible': ['|', '|', ('allow_billable', '=', False), ('sale_order_id', '=', False), ('pricing_type', '=', 'task_rate')]}"

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -12,7 +12,7 @@
                         type="object" name="action_view_so" icon="fa-dollar"
                         attrs="{'invisible': ['|', '|', ('allow_billable', '=', False), ('sale_order_id', '=', False), ('pricing_type', '=', 'task_rate')]}"
                         string="Sales Order"
-                        groups="sales_team.group_sale_salesman"/>
+                        groups="sales_team.group_sale_salesman_all_leads"/>
             </div>
             <xpath expr="//header" position="inside">
                 <button name="action_make_billable" string="Create Sales Order" type="object" attrs="{'invisible': [('display_create_order', '=', False)]}" groups="sales_team.group_sale_salesman"/>

--- a/addons/web/static/src/js/views/kanban/kanban_column_quick_create.js
+++ b/addons/web/static/src/js/views/kanban/kanban_column_quick_create.js
@@ -32,7 +32,7 @@ var ColumnQuickCreate = Widget.extend({
      */
     init: function (parent, options) {
         this._super.apply(this, arguments);
-        this.applyExamplesText = options.applyExampleText || _t("Use This For My Kanban");
+        this.applyExamplesText = options.applyExamplesText || _t("Use This For My Kanban");
         this.examples = options.examples;
         this.folded = true;
         this.isMobile = false;

--- a/addons/web/static/tests/views/kanban_tests.js
+++ b/addons/web/static/tests/views/kanban_tests.js
@@ -3801,6 +3801,47 @@ QUnit.module('Views', {
         kanban.destroy();
     });
 
+    QUnit.test("quick create column's apply button's display text", async function (assert) {
+        assert.expect(1);
+
+        const applyExamplesText = 'Use This For My Test';
+        kanbanExamplesRegistry.add('test', {
+            applyExamplesText: applyExamplesText,
+            examples:[{
+                name: "A first example",
+                columns: ["Column 1", "Column 2", "Column 3"],
+                description: "Some description",
+            }, {
+                name: "A second example",
+                columns: ["Col 1", "Col 2"],
+            }],
+        });
+
+        var kanban = await createView({
+            View: KanbanView,
+            model: 'partner',
+            data: this.data,
+            arch: '<kanban examples="test">' +
+                        '<field name="product_id"/>' +
+                        '<templates><t t-name="kanban-box">' +
+                            '<div><field name="foo"/></div>' +
+                        '</t></templates>' +
+                    '</kanban>',
+            groupBy: ['product_id'],
+        });
+
+        // open the quick create
+        await testUtils.dom.click(kanban.$('.o_column_quick_create .o_quick_create_folded'));
+
+        // click to see the examples
+        await testUtils.dom.click(kanban.$('.o_column_quick_create .o_kanban_examples'));
+
+        const $primaryActionButton = $('.modal footer.modal-footer button.btn-primary > span');
+        assert.strictEqual($primaryActionButton.text(), applyExamplesText, 'the primary button should display the value of applyExamplesText');
+
+        kanban.destroy();
+    });
+
     QUnit.test('quick create column and examples background with ghostColumns titles', async function (assert) {
         assert.expect(4);
 


### PR DESCRIPTION
Generic improvements have been made to improve the Project App and its onboarding.

## Web module

- kankan examples modal: change the 'use this for my kanban' button into 'use this for my project'. To do this, a small change is made in the web module to use the options variable called `applyExamplesText` to change the label of the button in project app.
- A private method called `_getFavoriteIcon` is added in `FavoriteWidget` to easily change the icon based on the boolean value when we override this widget in another module.

## Project App

For project.task model:
  - the label of the priority label has been changed from "Priority" to "Starred".
  - the user_id field should not be clickable in form view.

For project.project model:
  - the fa-star icon has been replaced by the fa-bookmark and fa-bookmark-o icons in the kanban view.
  - When the user is the 'Project User', the 'share' button and 'project overview' stat button are hidden in the project form view.
  - the 'sales order' stat button is only visible to users who have at least the `sales > all documents access right level` in project form view.

task-2440564

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
