### PR TITLE
[FIX] website_sale_stock : round quantity with zero decimal

### DIFF
--- a/addons/website_sale_stock/models/product_template.py
+++ b/addons/website_sale_stock/models/product_template.py
@@ -30,7 +30,7 @@ class ProductTemplate(models.Model):
             virtual_available = product.with_context(warehouse=website.warehouse_id.id).virtual_available
             combination_info.update({
                 'virtual_available': virtual_available,
-                'virtual_available_formatted': self.env['ir.qweb.field.float'].value_to_html(virtual_available, {'decimal_precision': 'Product Unit of Measure'}),
+                'virtual_available_formatted': self.env['ir.qweb.field.float'].value_to_html(virtual_available, {'precision': 0}),
                 'product_type': product.type,
                 'inventory_availability': product.inventory_availability,
                 'available_threshold': product.available_threshold,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Round with zero decimal (website_sale can only sell integer).

Before:
![image](https://user-images.githubusercontent.com/16716992/106917612-ba6c6f80-6708-11eb-91c5-da6c7ba3f5eb.png)


After:
![image](https://user-images.githubusercontent.com/16716992/106917503-9d37a100-6708-11eb-9552-8c0fb868f7cd.png)


@jke-be



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
