### PR TITLE
fix issue of notebook page with invisiblity modifier

### DIFF
--- a/addons/web/static/src/js/views/form/form_renderer.js
+++ b/addons/web/static/src/js/views/form/form_renderer.js
@@ -865,12 +865,20 @@ var FormRenderer = BasicRenderer.extend({
                 callback: function (element, modifiers) {
                     // if the active tab is invisible, activate the first visible tab instead
                     var $link = element.$el.find('.nav-link');
+                    var $firstVisibleTab = $headers.find('li:not(.o_invisible_modifier):first() > a');
                     if (modifiers.invisible && $link.hasClass('active')) {
                         $link.removeClass('active');
                         tab.$page.removeClass('active');
-                        var $firstVisibleTab = $headers.find('li:not(.o_invisible_modifier):first() > a');
                         $firstVisibleTab.addClass('active');
                         $pages.find($firstVisibleTab.attr('href')).addClass('active');
+                    }
+                    if (!modifiers.invisible) {
+                        // make first page active if there is only one page to display
+                        var $visibleTabs = $headers.find('li:not(.o_invisible_modifier)');
+                        if ($visibleTabs.length === 1) {
+                            $firstVisibleTab.addClass('active');
+                            $pages.find($firstVisibleTab.attr('href')).addClass('active');
+                        }
                     }
                 },
             });

--- a/addons/web/static/tests/views/form_tests.js
+++ b/addons/web/static/tests/views/form_tests.js
@@ -606,6 +606,42 @@ QUnit.module('Views', {
         form.destroy();
     });
 
+    QUnit.test('invisible attrs on notebook page which has only one page', function (assert) {
+        assert.expect(4);
+
+        var form = createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: '<form string="Partners">' +
+                    '<sheet>' +
+                        '<field name="bar"/>' +
+                        '<notebook>' +
+                            '<page string="Foo" attrs=\'{"invisible": [["bar", "!=", false]]}\'>' +
+                                '<field name="foo"/>' +
+                            '</page>' +
+                        '</notebook>' +
+                    '</sheet>' +
+                '</form>',
+            res_id: 1,
+        });
+
+        form.$buttons.find('.o_form_button_edit').click();
+        assert.notOk(form.$('.o_notebook .nav .nav-link:first()').hasClass('active'),
+            'first tab should not be active');
+        assert.ok(form.$('.o_notebook .nav .nav-item:first()').hasClass('o_invisible_modifier'),
+            'first tab should be invisible');
+
+        // enable checkbox
+        form.$('.o_field_boolean input').click();
+        assert.ok(form.$('.o_notebook .nav .nav-link:first()').hasClass('active'),
+            'first tab should be active');
+        assert.notOk(form.$('.o_notebook .nav .nav-item:first()').hasClass('o_invisible_modifier'),
+            'first tab should be visible');
+
+        form.destroy();
+    });
+
     QUnit.test('first notebook page invisible', function (assert) {
         assert.expect(2);
 


### PR DESCRIPTION
PURPOSE
When there is only one page in the notebook tag and there is a boolean field in the form to show/hide that notebook page based on invisibility attrs, if we toggle boolean field notebook hides, that's OK but when we toggle boolean field again then notebook page is displayed but it is not active and due to that content of notebook page is not displayed.

SPEC
When there is only one page in the notebook and it has attrs for invisibility, when we toggle boolean field to hide/show notebook page then notebook page, as well as content, is toggled.

TASK 2449053


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
