### PR TITLE
[FIX] web: fix incorrect rounding of scrollHeight

### DIFF
--- a/addons/web/static/src/js/libs/jquery.js
+++ b/addons/web/static/src/js/libs/jquery.js
@@ -171,7 +171,7 @@ $.fn.extend({
             // Search for a body child which is at least as tall as the body
             // and which has the ability to scroll if enough content in it. If
             // found, suppose this is the top scrolling element.
-            if (el.scrollHeight < bodyHeight) {
+            if (el.getBoundingClientRect().height < bodyHeight) {
                 continue;
             }
             const $el = $(el);

--- a/doc/cla/individual/feelwhy.md
+++ b/doc/cla/individual/feelwhy.md
@@ -1,0 +1,11 @@
+Russia, 2021-02-02
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Alexander Filippov aofilippov@gmail.com https://github.com/feelwhy


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Building block can't be selected in html fields (web_editor/static/static/src/js/field_html.js) if window scale is more than 100% (e.g. 125%)
The error occurs (for example, in mass_mailing):
"""
Uncaught TypeError: Cannot read property 'contains' of undefined
at Class._onSmoothDragStart (web.assets_common.js:5048)
at HTMLDivElement.start (web.assets_common.js:5028)
at $..._trigger (web.assets_common.js:2090)
at $..._trigger (web.assets_common.js:2229)
at $..._trigger (web.assets_common.js:2060)
at $..._mouseStart (web.assets_common.js:2153)
at $..._mouseStart (web.assets_common.js:2060)
at $..._mouseMove (web.assets_common.js:2137)
at $..._mouseMove (web.assets_common.js:2060)
at HTMLDocument._mouseMoveDelegate (web.assets_common.js:2134)
"""

Current behavior before PR:
When searching for scrolling element, the rounding of the scrollHeight results in incorrect check between height() and actual scrolling element height (e.g. 598 < 598.4).
As a result, web_editor field_html widget works improperly when the scale of window is more than 100%.

Desired behavior after PR is merged:
Scrolling element height is checked without rounding.
HTML fields (including mass_mailing html) work properly

Links:

#63306 - issue registered for mass_mailing blocks its usage
https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight - documentation explanation why getBoundingClientRect().height should be used instead of scrollHeight (the blue warning regarding rounding)

Also: [CLA] Individual signature for Alexander Filippov (feelwhy)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
