### PR TITLE
[FIX] web: Many2ManyTags: no crash when focusing out

### DIFF
--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -770,7 +770,7 @@ var FieldMany2One = AbstractField.extend({
         }
         const firstValue = this.suggestions.find(s => s.id);
         if (firstValue) {
-            this.reinitialize(firstValue.id);
+            this.reinitialize({ id: firstValue.id, display_name: firstValue.name });
         } else if (this.can_create) {
             new M2ODialog(this, this.string, this.$input.val()).open();
         }

--- a/addons/web/static/tests/fields/relational_fields_tests.js
+++ b/addons/web/static/tests/fields/relational_fields_tests.js
@@ -2016,6 +2016,30 @@ QUnit.module('relational_fields', {
         form.destroy();
     });
 
+    QUnit.test("select a many2many value by focusing out", async function (assert) {
+        assert.expect(4);
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: `<form><field name="timmy" widget="many2many_tags"/></form>`,
+        });
+
+        assert.containsNone(form, '.o_field_many2manytags .badge');
+
+        form.$('.o_field_many2manytags input').focus().val('go').trigger('input').trigger('keyup');
+        await testUtils.nextTick();
+        form.$('.o_field_many2manytags input').trigger('blur');
+        await testUtils.nextTick();
+
+        assert.containsNone(document.body, '.modal');
+        assert.containsOnce(form, '.o_field_many2manytags .badge');
+        assert.strictEqual(form.$('.o_field_many2manytags .badge').text().trim(), 'gold');
+
+        form.destroy();
+    });
+
     QUnit.module('FieldRadio');
 
     QUnit.test('fieldradio widget on a many2one in a new record', async function (assert) {


### PR DESCRIPTION
Commit [1] improves the focusout case of the Many2One field: if
the user typed something in the input that matches some records
(i.e. if there are records in the suggestion dropdown), the first
one is automatically set.

The Many2ManyTags field internally uses a FieldMany2One. However,
the same scenario inside a Many2ManyTags crashed. The reason is
that we sent the wrong value in this case (an id, instead of an
object).

[1] https://github.com/odoo/odoo/commit/1d4d2a6

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
