### PR TITLE
[FIX] sale: save Lead Time (customer_lead) on new line

### DIFF
--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -435,6 +435,7 @@
                                     <!-- We do not display the type because we don't want the user to be bothered with that information if he has no section or note. -->
                                     <field name="display_type" invisible="1"/>
                                     <field name="product_uom_category_id" invisible="1"/>
+                                    <field name="id" invisible="1"/>
 
                                     <field name="product_updatable" invisible="1"/>
                                     <field
@@ -529,7 +530,7 @@
                                     <field
                                         name="customer_lead"
                                         optional="hide"
-                                        attrs="{'readonly': [('parent.state', 'not in', ['draft', 'sent'])]}"
+                                        attrs="{'readonly': [('parent.state', 'not in', ['draft', 'sent']), ('id', '!=', False)]}"
                                     />
                                     <field
                                         name="price_unit"


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

When adding a line on an already confirmed order, the 'customer_lead'
field is filled by the onchange but never saved because the field
was readonly.
As a consequence there is a high chance that the SO line will have a
different scheduled date than other lines and won't be included in an
existing delivery if that was possible.

Here we ensure that the 'Lead Time' field is writable for new lines.
For existing lines on a confirmed order, the field will stay readonly like before.

**Current behavior before PR:**

`customer_lead` of new line is not editable/saved on confirmed order.

**Desired behavior after PR is merged:**

`customer_lead` of new line has to be editable and saved on confirmed order.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
