### PR TITLE
[IMP] [website_]event datetimes sales start/end

### DIFF
--- a/addons/event/data/event_demo.xml
+++ b/addons/event/data/event_demo.xml
@@ -19,24 +19,24 @@
         <field name="name">Free</field>
         <field name="description">Free entrance, no food !</field>
         <field name="event_id" ref="event.event_0"/>
-        <field name="start_sale_date" eval="(DateTime.today() + timedelta(days=5)).strftime('%Y-%m-%d')"/>
-        <field name="end_sale_date" eval="(DateTime.today() + timedelta(days=10)).strftime('%Y-%m-%d')"/>
+        <field name="start_sale_datetime" eval="(DateTime.today() + timedelta(days=5)).strftime('%Y-%m-%d 00:00:00')"/>
+        <field name="end_sale_datetime" eval="(DateTime.today() + timedelta(days=10)).strftime('%Y-%m-%d 23:00:00')"/>
         <field name="seats_max">0</field>
     </record>
     <record id="event_0_ticket_1" model="event.event.ticket">
         <field name="name">Standard</field>
         <field name="description">For only 10, you gain access to catering. Yum yum.</field>
         <field name="event_id" ref="event.event_0"/>
-        <field name="start_sale_date" eval="(DateTime.today() + timedelta(days=5)).strftime('%Y-%m-%d')"/>
-        <field name="end_sale_date" eval="(DateTime.today() + timedelta(days=10)).strftime('%Y-%m-%d')"/>
+        <field name="start_sale_datetime" eval="(DateTime.today() + timedelta(days=5)).strftime('%Y-%m-%d 00:00:00')"/>
+        <field name="end_sale_datetime" eval="(DateTime.today() + timedelta(days=10)).strftime('%Y-%m-%d 23:00:00')"/>
         <field name="seats_max">50</field>
     </record>
     <record id="event_0_ticket_2" model="event.event.ticket">
         <field name="name">VIP</field>
         <field name="description">You are truly among the best.</field>
         <field name="event_id" ref="event.event_0"/>
-        <field name="start_sale_date" eval="(DateTime.today() + timedelta(days=5)).strftime('%Y-%m-%d')"/>
-        <field name="end_sale_date" eval="(DateTime.today() + timedelta(days=10)).strftime('%Y-%m-%d')"/>
+        <field name="start_sale_datetime" eval="(DateTime.today() + timedelta(days=5)).strftime('%Y-%m-%d 00:00:00')"/>
+        <field name="end_sale_datetime" eval="(DateTime.today() + timedelta(days=10)).strftime('%Y-%m-%d 23:00:00')"/>
         <field name="seats_max">10</field>
     </record>
 
@@ -108,13 +108,13 @@
     <record id="event_2_ticket_1" model="event.event.ticket">
         <field name="name">Standard</field>
         <field name="event_id" ref="event.event_2"/>
-        <field name="end_sale_date" eval="(DateTime.today() + timedelta(90)).strftime('%Y-%m-%d')"/>
+        <field name="end_sale_datetime" eval="(DateTime.today() + timedelta(90)).strftime('%Y-%m-%d 23:00:00')"/>
         <field name="seats_max">50</field>
     </record>
     <record id="event_2_ticket_2" model="event.event.ticket">
         <field name="name">VIP</field>
         <field name="event_id" ref="event.event_2"/>
-        <field name="end_sale_date" eval="(DateTime.today() + timedelta(60)).strftime('%Y-%m-%d')"/>
+        <field name="end_sale_datetime" eval="(DateTime.today() + timedelta(60)).strftime('%Y-%m-%d 23:00:00')"/>
         <field name="seats_max">5</field>
     </record>
     <record id="activity_event_2_0" model="mail.activity">
@@ -144,13 +144,13 @@
     <record id="event_3_ticket_0" model="event.event.ticket">
         <field name="name">Standard</field>
         <field name="event_id" ref="event.event_3"/>
-        <field name="end_sale_date" eval="(DateTime.today() + timedelta(days=20)).strftime('%Y-%m-%d')"/>
+        <field name="end_sale_datetime" eval="(DateTime.today() + timedelta(days=20)).strftime('%Y-%m-%d 23:00:00')"/>
         <field name="seats_max">1200</field>
     </record>
     <record id="event_3_ticket_1" model="event.event.ticket">
         <field name="name">VIP</field>
         <field name="event_id" ref="event.event_3"/>
-        <field name="end_sale_date" eval="(DateTime.today() + timedelta(days=20)).strftime('%Y-%m-%d')"/>
+        <field name="end_sale_datetime" eval="(DateTime.today() + timedelta(days=20)).strftime('%Y-%m-%d 23:00:00')"/>
         <field name="seats_max">50</field>
     </record>
     <record id="activity_event_3_0" model="mail.activity">
@@ -185,7 +185,7 @@
     <record id="event_4_ticket_0" model="event.event.ticket">
         <field name="name">General Admission</field>
         <field name="event_id" ref="event.event_4"/>
-        <field name="end_sale_date" eval="(DateTime.today() - timedelta(30)).strftime('%Y-%m-%d')"/>
+        <field name="end_sale_datetime" eval="(DateTime.today() - timedelta(30)).strftime('%Y-%m-%d 23:00:00')"/>
         <field name="seats_max">4</field>
     </record>
     <record id="activity_event_4_0" model="mail.activity">
@@ -244,12 +244,12 @@
     <record id="event_7_ticket_1" model="event.event.ticket">
         <field name="name">Standard</field>
         <field name="event_id" ref="event.event_7"/>
-        <field name="end_sale_date" eval="(DateTime.now() + timedelta(days=2)).strftime('%Y-%m-%d 15:00:00')"/>
+        <field name="end_sale_datetime" eval="(DateTime.now() + timedelta(days=2)).strftime('%Y-%m-%d 15:00:00')"/>
     </record>
     <record id="event_7_ticket_2" model="event.event.ticket">
         <field name="name">VIP</field>
         <field name="event_id" ref="event.event_7"/>
-        <field name="end_sale_date" eval="(DateTime.now() + timedelta(days=2)).strftime('%Y-%m-%d 15:00:00')"/>
+        <field name="end_sale_datetime" eval="(DateTime.now() + timedelta(days=2)).strftime('%Y-%m-%d 15:00:00')"/>
         <field name="seats_max">10</field>
     </record>
 

--- a/addons/event/views/event_ticket_views.xml
+++ b/addons/event/views/event_ticket_views.xml
@@ -72,8 +72,8 @@
             <tree string="Tickets" editable="bottom">
                 <field name="name"/>
                 <field name="description" optional="hide"/>
-                <field name="start_sale_date" optional="show"/>
-                <field name="end_sale_date" optional="show"/>
+                <field name="start_sale_datetime" optional="show"/>
+                <field name="end_sale_datetime" optional="show"/>
                 <field name="seats_max" sum="Total" width="105px" string="Maximum"/>
                 <field name="seats_reserved" sum="Total" width="105px" string="Confirmed"/>
                 <field name="seats_unconfirmed" sum="Total" width="110px" string="Unconfirmed"/>
@@ -92,8 +92,8 @@
                         <group>
                             <field name="name"/>
                             <field name="description"/>
-                            <field name="start_sale_date"/>
-                            <field name="end_sale_date"/>
+                            <field name="start_sale_datetime"/>
+                            <field name="end_sale_datetime"/>
                         </group><group>
                             <field name="seats_max"/>
                             <field name="seats_reserved"/>
@@ -164,8 +164,8 @@
                             <field name="event_id"/>
                             <field name="seats_limited"/>
                             <field name="seats_available"/>
-                            <field name="start_sale_date"/>
-                            <field name="end_sale_date"/>
+                            <field name="start_sale_datetime"/>
+                            <field name="end_sale_datetime"/>
                         </group>
                         <group>
                             <field name="seats_max"/>

--- a/addons/event_sale/views/event_ticket_views.xml
+++ b/addons/event_sale/views/event_ticket_views.xml
@@ -36,10 +36,10 @@
         <field name="model">event.event.ticket</field>
         <field name="inherit_id" ref="event.event_event_ticket_view_tree_from_event"/>
         <field name="arch" type="xml">
-            <field name="start_sale_date" position="attributes">
+            <field name="start_sale_datetime" position="attributes">
                 <attribute name="string">Sales Start</attribute>
             </field>
-            <field name="end_sale_date" position="attributes">
+            <field name="end_sale_datetime" position="attributes">
                 <attribute name="string">Sales End</attribute>
             </field>
             <field name="name" position="after">
@@ -88,7 +88,7 @@
         <field name="model">event.event.ticket</field>
         <field name="inherit_id" ref="event.event_event_ticket_form_view"/>
         <field name="arch" type="xml">
-            <field name="end_sale_date" position="after">
+            <field name="end_sale_datetime" position="after">
                 <field name="price"/>
                 <field name="price_reduce" groups="base.group_no_one"/>
             </field>

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -221,7 +221,7 @@
                             opt_events_list_cards and 'border-top' or '',
                         )">
                         <span t-if="not event.event_registrations_open" class="text-danger">
-                            <t t-if="event.start_sale_date and event.start_sale_date &gt; datetime.date.today()">
+                            <t t-if="not event.event_registrations_started">
                                 Registrations not yet open
                             </t>
                             <t t-elif="event.event_registrations_sold_out">

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -124,8 +124,12 @@
     <div t-if="toast_message" class="o_wevent_register_toaster d-none" t-att-data-message="toast_message"/>
     <div t-if="not event.event_registrations_open" class="bg-white mb-5">
         <div class="alert alert-info mb-0 d-flex justify-content-between align-items-center" role="status">
-            <t t-if="event.start_sale_date and event.start_sale_date &gt; datetime.date.today()">
-                <em class="col-md-8">Ticket Sales starting on <t t-esc="event.start_sale_date"/></em>
+            <t t-if="not event.event_registrations_started">
+                <em class="col-md-8">Ticket Sales starting on
+                    <span class="" t-esc="event.start_sale_datetime"
+                            t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'short'}"/>
+                    <span t-esc="event.date_tz"/>
+                    </em>
                 <button class="btn btn-danger mr-1 ml-3 col-md-4"  disabled="1">Registrations not yet open</button>
             </t>
             <t t-else="">
@@ -173,8 +177,18 @@
                                 <small t-field="ticket.description" class="text-muted py-2"/>
                                 <br/>
                             </t>
-                            <small t-if="ticket.end_sale_date and ticket.sale_available and not ticket.is_expired" class="text-muted mr-3" itemprop="availabilityEnds">Sales end on <span itemprop="priceValidUntil" t-field="ticket.end_sale_date"/></small>
-                            <small t-if="ticket.start_sale_date and not ticket.sale_available and not ticket.is_expired" class="text-muted mr-3" itemprop="availabilityEnds">Sales start on <span itemprop="priceValidUntil" t-field="ticket.start_sale_date"/></small>
+                            <small t-if="ticket.end_sale_datetime and ticket.sale_available and not ticket.is_expired"
+                                   class="text-muted mr-3" itemprop="availabilityEnds">Sales end on
+                                <span itemprop="priceValidUntil" t-esc="ticket.end_sale_datetime"
+                                t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'short'}"/>
+                                <span t-esc="ticket.event_id.date_tz"/>
+                            </small>
+                            <small t-if="ticket.start_sale_datetime and not ticket.sale_available and not ticket.is_expired"
+                                   class="text-muted mr-3" itemprop="availabilityEnds">
+                                Sales start on <span itemprop="priceValidUntil" t-esc="ticket.start_sale_datetime"
+                                t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'short'}"/>
+                                <span t-esc="ticket.event_id.date_tz"/>
+                            </small>
                         </div>
                         <div class="col-md-4 col-xs-12 p-0 d-flex align-items-center justify-content-between">
                             <div class="o_wevent_registration_multi_select"/>
@@ -215,7 +229,11 @@
                             <span t-if="tickets" t-field="tickets.name"/>
                             <span t-else="">Registration</span>
                         </h6>
-                        <small t-if="tickets.end_sale_date and tickets.sale_available and not tickets.is_expired" class="text-muted mr-3" itemprop="availabilityEnds">Sales end on <span itemprop="priceValidUntil" t-field="tickets.end_sale_date"/></small>
+                        <small t-if="tickets.end_sale_datetime and tickets.sale_available and not tickets.is_expired" class="text-muted mr-3" itemprop="availabilityEnds">Sales end on
+                            <span itemprop="priceValidUntil" t-esc="tickets.end_sale_datetime"
+                                t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'short'}"/>
+                                <span t-esc="tickets.event_id.date_tz"/>
+                        </small>
                         <div class="ml-auto o_wevent_nowrap">
                             <t t-if="event.event_registrations_open">
                                 <span class="text-dark font-weight-bold align-middle pr-2">Qty</span>

--- a/addons/website_event_questions/tests/test_event_ui.py
+++ b/addons/website_event_questions/tests/test_event_ui.py
@@ -19,10 +19,10 @@ class TestUi(tests.HttpCase):
             'date_end': fields.Datetime.now() + relativedelta(days=15),
             'event_ticket_ids': [(0, 0, {
                 'name': 'Free',
-                'start_sale_date': fields.Datetime.now() - relativedelta(days=15)
+                'start_sale_datetime': fields.Datetime.now() - relativedelta(days=15)
             }), (0, 0, {
                 'name': 'Other',
-                'start_sale_date': fields.Datetime.now() - relativedelta(days=15)
+                'start_sale_datetime': fields.Datetime.now() - relativedelta(days=15)
             })],
             'website_published': True,
             'question_ids': [(0, 0, {

--- a/addons/website_event_sale/controllers/main.py
+++ b/addons/website_event_sale/controllers/main.py
@@ -61,7 +61,7 @@ class WebsiteEventSaleController(WebsiteEventController):
             context = dict(context or {}, default_event_ticket_ids=[[0, 0, {
                 'name': _('Registration'),
                 'product_id': product.id,
-                'end_sale_date': False,
+                'end_sale_datetime': False,
                 'seats_max': 1000,
                 'price': 0,
             }]])

--- a/addons/website_event_sale/tests/test_frontend_buy_tickets.py
+++ b/addons/website_event_sale/tests/test_frontend_buy_tickets.py
@@ -26,14 +26,14 @@ class TestUi(HttpCaseWithUserDemo):
             'name': 'Standard',
             'event_id': self.event_2.id,
             'product_id': self.env.ref('event_sale.product_product_event').id,
-            'start_sale_date': (Datetime.today() - timedelta(days=5)).strftime('%Y-%m-%d 07:00:00'),
-            'end_sale_date': (Datetime.today() + timedelta(90)).strftime('%Y-%m-%d'),
+            'start_sale_datetime': (Datetime.today() - timedelta(days=5)).strftime('%Y-%m-%d 07:00:00'),
+            'end_sale_datetime': (Datetime.today() + timedelta(90)).strftime('%Y-%m-%d'),
             'price': 1000.0,
         }, {
             'name': 'VIP',
             'event_id': self.event_2.id,
             'product_id': self.env.ref('event_sale.product_product_event').id,
-            'end_sale_date': (Datetime.today() + timedelta(90)).strftime('%Y-%m-%d'),
+            'end_sale_datetime': (Datetime.today() + timedelta(90)).strftime('%Y-%m-%d'),
             'price': 1500.0,
         }])
 


### PR DESCRIPTION
changed the start/end date fields to datetime fields,
in order to allow more flexibility for the user
and enable them to set a precise point in
time at which ticket sales should start/end, because
otherwise ticket sales/end would always be set at midnight
which is not very flexible.

Task-2431440

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
