### PR TITLE
[FIX] web_editor: fix oe_structure view that are not in extension mode

### DIFF
--- a/addons/web_editor/models/ir_ui_view.py
+++ b/addons/web_editor/models/ir_ui_view.py
@@ -84,9 +84,10 @@ class IrUiView(models.Model):
             'arch': self._pretty_arch(arch),
             'key': '%s_%s' % (self.key, el.get('id')),
             'type': 'qweb',
+            'mode': 'extension',
         }
         vals.update(self._save_oe_structure_hook())
-        self.create(vals)
+        self.env['ir.ui.view'].create(vals)
 
         return True
 


### PR DESCRIPTION
Issue occurs due to the way we compute the default value in base ir ui view.
The method _compute_defaults don't set extension mode under some condition
even if we provide an inherit_id view.

This commit double fix it, we use now self.env['ir.ui.view'] to create the
new view and so always compute the mode based on 'if inherit id or not'.
Second fixes is to explicitely set mode manually as 'extension'.

before commit:
when you drop snippet to blog sidebar and click save button.
The changes of user is not visible in sidebar because view created in mode
'primary' and not 'extension'

task-2311520

X-original-commit: a944ce9beaaf984a7b1282785d03d4bfc8220f18
Co-authored-by: jpr-odoo <jpr@openerp.com>
Co-authored-by: Jairo Llopis <jairo.llopis@tecnativa.com>
