### PR TITLE
[REM] core: useless translation mark

### DIFF
--- a/odoo/tools/osutil.py
+++ b/odoo/tools/osutil.py
@@ -13,8 +13,6 @@ import zipfile
 from contextlib import contextmanager
 from os.path import join as opj
 
-from .translate import _
-
 _logger = logging.getLogger(__name__)
 
 WINDOWS_RESERVED = re.compile(r'''
@@ -53,8 +51,8 @@ def clean_filename(name, replacement=''):
     :rtype: str
     """
     if WINDOWS_RESERVED.match(name):
-        return _("Untitled")
-    return re.sub(r'[^\w_.()\[\] -]+', replacement, name).lstrip('.-') or _("Untitled")
+        return "Untitled"
+    return re.sub(r'[^\w_.()\[\] -]+', replacement, name).lstrip('.-') or "Untitled"
 
 def listdir(dir, recursive=False):
     """Allow to recursively get the file listing following symlinks, returns


### PR DESCRIPTION
I misremembered that `_` would go look for the translation stuff
through the stack, but it only goes up to the caller of `_` itself.

Since `clean_filename` has no `cr`, `cursor` or `self` that's never
going to do anything, and it's thus completely useless.
