### PR TITLE
[FIX] mail: fix alignement for chatter in window

### DIFF
--- a/addons/mail/static/src/components/chat_window_header/chat_window_header.js
+++ b/addons/mail/static/src/components/chat_window_header/chat_window_header.js
@@ -29,6 +29,7 @@ class ChatWindowHeader extends Component {
                 thread,
                 threadLocalMessageUnreadCounter: thread && thread.localMessageUnreadCounter,
                 threadMassMailing: thread && thread.mass_mailing,
+                threadModel: thread && thread.model,
             };
         });
     }

--- a/addons/mail/static/src/components/chat_window_header/chat_window_header.xml
+++ b/addons/mail/static/src/components/chat_window_header/chat_window_header.xml
@@ -9,7 +9,7 @@
                         <i class="fa fa-arrow-left"/>
                     </div>
                 </t>
-                <t t-if="chatWindow.thread">
+                <t t-if="chatWindow.thread and chatWindow.thread.model === 'mail.channel'">
                     <ThreadIcon
                         class="o_ChatWindowHeader_icon o_ChatWindowHeader_item"
                         threadLocalId="chatWindow.thread.localId"


### PR DESCRIPTION
**Before this commit:**

For chatter in window, the name of the record is not in an appropriate place in
header as there is an empty space before name.

**After this commit:**

The name of the record is aligned to the left, and there is no empty space
before the name.

**LINKS**

Task- 2442652
PR https://github.com/odoo/odoo/pull/65600