### PR TITLE
[IMP] mail: notify user with notification after preference changes

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -7000,3 +7000,10 @@ msgstr ""
 #: model:ir.model.fields.selection,name:mail.selection__mail_activity_type__delay_unit__weeks
 msgid "weeks"
 msgstr ""
+
+#. module: mail
+#. openerp-web
+#: code:addons/mail/static/src/models/follower/follower.js:0
+#, python-format
+msgid "The subscription preferences were successfully applied."
+msgstr ""

--- a/addons/mail/static/src/models/follower/follower.js
+++ b/addons/mail/static/src/models/follower/follower.js
@@ -158,6 +158,10 @@ function factory(dependencies) {
                     args: [[this.followedThread.id]],
                     kwargs,
                 }));
+                this.env.services['notification'].notify({
+                    type: 'success',
+                    message: this.env._t("The subscription preferences were successfully applied."),
+                });
             }
             this.closeSubtypes();
         }


### PR DESCRIPTION
**PURPOSE**

Currently, the user doesn't receive any feedback or notification when updating
his subscription preferences. Therefore, he might be prompted to open the
subscription modal again to double-check that his modifications were correctly
applied or not.

**SPECIFICATION**

We are now displaying screen notifications using notify method of the notification widget.

**Task : 2445481**