### PR TITLE
[FIX] mass_mailing, web_editor: send mail to outlook and keep image size


### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -71,6 +71,15 @@ var MassMailingFieldHtml = FieldHtml.extend({
                 convertInline.fontToImg($editable);
                 convertInline.classToStyle($editable);
 
+                // fix outlook image rendering bug
+                _.each(['width', 'height'], function(attribute) {
+                    $editable.find('img[style*="width"], img[style*="height"]').attr(attribute, function(){
+                        return $(this)[attribute]();
+                    }).css(attribute, function(){
+                        return $(this).get(0).style[attribute] || 'auto';
+                    });
+                });
+
                 self.trigger_up('field_changed', {
                     dataPointID: self.dataPointID,
                     changes: _.object([fieldName], [self._unWrap($editable.html())])

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -422,6 +422,16 @@ FieldHtml.include({
         attachmentThumbnailToLinkImg($editable);
         fontToImg($editable);
         classToStyle($editable);
+
+        // fix outlook image rendering bug
+        _.each(['width', 'height'], function(attribute) {
+            $editable.find('img[style*="width"], img[style*="height"]').attr(attribute, function(){
+                return $(this)[attribute]();
+            }).css(attribute, function(){
+                return $(this).get(0).style[attribute] || 'auto';
+            });
+        });
+
         this.wysiwyg.setValue($editable.html(), {
             notifyChange: false,
         });
@@ -439,6 +449,10 @@ FieldHtml.include({
         styleToClass($editable);
         imgToFont($editable);
         linkImgToAttachmentThumbnail($editable);
+
+        // fix outlook image rendering bug
+        $editable.find('img[style*="width"], img[style*="height"]').removeAttr('height width');
+
         this.wysiwyg.setValue($editable.html(), {
             notifyChange: false,
         });


### PR DESCRIPTION

Office Outlook doesn't take into account the [style] attribute, and it
doesn't manage width/height in percent value.

This commit set width/heigth attribute in pixels and also always set the
width/height in style attribute (keeping them in the original unit and
setting them to auto if not present).

This is a reintroduction of 2015 commit bdf58adb465b

opw-2447756
