### PR TITLE
[FIX] l10n_in: If vat is not available in delivery address then check same in customer

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -105,7 +105,9 @@ class AccountMove(models.Model):
                 move.l10n_in_state_id = company_unit_partner.state_id
 
             shipping_partner = move._l10n_in_get_shipping_partner()
-            move.l10n_in_gstin = move._l10n_in_get_shipping_partner_gstin(shipping_partner)
+            # In case of shipping address does not have GSTN then also check customer(partner_id) GSTN
+            # This happens when Bill-to Ship-to transaction where shipping(Ship-to) address is unregistered and customer(Bill-to) is registred.
+            move.l10n_in_gstin = move._l10n_in_get_shipping_partner_gstin(shipping_partner) or move.partner_id.vat
             if not move.l10n_in_gstin and move.l10n_in_gst_treatment in ['regular', 'composition', 'special_economic_zone', 'deemed_export']:
                 raise ValidationError(_(
                     "Partner %(partner_name)s (%(partner_id)s) GSTIN is required under GST Treatment %(name)s",


### PR DESCRIPTION
The below case is not working before this commit:
when Bill to Ship to where Delivery address partner is not registered and not have GSTIN

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
