### PR TITLE
[FIX] account: Batch Payment available to Invoicing App

### DIFF
--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -339,9 +339,7 @@
                                     </div>
                                 </div>
                             </div>
-                            <div class="col-12 col-lg-6 o_setting_box"
-                                id="account_batch_payment"
-                                groups="account.group_account_user">
+                            <div class="col-12 col-lg-6 o_setting_box" id="account_batch_payment">
                                 <div class="o_setting_left_pane">
                                     <field name="module_account_batch_payment" widget="upgrade_boolean"/>
                                 </div>


### PR DESCRIPTION
Beforehand, when installing the SEPA DD module, the Accounting App
was also installed, because of a dependency between the batch payment
feature and the account_accountant module.

Now, a bridge module breaks this dependency, and SEPA DD can be used with
the Invoicing App. This means that Batch Payment, being a dependency of
SEPA DD, is available to the Invoicing App.

task-2375697
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
