### PR TITLE
[FIX] sms: autofocus on "body" if phone number is valid

### DIFF
--- a/addons/sms/wizard/sms_composer_views.xml
+++ b/addons/sms/wizard/sms_composer_views.xml
@@ -48,7 +48,8 @@
                             <field name="recipient_single_number_itf" class="oe_inline" nolabel="1" options="{'onchange_on_keydown': True}" placeholder="e.g. +1 415 555 0100"/>
                         </div>
                                                 
-                        <field name="body" widget="sms_widget"/>
+                        <field name="body" widget="sms_widget" attrs="{'invisible': ['|', ('comment_single_recipient', '=', False), ('recipient_single_valid', '=', True)]}"/>
+                        <field name="body" widget="sms_widget" attrs="{'invisible': [('comment_single_recipient', '=', True), ('recipient_single_valid', '=', False)]}" default_focus="1"/>
                         <field name="mass_keep_log" invisible="1"/>
                     </group>
                 </sheet>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- As a user wanting to send SMS Text Message to a contact, I Edit the record and input a phone
 number Save Click on the SMS widget Expect to be able to write the message already

 - Instead, the focus is put on the phone number field again. This means that if I start typing,
 I'll actually "corrupt" the phone number, need to discard my change, and then click in the body
 to finally start typing my SMS Text Message.

Desired behavior after PR is merged:
- When the SMS composer opens, the focus will be put on the body field if the phone number is valid.

Task: https://www.odoo.com/web#id=2394488&action=4043&model=project.task&view_type=form&cids=2&menu_id=4720


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
