### PR TITLE
[FIX] mail: corrects the domain of message_fetch

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1026,14 +1026,15 @@ class Message(models.Model):
             channels_dom_index = None
             channels_dom = []
             for i, sub_dom in enumerate(domain):
-                if 'channel_ids' in sub_dom:
+                if sub_dom[0] == 'channel_ids' and sub_dom[1] == 'in':
                     channels_dom_index = i
                     channels_dom = sub_dom
                     break
             if type(channels_dom_index) == int:
+                filtered_moderated_channel_ids = list(set(channels_dom[2]) & set(moderated_channel_ids))
                 domain = domain[:channels_dom_index] + expression.OR([[channels_dom], [
                     ('model', '=', 'mail.channel'),
-                    ('res_id', 'in', moderated_channel_ids),
+                    ('res_id', 'in', filtered_moderated_channel_ids),
                     '|',
                     ('author_id', '=', self.env.user.partner_id.id),
                     ('moderation_status', '=', 'pending_moderation'),

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1039,7 +1039,6 @@ class Message(models.Model):
                     ('moderation_status', '=', 'pending_moderation'),
                 ]]) + domain[channels_dom_index+1:]
         messages = self.search(domain, limit=limit)
-        messages = messages.sorted(key='id', reverse=True)[:limit]
         return messages.message_format()
 
     def message_format(self):

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1031,14 +1031,16 @@ class Message(models.Model):
                     channels_dom = sub_dom
                     break
             if type(channels_dom_index) == int:
+                domain.pop(channels_dom_index)
                 filtered_moderated_channel_ids = list(set(channels_dom[2]) & set(moderated_channel_ids))
-                domain = domain[:channels_dom_index] + expression.OR([[channels_dom], [
+                target_domain = expression.OR([[channels_dom], [
                     ('model', '=', 'mail.channel'),
                     ('res_id', 'in', filtered_moderated_channel_ids),
                     '|',
                     ('author_id', '=', self.env.user.partner_id.id),
                     ('moderation_status', '=', 'pending_moderation'),
-                ]]) + domain[channels_dom_index+1:]
+                ]])
+                domain = expression.AND([target_domain, domain])
         messages = self.search(domain, limit=limit)
         return messages.message_format()
 


### PR DESCRIPTION
This commit ensures that the domain of `message_fetch()` is correct
when used with  `moderated_channel_ids`.

opw-2352656

