### PR TITLE
[IMP] utm*: Improve utm campaigns filtering

### DIFF
--- a/addons/mass_mailing/data/mass_mailing_demo.xml
+++ b/addons/mass_mailing/data/mass_mailing_demo.xml
@@ -70,6 +70,7 @@
             <field name="stage_id" ref="utm.campaign_stage_1"/>
             <field name="user_id" ref="base.user_admin"/>
             <field name="tag_ids" eval="[(6,0,[ref('utm.utm_tag_1')])]"/>
+            <field name="is_relevant" eval="True"/>
         </record>
 
         <record id="mass_mail_1" model="mailing.mailing">

--- a/addons/mass_mailing/views/utm_campaign_views.xml
+++ b/addons/mass_mailing/views/utm_campaign_views.xml
@@ -100,7 +100,8 @@
             Campaigns are the perfect tool to track results across multiple mailings.
             </p>
         </field>
-        <field name="domain">[('is_website', '=', False)]</field>
+        <field name="domain">[('is_relevant', '=', True)]</field>
+        <field name="context">{'default_is_relevant': True}</field>
     </record>
 
     <menuitem name="Campaigns" id="menu_email_campaigns"

--- a/addons/mass_mailing_sms/data/utm_demo.xml
+++ b/addons/mass_mailing_sms/data/utm_demo.xml
@@ -9,5 +9,6 @@
         <field name="stage_id" ref="utm.campaign_stage_1"/>
         <field name="user_id" ref="base.user_admin"/>
         <field name="tag_ids" eval="[(4, ref('mailing_tag_0')), (4, ref('utm.utm_tag_1'))]"/>
+        <field name="is_relevant" eval="True"/>
     </record>
 </data></odoo>

--- a/addons/utm/__manifest__.py
+++ b/addons/utm/__manifest__.py
@@ -7,7 +7,7 @@
     'description': """
 Enable management of UTM trackers: campaign, medium, source.
 """,
-    'version': '1.0',
+    'version': '1.0.1',
     'depends': ['base', 'web'],
     'data': [
         'data/utm_data.xml',

--- a/addons/utm/data/utm_demo.xml
+++ b/addons/utm/data/utm_demo.xml
@@ -19,22 +19,18 @@
         <record model="utm.campaign" id="utm_campaign_fall_drive">
             <field name="name">Sale</field>
             <field name="stage_id" ref="utm.default_utm_stage" />
-            <field name="is_website" eval="True" />
         </record>
         <record model="utm.campaign" id="utm_campaign_christmas_special">
             <field name="name">Christmas Special</field>
             <field name="stage_id" ref="utm.default_utm_stage" />
-            <field name="is_website" eval="True" />
         </record>
         <record model="utm.campaign" id="utm_campaign_email_campaign_services">
             <field name="name">Email Campaign - Services</field>
             <field name="stage_id" ref="utm.default_utm_stage" />
-            <field name="is_website" eval="True" />
         </record>
         <record model="utm.campaign" id="utm_campaign_email_campaign_products">
             <field name="name">Email Campaign - Products</field>
             <field name="stage_id" ref="utm.default_utm_stage" />
-            <field name="is_website" eval="True" />
         </record>
     </data>
 </odoo>

--- a/addons/utm/models/utm.py
+++ b/addons/utm/models/utm.py
@@ -44,7 +44,7 @@ class UtmCampaign(models.Model):
         'utm.tag', 'utm_tag_rel',
         'tag_id', 'campaign_id', string='Tags')
 
-    is_website = fields.Boolean(default=False, help="Allows us to filter relevant Campaign")
+    is_relevant = fields.Boolean(default=False, help="Allows us to filter relevant Campaign")
     color = fields.Integer(string='Color Index')
 
     @api.model

--- a/addons/utm/models/utm_mixin.py
+++ b/addons/utm/models/utm_mixin.py
@@ -37,10 +37,7 @@ class UtmMixin(models.AbstractModel):
                     Model = self.env[field.comodel_name]
                     records = Model.search([('name', '=', value)], limit=1)
                     if not records:
-                        if 'is_website' in records._fields:
-                            records = Model.create({'name': value, 'is_website': True})
-                        else:
-                            records = Model.create({'name': value})
+                        records = Model.create({'name': value})
                     value = records.id
                 if value:
                     values[field_name] = value

--- a/addons/utm/views/utm_campaign_views.xml
+++ b/addons/utm/views/utm_campaign_views.xml
@@ -33,6 +33,7 @@
                         <field class="o_text_overflow" name="name" string="Campaign Name" placeholder="e.g. Black Friday"/>
                         <field name="user_id" domain="[('share', '=', False)]"/>
                         <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
+                        <field name="is_relevant" invisible="1"/>
                     </group>
                     <notebook>
                     </notebook>
@@ -64,6 +65,7 @@
                     <field class="o_text_overflow" name="name" string="Campaign Name" placeholder="e.g. Black Friday"/>
                     <field name="user_id" domain="[('share', '=', False)]"/>
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
+                    <field name="is_relevant" invisible="1"/>
                 </group>
             </form>
         </field>

--- a/addons/utm/views/utm_views.xml
+++ b/addons/utm/views/utm_views.xml
@@ -24,6 +24,8 @@
                 Campaigns are used to centralize your marketing efforts and track their results.
             </p>
         </field>
+        <field name="domain">[('is_relevant', '=', True)]</field>
+        <field name="context">{'default_is_relevant': True}</field>
     </record>
 
     <menuitem id="menu_utm_campaign_act"

--- a/addons/website_links/static/src/js/website_links.js
+++ b/addons/website_links/static/src/js/website_links.js
@@ -84,9 +84,6 @@ var SelectBox = publicWidget.Widget.extend({
         var args = {
             name: name
         };
-        if (this.obj === "utm.campaign"){
-            args.is_website = true;
-        }
         return this._rpc({
             model: this.obj,
             method: 'create',


### PR DESCRIPTION
This commit improves the way we define the relevancy of
an utm campaign.

Before this commit, we filtered out campaigns with a "is_website" flag
that we set as True whenever a campaign was created through the default_get
of utm mixins.

However, it came to our attention that creating a marketing campaign
from marketing_automation would still pollute the list of campaigns that we
considered relevant.

So, instead of setting the is_website flag as true and confusing people
with its naming, I replaced the field with another boolean "is_relevant"
and based the filtering on that new field.

LINKS:
TaskID: 2414694
PR: #xxxxxx





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
