### PR TITLE
[FIX] transifex: Wrong link on translations to go to transifex

### DIFF
--- a/addons/transifex/data/ir_translation_view.xml
+++ b/addons/transifex/data/ir_translation_view.xml
@@ -5,9 +5,10 @@
         <field name="model">ir.translation</field>
         <field name="inherit_id" ref="base.view_translation_tree"/>
         <field name="arch" type="xml">
-            <field name="lang" position="after">
+            <field name="state" position="after">
                 <field name="transifex_url"
-                       widget="link_button"
+                       widget="url"
+                       text="Contribute"
                        string="Transifex" />
             </field>
         </field>
@@ -18,9 +19,10 @@
         <field name="model">ir.translation</field>
         <field name="inherit_id" ref="base.view_translation_dialog_tree"/>
         <field name="arch" type="xml">
-            <field name="lang" position="after">
+            <field name="state" position="after">
                 <field name="transifex_url"
-                       widget="link_button"
+                       widget="url"
+                       text="Contribute"
                        string="Transifex" />
             </field>
         </field>

--- a/addons/transifex/i18n/transifex.pot
+++ b/addons/transifex/i18n/transifex.pot
@@ -31,6 +31,11 @@ msgid "Last Modified on"
 msgstr ""
 
 #. module: transifex
+#: model:ir.model.fields,help:transifex.field_ir_translation__transifex_url
+msgid "Propose a modification in the official version of Odoo"
+msgstr ""
+
+#. module: transifex
 #: model_terms:ir.ui.view,arch_db:transifex.ir_translation_dialog_view_tree_transifex
 #: model_terms:ir.ui.view,arch_db:transifex.ir_translation_view_tree_transifex
 msgid "Transifex"

--- a/addons/transifex/models/ir_translation.py
+++ b/addons/transifex/models/ir_translation.py
@@ -14,7 +14,7 @@ class IrTranslation(models.Model):
 
     _inherit = 'ir.translation'
 
-    transifex_url = fields.Char("Transifex URL", compute='_get_transifex_url')
+    transifex_url = fields.Char("Transifex URL", compute='_get_transifex_url', help="Propose a modification in the official version of Odoo")
 
     def _get_transifex_url(self):
         """ Construct transifex URL based on the module on configuration """
@@ -74,13 +74,13 @@ class IrTranslation(models.Model):
                     translation.transifex_url = False
                     continue
 
-                # e.g. https://www.transifex.com/odoo/odoo-10/translate/#fr/sale/42?q=text'Sale+Order'
+                # e.g. https://www.transifex.com/odoo/odoo-10/translate/#fr/sale/42?q=text:'Sale+Order'
+                src = werkzeug.urls.url_quote_plus(translation.src[:50].replace("\n", "").replace("'", ""))
+                src = f"'{src}'" if "+" in src else src
                 translation.transifex_url = "%(url)s/%(project)s/translate/#%(lang)s/%(module)s/42?q=%(src)s" % {
                     'url': base_url,
                     'project': project,
                     'lang': lang_code,
                     'module': translation.module,
-                    'src': "text:'" + werkzeug.urls.url_quote_plus(
-                               translation.src[:50].replace("\n", "").replace("'", "")
-                           ) + "'",
+                    'src': f"text%3A{src}",
                 }


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a user U with fr_BE as lang
- Log as U and active developper tool
- Go on any record, click on debug button
- Select Technical translation
- Choose a translation and click on the transifex url button

Bug:

The URL contained the iso code fr_BE but this iso code didn't match
any code in Transifex.

From: https://www.transifex.com/odoo/odoo-14/languages/

We can see that the only iso codes with a '_' are: 'zh_CN', 'zh_TW', 'pt_BR'

opw:2448533