### PR TITLE
[FIX] crm: prevent crash due to invalid config param

### DIFF
--- a/addons/crm/models/res_config_settings.py
+++ b/addons/crm/models/res_config_settings.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import timedelta
+
 from odoo import api, fields, models
-from datetime import date
 
 
 class ResConfigSettings(models.TransientModel):
@@ -62,7 +63,16 @@ class ResConfigSettings(models.TransientModel):
         """ As config_parameters does not accept Date field,
             we get the date back from the Char config field, to ease the configuration in config panel """
         for setting in self:
-            setting.predictive_lead_scoring_start_date = fields.Date.to_date(setting.predictive_lead_scoring_start_date_str)
+            lead_scoring_start_date = setting.predictive_lead_scoring_start_date_str
+            # if config param is deleted / empty, set the date 8 days prior to current date
+            if not lead_scoring_start_date:
+                setting.predictive_lead_scoring_start_date = fields.Date.to_date(fields.Date.today() - timedelta(days=8))
+            else:
+                try:
+                    setting.predictive_lead_scoring_start_date = fields.Date.to_date(lead_scoring_start_date)
+                except ValueError:
+                    # the config parameter is malformed, so set the date 8 days prior to current date
+                    setting.predictive_lead_scoring_start_date = fields.Date.to_date(fields.Date.today() - timedelta(days=8))
 
     def _inverse_pls_start_date_str(self):
         """ As config_parameters does not accept Date field,

--- a/addons/crm/tests/test_crm_pls.py
+++ b/addons/crm/tests/test_crm_pls.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import timedelta
+
+from odoo import fields, tools
 from odoo.tests.common import TransactionCase
-from odoo import tools
 
 
 class TestCRMPLS(TransactionCase):
@@ -80,3 +82,24 @@ class TestCRMPLS(TransactionCase):
 
         self.assertEquals(tools.float_compare(leads[3].automated_probability, 33.49, 2), 0)
         self.assertEquals(tools.float_compare(leads[7].automated_probability, 7.74, 2), 0)
+
+    def test_settings_pls_start_date(self):
+        # We test here that settings never crash due to ill-configured config param 'crm.pls_start_date'
+        set_param = self.env['ir.config_parameter'].sudo().set_param
+        str_date_8_days_ago = fields.Date.to_string(fields.Date.today() - timedelta(days=8))
+        resConfig = self.env['res.config.settings']
+
+        set_param("crm.pls_start_date", "2021-10-10")
+        res_config_new = resConfig.new()
+        self.assertEqual(fields.Date.to_string(res_config_new.predictive_lead_scoring_start_date),
+            "2021-10-10", "If config param is a valid date, date in settings it should match with config param")
+
+        set_param("crm.pls_start_date", "")
+        res_config_new = resConfig.new()
+        self.assertEqual(fields.Date.to_string(res_config_new.predictive_lead_scoring_start_date),
+            str_date_8_days_ago, "If config param is empty, date in settings should be set to 8 days before today")
+
+        set_param("crm.pls_start_date", "One does not simply walk into system parameters to corrupt them")
+        res_config_new = resConfig.new()
+        self.assertEqual(fields.Date.to_string(res_config_new.predictive_lead_scoring_start_date),
+            str_date_8_days_ago, "If config param is not a valid date, date in settings should be set to 8 days before today")


### PR DESCRIPTION
In the crm.pls_start_date is not valid (or not set / deleted),
than set the predictive_lead_scoring_start_date of settings
to a date 8 days prior to current date.
if date is not set or deleted than user get the traceback
after this commit user can not get the traceback in crm settings.

**TaskId: 2448248**
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
