### PR TITLE
[FIX] project: filter when not required

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1374,6 +1374,7 @@ class Task(models.Model):
         else:
             default_project = self.project_id.subtask_project_id or self.project_id
         ctx = dict(self.env.context)
+        ctx = {k: v for k, v in ctx.items() if not k.startswith('search_default_')}
         ctx.update({
             'default_name': self.env.context.get('name', self.name) + ':',
             'default_parent_id': self.id,  # will give default subtask field in `default_get`


### PR DESCRIPTION
**Current behavior before PR:**

A method action_subtask is including the other actions context if have which
reflects while clicking on the Sub-tasks stat button. For examples:

- When click on the stat button 'Sub-tasks' of any task which one is clicked by
  systray activity icon results
- When click on the task menu in project there a default search filter 'My task'
  which also passes when click on 'sub tasks' stat button

**Desired behavior after PR is merged:**

Remove the context that startswith `search_default'.
Hence, now subtask will display with the correct context.

**LINKS:**
PR #65395
Task-2413127

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
