### PR TITLE
[FIX] account: fix unselectable Report Line in Tax Adjustments wizard

### DIFF
--- a/addons/account/wizard/wizard_tax_adjustments_view.xml
+++ b/addons/account/wizard/wizard_tax_adjustments_view.xml
@@ -11,7 +11,7 @@
             </h1>
             <group>
                 <field name="report_id" invisible="1"/>
-                <field name="tax_report_line_id" widget="selection" domain="[('tag_name', '!=', None), ('report_id', '=', report_id)]"/>
+                <field name="tax_report_line_id" widget="selection" domain="[('tag_name', '!=', None)]"/>
             </group>
             <group>
                 <group>


### PR DESCRIPTION
- Go to Accounting > Configuration > Tax Report
- Create a Tax Report (with Lines having Tag Name)
- Go to Accounting > Accounting > Tax Adjustments
In wizard, no Report Line can be selected for mandatory "Report Line" field.

Report lines are filtered on "report_id" field, which is a related field to the report line field.
Therefore there is no way to select a Report Line.

opw-2449295

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
