### PR TITLE
[FIX] core: fix adding a field related to Binary(attachment=True) or x2many

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -927,6 +927,8 @@ class Field(MetaField('DummyField', (object,), {})):
             not column
             and len(self.related or ()) == 2
             and self.related_field.store and not self.related_field.compute
+            and not (self.related_field.type == 'binary' and self.related_field.attachment)
+            and self.related_field.type not in ('one2many', 'many2many')
         ):
             join_field = model._fields[self.related[0]]
             if (


### PR DESCRIPTION
such fields have store=True, but they don't exist in table

---

https://github.com/odoo/odoo/pull/65232#issuecomment-773298323
https://github.com/odoo/odoo/commit/02417290191c22c9c99e6dc96a572c21f38e64f1

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
