### PR TITLE
[IMP] product: prevent the hierarchical category name in search panel

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -60,6 +60,11 @@ class ProductCategory(models.Model):
     def name_create(self, name):
         return self.create({'name': name}).name_get()[0]
 
+    def name_get(self):
+        if not self.env.context.get('hierarchical_naming', True):
+            return [(record.id, record.name) for record in self]
+        return super().name_get()
+
     @api.ondelete(at_uninstall=False)
     def _unlink_except_default_category(self):
         main_category = self.env.ref('product.product_category_all')


### PR DESCRIPTION
Purpose of the commit is to prevent the hierarchical name of
category in search panel.

So in this commit, Override the the name_get to prevent the category
hierarchy on search panel and we already displaying parent category
separately in search panel.


TaskID: 2417252
Related PR: https://github.com/odoo/enterprise/pull/15550