### PR TITLE
[FIX] registry: do not signal a phantom cache clear on load

### DIFF
--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -601,7 +601,11 @@ class Registry(Mapping):
             elif self.cache_sequence != c:
                 _logger.info("Invalidating all model caches after database signaling.")
                 self.clear_caches()
-                self.cache_invalidated = False
+
+            # prevent re-signaling the clear_caches() above, or any residual one that
+            # would be inherited from the master process (first request in pre-fork mode)
+            self.cache_invalidated = False
+
             self.registry_sequence = r
             self.cache_sequence = c
 

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -219,7 +219,9 @@ class Registry(Mapping):
         """
         from .. import models
 
-        self.clear_caches()
+        # clear cache to ensure consistency, but do not signal it
+        self.__cache.clear()
+
         lazy_property.reset_all(self)
 
         # Instantiate registered classes (via the MetaModel automatic discovery
@@ -244,7 +246,9 @@ class Registry(Mapping):
             for model in env.values():
                 model._unregister_hook()
 
-        self.clear_caches()
+        # clear cache to ensure consistency, but do not signal it
+        self.__cache.clear()
+
         lazy_property.reset_all(self)
         self.registry_invalidated = True
 


### PR DESCRIPTION
During loading, the registry clears all `ormcache` data multiple times, in order to ensure consistency with the newly loaded module data.

This is done by calling `self.clear_cache()`, with the side-effect of signalling to all other worker processes that the cache *needs* to be invalidated, which is untrue.

If the other workers have any reason to reload their own registries, they will also clear their own cache in the process - there is no need to forcefully invalidate it globally.

One could think that combining the pre-fork mode with the `-d <db>` parameter would mitigate this issue, by making all workers inherit from a fully loaded registry, In reality it doesn't work, because they also inherit from the `cache_invalidated=True` flag, that was never cleared in the master process. So despite having a fully loaded registry, the newly forked workers will signal a cache invalidation upon serving their first request.

Further, in a multi-tenant setup with large numbers of databases, registries may be recycled and loaded much more frequently than new workers are starting, due to the limited registry LRU, amplifying this effect a bit.

~~

This patch directly clears the cache LRU without going through `clear_cache()`, avoiding setting the `cache_invalidated` flag of the registry, and thus not signalling to other workers.

This is similar to what was being done before 083c70bbb63f27839b2c9a4b549e216947bc4dd1, where the LRU was dropped like all other lazy properties.


**Edit:** Added a second commit with a complementary approach: `check_signaling()` can always reset the `cache_invalidated` flag at the beginning of each request, after verifying that it did indeed execute any invalidation. This ensures that any future "involuntary leak" of the `cache_invalidated` flag from the master process can never trigger the problem again.


PS: a future version of the `clear_caches()` API might take a parameter to decide whether signalling is desirable.
