### PR TITLE
[FIX] product: property_product_pricelist of a partner child

### DIFF
--- a/addons/product/models/res_partner.py
+++ b/addons/product/models/res_partner.py
@@ -15,6 +15,15 @@ class Partner(models.Model):
         help="This pricelist will be used, instead of the default one, for sales to the current partner")
 
     @api.multi
+    def write(self, vals):
+        if 'parent_id' in vals:
+            Property = self.env['ir.property'].with_context(force_company=self.env.user.company_id.id)
+            properties = Property.get_multi('property_product_pricelist', 'res.partner', self.ids)
+            for partner_id in self.ids:
+                properties[partner_id].unlink()
+        return super(Partner, self).write(vals)
+
+    @api.multi
     @api.depends('country_id')
     def _compute_product_pricelist(self):
         company = self.env.context.get('force_company', False)


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a country group CG with one country C
- Let's consider two pricelists PL1 (with sequence=5), PL2 (with sequence=10)
- PL1, PL2 have both CG as country group
- Create a company partner Co with C as country (PL1 will be set automatically)
- Create a child partner Ch with Co as parent_id ("Pricelists are managed on the parent company" will be written)
- Change sequence of PL1 with 10 and PL2 with 5
- Create a sale order SO1 with Ch as partner

Bug:

PL1 is suggested on the SO1 instead of PL2 (because a property with PL1 is set on Ch)

When creating a sale order SO2 with Co as partner, PL2 is suggested as pricelist

PS: On the contact form of Ch, it's written on the field pricelist:

"Pricelists are managed on the parent company"

opw:2414032