### PR TITLE
[FIX] pos_restaurant: Kitchen Printer fails with HTTP

### DIFF
--- a/addons/pos_restaurant/static/src/js/multiprint.js
+++ b/addons/pos_restaurant/static/src/js/multiprint.js
@@ -62,7 +62,7 @@ models.load_models({
                 if(url.indexOf('//') < 0){
                     url = window.location.protocol + '//' + url;
                 }
-                if(url.indexOf(':',url.indexOf('//')+2) < 0 && window.location.protocol === 'http'){
+                if(url.indexOf(':',url.indexOf('//')+2) < 0 && window.location.protocol === 'http:'){
                     url = url+':8069';
                 }
                 var printer = new Printer(self,{url:url});


### PR DESCRIPTION
Since 129de2971950a4d306469e19ef419ecbc2c60ab0, the port was no longer
added to the URL of the box when using HTTP.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
