### PR TITLE
[IMP] ir.cron: Trigger Multi

### DIFF
--- a/addons/calendar/tests/test_event_notifications.py
+++ b/addons/calendar/tests/test_event_notifications.py
@@ -162,7 +162,10 @@ class TestEventNotifications(TransactionCase, MailCase):
         triggers_after = self.env['ir.cron.trigger'].search([('cron_id', '=', cron_id)])
         new_triggers = triggers_after - triggers_before
         new_triggers.ensure_one()
-        self.assertEqual(new_triggers.call_at, now - relativedelta(minutes=5))
+        self.assertEqual(
+            new_triggers.call_at,
+            now.replace(second=0) - relativedelta(minutes=5),
+        )
 
         with patch.object(fields.Datetime, 'now', lambda: now):
             with self.assertSinglePostNotifications([{'partner': self.partner, 'type': 'inbox'}], {


### PR DESCRIPTION
Often the business want to trigger the cron several time at different
moments.  The typical use case is the business holds a recordset and
needs to trigger the cron for every record.  The current solution is to
loop on each record to call `_trigger` times.

We now allow to invoke `_trigger` with an iterable of `datetime`
objects, and isolate the implementation in method `_trigger_list`.

We also removed the `delay` argument as it was not used.

Task: 2452697