### PR TITLE
[FIX] pos_cash_rounding: fix cash rounding for cash method only

### DIFF
--- a/addons/pos_cash_rounding/models/pos_order.py
+++ b/addons/pos_cash_rounding/models/pos_order.py
@@ -9,16 +9,20 @@ class PosOrder(models.Model):
 
 
     def _get_rounded_amount(self, amount):
-        if self.config_id.cash_rounding:
+        if self.config_id.cash_rounding and (
+                not self.config_id.only_round_cash_method or self.payment_ids.filtered(lambda p: p.payment_method_id.is_cash_count)):
             amount = float_round(amount, precision_rounding=self.config_id.rounding_method.rounding, rounding_method=self.config_id.rounding_method.rounding_method)
         return super(PosOrder, self)._get_rounded_amount(amount)
 
     def _prepare_invoice_vals(self):
         vals = super(PosOrder, self)._prepare_invoice_vals()
-        vals['invoice_cash_rounding_id'] = self.config_id.rounding_method.id
+        if self.config_id.cash_rounding and (
+                not self.config_id.only_round_cash_method or self.payment_ids.filtered(lambda p: p.payment_method_id.is_cash_count)):
+            vals['invoice_cash_rounding_id'] = self.config_id.rounding_method.id
         return vals
 
     def _get_amount_receivable(self):
-        if self.config_id.cash_rounding:
+        if self.config_id.cash_rounding and (
+                not self.config_id.only_round_cash_method or self.payment_ids.filtered(lambda p: p.payment_method_id.is_cash_count)):
             return self.amount_paid
         return super(PosOrder, self)._get_amount_receivable()


### PR DESCRIPTION
- Go to Point of Sale > Configuration > Settings & enable "Cash Rounding"
- Configure POS:
  * Enable Invoicing
  * Enable "Cash Rounding" and "Only on cash methods"
  * Select 0.05 HALF-UP Rounding Method
- Start POS session
- Select a Product and change its Price to a value that should be rounded (i.e. $ 16.51)
- Select a Customer
- Proceed to Payment
- Enable Invoice
- Select Bank Payment method
- Validate
An error is raised: "Could not fully process the POS Order: Order / is not fully paid.".
And a popup is diplayed: "Please print the invoice from backend"

The issue comes from the fact that amount is also rounded for other payment methods
than cash, even if "Only on cash methods" has been enabled.

opw-2449222

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
