### PR TITLE
[FIX] base: remove trigger coalescing

### DIFF
--- a/addons/calendar/tests/test_event_notifications.py
+++ b/addons/calendar/tests/test_event_notifications.py
@@ -162,10 +162,7 @@ class TestEventNotifications(TransactionCase, MailCase):
         triggers_after = self.env['ir.cron.trigger'].search([('cron_id', '=', cron_id)])
         new_triggers = triggers_after - triggers_before
         new_triggers.ensure_one()
-        self.assertEqual(
-            new_triggers.call_at,
-            now.replace(second=0) - relativedelta(minutes=5),
-        )
+        self.assertLessEqual(new_triggers.call_at, now)
 
         with patch.object(fields.Datetime, 'now', lambda: now):
             with self.assertSinglePostNotifications([{'partner': self.partner, 'type': 'inbox'}], {

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -10,7 +10,6 @@ from dateutil.relativedelta import relativedelta
 import odoo
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-from odoo.tools import unique
 
 _logger = logging.getLogger(__name__)
 
@@ -432,10 +431,7 @@ class ir_cron(models.Model):
             return
 
         self.ensure_one()
-        now = datetime.utcnow().replace(second=0, microsecond=0)
-
-        # compress the list to insert at most one trigger per minute
-        at_list = list(unique(at.replace(second=0, microsecond=0) for at in at_list))
+        now = fields.Datetime.now()
 
         self.env['ir.cron.trigger'].sudo().create([
             {'cron_id': self.id, 'call_at': at}


### PR DESCRIPTION
You have have a scheduled activity precisely at 8:12:34 AM (send an
email, anything). You trigger the cron using that precise moment. The
cron runs at 8:12:00 AM which is before the scheduled moment so the
activity is skipped. Imagine there is no other scheduled activity that
coudld trigger the cron, it is only run at worst 23h59 minutes later
thanks to the daily cron execution fallback.

The assumption of a29bb54 is wrong, it groups the moments the
cron should be triggered by grouping the moments on the rounded down
minute. This is not consistent with the trigger API that promises the
cron will run *as soon as possible but **not before*** the scheduled
moment.

Task: 2452697