### PR TITLE
[IMP] mass_mailing: protect "opt-out-ness" of contacts on mailing lis…

### DIFF
--- a/addons/mass_mailing/models/mailing_contact.py
+++ b/addons/mass_mailing/models/mailing_contact.py
@@ -31,13 +31,17 @@ class MassMailingContactListRel(models.Model):
     def create(self, vals_list):
         now = fields.Datetime.now()
         for vals in vals_list:
-            if 'opt_out' in vals:
+            if 'opt_out' in vals and 'unsubscription_date' not in vals:
                 vals['unsubscription_date'] = now if vals['opt_out'] else False
+            if vals.get('unsubscription_date'):
+                vals['opt_out'] = True
         return super().create(vals_list)
 
     def write(self, vals):
-        if 'opt_out' in vals:
+        if 'opt_out' in vals and 'unsubscription_date' not in vals:
             vals['unsubscription_date'] = fields.Datetime.now() if vals['opt_out'] else False
+        if vals.get('unsubscription_date'):
+            vals['opt_out'] = True
         return super(MassMailingContactListRel, self).write(vals)
 
 

--- a/addons/mass_mailing/models/mailing_list.py
+++ b/addons/mass_mailing/models/mailing_list.py
@@ -22,11 +22,11 @@ class MassMailingList(models.Model):
     contact_pct_bounce = fields.Float(compute="_compute_mailing_list_statistics", string="Percentage of Bouncing")
     contact_ids = fields.Many2many(
         'mailing.contact', 'mailing_contact_list_rel', 'list_id', 'contact_id',
-        string='Mailing Lists')
+        string='Mailing Lists', copy=False)
     mailing_count = fields.Integer(compute="_compute_mailing_list_count", string="Number of Mailing")
-    mailing_ids = fields.Many2many('mailing.mailing', 'mail_mass_mailing_list_rel', string='Mass Mailings')
+    mailing_ids = fields.Many2many('mailing.mailing', 'mail_mass_mailing_list_rel', string='Mass Mailings', copy=False)
     subscription_ids = fields.One2many('mailing.contact.subscription', 'list_id',
-        string='Subscription Information')
+        string='Subscription Information', copy=True)
     is_public = fields.Boolean(default=True, help="The mailing list can be accessible by recipient in the unsubscription"
                                                   " page to allows him to update his subscription preferences.")
 
@@ -108,6 +108,13 @@ class MassMailingList(models.Model):
 
     def name_get(self):
         return [(list.id, "%s (%s)" % (list.name, list.contact_count)) for list in self]
+
+    def copy(self, default=None):
+        self.ensure_one()
+
+        default = dict(default or {},
+                       name=_('%s (copy)', self.name),)
+        return super(MassMailingList, self).copy(default)
 
     # ------------------------------------------------------
     # ACTIONS


### PR DESCRIPTION
…t duplication

before this commit, on duplication, the contacts who opted-out
from the original list have the opt-out field set to False on
the duplicated list.

after this commit,on duplication, for a contact who has opted-out
from the original list,the opt-out field will be set to True
on the duplicated list, because, when a recepient opt-out
from a mailing list, chances are high that he does not want
to be included in the new duplicated list.

Task-2431383

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
