### PR TITLE
[FIX] stock: sort move without description

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -773,10 +773,13 @@ class StockMove(models.Model):
     @api.model
     def _prepare_merge_move_sort_method(self, move):
         move.ensure_one()
+
+        description_picking = move.description_picking or ""
+
         return [
             move.product_id.id, move.price_unit, move.procure_method, move.location_id, move.location_dest_id,
             move.product_uom.id, move.restrict_partner_id.id, move.scrapped, move.origin_returned_move_id.id,
-            move.package_level_id.id, move.propagate_cancel, move.description_picking
+            move.package_level_id.id, move.propagate_cancel, description_picking
         ]
 
     def _clean_merged(self):


### PR DESCRIPTION
Steps:
- Go to Inventory > Configuration > Warehouse Management / Operations
  Types
- Edit Delivery Orders:
  - Show Detailed Operations: Checked
- Go to Overview
- Create a new Delivery Order:
  - Detailed Operations tab:
    - Add a product (1)
  - Operations tab:
    - Add the same product (1) and make sure it has a description
- Save

Bug:
Traceback here:
https://github.com/odoo/odoo/blob/82b188a090aa34c258840343cbf594969489dd6b/addons/stock/models/stock_move.py#L807
TypeError: '<' not supported between instances of 'str' and 'bool'

Explanation:
A detailed operation has no description. Calling the description returns
`False`. When trying to save the delivery order with both detailed
operations and "normal" operations, the system tries to sort them out.
You cannot sort between different types (here, `str` and `bool`).

opw:2447720