### PR TITLE
[FIX] stock_account: fix valuation with negative value after an adjus…

### DIFF
--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -479,14 +479,7 @@ class TestStockValuation(TransactionCase):
         move6._action_confirm()
         move6._action_assign()
         move6.move_line_ids.qty_done = 10.0
-        move6._action_done()
-
-        # stock_account values for move6
-        self.assertEqual(move6.product_uom_qty, 10)
-        self.assertEqual(move6.price_unit, 12.0)
-        self.assertEqual(move6.remaining_qty, 10.0)
-        self.assertEqual(move6.value, 120)
-        self.assertEqual(move6.remaining_value, 120)
+        move6._action_done()  # move6 triggers vacuum
 
         # account values for move6
         input_aml = self._get_stock_input_move_lines()
@@ -496,8 +489,8 @@ class TestStockValuation(TransactionCase):
         self.assertEqual(move6_input_aml.credit, 120)
 
         valuation_aml = self._get_stock_valuation_move_lines()
-        move6_valuation_aml = valuation_aml[-1]
-        self.assertEqual(len(valuation_aml), 7)
+        move6_valuation_aml = valuation_aml[-2]
+        self.assertEqual(len(valuation_aml), 8)
         self.assertEqual(move6_valuation_aml.debit, 120)
         self.assertEqual(move6_valuation_aml.credit, 0)
         self.assertEqual(move6_valuation_aml.product_id.id, self.product1.id)
@@ -505,45 +498,11 @@ class TestStockValuation(TransactionCase):
         self.assertEqual(move6_valuation_aml.product_uom_id.id, self.uom_unit.id)
 
         output_aml = self._get_stock_output_move_lines()
-        self.assertEqual(len(output_aml), 3)
+        self.assertEqual(len(output_aml), 4)
 
         # link between stock move and account move
         self.assertEqual(len(move6.account_move_ids), 1)
         self.assertTrue(set(move6.account_move_ids.line_ids.ids) == {move6_valuation_aml.id, move6_input_aml.id})
-
-        # older moves
-        self.assertEqual(move1.product_uom_qty, 12)
-        self.assertEqual(move1.price_unit, 10.0)
-        self.assertEqual(move1.remaining_qty, 0)
-        self.assertEqual(move1.value, 120)
-        self.assertEqual(move1.remaining_value, 0)
-        self.assertEqual(move2.product_uom_qty, 10.0)
-        self.assertEqual(move2.price_unit, 8.0)
-        self.assertEqual(move2.remaining_qty, 0)
-        self.assertEqual(move2.value, 80.0)
-        self.assertEqual(move2.remaining_value, 0)
-        self.assertEqual(move3.product_uom_qty, 3.0)
-        self.assertEqual(move3.remaining_qty, 0.0)
-        self.assertEqual(move3.value, -30.0)
-        self.assertEqual(move3.remaining_value, 0.0)
-        self.assertEqual(move4.product_uom_qty, 9.0)
-        self.assertEqual(move4.remaining_qty, 0.0)
-        self.assertEqual(move4.value, -90.0)
-        self.assertEqual(move4.remaining_value, 0)
-        self.assertEqual(move5.product_uom_qty, 20.0)
-        self.assertEqual(move5.remaining_qty, -10.0)
-        self.assertEqual(move5.value, -160.0)
-        self.assertEqual(move5.remaining_value, -80.0)
-        self.assertTrue(set(move1.account_move_ids.mapped('line_ids').ids) == {move1_input_aml.id, move1_valuation_aml.id, move1_correction_input_aml.id, move1_correction_valuation_aml.id})
-        self.assertTrue(set(move2.account_move_ids.line_ids.ids) == {move2_valuation_aml.id, move2_input_aml.id})
-        self.assertTrue(set(move3.account_move_ids.line_ids.ids) == {move3_valuation_aml.id, move3_output_aml.id})
-        self.assertTrue(set(move4.account_move_ids.line_ids.ids) == {move4_valuation_aml.id, move4_output_aml.id})
-        self.assertTrue(set(move5.account_move_ids.line_ids.ids) == {move5_valuation_aml.id, move5_output_aml.id})
-
-        # ---------------------------------------------------------------------
-        # Vacuum is called, we cleanup the negatives.
-        # ---------------------------------------------------------------------
-        self.env['stock.move']._run_fifo_vacuum()
 
         # account values after vacuum
         input_aml = self._get_stock_input_move_lines()
@@ -654,25 +613,18 @@ class TestStockValuation(TransactionCase):
         move7._action_confirm()
         move7._action_assign()
         move7.move_line_ids.qty_done = 4.0
-        move7._action_done()
-
-        # stock_account values for move1
-        self.assertEqual(move7.product_uom_qty, 4.0)
-        self.assertEqual(move7.price_unit, 15.0)
-        self.assertEqual(move7.remaining_qty, 4.0)
-        self.assertEqual(move7.value, 60.0)
-        self.assertEqual(move7.remaining_value, 60.0)
+        move7._action_done()  # move7 triggers vacuum
 
         # account values for move7
         input_aml = self._get_stock_input_move_lines()
-        self.assertEqual(len(input_aml), 6)
-        move7_input_aml = input_aml[-1]
+        self.assertEqual(len(input_aml), 7)
+        move7_input_aml = input_aml[-2]
         self.assertEqual(move7_input_aml.debit, 0)
         self.assertEqual(move7_input_aml.credit, 60)
 
         valuation_aml = self._get_stock_valuation_move_lines()
-        move7_valuation_aml = valuation_aml[-1]
-        self.assertEqual(len(valuation_aml), 10)
+        move7_valuation_aml = valuation_aml[-2]
+        self.assertEqual(len(valuation_aml), 11)
         self.assertEqual(move7_valuation_aml.debit, 60)
         self.assertEqual(move7_valuation_aml.credit, 0)
         self.assertEqual(move7_valuation_aml.product_id.id, self.product1.id)
@@ -682,11 +634,6 @@ class TestStockValuation(TransactionCase):
         # link between stock move and account move
         self.assertEqual(len(move7.account_move_ids), 1)
         self.assertTrue(set(move7.account_move_ids.line_ids.ids) == {move7_valuation_aml.id, move7_input_aml.id})
-
-        # -----------------------------------------------------------
-        # vacuum, compensate in
-        # -----------------------------------------------------------
-        self.env['stock.move']._run_fifo_vacuum()
 
         # account values after vacuum
         input_aml = self._get_stock_input_move_lines()
@@ -1288,28 +1235,7 @@ class TestStockValuation(TransactionCase):
             })]
         })
         move2._action_confirm()
-        move2._action_done()
-
-        # stock values for move2
-        self.assertEqual(move2.value, 600.0)
-        self.assertEqual(move2.remaining_qty, 40.0)
-        self.assertEqual(move2.price_unit, 15.0)
-        self.assertEqual(move2.remaining_value, 600.0)
-
-        # account values for move2
-        valuation_aml = self._get_stock_valuation_move_lines()
-        move2_valuation_aml = valuation_aml[-1]
-        self.assertEqual(move2_valuation_aml.debit, 600)
-        self.assertEqual(move2_valuation_aml.credit, 0)
-        input_aml = self._get_stock_input_move_lines()
-        move2_input_aml = input_aml[-1]
-        self.assertEqual(move2_input_aml.debit, 0)
-        self.assertEqual(move2_input_aml.credit, 600)
-
-        # ---------------------------------------------------------------------
-        # Run the vacuum
-        # ---------------------------------------------------------------------
-        self.env['stock.move']._run_fifo_vacuum()
+        move2._action_done()  #move2 triggers vacuum
 
         # stock values for move1 and move2
         self.assertEqual(move1.value, -680.0)  # 40@15 + 10@8
@@ -1354,27 +1280,7 @@ class TestStockValuation(TransactionCase):
             })]
         })
         move3._action_confirm()
-        move3._action_done()
-
-        # stock values for move3
-        self.assertEqual(move3.value, 500.0)
-        self.assertEqual(move3.remaining_value, 500.0)
-        self.assertEqual(move3.remaining_qty, 20.0)
-
-        # account values for move3
-        valuation_aml = self._get_stock_valuation_move_lines()
-        move3_valuation_aml = valuation_aml[-1]
-        self.assertEqual(move3_valuation_aml.debit, 500)
-        self.assertEqual(move3_valuation_aml.credit, 0)
-        input_aml = self._get_stock_input_move_lines()
-        move3_input_aml = input_aml[-1]
-        self.assertEqual(move3_input_aml.debit, 0)
-        self.assertEqual(move3_input_aml.credit, 500)
-
-        # ---------------------------------------------------------------------
-        # Run the vacuum
-        # ---------------------------------------------------------------------
-        self.env['stock.move']._run_fifo_vacuum()
+        move3._action_done()  #move3 triggers vacuum
 
         # stock values for move1-3
         self.assertEqual(move1.value, -850.0)  # 40@15 + 10@25
@@ -1749,7 +1655,6 @@ class TestStockValuation(TransactionCase):
         DO02 1 product2
         DO02 correction 1 -> 2 (negative stock)
         IN03 2@30 product2
-        vacuum
         """
         self.product1.product_tmpl_id.cost_method = 'fifo'
 
@@ -1952,15 +1857,7 @@ class TestStockValuation(TransactionCase):
             })]
         })
         move5._action_confirm()
-        move5._action_done()
-
-        self.assertEqual(sum(self._get_stock_valuation_move_lines().mapped('debit')), 380)
-        self.assertEqual(sum(self._get_stock_valuation_move_lines().mapped('credit')), 260)
-
-        # ---------------------------------------------------------------------
-        # run vacuum
-        # ---------------------------------------------------------------------
-        self.env['stock.move']._run_fifo_vacuum()
+        move5._action_done()  #move5 triggers vacuum
 
         self.assertEqual(sum(self._get_stock_input_move_lines().mapped('debit')), 0)
         self.assertEqual(sum(self._get_stock_input_move_lines().mapped('credit')), 380) # 10*10 + 11*20
@@ -3672,7 +3569,7 @@ class TestStockValuation(TransactionCase):
 
         # send 15
         move3 = self.env['stock.move'].create({
-            'name': 'out 10',
+            'name': 'out 15',
             'location_id': self.stock_location.id,
             'location_dest_id': self.customer_location.id,
             'product_id': self.product1.id,
@@ -3692,7 +3589,7 @@ class TestStockValuation(TransactionCase):
 
         # send 20
         move4 = self.env['stock.move'].create({
-            'name': 'out 10',
+            'name': 'out 20',
             'location_id': self.stock_location.id,
             'location_dest_id': self.customer_location.id,
             'product_id': self.product1.id,
@@ -3712,7 +3609,7 @@ class TestStockValuation(TransactionCase):
 
         # receive 100@15
         move5 = self.env['stock.move'].create({
-            'name': 'in 10',
+            'name': 'in 100',
             'location_id': self.supplier_location.id,
             'location_dest_id': self.stock_location.id,
             'product_id': self.product1.id,
@@ -3723,16 +3620,10 @@ class TestStockValuation(TransactionCase):
         move5._action_confirm()
         move5._action_assign()
         move5.move_line_ids.qty_done = 100
-        move5._action_done()
+        move5._action_done()  #move5 triggers vacuum
         move5.date = date5
         move5.account_move_ids.write({'date': date5})
 
-        self.assertEqual(self.product1.qty_available, 85)
-        self.assertAlmostEqual(self.product1.qty_at_date, 85.0)
-        self.assertEqual(self.product1.stock_value, 1320)
-
-        # run the vacuum to compensate the negative stock move
-        self.env['stock.move']._run_fifo_vacuum()
         move4.account_move_ids[0].write({'date': date6})
 
         self.assertEqual(self.product1.qty_available, 85)
@@ -3866,13 +3757,13 @@ class TestStockValuation(TransactionCase):
         move4._action_confirm()
         move4._action_assign()
         move4.move_line_ids.qty_done = 10
-        move4._action_done()
+        move4._action_done()  #move4 triggers vacuum
         move4.date = date4
         move4.account_move_ids.write({'date': date4})
 
         self.assertEqual(self.product1.qty_available, 0)
         self.assertAlmostEqual(self.product1.qty_at_date, 0.0)
-        self.assertEqual(self.product1.stock_value, 50)
+        self.assertEqual(self.product1.stock_value, 0)
 
         # receive 10@10
         move5 = self.env['stock.move'].create({
@@ -3891,12 +3782,6 @@ class TestStockValuation(TransactionCase):
         move5.date = date5
         move5.account_move_ids.write({'date': date5})
 
-        self.assertEqual(self.product1.qty_available, 10)
-        self.assertAlmostEqual(self.product1.qty_at_date, 10.0)
-        self.assertEqual(self.product1.stock_value, 150)
-
-        # run the vacuum to compensate the negative stock move
-        self.env['stock.move']._run_fifo_vacuum()
         move3.account_move_ids[0].write({'date': date6})
 
         self.assertEqual(self.product1.qty_available, 10)


### PR DESCRIPTION
…tment

- Install account_accountant, stock_account, purchase & sale_management
- Create a Product (i.e. Product X)
- Edit Product Category:
  * Costing Method: Average Cost (AVCO)
  * Inventory Valuation: Automated
- Create a PO with Product X for 5 quantities at $5
- Receive the Products
- In Inventory > Report > Inventory Valuation, for Product X, we have (qty: 5, value: $25)
- Create a SO with Product X for 10 quantities
- Deliver Products
- Valuation for Product X = (qty: -5, value: $-25) => Correct
- In Inventory > Operations > Inventory Adjustments, create an adjustment for Product X to 0
- In Product X form, update cost to 0 (You may need to remove Vendors from Purchase tab to be able to do it)
- There is no more valuation for Product X => Correct
- Edit Product Category by setting "Costing Method" to "First In First Out (FIFO)"
- /!\ Do not recompute Inventory Valuation via Inventory > Report > Inventory Valuation
- Create a PO with Product X for 10 quantities at $7
- Valuation for Product X = (qty: 10, value: $70) => Correct
- Create a SO with Product X for 7 quantities
- Deliver Products
At this point, Inventory Valuation for Product X is incorrect. The Quantity is 3, which is correct,
but the value is $31, instead of $21 (3 * $7).

With FIFO Costing Method, the valuation of the last SO should be (7 units at $7) = $49.
But here, we have (5 units at $5 + 2 units at $7) = $39.
When the Inventory Adjustment has been made to set Product X to 0, a move of (qty:5, value: $25)
has been made to balance the previous Valuation of (qty: -5, value: $-25).
Values from this move are used during the last SO, but it shouldn't.

It happens because the "remaining_qty" field of the move created for the adjustment
has a value of 5 (the original move qty), instead of 0 (the real remaining qty).
Therefore the quantities from this move are used when running "_run_fifo" method,
although they should have been used to cancel the negative "remaining_qty" (-5) from
the move generated by the first SO.

To prevent this, moves with negative "remaining_qty" should be fixed when an in move is validated.

PS: The issue is also reproducible with FIFO Costing Method from the start,
as long as no Inventory Valuation recomputation is performed once the
inventory adjustment has been made.

opw-2425909

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
