### PR TITLE
[FIX] mail: odoo shortcuts doesn't work if chat window is focused

### DIFF
--- a/addons/mail/static/src/components/chat_window/chat_window.js
+++ b/addons/mail/static/src/components/chat_window/chat_window.js
@@ -289,12 +289,6 @@ class ChatWindow extends Component {
      * @param {KeyboardEvent} ev
      */
     _onKeydown(ev) {
-        /**
-         * Prevent auto-focus of fuzzy search in the home menu.
-         * Useful in order to allow copy/paste content inside chat window with
-         * CTRL-C & CTRL-V when on the home menu.
-         */
-        ev.stopPropagation();
         if (!this.chatWindow) {
             // prevent crash during delete
             return;


### PR DESCRIPTION
**Current behavior before PR:**

When chat window is focused odoo shortcuts (with alt) did not work because of
there is stop propagation in _onKeydown method.

**Desired behavior after PR is merged:**

Remove stop propagation. Now odoo shortcuts (with alt) work properly.

**LINKS:**
PR #65478
Task-2388829

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
