### PR TITLE
[FIX] web: invisible currency stay invisible in calendar


### DIFF
--- a/addons/web/static/src/js/views/calendar/calendar_popover.js
+++ b/addons/web/static/src/js/views/calendar/calendar_popover.js
@@ -114,6 +114,7 @@ var CalendarPopover = Widget.extend(WidgetAdapterMixin, StandaloneFieldManagerMi
                 string: displayFieldInfo.attrs.string || fieldInfo.string,
                 value: self.event.extendedProps.record[fieldName],
                 type: fieldInfo.type,
+                invisible: displayFieldInfo.attrs.invisible,
             };
             if (field.type === 'selection') {
                 field.selection = fieldInfo.selection;


### PR DESCRIPTION

In #47607 we allowed to show the monetary field symbol in calendar but
it seems a part was missing in forward-port.

opw-2214445
