### PR TITLE
[IMP] mass_mailing, mass_mailing_sms: revamp mail trace form

### DIFF
--- a/addons/mass_mailing/models/mailing_trace.py
+++ b/addons/mass_mailing/models/mailing_trace.py
@@ -27,6 +27,8 @@ class MailingTrace(models.Model):
     )
     email = fields.Char(string="Email", help="Normalized email address")
     message_id = fields.Char(string='Message-ID')
+    medium_id = fields.Many2one(related='mass_mailing_id.medium_id')
+    source_id = fields.Many2one(related='mass_mailing_id.source_id')
     # document
     model = fields.Char(string='Document model')
     res_id = fields.Integer(string='Document ID')
@@ -97,6 +99,16 @@ class MailingTrace(models.Model):
             if 'mail_mail_id' in values:
                 values['mail_mail_id_int'] = values['mail_mail_id']
         return super(MailingTrace, self).create(values_list)
+
+    def action_view_contact(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'view_mode': 'form',
+            'res_model': self.model,
+            'target': 'current',
+            'res_id': self.res_id
+        }
 
     def _get_records(self, mail_mail_ids=None, mail_message_ids=None, domain=None):
         if not self.ids and mail_mail_ids:

--- a/addons/mass_mailing/views/mailing_trace_views.xml
+++ b/addons/mass_mailing/views/mailing_trace_views.xml
@@ -56,47 +56,41 @@
         <field name="name">mailing.trace.form</field>
         <field name="model">mailing.trace</field>
         <field name="arch" type="xml">
-            <form string="Mail Statistics" create="0">
+            <form string="Mail Statistics" create="0" edit="0">
                 <header>
                     <field name="state" widget="statusbar"/>
                 </header>
                 <sheet>
-                    <div class="alert alert-info text-center" role="alert" name="alert_mail_exception"
-                        attrs="{'invisible': [('exception', '=', False), ('bounced', '=', False)]}">
-                        <p>
-                            <strong><span name="trace_type_name_mail">This email</span>
-                            <span attrs="{'invisible': [('exception', '=', False)]}"> could not be sent</span>
-                            <span attrs="{'invisible': [('bounced', '=', False)]}"> appears to be invalid</span>
-                            </strong>
-                        </p>
+                    <div class="oe_button_box" name="button_box">
+                        <button name="action_view_contact"
+                                type="object" icon="fa-user" class="oe_stat_button">
+                            <span widget="statinfo">Open Recipient</span>
+                        </button>
                     </div>
                     <group>
-                        <group string="Recipient">
+                        <group string="Mailing">
                             <field name="trace_type" invisible="1"/>
-                            <field name="email"/>
-                            <field name="mail_mail_id_int"/>
-                            <field name="message_id"/>
+                            <field name="email" string="Recipient Address" readonly="1"/>
+                            <field name="sent" attrs="{'invisible' : [('sent', '=', False)]}" readonly="1"/>
+                            <field name="opened" attrs="{'invisible' : [('opened', '=', False)]}" readonly="1"/>
+                            <field name="replied" attrs="{'invisible' : [('replied', '=', False)]}" readonly="1"/>
+                            <field name="bounced" attrs="{'invisible' : [('bounced', '=', False)]}" readonly="1"/>
+                            <field name="ignored" attrs="{'invisible' : [('ignored', '=', False)]}" readonly="1"/>
+                            <field name="failure_type" attrs="{'invisible' : [('failure_type', '=', False)]}" readonly="1"/>
                         </group>
-                        <group string="Document">
-                            <field name="model"/>
-                            <field name="res_id"/>
-                            <field name="state_update"/>
+
+                        <group string="Marketing">
+                            <field name="campaign_id" readonly="1"/>
+                            <field name="medium_id" readonly="1"/>
+                            <field name="source_id" readonly="1"/>
+                            <field name="mass_mailing_id" readonly="1"/>
                         </group>
-                    </group>
-                    <group string="Marketing">
-                        <group>
-                            <field name="mass_mailing_id"/>
-                            <field name="campaign_id"/>
-                            <field name="sent"/>
-                            <field name="opened"/>
-                            <field name="clicked"/>
-                            <field name="replied"/>
-                        </group>
-                        <group>
-                            <field name="exception"/>
-                            <field name="ignored"/>
-                            <field name="bounced"/>
-                            <field name="failure_type"/>
+
+                        <group string="Technical">
+                            <field name="exception" readonly="1"/>
+                            <field name="state_update" readonly="1"/>
+                            <field name="mail_mail_id_int" string="Mail ID" readonly="1"/>
+                            <field name="message_id" readonly="1"/>
                         </group>
                     </group>
                 </sheet>

--- a/addons/mass_mailing_sms/views/mailing_trace_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_trace_views.xml
@@ -51,12 +51,6 @@
         <field name="model">mailing.trace</field>
         <field name="inherit_id" ref="mass_mailing.mailing_trace_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//span[@name='trace_type_name_mail']" position="attributes">
-                <attribute name="attrs">{'invisible': [('trace_type', '!=', 'mail')]}</attribute>
-            </xpath>
-            <xpath expr="//span[@name='trace_type_name_mail']" position="after">
-                <span name="trace_type_name_sms" attrs="{'invisible': [('trace_type', '!=', 'sms')]}">This sms</span>
-            </xpath>
             <xpath expr="//field[@name='email']" position="attributes">
                 <attribute name="attrs">{'invisible': [('trace_type', '!=', 'mail')]}</attribute>
             </xpath>
@@ -67,14 +61,20 @@
                 <attribute name="attrs">{'invisible': [('trace_type', '!=', 'mail')]}</attribute>
             </xpath>
             <xpath expr="//field[@name='opened']" position="attributes">
-                <attribute name="attrs">{'invisible': [('trace_type', '=', 'sms')]}</attribute>
+                <attribute name="attrs">
+                    {'invisible': ['|', ('opened', '=', False), ('trace_type', '=', 'sms')]}
+                </attribute>
             </xpath>
             <xpath expr="//field[@name='replied']" position="attributes">
-                <attribute name="attrs">{'invisible': [('trace_type', '=', 'sms')]}</attribute>
+                <attribute name="attrs">
+                    {'invisible': ['|', ('replied', '=', False), ('trace_type', '=', 'sms')]}
+                </attribute>
             </xpath>
             <xpath expr="//field[@name='email']" position="after">
                 <field name="sms_number" attrs="{'invisible': [('trace_type', '!=', 'sms')]}"/>
-                <field name="sms_sms_id_int" attrs="{'invisible': [('trace_type', '!=', 'sms')]}"/>
+            </xpath>
+            <xpath expr="//field[@name='mail_mail_id_int']" position="after">
+                <field name="sms_sms_id_int" string="SMS ID" attrs="{'invisible': [('trace_type', '!=', 'sms')]}"/>
                 <field name="sms_code" attrs="{'invisible': [('trace_type', '!=', 'sms')]}"/>
             </xpath>
         </field>


### PR DESCRIPTION
[IMP] mass_mailing, mass_mailing_sms: revamp mail trace form

- make all the mailing trace fields readonly inside the form,
  beacause a user would not want to edit a mailing trace as
  this will make the related statistics about the mailings
  incorrect
- change the mailing trace form view interface to give more
  clarity to the user and to better separate between different
  fields
- add a stat button to redirect the user to the coressponding
  mailing contact so that he can easily access the mailing
  contact in order to blacklist/output/correct the email address
  or the phone number
- remove the warning messages in the mailing trace form view
  because the user already has all the information in the
  status bar of the form
- update the inherited mailing trace form view located in the
  mass_mailing_sms module to adapt to the new changes in the
  trace form view of the mass_mailing module

Task-2440420
Enterprise PR: odoo/enterprise#16105