### PR TITLE
[FIX] l10n_ch: use commercial company name in invoice PDF

### DIFF
--- a/addons/l10n_ch/models/res_bank.py
+++ b/addons/l10n_ch/models/res_bank.py
@@ -126,7 +126,7 @@ class ResPartnerBank(models.Model):
             '{:.2f}'.format(amount),                              # Amount
             currency_name,                                        # Currency
             'K',                                                  # Ultimate Debtor Address Type
-            debtor_partner.name[:71],                             # Ultimate Debtor Name
+            debtor_partner.commercial_company_name[:71],          # Ultimate Debtor Name
             debtor_addr_1,                                        # Ultimate Debtor Address Line 1
             debtor_addr_2,                                        # Ultimate Debtor Address Line 2
             '',                                                   # Ultimate Debtor Postal Code (not to be provided for address type K)

--- a/addons/l10n_ch/report/swissqr_report.xml
+++ b/addons/l10n_ch/report/swissqr_report.xml
@@ -51,7 +51,7 @@
                             </t>
 
                             <span class="swissqr_text title">Payable by</span><br/>
-                            <span class="swissqr_text content" t-field="o.partner_id.name"/><br/>
+                            <span class="swissqr_text content" t-field="o.partner_id.commercial_company_name"/><br/>
                             <span class="swissqr_text content" t-field="o.partner_id.country_id.code"/>
                             <span class="swissqr_text content" t-field="o.partner_id.zip"/>
                             <span class="swissqr_text content" t-field="o.partner_id.city"/><br/>
@@ -101,7 +101,7 @@
                             <br/>
 
                             <span class="swissqr_text title">Payable by</span><br/>
-                            <span class="swissqr_text content" t-field="o.partner_id.name"/><br/>
+                            <span class="swissqr_text content" t-field="o.partner_id.commercial_company_name"/><br/>
                             <span class="swissqr_text content" t-field="o.partner_id.street"> </span>
                             <span class="swissqr_text content" t-field="o.partner_id.street2"/><br/>
                             <span class="swissqr_text content" t-field="o.partner_id.country_id.code"/>


### PR DESCRIPTION
Steps:
- Edit the current company (1):
  - Country: Switzerland
  - Currency: CHF
- Install l10n_ch
- Go to Invoicing > Configuration > Bank Accounts
- Edit Bank:
  - Bank Account: create a new one:
    - Account Holder: (1)
- Go to Configuration > Journal
- Edit Customer Invoices:
  - Advanced Settings tab:
    - Communication Standards: Switzerland
- Go to Customers > Customers
- Create a new customer (2):
  - Fill in street, city, zip code and country
- Edit (2):
  - Contacts & Addresses tab:
    - Add:
      - Select Invoice Address
      - Contact Name: Keep this field blank
- Go to Customers > Invoices
- Create a new one:
  - Customer: "(2), Invoice Address"
  - Add a product
- Validate it
- Click Print QR-Bill

Bug:
Traceback here:
https://github.com/odoo/odoo/blob/b76e9ef658bde0178fa1660b6ad27b880e91632a/addons/l10n_ch/models/res_bank.py#L129
TypeError: 'bool' object is not subscriptable

Explanation:
The contact name of an address is optional. When nothing is filled in
that field, it returns `False`, hence the error.
Using the commercial company name ensures a name is put in the invoice,
even if the contact doesn't belong to a company.

opw:2447158