### PR TITLE
[FIX] product_margin: fix Avg. Sale Unit Price

### DIFF
--- a/addons/product_margin/models/product_product.py
+++ b/addons/product_margin/models/product_product.py
@@ -112,7 +112,10 @@ class ProductProduct(models.Model):
             sqlstr = """
                 WITH currency_rate AS ({})
                 SELECT
-                    SUM(l.price_unit / (CASE COALESCE(cr.rate, 0) WHEN 0 THEN 1.0 ELSE cr.rate END) * l.quantity) / NULLIF(SUM(l.quantity),0) AS avg_unit_price,
+                    SUM(
+                        l.price_unit / (CASE COALESCE(cr.rate, 0) WHEN 0 THEN 1.0 ELSE cr.rate END) *
+                        l.quantity * (CASE WHEN i.type IN ('out_invoice', 'in_invoice') THEN 1 ELSE -1 END) * ((100 - l.discount) * 0.01)
+                    ) / NULLIF(SUM(l.quantity * (CASE WHEN i.type IN ('out_invoice', 'in_invoice') THEN 1 ELSE -1 END)), 0) AS avg_unit_price,
                     SUM(l.quantity * (CASE WHEN i.type IN ('out_invoice', 'in_invoice') THEN 1 ELSE -1 END)) AS num_qty,
                     SUM(ABS(l.balance) * (CASE WHEN i.type IN ('out_invoice', 'in_invoice') THEN 1 ELSE -1 END)) AS total,
                     SUM(l.quantity * pt.list_price * (CASE WHEN i.type IN ('out_invoice', 'in_invoice') THEN 1 ELSE -1 END)) AS sale_expected


### PR DESCRIPTION
- Install product_margin
- Go to Invoicing > Customers > Invoices and create an Invoice
- Add a Credit Note
- Go to Accounting > Reporting > Product Margins and check Product used in the Invoice
The "Avg. Sale Unit Price" is incorrect. It should be 0 as it is for "# Invoiced in Sale"

Credit Notes are not taken into consideration when computing "Avg. Sale Unit Price".
This is also the case for discount.

opw-2382797

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
