### PR TITLE
[FIX] tools: prevent call to pillow exif_transpose image method

### DIFF
--- a/odoo/addons/base/tests/test_image.py
+++ b/odoo/addons/base/tests/test_image.py
@@ -21,6 +21,23 @@ class TestImage(TransactionCase):
         self.base64_1x1_png = b'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgYGAAAAAEAAH2FzhVAAAAAElFTkSuQmCC'
         self.base64_svg = base64.b64encode(b'<svg></svg>')
         self.base64_1920x1080_jpeg = tools.image_to_base64(Image.new('RGB', (1920, 1080)), 'JPEG')
+        # The following image contains a tag `Lens Info` with a value of `3.99mm f/1.8`
+        # This particular tag 0xa432 makes the `exif_transpose` method fail in 5.4.1 < Pillow < 7.2.0
+        self.base64_exif_jpg = b"""/9j/4AAQSkZJRgABAQAAAQABAAD/4QDQRXhpZgAATU0AKgAAAAgABgESAAMAAAABAAYAAAEaAAUA
+                                  AAABAAAAVgEbAAUAAAABAAAAXgEoAAMAAAABAAEAAAITAAMAAAABAAEAAIdpAAQAAAABAAAAZgAA
+                                  AAAAAAABAAAAAQAAAAEAAAABAAWQAAAHAAAABDAyMzGRAQAHAAAABAECAwCgAAAHAAAABDAxMDCg
+                                  AQADAAAAAf//AACkMgAFAAAABAAAAKgAAAAAAAABjwAAAGQAAAGPAAAAZAAAAAkAAAAFAAAACQAA
+                                  AAX/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAx
+                                  NDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIy
+                                  MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAADAAYDASIAAhEBAxEB/8QAHwAAAQUBAQEB
+                                  AQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1Fh
+                                  ByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZ
+                                  WmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXG
+                                  x8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAEC
+                                  AwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHB
+                                  CSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0
+                                  dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX
+                                  2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3+iiigD//2Q=="""
 
         # Draw a red square in the middle of the image, this will be used to
         # verify crop is working. The border is going to be `self.bg_color` and
@@ -90,6 +107,13 @@ class TestImage(TransactionCase):
         self._orientation_test(6, (yellow, pink, blue, green), size, expected)  # right/top
         self._orientation_test(7, (pink, yellow, green, blue), size, expected)  # right/bottom
         self._orientation_test(8, (green, blue, pink, yellow), size, expected)  # left/bottom
+
+    def test_03_image_fix_orientation_exif(self):
+        """Test that a jpg image with exif orientation tag gets rotated"""
+        image = tools.base64_to_image(self.base64_exif_jpg)
+        self.assertEqual(image.size, (6,3))
+        image = tools.image_fix_orientation(image)
+        self.assertEqual(image.size, (3,6))
 
     def test_10_image_process_base64_source(self):
         """Test the base64_source parameter of image_process."""

--- a/odoo/tools/image.py
+++ b/odoo/tools/image.py
@@ -378,16 +378,14 @@ def image_fix_orientation(image):
         or the source image if no operation was applied
     :rtype: PIL.Image
     """
-    if (image.format or '').upper() == 'JPEG' and hasattr(image, '_getexif'):
-        exif = image._getexif()
+    getexif = getattr(image, 'getexif', None) or getattr(image, '_getexif', None)  # support PIL < 6.0
+    if getexif:
+        exif = getexif()
         if exif:
             orientation = exif.get(EXIF_TAG_ORIENTATION, 0)
             for method in EXIF_TAG_ORIENTATION_TO_TRANSPOSE_METHODS.get(orientation, []):
                 image = image.transpose(method)
             return image
-    # `exif_transpose` was added in Pillow 6.0
-    if hasattr(ImageOps, 'exif_transpose'):
-        return ImageOps.exif_transpose(image)
     return image
 
 


### PR DESCRIPTION
In a previous fix [0], the call to exif_transpose was kept to allow
rotation of images format different than `JPEG`.

After a small test, it appeared that the call would crash if the image
in another format had the same `LensInfo` tag.
So it's safer to not call this method at all.

With this commit, the rotation tag is retrieved disregarding the file
format by using the proper `getexif`method instead of the private one.

As a bonus, a test is also added with a small embedded `PNG` image,
crafted with an `Orientation` exif tag and, for reference,  the
`LensInfo`tag that caused so much trouble.

[0] b83c48d5c48954193
