### PR TITLE
[FIX] tools: prevent pillow 7.0 bug on exif_transpose

### DIFF
--- a/odoo/tools/image.py
+++ b/odoo/tools/image.py
@@ -378,15 +378,16 @@ def image_fix_orientation(image):
         or the source image if no operation was applied
     :rtype: PIL.Image
     """
-    # `exif_transpose` was added in Pillow 6.0
-    if hasattr(ImageOps, 'exif_transpose'):
-        return ImageOps.exif_transpose(image)
     if (image.format or '').upper() == 'JPEG' and hasattr(image, '_getexif'):
         exif = image._getexif()
         if exif:
             orientation = exif.get(EXIF_TAG_ORIENTATION, 0)
             for method in EXIF_TAG_ORIENTATION_TO_TRANSPOSE_METHODS.get(orientation, []):
                 image = image.transpose(method)
+            return image
+    # `exif_transpose` was added in Pillow 6.0
+    if hasattr(ImageOps, 'exif_transpose'):
+        return ImageOps.exif_transpose(image)
     return image
 
 


### PR DESCRIPTION
On odoo.sh, in some circumstances, when uploading an image as attachment
in odoo leads to a blank image thumbnail. The same image was
successfully uploaded in the same odoo version on runbot instance.

After some investigations, it appears that the issue comes from the
python-pillow version used. A few bugs exists [0,1,2] in python-pillow
7.0.0 (packaged in ubuntu Focal) that are now fixed in version 8.1.0
[3,4,5] (packaged in Debian and specified in Odoo requirements.txt),
that causes the `ImageOps.exif_transpose` method to fail.

The present issue can be considered as a corner case as only images with
particular exif tags cause the issue.

The present fix is a simple workaround by first checking the presence of
the orientation tag and using it, we can avoid a call to the
`exif_transpose` method.

opw-2369166

[0] python-pillow/Pillow#4346
[1] python-pillow/Pillow#3973
[2] python-pillow/Pillow#4238
[3] python-pillow/Pillow#4637
[4] python-pillow/Pillow#3980
[5] python-pillow/Pillow#4009
