### PR TITLE
[FIX] calendar: using many2many to event and recurrence


### DIFF
--- a/addons/calendar/models/calendar.py
+++ b/addons/calendar/models/calendar.py
@@ -1124,6 +1124,9 @@ class Meeting(models.Model):
         if 'id' not in order_fields:
             order_fields.append('id')
 
+        # code does not handle '!' operator
+        domain = expression.distribute_not(expression.normalize_domain(domain))
+
         leaf_evaluations = None
         recurrent_ids = [meeting.id for meeting in self if meeting.recurrency and meeting.rrule]
         #compose a query of the type SELECT id, condition1 as domain1, condition2 as domaine2

--- a/addons/calendar/tests/test_calendar_recurrent_event_case2.py
+++ b/addons/calendar/tests/test_calendar_recurrent_event_case2.py
@@ -205,3 +205,12 @@ class TestRecurrentEvent(common.TransactionCase):
         ])
         base_ids = [calendar_id2real_id(meeting.id, with_date=False) for meeting in meetings]
         self.assertIn(ev.id, base_ids, "Event does match the domain")
+
+        meetings = self.CalendarEvent.with_context({'virtual_id': True}).search(['!', ['id', 'in', []]])
+        all_meetings = self.CalendarEvent.with_context({'virtual_id': True}).search([])
+        self.assertEqual(meetings, all_meetings, "All events match the domain")
+
+        recurrent_ids = ['{}-20180706110000'.format(ev.id), '{}-20180629110000'.format(ev.id)]
+        meetings = self.CalendarEvent.with_context({'virtual_id': True}).search(['!', ['id', 'in', recurrent_ids[:1]]])
+        excluded_meetings = (all_meetings - meetings).ids
+        self.assertEqual(excluded_meetings, recurrent_ids, "Recurrent event is excluded by the domain")


### PR DESCRIPTION

The current code to search recurring ids doesn't handle '!' operator.

If for example we use calendar.event as target of many2many field, we
use a domain ['!', ['id', 'in', {{current_ids}}]] which if there is
recurrent events causes an error.

With this changeset, we avoid `!` operator by distributing it.

Code added in test without the fix fails with:

  AssertionError: This domain is syntactically not correct: ['!']

when inside calendar.event().get_recurrent_ids we do (with arg=='!'):

  e = expression.expression([arg], self)

opw-2442353
