### PR TITLE
[FIX] stock: fix rounding issue on available quantity

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1213,7 +1213,7 @@ class StockMove(models.Model):
         # way, we'll never reserve more than allowed. We do not apply this logic if
         # `available_quantity` is brought by a chained move line. In this case, `_prepare_move_line_vals`
         # will take care of changing the UOM to the UOM of the product.
-        if not strict:
+        if not strict and self.product_id.uom_id != self.product_uom:
             taken_quantity_move_uom = self.product_id.uom_id._compute_quantity(taken_quantity, self.product_uom, rounding_method='DOWN')
             taken_quantity = self.product_uom._compute_quantity(taken_quantity_move_uom, self.product_id.uom_id, rounding_method='HALF-UP')
 


### PR DESCRIPTION
- Have a storable product with 3140.0 quantity on hand
- Make a sale order for 3106.40, confirm and validate delivery
- Reserved quantity will be 3106.40
- Make another sale order for 33.60, confirm and go to delivery
- Reserved quantity will be 33.59 because of a rounding issue when
calculating the available quantity

opw-2449732

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
