### PR TITLE
[FIX] mail: corrects the domain of message_fetch

### DIFF
--- a/addons/mail/static/src/components/chat_window_manager/chat_window_manager_tests.js
+++ b/addons/mail/static/src/components/chat_window_manager/chat_window_manager_tests.js
@@ -1948,7 +1948,7 @@ QUnit.test('chat window does not fetch messages if hidden', async function (asse
         mockRPC(route, args) {
             if (args.method === 'message_fetch') {
                 // domain should be like [['channel_id', 'in', [X]]] with X the channel id
-                const channel_ids = args.kwargs.domain[0][2];
+                const channel_ids = args.kwargs.target_domain[0][2];
                 assert.strictEqual(channel_ids.length, 1, "messages should be fetched channel per channel");
                 assert.step(`rpc:message_fetch:${channel_ids[0]}`);
             }

--- a/addons/mail/static/src/components/discuss/tests/discuss_tests.js
+++ b/addons/mail/static/src/components/discuss/tests/discuss_tests.js
@@ -1214,7 +1214,7 @@ QUnit.test('load single message from channel initially', async function (assert)
                     "should fetch up to 30 messages"
                 );
                 assert.deepEqual(
-                    args.kwargs.domain,
+                    args.kwargs.target_domain,
                     [["channel_ids", "in", [20]]],
                     "should fetch messages from channel"
                 );

--- a/addons/mail/static/src/models/message/message.js
+++ b/addons/mail/static/src/models/message/message.js
@@ -206,9 +206,10 @@ function factory(dependencies) {
          * @param {integer} [limit]
          * @param {integer[]} [moderated_channel_ids]
          * @param {Object} [context]
+         * @param {Array[]} [targetDomain]
          * @returns {mail.message[]}
          */
-        static async performRpcMessageFetch(domain, limit, moderated_channel_ids, context) {
+        static async performRpcMessageFetch(domain, limit, moderated_channel_ids, context, target_domain) {
             const messagesData = await this.env.services.rpc({
                 model: 'mail.message',
                 method: 'message_fetch',
@@ -217,6 +218,7 @@ function factory(dependencies) {
                     domain,
                     limit,
                     moderated_channel_ids,
+                    target_domain,
                 },
             }, { shadow: true });
             const messages = this.env.models['mail.message'].insert(messagesData.map(


### PR DESCRIPTION
This commit ensures that the domain of message_fetch() is correct
when used with moderated_channel_ids.

opw-2352656