### PR TITLE
[IMP] website: make carousel arrows not editable

### DIFF
--- a/addons/web_editor/static/src/js/editor/rte.js
+++ b/addons/web_editor/static/src/js/editor/rte.js
@@ -565,6 +565,10 @@ var RTEWidget = Widget.extend({
         if ($editable.is('[data-oe-model]') && !$editable.is('[data-oe-model="ir.ui.view"]') && !$editable.is('[data-oe-type="html"]')) {
             $editable.data('layoutInfo').popover().find('.btn-group:not(.note-history)').remove();
         }
+        if ($editable.data('oe-type') === "image") {
+            $editable.attr('contenteditable', false);
+            $editable.find('img').attr('contenteditable', true);
+        }
     },
     /**
      * When an element enters edition, summernote is initialized on it. This

--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -125,8 +125,10 @@ $o-we-zindex: $o-we-overlay-zindex + 1 !default;
         outline: none !important;
     }
     .dropdown-menu {
+        transform: none !important;
         margin-top: $o-we-dropdown-spacing;
         padding: 0;
+        margin-top: $o-we-toolbar-height;
         border: $o-we-dropdown-border-width solid $o-we-dropdown-border-color;
         background-color: $o-we-dropdown-bg;
         box-shadow: $o-we-dropdown-shadow;

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -46,8 +46,12 @@ body.editor_enable.editor_has_snippets {
     $-text-tools-header-height: 35px;
 
     padding: $-text-tools-header-height $o-we-sidebar-content-padding-base 0 $o-we-sidebar-content-indent;
+    margin-bottom: $o-we-sidebar-content-padding-base;
     box-shadow: $o-we-item-standup-top rgba($o-we-item-standup-color-light, .2);
     z-index: $o-we-zindex;
+    display: flex;
+    flex: 1;
+    overflow-y: auto;
 
     .popover {
         position: static !important;
@@ -132,10 +136,7 @@ body.editor_enable.editor_has_snippets {
             position: static;
         }
         .dropdown-menu { // Drop up
-          top: auto;
-          bottom: 100%;
-          margin-top: 0;
-          margin-bottom: $dropdown-spacer;
+            margin-top: $o-we-dropdown-spacing;
         }
     }
     .note-popover ~ .note-popover,

--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -1639,6 +1639,13 @@ msgstr ""
 
 #. module: website
 #. openerp-web
+#: code:addons/website/static/src/js/menu/new_content.js:0
+#, python-format
+msgid "Building your %s"
+msgstr ""
+
+#. module: website
+#. openerp-web
 #: code:addons/website/static/src/xml/theme_preview.xml:0
 #, python-format
 msgid "Building your website..."

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -2513,6 +2513,7 @@ options.registry.SnippetMove = options.Class.extend({
             dom.scrollTo(this.$target[0], {
                 extraOffset: 50,
                 easing: 'linear',
+                duration: 550,
             });
         }
     },

--- a/addons/website/static/src/js/menu/new_content.js
+++ b/addons/website/static/src/js/menu/new_content.js
@@ -7,8 +7,7 @@ var websiteNavbarData = require('website.navbar');
 var wUtils = require('website.utils');
 var tour = require('web_tour.tour');
 
-var qweb = core.qweb;
-var _t = core._t;
+const {qweb, _t} = core;
 
 var enableFlag = 'enable_new_content';
 
@@ -68,6 +67,7 @@ var NewContentMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
             );
             this._showMenu();
         }
+        this.$loader = $(qweb.render('website.new_content_loader'));
         return this._super.apply(this, arguments);
     },
 
@@ -188,6 +188,23 @@ var NewContentMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
             wUtils.removeLoader();
         });
     },
+    /**
+     * Called to add loader element in DOM.
+     *
+     * @param {string} moduleName
+     * @private
+     */
+    _addLoader(moduleName) {
+        const newContentLoaderText = _.str.sprintf(_t("Building your %s"), moduleName);
+        this.$loader.find('#new_content_loader_text').replaceWith(newContentLoaderText);
+        $('body').append(this.$loader);
+    },
+    /**
+     * @private
+     */
+    _removeLoader() {
+        this.$loader.remove();
+    },
 
     //--------------------------------------------------------------------------
     // Handlers
@@ -297,6 +314,7 @@ var NewContentMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
                             $p.removeClass('o_uninstalled_module')
                                 .text(_.str.sprintf(self.newContentText.installPleaseWait, name));
                             $el.fadeTo(1000, 1);
+                            self._addLoader(name);
                         });
                     }
 
@@ -304,6 +322,7 @@ var NewContentMenu = websiteNavbarData.WebsiteNavbarActionWidget.extend({
                         var origin = window.location.origin;
                         var redirectURL = $el.find('a').data('url') || (window.location.pathname + '?' + enableFlag);
                         window.location.href = origin + redirectURL;
+                        self._removeLoader();
                     }, function () {
                         $i.removeClass()
                             .addClass('fa fa-exclamation-triangle');

--- a/addons/website/static/src/scss/website.editor.ui.scss
+++ b/addons/website/static/src/scss/website.editor.ui.scss
@@ -60,3 +60,20 @@ $o-we-switch-inactive-color: #F7F7F7 !default;
         }
     }
 }
+
+.o_new_content_loader_container {
+    background-color: rgba($o-shadow-color, .9);
+    pointer-events: all;
+    font-size: 3.5rem;
+    justify-content: center;
+    z-index: $zindex-modal - 1;
+}
+.o_new_content_loader {
+    position: relative;
+    display: inline-block;
+    width: 400px;
+    height: 220px;
+    background-image: url('/website/static/src/img/theme_loader.gif');
+    background-size: cover;
+    border-radius: 6px;
+}

--- a/addons/website/static/src/snippets/s_share/000.scss
+++ b/addons/website/static/src/snippets/s_share/000.scss
@@ -8,6 +8,11 @@
         margin: 0 .4rem 0 0;
     }
     a {
+        i.fa {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
         margin: .2rem;
     }
     &:not(.no_icon_color) {

--- a/addons/website/static/src/xml/website.editor.xml
+++ b/addons/website/static/src/xml/website.editor.xml
@@ -143,4 +143,12 @@
         <div class="mb-2" t-esc="contentText"/>
         <div class="o_ace_editor_container"/>
     </div>
+
+    <t t-name="website.new_content_loader">
+        <div class="o_new_content_loader_container position-fixed fixed-top fixed-left
+            h-100 w-100 d-flex flex-column align-items-center text-white font-weight-bold">
+            <p id="new_content_loader_text"/>
+            <div class="o_new_content_loader"/>
+        </div>
+    </t>
 </templates>

--- a/addons/website/views/snippets/s_carousel.xml
+++ b/addons/website/views/snippets/s_carousel.xml
@@ -56,11 +56,11 @@
                 </div>
             </div>
             <!-- Controls -->
-            <a class="carousel-control-prev" href="#myCarousel" data-slide="prev" role="img" aria-label="Previous" title="Previous">
+            <a class="carousel-control-prev o_not_editable" contenteditable="false" href="#myCarousel" data-slide="prev" role="img" aria-label="Previous" title="Previous">
                 <span class="carousel-control-prev-icon"/>
                 <span class="sr-only">Previous</span>
             </a>
-            <a class="carousel-control-next" href="#myCarousel" data-slide="next" role="img" aria-label="Next" title="Next">
+            <a class="carousel-control-next o_not_editable" contenteditable="false" href="#myCarousel" data-slide="next" role="img" aria-label="Next" title="Next">
                 <span class="carousel-control-next-icon"/>
                 <span class="sr-only">Next</span>
             </a>

--- a/addons/website/views/snippets/s_company_team.xml
+++ b/addons/website/views/snippets/s_company_team.xml
@@ -7,8 +7,8 @@
             <div class="row s_nb_column_fixed">
                 <div class="col-lg-6 pt24 pb24">
                     <div class="row s_col_no_resize s_col_no_bgcolor">
-                        <div class="col-lg-4 pb16">
-                            <img alt="" src="/web/image/website.s_company_team_image_1" class="img-fluid rounded-circle mx-auto"/>
+                        <div class="col-lg-4 pb16 o_not_editable" contenteditable="false">
+                            <img alt="" src="/web/image/website.s_company_team_image_1" class="img-fluid rounded-circle mx-auto" contenteditable="true"/>
                         </div>
                         <div class="col-lg-8">
                             <h4>Tony Fred, CEO</h4>
@@ -22,8 +22,8 @@
                 </div>
                 <div class="col-lg-6 pt24 pb24">
                     <div class="row s_col_no_resize s_col_no_bgcolor">
-                        <div class="col-lg-4 pb16">
-                            <img alt="" src="/web/image/website.s_company_team_image_2" class="img-fluid rounded-circle mx-auto"/>
+                        <div class="col-lg-4 pb16 o_not_editable" contenteditable="false">
+                            <img alt="" src="/web/image/website.s_company_team_image_2" class="img-fluid rounded-circle mx-auto" contenteditable="true"/>
                         </div>
                         <div class="col-lg-8">
                             <h4>Mich Stark, COO</h4>
@@ -33,8 +33,8 @@
                 </div>
                 <div class="col-lg-6 pt24 pb24">
                     <div class="row s_col_no_resize s_col_no_bgcolor">
-                        <div class="col-lg-4 pb16">
-                            <img alt="" src="/web/image/website.s_company_team_image_3" class="img-fluid rounded-circle mx-auto"/>
+                        <div class="col-lg-4 pb16 o_not_editable" contenteditable="false">
+                            <img alt="" src="/web/image/website.s_company_team_image_3" class="img-fluid rounded-circle mx-auto" contenteditable="true"/>
                         </div>
                         <div class="col-lg-8">
                             <h4>Aline Turner, CTO</h4>
@@ -44,8 +44,8 @@
                 </div>
                 <div class="col-lg-6 pt24 pb24">
                     <div class="row s_col_no_resize s_col_no_bgcolor">
-                        <div class="col-lg-4 pb16">
-                            <img alt="" src="/web/image/website.s_company_team_image_4" class="img-fluid rounded-circle mx-auto"/>
+                        <div class="col-lg-4 pb16 o_not_editable" contenteditable="false">
+                            <img alt="" src="/web/image/website.s_company_team_image_4" class="img-fluid rounded-circle mx-auto" contenteditable="true"/>
                         </div>
                         <div class="col-lg-8">
                             <h4>Iris Joe, CFO</h4>

--- a/addons/website/views/snippets/s_quotes_carousel.xml
+++ b/addons/website/views/snippets/s_quotes_carousel.xml
@@ -59,11 +59,11 @@
                 </div>
             </div>
             <!-- Controls -->
-            <div class="carousel-control-prev" data-target="#myQuoteCarousel" data-slide="prev" role="img" aria-label="Previous" title="Previous">
+            <div class="carousel-control-prev o_not_editable" data-target="#myQuoteCarousel" data-slide="prev" role="img" aria-label="Previous" title="Previous">
                 <span class="carousel-control-prev-icon"/>
                 <span class="sr-only">Previous</span>
             </div>
-            <div class="carousel-control-next" data-target="#myQuoteCarousel" data-slide="next" role="img" aria-label="Next" title="Next">
+            <div class="carousel-control-next o_not_editable" data-target="#myQuoteCarousel" data-slide="next" role="img" aria-label="Next" title="Next">
                 <span class="carousel-control-next-icon"/>
                 <span class="sr-only">Next</span>
             </div>

--- a/addons/website/views/snippets/s_share.xml
+++ b/addons/website/views/snippets/s_share.xml
@@ -3,7 +3,7 @@
 
 <template id="s_share" name="Share">
     <div t-attf-class="s_share text-left #{_classes}">
-        <h4 t-if="not _no_title" class="s_share_title">Share</h4>
+        <h4 t-if="not _no_title" class="s_share_title d-none">Share</h4>
         <a href="https://www.facebook.com/sharer/sharer.php?u={url}" t-attf-class="s_share_facebook #{_link_classes}" target="_blank">
             <i t-attf-class="fa fa-facebook #{not _link_classes and 'rounded shadow-sm'}"/>
         </a>

--- a/addons/website_blog/views/snippets/snippets.xml
+++ b/addons/website_blog/views/snippets/snippets.xml
@@ -28,5 +28,10 @@
     <xpath expr="//*[@data-js='anchor']" position="attributes">
         <attribute name="data-exclude" add=".o_wblog_post_content_field > :not(div, section)" separator=","/>
     </xpath>
+
+    <!-- Hides ContainerWidth option for content in blog posts -->
+    <xpath expr="//div[@data-js='ContainerWidth']" position="attributes">
+        <attribute name="data-exclude" add="#o_wblog_post_content *" separator=","/>
+    </xpath>
 </template>
 </odoo>

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -75,7 +75,9 @@ $o-wsale-products-layout-grid-gutter-width: min($grid-gutter-width / 2, $o-wsale
         text-align: center;
 
         img {
-            max-height: 100%;
+            height: 100%;
+            width: 100%;
+            object-fit: scale-down;
         }
     }
     .o_wsale_product_information {
@@ -447,6 +449,14 @@ a.no-decoration {
     .carousel-outer {
         height: 400px;
         max-height: 90vh;
+
+        .carousel-inner {
+            img {
+                height: 100%;
+                width: 100%;
+                object-fit: scale-down;
+            }
+        }
     }
 
     .carousel-control-prev, .carousel-control-next {


### PR DESCRIPTION
Added o_not_editable class to carousel-control-prev and
carousel-control-next container divs so that the user can't add text
when sliding carousel items

task-2446852

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
