### PR TITLE
[FIX] web,base: save when tab/browser closes

### DIFF
--- a/addons/web/static/src/js/views/basic/basic_controller.js
+++ b/addons/web/static/src/js/views/basic/basic_controller.js
@@ -48,6 +48,13 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
         // discard when discardChanges is called
         this.savingDef = Promise.resolve();
         this.viewId = params.viewId;
+
+        // In this controller, '_applyChanges' is overridden s.t. '_notifyChanges'
+        // of the model is called in a mutex. The following structure is used to
+        // accumulate change requests that haven't been sent to the model yet,
+        // because of the mutex. This is useful when we want to quickly save a
+        // record before leaving Odoo (see @_urgentSave).
+        this.pendingChanges = [];
     },
     /**
      * @override
@@ -58,6 +65,32 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
         // correctly display the nocontent helper)
         this.$el.toggleClass('o_cannot_create', !this.activeActions.create);
         await this._super(...arguments);
+    },
+    /**
+     * @override
+     */
+    destroy: function () {
+        this._super(...arguments);
+        if (this._boundOnBeforeUnload) {
+            window.removeEventListener("beforeunload", this._boundOnBeforeUnload);
+        }
+    },
+    /**
+     * @override
+     */
+    on_attach_callback: function () {
+        this._super(...arguments);
+        this._boundOnBeforeUnload = this._onBeforeUnload.bind(this);
+        window.addEventListener("beforeunload", this._boundOnBeforeUnload);
+    },
+    /**
+     * @override
+     */
+    on_detach_callback: function () {
+        this._super(...arguments);
+        if (this._boundOnBeforeUnload) {
+            window.removeEventListener("beforeunload", this._boundOnBeforeUnload);
+        }
     },
 
     //--------------------------------------------------------------------------
@@ -232,13 +265,19 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
     },
     /**
      * We override applyChanges (from the field manager mixin) to protect it
-     * with a mutex.
+     * with a mutex. As we do so, we need to accumulate change requests that
+     * haven't been sent to the model yet, just in case we would leave Odoo
+     * (close tab/browser). If this happens, we will bypass the mutex and notify
+     * the model directly of those changes, to save them if possible (see
+     * @_urgentSave).
      *
      * @override
      */
     _applyChanges: function (dataPointID, changes, event) {
+        this.pendingChanges.push({ dataPointID, changes, event });
         var _super = FieldManagerMixin._applyChanges.bind(this);
-        return this.mutex.exec(function () {
+        return this.mutex.exec(() => {
+            this.pendingChanges.shift();
             return _super(dataPointID, changes, event);
         });
     },
@@ -656,6 +695,48 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
         });
         return this.updateControlPanel(props);
     },
+    /**
+     * To be called **only** when Odoo is about to be closed, and we want to
+     * save potential changes on a given record.
+     *
+     * We can't follow the normal flow (onchange(s) + save, mutexified),
+     * because the 'beforeunload' handler must be *almost* sync (< 10 ms
+     * setTimeout seems fine, but an rpc roundtrip is definitely too long),
+     * so here we bypass the standard mechanism of notifying changes and
+     * saving them:
+     *  - we ask the model to bypass its mutex for upcoming 'notifyChanges' and
+     *   'save' requests
+     *  - we ask all widgets to commit their changes (in case there would
+     *    be a focused field with a fresh value)
+     *  - we take all pendingChanges (changes that have been reported to the
+     *    controller, but not yet sent to the model because of the mutex),
+     *    and directly notify the model about them
+     *  - we reset the widgets with all those changes, s.t. a further call
+     *    to 'canBeRemoved' uses the correct data (it asks the widgets if
+     *    they are set/valid, based on their internal state)
+     *  - if the record is dirty, we save directly
+     *
+     * @param {string} recordID
+     * @private
+     */
+    _urgentSave(recordID) {
+        this.model.executeDirectly(() => {
+            this.renderer.commitChanges(recordID);
+            for (const key in this.pendingChanges) {
+                const { changes, dataPointID, event } = this.pendingChanges[key];
+                const options = {
+                    context: event.data.context,
+                    viewType: event.data.viewType,
+                    notifyChange: false,
+                };
+                this.model.notifyChanges(dataPointID, changes, options);
+                this._confirmChange(dataPointID, Object.keys(changes), event);
+            }
+            if (this.isDirty()) {
+                this._saveRecord(recordID, { reload: false, stayInEdit: true });
+            }
+        });
+    },
 
     //--------------------------------------------------------------------------
     // Handlers
@@ -730,6 +811,16 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
         if (state.limit === limit) {
             this.trigger_up('scrollTo', { top: 0 });
         }
+    },
+    /**
+     * Called when the user closes the tab or browser. To be overriden by
+     * specific controllers to execute some code (e.g. save pending changes)
+     * just before leaving Odoo.
+     *
+     * @abstract
+     * @private
+     */
+    _onBeforeUnload: function () {
     },
     /**
      * When a reload event triggers up, we need to reload the full view.

--- a/addons/web/static/src/js/views/form/form_controller.js
+++ b/addons/web/static/src/js/views/form/form_controller.js
@@ -479,6 +479,14 @@ var FormController = BasicController.extend({
     //--------------------------------------------------------------------------
 
     /**
+     * Save the record when we are about to leave Odoo.
+     *
+     * @override
+     */
+    _onBeforeUnload: function () {
+        this._urgentSave(this.handle);
+    },
+    /**
      * @private
      * @param {OdooEvent} ev
      */

--- a/addons/web/static/src/js/views/list/list_controller.js
+++ b/addons/web/static/src/js/views/list/list_controller.js
@@ -691,6 +691,17 @@ var ListController = BasicController.extend({
         }
     },
     /**
+     * Save the row in edition, if any, when we are about to leave Odoo.
+     *
+     * @override
+     */
+    _onBeforeUnload: function () {
+        const recordId = this.renderer.getEditableRecordID();
+        if (recordId) {
+            this._urgentSave(recordId);
+        }
+    },
+    /**
      * Handles a click on a button by performing its action.
      *
      * @private

--- a/odoo/addons/base/static/src/js/res_config_settings.js
+++ b/odoo/addons/base/static/src/js/res_config_settings.js
@@ -414,6 +414,13 @@ var BaseSettingController = FormController.extend({
             this._super.apply(this, arguments);
         }
     },
+    /**
+     * @override
+     * @private
+     */
+    _onBeforeUnload: function () {
+        // We should not save when leaving Odoo in the settings
+    },
 
 });
 


### PR DESCRIPTION
PR [1] introduced the auto save feature (changes in form and list
views are automatically saved when the view is left, e.g. with
the pager, breadcrumbs, stat buttons, menus...).

However, there was one case that had been left aside: when we close
the tab or browser. This commit ensures that we also save the
changes in this case.

The record is saved only if it is valid, otherwise the changes are
simply lost (we don't block the tab/browser from closing itself).

Moreover, the beforeunload handler must be *almost* sync (a few
ms setTimeout seems ok, but definitely not an rpc roundtrip). For
that reason, we cannot wait for onchanges to apply before saving.

part of task 2330101

[1] https://github.com/odoo/odoo/pull/60693

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
