### PR TITLE
[FIX] l10n_in: decrease a value of B2CS and HSN in case of refund

### DIFF
--- a/addons/l10n_in/report/account_invoice_report.py
+++ b/addons/l10n_in/report/account_invoice_report.py
@@ -75,7 +75,7 @@ class L10nInAccountInvoiceReport(models.Model):
             sub.shipping_bill_number,
             sub.shipping_bill_date,
             sub.shipping_port_code_id,
-            sub.total,
+            sub.total * sub.b2cs_refund_sign as total,
             sub.journal_id,
             sub.company_id,
             sub.move_type,
@@ -100,11 +100,11 @@ class L10nInAccountInvoiceReport(models.Model):
             sub.gst_format_date,
             sub.gst_format_refund_date,
             sub.gst_format_shipping_bill_date,
-            sum(sub.igst_amount) * sub.amount_sign AS igst_amount,
-            sum(sub.cgst_amount) * sub.amount_sign AS cgst_amount,
-            sum(sub.sgst_amount) * sub.amount_sign AS sgst_amount,
-            avg(sub.cess_amount) * sub.amount_sign AS cess_amount,
-            sum(sub.price_total) AS price_total,
+            sum(sub.igst_amount) * sub.amount_sign * sub.b2cs_refund_sign AS igst_amount,
+            sum(sub.cgst_amount) * sub.amount_sign * sub.b2cs_refund_sign AS cgst_amount,
+            sum(sub.sgst_amount) * sub.amount_sign * sub.b2cs_refund_sign AS sgst_amount,
+            avg(sub.cess_amount) * sub.amount_sign * sub.b2cs_refund_sign AS cess_amount,
+            sum(sub.price_total) * sub.amount_sign * sub.b2cs_refund_sign AS price_total,
             sub.tax_id
         """
         return select_str
@@ -230,9 +230,16 @@ class L10nInAccountInvoiceReport(models.Model):
                 CASE WHEN tag_rep_ln.account_tax_report_line_id IN
                     (SELECT res_id FROM ir_model_data WHERE module='l10n_in' AND name='tax_report_line_sgst') OR at.l10n_in_reverse_charge = True
                     THEN NULL
-                    ELSE (CASE WHEN aml.tax_base_amount <> 0 THEN aml.tax_base_amount ELSE NULL END)
+                    ELSE (CASE WHEN aml.tax_base_amount <> 0 THEN aml.tax_base_amount * (CASE WHEN aml.balance < 0 THEN -1 ELSE 1 END) ELSE NULL END)
                     END AS price_total,
                 (CASE WHEN aj.type = 'sale' AND (am.type IS NULL OR am.type != 'out_refund') THEN -1 ELSE 1 END) AS amount_sign,
+                (CASE WHEN am.type in ('in_refund','out_refund')
+                      AND p.vat IS NULL
+                      AND (aj.l10n_in_import_export IS NULL or aj.l10n_in_import_export = false)
+                      AND (ABS(am.amount_total_signed) <= 250000 OR
+                          (ps.id = cp.state_id OR p.id IS NULL))
+                      THEN -1
+                      ELSE 1 END) AS b2cs_refund_sign,
                 (CASE WHEN atr.parent_tax IS NOT NULL THEN atr.parent_tax
                     ELSE at.id END) AS tax_id,
                 (CASE WHEN atr.parent_tax IS NOT NULL THEN parent_at.amount
@@ -302,7 +309,8 @@ class L10nInAccountInvoiceReport(models.Model):
             sub.gst_format_shipping_bill_date,
             sub.amount_sign,
             sub.tax_id,
-            sub.tax_rate
+            sub.tax_rate,
+            sub.b2cs_refund_sign
         """
         return group_by_str
 


### PR DESCRIPTION
Before this commit:

  B2CS is not decreased in case of refund but it's shown in CDNUR but CDNUR has a condition that only shows a refund of B2CL.
  HSN value is not decreased in case of refund

After this commit:

  Refund is decreased from B2CS and not show that in CDNUR
  HSN value is decreased in case of refund

B2CS = Business to Consumers Small
B2CL = Business to Consumers Large (invoice value is more than Rs.2.5 lakhs)
CDNUR = Credit/Debit Notes for Unregistered
HSN = Harmonized System of Nomenclature(hsn code per product)

OPW: 2446769

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
