### PR TITLE
[12.0] purchase: recover vendor bill auto-complete by vendor reference

### DIFF
--- a/addons/purchase/report/purchase_bill.py
+++ b/addons/purchase/report/purchase_bill.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, tools
+from odoo.osv import expression
 from odoo.tools import formatLang
 
 class PurchaseBillUnion(models.Model):
@@ -53,3 +54,12 @@ class PurchaseBillUnion(models.Model):
             name += ': ' + formatLang(self.env, amount, monetary=True, currency_obj=doc.currency_id)
             result.append((doc.id, name))
         return result
+
+    @api.model
+    def _name_search(self, name, args=None, operator='ilike', limit=100, name_get_uid=None):
+        args = args or []
+        domain = []
+        if name:
+            domain = ['|', ('name', operator, name), ('reference', operator, name)]
+        purchase_bills_union_ids = self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
+        return self.browse(purchase_bills_union_ids).name_get()


### PR DESCRIPTION
What are the steps to reproduce your issue?

- Create a purchase order and set whatever vendor reference (i.e: 123456)

- Receive the products

- Go to Vendor Bills and create a new vendor Bill.

- In the Auto-Complete field, try to type the vendor reference.

What is the current behavior that you observe?

It's not possible to find a purchase order by vendor reference, only by Odoo sequence.

What would be your expected behavior in this case?

This is not very convenient in this case, as this is the reference that we'll have in every document the supplier gives us.

It used to be searchable up to v11

opw-27434

cc @Tecnativa TT27434



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
