### PR TITLE
[FIX] l10n_fr_fec : prevent memory error

### DIFF
--- a/addons/l10n_fr_fec/wizard/account_fr_fec.py
+++ b/addons/l10n_fr_fec/wizard/account_fr_fec.py
@@ -17,7 +17,7 @@ class AccountFrFec(models.TransientModel):
 
     date_from = fields.Date(string='Start Date', required=True)
     date_to = fields.Date(string='End Date', required=True)
-    fec_data = fields.Binary('FEC File', readonly=True, attachment=False)
+    fec_data = fields.Binary('FEC File', readonly=True)
     filename = fields.Char(string='Filename', size=256, readonly=True)
     test_file = fields.Boolean()
     export_type = fields.Selection([


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Get a big database.
Try to get the file store.

Error
`InternalError: invalid memory alloc request size 1073741824`

It doesn't make sens to save file in SQL.

@oco-odoo 



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
