### PR TITLE
[FIX] web_editor: update image gallery miniatures

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
@@ -497,6 +497,7 @@ var FileWidget = SearchableMediaWidget.extend({
                     self.$media.removeAttr('data-' + attr);
                 });
             }
+            self.$media.trigger('save')
             return self.media;
         });
     },


### PR DESCRIPTION
When changing an image in the image gallery snippet, its miniature was not updated.

task-2438556

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
