### PR TITLE
[IMP] website: make website.menu.tree non-editable

### DIFF
--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -221,7 +221,7 @@
             <field name="model">website.menu</field>
             <field name="field_parent">child_id</field>
             <field name="arch" type="xml">
-                <tree string="Website menu" editable="bottom">
+                <tree string="Website menu">
                     <field name="sequence" widget="handle"/>
                     <field name="website_id" options="{'no_create': True}" groups="website.group_multi_website"/>
                     <field name="name"/>


### PR DESCRIPTION
By making this tree non-editable, clicking on the rows opens the corresponding form, and gives access to more information and better navigation.