### PR TITLE
[IMP] event(_sale), website_event_track: UX Refinement

### DIFF
--- a/addons/event/data/mail_template_data.xml
+++ b/addons/event/data/mail_template_data.xml
@@ -240,7 +240,7 @@
         Sent by <a target="_blank" href="${object.company_id.website}" style="color: #875A7B;">${object.company_id.name}</a>
         % if is_online:
         <br />
-        Discover <a href="/event" style="text-decoration:none;color:#717188;">all our events</a>.
+        Discover <a href="/event" style="color:#875A7B;">all our events</a>.
         % endif
       </td></tr>
     </table>
@@ -464,7 +464,7 @@
         Sent by <a target="_blank" href="${object.company_id.website}" style="color: #875A7B;">${object.company_id.name}</a>
         % if 'website_url' in object.event_id and object.event_id.website_url:
         <br />
-        Discover <a href="/event" style="text-decoration:none;color:#717188;">all our events</a>.
+        Discover <a href="/event" style="color:#875A7B;">all our events</a>.
         % endif
       </td></tr>
     </table>

--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -501,6 +501,9 @@ class EventEvent(models.Model):
         return events
 
     def write(self, vals):
+        if 'stage_id' in vals and 'kanban_state' not in vals:
+            # reset kanban state when changing stage
+            vals['kanban_state'] = 'normal'
         res = super(EventEvent, self).write(vals)
         if vals.get('organizer_id'):
             self.message_subscribe([vals['organizer_id']])

--- a/addons/event_sale/data/event_sale_data.xml
+++ b/addons/event_sale/data/event_sale_data.xml
@@ -7,9 +7,9 @@
         </record>
 
         <record id="product_product_event" model="product.product">
-            <field name="list_price">10.0</field>
+            <field name="list_price">30.0</field>
             <field name="event_ok" eval="True"/>
-            <field name="standard_price">30.0</field>
+            <field name="standard_price">10.0</field>
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="uom_po_id" ref="uom.product_uom_unit"/>
             <field name="name">Event Registration</field>

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -124,7 +124,8 @@ class Track(models.Model):
         string='Always Wishlisted',
         help="""If set, the talk will be starred for each attendee registered to the event. The attendee won't be able to un-star this talk.""")
     # Call to action
-    website_cta = fields.Boolean('Magic Button')
+    website_cta = fields.Boolean('Magic Button',
+                                 help="Display a Call to Action button to your Attendees while they watch your Track.")
     website_cta_title = fields.Char('Button Title')
     website_cta_url = fields.Char('Button Target URL')
     website_cta_delay = fields.Integer('Button appears')

--- a/addons/website_event_track/views/event_track_views.xml
+++ b/addons/website_event_track/views/event_track_views.xml
@@ -203,7 +203,7 @@
                                         attrs="{'invisible': [('website_cta', '=', False)]}"/>
                                     <div attrs="{'invisible': [('website_cta', '=', False)]}">
                                         <field name="website_cta_delay" class="oe_inline"
-                                            attrs="{'required': [('website_cta', '=', True)]}"/> minutes after talk start
+                                            attrs="{'required': [('website_cta', '=', True)]}"/> minutes after track starts
                                     </div>
                                 </group>
                             </group>


### PR DESCRIPTION
This commit aims at refining the UX for events, notably:

- create a helper for the magic button on the event_track form, because without
  this the user won't be able to understand what the button does.

- on stage update, the kanban state will be automatically set to "gray"
  beacause when changing stages it does not make sense to keep the previous
  kanban state especially when it is set to "green" or to "red".

- make the cost of the event registration product demo data lower then the sale
  price as it is not normal to have a sale price lower then the cost.

- change the style of the "discover all our events" marketing link in the event
  reminder email template in order to make it pop a bit more for the user as
  this is an important link

Task-2451125
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
