### PR TITLE
[FIX] base: query company dependant as superuser

### DIFF
--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -1374,6 +1374,12 @@ class TestFields(TransactionCaseWithUserDemo):
         self.assertEqual(attribute_record.company.foo, 'DEF')
         self.assertEqual(attribute_record.bar, 'DEFDEF')
 
+        # a low priviledge user should be able to search on company_dependent fields
+        company_record.env.user.groups_id -= self.env.ref('base.group_system')
+        self.assertFalse(company_record.env.user.has_group('base.group_system'))
+        company_records = self.env['test_new_api.company'].search([('foo', '=', 'DEF')])
+        self.assertEqual(len(company_records), 1)
+
     def test_30_read(self):
         """ test computed fields as returned by read(). """
         discussion = self.env.ref('test_new_api.discussion_0')

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -607,7 +607,7 @@ class Field(MetaField('DummyField', (object,), {})):
         Property._set_multi(self.name, self.model_name, values)
 
     def _search_company_dependent(self, records, operator, value):
-        Property = records.env['ir.property']
+        Property = records.env['ir.property'].sudo()
         return Property.search_multi(self.name, self.model_name, operator, value)
 
     #


### PR DESCRIPTION
When retrieving company dependant values, the computed domain called `search_multi` method of `ir.property` as normal user.
Since odoo/odoo@8f578637076d4b65 ir.property records are no longer readable by a normal classical user.

To reproduce:
Add a domain using a `company_dependant` field
e.g. on `res.partner`, with purchase installed, modify the `parent_id` field in form view to
```xml
  <field name="parent_id" ... domain="[('property_purchase_currency_id','=',property_purchase_currency_id)]" />
```
When clicking on the parent_id with a low priviledge user, an access-right error is raised, as the user doesn't have access to ir.property records

Fixes odoo/odoo#65450
