### PR TITLE
Master expense create report shall open edit mode bmo

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -689,7 +689,7 @@
                             groups="account.group_account_invoice"/>
                     <button name="%(hr_expense.hr_expense_refuse_wizard_action)d" states="submit,approve" context="{'hr_expense_refuse_model':'hr.expense.sheet'}" string="Refuse" type="action" groups="hr_expense.group_hr_expense_team_approver" />
                     <button name="reset_expense_sheets" string="Reset to Draft" type="object" attrs="{'invisible': ['|', ('can_reset', '=', False), ('state', 'not in', ['submit', 'cancel'])]}"/>
-                    <field name="state" widget="statusbar" statusbar_visible="draft,submit,approve,post,done"/>
+                    <field name="state" widget="statusbar" statusbar_visible="draft,submit,approve,post,done" force_save="1"/>
                 </header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
@@ -734,8 +734,8 @@
                                 <field name="analytic_tag_ids" optional="hide" widget="many2many_tags" groups="analytic.group_analytic_tags"/>
                                 <field name="account_id" optional="hide"/>
                                 <field name="message_unread" invisible="1"/>
-                                <field name="attachment_number" string=" "/>
-                                <button name="action_get_attachment_view"  string="View Attachments" type="object" icon="fa-paperclip"/>
+                                <button name="action_get_attachment_view" type="object" icon="fa-paperclip" aria-label="View Attachments" title="View Attachments" class="float-right pr-0"/>
+                                <field name="attachment_number" class="text-left pl-0" nolabel="1"/>
                                 <field name="unit_amount" optional="hide" widget="monetary" options="{'currency_field': 'currency_id'}"/>
                                 <field name="currency_id" optional="hide"/>
                                 <field name="quantity" optional="hide"/>
@@ -1088,19 +1088,6 @@
                 <p class="o_view_nocontent_smiling_face">
                     No data yet!
                 </p>
-            </field>
-        </record>
-
-        <record id="hr_expense_submit_action_server" model="ir.actions.server">
-            <field name="name">Create Report</field>
-            <field name="type">ir.actions.server</field>
-            <field name="model_id" ref="model_hr_expense"/>
-            <field name="binding_model_id" ref="model_hr_expense"/>
-            <field name="binding_view_types">list</field>
-            <field name="state">code</field>
-            <field name="code">
-if records:
-    action = records.action_submit_expenses()
             </field>
         </record>
 


### PR DESCRIPTION
[FIX] hr_expense: [Expense] create report shall on without saving mode
    
    In hr_expense module in after selecting expenses when user click on create report button that time create report function save data and
    after show data in view form, but there is one field which is expense report summary which is not show in vieww form because of
    field is empty. So , after solving that issue create report button open shell in edit mode.
    
    Whwn user in list of expense page to create report , select number of expenses which are required for perfect expenses report and
    then click on create report.
    Discard button is not working as remove data from current expenses list and discard create report for particular report. Because of
    create report button first save the data and after pass data in create report shell so when user click on discard then data are not
    remove because of discard button remove only that data which are temporary. So , using context pass the data to create report shell
    and in the field of create report summary set minimum and maximum expanse date if minimum and maximum expense date are same then only
    minimum expense date by default set.
    
 **TaskId** - **2359834**


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
