### PR TITLE
[FIX] stock_account: Update standard price from import

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -171,6 +171,15 @@ class ProductProduct(models.Model):
                 vals.update(fifo_vals)
         return vals
 
+    def write(self, vals):
+        res = super(ProductProduct, self).write(vals)
+        if self.env.context.get('import_file') and not self.env.context.get('import_standard_price'):
+            if 'standard_price' in vals:
+                for product in self:
+                    counterpart_account_id = product.property_account_expense_id.id or product.categ_id.property_account_expense_categ_id.id
+                    product.with_context(import_standard_price=True)._change_standard_price(vals['standard_price'], counterpart_account_id)
+        return res
+
     def _change_standard_price(self, new_price, counterpart_account_id=False):
         """Helper to create the stock valuation layers and the account moves
         after an update of standard price.


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a storable product P with cost = 10€
- Let's update quantity to 10 units
- Export an update of P in an xlsx file F
- Change in F the cost of P from 10€ to 20€
- Import F
- Go to Inventory valuation

Bug:

The valuation of P was still 100€ instead of 200€

opw:2424292