### PR TITLE
[IMP] stock: show date_done in picking tree view as optional hide

### DIFF
--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -202,6 +202,7 @@
                     <field name="user_id" optional="hide" widget="many2one_avatar_user"/>
                     <field name="scheduled_date" optional="show" widget="remaining_days" attrs="{'invisible':[('state', 'in', ('done', 'cancel'))]}"/>
                     <field name="date_deadline" optional="hide" widget="remaining_days" attrs="{'invisible':[('state', 'in', ('done', 'cancel'))]}"/>
+                    <field name="date_done" optional="hide" attrs="{'invisible':[('state', '!=', 'done')]}"/>
                     <field name="origin" optional="show"/>
                     <field name="group_id" invisible="1"/>
                     <field name="backorder_id" optional="hide"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
It is better to show date_done in stock picking  tree view as optional hide. 
Users can show or hide it by themselves
  
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
