### PR TITLE
[FIX] core: copy values for new stored related field via sql

### DIFF
--- a/odoo/addons/base/tests/test_ir_actions.py
+++ b/odoo/addons/base/tests/test_ir_actions.py
@@ -383,3 +383,47 @@ class TestCustomFields(common.TransactionCase):
         # uninstall mode: unlink dependant fields
         field.with_context(_force_unlink=True).unlink()
         self.assertFalse(dependant.exists())
+
+    def test_related_field(self):
+        """ create a custom related field, and check filled values """
+        #
+        # Add a custom field equivalent to the following definition:
+        #
+        # class Partner(models.Model)
+        #     _inherit = 'res.partner'
+        #     x_oh_boy = fields.Char(related="country_id.code", store=True)
+        #
+
+        # pick N=100 records in comodel
+        countries = self.env['res.country'].search([('code', '!=', False)], limit=100)
+        self.assertEqual(len(countries), 100, "Not enough records in comodel 'res.country'")
+
+        # create records in model, with N distinct values for the related field
+        partners = self.env['res.partner'].create([
+            {'name': country.code, 'country_id': country.id} for country in countries
+        ])
+
+        # determine how many queries it takes to create a non-computed field
+        query_count = self.cr.sql_log_count
+        self.env['ir.model.fields'].create({
+            'model_id': self.env['ir.model']._get_id('res.partner'),
+            'name': 'x_oh_box',
+            'field_description': 'x_oh_box',
+            'ttype': 'char',
+        })
+        query_count = self.cr.sql_log_count - query_count
+
+        # create the related field, and assert it only takes 3 extra queries
+        with self.assertQueryCount(query_count + 3):
+            self.env['ir.model.fields'].create({
+                'model_id': self.env['ir.model']._get_id('res.partner'),
+                'name': 'x_oh_boy',
+                'field_description': 'x_oh_boy',
+                'ttype': 'char',
+                'related': 'country_id.code',
+                'store': True,
+            })
+
+        # check the computed values
+        for partner in partners:
+            self.assertEqual(partner.x_oh_boy, partner.country_id.code)

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -922,6 +922,21 @@ class Field(MetaField('DummyField', (object,), {})):
         self.update_db_notnull(model, column)
         self.update_db_index(model, column)
 
+        # optimization for computing simple related fields like 'foo_id.bar'
+        if (
+            not column
+            and len(self.related or ()) == 2
+            and self.related_field.store and not self.related_field.compute
+        ):
+            join_field = model._fields[self.related[0]]
+            if (
+                join_field.type == 'many2one'
+                and join_field.store and not join_field.compute
+            ):
+                model.pool.post_init(self.update_db_related, model)
+                # discard the "classical" computation
+                return False
+
         return not column
 
     def update_db_column(self, model, column):
@@ -988,6 +1003,22 @@ class Field(MetaField('DummyField', (object,), {})):
                 _schema.error("Unable to add index for %s", self)
         else:
             sql.drop_index(model._cr, indexname, model._table)
+
+    def update_db_related(self, model):
+        """ Compute a stored related field directly in SQL. """
+        comodel = model.env[self.related_field.model_name]
+        model.env.cr.execute("""
+            UPDATE "{model_table}" AS x
+            SET "{model_field}" = y."{comodel_field}"
+            FROM "{comodel_table}" AS y
+            WHERE x."{join_field}" = y.id
+        """.format(
+            model_table=model._table,
+            model_field=self.name,
+            comodel_table=comodel._table,
+            comodel_field=self.related[1],
+            join_field=self.related[0],
+        ))
 
     ############################################################################
     #


### PR DESCRIPTION
Direct filling new column is dramatically faster than doing it via ORM, which
iterates over each row.

Test results for updating new related field in 10 records:

BEFORE:
sql_update_log: 12
sql_from_log: 5
sql_into_log: 0

AFTER:
sql_update_log: 1
sql_from_log: 3
sql_into_log: 0

---

task-2449313
opw-2380445
opw-2389376
odoo/enterprise#15910