### PR TITLE
[FIX] mail: channels alphabetical order should not be case sensitive

### DIFF
--- a/addons/mail/static/src/components/discuss/tests/discuss_sidebar_tests.js
+++ b/addons/mail/static/src/components/discuss/tests/discuss_sidebar_tests.js
@@ -138,6 +138,24 @@ QUnit.test('sidebar find shows channels matching search term even when user is m
     );
 });
 
+QUnit.test('sidebar channels should be ordered case insensitive alphabetically', async function (assert) {
+    assert.expect(1);
+
+    this.data['mail.channel'].records.push(
+        { id: 19, name: "Xyz" },
+        { id: 20, name: "abc" },
+        { id: 21, name: "Abc" },
+        { id: 22, name: "Xyz" }
+    );
+    await this.start();
+    const results = document.querySelectorAll('.o_DiscussSidebar_groupChannel .o_DiscussSidebarItem_name');
+    assert.deepEqual(
+        [results[0].textContent, results[1].textContent, results[2].textContent, results[3].textContent],
+        ["abc", "Abc", "Xyz", "Xyz"],
+        "Channel name should be in case insensitive alphabetical order"
+    );
+});
+
 });
 });
 });

--- a/addons/mail/static/src/components/discuss_sidebar/discuss_sidebar.js
+++ b/addons/mail/static/src/components/discuss_sidebar/discuss_sidebar.js
@@ -116,7 +116,17 @@ class DiscussSidebar extends Component {
                 thread.isPinned &&
                 thread.model === 'mail.channel'
             )
-            .sort((c1, c2) => c1.displayName < c2.displayName ? -1 : 1);
+            .sort((c1, c2) => {
+                if (c1.displayName && !c2.displayName) {
+                    return -1;
+                } else if (!c1.displayName && c2.displayName) {
+                    return 1;
+                } else if (c1.displayName && c2.displayName && c1.displayName !== c2.displayName) {
+                    return c1.displayName.toLowerCase() < c2.displayName.toLowerCase() ? -1 : 1;
+                } else {
+                    return c1.id - c2.id;
+                }
+            });
         if (!this.discuss.sidebarQuickSearchValue) {
             return allOrderedAndPinnedMultiUserChannels;
         }


### PR DESCRIPTION
**PURPOSE**

Currently, In channels listing, the order of the channels is case sensitive.
The Uppercase names are listing first and then all the Lowercase ones.
but it should be displayed in the alphabetical case insensitive order.

**SPECIFICATION**

We are now comparing the lowercase value in the comparison function of the sort method.
Now channels are listing in a case insensitive alphabetical manner.

**Task : 2453592**