### PR TITLE
[IMP] base_address: add home/door in children form views

### DIFF
--- a/addons/base_address_extended/views/base_address_extended.xml
+++ b/addons/base_address_extended/views/base_address_extended.xml
@@ -31,6 +31,21 @@
                     <field name="street_number2" attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}"/>
                 </div>
             </xpath>
+
+            <xpath expr="//div[hasclass('o_address_format')]/field[@name='street']" position="replace">
+                <div>
+                    <field name="street" class="oe_read_only"/>
+                </div>
+                <field name="street_name" placeholder="Street Name..." attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}" class="oe_edit_only"/>
+                <div class="oe_edit_only o_row">
+                    <label for="street_number"/>
+                    <span> </span>
+                    <field name="street_number" attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}"/>
+                    <label for="street_number2"/>
+                    <field name="street_number2" attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}"/>
+                </div>
+            </xpath>
+
         </field>
     </record>
 


### PR DESCRIPTION
add home/door fields in children form views to align it
with the full form view so that the user can
edit these fields from the quick child form without having
to leave and open the full form

Task-2423694
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
