### PR TITLE
[IMP] hr_contract: Add stat button to access contracts from calendars

### DIFF
--- a/addons/hr_contract/__manifest__.py
+++ b/addons/hr_contract/__manifest__.py
@@ -26,6 +26,7 @@ You can assign several contracts per employee.
         'report/hr_contract_history_report_views.xml',
         'views/hr_contract_views.xml',
         'views/assets.xml',
+        'views/resource_calendar_views.xml',
         'wizard/hr_departure_wizard_views.xml',
     ],
     'demo': ['data/hr_contract_demo.xml'],

--- a/addons/hr_contract/models/resource.py
+++ b/addons/hr_contract/models/resource.py
@@ -1,13 +1,16 @@
 # -*- coding:utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from datetime import datetime
 
-from odoo import models, fields, api
+from odoo import fields, models
 from odoo.osv.expression import AND
 
 
 class ResourceCalendar(models.Model):
     _inherit = 'resource.calendar'
+
+    contracts_count = fields.Integer("# Contracts using it", compute='_compute_contracts_count', groups="hr_contract.group_hr_contract_manager")
 
     def transfer_leaves_to(self, other_calendar, resources=None, from_date=None):
         """
@@ -26,3 +29,17 @@ class ResourceCalendar(models.Model):
             'calendar_id': other_calendar.id,
         })
 
+    def _compute_contracts_count(self):
+        count_data = self.env['hr.contract'].read_group(
+            [('resource_calendar_id', 'in', self.ids)],
+            ['resource_calendar_id'],
+            ['resource_calendar_id'])
+        mapped_counts = {cd['resource_calendar_id'][0]: cd['resource_calendar_id_count'] for cd in count_data}
+        for calendar in self:
+            calendar.contracts_count = mapped_counts.get(calendar.id, 0)
+
+    def action_open_contracts(self):
+        self.ensure_one()
+        action = self.env["ir.actions.actions"]._for_xml_id("hr_contract.action_hr_contract")
+        action.update({'domain': [('resource_calendar_id', '=', self.id)]})
+        return action

--- a/addons/hr_contract/report/hr_contract_history_report_views.xml
+++ b/addons/hr_contract/report/hr_contract_history_report_views.xml
@@ -40,6 +40,7 @@
                     <button name="hr_contract_view_form_new_action" string="Create" type="object" groups="hr_contract.group_hr_contract_manager"/>
                 </header>
                 <sheet>
+                    <div class="oe_button_box" name="button_box"/>
                     <h1>
                         <div class="d-flex justify-content-start">
                             <div>

--- a/addons/hr_contract/views/resource_calendar_views.xml
+++ b/addons/hr_contract/views/resource_calendar_views.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="resource_calendar_view_tree" model="ir.ui.view">
+        <field name="name">resource.calendar.view.tree.inherit.hr.contract</field>
+        <field name="model">resource.calendar</field>
+        <field name="inherit_id" ref="resource.view_resource_calendar_tree"/>
+        <field name="arch" type="xml">
+            <field name="company_id" position="after">
+                <field name="contracts_count"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="resource_calendar_view_form" model="ir.ui.view">
+        <field name="name">resource.calendar.view.form.inherit.hr.contract</field>
+        <field name="model">resource.calendar</field>
+        <field name="inherit_id" ref="resource.resource_calendar_form"/>
+        <field name="arch" type="xml">
+            <div name="button_box" position="inside">
+                <button class="oe_stat_button" name="action_open_contracts"
+                        type="object" icon="fa-book" groups="hr_contract.group_hr_contract_manager">
+                    <field name="contracts_count" string="Contracts" widget="statinfo"/>
+                </button>
+            </div>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Purpose
=======

Currently there's no easy way to retrieve all the contract using a given
calendar.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
