### PR TITLE
restore save button to normal once saved

### DIFF
--- a/addons/web_editor/static/src/js/common/ace.js
+++ b/addons/web_editor/static/src/js/common/ace.js
@@ -914,7 +914,7 @@ var ViewEditor = Widget.extend({
      */
     _onSaveClick: function (ev) {
         const restore = dom.addButtonLoadingEffect(ev.currentTarget);
-        this._saveResources().guardedCatch(restore);
+        this._saveResources().then(restore).guardedCatch(restore);
     },
     /**
      * Called when the user wants to switch from xml to scss or vice-versa ->


### PR DESCRIPTION
PURPOSE
When editor save button is clicked it shows loading effect once save is success/fails still it shows loading effect, save button should be normal once editor cahnges saved successfully/failed so that user can do other changes and click on
save button again.

SPEC
Once editor save is successfull/fail then save button will be normal so that user can do changes again and can click on save button again.

TASK 2440440

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
