### PR TITLE
[FIX] account,sale: information after adding credit note

### DIFF
--- a/addons/account/models/account_invoice.py
+++ b/addons/account/models/account_invoice.py
@@ -1551,7 +1551,7 @@ class AccountInvoice(models.Model):
         values['date_due'] = values['date_invoice']
         values['state'] = 'draft'
         values['number'] = False
-        values['origin'] = invoice.number
+        values['origin'] = invoice.origin
         values['refund_invoice_id'] = invoice.id
         values['reference'] = False
 

--- a/addons/sale/models/account_invoice.py
+++ b/addons/sale/models/account_invoice.py
@@ -83,12 +83,10 @@ class AccountInvoice(models.Model):
     @api.model
     def _refund_cleanup_lines(self, lines):
         result = super(AccountInvoice, self)._refund_cleanup_lines(lines)
-        if self.env.context.get('mode') == 'modify':
-            for i, line in enumerate(lines):
-                for name, field in line._fields.items():
-                    if name == 'sale_line_ids':
-                        result[i][2][name] = [(6, 0, line[name].ids)]
-                        line[name] = False
+        for i, line in enumerate(lines):
+            for name, field in line._fields.items():
+                if name == 'sale_line_ids':
+                    result[i][2][name] = [(6, 0, line[name].ids)]
         return result
 
     @api.multi


### PR DESCRIPTION
When adding a credit note to cancel an invoice, in the corresponding SO,
the invoiced quantities of the products are not updated. Moreover, the source
document of the refund invoice is incorrect.

To reproduce the error:
1. Create a SO with a product P
        - Set P-product's quantity to X
2. Confirm the SO
3. Invoice the X P-products, Validate the invoice
4. Go back to SO
        - The "Invoiced Quantity" for P-product is X
5. Go back to the invoice: Add credit note
        - Method: Cancel
5. Go back to SO

Result:

- Error01 (sale):

The "Invoiced Quantity" of the product is not reset: the value is
still X. It should be 0. This flow works correctly from version 13 onwards.

The issue comes from the refund invoice creation which does not add the
link between SO's lines and refund invoice's lines. As a result, when
computing the invoiced quantity:
https://github.com/odoo/odoo/blob/ad2d96db8ad3e1fd7af2edda218fc34c0c1d259a/addons/sale/models/sale.py#L1045-L1053
`line.invoice_lines` will not contain the refund invoice lines, so
`qty_invoiced` will not decreased.

- Error02 (account):

The source document of the invoice generated by the refund is the  
original one (from step 3). It should be the SO. This flow works correctly from 
version 13 onwards.

OPW-2419786