### PR TITLE
[IMP] delivery: group sales fields together in contact form

### DIFF
--- a/addons/delivery/views/partner_view.xml
+++ b/addons/delivery/views/partner_view.xml
@@ -6,7 +6,7 @@
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="base.view_partner_form" />
             <field name="arch" type="xml">
-                <xpath expr="//page[@name='sales_purchases']//field[@name='user_id']" position="after">
+                <xpath expr="//page[@name='sales_purchases']//field[@name='team_id']" position="after">
                     <field name="property_delivery_carrier_id"/>
                 </xpath>
             </field>


### PR DESCRIPTION
This commit keeps the sales related fields together in a contact
form view by moving 'property_delivery_carrier_id' field out of
in between 'user_id' (Sales Person) and 'team_id' (Sales Team).

Task Id : 2445997
