### PR TITLE
[FIX] rating: display smiley and text below the title

### DIFF
--- a/addons/rating/views/rating_template.xml
+++ b/addons/rating/views/rating_template.xml
@@ -19,8 +19,8 @@
             <t t-call="web.frontend_layout">
                 <div class="container card mb-5 mt-4 o_rating_page_submit">
                     <div class="card-body">
-                        <div class="row">
-                            <h1 class="mt-5">Thank you for rating our services!</h1>
+                        <div class="row text-center justify-content-center">
+                            <h1 class="col-12 mt-5">Thank you for rating our services!</h1>
                             <form t-attf-action="/rate/#{token}/submit_feedback" method="post">
                                 <div class="btn-group btn-group-toggle row" data-toggle="buttons">
                                     <t t-foreach="rate_names" t-as="rate_name">


### PR DESCRIPTION
Currently, after the customer sends the survey feedback, their ratings and
message (the smileys and text area) is displayed on the right of the title.

By this commit, the smileys and the text area should be displayed below
the title.

task - 2452502

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
