### PR TITLE
[FIX] website_sale : minor ui fixes

### DIFF
--- a/addons/web/static/src/scss/colorpicker.scss
+++ b/addons/web/static/src/scss/colorpicker.scss
@@ -28,6 +28,9 @@
     }
     .o_slider_pointer, .o_opacity_pointer, .o_picker_pointer, .o_color_preview, .o_hex_div, .o_rgba_div  {
         border: 1px solid black;
+        &:focus-within {
+            border-color: $o-we-sidebar-content-field-input-border-color;
+        }
     }
     .o_color_picker_inputs {
         font-size: 10px;
@@ -36,6 +39,10 @@
             font-family: monospace !important; // FIXME: the monospace font used in the editor has not consistent ch units on Firefox
             height: 18px;
             font-size: 11px;
+            border: none;
+            &:focus {
+                outline: none;
+            }
         }
         .o_hex_div input {
             width: 7ch;

--- a/addons/web/static/src/xml/colorpicker.xml
+++ b/addons/web/static/src/xml/colorpicker.xml
@@ -16,7 +16,7 @@
         </div>
         <div t-if="widget.options.colorPreview" class="o_color_preview mb-1 w-100 p-2"/>
         <div class="o_color_picker_inputs d-flex justify-content-between mb-2">
-            <t t-set="input_classes">p-0 border-0 text-center text-monospace bg-transparent text-white</t>
+            <t t-set="input_classes">p-0 text-center text-monospace bg-transparent text-white</t>
 
             <div class="o_hex_div bg-black-50 px-1 d-flex align-items-baseline">
                 <input type="text" t-attf-class="o_hex_input {{input_classes}}" data-color-method="hex" size="1"/>

--- a/addons/website/static/src/snippets/s_image_gallery/options.js
+++ b/addons/website/static/src/snippets/s_image_gallery/options.js
@@ -21,7 +21,7 @@ options.registry.gallery = options.Class.extend({
         this.$target.addClass('o_fake_not_editable').attr('contentEditable', false);
 
         // Make sure image previews are updated if images are changed
-        this.$target.on('save', 'img', function (ev) {
+        this.$target.on('image_changed', 'img', function (ev) {
             var $img = $(ev.currentTarget);
             var index = self.$target.find('.carousel-item.active').index();
             self.$('.carousel:first li[data-target]:eq(' + index + ')')

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -553,7 +553,7 @@
                                     <ul class="nav nav-pills flex-column">
                                         <t t-foreach="a.value_ids" t-as="v">
                                             <li class="nav-item">
-                                                <label style="padding: 0.25rem 0rem; margin: 0" t-attf-class="nav-link#{' active' if v.id in attrib_set else ''}">
+                                                <label style="padding: 0; margin: 0" t-attf-class="nav-link#{' active' if v.id in attrib_set else ''}">
                                                     <input type="checkbox" name="attrib" t-att-value="'%s-%s' % (a.id,v.id)" t-att-checked="'checked' if v.id in attrib_set else None" />
                                                     <span style="font-weight: normal" t-field="v.name" />
                                                 </label>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -729,7 +729,7 @@
         </xpath>
     </template>
 
-    <template id="recently_viewed_products_product" inherit_id="website_sale.product" active="True" customize_show="True" name="Recently Viewed Products" priority="16">
+    <template id="recently_viewed_products_product" inherit_id="website_sale.product" active="False" customize_show="True" name="Recently Viewed Products" priority="16">
         <xpath expr="//div[@t-field='product.website_description']" position="after">
             <t t-snippet-call="website_sale.s_products_recently_viewed"/>
         </xpath>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Improve onboarding of new users to the website builder by making some layout quick wins.
Also trying to make the tool as consistent as possible.

Current behavior before PR:
There is a padding between Product Attributes filter subitems
'Recently View Products' is active by default
Image gallery miniatures are not updated when changing an image

Desired behavior after PR is merged:
There is no padding between Product Attributes filter subitems
'Recently View Products' is inactive by default
Image gallery miniatures are updated when changing an image

task-2438556


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
