### PR TITLE
[IMP] web, website, website_sale: minor ui improvements

### DIFF
--- a/addons/web/static/src/js/widgets/colorpicker.js
+++ b/addons/web/static/src/js/widgets/colorpicker.js
@@ -36,6 +36,7 @@ var ColorpickerWidget = Widget.extend({
         this.opacitySliderFlag = false;
         this.colorComponents = {};
         this.uniqueId = _.uniqueId('colorpicker');
+        this.selectedHexValue = '';
 
         // Needs to be bound on document to work in all possible cases.
         const $document = $(document);
@@ -287,6 +288,12 @@ var ColorpickerWidget = Widget.extend({
     _onClick: function (ev) {
         ev.originalEvent.__isColorpickerClick = true;
         $(ev.target).find('> .o_opacity_pointer, > .o_slider_pointer, > .o_picker_pointer').addBack('.o_opacity_pointer, .o_slider_pointer, .o_picker_pointer').focus();
+        if (ev.target.dataset.colorMethod === 'hex' && !this.selectedHexValue) {
+            ev.target.select();
+            this.selectedHexValue = ev.target.value;
+            return;
+        }
+        this.selectedHexValue = '';
     },
     /**
      * Updates color when the user starts clicking on the picker.

--- a/addons/website/static/src/js/content/website_root.js
+++ b/addons/website/static/src/js/content/website_root.js
@@ -3,12 +3,11 @@ odoo.define('website.root', function (require) {
 
 const ajax = require('web.ajax');
 const {_t} = require('web.core');
-var Dialog = require('web.Dialog');
 const KeyboardNavigationMixin = require('web.KeyboardNavigationMixin');
 const session = require('web.session');
 var publicRootData = require('web.public.root');
 require("web.zoomodoo");
-
+const {FullscreenIndication} = require('@website/js/widgets/fullscreen_indication');
 var websiteRootRegistry = publicRootData.publicRootRegistry;
 
 var WebsiteRoot = publicRootData.PublicRoot.extend(KeyboardNavigationMixin, {
@@ -34,6 +33,16 @@ var WebsiteRoot = publicRootData.PublicRoot.extend(KeyboardNavigationMixin, {
             autoAccessKeys: false,
         });
         return this._super(...arguments);
+    },
+    /**
+     * @override
+     */
+    willStart: async function () {
+        this.fullscreenIndication = new FullscreenIndication(this);
+        return Promise.all([
+            this._super(...arguments),
+            this.fullscreenIndication.appendTo(document.body),
+        ]);
     },
     /**
      * @override
@@ -170,6 +179,11 @@ var WebsiteRoot = publicRootData.PublicRoot.extend(KeyboardNavigationMixin, {
      */
     _toggleFullscreen(state) {
         this.isFullscreen = state;
+        if (this.isFullscreen) {
+            this.fullscreenIndication.show();
+        } else {
+            this.fullscreenIndication.hide();
+        }
         document.body.classList.add('o_fullscreen_transition');
         document.body.classList.toggle('o_fullscreen', this.isFullscreen);
         document.body.style.overflowX = 'hidden';

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -217,10 +217,10 @@ function goBackToBlocks(position = "bottom") {
     };
 }
 
-function goToOptions(position = "bottom") {
+function goToTheme(position = "bottom") {
     return {
         trigger: '.o_we_customize_theme_btn',
-        content: _t("Go to the Options tab"),
+        content: _t("Go to the Theme tab"),
         position: position,
         run: "click",
     };
@@ -280,7 +280,7 @@ return {
     clickOnText,
     dragNDrop,
     goBackToBlocks,
-    goToOptions,
+    goToTheme,
     selectColorPalette,
     selectHeader,
     selectNested,

--- a/addons/website/static/src/js/utils.js
+++ b/addons/website/static/src/js/utils.js
@@ -4,7 +4,7 @@ odoo.define('website.utils', function (require) {
 var ajax = require('web.ajax');
 var core = require('web.core');
 
-var qweb = core.qweb;
+const { qweb, _t } = core;
 
 /**
  * Allows to load anchors from a page.
@@ -164,6 +164,8 @@ function prompt(options, _qweb) {
         field_name: '',
         'default': '', // dict notation for IE<9
         init: function () {},
+        btn_primary_title: _t('Create'),
+        btn_secondary_title: _t('Cancel'),
     }, options || {});
 
     var type = _.intersection(Object.keys(options), ['input', 'textarea', 'select']);

--- a/addons/website/static/src/js/widgets/fullscreen_indication.js
+++ b/addons/website/static/src/js/widgets/fullscreen_indication.js
@@ -1,0 +1,40 @@
+/** @odoo-module **/
+
+import Widget from 'web.Widget';
+
+export const FullscreenIndication = Widget.extend({
+    xmlDependencies: ['/website/static/src/xml/website.xml'],
+    template: 'website.fullscreen_indication', 
+
+    init: function () {
+        this.visible = false;
+        this.displayTime = 2000;
+        this._super(...arguments);
+    },
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    /**
+     * Displays the fullscreen indication modal
+     */
+    show: function () {
+        clearTimeout(this.autofade);
+        this.visible = true;
+        this.el.classList.add('o_transition', 'o_visible');
+        this.autofade = setTimeout(() => {
+            this.hide(true);
+        }, this.displayTime);
+    },
+    /**
+     * Hides the fullscreen indication modal with optionnal transition
+     * 
+     * @param {boolean} [withTransition=false]
+     */
+    hide: function (withTransition = false) {
+        this.el.classList.toggle('o_transition', withTransition);
+        this.el.classList.remove('o_visible');
+        this.visible = false;
+    },
+});

--- a/addons/website/static/src/scss/website.ui.scss
+++ b/addons/website/static/src/scss/website.ui.scss
@@ -41,6 +41,36 @@ body.o_connected_user {
     }
 }
 
+//FULLSCREEN INDICATION LAYOUT
+.o_fullscreen_indication {
+    display: flex;
+    position: absolute;
+    width: 100%;
+    align-items: center;
+    justify-content: center;
+    top: 0;
+    margin-top: $o-navbar-height!important;
+    opacity: 0;
+    p {
+        padding: 15px 30px;
+        background-color: rgba(0, 0, 0, 0.7);
+        color: white;
+        span {
+            border: 1px solid white;
+            border-color: white;
+            border-radius: 5px;
+            padding: 7px 5px;
+            margin: 5px;
+        }
+    }
+    &.o_transition {
+        transition: opacity 400ms;
+    }
+    &.o_visible {
+        opacity: 1;
+    }
+}
+
 // MAIN MENU STYLE (added above navbar.scss)
 #oe_main_menu_navbar {
     @include o-w-preserve-dropdown-menus;

--- a/addons/website/static/src/xml/website.xml
+++ b/addons/website/static/src/xml/website.xml
@@ -98,4 +98,8 @@
             </a>
         </t>
     </t>
+
+    <div t-name="website.fullscreen_indication" class="o_fullscreen_indication">
+        <p>Press <span>esc</span> to exit full screen</p>
+    </div>
 </templates>

--- a/addons/website/static/src/xml/website.xml
+++ b/addons/website/static/src/xml/website.xml
@@ -12,7 +12,7 @@
                         <form role="form" t-att-id="id">
                             <div class="form-group row mb0">
                                 <label for="page-name" class="col-md-3 col-form-label">
-                                    <t t-esc="field_name"/>:
+                                    <t t-esc="field_name"/>
                                 </label>
                                 <div class="col-md-9">
                                     <input t-if="field_type == 'input'" type="text" class="form-control" required="required"/>
@@ -23,8 +23,8 @@
                         </form>
                     </main>
                     <footer class="modal-footer">
-                        <button type="button" class="btn btn-primary btn-continue">Continue</button>
-                        <button type="button" class="btn btn-secondary" data-dismiss="modal" aria-label="Cancel">Cancel</button>
+                        <button type="button" class="btn btn-primary btn-continue"><t t-esc="btn_primary_title"/></button>
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal" aria-label="Cancel"><t t-esc="btn_secondary_title"/></button>
                     </footer>
                 </div>
             </div>

--- a/addons/website/views/assets.xml
+++ b/addons/website/views/assets.xml
@@ -82,6 +82,7 @@
         <script type="text/javascript" src="/website/static/src/js/utils.js"/>
 
         <script type="text/javascript" src="/website/static/src/js/content/website_root.js"/>
+        <script type="text/javascript" src="/website/static/src/js/widgets/fullscreen_indication.js"/>
         <script type="text/javascript" src="/website/static/src/js/content/compatibility.js"/>
         <script type="text/javascript" src="/website/static/src/js/content/menu.js"/>
         <script type="text/javascript" src="/website/static/src/js/content/snippets.animation.js"/>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -5,9 +5,8 @@
 <template id="snippets" inherit_id="web_editor.snippets" primary="True" groups="base.group_user">
     <xpath expr="//div[@id='snippets_menu']" position="inside">
         <button type="button" tabindex="3" class="o_we_customize_theme_btn text-uppercase"
-                data-title="Customize your theme"
                 groups="website.group_website_designer" accesskey="2">
-            <span>Options</span>
+            <span>Theme</span>
         </button>
     </xpath>
     <xpath expr="//t[@id='default_snippets']" position="replace">

--- a/addons/website_sale/static/src/js/website_sale.editor.js
+++ b/addons/website_sale/static/src/js/website_sale.editor.js
@@ -28,7 +28,7 @@ WebsiteNewMenu.include({
         return wUtils.prompt({
             id: "editor_new_product",
             window_title: _t("New Product"),
-            input: _t("Name"),
+            input: _t("Product Name"),
         }).then(function (result) {
             if (!result.val) {
                 return;


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Improve onboarding of new users to the website builder by making some layout quick wins.
Also trying to make the tool as consistent as possible.

Current behavior before PR:
Hex color is not selected when clicking on it

Desired behavior after PR is merged:
Hex color is selected when clicking on it
Options tab label is renamed Themed
When creating a product Continue button is renamed Create
An indication is displayed when the user enters fullscreen


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
