### PR TITLE
[FIX] mass_mailing: save error does not break inlining


### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -75,6 +75,7 @@ var MassMailingFieldHtml = FieldHtml.extend({
                     dataPointID: self.dataPointID,
                     changes: _.object([fieldName], [self._unWrap($editable.html())])
                 });
+                self.wysiwyg.setValue(result.html);
 
                 if (self._isDirty && self.mode === 'edit') {
                     return self._doAction();


### PR DESCRIPTION
Scenario:

- create mass mailing with icons and without title
- save and get error "The followign fields are invalid: Subject"
- fill subject and save
- edit

=> the icons have disappeared

This is because mass mailing widget is using:

- a "body_html" field that contains inlined html
- a wysiwyg editor to edit field "body_arch"
- a textarea containing "body_arch" value to be saved

When we save this happens:

1. we save the current value of wysiwyg into textarea
2. wysiwyg content is inlined (eg. transforming font in image)
3. inlined wysiwyg content is set to "body_html" field
4. if there:

   - is no error while saving => body_html and body_arch are saved and
     will be used on next edition
   
   - if there is an error the fields are not saved, and we now have an
     inlined content on wysiwyg, so next time we save the "body_arch" is
     going to be inlined:

     => this for example breaking the icons on edition

Issue discovered when fixing opw-2447756
