### PR TITLE
[FIX] point_of_sale: IoT Box modules list on a single line

### DIFF
--- a/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init.d/odoo
+++ b/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init.d/odoo
@@ -20,7 +20,7 @@ DESC=odoo
 CONFIG=/home/pi/odoo/addons/point_of_sale/tools/posbox/configuration/odoo.conf
 LOGFILE=/var/log/odoo/odoo-server.log
 PIDFILE=/var/run/${NAME}.pid
-MODULES=$(ls /home/pi/odoo/addons/ -m | tr -d ' ')
+MODULES=$(ls /home/pi/odoo/addons/ -m -w0 | tr -d ' ')
 USER=pi
 
 test -x $DAEMON || exit 0


### PR DESCRIPTION
By default, the `ls` command has a width limit. Everything after this
limit will be split on a second line.

This happened when listing the modules present on the IoT Box in v12.
The list of modules was split across two lines, the modules on the
second line were then not loaded when starting the Odoo service.


i.e. in v12, the list of modules we retrieved was:
```
hw_blackbox_be,hw_drivers,hw_escpos,hw_posbox_homepage,hw_proxy,
point_of_sale,web
```
and is now:
```
hw_blackbox_be,hw_drivers,hw_escpos,hw_posbox_homepage,hw_proxy,point_of_sale,web
```

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
