### PR TITLE
[FIX] web_editor: update image gallery miniatures

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/media_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/media_dialog.js
@@ -151,6 +151,7 @@ var MediaDialog = Dialog.extend({
                     media: data,
                 });
             }
+            $(data).trigger('save')
             return _super.apply(self, args);
         });
     },


### PR DESCRIPTION
When changing an image in the image gallery snippet, its miniature was not updated.

task-2438556
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
