### PR TITLE
[12.0] Adds attribute default=1.0 in quantity PO line

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -449,7 +449,7 @@ class PurchaseOrderLine(models.Model):
 
     name = fields.Text(string='Description', required=True)
     sequence = fields.Integer(string='Sequence', default=10)
-    product_qty = fields.Float(string='Quantity', digits=dp.get_precision('Product Unit of Measure'), required=True)
+    product_qty = fields.Float(string='Quantity', digits=dp.get_precision('Product Unit of Measure'), required=True, default=1.0)
     product_uom_qty = fields.Float(string='Total Quantity', compute='_compute_product_uom_qty', store=True)
     date_planned = fields.Datetime(string='Scheduled Date', required=True, index=True)
     taxes_id = fields.Many2many('account.tax', string='Taxes', domain=['|', ('active', '=', False), ('active', '=', True)])


### PR DESCRIPTION
Adds attribute default=1.0 for product_qty field in purchase.line

Description of the issue/feature this PR addresses:
In Odoo's documents lines like [sale.order.line](https://github.com/odoo/odoo/blob/12.0/addons/sale/models/sale.py#L1189), [account.invoice.line](https://github.com/odoo/odoo/blob/12.0/addons/account/models/account_invoice.py#L1749) there is a default=1.0 attribute in product_qty field, but in [purchase.order.line](https://github.com/odoo/odoo/blob/12.0/addons/purchase/models/purchase.py#L452) there is not default=1.0 I created this PR to add a default=1.0 and avoid any error in compute fields if quantity is not changed by user.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
