### PR TITLE
[IMP] mass_mailing: use cron trigger to send "now"

### DIFF
--- a/addons/mass_mailing/data/mass_mailing_data.xml
+++ b/addons/mass_mailing/data/mass_mailing_data.xml
@@ -8,8 +8,8 @@
             <field name="state">code</field>
             <field name="code">model._process_mass_mailing_queue()</field>
             <field name="user_id" ref="base.user_root" />
-            <field name="interval_number">60</field>
-            <field name="interval_type">minutes</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
             <field name="numbercall">-1</field>
             <field eval="False" name="doall" />
         </record>

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -358,6 +358,11 @@ class MassMailing(models.Model):
 
     def action_put_in_queue(self):
         self.write({'state': 'in_queue'})
+        cron = self.env.ref('mass_mailing.ir_cron_mass_mailing_queue')
+        cron._trigger(
+            schedule_date or fields.Datetime.now()
+            for schedule_date in self.mapped('schedule_date')
+        )
 
     def action_cancel(self):
         self.write({'state': 'draft', 'schedule_date': False, 'schedule_type': 'now', 'next_departure': False})


### PR DESCRIPTION
The "launch" button of an email campaign mark the current campaign ready
to be processed. As sending all the mails is a pretty heavy operation,
it is done asynchronously in a cron. The cron was running every hour, it
means the cron was running even if there was no active campaign and it
has a best precision of 1 hour.

We now use the new mechanism of [cron triggers] to schedule the cron
execution at the time the campaign is configured to be sent. It achieves
a better precision and ensure the cron only runs when there are stuff to
process.

We decreased the frequency of the cron to once a day, this is mostly a
security.

[cron triggers]: 4b28f1162a85d03f9dbe0338b06758ad151ea6a8

Task: 2416741
