### PR TITLE
[FIX] hr_expense: Create an expense product with vendor taxes

### DIFF
--- a/addons/hr_expense/models/product_template.py
+++ b/addons/hr_expense/models/product_template.py
@@ -14,7 +14,7 @@ class ProductTemplate(models.Model):
         for vals in vals_list:
             # When creating an expense product on the fly, you don't expect to
             # have taxes on it
-            if vals.get('can_be_expensed', False):
+            if vals.get('can_be_expensed', False) and not self.env.context.get('import_file'):
                 vals.update({'supplier_taxes_id': False})
         return super(ProductTemplate, self).create(vals_list)
 


### PR DESCRIPTION
Steps to reproduce the bug:

When trying to import or create a expense product with supplier taxes,
the supplier taxes were removed.

PS: The field vendor taxes is available in the expense product view

opw:2444551

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
