### PR TITLE
[FIX] stock: traceability report mounted called twice

### DIFF
--- a/addons/stock/static/src/js/stock_traceability_report_backend.js
+++ b/addons/stock/static/src/js/stock_traceability_report_backend.js
@@ -99,10 +99,6 @@ var stock_report_generic = AbstractAction.extend({
         });
         return this.$buttons;
     },
-    do_show: function() {
-        this._super();
-        this.update_cp();
-    },
 });
 
 core.action_registry.add("stock_report_generic", stock_report_generic);

--- a/addons/stock/static/tests/stock_traceability_report_backend_tests.js
+++ b/addons/stock/static/tests/stock_traceability_report_backend_tests.js
@@ -1,9 +1,12 @@
 odoo.define('stock.stock_traceability_report_backend_tests', function (require) {
     "use strict";
 
+    const ControlPanel = require('web.ControlPanel');
     const dom = require('web.dom');
     const StockReportGeneric = require('stock.stock_report_generic');
     const testUtils = require('web.test_utils');
+
+    const { createActionManager, dom: domUtils } = testUtils;
 
     /**
      * Helper function to instantiate a stock report action.
@@ -66,6 +69,83 @@ odoo.define('stock.stock_traceability_report_backend_tests', function (require) 
                 "Displayed template should match");
 
             report.destroy();
+        });
+
+        QUnit.test("mounted is called once when returning on 'Stock report' from breadcrumb", async assert => {
+            // This test can be removed as soon as we don't mix legacy and owl layers anymore.
+            assert.expect(7);
+
+            let mountCount = 0;
+
+            ControlPanel.patch('test.ControlPanel', T => {
+                class ControlPanelPatchTest extends T {
+                    mounted() {
+                        mountCount = mountCount + 1;
+                        this.__uniqueId = mountCount;
+                        assert.step(`mounted ${this.__uniqueId}`);
+                        super.mounted(...arguments);
+                    }
+                    willUnmount() {
+                        assert.step(`willUnmount ${this.__uniqueId}`);
+                        super.mounted(...arguments);
+                    }
+                }
+                return ControlPanelPatchTest;
+            });
+
+            const actionManager = await createActionManager({
+                actions: [
+                    {
+                        id: 42,
+                        name: "Stock report",
+                        tag: 'stock_report_generic',
+                        type: 'ir.actions.client',
+                        context: {},
+                        params: {},
+                    },
+                ],
+                archs: {
+                    'partner,false,form': '<form><field name="display_name"/></form>',
+                    'partner,false,search': '<search></search>',
+                },
+                data: {
+                    partner: {
+                        fields: {
+                            display_name: { string: "Displayed name", type: "char" },
+                        },
+                        records: [
+                            {id: 1, display_name: "Genda Swami"},
+                        ],
+                    },
+                },
+                mockRPC: function (route) {
+                    if (route === '/web/dataset/call_kw/stock.traceability.report/get_html') {
+                        return Promise.resolve({
+                            html: '<a class="o_stock_reports_web_action" href="#" data-active-id="1" data-res-model="partner">Go to form view</a>',
+                        });
+                    }
+                    return this._super.apply(this, arguments);
+                },
+                intercepts: {
+                    do_action: ev => actionManager.doAction(ev.data.action, ev.data.options),
+                },
+            });
+
+            await actionManager.doAction(42);
+            await domUtils.click(actionManager.$('.o_stock_reports_web_action'));
+            await domUtils.click(actionManager.$('.breadcrumb-item:first'));
+            actionManager.destroy();
+
+            assert.verifySteps([
+                'mounted 1',
+                'willUnmount 1',
+                'mounted 2',
+                'willUnmount 2',
+                'mounted 3',
+                'willUnmount 3',
+            ]);
+
+            ControlPanel.unpatch('test.ControlPanel');
         });
     });
 });

--- a/addons/web/static/src/js/report/client_action.js
+++ b/addons/web/static/src/js/report/client_action.js
@@ -53,15 +53,6 @@ var ReportAction = AbstractAction.extend({
         });
     },
 
-    do_show: function () {
-        this.updateControlPanel({
-            cp_content: {
-                $buttons: this.$buttons,
-            },
-        });
-        return this._super.apply(this, arguments);
-    },
-
     on_attach_callback: function () {
         // Register now the postMessage event handler. We only want to listen to ~trusted
         // messages and we can only filter them by their origin, so we chose to ignore the

--- a/addons/web/static/tests/report/client_action_tests.js
+++ b/addons/web/static/tests/report/client_action_tests.js
@@ -1,0 +1,111 @@
+odoo.define('web/static/tests/report/client_action_tests', function (require) {
+    "use strict";
+
+    const ControlPanel = require('web.ControlPanel');
+    const ReportClientAction = require('report.client_action');
+    const testUtils = require("web.test_utils");
+
+    const { createActionManager, dom, mock } = testUtils;
+
+    QUnit.module('Client Action Report', {}, () => {
+        QUnit.test("mounted is called once when returning on 'Client Action Report' from breadcrumb", async assert => {
+            // This test can be removed as soon as we don't mix legacy and owl layers anymore.
+            assert.expect(7);
+
+            let mountCount = 0;
+
+            // patch the report client action to override its iframe's url so that
+            // it doesn't trigger an RPC when it is appended to the DOM (for this
+            // usecase, using removeSRCAttribute doesn't work as the RPC is
+            // triggered as soon as the iframe is in the DOM, even if its src
+            // attribute is removed right after)
+            mock.patch(ReportClientAction, {
+                start: function () {
+                    var self = this;
+                    return this._super.apply(this, arguments).then(function () {
+                        self._rpc({route: self.iframe.getAttribute('src')});
+                        self.iframe.setAttribute('src', 'about:blank');
+                    });
+                }
+            });
+
+            ControlPanel.patch('test.ControlPanel', T => {
+                class ControlPanelPatchTest extends T {
+                    mounted() {
+                        mountCount = mountCount + 1;
+                        this.__uniqueId = mountCount;
+                        assert.step(`mounted ${this.__uniqueId}`);
+                        super.mounted(...arguments);
+                    }
+                    willUnmount() {
+                        assert.step(`willUnmount ${this.__uniqueId}`);
+                        super.mounted(...arguments);
+                    }
+                }
+                return ControlPanelPatchTest;
+            });
+            const actionManager = await createActionManager({
+                actions: [
+                    {
+                        id: 42,
+                        name: "Client Action Report",
+                        tag: 'report.client_action',
+                        type: 'ir.actions.report',
+                        report_type: 'qweb-html',
+                    },
+                    {
+                        id: 43,
+                        type: "ir.actions.act_window",
+                        res_id: 1,
+                        res_model: "partner",
+                        views: [
+                            [false, "form"],
+                        ],
+                    }
+                ],
+                archs: {
+                    'partner,false,form': '<form><field name="display_name"/></form>',
+                    'partner,false,search': '<search></search>',
+                },
+                data: {
+                    partner: {
+                        fields: {
+                            display_name: { string: "Displayed name", type: "char" },
+                        },
+                        records: [
+                            {id: 1, display_name: "Genda Swami"},
+                        ],
+                    },
+                },
+                mockRPC: function (route) {
+                    if (route === '/report/html/undefined?context=%7B%7D') {
+                        return Promise.resolve('<a action="go_to_details">Go to detail view</a>');
+                    }
+                    return this._super.apply(this, arguments);
+                },
+                intercepts: {
+                    do_action: ev => actionManager.doAction(ev.data.action, ev.data.options),
+                },
+            });
+
+            await actionManager.doAction(42);
+            // simulate an action as we are not able to reproduce a real doAction using 'Client Action Report'
+            await actionManager.doAction(43);
+            await dom.click(actionManager.$('.breadcrumb-item:first'));
+            actionManager.destroy();
+
+            assert.verifySteps([
+                'mounted 1',
+                'willUnmount 1',
+                'mounted 2',
+                'willUnmount 2',
+                'mounted 3',
+                'willUnmount 3',
+            ]);
+
+            ControlPanel.unpatch('test.ControlPanel');
+            mock.unpatch(ReportClientAction);
+        });
+    });
+
+});

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -777,6 +777,8 @@
         <script type="text/javascript" src="/web/static/tests/widgets/model_field_selector_tests.js"/>
         <script type="text/javascript" src="/web/static/tests/widgets/rainbow_man_tests.js"/>
 
+        <script type="text/javascript" src="/web/static/tests/report/client_action_tests.js"/>
+
         <script type="text/javascript" src="/web/static/tests/tools/debug_manager_tests.js"/>
 
         <script type="text/javascript" src="/web/static/tests/helpers/test_utils_tests.js"></script>


### PR DESCRIPTION
Before this commit, the 'mounted' method of the ControlPanel in
the traceability report was called twice.

It happened because the traceability report updated the ControlPanel
before being actually mounted, so mounted was called once when the
traceability report was mounted, and once when the update was applied.

Ideally, this should not be an issue (this isn't an issue with owl).
However, in Odoo, we mix layers of Owl Components and legacy
widgets. In these situations, the above scenario isn't properly
handled (and can't be).

As a consequence, in mobile (enterprise), it crashed because an
handler bound in mounted (thus twice) was only unbound once.

This commit avoids the issue as the update was actually useless.

Steps to reproduces:
* Go to Manufacturing (MRP)
* Open the "burger menu"
* Select "Products" -> "Lots/Serial Numbers"
* Select one product in the list (unfold group first)
* Click on the "Traceability" ("stat button")
* Select one line to go to the form view
* Go back to the previous view using breadcrumb
* Optional: Go to another app if the screen can't scroll (e.g. go to Sales)
* Scroll the view => Bug

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
