### PR TITLE
[IMP] crm: display tag color in kanban lead view

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -379,7 +379,7 @@
                                     <span class="o_kanban_record_subtitle"><field name="contact_name"/></span>
                                 </div>
                                 <div>
-                                  <field name="tag_ids"/>
+                                  <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                                 </div>
                                 <div class="o_kanban_record_bottom">
                                     <div class="oe_kanban_bottom_left">


### PR DESCRIPTION
Currently if we create coloured tags for leads in crm from
the form view the same is not appearing  in the respective
kanban view.
So in this improvement we fixed this tag colour in kanban view.

Task-id : 2453047

