### PR TITLE
[IMP] web, website, website_sale : minor ui improvements

### DIFF
--- a/addons/web/static/src/js/widgets/colorpicker.js
+++ b/addons/web/static/src/js/widgets/colorpicker.js
@@ -276,6 +276,14 @@ var ColorpickerWidget = Widget.extend({
     _onClick: function (ev) {
         ev.originalEvent.__isColorpickerClick = true;
         $(ev.target).find('> .o_opacity_pointer, > .o_slider_pointer, > .o_picker_pointer').addBack('.o_opacity_pointer, .o_slider_pointer, .o_picker_pointer').focus();
+        
+        switch ($(ev.target).data('colorMethod')) {
+            case 'hex':
+                this.$('.o_hex_input').select();
+                break;
+            default:
+                break;
+        }
     },
     /**
      * Updates color when the user starts clicking on the picker.

--- a/addons/website/static/src/js/utils.js
+++ b/addons/website/static/src/js/utils.js
@@ -164,6 +164,7 @@ function prompt(options, _qweb) {
         field_name: '',
         'default': '', // dict notation for IE<9
         init: function () {},
+        cta_title: 'Continue'
     }, options || {});
 
     var type = _.intersection(Object.keys(options), ['input', 'textarea', 'select']);

--- a/addons/website/static/src/xml/website.xml
+++ b/addons/website/static/src/xml/website.xml
@@ -12,7 +12,7 @@
                         <form role="form" t-att-id="id">
                             <div class="form-group row mb0">
                                 <label for="page-name" class="col-md-3 col-form-label">
-                                    <t t-esc="field_name"/>:
+                                    <t t-esc="field_name"/>
                                 </label>
                                 <div class="col-md-9">
                                     <input t-if="field_type == 'input'" type="text" class="form-control" required="required"/>
@@ -23,7 +23,7 @@
                         </form>
                     </main>
                     <footer class="modal-footer">
-                        <button type="button" class="btn btn-primary btn-continue">Continue</button>
+                        <button type="button" class="btn btn-primary btn-continue"><t t-esc="cta_title"/></button>
                         <button type="button" class="btn btn-secondary" data-dismiss="modal" aria-label="Cancel">Cancel</button>
                     </footer>
                 </div>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -5,9 +5,8 @@
 <template id="snippets" inherit_id="web_editor.snippets" primary="True" groups="base.group_user">
     <xpath expr="//div[@id='snippets_menu']" position="inside">
         <button type="button" tabindex="3" class="o_we_customize_theme_btn text-uppercase"
-                data-title="Customize your theme"
                 groups="website.group_website_designer" accesskey="2">
-            <span>Options</span>
+            <span>Theme</span>
         </button>
     </xpath>
     <xpath expr="//t[@id='default_snippets']" position="replace">

--- a/addons/website_sale/static/src/js/website_sale.editor.js
+++ b/addons/website_sale/static/src/js/website_sale.editor.js
@@ -28,7 +28,8 @@ WebsiteNewMenu.include({
         return wUtils.prompt({
             id: "editor_new_product",
             window_title: _t("New Product"),
-            input: _t("Name"),
+            input: _t("Product Name"),
+            cta_title: _t("Create")
         }).then(function (result) {
             if (!result.val) {
                 return;


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Improve onboarding of new users to the website builder by making some layout quick wins.
Also trying to make the tool as consistent as possible.

Current behavior before PR:
Hex color is not selected when clicking on it

Desired behavior after PR is merged:
Hex color is selected when clicking on it
Options tab label is renamed Themed
When creating a product Continue button is renamed Create




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
