### PR TITLE
[FIX] website_sale: send confirmation email when no amount

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -351,6 +351,13 @@ class SaleOrder(models.Model):
                 sent_orders |= order
         sent_orders.write({'cart_recovery_email_sent': True})
 
+    def action_confirm(self):
+        res = super(SaleOrder, self).action_confirm()
+        for order in self:
+            if not order.transaction_ids and not order.amount_total and self._context.get('send_email'):
+                order._send_order_confirmation_mail()
+        return res
+
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"


### PR DESCRIPTION
As user access the ecommerce and add to cart a free product (0$ total)
Checkout and Confirm
No email will be sent for confirmation

This occur because the confirmation email is normally sent in the
transaction callback, which is not created when the amount is 0

opw-2440335

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
