### PR TITLE
[IMP] point_of_sale,pos_discount: new global discount

### DIFF
--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -337,7 +337,7 @@
                             <div class="o_setting_right_pane">
                                 <label for="module_pos_discount"/>
                                 <div class="text-muted">
-                                    Allow global discounts on orders
+                                    Allow a percentage global discount in one go on each product of the order
                                 </div>
                                 <div class="content-group" id="warning_text_pos_discount" attrs="{'invisible':[('module_pos_discount','=',False)]}">
                                     <div class="text-warning mt16 mb4">

--- a/addons/pos_discount/static/src/xml/DiscountButton.xml
+++ b/addons/pos_discount/static/src/xml/DiscountButton.xml
@@ -3,7 +3,7 @@
 
     <t t-name="DiscountButton" owl="1">
         <span class="control-button js_discount">
-            <i class="fa fa-tag"></i>
+            <i class="fa fa-percent"></i>
             <span> </span>
             <span>Discount</span>
         </span>

--- a/addons/pos_discount/views/pos_discount_views.xml
+++ b/addons/pos_discount/views/pos_discount_views.xml
@@ -6,12 +6,8 @@
             <field name="inherit_id" ref="point_of_sale.pos_config_view_form" />
             <field name="arch" type="xml">
                 <div id="warning_text_pos_discount" position="replace">
-                    <div class="row mt16">
-                        <label string="Discount Product" for="discount_product_id" class="col-lg-3 o_light_label"/>
-                        <field name="discount_product_id" attrs="{'required':[('module_pos_discount','=',True)]}"/>
-                    </div>
                     <div class="row">
-                        <label string="Discount %" for="discount_pc" class="col-lg-3 o_light_label"/>
+                        <label string="Default Discount %" for="discount_pc" class="col-lg-3 o_light_label"/>
                         <field name="discount_pc"/>
                     </div>
                 </div>


### PR DESCRIPTION
The previous application of global discount adds a discount orderline.
With this approach, tax can't be computed correctly when the orderlines
have different taxes.

This commit changes this global discount application. So instead of
creating a discount line, we apply to each line the discount. As a result
tax is calculated properly regardless of the taxes configuration of
the orderlines.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
