### PR TITLE
[FIX] packaging: add a bom to nsi script

### DIFF
--- a/setup/win32/setup.nsi
+++ b/setup/win32/setup.nsi
@@ -1,4 +1,4 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
+﻿# Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 # TODO: Avoid to uninstall the database
 # TODO: We can update the server or the clients without to uninstall the all-in-one


### PR DESCRIPTION
When using the windows installer in French language, the `Hôte` label
used to configure postgresql server does not display correctly.

The LangString documentation does not specify how to use the special
characters but after some tests, specifying a BOM for the nsi file seems
to be the way to go.