### PR TITLE
[FIX] account: set printed invoice as main attachment

### DIFF
--- a/addons/account/models/ir_actions_report.py
+++ b/addons/account/models/ir_actions_report.py
@@ -29,4 +29,7 @@ class IrActionsReport(models.Model):
         # don't save the 'account.report_original_vendor_bill' report as it's just a mean to print existing attachments
         if self.report_name == 'account.report_original_vendor_bill':
             return None
-        return super(IrActionsReport, self).postprocess_pdf_report(record, buffer)
+        res = super(IrActionsReport, self).postprocess_pdf_report(record, buffer)
+        if self.model == 'account.move' and record.is_sale_document(include_receipts=True):
+            self.retrieve_attachment(record).register_as_main_attachment(force=False)
+        return res


### PR DESCRIPTION
When printing some invoices, they are not registered as main
attachment. Therefore, when sending a follow-up report, a UserError
message asks the user to print the invoices first.

To reproduce the error:
(Need account_accountant, use demo data)
1. Go to Accounting > Configuration > Invoicing > Follow-up Levels
2. Select "First Reminder Email"
3. Enable "Join open Invoices"
4. Create an invoice INV01 for customer C01 + Post INV01
5. Go back to Accounting > Customers > Invoices, select INV01
	- ! Do not open the invoice. Just select it.
6. Print > Invoices
7. Go to Follow-up Reports
8. Select C01
9. Send by mail

Error: An error message is displayed: "You are trying to send a followup
report to a partner for which you didn't print all the invoices" but it
does not make sense because the invoice has been printed.

For a follow-up report to be sent, the invoices must have the field
`message_main_attachment_id` defined (see [code](https://github.com/odoo/enterprise/blob/476d862aba396c54c7a47950e02af7aed008a2db/account_followup/models/account_followup_report.py#L311-L313)).
There are two ways for this field to be set:
- When sending the invoice, `_message_set_main_attachment_id` is called,
selects one attachment and marks it as main one
https://github.com/odoo/odoo/blob/437b49860b46b5abb8f55ced349fece984968998/addons/mail/models/mail_thread.py#L1918-L1924
- When opening the invoice, if the screen is large enough, a pdf viewer
is opened next to the invoice. This pdf viewer will call
`register_as_main_attachment`, the latter marks the `ir_attachment` as
main one:
https://github.com/odoo/odoo/blob/e6a41b118a94c5b101d127f6b70fc54958e9346b/addons/mail/models/ir_attachment.py#L17-L20

However, when the user only prints an invoice, nothing will set the
`message_main_attachment_id` field. Thus, this fix will call
`register_as_main_attachment` when a pdf is generated and will mark it
as main attachment.

OPW-2427247