### PR TITLE
[FIX] crm: repositioning the tour bubble 

### DIFF
--- a/addons/crm/static/src/js/tours/crm.js
+++ b/addons/crm/static/src/js/tours/crm.js
@@ -44,7 +44,7 @@ tour.register('crm_tour', {
     trigger: ".o_opportunity_kanban .o_kanban_group:first-child .o_kanban_record:last-child .oe_kanban_content",
     extra_trigger: ".o_opportunity_kanban",
     content: _t("<b>Drag &amp; drop opportunities</b> between columns as you progress in your sales cycle."),
-    position: "bottom",
+    position: "right",
     run: "drag_and_drop .o_opportunity_kanban .o_kanban_group:eq(2) ",
 }, {
     trigger: ".o_kanban_record:not(.o_updating) .o_activity_color_default",


### PR DESCRIPTION
During this step of the tour, we want the user to drag
and drop the card. But one should still be able to schedule
an activity. The tour should never prevent you from doing something.

In this commit the possition of the bubble is changed from
bottom to the right of the card, thus it will not prevent
users from scheduling activities.

task-id: 2449223
