### PR TITLE
[FIX] web: Display Header/Footer company details on Contact reports

### DIFF
--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -525,7 +525,7 @@
             <t t-if="company_id">
                 <t t-set="company" t-value="company_id"/>
             </t>
-            <t t-elif="o and 'company_id' in o">
+            <t t-elif="o and 'company_id' in o and o.company_id.sudo()">
                 <t t-set="company" t-value="o.company_id.sudo()"/>
             </t>
             <t t-else="else">
@@ -546,7 +546,7 @@
             <t t-if="company_id">
                 <t t-set="company" t-value="company_id"/>
             </t>
-            <t t-elif="o and 'company_id' in o">
+            <t t-elif="o and 'company_id' in o and o.company_id.sudo()">
                 <t t-set="company" t-value="o.company_id.sudo()"/>
             </t>
             <t t-else="else">


### PR DESCRIPTION
Issue

	- Install "Contacts" and "Studio" modules
	- Go to "Contacts" and switch to Studio
	- Go to "Reports" tab
	- Create a new report
	- Select "External" layout

	Header and footer are missing on report.

Cause

	Header is displayed if 'company' has a value.
	However, here, we only check if 'company_id' is available
	in current record fields, not checking if also set.

Solution

	Check that 'company_id' is set on current record, else,
	fallback on 'res_company'.

opw-2443234