### PR TITLE
[FIX] web: FieldRadio: getFocusableElement defined twice

### DIFF
--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -3046,22 +3046,6 @@ var FieldRadio = FieldSelection.extend({
     //--------------------------------------------------------------------------
 
     /**
-     * @override
-     * @returns {jQuery}
-     */
-    getFocusableElement: function () {
-        return this.mode === 'edit' && this.$input || this.$el;
-    },
-
-    /**
-     * @override
-     * @returns {boolean} always true
-     */
-    isSet: function () {
-        return true;
-    },
-
-    /**
      * Returns the currently-checked radio button, or the first one if no radio
      * button is checked.
      *
@@ -3070,6 +3054,14 @@ var FieldRadio = FieldSelection.extend({
     getFocusableElement: function () {
         var checked = this.$("[checked='true']");
         return checked.length ? checked : this.$("[data-index='0']");
+    },
+
+    /**
+     * @override
+     * @returns {boolean} always true
+     */
+    isSet: function () {
+        return true;
     },
 
     /**


### PR DESCRIPTION
Commit [1] adds an override of the getFocusableElement of
AbstractField in FieldRadio, but this function was already defined.

Even though it doesn't crash, this is obviously not something to
do. This commit removes the first occurence (which was overriden
by the second).

[1] https://github.com/odoo/odoo/commit/ebe118fc607391737adc37e18c3278a3d2c87b5e

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
