### PR TITLE
[FIX] account: remove constraint on bank statement line amount = 0

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -809,18 +809,12 @@ class AccountBankStatementLine(models.Model):
     @api.constrains('amount', 'amount_currency', 'currency_id', 'foreign_currency_id', 'journal_id')
     def _check_amounts_currencies(self):
         ''' Ensure the consistency the specified amounts and the currencies. '''
-        if self._context.get('skip_check_amounts_currencies'):
-            return
 
         for st_line in self:
             if st_line.journal_id != st_line.statement_id.journal_id:
                 raise ValidationError(_('The journal of a statement line must always be the same as the bank statement one.'))
-            if st_line.currency_id.is_zero(st_line.amount):
-                raise ValidationError(_("The amount of a statement line can't be equal to zero."))
             if st_line.foreign_currency_id == st_line.currency_id:
                 raise ValidationError(_("The foreign currency must be different than the journal one: %s", st_line.currency_id.name))
-            if st_line.foreign_currency_id and st_line.foreign_currency_id.is_zero(st_line.amount_currency):
-                raise ValidationError(_("The amount in foreign currency must be set if the amount is not equal to zero."))
             if not st_line.foreign_currency_id and st_line.amount_currency:
                 raise ValidationError(_("You can't provide an amount in foreign currency without specifying a foreign currency."))
 

--- a/addons/account/tests/test_account_bank_statement.py
+++ b/addons/account/tests/test_account_bank_statement.py
@@ -538,7 +538,7 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
     def test_zero_amount_journal_curr_1_statement_curr_2(self):
         self.bank_journal_2.currency_id = self.currency_1
 
-        statement = self.env['account.bank.statement'].with_context(skip_check_amounts_currencies=True).create({
+        statement = self.env['account.bank.statement'].create({
             'name': 'test_statement',
             'date': '2019-01-01',
             'journal_id': self.bank_journal_2.id,
@@ -562,7 +562,7 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
     def test_zero_amount_currency_journal_curr_1_statement_curr_2(self):
         self.bank_journal_2.currency_id = self.currency_1
 
-        statement = self.env['account.bank.statement'].with_context(skip_check_amounts_currencies=True).create({
+        statement = self.env['account.bank.statement'].create({
             'name': 'test_statement',
             'date': '2019-01-01',
             'journal_id': self.bank_journal_2.id,
@@ -586,7 +586,7 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
     def test_zero_amount_journal_curr_2_statement_curr_1(self):
         self.bank_journal_2.currency_id = self.currency_2
 
-        statement = self.env['account.bank.statement'].with_context(skip_check_amounts_currencies=True).create({
+        statement = self.env['account.bank.statement'].create({
             'name': 'test_statement',
             'date': '2019-01-01',
             'journal_id': self.bank_journal_2.id,
@@ -610,7 +610,7 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
     def test_zero_amount_currency_journal_curr_2_statement_curr_1(self):
         self.bank_journal_2.currency_id = self.currency_2
 
-        statement = self.env['account.bank.statement'].with_context(skip_check_amounts_currencies=True).create({
+        statement = self.env['account.bank.statement'].create({
             'name': 'test_statement',
             'date': '2019-01-01',
             'journal_id': self.bank_journal_2.id,
@@ -634,7 +634,7 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
     def test_zero_amount_journal_curr_2_statement_curr_3(self):
         self.bank_journal_2.currency_id = self.currency_2
 
-        statement = self.env['account.bank.statement'].with_context(skip_check_amounts_currencies=True).create({
+        statement = self.env['account.bank.statement'].create({
             'name': 'test_statement',
             'date': '2019-01-01',
             'journal_id': self.bank_journal_2.id,
@@ -658,7 +658,7 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
     def test_zero_amount_currency_journal_curr_2_statement_curr_3(self):
         self.bank_journal_2.currency_id = self.currency_2
 
-        statement = self.env['account.bank.statement'].with_context(skip_check_amounts_currencies=True).create({
+        statement = self.env['account.bank.statement'].create({
             'name': 'test_statement',
             'date': '2019-01-01',
             'journal_id': self.bank_journal_2.id,
@@ -703,23 +703,10 @@ class TestAccountBankStatementLine(TestAccountBankStatementCommon):
 
         # ==== Test constraints at creation ====
 
-        # Amount can't be 0.0 on a statement line.
-        assertStatementLineConstraint(statement_vals, {
-            **statement_line_vals,
-            'amount': 0.0,
-        })
-
         # Foreign currency must not be the same as the journal one.
         assertStatementLineConstraint(statement_vals, {
             **statement_line_vals,
             'foreign_currency_id': self.currency_1.id,
-        })
-
-        # Can't have amount_currency = 0.0 with a specified foreign currency.
-        assertStatementLineConstraint(statement_vals, {
-            **statement_line_vals,
-            'foreign_currency_id': self.currency_2.id,
-            'amount_currency': 0.0,
         })
 
         # Can't have a stand alone amount in foreign currency without foreign currency set.


### PR DESCRIPTION
A former constraint made it impossible to import bank statements with lines = 0.
The task #2403369 removed that constraint.
But the user could no longer reconcile Bank Statement Lines = 0.

Drawbacks :
- The user is then blocked when setting a lock date.
- The bank statement remains endlessly in Status Processing

A previous fix made a bank statement line = 0 immediately reconciled.

Closes task #2449127.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
