### PR TITLE
[IMP] Improve pos employee closing

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -181,7 +181,7 @@
                                         <field name="employee_type"/>
                                         <field name="user_id" string="Related User" domain="[('share', '=', False)]"/>
                                     </group>
-                                    <group string="Attendance" name="identification_group">
+                                    <group string="Attendance/Point of Sale" name="identification_group">
                                         <field name="pin" string="PIN Code"/>
                                         <label for="barcode"/>
                                         <div class="o_row">

--- a/addons/point_of_sale/static/src/css/pos.css
+++ b/addons/point_of_sale/static/src/css/pos.css
@@ -3603,3 +3603,7 @@ td {
     bottom: 5%;
     font-size: 17px;
 }
+
+.pos .pos-topheader .oe_status:hover {
+    background: rgb(104,69,95);
+}

--- a/addons/pos_hr/static/src/css/pos.css
+++ b/addons/pos_hr/static/src/css/pos.css
@@ -101,11 +101,6 @@
         border-color: #00A09D;
         height: 38px;
     }
-    .pos .popups .popup-selection {
-        width: 90%;
-        left: initial;
-        right: initial;
-    }
     .pos .login-barcode-text {
         color: #adb5bd;
         margin-top: 8px;

--- a/addons/pos_hr/static/src/js/LoginScreen.js
+++ b/addons/pos_hr/static/src/js/LoginScreen.js
@@ -30,9 +30,6 @@ odoo.define('pos_hr.LoginScreen', function (require) {
         get shopName() {
             return this.env.pos.config.name;
         }
-        closeSession() {
-            this.trigger('close-pos');
-        }
         async selectCashier() {
             const list = this.env.pos.employees.map((employee) => {
                 return {

--- a/addons/pos_hr/static/src/xml/LoginScreen.xml
+++ b/addons/pos_hr/static/src/xml/LoginScreen.xml
@@ -18,11 +18,6 @@
                                 t-on-click="selectCashier">Select Cashier</button>
                     </span>
                 </div>
-                <div class="login-footer">
-                    <small>
-                        <button class="login-button close-session" t-on-click="closeSession">Close session</button>
-                    </small>
-                </div>
             </div>
         </div>
     </t>


### PR DESCRIPTION
We remove the "close session" button to prevent an employee to have access to the back end if not eligible.
For example:
User A start a pos session.
Employee B, not related to User A, could close the session and have access to the back end as User A.

This commit also allows to display the select cashier popup correctly in mobile view.

task-id: 2244289
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
