### PR TITLE
[FIX] web: fix scroll issue in full calendar

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -356,7 +356,7 @@
         <field name="name">hr.leave.view.dashboard</field>
         <field name="model">hr.leave</field>
         <field name="arch" type="xml">
-            <calendar js_class="time_off_calendar" string="Time Off Request" form_view_id="%(hr_holidays.hr_leave_view_form_dashboard)d" event_open_popup="true" date_start="date_from" date_stop="date_to" mode="year" quick_add="False" show_unusual_days="True" color="holiday_status_id" hide_time="True">
+            <calendar js_class="time_off_calendar" string="Time Off Request" form_view_id="%(hr_holidays.hr_leave_view_form_dashboard)d" event_open_popup="true" date_start="date_from" date_stop="date_to" mode="month" quick_add="False" show_unusual_days="True" color="holiday_status_id" hide_time="True">
                 <field name="display_name"/>
                 <field name="holiday_status_id" filters="1" invisible="1"/>
                 <field name="state" invisible="1"/>

--- a/addons/web/static/src/scss/web_calendar.scss
+++ b/addons/web/static/src/scss/web_calendar.scss
@@ -338,7 +338,6 @@ $o-cw-filter-avatar-size: 20px;
         .fc-dayGridYear-view {
             border: none;
             height: 100%;
-            padding-top: 1rem;
             padding-left: $o-horizontal-padding;
             box-sizing: border-box;
             display: flex;
@@ -380,7 +379,7 @@ $o-cw-filter-avatar-size: 20px;
                     margin: auto;
 
                     > .fc-toolbar.fc-header-toolbar {
-                        margin-top: 10px;
+                        padding-top: 10px;
                         margin-bottom: 4px;
                         cursor: default;
 


### PR DESCRIPTION
Currently, if there is a year scale in the full calendar,
the space above the scroll.
After this commit, there will be no space above the scroll.
