### PR TITLE
[FIX] calendar: currency in popover fullcalendar V4


### DIFF
--- a/addons/web/static/src/js/views/calendar/calendar_popover.js
+++ b/addons/web/static/src/js/views/calendar/calendar_popover.js
@@ -120,7 +120,7 @@ var CalendarPopover = Widget.extend(WidgetAdapterMixin, StandaloneFieldManagerMi
             }
             if (field.type === 'monetary') {
                 var currencyField = field.currency_field || 'currency_id';
-                if (!fields.includes(currencyField) && _.has(self.event.record, currencyField)) {
+                if (!fields.includes(currencyField) && _.has(self.event.extendedProps.record, currencyField)) {
                     fields.push(currencyField);
                 }
             }


### PR DESCRIPTION

The update of fullcalendar (ebce7719b) in 14.0 made #45881 not working
(they both happened in same month).

opw-2214445
