### PR TITLE
[IMP] auth_signup : add hook to add custom fields

### DIFF
--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -115,10 +115,13 @@ class AuthSignupHome(Home):
                 qcontext['error'] = _("Invalid signup token")
                 qcontext['invalid_token'] = True
         return qcontext
+    
+    def _allowed_field_signup(self):
+        return ('login', 'name', 'password')
 
     def do_signup(self, qcontext):
         """ Shared helper that creates a res.partner out of a token """
-        values = { key: qcontext.get(key) for key in ('login', 'name', 'password') }
+        values = { key: qcontext.get(key) for key in self._allowed_field_signup() }
         if not values:
             raise UserError(_("The form was not properly filled in."))
         if values.get('password') != qcontext.get('confirm_password'):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In case you want add some custom field during sign up, you should override all method.

@odony 

Note : can be merge in master


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
