### PR TITLE
[FIX] website_sale_delivery: prevent free shipping

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_buy.js
+++ b/addons/website_sale/static/tests/tours/website_sale_buy.js
@@ -53,14 +53,20 @@ tour.register('shop_buy_product', {
             trigger: '#cart_products tr:contains("Storage Box") a.js_add_cart_json:first',
         },
         {
-            content: "set one",
+            content: "set three",
             extra_trigger: '#wrap:not(:has(#cart_products tr:contains("Storage Box")))',
             trigger: '#cart_products input.js_quantity',
-            run: 'text 1',
+            run: 'text 3',
+        },
+        {
+            content: "check amount",
+            // wait for cart_update_json to prevent concurrent update
+            trigger: '#order_total span.oe_currency_value:contains("49.50")',
+            run: function () {}, // it's a check
         },
         {
             content: "go to checkout",
-            extra_trigger: '#cart_products input.js_quantity:propValue(1)',
+            extra_trigger: '#cart_products input.js_quantity:propValue(3)',
             trigger: 'a[href*="/shop/checkout"]',
         },
         {

--- a/addons/website_sale_delivery/controllers/main.py
+++ b/addons/website_sale_delivery/controllers/main.py
@@ -4,7 +4,7 @@
 from odoo import http, _
 from odoo.http import request
 from odoo.addons.website_sale.controllers.main import WebsiteSale
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 
 
 class WebsiteSaleDelivery(WebsiteSale):
@@ -21,6 +21,13 @@ class WebsiteSaleDelivery(WebsiteSale):
                 return request.redirect("/shop/payment")
 
         return super(WebsiteSaleDelivery, self).payment(**post)
+
+    @http.route()
+    def payment_transaction(self, *args, **kwargs):
+        order = request.website.sale_get_order()
+        if not order.is_all_service and not order.delivery_set:
+            raise ValidationError(_('There is an issue with your delivery method. Please refresh the page and try again.'))
+        return super().payment_transaction(*args, **kwargs)
 
     @http.route(['/shop/update_carrier'], type='json', auth='public', methods=['POST'], website=True, csrf=False)
     def update_eshop_carrier(self, **post):

--- a/addons/website_sale_delivery/i18n/website_sale_delivery.pot
+++ b/addons/website_sale_delivery/i18n/website_sale_delivery.pot
@@ -124,6 +124,13 @@ msgid ""
 msgstr ""
 
 #. module: website_sale_delivery
+#: code:addons/website_sale_delivery/controllers/main.py:0
+#, python-format
+msgid ""
+"There is an issue with your delivery method. Please refresh the page and try again."
+msgstr ""
+
+#. module: website_sale_delivery
 #: model:ir.model.fields,field_description:website_sale_delivery.field_delivery_carrier____last_update
 #: model:ir.model.fields,field_description:website_sale_delivery.field_res_country____last_update
 #: model:ir.model.fields,field_description:website_sale_delivery.field_sale_order____last_update


### PR DESCRIPTION
Impacted versions: 14.0, and maybe other

Steps to reproduce:
- go to runbot
- add carrier (with a fixed price: 100)
- got to website
- open an other tab : 1
- select product A (cost 200), checkout, arrive in the /shop/payment page, select the carrier
- open an other tab : 2
- select product A (cost 200), add to cart then click on continue shopping
- go back on tab 1
- click Pay Now
- then you arrive on the confirmation page
--> Issue : the total price is 400€, it should be 500€ (200 + 200 + 100)

Cause 1 : when you update the cart, delivery line have removed : https://github.com/odoo/odoo/blob/14.0/addons/website_sale_delivery/models/sale_order.py#L83
Cause 2 : in shop/payment/transaction there are no check https://github.com/odoo/odoo/blob/14.0/addons/website_sale/controllers/main.py#L877

@odony 
@nim-odoo
@simongoffin 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
