### PR TITLE
[FIX] account: clearer bank account holder validation message

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -9577,7 +9577,9 @@ msgstr ""
 #. module: account
 #: code:addons/account/models/account.py:564
 #, python-format
-msgid "The holder of a journal's bank account must be the company (%s)."
+msgid "The holder of the bank account of a \"Bank\" type journal must be the company (%s).\n"
+"However, the holder of \"%s\" is \"%s\".\n"
+"Please select another bank account or change the holder of \"%s\"."
 msgstr ""
 
 #. module: account

--- a/addons/account/models/account.py
+++ b/addons/account/models/account.py
@@ -573,7 +573,10 @@ class AccountJournal(models.Model):
             # A bank account can belong to a customer/supplier, in which case their partner_id is the customer/supplier.
             # Or they are part of a bank journal and their partner_id must be the company's partner_id.
             if self.bank_account_id.partner_id != self.company_id.partner_id:
-                raise ValidationError(_('The holder of a journal\'s bank account must be the company (%s).') % self.company_id.name)
+                raise ValidationError(_('The holder of the bank account of a "Bank" type journal must be the company (%s).\n'
+                                        'However, the holder of "%s" is "%s".\n'
+                                        'Please select another bank account or change the holder of "%s".'
+                                        ) % (self.company_id.name, self.bank_account_id.acc_number, self.bank_account_id.partner_id.name, self.bank_account_id.acc_number))
 
     @api.onchange('default_debit_account_id')
     def onchange_debit_account_id(self):


### PR DESCRIPTION


Steps:
- Go to Accounting > Configuration > Accounting > Bank Accounts
- Create a new Bank Account
  - "Bank Account" field: create and edit a new one
    - Account Holder: Anyone but your company
- Save

Bug:
Validation Error: The holder of a journal's bank account must be the
company (YourCompany).

Explanation:
The error is not clear enough. Users may be confused because this
validation error appears upon saving a "Bank Account Journal" 
(`account.journal`) but is talking about "Partner Bank Account"
(`res.partner.bank`) which is a field of the "Bank Account Journal".

opw:2448183

