### PR TITLE
[IMP] stock: use optimization on searching by qty_available

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -287,7 +287,7 @@ class Product(models.Model):
         # to use the quants, not the stock moves. Therefore, we bypass the usual
         # '_search_product_quantity' method and call '_search_qty_available_new' instead. This
         # allows better performances.
-        if value == 0.0 and operator == '>' and not ({'from_date', 'to_date'} & set(self.env.context.keys())):
+        if (not ({'from_date', 'to_date'} & set(self.env.context.keys()))):
             product_ids = self._search_qty_available_new(
                 operator, value, self.env.context.get('lot_id'), self.env.context.get('owner_id'),
                 self.env.context.get('package_id')


### PR DESCRIPTION
Such requests could be done via Products list and there is no reason to don't
use optimization

---

opw-2452728

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
