### PR TITLE
[FIX] web: nested invisible x2many in sub form view

### DIFF
--- a/addons/web/static/src/js/views/basic/basic_view.js
+++ b/addons/web/static/src/js/views/basic/basic_view.js
@@ -140,6 +140,11 @@ var BasicView = AbstractView.extend({
                     if ((fieldType === 'one2many' || fieldType === 'many2many')) {
                         var x2mFieldInfo = record.fieldsInfo[this.viewType][name];
                         var viewType = x2mFieldInfo.viewType || x2mFieldInfo.mode;
+                        if (!record.data[name].fieldsInfo) {
+                            // we don't load the fieldsInfo for invisible x2many fields,
+                            // so at this point, it might happen that fieldsInfo is undefined
+                            return;
+                        }
                         var knownFields = Object.keys(record.data[name].fieldsInfo[record.data[name].viewType] || {});
                         var newFields = Object.keys(record.data[name].fieldsInfo[viewType]);
                         if (_.difference(newFields, knownFields).length) {

--- a/addons/web/static/tests/fields/relational_fields/field_one2many_tests.js
+++ b/addons/web/static/tests/fields/relational_fields/field_one2many_tests.js
@@ -7132,6 +7132,36 @@ QUnit.module('fields', {}, function () {
             form.destroy();
         });
 
+        QUnit.test('nested one2manys with no widget in list and as invisible list in form', async function (assert) {
+            assert.expect(4);
+
+            this.data.partner.records[0].p = [1];
+
+            const form = await createView({
+                View: FormView,
+                model: 'partner',
+                data: this.data,
+                arch: `
+                    <form>
+                        <field name="p">
+                            <tree><field name="turtles"/></tree>
+                            <form><field name="turtles" invisible="1"/></form>
+                        </field>
+                    </form>`,
+                res_id: 1,
+            });
+
+            assert.containsOnce(form, '.o_data_row');
+            assert.strictEqual(form.$('.o_data_row .o_data_cell').text(), '1 record');
+
+            await testUtils.dom.click(form.$('.o_data_row'));
+
+            assert.containsOnce(document.body, '.modal .o_form_view');
+            assert.isNotVisible($('.modal .o_field_one2many'));
+
+            form.destroy();
+        });
+
         QUnit.test('one2many with multiple pages and sequence field', async function (assert) {
             assert.expect(1);
 


### PR DESCRIPTION
PR [1] recently backported several tricky x2many fixes from 14.0
to 13.0. Unfortunately, in 13.0, there is a scenario (that isn't
in 14.0) for which commit [2] produces a crash:

 - have an x2many field A (displayed as a list) that contains
   another x2many field, say B
 - B is also in A's form view, but it is 'invisible="1"'

Before this commit, it crashes when you try to open A's form
view.

For instance, go to Manufacturing > Bill of Materials > form view > click on a component line.

Since B is invisible in A's form view, we don't load its
fieldsInfo (as we won't need to display it). This commit refines
[2] to detect this case and avoid the crash.

[1] https://github.com/odoo/odoo/pull/65101/
[2] https://github.com/odoo/odoo/pull/65101/commits/ab7b7cfe5365a37fcf44f98154f1b48c754ea80c

opw 2452732

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
