### PR TITLE
[FIX] account: Fix 'is_reconciled' flag for zero-amount statement line

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -781,19 +781,6 @@ class AccountBankStatementLine(models.Model):
         for st_line in self:
             liquidity_lines, suspense_lines, other_lines = st_line._seek_for_lines()
 
-            # Compute is_reconciled
-            if not st_line.id:
-                # New record: The journal items are not yet there.
-                st_line.is_reconciled = False
-            elif suspense_lines:
-                # In case of the statement line comes from an older version, it could have a residual amount of zero.
-                st_line.is_reconciled = all(suspense_line.reconciled for suspense_line in suspense_lines)
-            elif st_line.currency_id.is_zero(st_line.amount):
-                st_line.is_reconciled = True
-            else:
-                # The journal entry seems reconciled.
-                st_line.is_reconciled = True
-
             # Compute residual amount
             if st_line.to_check:
                 st_line.amount_residual = -st_line.amount_currency if st_line.foreign_currency_id else -st_line.amount
@@ -801,6 +788,19 @@ class AccountBankStatementLine(models.Model):
                 st_line.amount_residual = sum(suspense_lines.mapped('amount_residual_currency'))
             else:
                 st_line.amount_residual = sum(suspense_lines.mapped('amount_currency'))
+
+            # Compute is_reconciled
+            if not st_line.id:
+                # New record: The journal items are not yet there.
+                st_line.is_reconciled = False
+            elif suspense_lines:
+                # In case of the statement line comes from an older version, it could have a residual amount of zero.
+                st_line.is_reconciled = suspense_lines.currency_id.is_zero(st_line.amount_residual)
+            elif st_line.currency_id.is_zero(st_line.amount):
+                st_line.is_reconciled = True
+            else:
+                # The journal entry seems reconciled.
+                st_line.is_reconciled = True
 
     # -------------------------------------------------------------------------
     # CONSTRAINT METHODS

--- a/addons/account/tests/test_account_bank_statement.py
+++ b/addons/account/tests/test_account_bank_statement.py
@@ -1549,3 +1549,23 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
             {'amount_currency': 226.04,     'debit': 193.22,    'credit': 0.0},
             {'amount_currency': -7767.70,   'debit': 0.0,       'credit': 6640.19},
         ])
+
+    def test_zero_amount_statement_line(self):
+        ''' Ensure the statement line is directly marked as reconciled when having an amount of zero. '''
+        self.company_data['company'].account_journal_suspense_account_id.reconcile = False
+
+        statement = self.env['account.bank.statement'].with_context(skip_check_amounts_currencies=True).create({
+            'name': 'test_statement',
+            'date': '2017-01-01',
+            'journal_id': self.bank_journal_2.id,
+            'line_ids': [
+                (0, 0, {
+                    'date': '2019-01-01',
+                    'payment_ref': "Happy new year",
+                    'amount': 0.0,
+                }),
+            ],
+        })
+        statement_line = statement.line_ids
+
+        self.assertRecordValues(statement_line, [{'is_reconciled': True, 'amount_residual': 0.0}])


### PR DESCRIPTION
When the suspense account is not reconcilable, 'suspense_lines.reconciled' always gives 'False' leading to a not reconciled statement line.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
