### PR TITLE
[IMP] hr_expense: add "payment_status" field + change error msg

### DIFF
--- a/addons/hr_expense/models/account_move_line.py
+++ b/addons/hr_expense/models/account_move_line.py
@@ -3,6 +3,15 @@
 
 from odoo import api, fields, models
 
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def _payment_state_matters(self):
+        self.ensure_one()
+        if self.line_ids.expense_id:
+            return True
+        return super()._payment_state_matters()
+
 
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -8,6 +8,61 @@ from odoo import fields
 @tagged('-at_install', 'post_install')
 class TestExpenses(TestExpenseCommon):
 
+    def test_expense_sheet_payment_state(self):
+        ''' Test expense sheet payment states when partially paid, in payment and paid. '''
+
+        def get_payment(expense_sheet, amount):
+            ctx = {'active_model': 'account.move', 'active_ids': expense_sheet.account_move_id.ids}
+            payment_register = self.env['account.payment.register'].with_context(**ctx).create({
+                'amount': amount,
+                'journal_id': self.company_data['default_journal_bank'].id,
+                'payment_method_id': self.env.ref('account.account_payment_method_manual_in').id,
+            })
+            return payment_register._create_payments()
+
+        expense_sheet = self.env['hr.expense.sheet'].create({
+            'name': 'Expense for John Smith',
+            'employee_id': self.expense_employee.id,
+            'accounting_date': '2021-01-01',
+            'expense_line_ids': [(0, 0, {
+                'name': 'Car Travel Expenses',
+                'employee_id': self.expense_employee.id,
+                'product_id': self.product_a.id,
+                'unit_amount': 350.00,
+            })]
+        })
+
+        expense_sheet.action_submit_sheet()
+        expense_sheet.approve_expense_sheets()
+        expense_sheet.action_sheet_move_create()
+
+        payment = get_payment(expense_sheet, 100.0)
+        liquidity_lines1 = payment._seek_for_lines()[0]
+
+        self.assertEqual(expense_sheet.payment_state, 'partial', 'payment_state should be partial')
+
+        payment = get_payment(expense_sheet, 250.0)
+        liquidity_lines2 = payment._seek_for_lines()[0]
+
+        in_payment_state = expense_sheet.account_move_id._get_invoice_in_payment_state()
+        self.assertEqual(expense_sheet.payment_state, in_payment_state, 'payment_state should be ' + in_payment_state)
+
+        statement = self.env['account.bank.statement'].create({
+            'name': 'test_statement',
+            'journal_id': self.company_data['default_journal_bank'].id,
+            'line_ids': [
+                (0, 0, {
+                    'payment_ref': 'pay_ref',
+                    'amount': -350.0,
+                    'partner_id': self.expense_employee.address_home_id.id,
+                }),
+            ],
+        })
+        statement.button_post()
+        statement.line_ids.reconcile([{'id': liquidity_lines1.id}, {'id': liquidity_lines2.id}])
+
+        self.assertEqual(expense_sheet.payment_state, 'paid', 'payment_state should be paid')
+
     def test_expense_values(self):
         """ Checking accounting move entries and analytic entries when submitting expense """
 

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -625,6 +625,7 @@
                     <field name="currency_id" optional="hide"/>
                     <field name="journal_id" optional="hide"/>
                     <field name="state" optional="show" decoration-info="state == 'draft'" decoration-success="state in ['submit', 'approve', 'post', 'done']" decoration-danger="state == 'cancel'" widget="badge"/>
+                    <field name="payment_state" optional="show" decoration-info="payment_state in ('partial','in_payment')" decoration-success="payment_state == 'paid'" decoration-danger="payment_state in ('reversed','not_paid')" widget="badge"/>
                     <field name="message_unread" invisible="1"/>
                 </tree>
             </field>
@@ -698,7 +699,11 @@
                             <field name="attachment_number" widget="statinfo" string="Documents"/>
                         </button>
                     </div>
-                    <widget name="web_ribbon" title="Paid" bg_color="bg-success" attrs="{'invisible': [('state', '!=', 'done')]}"/>
+                    <field name="payment_state" invisible="True"/>
+                    <widget name="web_ribbon" title="Paid" bg_color="bg-success" attrs="{'invisible': [('payment_state', '!=', 'paid')]}"/>
+                    <widget name="web_ribbon" title="Partial" bg_color="bg-info" attrs="{'invisible': [('payment_state', '!=', 'partial')]}"/>
+                    <widget name="web_ribbon" title="Reversed" bg_color="bg-danger" attrs="{'invisible': [('payment_state', '!=', 'reversed')]}"/>
+                    <widget name="web_ribbon" title="In Payment" attrs="{'invisible': [('payment_state', '!=', 'in_payment')]}"/>
                     <div class="oe_title">
                         <label for="name"/>
                         <h1>


### PR DESCRIPTION
- Add "payment_status" field to be more explicit.
- Turn error message "Expenses must have an expense journal specified to
  generate accounting entries." into "Specify expense journal in tab
  Other Info to generate accounting entries."

Task: 2424870