### PR TITLE
[FIX] sale: Display color tootlip in product configurator

### DIFF
--- a/addons/sale/static/src/js/variant_mixin.js
+++ b/addons/sale/static/src/js/variant_mixin.js
@@ -363,7 +363,7 @@ var VariantMixin = {
         $parent
             .find('option, input, label')
             .removeClass('css_not_available')
-            .attr('title', '')
+            .attr('title', function () { return $(this).data('value_name') || ''; })
             .data('excluded-by', '');
 
         // exclusion rules: array of ptav


### PR DESCRIPTION
Issue

	- Install "Sales" module
	- Go to settings and activate "Product Configurator" feature
	- Create a product X with mutilple color (variants)
	- Create a quotation
	- Add product X (Product Configurator should open)
	- Hover any color

	Popup with color name does not appear.

Cause

	'title' attribute value is removed.

Solution

	Don't remove 'title' attribute value.

opw-2438704