### PR TITLE
[IMP] mail: increase systray message dropdown menu height

### DIFF
--- a/addons/mail/static/src/components/messaging_menu/messaging_menu.scss
+++ b/addons/mail/static/src/components/messaging_menu/messaging_menu.scss
@@ -29,7 +29,7 @@
         flex: 0 1 auto;
         width: 350px;
         min-height: 50px;
-        max-height: 400px;
+        max-height: 575px;
         z-index: 1100; // on top of chat windows
     }
 


### PR DESCRIPTION
**PURPOSE**

The goal of this task to increase the height of the systray message dropdown
to simply allow more messages to be displayed at once for better readability.

**SPECIFICATION**

We have changed the height of the dropdown menu.

**Task : 2428779**