### PR TITLE
[14.0] Adds attribute default in quantity PO line

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -758,7 +758,7 @@ class PurchaseOrderLine(models.Model):
 
     name = fields.Text(string='Description', required=True)
     sequence = fields.Integer(string='Sequence', default=10)
-    product_qty = fields.Float(string='Quantity', digits='Product Unit of Measure', required=True)
+    product_qty = fields.Float(string='Quantity', digits='Product Unit of Measure', required=True, default=1.0)
     product_uom_qty = fields.Float(string='Total Quantity', compute='_compute_product_uom_qty', store=True)
     date_planned = fields.Datetime(string='Delivery Date', index=True,
         help="Delivery date expected from vendor. This date respectively defaults to vendor pricelist lead time then today's date.")


### PR DESCRIPTION
Adds attribute default=1.0 for product_qty field in purchase.line

Description of the issue/feature this PR addresses:
In Odoo's documents lines like sale.order.line, account.invoice.line there is a default=1.0 attribute in product_qty field, but in purchase.order.line there is not default=1.0 I created this PR to add a default=1.0 and avoid any error in compute fields if quantity is not changed by user.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr