### PR TITLE
[FIX] hr_expense: Create an expense product with vendor taxes

### DIFF
--- a/addons/hr_expense/models/product_template.py
+++ b/addons/hr_expense/models/product_template.py
@@ -9,15 +9,6 @@ class ProductTemplate(models.Model):
 
     can_be_expensed = fields.Boolean(string="Can be Expensed", help="Specify whether the product can be selected in an expense.")
 
-    @api.model_create_multi
-    def create(self, vals_list):
-        for vals in vals_list:
-            # When creating an expense product on the fly, you don't expect to
-            # have taxes on it
-            if vals.get('can_be_expensed', False):
-                vals.update({'supplier_taxes_id': False})
-        return super(ProductTemplate, self).create(vals_list)
-
     @api.onchange('type')
     def _onchange_type_for_expense(self):
         if self.type not in ['consu', 'service']:  # storable can not be expensed.


### PR DESCRIPTION
Steps to reproduce the bug:

When trying to import or create a expense product with supplier taxes,
the supplier taxes were removed.

PS: The field vendor taxes is available in the expense product view

opw:2444551