### PR TITLE
[FIX] mail: check alias_name for one record

### DIFF
--- a/addons/mail/models/mail_alias.py
+++ b/addons/mail/models/mail_alias.py
@@ -85,7 +85,7 @@ class Alias(models.Model):
             local-part. Quoted-string and internationnal characters are
             to be rejected. See rfc5322 sections 3.4.1 and 3.2.3
         """
-        if self.alias_name and not dot_atom_text.match(self.alias_name):
+        if any(alias.alias_name and not dot_atom_text.match(alias.alias_name) for alias in self):
             raise ValidationError(_("You cannot use anything else than unaccented latin characters in the alias address."))
 
     @api.multi


### PR DESCRIPTION
Before this commit there would be `ValueError: Expected singleton:` error on updating `alias_name` on multiple records at same time.

Now, we access single to record to check this constrains.

Fixes #65127

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
