### PR TITLE
[FIX] stock: use returned moves when confirming

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -625,7 +625,7 @@ class Picking(models.Model):
                                                     'picking_type_id': pick.picking_type_id.id,
                                                    })
                     ops.move_id = new_move.id
-                    new_move._action_confirm()
+                    new_move = new_move._action_confirm()
                     todo_moves |= new_move
                     #'qty_done': ops.qty_done})
         todo_moves._action_done()


### PR DESCRIPTION
Steps:
- Install mrp, stock
- Go to Inventory > Configuration > Operation Types
- Edit Delivery Orders:
  - Show Detailed Operations: Checked
- Go to Master Data > Products
- Create two products (1) (2)
- Click (1)
- Click the "Bill of Material" smart button
- Create a BoM:
  - BoM Type: Kit
  - Component: (2)
- Go to Overview
- Click Delivery Orders
- Create a Delivery Order:
  - Add (1) with an initial demand of 1
- Mark as ToDo
- Click Edit:
  - Detailed Operations tab:
    - Add (1) with a done quantity of 1
- Validate and create a Backorder

Bug:
Record does not exist or has been deleted.
(Record: stock.move(60,), User: 2)

Explanation:
When confirming a `stock.picking` with `mrp` installed, the action goes
through `action_explode()`.
https://github.com/odoo/odoo/blob/d9ea1d5f054f05197581acf67c8a9c1e6acb8d02/addons/mrp/models/stock_move.py#L154
This action splits the components of the product with a Kit (`phantom`)
BoM instead of manufacturing it. When everything is split, the
`stock.move` unlinks itself because it has been replaced with its
components. `action_explode()` then returns the new components. Trying
to call a method on the unlinked move will result in an error.

This commit replaces the move with the newly generated component moves.

This is safe to do in `stock` because the non-overridden
`_action_confirm()` returns the move it was called on as seen here:
https://github.com/odoo/odoo/blob/d9ea1d5f054f05197581acf67c8a9c1e6acb8d02/addons/stock/models/stock_move.py#L790

opw:2450016