### PR TITLE
[FIX] website_sale : remove wrong code

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -515,9 +515,6 @@ class WebsiteSale(ProductConfiguratorController):
                         partner_id = int(kw.get('partner_id'))
                     if partner_id in shippings.mapped('id'):
                         order.partner_shipping_id = partner_id
-                elif not order.partner_shipping_id:
-                    last_order = request.env['sale.order'].sudo().search([("partner_id", "=", order.partner_id.id)], order='id desc', limit=1)
-                    order.partner_shipping_id.id = last_order and last_order.id
 
         values = {
             'order': order,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
@JKE-be this part of code doesn't make sens (save an id of order in an id of partner).

it is better to remove it to prevent a fatal 500 error.
@mart-e 



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
