### PR TITLE
[FIX] Resequence wizard not working in latam

### DIFF
--- a/addons/l10n_latam_invoice_document/models/account_move.py
+++ b/addons/l10n_latam_invoice_document/models/account_move.py
@@ -77,7 +77,7 @@ class AccountMove(models.Model):
         """ Indicates if this document type uses a sequence or if the numbering is made manually """
         recs_with_journal_id = self.filtered(lambda x: x.journal_id and x.journal_id.l10n_latam_use_documents)
         for rec in recs_with_journal_id:
-            rec.l10n_latam_manual_document_number = self._is_manual_document_number(rec.journal_id)
+            rec.l10n_latam_manual_document_number = rec._is_manual_document_number(rec.journal_id)
         remaining = self - recs_with_journal_id
         remaining.l10n_latam_manual_document_number = False
 

--- a/doc/cla/corporate/trescloud.md
+++ b/doc/cla/corporate/trescloud.md
@@ -1,0 +1,15 @@
+Ecuador, 11/02/2021
+
+TRESCLOUD CÍA LTDA agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Andrés Calle andres.calle@trescloud.com https://github.com/pepetreshere
+
+List of contributors:
+
+Andrés Calle andres.calle@trescloud.com https://github.com/pepetreshere


### PR DESCRIPTION
The resequence wizard fails with "expected singleton" error.
The resequence wizard located at Accounting / Accounting / Journal Entries, under the action "Resequence" should allow to change the number of manual jorunal entries, but it fails in localizations where whe need to inherit the method _is_manual_document_number() as it is called with self instad of rec.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
