### PR TITLE
[IMP] mail: mark first welcome message as read for the admin

### DIFF
--- a/addons/mail/data/mail_channel_data.xml
+++ b/addons/mail/data/mail_channel_data.xml
@@ -4,7 +4,6 @@
 
         <record model="mail.channel" id="channel_all_employees">
             <field name="name">general</field>
-            <field name="group_ids" eval="[(4, ref('base.group_user'))]"/>
             <field name="description">General announcements for all employees.</field>
         </record>
 
@@ -18,6 +17,17 @@
             <field name="subject">Welcome to Odoo!</field>
             <field name="body"><![CDATA[<p>Welcome to the #general channel.</p>
             <p>This channel is accessible to all users to <b>easily share company information</b>.</p>]]></field>
+        </record>
+
+        <record model="mail.channel.partner" id="channel_partner_general_channel_for_admin">
+            <field name="partner_id" ref="base.partner_admin"/>
+            <field name="channel_id" ref="mail.channel_all_employees"/>
+            <field name="fetched_message_id" ref="mail.module_install_notification"/>
+            <field name="seen_message_id" ref="mail.module_install_notification"/>
+        </record>
+
+        <record model="mail.channel" id="mail.channel_all_employees">
+            <field name="group_ids" eval="[(4, ref('base.group_user'))]"/>
         </record>
     </data>
 </odoo>


### PR DESCRIPTION
**PURPOSE**

Actually, We don't want to distract the admin with an unnecessary notification
on General Channel. The main focus should be on odoobot's tour, not on the
general channel's welcome message. And it is also not a good idea to remove the
general channel as it would reduce the discoverability of the feature.

**SPECIFICATION**

So, we are marking the first message as read at least for the admin user.
therefore admin can not distract over the unnecessary welcome notifications and
focus more on the rest of the functionality.

PS: we can not use "_set_last_seen_message" method as it takes partner_id of SUPERUSER 
because this method calls once during installation and installation is taken place by SUPERUSER
But we required admin users to mark the first message as read.

**Task : 2442023**