### PR TITLE
[FIX] point_of_sale: use correct label

### DIFF
--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -542,7 +542,7 @@
                                 </div>
                                 <div attrs="{'invisible' : [('ship_later', '=', False)]}">
                                     <div>
-                                        <label for="route_id" string="Warehouse" class="font-weight-normal"/>
+                                        <label for="warehouse_id" string="Warehouse" class="font-weight-normal"/>
                                         <field name="warehouse_id" attrs="{'required': [('ship_later', '=', True)]}"/>
                                     </div>
                                     <div groups="stock.group_adv_location">


### PR DESCRIPTION
Use correct field label for Warehouse

Followup on dd2aaf0b1dc4ff3997ca753ee1feb67920f5cbfa

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
