### PR TITLE
[IMP] auth_signup : add hook to add custom fields

### DIFF
--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -116,8 +116,7 @@ class AuthSignupHome(Home):
                 qcontext['invalid_token'] = True
         return qcontext
 
-    def do_signup(self, qcontext):
-        """ Shared helper that creates a res.partner out of a token """
+    def _prepare_signup_values(self, qcontext):
         values = { key: qcontext.get(key) for key in ('login', 'name', 'password') }
         if not values:
             raise UserError(_("The form was not properly filled in."))
@@ -127,6 +126,11 @@ class AuthSignupHome(Home):
         lang = request.context.get('lang', '')
         if lang in supported_lang_codes:
             values['lang'] = lang
+        return values
+
+    def do_signup(self, qcontext):
+        """ Shared helper that creates a res.partner out of a token """
+        values = self._prepare_signup_values(qcontext)
         self._signup_with_values(qcontext.get('token'), values)
         request.env.cr.commit()
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In case you want add some custom field during sign up, you should override all method.

@odony



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
