### PR TITLE
[FIX] web_editor: insert record name as text in web_editor many2one

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -1344,7 +1344,7 @@ registry.many2one = SnippetOption.extend({
                     });
                 });
         } else {
-            self.$target.html($li.data('name'));
+            self.$target.text($li.data('name'));
         }
 
         _.defer(function () {


### PR DESCRIPTION
Previously, the many2one widget from the web_editor used jQuery's
'.html()' method when inserting a record name into the page. The record
name was not HTML-escpaed before this, resulting in the text being
interpreted as HTML.

This commit fixes that by using the '.text()' method instead.

This vulenrability only affects the person changing the value of a
many2one record inside of the page, once the record has been changed, it
is not saved as HTML but the corresponding record is changed with the
updated one2many id, and refreshing the page will rerender the one2many
in python as a regular one2many field.