### PR TITLE
fix pivot title tooltip placement issue

### DIFF
--- a/addons/web/static/src/scss/pivot_view.scss
+++ b/addons/web/static/src/scss/pivot_view.scss
@@ -64,6 +64,10 @@
                 content: "";
                 margin-right: 8px;
             }
+            span {
+                width: 100%;
+                display: inline-block;
+            }
         }
 
         .o_pivot_header_cell_opened {

--- a/addons/web/static/src/xml/pivot.xml
+++ b/addons/web/static/src/xml/pivot.xml
@@ -58,8 +58,8 @@
         <th t-att-colspan="isXAxis ? cell.width : undefined" t-att-rowspan="isXAxis ? cell.height : undefined" t-att-class="{
                 o_pivot_header_cell_closed: cell.isLeaf,
                 o_pivot_header_cell_opened: !cell.isLeaf,
-            }" t-attf-style="{{ isXAxis ? undefined : 'padding-left: ' + _getPadding(cell) + 'px;' }}" t-att-title="cell.label" t-on-click.self.prevent="_onHeaderClick(cell, isXAxis ? 'col' : 'row')">
-            <span t-on-click.self.prevent="_onHeaderClick(cell, isXAxis ? 'col' : 'row')" t-esc="cell.title"/>
+            }" t-attf-style="{{ isXAxis ? undefined : 'padding-left: ' + _getPadding(cell) + 'px;' }}" t-on-click.self.prevent="_onHeaderClick(cell, isXAxis ? 'col' : 'row')">
+            <span t-att-title="cell.label" t-on-click.self.prevent="_onHeaderClick(cell, isXAxis ? 'col' : 'row')" t-esc="cell.title"/>
             <t t-if="_isClicked(cell.groupId, isXAxis)" t-call="web.PivotGroupBySelection"/>
         </th>
     </t>


### PR DESCRIPTION
PURPOSE
When opening field selection dropdown from pivot header and move hover on table cell it shows tooltip but if user moves mouse over grouby fields dropdown still tooltip is visible while mouse out from table cell should hide title.
It is happening because help title is set on table cell and groupby fields dropdown is child of table cell, so there is no mouse out when user mouse over on fields dropdown.

SPEC
Hovering on table cell will show tooltip while hovering over fields selection dropdown should hide title tooltip.

TASK 2422447


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
