### PR TITLE
[FIX] mrp: fix group name conflict when manufacturing directly

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -78,6 +78,7 @@ class StockRule(models.Model):
                 # Create now the procurement group that will be assigned to the new MO
                 # This ensure that the outgoing move PostProduction -> Stock is linked to its MO
                 # rather than the original record (MO or SO)
+                self = self.with_context(use_group_name=True)
                 procurement.values['group_id'] = self.env["procurement.group"].create({'name': name})
         return super()._run_pull(procurements)
 
@@ -119,7 +120,7 @@ class StockRule(models.Model):
         if location_id.get_warehouse().manufacture_steps == 'pbm_sam':
             # Use the procurement group created in _run_pull mrp override
             # Preserve the origin from the original stock move, if available
-            if len(values.get('move_dest_ids', [])) == 1 and values['move_dest_ids'][0].origin and values['group_id']:
+            if len(values.get('move_dest_ids', [])) == 1 and values['move_dest_ids'][0].origin and values['group_id'] and self._context.get('use_group_name'):
                 origin = values['move_dest_ids'][0].origin
                 mo_values.update({
                     'name': values['group_id'].name,


### PR DESCRIPTION
Fine tuning of abf6c0c

When an user set its own routes for a manufactured product with
subcomponent BOM `_run_manufacture` could be called before
`_run_pull`.

A new procurement group is not created in `_run_pull`, so the same name
will be reused causing a conflict when the MO is confirmed

Adding a context key to make sure we take the group name from the values
only in the right flow

opw-2378583

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
