### PR TITLE
[FIX] point_of_sale: error in pos.config form when saving/discarding.

### DIFF
--- a/addons/point_of_sale/static/src/js/web_overrides/pos_config_form.js
+++ b/addons/point_of_sale/static/src/js/web_overrides/pos_config_form.js
@@ -8,14 +8,16 @@ odoo.define('point_of_sale.pos_config_form', function (require) {
     var PosConfigFormController = FormController.extend({
         _enableButtons: function (changedFields) {
             let shouldReload = false;
-            for (let field of (changedFields || [])) {
-                if (
-                    field.startsWith('module_') ||
-                    field.startsWith('group_') ||
-                    field === 'is_posbox'
-                ) {
-                    shouldReload = true;
-                    break;
+            if (Array.isArray(changedFields)) {
+                for (let field of (changedFields)) {
+                    if (
+                        field.startsWith('module_') ||
+                        field.startsWith('group_') ||
+                        field === 'is_posbox'
+                    ) {
+                        shouldReload = true;
+                        break;
+                    }
                 }
             }
             if (shouldReload) {


### PR DESCRIPTION
 Adjustment of a previous commit b1dff85a85dc1819c029b564dbb87871c2f5e7ea
 It is possible for the argument to be something else than `undefined` or an array. We're adding a check to prevent an error to occur in that case.
