### PR TITLE
[MERGE] project: following a private project no longer required

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -24,7 +24,7 @@ class AccountAnalyticLine(models.Model):
         domain = [('allow_timesheets', '=', True)]
         if not self.user_has_groups('hr_timesheet.group_timesheet_manager'):
             return expression.AND([domain,
-                ['|', ('privacy_visibility', '!=', 'followers'), ('allowed_internal_user_ids', 'in', self.env.user.ids)]
+                ['|', ('privacy_visibility', '!=', 'followers'), ('message_partner_ids', 'in', [self.env.user.partner_id.id])]
             ])
         return domain
 
@@ -35,7 +35,7 @@ class AccountAnalyticLine(models.Model):
 
     def _domain_task_id(self):
         if not self.user_has_groups('hr_timesheet.group_hr_timesheet_approver'):
-            return ['|', ('privacy_visibility', '!=', 'followers'), ('allowed_user_ids', 'in', self.env.user.ids)]
+            return ['|', ('privacy_visibility', '!=', 'followers'), ('message_partner_ids', 'in', [self.env.user.partner_id.id])]
         return []
 
     task_id = fields.Many2one(
@@ -139,11 +139,9 @@ class AccountAnalyticLine(models.Model):
             # Then, he is internal user, and we take the domain for this current user
             return self.env['ir.rule']._compute_domain(self._name)
         return ['&',
-                    '|', '|', '|',
+                    '|',
                     ('task_id.project_id.message_partner_ids', 'child_of', [self.env.user.partner_id.commercial_partner_id.id]),
                     ('task_id.message_partner_ids', 'child_of', [self.env.user.partner_id.commercial_partner_id.id]),
-                    ('task_id.project_id.allowed_portal_user_ids', 'child_of', [self.env.user.id]),
-                    ('task_id.allowed_user_ids', 'in', [self.env.user.id]),
                 ('task_id.project_id.privacy_visibility', '=', 'portal')]
 
     def _timesheet_preprocess(self, vals):

--- a/addons/hr_timesheet/security/hr_timesheet_security.xml
+++ b/addons/hr_timesheet/security/hr_timesheet_security.xml
@@ -38,8 +38,8 @@
                 ('project_id', '!=', False),
                 '|', '|',
                     ('project_id.privacy_visibility', '!=', 'followers'),
-                    ('project_id.allowed_internal_user_ids', 'in', user.ids),
-                    ('task_id.allowed_user_ids', 'in', user.ids)
+                    ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
+                    ('task_id.message_partner_ids', 'in', [user.partner_id.id])
             ]</field>
             <field name="groups" eval="[(4, ref('group_hr_timesheet_user'))]"/>
         </record>
@@ -51,7 +51,7 @@
                 ('project_id', '!=', False),
                 '|',
                     ('project_id.privacy_visibility', '!=', 'followers'),
-                    ('project_id.allowed_internal_user_ids', 'in', user.ids)
+                    ('project_id.message_partner_ids', 'in', [user.partner_id.id])
             ]</field>
             <field name="groups" eval="[(4, ref('hr_timesheet.group_hr_timesheet_approver'))]" />
         </record>

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -203,24 +203,19 @@ class Project(models.Model):
         help="Internal email associated with this project. Incoming emails are automatically synchronized "
              "with Tasks (or optionally Issues if the Issue Tracker module is installed).")
     privacy_visibility = fields.Selection([
-            ('followers', 'Invited internal users'),
-            ('employees', 'All internal users'),
-            ('portal', 'Invited portal users and all internal users'),
+            ('followers', 'Invited employees'),
+            ('employees', 'All employees'),
+            ('portal', 'Portal users and all employees'),
         ],
         string='Visibility', required=True,
         default='portal',
         help="Defines the visibility of the tasks of the project:\n"
-                "- Invited internal users: employees may only see the followed projects and tasks.\n"
-                "- All internal users: employees may see all projects and tasks.\n"
-                "- Invited portal and all internal users: employees may see everything.\n"
-                "   Portal users may see project and tasks followed by\n"
-                "   them or by someone in their company.")
-
-    allowed_user_ids = fields.Many2many('res.users', compute='_compute_allowed_users', inverse='_inverse_allowed_user')
-    allowed_internal_user_ids = fields.Many2many('res.users', 'project_allowed_internal_users_rel',
-                                                 string="Allowed Internal Users", default=lambda self: self.env.user, domain=[('share', '=', False)])
-    allowed_portal_user_ids = fields.Many2many('res.users', 'project_allowed_portal_users_rel', string="Allowed Portal Users", domain=[('share', '=', True)])
-    doc_count = fields.Integer(compute='_compute_attached_docs_count', string="Number of Documents Attached")
+            "- Invited employees: employees may only see the followed project and tasks.\n"
+            "- All employees: employees may see all project and tasks.\n"
+            "- Portal users and all employees: employees may see everything."
+            "   Portal users may see project and tasks followed by.\n"
+            "   them or by someone of their company.")
+    doc_count = fields.Integer(compute='_compute_attached_docs_count', string="Number of documents attached")
     date_start = fields.Date(string='Start Date')
     date = fields.Date(string='Expiration Date', index=True, tracking=True)
     allow_subtasks = fields.Boolean('Sub-tasks', default=lambda self: self.env.user.has_group('project.group_subtask_project'))
@@ -280,18 +275,6 @@ class Project(models.Model):
     def _compute_alias_enabled(self):
         for project in self:
             project.alias_enabled = project.alias_domain and project.alias_id.alias_name
-
-    @api.depends('allowed_internal_user_ids', 'allowed_portal_user_ids')
-    def _compute_allowed_users(self):
-        for project in self:
-            users = project.allowed_internal_user_ids | project.allowed_portal_user_ids
-            project.allowed_user_ids = users
-
-    def _inverse_allowed_user(self):
-        for project in self:
-            allowed_users = project.allowed_user_ids
-            project.allowed_portal_user_ids = allowed_users.filtered('share')
-            project.allowed_internal_user_ids = allowed_users - project.allowed_portal_user_ids
 
     def _compute_access_url(self):
         super(Project, self)._compute_access_url()
@@ -356,27 +339,16 @@ class Project(models.Model):
         # Prevent double project creation
         self = self.with_context(mail_create_nosubscribe=True)
         project = super(Project, self).create(vals)
-        if project.privacy_visibility == 'portal' and project.partner_id.user_ids:
-            project.allowed_user_ids |= project.partner_id.user_ids
+        if project.privacy_visibility == 'portal' and project.partner_id:
+            project.message_subscribe(project.partner_id.ids)
         return project
 
     def write(self, vals):
-        allowed_users_changed = 'allowed_portal_user_ids' in vals or 'allowed_internal_user_ids' in vals
-        if allowed_users_changed:
-            allowed_users = {project: project.allowed_user_ids for project in self}
         # directly compute is_favorite to dodge allow write access right
         if 'is_favorite' in vals:
             vals.pop('is_favorite')
             self._fields['is_favorite'].determine_inverse(self)
         res = super(Project, self).write(vals) if vals else True
-
-        if allowed_users_changed:
-            for project in self:
-                permission_removed = allowed_users.get(project) - project.allowed_user_ids
-                allowed_portal_users_removed = permission_removed.filtered('share')
-                project.message_unsubscribe(partner_ids=allowed_portal_users_removed.partner_id.commercial_partner_id.ids)
-                for task in project.task_ids:
-                    task.allowed_user_ids -= permission_removed
 
         if 'allow_recurring_tasks' in vals and not vals.get('allow_recurring_tasks'):
             self.env['project.task'].search([('project_id', 'in', self.ids), ('recurring_task', '=', True)]).write({'recurring_task': False})
@@ -386,8 +358,9 @@ class Project(models.Model):
             self.with_context(active_test=False).mapped('tasks').write({'active': vals['active']})
         if vals.get('partner_id') or vals.get('privacy_visibility'):
             for project in self.filtered(lambda project: project.privacy_visibility == 'portal'):
-                project.allowed_user_ids |= project.partner_id.user_ids
-
+                project.message_subscribe(project.partner_id.ids)
+        if vals.get('privacy_visibility'):
+            self._change_privacy_visibility()
         return res
 
     def action_unlink(self):
@@ -426,7 +399,6 @@ class Project(models.Model):
     def message_subscribe(self, partner_ids=None, subtype_ids=None):
         """
         Subscribe to all existing active tasks when subscribing to a project
-        And add the portal user subscribed to allowed portal users
         """
         res = super(Project, self).message_subscribe(partner_ids=partner_ids, subtype_ids=subtype_ids)
         project_subtypes = self.env['mail.message.subtype'].browse(subtype_ids) if subtype_ids else None
@@ -434,12 +406,6 @@ class Project(models.Model):
         if not subtype_ids or task_subtypes:
             self.mapped('tasks').message_subscribe(
                 partner_ids=partner_ids, subtype_ids=task_subtypes)
-        if partner_ids:
-            all_users = self.env['res.partner'].browse(partner_ids).user_ids
-            portal_users = all_users.filtered('share')
-            internal_users = all_users - portal_users
-            self.allowed_portal_user_ids |= portal_users
-            self.allowed_internal_user_ids |= internal_users
         return res
 
     def message_unsubscribe(self, partner_ids=None):
@@ -543,6 +509,19 @@ class Project(models.Model):
             project._compute_rating_request_deadline()
             self.env.cr.commit()
 
+    # ---------------------------------------------------
+    # Privacy
+    # ---------------------------------------------------
+
+    def _change_privacy_visibility(self):
+        """
+        Unsubscribe non-internal users from the project and tasks if the project privacy visibility
+        goes to a value different than 'portal'
+        """
+        for project in self.filtered(lambda p: p.privacy_visibility != 'portal'):
+            portal_users = project.message_partner_ids.user_ids.filtered('share')
+            project.message_unsubscribe(partner_ids=portal_users.partner_id.ids)
+            project.mapped('tasks')._change_project_privacy_visibility()
 
 class Task(models.Model):
     _name = "project.task"
@@ -653,7 +632,6 @@ class Task(models.Model):
     subtask_count = fields.Integer("Sub-task Count", compute='_compute_subtask_count')
     email_from = fields.Char(string='Email From', help="These people will receive email.", index=True,
         compute='_compute_email_from', store="True", readonly=False)
-    allowed_user_ids = fields.Many2many('res.users', string="Visible to", groups='project.group_project_manager', compute='_compute_allowed_user_ids', store=True, readonly=False, copy=False)
     project_privacy_visibility = fields.Selection(related='project_id.privacy_visibility', string="Project Visibility")
     # Computed field about working time elapsed between record creation and assignation/closing.
     working_hours_open = fields.Float(compute='_compute_elapsed', string='Working Hours to Assign', store=True, group_operator="avg")
@@ -869,34 +847,11 @@ class Task(models.Model):
         if not self._check_recursion():
             raise ValidationError(_('Error! You cannot create a recursive hierarchy of tasks.'))
 
-    @api.constrains('allowed_user_ids')
-    def _check_no_portal_allowed(self):
-        for task in self.filtered(lambda t: t.project_id.privacy_visibility != 'portal'):
-            portal_users = task.allowed_user_ids.filtered('share')
-            if portal_users:
-                user_names = ', '.join(portal_users[:10].mapped('name'))
-                raise ValidationError(_("The project visibility setting doesn't allow portal users to see the project's tasks. (%s)", user_names))
-
     def _compute_attachment_ids(self):
         for task in self:
             attachment_ids = self.env['ir.attachment'].search([('res_id', '=', task.id), ('res_model', '=', 'project.task')]).ids
             message_attachment_ids = task.mapped('message_ids.attachment_ids').ids  # from mail_thread
             task.attachment_ids = [(6, 0, list(set(attachment_ids) - set(message_attachment_ids)))]
-
-    @api.depends('project_id.allowed_user_ids', 'project_id.privacy_visibility')
-    def _compute_allowed_user_ids(self):
-        for task in self:
-            portal_users = task.allowed_user_ids.filtered('share')
-            internal_users = task.allowed_user_ids - portal_users
-            if task.project_id.privacy_visibility == 'followers':
-                task.allowed_user_ids |= task.project_id.allowed_internal_user_ids
-                task.allowed_user_ids -= portal_users
-            elif task.project_id.privacy_visibility == 'portal':
-                task.allowed_user_ids |= task.project_id.allowed_portal_user_ids
-            if task.project_id.privacy_visibility != 'portal':
-                task.allowed_user_ids -= portal_users
-            elif task.project_id.privacy_visibility != 'followers':
-                task.allowed_user_ids -= internal_users
 
     @api.depends('create_date', 'date_end', 'date_assign')
     def _compute_elapsed(self):
@@ -1017,17 +972,6 @@ class Task(models.Model):
             empty_list_help_document_name=tname,
         )
         return super(Task, self).get_empty_list_help(help)
-
-    def message_subscribe(self, partner_ids=None, subtype_ids=None):
-        """
-        Add the users subscribed to allowed portal users
-        """
-        res = super(Task, self).message_subscribe(partner_ids=partner_ids, subtype_ids=subtype_ids)
-        if partner_ids:
-            new_allowed_users = self.env['res.partner'].browse(partner_ids).user_ids.filtered('share')
-            tasks = self.filtered(lambda task: task.project_id.privacy_visibility == 'portal')
-            tasks.sudo().write({'allowed_user_ids': [(4, user.id) for user in new_allowed_users]})
-        return res
 
     # ----------------------------------------
     # Case management
@@ -1266,28 +1210,19 @@ class Task(models.Model):
         self.ensure_one()
 
         project_user_group_id = self.env.ref('project.group_project_user').id
-
-        group_func = lambda pdata: pdata['type'] == 'user' and project_user_group_id in pdata['groups']
-        if self.project_privacy_visibility == 'followers':
-            allowed_user_ids = self.project_id.allowed_internal_user_ids.partner_id.ids
-            group_func = lambda pdata: pdata['type'] == 'user' and project_user_group_id in pdata['groups'] and pdata['id'] in allowed_user_ids
-        new_group = ('group_project_user', group_func, {})
-
+        new_group = ('group_project_user', lambda pdata: pdata['type'] == 'user' and project_user_group_id in pdata['groups'], {})
         if not self.user_id and not self.stage_id.fold:
             take_action = self._notify_get_action_link('assign', **msg_vals)
             project_actions = [{'url': take_action, 'title': _('I take it')}]
             new_group[2]['actions'] = project_actions
-
         groups = [new_group] + groups
 
-        if self.project_id.privacy_visibility == 'portal':
-            allowed_user_ids = self.project_id.allowed_portal_user_ids.partner_id.ids
+        if self.project_privacy_visibility == 'portal':
             groups.insert(0, (
                 'allowed_portal_users',
-                lambda pdata: pdata['type'] == 'portal' and pdata['id'] in allowed_user_ids,
+                lambda pdata: pdata['type'] == 'portal',
                 {}
             ))
-
         portal_privacy = self.project_id.privacy_visibility == 'portal'
         for group_name, group_method, group_data in groups:
             if group_name in ('customer', 'user') or group_name == 'portal_customer' and not portal_privacy:
@@ -1462,6 +1397,13 @@ class Task(models.Model):
     def _rating_get_parent_field_name(self):
         return 'project_id'
 
+    # ---------------------------------------------------
+    # Privacy
+    # ---------------------------------------------------
+    def _change_project_privacy_visibility(self):
+        for task in self.filtered(lambda t: t.project_privacy_visibility != 'portal'):
+            portal_users = task.message_partner_ids.user_ids.filtered('share')
+            task.message_unsubscribe(partner_ids=portal_users.partner_id.ids)
 
 class ProjectTags(models.Model):
     """ Tags of project's tasks """

--- a/addons/project/models/project_task_recurrence.py
+++ b/addons/project/models/project_task_recurrence.py
@@ -143,7 +143,7 @@ class ProjectTaskRecurrence(models.Model):
 
     @api.model
     def _get_recurring_fields(self):
-        return ['allowed_user_ids', 'company_id', 'description', 'displayed_image_id', 'email_cc',
+        return ['message_partner_ids', 'company_id', 'description', 'displayed_image_id', 'email_cc',
                 'parent_id', 'partner_email', 'partner_id', 'partner_phone', 'planned_hours',
                 'project_id', 'project_privacy_visibility', 'sequence', 'tag_ids', 'recurrence_id',
                 'name', 'recurring_task']

--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -58,13 +58,12 @@
     </record>
 
     <record model="ir.rule" id="project_public_members_rule">
-        <field name="name">Project: Only invited users</field>
+        <field name="name">Project: employees: following required for follower-only projects</field>
         <field name="model_id" ref="model_project_project"/>
-        <field name="domain_force">[
-        '|',
-            ('privacy_visibility', '!=', 'followers'),
-            ('allowed_internal_user_ids', 'in', user.ids),
-        ]</field>
+        <field name="domain_force">['|',
+                                        ('privacy_visibility', '!=', 'followers'),
+                                        ('message_partner_ids', 'in', [user.partner_id.id])
+                                    ]</field>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
     </record>
 
@@ -80,7 +79,12 @@
         <field name="domain_force">[
         '|',
             ('project_id.privacy_visibility', '!=', 'followers'),
-            ('allowed_user_ids', 'in', user.ids),
+            '|',
+                ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
+                '|',
+                    ('message_partner_ids', 'in', [user.partner_id.id]),
+                    # to subscribe check access to the record, follower is not enough at creation
+                    ('user_id', '=', user.id)
         ]</field>
         <field name="groups" eval="[(4,ref('base.group_user'))]"/>
     </record>
@@ -103,8 +107,9 @@
         <field name="name">Project: portal users: portal and following</field>
         <field name="model_id" ref="project.model_project_project"/>
         <field name="domain_force">[
-            ('privacy_visibility', '=', 'portal'),
-            ('allowed_portal_user_ids', 'in', user.ids),
+            '&amp;',
+                ('privacy_visibility', '=', 'portal'),
+                ('message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
         ]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>
@@ -113,8 +118,13 @@
         <field name="name">Project/Task: portal users: (portal and following project) or (portal and following task)</field>
         <field name="model_id" ref="project.model_project_task"/>
         <field name="domain_force">[
-            ('project_id.privacy_visibility', '=', 'portal'),
-            ('allowed_user_ids', 'in', user.ids),
+        '|',
+            '&amp;',
+                ('project_id.privacy_visibility', '=', 'portal'),
+                ('project_id.message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
+            '&amp;',
+                ('project_id.privacy_visibility', '=', 'portal'),
+                ('message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
         ]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>

--- a/addons/project/tests/__init__.py
+++ b/addons/project/tests/__init__.py
@@ -6,5 +6,6 @@ from . import test_project_config
 from . import test_project_flow
 from . import test_project_recurrence
 from . import test_project_ui
+from . import test_portal
 from . import test_multicompany
 from . import test_task_dependencies

--- a/addons/project/tests/test_access_rights.py
+++ b/addons/project/tests/test_access_rights.py
@@ -5,10 +5,9 @@ from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.project.tests.test_project_base import TestProjectCommon
 from odoo.exceptions import AccessError, ValidationError
 from odoo.tests.common import users
-
+from odoo.tools import mute_logger
 
 class TestAccessRights(TestProjectCommon):
-
     def setUp(self):
         super().setUp()
         self.task = self.create_task('Make the world a better place')
@@ -18,7 +17,6 @@ class TestAccessRights(TestProjectCommon):
     def create_task(self, name, *, with_user=None, **kwargs):
         values = dict(name=name, project_id=self.project_pigs.id, **kwargs)
         return self.env['project.task'].with_user(with_user or self.env.user).create(values)
-
 
 class TestCRUDVisibilityFollowers(TestAccessRights):
 
@@ -31,7 +29,7 @@ class TestCRUDVisibilityFollowers(TestAccessRights):
         with self.assertRaises(AccessError, msg="%s should not be able to write on the project" % self.env.user.name):
             self.project_pigs.with_user(self.env.user).name = "Take over the world"
 
-        self.project_pigs.allowed_user_ids = self.env.user
+        self.project_pigs.message_subscribe(partner_ids=[self.env.user.partner_id.id])
         with self.assertRaises(AccessError, msg="%s should not be able to write on the project" % self.env.user.name):
             self.project_pigs.with_user(self.env.user).name = "Take over the world"
 
@@ -41,7 +39,7 @@ class TestCRUDVisibilityFollowers(TestAccessRights):
         with self.assertRaises(AccessError, msg="%s should not be able to unlink the project" % self.env.user.name):
             self.project_pigs.with_user(self.env.user).unlink()
 
-        self.project_pigs.allowed_user_ids = self.env.user
+        self.project_pigs.message_subscribe(partner_ids=[self.env.user.partner_id.id])
         self.project_pigs.task_ids.unlink()
         with self.assertRaises(AccessError, msg="%s should not be able to unlink the project" % self.env.user.name):
             self.project_pigs.with_user(self.env.user).unlink()
@@ -54,14 +52,16 @@ class TestCRUDVisibilityFollowers(TestAccessRights):
 
     @users('Portal user')
     def test_project_allowed_portal_no_read(self):
-        self.project_pigs.allowed_user_ids = self.env.user
+        self.project_pigs.privacy_visibility = 'portal'
+        self.project_pigs.message_subscribe(partner_ids=[self.env.user.partner_id.id])
+        self.project_pigs.privacy_visibility = 'followers'
         self.project_pigs.invalidate_cache()
         with self.assertRaises(AccessError, msg="%s should not be able to read the project" % self.env.user.name):
             self.project_pigs.with_user(self.env.user).name
 
     @users('Internal user')
     def test_project_allowed_internal_read(self):
-        self.project_pigs.allowed_user_ids = self.env.user
+        self.project_pigs.message_subscribe(partner_ids=[self.env.user.partner_id.id])
         self.project_pigs.invalidate_cache()
         self.project_pigs.with_user(self.env.user).name
 
@@ -73,14 +73,16 @@ class TestCRUDVisibilityFollowers(TestAccessRights):
 
     @users('Portal user')
     def test_task_allowed_portal_no_read(self):
-        self.project_pigs.allowed_user_ids = self.env.user
+        self.project_pigs.privacy_visibility = 'portal'
+        self.project_pigs.message_subscribe(partner_ids=[self.env.user.partner_id.id])
+        self.project_pigs.privacy_visibility = 'followers'
         self.task.invalidate_cache()
         with self.assertRaises(AccessError, msg="%s should not be able to read the task" % self.env.user.name):
             self.task.with_user(self.env.user).name
 
     @users('Internal user')
     def test_task_allowed_internal_read(self):
-        self.project_pigs.allowed_user_ids = self.env.user
+        self.project_pigs.message_subscribe(partner_ids=[self.env.user.partner_id.id])
         self.task.invalidate_cache()
         self.task.with_user(self.env.user).name
 
@@ -89,7 +91,7 @@ class TestCRUDVisibilityFollowers(TestAccessRights):
         with self.assertRaises(AccessError, msg="%s should not be able to write on the task" % self.env.user.name):
             self.task.with_user(self.env.user).name = "Paint the world in black & white"
 
-        self.project_pigs.allowed_user_ids = self.env.user
+        self.project_pigs.message_subscribe(partner_ids=[self.env.user.partner_id.id])
         with self.assertRaises(AccessError, msg="%s should not be able to write on the task" % self.env.user.name):
             self.task.with_user(self.env.user).name = "Paint the world in black & white"
 
@@ -98,7 +100,7 @@ class TestCRUDVisibilityFollowers(TestAccessRights):
         with self.assertRaises(AccessError, msg="%s should not be able to create a task" % self.env.user.name):
             self.create_task("Archive the world, it's not needed anymore")
 
-        self.project_pigs.allowed_user_ids = self.env.user
+        self.project_pigs.message_subscribe(partner_ids=[self.env.user.partner_id.id])
         with self.assertRaises(AccessError, msg="%s should not be able to create a task" % self.env.user.name):
             self.create_task("Archive the world, it's not needed anymore")
 
@@ -107,10 +109,9 @@ class TestCRUDVisibilityFollowers(TestAccessRights):
         with self.assertRaises(AccessError, msg="%s should not be able to unlink the task" % self.env.user.name):
             self.task.with_user(self.env.user).unlink()
 
-        self.project_pigs.allowed_user_ids = self.env.user
+        self.project_pigs.message_subscribe(partner_ids=[self.env.user.partner_id.id])
         with self.assertRaises(AccessError, msg="%s should not be able to unlink the task" % self.env.user.name):
             self.task.with_user(self.env.user).unlink()
-
 
 class TestCRUDVisibilityPortal(TestAccessRights):
 
@@ -126,14 +127,13 @@ class TestCRUDVisibilityPortal(TestAccessRights):
 
     @users('Portal user')
     def test_task_allowed_portal_read(self):
-        self.project_pigs.allowed_user_ids = self.env.user
+        self.project_pigs.message_subscribe(partner_ids=[self.env.user.partner_id.id])
         self.task.invalidate_cache()
         self.task.with_user(self.env.user).name
 
     @users('Internal user')
     def test_task_internal_read(self):
         self.task.with_user(self.env.user).name
-
 
 class TestCRUDVisibilityEmployees(TestAccessRights):
 
@@ -147,7 +147,7 @@ class TestCRUDVisibilityEmployees(TestAccessRights):
         with self.assertRaises(AccessError, msg="%s should not be able to read the task" % self.env.user.name):
             self.task.with_user(self.env.user).name
 
-        self.project_pigs.allowed_user_ids = self.env.user
+        self.project_pigs.message_subscribe(partner_ids=[self.env.user.partner_id.id])
         self.task.invalidate_cache()
         with self.assertRaises(AccessError, msg="%s should not be able to read the task" % self.env.user.name):
             self.task.with_user(self.env.user).name
@@ -157,7 +157,6 @@ class TestCRUDVisibilityEmployees(TestAccessRights):
         self.task.invalidate_cache()
         self.task.with_user(self.env.user).name
 
-
 class TestAllowedUsers(TestAccessRights):
 
     def setUp(self):
@@ -165,64 +164,154 @@ class TestAllowedUsers(TestAccessRights):
         self.project_pigs.privacy_visibility = 'followers'
 
     def test_project_permission_added(self):
-        self.project_pigs.allowed_user_ids = self.user
-        self.assertIn(self.user, self.task.allowed_user_ids)
+        self.project_pigs.message_subscribe(partner_ids=[self.user.partner_id.id])
+        self.assertIn(self.user.partner_id, self.task.message_partner_ids)
 
     def test_project_default_permission(self):
-        self.project_pigs.allowed_user_ids = self.user
+        self.project_pigs.message_subscribe(partner_ids=[self.user.partner_id.id])
         task = self.create_task("Review the end of the world")
-        self.assertIn(self.user, task.allowed_user_ids)
+        self.assertIn(self.user.partner_id, self.task.message_partner_ids)
 
     def test_project_default_customer_permission(self):
         self.project_pigs.privacy_visibility = 'portal'
-        self.project_pigs.partner_id = self.portal.partner_id
-        self.assertIn(self.portal, self.task.allowed_user_ids)
-        self.assertIn(self.portal, self.project_pigs.allowed_user_ids)
+        self.project_pigs.message_subscribe(partner_ids=[self.portal.partner_id.id])
+        self.assertIn(self.portal.partner_id, self.task.message_partner_ids)
+        self.assertIn(self.portal.partner_id, self.project_pigs.message_partner_ids)
 
     def test_project_permission_removed(self):
-        self.project_pigs.allowed_user_ids = self.user
-        self.project_pigs.allowed_user_ids -= self.user
-        self.assertNotIn(self.user, self.task.allowed_user_ids)
+        self.project_pigs.message_subscribe(partner_ids=[self.user.partner_id.id])
+        self.project_pigs.message_unsubscribe(partner_ids=[self.user.partner_id.id])
+        self.assertNotIn(self.user.partner_id, self.task.message_partner_ids)
 
     def test_project_specific_permission(self):
-        self.project_pigs.allowed_user_ids = self.user
-        john = mail_new_test_user(self.env, login='John')
-        self.task.allowed_user_ids |= john
-        self.project_pigs.allowed_user_ids -= self.user
-        self.assertIn(john, self.task.allowed_user_ids, "John should still be allowed to read the task")
+        self.project_pigs.message_subscribe(partner_ids=[self.user.partner_id.id])
+        john = mail_new_test_user(self.env, 'John')
+        self.project_pigs.message_subscribe(partner_ids=[john.partner_id.id])
+        self.project_pigs.message_unsubscribe(partner_ids=[self.user.partner_id.id])
+        self.assertIn(john.partner_id, self.task.message_partner_ids, "John should still be allowed to read the task")
 
     def test_project_specific_remove_mutliple_tasks(self):
-        self.project_pigs.allowed_user_ids = self.user
-        john = mail_new_test_user(self.env, login='John')
+        self.project_pigs.message_subscribe(partner_ids=[self.user.partner_id.id])
+        john = mail_new_test_user(self.env, 'John')
         task = self.create_task('task')
-        self.task.allowed_user_ids |= john
-        self.project_pigs.allowed_user_ids -= self.user
-        self.assertIn(john, self.task.allowed_user_ids)
-        self.assertNotIn(john, task.allowed_user_ids)
-        self.assertNotIn(self.user, task.allowed_user_ids)
-        self.assertNotIn(self.user, self.task.allowed_user_ids)
-
-    def test_no_portal_allowed(self):
-        with self.assertRaises(ValidationError, msg="It should not allow to add portal users"):
-            self.task.allowed_user_ids = self.portal
+        self.task.message_subscribe(partner_ids=[john.partner_id.id])
+        self.project_pigs.message_unsubscribe(partner_ids=[self.user.partner_id.id])
+        self.assertIn(john.partner_id, self.task.message_partner_ids)
+        self.assertNotIn(john.partner_id, task.message_partner_ids)
+        self.assertNotIn(self.user.partner_id, task.message_partner_ids)
+        self.assertNotIn(self.user.partner_id, self.task.message_partner_ids)
 
     def test_visibility_changed(self):
         self.project_pigs.privacy_visibility = 'portal'
-        self.task.allowed_user_ids |= self.portal
-        self.assertNotIn(self.user, self.task.allowed_user_ids, "Internal user should have been removed from allowed users")
-        self.project_pigs.privacy_visibility = 'employees'
-        self.assertNotIn(self.portal, self.task.allowed_user_ids, "Portal user should have been removed from allowed users")
+        self.task.message_subscribe(partner_ids=[self.portal.partner_id.id])
+        self.assertNotIn(self.user.partner_id, self.task.message_partner_ids, "Internal user should have been removed from allowed users")
+        self.project_pigs.write({'privacy_visibility': 'employees'})
+        self.assertNotIn(self.portal.partner_id, self.task.message_partner_ids, "Portal user should have been removed from allowed users")
 
     def test_write_task(self):
         self.user.groups_id |= self.env.ref('project.group_project_user')
-        self.assertNotIn(self.user, self.project_pigs.allowed_user_ids)
-        self.task.allowed_user_ids = self.user
+        self.assertNotIn(self.user.partner_id, self.project_pigs.message_partner_ids)
+        self.task.message_subscribe(partner_ids=[self.user.partner_id.id])
         self.project_pigs.invalidate_cache()
         self.task.invalidate_cache()
         self.task.with_user(self.user).name = "I can edit a task!"
 
     def test_no_write_project(self):
         self.user.groups_id |= self.env.ref('project.group_project_user')
-        self.assertNotIn(self.user, self.project_pigs.allowed_user_ids)
+        self.assertNotIn(self.user.partner_id, self.project_pigs.message_partner_ids)
         with self.assertRaises(AccessError, msg="User should not be able to edit project"):
             self.project_pigs.with_user(self.user).name = "I can't edit a task!"
+
+class TestProjectPortalCommon(TestProjectCommon):
+
+    def setUp(self):
+        super(TestProjectPortalCommon, self).setUp()
+        self.user_noone = self.env['res.users'].with_context({'no_reset_password': True, 'mail_create_nosubscribe': True}).create({
+            'name': 'Noemie NoOne',
+            'login': 'noemie',
+            'email': 'n.n@example.com',
+            'signature': '--\nNoemie',
+            'notification_type': 'email',
+            'groups_id': [(6, 0, [])]})
+
+        self.task_3 = self.env['project.task'].with_context({'mail_create_nolog': True}).create({
+            'name': 'Test3', 'user_id': self.user_portal.id, 'project_id': self.project_pigs.id})
+        self.task_4 = self.env['project.task'].with_context({'mail_create_nolog': True}).create({
+            'name': 'Test4', 'user_id': self.user_public.id, 'project_id': self.project_pigs.id})
+        self.task_5 = self.env['project.task'].with_context({'mail_create_nolog': True}).create({
+            'name': 'Test5', 'user_id': False, 'project_id': self.project_pigs.id})
+        self.task_6 = self.env['project.task'].with_context({'mail_create_nolog': True}).create({
+            'name': 'Test5', 'user_id': False, 'project_id': self.project_pigs.id})
+
+class TestPortalProject(TestProjectPortalCommon):
+
+    @mute_logger('odoo.addons.base.models.ir_model')
+    def test_employee_project_access_rights(self):
+        pigs = self.project_pigs
+
+        pigs.write({'privacy_visibility': 'employees'})
+        # Do: Alfred reads project -> ok (employee ok employee)
+        pigs.with_user(self.user_projectuser).read(['user_id'])
+        # Test: all project tasks visible
+        tasks = self.env['project.task'].with_user(self.user_projectuser).search([('project_id', '=', pigs.id)])
+        test_task_ids = set([self.task_1.id, self.task_2.id, self.task_3.id, self.task_4.id, self.task_5.id, self.task_6.id])
+        self.assertEqual(set(tasks.ids), test_task_ids,
+                         'access rights: project user cannot see all tasks of an employees project')
+        # Do: Bert reads project -> crash, no group
+        self.assertRaises(AccessError, pigs.with_user(self.user_noone).read, ['user_id'])
+        # Do: Donovan reads project -> ko (public ko employee)
+        self.assertRaises(AccessError, pigs.with_user(self.user_public).read, ['user_id'])
+        # Do: project user is employee and can create a task
+        tmp_task = self.env['project.task'].with_user(self.user_projectuser).with_context({'mail_create_nolog': True}).create({
+            'name': 'Pigs task',
+            'project_id': pigs.id})
+        tmp_task.with_user(self.user_projectuser).unlink()
+
+    @mute_logger('odoo.addons.base.models.ir_model')
+    def test_favorite_project_access_rights(self):
+        pigs = self.project_pigs.with_user(self.user_projectuser)
+
+        # we can't write on project name
+        self.assertRaises(AccessError, pigs.write, {'name': 'False Pigs'})
+        # we can write on is_favorite
+        pigs.write({'is_favorite': True})
+
+    @mute_logger('odoo.addons.base.ir.ir_model')
+    def test_followers_project_access_rights(self):
+        pigs = self.project_pigs
+        pigs.write({'privacy_visibility': 'followers'})
+        pigs.flush(['privacy_visibility'])
+        # Do: Alfred reads project -> ko (employee ko followers)
+        self.assertRaises(AccessError, pigs.with_user(self.user_projectuser).read, ['user_id'])
+        # Test: no project task visible
+        tasks = self.env['project.task'].with_user(self.user_projectuser).search([('project_id', '=', pigs.id)])
+        self.assertEqual(tasks, self.task_1,
+                         'access rights: employee user should not see tasks of a not-followed followers project, only assigned')
+
+        # Do: Bert reads project -> crash, no group
+        self.assertRaises(AccessError, pigs.with_user(self.user_noone).read, ['user_id'])
+
+        # Do: Donovan reads project -> ko (public ko employee)
+        self.assertRaises(AccessError, pigs.with_user(self.user_public).read, ['user_id'])
+
+        pigs.message_subscribe(partner_ids=[self.user_projectuser.partner_id.id])
+
+        # Do: Alfred reads project -> ok (follower ok followers)
+        donkey = pigs.with_user(self.user_projectuser)
+        donkey.invalidate_cache()
+        donkey.read(['user_id'])
+
+        # Do: Donovan reads project -> ko (public ko follower even if follower)
+        self.assertRaises(AccessError, pigs.with_user(self.user_public).read, ['user_id'])
+        # Do: project user is follower of the project and can create a task
+        self.env['project.task'].with_user(self.user_projectuser).with_context({'mail_create_nolog': True}).create({
+            'name': 'Pigs task', 'project_id': pigs.id
+        })
+        # not follower user should not be able to create a task
+        pigs.with_user(self.user_projectuser).message_unsubscribe(partner_ids=[self.user_projectuser.partner_id.id])
+        self.assertRaises(AccessError, self.env['project.task'].with_user(self.user_projectuser).with_context({
+            'mail_create_nolog': True}).create, {'name': 'Pigs task', 'project_id': pigs.id})
+
+        # Do: project user can create a task without project
+        self.assertRaises(AccessError, self.env['project.task'].with_user(self.user_projectuser).with_context({
+            'mail_create_nolog': True}).create, {'name': 'Pigs task', 'project_id': pigs.id})

--- a/addons/project/tests/test_portal.py
+++ b/addons/project/tests/test_portal.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.project.tests.test_access_rights import TestProjectPortalCommon
+from odoo.exceptions import AccessError
+from odoo.tools import mute_logger
+
+
+class TestPortalProject(TestProjectPortalCommon):
+    @mute_logger('odoo.addons.base.models.ir_model')
+    def test_portal_project_access_rights(self):
+        pigs = self.project_pigs
+        pigs.write({'privacy_visibility': 'portal'})
+
+        # Do: Alfred reads project -> ok (employee ok public)
+        pigs.with_user(self.user_projectuser).read(['user_id'])
+        # Test: all project tasks visible
+        tasks = self.env['project.task'].with_user(self.user_projectuser).search([('project_id', '=', pigs.id)])
+        self.assertEqual(tasks, self.task_1 | self.task_2 | self.task_3 | self.task_4 | self.task_5 | self.task_6,
+                         'access rights: project user should see all tasks of a portal project')
+
+        # Do: Bert reads project -> crash, no group
+        self.assertRaises(AccessError, pigs.with_user(self.user_noone).read, ['user_id'])
+        # Test: no project task searchable
+        self.assertRaises(AccessError, self.env['project.task'].with_user(self.user_noone).search, [('project_id', '=', pigs.id)])
+
+        # Data: task follower
+        pigs.with_user(self.user_projectmanager).message_subscribe(partner_ids=[self.user_portal.partner_id.id])
+        self.task_1.with_user(self.user_projectuser).message_subscribe(partner_ids=[self.user_portal.partner_id.id])
+        self.task_3.with_user(self.user_projectuser).message_subscribe(partner_ids=[self.user_portal.partner_id.id])
+        # Do: Chell reads project -> ok (portal ok public)
+        pigs.with_user(self.user_portal).read(['user_id'])
+        # Do: Donovan reads project -> ko (public ko portal)
+        self.assertRaises(AccessError, pigs.with_user(self.user_public).read, ['user_id'])
+        # Test: no access right to project.task
+        self.assertRaises(AccessError, self.env['project.task'].with_user(self.user_public).search, [])
+        # Data: task follower cleaning
+        self.task_1.with_user(self.user_projectuser).message_unsubscribe(partner_ids=[self.user_portal.partner_id.id])
+        self.task_3.with_user(self.user_projectuser).message_unsubscribe(partner_ids=[self.user_portal.partner_id.id])

--- a/addons/project/views/project_portal_templates.xml
+++ b/addons/project/views/project_portal_templates.xml
@@ -194,7 +194,7 @@
                     </div>
                 </t>
                 <t t-set="card_body">
-                    <div class="mb-1" t-if="user in task.sudo().project_id.allowed_user_ids">
+                    <div class="mb-1" t-if="user.partner_id.id in task.sudo().project_id.message_partner_ids.ids">
                         <strong>Project:</strong> <a t-attf-href="/my/project/#{task.project_id.id}" t-field="task.project_id.name"/>
                     </div>
 

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -306,17 +306,6 @@
                                 <group>
                                     <field name="analytic_account_id" domain="['|', ('company_id', '=', company_id), ('company_id', '=', False)]" context="{'default_partner_id': partner_id}" groups="analytic.group_analytic_accounting"/>
                                     <field name="privacy_visibility" widget="radio"/>
-                                    <field name="allowed_internal_user_ids" widget="many2many_tags" attrs="{'invisible': [('privacy_visibility', '!=', 'followers')]}"/>
-                                    <field name="allowed_portal_user_ids" widget="many2many_tags" options="{'no_create': True}" attrs="{'invisible': [('privacy_visibility', '!=', 'portal')]}"/>
-                                    <span colspan="2" class="oe_edit_only text-muted"
-                                          attrs="{'invisible': [('privacy_visibility', '!=', 'portal')]}">
-                                        <dl class="o_project_portal_warning_dl">
-                                            <dt class="o_project_portal_warning_dt" aria-hidden="True">
-                                                <i class="fa fa-exclamation-triangle fa-sm"/>&amp;nbsp;</dt>
-                                            <dd class="o_project_portal_warning_dd">Allowed Portal Users will see all the tasks of this project without distinction.<br/>
-                                                Leave empty to restrict the access to the portal users' own tasks.</dd>
-                                        </dl>
-                                    </span>
                                     <field name="company_id" groups="base.group_multi_company"/>
                                 </group>
                                 <group name="extra_settings">
@@ -794,9 +783,6 @@
                                     <field name="sequence" groups="base.group_no_one"/>
                                     <field name="email_from" invisible="1"/>
                                     <field name="email_cc" groups="base.group_no_one"/>
-                                    <field name="project_privacy_visibility" groups="base.group_no_one"/>
-                                    <field name="allowed_user_ids" widget="many2many_tags"
-                                           groups="base.group_no_one" attrs="{'invisible': [('project_privacy_visibility', 'not in', ('followers', 'portal'))]}"/>
                                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
                                     <field name="displayed_image_id" groups="base.group_no_one"/>
                                 </group>


### PR DESCRIPTION
This commit reverts and fixes bugs introduced by the revert of commit :
7059b17

This commit translates tests introduced in this reverted commit to be
aligned with the current workflow.

This commit reverts functionality or business logic linked to the
reverted commit :
- #47248 : You no longer have to be an allowed user to see the
timesheets but only a message partner.
- #49021 : We no longer deal with allowed_user_ids or
allowed_portal_user_ids
- f2a1a00 : We no longer deal with the allowed users lists.

task-2439329