### PR TITLE
[FIX] project: remove chatter glitches in form without sheet tag

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -482,7 +482,7 @@
                     <notebook>
                         <page name="description_page" string="Description">
                             <field name="description" type="html"/>
-                            <div class="oe_clear"/>
+                            <div class="d-none oe_clear"/>
                         </page>
                         <page name="extra_info" string="Extra Info">
                             <group>


### PR DESCRIPTION
**Before this commit:**

In edit mode, glitching of chatter is visible in project.task's form view
(without sheet tag).

**After this commit:**

Removed this glinch of chatter and displaying it with full width in the form
(without sheet tag).

**LINKS**

PR https://github.com/odoo/odoo/pull/65447
Task- 2411632
