### PR TITLE
[FIX] mail: do not scare away customers

### DIFF
--- a/addons/sale/data/mail_templates.xml
+++ b/addons/sale/data/mail_templates.xml
@@ -7,12 +7,12 @@
                 <t t-if="record.has_to_be_signed(include_draft=True)">
                     <t t-if="record.has_to_be_paid()" t-set="access_name">
                         <t t-if="is_transaction_pending">View Quotation</t>
-                        <t t-else="">Sign &amp; Pay Quotation</t>
+                        <t t-else="">Review, Sign &amp; Pay Quotation</t>
                     </t>
-                    <t t-else="" t-set="access_name">Accept &amp; Sign Quotation</t>
+                    <t t-else="" t-set="access_name">Review, Accept &amp; Sign Quotation</t>
                 </t>
                 <t t-elif="record.has_to_be_paid(include_draft=True) and not is_transaction_pending">
-                    <t t-set="access_name">Accept &amp; Pay Quotation</t>
+                    <t t-set="access_name">Review, Accept &amp; Pay Quotation</t>
                 </t>
                 <t t-elif="record.state in ('draft', 'sent')">
                     <t t-set="access_name">View Quotation</t>


### PR DESCRIPTION
Some customers are scared of clicking on a button that says "Accept & pay" directly from an email.

So, instead of using the online features, they download the PDF, sign it and return it.

It seems legit, due to the text that you can read, so as an UX enhancement, I propose to change that button's text.

@Tecnativa TT27664



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
