### PR TITLE
[FIX] mass_mailing: do not provide access for campaigns

### DIFF
--- a/addons/mass_mailing/models/utm.py
+++ b/addons/mass_mailing/models/utm.py
@@ -10,8 +10,8 @@ class UtmCampaign(models.Model):
     mailing_mail_ids = fields.One2many(
         'mailing.mailing', 'campaign_id',
         domain=[('mailing_type', '=', 'mail')],
-        string='Mass Mailings')
-    mailing_mail_count = fields.Integer('Number of Mass Mailing', compute="_compute_mailing_mail_count")
+        string='Mass Mailings', groups="mass_mailing.group_mass_mailing_user")
+    mailing_mail_count = fields.Integer('Number of Mass Mailing', compute="_compute_mailing_mail_count", groups="mass_mailing.group_mass_mailing_user")
     # stat fields
     received_ratio = fields.Integer(compute="_compute_statistics", string='Received Ratio')
     opened_ratio = fields.Integer(compute="_compute_statistics", string='Opened Ratio')

--- a/addons/mass_mailing/security/mass_mailing_security.xml
+++ b/addons/mass_mailing/security/mass_mailing_security.xml
@@ -17,6 +17,7 @@ professional emails and reuse templates.</field>
     <record id="group_mass_mailing_campaign" model="res.groups">
         <field name="name">Manage Mass Mailing Campaigns</field>
         <field name="category_id" ref="base.module_category_hidden"/>
+        <field name="implied_ids" eval="[(4,ref('mass_mailing.group_mass_mailing_user'))]"/>
     </record>
 
     <data noupdate="1">

--- a/addons/mass_mailing/views/utm_campaign_views.xml
+++ b/addons/mass_mailing/views/utm_campaign_views.xml
@@ -6,17 +6,17 @@
         <field name="inherit_id" ref="utm.utm_campaign_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//header" position="inside">
-                    <button name="%(action_create_mass_mailings_from_campaign)d" type="action" class="oe_highlight" groups="mass_mailing.group_mass_mailing_campaign" string="Send new Mailing"/>
+                    <button name="%(action_create_mass_mailings_from_campaign)d" type="action" class="oe_highlight" groups="mass_mailing.group_mass_mailing_user" string="Send new Mailing"/>
             </xpath>
             <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
                 <button name="%(action_view_mass_mailings_from_campaign)d"
                     type="action" class="oe_stat_button order-9" icon="fa-envelope-o"
-                    attrs="{'invisible': [('mailing_mail_count', '=', 0)]}" groups="mass_mailing.group_mass_mailing_campaign">
+                    attrs="{'invisible': [('mailing_mail_count', '=', 0)]}" groups="mass_mailing.group_mass_mailing_user">
                     <field name="mailing_mail_count" widget="statinfo" string="Mailings"/>
                 </button>
             </xpath>
             <xpath expr="//notebook" position="inside">
-                <page string="Mailings" name="mailings" attrs="{'invisible': [('mailing_mail_count', '=', 0)]}">
+                <page string="Mailings" name="mailings" attrs="{'invisible': [('mailing_mail_count', '=', 0)]}" groups="mass_mailing.group_mass_mailing_user">
                     <field name="mailing_mail_ids" readonly="1" nolabel="1">
                         <tree>
                             <field name="subject"/>


### PR DESCRIPTION
If user can manage Mass Mailing Campaigns (with help of group technical
group 'mass_mailing.group_mass_mailing_campaign'), it means that we also
grant access of menu 'Email Marketing > Campaigns' to that user. So even
if such user doesn't have basic mass mailing user rights, the root menu
'Email Marketing' appears (because we granted access to one of the child
menu) which is not correct.

For fixing this issue, we black list 'Email Marketing > Campaigns' menu for
users who does not have basic mass mailing rights.

**Task ID - 2417993**

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
