### PR TITLE
[REF] product, sale, stock: filter all linked products

### DIFF
--- a/addons/sale/models/product_product.py
+++ b/addons/sale/models/product_product.py
@@ -56,12 +56,6 @@ class ProductProduct(models.Model):
         self.ensure_one()
         return self.product_tmpl_id._get_combination_info(self.product_template_attribute_value_ids, self.id, add_qty, pricelist, parent_combination)
 
-    def _filter_to_unlink(self):
-        domain = [('product_id', 'in', self.ids)]
-        lines = self.env['sale.order.line'].read_group(domain, ['product_id'], ['product_id'])
-        linked_product_ids = [group['product_id'][0] for group in lines]
-        return super(ProductProduct, self - self.browse(linked_product_ids))._filter_to_unlink()
-
 
 class ProductAttributeCustomValue(models.Model):
     _inherit = "product.attribute.custom.value"

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -539,13 +539,6 @@ class Product(models.Model):
             return self._get_rules_from_location(rule.location_src_id, seen_rules=seen_rules | rule)
 
 
-    def _filter_to_unlink(self):
-        domain = [('product_id', 'in', self.ids)]
-        lines = self.env['stock.production.lot'].read_group(domain, ['product_id'], ['product_id'])
-        linked_product_ids = [group['product_id'][0] for group in lines]
-        return super(Product, self - self.browse(linked_product_ids))._filter_to_unlink()
-
-
 class ProductTemplate(models.Model):
     _inherit = 'product.template'
     _check_company_auto = True


### PR DESCRIPTION
Previous implementation requires annoying maintaining of custom versions of
_filter_to_unlink method. Instead of that we can get linked fields from
``self.env`` and make the same search for all models.

---

https://github.com/odoo/odoo/pull/64997
task-2447826

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
