### PR TITLE
[FIX] project: remove chatter glitches in form without sheet tag

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -287,7 +287,7 @@
                     <notebook>
                         <page name="description_page" string="Description">
                             <field name="description" nolabel="1" placeholder="Describe your project..." type="html"/>
-                            <div class="oe_clear"/>
+                            <div class="d-none oe_clear"/>
                         </page>
                         <page name="settings" string="Settings">
                             <group>


### PR DESCRIPTION
**Before this commit:**

In edit mode, glitching of chatter is visible in project.project's form view
(without sheet tag).

**After this commit:**

Removed this glinch of chatter and displaying it with full width in the form
(without sheet tag).

**LINKS**

PR https://github.com/odoo/odoo/pull/65448
Task- 2411632