### PR TITLE
[FIX] utm: `utm.stage` must be defined before being used in a `default=`

### DIFF
--- a/addons/utm/models/utm.py
+++ b/addons/utm/models/utm.py
@@ -4,6 +4,17 @@
 from odoo import fields, models, api, SUPERUSER_ID
 
 
+class UtmStage(models.Model):
+
+    """Stage for utm campaigns. """
+    _name = 'utm.stage'
+    _description = 'Campaign Stage'
+    _order = 'sequence'
+
+    name = fields.Char(required=True, translate=True)
+    sequence = fields.Integer()
+
+
 class UtmMedium(models.Model):
     # OLD crm.case.channel
     _name = 'utm.medium'
@@ -47,16 +58,6 @@ class UtmSource(models.Model):
     _description = 'UTM Source'
 
     name = fields.Char(string='Source Name', required=True, translate=True)
-
-class UtmStage(models.Model):
-
-    """Stage for utm campaigns. """
-    _name = 'utm.stage'
-    _description = 'Campaign Stage'
-    _order = 'sequence'
-
-    name = fields.Char(required=True, translate=True)
-    sequence = fields.Integer()
 
 class UtmTag(models.Model):
     """Model of categories of utm campaigns, i.e. marketing, newsletter, ... """


### PR DESCRIPTION
Otherwise, this can raise the below issue during an upgrade (`-u`):
```
  File "/home/odoo/src/odoo/13.0/odoo/modules/registry.py", line 369, in init_models
    model._auto_init()
  File "/home/odoo/src/odoo/13.0/odoo/models.py", line 2529, in _auto_init
    new = field.update_db(self, columns)
  File "/home/odoo/src/odoo/13.0/odoo/fields.py", line 2456, in update_db
    return super(Many2one, self).update_db(model, columns)
  File "/home/odoo/src/odoo/13.0/odoo/fields.py", line 857, in update_db
    self.update_db_notnull(model, column)
  File "/home/odoo/src/odoo/13.0/odoo/fields.py", line 897, in update_db_notnull
    model._init_column(self.name)
  File "/home/odoo/src/odoo/13.0/odoo/models.py", line 2455, in _init_column
    value = field.default(self)
  File "/home/odoo/src/odoo/13.0/addons/utm/models/utm.py", line 28, in <lambda>
    default=lambda self: self.env['utm.stage'].search([], limit=1),
  File "/home/odoo/src/odoo/13.0/odoo/models.py", line 1648, in search
    res = self._search(args, offset=offset, limit=limit, order=order, count=count)
  File "/home/odoo/src/odoo/13.0/odoo/models.py", line 4497, in _search
    self._cr.execute(query_str, where_clause_params)
  File "/home/odoo/src/odoo/13.0/odoo/sql_db.py", line 173, in wrapper
    return f(self, *args, **kwargs)
  File "/home/odoo/src/odoo/13.0/odoo/sql_db.py", line 250, in execute
    res = self._obj.execute(query, params)
psycopg2.errors.UndefinedColumn: column utm_stage.sequence does not exist
LINE 1: SELECT "utm_stage".id FROM "utm_stage" ORDER BY "utm_stage"
```

upg-5396

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
