### PR TITLE
[FIX] sale_management: Price unit on options with model template

### DIFF
--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -49,7 +49,7 @@ class SaleOrder(models.Model):
         }
 
     def _compute_option_data_for_template_change(self, option):
-        if self.pricelist_id:
+        if self.pricelist_id and not option.price_unit:
             price = self.pricelist_id.with_context(uom=option.uom_id.id).get_product_price(option.product_id, 1, False)
         else:
             price = option.price_unit


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a model template MT with one line L and one option line OL
- Let's consider a product P with a sales price of 100€
- Let's consider a pricelist PL in €
- Set P on L with a price unit of 50€
- Set P on OL with a price unit of 50€
- Create a sale order SO and set PL on it
- Set MT on SO

Bug:

The price unit of P in the optional line is 100€ instead of 50€

PS: The unit price of P in the SO line is 50€

This fix keeps the same logic with this 2 behaviours.

Inspired from https://github.com/odoo/odoo/blob/13.0/addons/sale_management/models/sale_order.py#L80

opw:2431953