### PR TITLE
[FIX] google_calendar: prevent useless partners creation

### DIFF
--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -88,7 +88,7 @@ class Meeting(models.Model):
         attendee_commands = []
         partner_commands = []
         google_attendees = google_event.attendees or []
-        if google_event.organizer and google_event.organizer.get('self', False):
+        if len(google_attendees) == 0 and google_event.organizer and google_event.organizer.get('self', False):
             user = google_event.owner(self.env)
             google_attendees += [{
                 'email': user.partner_id.email,
@@ -107,7 +107,7 @@ class Meeting(models.Model):
                 attendee_commands += [(1, attendees_by_emails[email].id, {'state': attendee.get('responseStatus')})]
             else:
                 # Create new attendees
-                partner = self.env['res.partner'].find_or_create(attendee.get('email'))
+                partner = self.env.user.partner_id if attendee.get('self') else self.env['res.partner'].find_or_create(attendee.get('email'))
                 attendee_commands += [(0, 0, {'state': attendee.get('responseStatus'), 'partner_id': partner.id})]
                 partner_commands += [(4, partner.id)]
                 if attendee.get('displayName') and not partner.name:


### PR DESCRIPTION
When syncing with a Google account, if user's email is different from
Google account, the server creates a new partner. Moreover, the synced
event are not linked to the current partner.

To reproduce the error:
1. Have two Google accounts GA01 and GA02
2. With GA01, add an event to Google Calendar and add GA02 to guests
3. In Odoo, sync with Google Calendar using GA02
	- The partner linked to the current Odoo user must have an email
different from GA02's email

Error: The calendar is synced, but the user needs to check "Everybody's
calendars" to see the synced events. A new partner has been created
using GA02's email. The synced events are linked to this new partner
instead of current user's partner (`self.env.user.partner_id`).
Moreover, Google event's organizer is always added to attendees but, if
it this is indeed the case (so if the organizer is also an attendee),
`google_event.attendees` already contains this organizer.

OPW-2440033