### PR TITLE
[FIX] payment_alipay, payment_paypal: Online payment with public user

### DIFF
--- a/addons/payment_alipay/models/payment.py
+++ b/addons/payment_alipay/models/payment.py
@@ -57,7 +57,7 @@ class PaymentAcquirer(models.Model):
         fees = 0.0
         if self.fees_active:
             country = self.env['res.country'].browse(country_id)
-            if country and self.company_id.country_id.id == country.id:
+            if country and self.company_id.sudo().country_id.id == country.id:
                 percentage = self.fees_dom_var
                 fixed = self.fees_dom_fixed
             else:

--- a/addons/payment_paypal/models/payment.py
+++ b/addons/payment_paypal/models/payment.py
@@ -75,7 +75,7 @@ class AcquirerPaypal(models.Model):
         if not self.fees_active:
             return 0.0
         country = self.env['res.country'].browse(country_id)
-        if country and self.company_id.country_id.id == country.id:
+        if country and self.company_id.sudo().country_id.id == country.id:
             percentage = self.fees_dom_var
             fixed = self.fees_dom_fixed
         else:


### PR DESCRIPTION
Steps to reproduce the bug:

1) Enable Paypal on the Payment Acquirers and select "BE Company CoA" on the company
2) fill the email and enable the "Add Extra Fees"
3) create an invoice on the company "BE Company CoA"
4) preview it as a public user

Bug:
An access error was raised:

Due to security restrictions, you are not allowed to access 'Companies' (res.company) records.

opw:2439896