### PR TITLE
[FIX] base: correct Lesotho's currency symbol

### DIFF
--- a/odoo/addons/base/data/res_currency_data.xml
+++ b/odoo/addons/base/data/res_currency_data.xml
@@ -905,7 +905,7 @@
 
         <record id="LSL" model="res.currency">
             <field name="name">LSL</field>
-            <field name="symbol">L</field>
+            <field name="symbol">M</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Loti</field>


### PR DESCRIPTION
The Lesotho Loti has the symbol M and not L
Example of use:
http://lestimes.com/businessman-xie-in-m27-million-scandal/
http://lra.org.ls/sites/default/files/2020-10/LRA%20Integrated%20Annual%20Report%202019.pdf

Fixes odoo/odoo#62807
