### PR TITLE
[FIX] point_of_sale: Open cashdrawer with change

### DIFF
--- a/addons/point_of_sale/static/src/js/screens.js
+++ b/addons/point_of_sale/static/src/js/screens.js
@@ -2136,7 +2136,7 @@ var PaymentScreenWidget = ScreenWidget.extend({
         var self = this;
         var order = this.pos.get_order();
 
-        if (order.is_paid_with_cash() && this.pos.config.iface_cashdrawer) { 
+        if ((order.is_paid_with_cash() || order.get_change()) && this.pos.config.iface_cashdrawer) { 
 
                 this.pos.proxy.open_cashbox();
         }


### PR DESCRIPTION
We should open the cashdrawer when paying with a non cash payment
method if change should be returned to the customer.

Use case: The customer wants to pay 10€ more with his card to get 10€
in cash in return.

TaskID: 2449312





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
