### PR TITLE
[FIX] im_livechat: smiley feedback correspond to choice


### DIFF
--- a/addons/im_livechat/static/src/legacy/public_livechat.js
+++ b/addons/im_livechat/static/src/legacy/public_livechat.js
@@ -22,8 +22,8 @@ var LIVECHAT_COOKIE_HISTORY = 'im_livechat_history';
 var HISTORY_LIMIT = 15;
 
 var RATING_TO_EMOJI = {
-    "10": "😊",
-    "5": "😐",
+    "5": "😊",
+    "3": "😐",
     "1": "😞"
 };
 


### PR DESCRIPTION

When a user on website sends livechat feedbacks:

- Good -> send an average smiley 😐
- Average -> send ?? instead of smiley

This is because in e4a4ffb value of good (😊) was changed from 10 to 5,
and value for average (😐) was changed from 5 to 3, but it was not
refelcted in one part of the code.

opw-2447246
