### PR TITLE
[FIX] l10n_ch: use commercial partner name instead of computed field

### DIFF
--- a/addons/l10n_ch/models/res_bank.py
+++ b/addons/l10n_ch/models/res_bank.py
@@ -126,7 +126,7 @@ class ResPartnerBank(models.Model):
             '{:.2f}'.format(amount),                              # Amount
             currency_name,                                        # Currency
             'K',                                                  # Ultimate Debtor Address Type
-            debtor_partner.commercial_company_name[:71],          # Ultimate Debtor Name
+            debtor_partner.commercial_partner_id.name[:71],       # Ultimate Debtor Name
             debtor_addr_1,                                        # Ultimate Debtor Address Line 1
             debtor_addr_2,                                        # Ultimate Debtor Address Line 2
             '',                                                   # Ultimate Debtor Postal Code (not to be provided for address type K)

--- a/addons/l10n_ch/report/swissqr_report.xml
+++ b/addons/l10n_ch/report/swissqr_report.xml
@@ -51,7 +51,7 @@
                             </t>
 
                             <span class="swissqr_text title">Payable by</span><br/>
-                            <span class="swissqr_text content" t-field="o.partner_id.commercial_company_name"/><br/>
+                            <span class="swissqr_text content" t-field="o.partner_id.commercial_partner_id.name"/><br/>
                             <span class="swissqr_text content" t-field="o.partner_id.country_id.code"/>
                             <span class="swissqr_text content" t-field="o.partner_id.zip"/>
                             <span class="swissqr_text content" t-field="o.partner_id.city"/><br/>
@@ -101,7 +101,7 @@
                             <br/>
 
                             <span class="swissqr_text title">Payable by</span><br/>
-                            <span class="swissqr_text content" t-field="o.partner_id.commercial_company_name"/><br/>
+                            <span class="swissqr_text content" t-field="o.partner_id.commercial_partner_id.name"/><br/>
                             <span class="swissqr_text content" t-field="o.partner_id.street"> </span>
                             <span class="swissqr_text content" t-field="o.partner_id.street2"/><br/>
                             <span class="swissqr_text content" t-field="o.partner_id.country_id.code"/>


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/65357