### PR TITLE
[FIX] hr_holidays: don't work during weekend

### DIFF
--- a/addons/hr_holidays/data/hr_holidays_demo.xml
+++ b/addons/hr_holidays/data/hr_holidays_demo.xml
@@ -81,9 +81,9 @@
         <field name="name">Doctor Appointment</field>
         <field name="holiday_status_id" ref="holiday_status_sl"/>
         <field eval="time.strftime('%Y-%m-20')" name="date_from"/>
-        <field eval="time.strftime('%Y-%m-22')" name="date_to"/>
+        <field eval="time.strftime('%Y-%m-23')" name="date_to"/>
         <field eval="time.strftime('%Y-%m-20')" name="request_date_from"/>
-        <field eval="time.strftime('%Y-%m-22')" name="request_date_to"/>
+        <field eval="time.strftime('%Y-%m-23')" name="request_date_to"/>
         <field name="number_of_days">3</field>
         <field name="employee_id" ref="hr.employee_admin"/>
         <field name="state">confirm</field>


### PR DESCRIPTION
The 20 and 21 of February 2021 are Saturday and Sunday (22 not
included as actually `2021-02-22 00:00:00`)
