### PR TITLE
[FIX] payment,sale: Use record website domain in links 

### DIFF
--- a/addons/payment/wizards/payment_link_wizard.py
+++ b/addons/payment/wizards/payment_link_wizard.py
@@ -67,11 +67,11 @@ class PaymentLinkWizard(models.TransientModel):
             link.company_id = record.company_id if 'company_id' in record else False
 
     def _generate_link(self):
-        base_url = self.env['ir.config_parameter'].sudo().get_param('web.base.url')
         for payment_link in self:
+            record = self.env[payment_link.res_model].browse(payment_link.res_id)
             link = ('%s/website_payment/pay?reference=%s&amount=%s&currency_id=%s'
                     '&partner_id=%s&access_token=%s') % (
-                        base_url,
+                        record.get_base_url(),
                         urls.url_quote(payment_link.description),
                         payment_link.amount,
                         payment_link.currency_id.id,

--- a/addons/sale/wizard/sale_payment_link.py
+++ b/addons/sale/wizard/sale_payment_link.py
@@ -26,7 +26,6 @@ class SalePaymentLink(models.TransientModel):
 
     def _generate_link(self):
         """ Override of the base method to add the order_id in the link. """
-        base_url = self.env['ir.config_parameter'].sudo().get_param('web.base.url')
         for payment_link in self:
             # only add order_id for SOs,
             # otherwise the controller might try to link it with an unrelated record
@@ -34,9 +33,10 @@ class SalePaymentLink(models.TransientModel):
             # however, should parsing of the id fail in the controller, let's include
             # it anyway
             if payment_link.res_model == 'sale.order':
+                record = self.env[payment_link.res_model].browse(payment_link.res_id)
                 payment_link.link = ('%s/website_payment/pay?reference=%s&amount=%s&currency_id=%s'
                                     '&partner_id=%s&order_id=%s&company_id=%s&access_token=%s') % (
-                                        base_url,
+                                        record.get_base_url(),
                                         urls.url_quote(payment_link.description),
                                         payment_link.amount,
                                         payment_link.currency_id.id,


### PR DESCRIPTION


Steps:
- Go to Settings > Users & Companies > Companies
- Create a new company (1)
- Install a payment acquirer and Website
- Go to Website > Configuration > Settings:
- Select "My Website 2"
- Assign it to company (1)
- Add a custom domain
- Save
- Switch to company (1)
- Go to Invoicing
- Create a new Invoice:
  - Add a product line
- Post it
- Click Action > Generate a Payment Link

Bug:
The base domain is used instead of the domain of the website linked to
the invoicing company.

Explanation:
The app only uses the URL on which the user has logged in to generate a
payment link. If the user has multiple companies, this can confuse
customers if they land on another domain than the one they are used to.
This commit makes the app use the domain of the website of the record
linked to the payment if it has one.

opw:2440251

