### PR TITLE
[FIX] packaging: update rpm packaging for fedora 32

### DIFF
--- a/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
+++ b/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
@@ -66,7 +66,6 @@ PKGS_TO_INSTALL="
     python3-psutil \
     python3-psycopg2 \
     python3-pydot \
-    python3-pyparsing \
     python3-pypdf2 \
     python3-qrcode \
     python3-reportlab \

--- a/debian/control
+++ b/debian/control
@@ -39,7 +39,6 @@ Depends:
  python3-psutil,
  python3-psycopg2,
  python3-pydot,
- python3-pyparsing,
  python3-pypdf2,
  python3-qrcode,
  python3-reportlab,

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,6 @@ psycopg2==2.7.7; sys_platform != 'win32' and python_version < '3.8'
 psycopg2==2.8.5; sys_platform == 'win32' or python_version >= '3.8'
 pydot==1.4.1
 python-ldap==3.1.0; sys_platform != 'win32'
-pyparsing==2.2.0
 PyPDF2==1.26.0
 pyserial==3.4
 python-dateutil==2.7.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,12 +7,8 @@ install-script = setup/redhat/install.sh
 post-install = setup/redhat/postinstall.sh
 
 requires =
-  babel
   sassc
-  libxslt-python
-  pychart
-  pyparsing
-  python(abi) >= 3.6
+  python(abi) >= 3.8
   python3-babel
   python3-decorator
   python3-docutils
@@ -35,7 +31,6 @@ requires =
   python3-psycopg2
   python3-polib
   python3-pydot
-  python3-pyparsing
   python3-PyPDF2
   python3-pyserial
   python3-dateutil

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(
         'psutil',  # windows binary code.google.com/p/psutil/downloads/list
         'psycopg2 >= 2.2',
         'pydot',
-        'pyparsing',
         'pypdf2',
         'pyserial',
         'python-dateutil',

--- a/setup/package.dfdebian
+++ b/setup/package.dfdebian
@@ -41,7 +41,6 @@ RUN apt-get update -qq &&  \
         python3-psutil \
         python3-psycopg2 \
         python3-pydot \
-        python3-pyparsing \
         python3-pypdf2 \
         python3-qrcode \
         python3-reportlab \

--- a/setup/package.dffedora
+++ b/setup/package.dffedora
@@ -1,60 +1,59 @@
 # Please note that this Dockerfile is used for testing nightly builds and should
 # not be used to deploy Odoo
-FROM fedora:30
+FROM fedora:32
 MAINTAINER Odoo S.A. <info@odoo.com>
 
 # Dependencies and postgres
 RUN dnf update -d 0 -e 0 -y && \
-	dnf install -d 0 -e 0 \
-		babel \
-		createrepo \
-		pychart \
-		pyparsing \
-		python3-babel \
-	  python3-decorator \
-	  python3-docutils \
-	  python3-feedparser \
-	  python3-gevent \
-	  python3-greenlet \
-	  python3-html2text \
-	  python3-jinja2 \
-	  python3-lxml \
-	  python3-mako \
-	  python3-markupsafe \
-	  python3-num2words \
-	  python3-ofxparse \
-	  python3-passlib \
-	  python3-pillow \
-	  python3-psutil \
-	  python3-pydot \
-	  python3-pyldap \
-	  python3-pyparsing \
-	  python3-PyPDF2 \
-	  python3-pyserial \
-	  python3-dateutil \
-	  python3-polib \
-	  python3-pytz \
-	  python3-pyusb \
-	  python3-qrcode \
-	  python3-reportlab \
-	  python3-requests \
-	  python3-six \
-	  python3-stdnum \
-	  python3-suds \
-	  python3-vobject \
-	  python3-werkzeug \
-	  python3-xlwt \
-	  python3-xlrd \
-		python3-xlsxwriter \
-		libsass \
-		pytz \
-		postgresql \
-		postgresql-server \
-		postgresql-libs \
-		postgresql-contrib \
-		postgresql-devel \
-		rpmdevtools -y && \
-	dnf clean all
+    dnf install -d 0 -e 0 \
+        createrepo \
+        libsass \
+        postgresql \
+        postgresql-contrib \
+        postgresql-devel \
+        postgresql-libs \
+        postgresql-server \
+        python3-PyPDF2 \
+        python3-babel \
+        python3-dateutil \
+        python3-decorator \
+        python3-docutils \
+        python3-feedparser \
+        python3-freezegun \
+        python3-gevent \
+        python3-greenlet \
+        python3-html2text \
+        python3-idna \
+        python3-jinja2 \
+        python3-lxml \
+        python3-mako \
+        python3-markupsafe \
+        python3-mock \
+        python3-num2words \
+        python3-ofxparse \
+        python3-passlib \
+        python3-pillow \
+        python3-polib \
+        python3-psutil \
+        python3-psycopg2 \
+        python3-pydot \
+        python3-pyldap \
+        python3-pyserial \
+        python3-pytz \
+        python3-pyusb \
+        python3-qrcode \
+        python3-reportlab \
+        python3-requests \
+        python3-six \
+        python3-stdnum \
+        python3-suds \
+        python3-vobject \
+        python3-werkzeug \
+        python3-xlrd \
+        python3-xlsxwriter \
+        python3-xlwt \
+        rpmdevtools -y && \
+    dnf clean all
 
 # Postgres configuration
 RUN mkdir -p /var/lib/postgres/data

--- a/setup/package.dfsrc
+++ b/setup/package.dfsrc
@@ -20,15 +20,8 @@ RUN apt-get update -qq &&  \
 		postgresql-server-dev-all \
 		postgresql-client \
 		adduser \
-		libsass1 \
-		libxml2-dev \
-		libxslt1-dev \
 		libldap2-dev \
 		libsasl2-dev \
-		libssl-dev \
-		libjpeg-dev \
-		zlib1g-dev \
-		python3-dev \
 		python3-pip \
 		python3-wheel \
 		build-essential \

--- a/setup/redhat/install.sh
+++ b/setup/redhat/install.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 set -e
-python3 setup.py install --prefix=/usr --root=$RPM_BUILD_ROOT --record=INSTALLED_FILES --install-lib usr/lib/python3.7/site-packages/
+ABI=$(rpm -q --provides python3 | awk '/abi/ {print $NF}')
+python3 setup.py install --prefix=/usr --root=$RPM_BUILD_ROOT --record=INSTALLED_FILES --install-lib usr/lib/python${ABI}/site-packages/

--- a/setup/redhat/postinstall.sh
+++ b/setup/redhat/postinstall.sh
@@ -9,6 +9,7 @@ ODOO_GROUP="odoo"
 ODOO_LOG_DIR=/var/log/odoo
 ODOO_LOG_FILE=$ODOO_LOG_DIR/odoo-server.log
 ODOO_USER="odoo"
+ABI=$(rpm -q --provides python3 | awk '/abi/ {print $NF}')
 
 if ! getent passwd | grep -q "^odoo:"; then
     groupadd $ODOO_GROUP
@@ -28,7 +29,7 @@ db_host = False
 db_port = False
 db_user = $ODOO_USER
 db_password = False
-addons_path = /usr/lib/python3.7/site-packages/odoo/addons
+addons_path = /usr/lib/python${ABI}/site-packages/odoo/addons
 " > $ODOO_CONFIGURATION_FILE
     chown $ODOO_USER:$ODOO_GROUP $ODOO_CONFIGURATION_FILE
     chmod 0640 $ODOO_CONFIGURATION_FILE


### PR DESCRIPTION
As Fedora 32 was the current release when Odoo 14.0 was released, this should be
the supported version.

Also, a few  old libs were still in mentioned in the packaging files.
They flew under the radar because they never broke the packaging.
This is not the case anymore, those libs disappeared from the Fedora
repos.

It seems that pyparsing is not used anymore since 5a1c06a19 and thus can
be safely removed from `requirements.txt` too.

pychart is not used anymore since 3425752ea.

Fixes #63719

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
