### PR TITLE
[FIX] account: Fix computed fields when editing payment account

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1217,8 +1217,10 @@ class AccountMove(models.Model):
         return 'paid'
 
     @api.depends(
+        'line_ids.matched_debit_ids.debit_move_id.move_id.payment_id.is_matched',
         'line_ids.matched_debit_ids.debit_move_id.move_id.line_ids.amount_residual',
         'line_ids.matched_debit_ids.debit_move_id.move_id.line_ids.amount_residual_currency',
+        'line_ids.matched_credit_ids.credit_move_id.move_id.payment_id.is_matched',
         'line_ids.matched_credit_ids.credit_move_id.move_id.line_ids.amount_residual',
         'line_ids.matched_credit_ids.credit_move_id.move_id.line_ids.amount_residual_currency',
         'line_ids.debit',

--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -272,7 +272,7 @@ class AccountPayment(models.Model):
     # COMPUTE METHODS
     # -------------------------------------------------------------------------
 
-    @api.depends('move_id.line_ids.amount_residual', 'move_id.line_ids.amount_residual_currency')
+    @api.depends('move_id.line_ids.amount_residual', 'move_id.line_ids.amount_residual_currency', 'move_id.line_ids.account_id')
     def _compute_reconciliation_status(self):
         ''' Compute the field indicating if the payments are already reconciled with something.
         This field is used for display purpose (e.g. display the 'reconcile' button redirecting to the reconciliation


### PR DESCRIPTION
When changing the bank account by the outstanding account of a payment, invoice's payment_state should be recomputed by the orm.

So, when writing `account_id` on the liquidity line, `is_matched` must be recomputed on payment (`_compute_reconciliation_status`). Then, if reconciled to some invoices, `payment_state` must be recomputed as well (`_compute_amount`).

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
