### PR TITLE
[FIX] website: open navbar dropdown to right place

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1068,7 +1068,7 @@ header {
                         white-space: initial;
                     }
                     .dropdown-menu {
-                        position: relative;
+                        position: static;
                     }
                 }
             }


### PR DESCRIPTION
Imepcted borwser: google chrome

Before Commit:
------------
when website header is right side i.e. header template
is set to 'sidebar'.opening navbar dropdown does not open
in the right place, instead, it opens below another the menu.

After commit:
------------
Fix the issue by changing the CSS position, so, the navbar
dropdown menu will be displayed in the proper place.