### PR TITLE
[MERGE][FIX] event, website_event_track: split stored editable compute fields methods

### DIFF
--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from dateutil.relativedelta import relativedelta
 
 from odoo import _, api, fields, models
 from odoo.tools import format_datetime
 from odoo.exceptions import AccessError, ValidationError
-
-from dateutil.relativedelta import relativedelta
 
 
 class EventRegistration(models.Model):
@@ -32,10 +31,10 @@ class EventRegistration(models.Model):
         states={'done': [('readonly', True)]})
     name = fields.Char(
         string='Attendee Name', index=True,
-        compute='_compute_contact_info', readonly=False, store=True, tracking=10)
-    email = fields.Char(string='Email', compute='_compute_contact_info', readonly=False, store=True, tracking=11)
-    phone = fields.Char(string='Phone', compute='_compute_contact_info', readonly=False, store=True, tracking=12)
-    mobile = fields.Char(string='Mobile', compute='_compute_contact_info', readonly=False, store=True, tracking=13)
+        compute='_compute_name', readonly=False, store=True, tracking=10)
+    email = fields.Char(string='Email', compute='_compute_email', readonly=False, store=True, tracking=11)
+    phone = fields.Char(string='Phone', compute='_compute_phone', readonly=False, store=True, tracking=12)
+    mobile = fields.Char(string='Mobile', compute='_compute_mobile', readonly=False, store=True, tracking=13)
     # organization
     date_open = fields.Datetime(string='Registration Date', readonly=True, default=lambda self: fields.Datetime.now())  # weird crash is directly now
     date_closed = fields.Datetime(
@@ -72,16 +71,40 @@ class EventRegistration(models.Model):
                 registration.update(registration._synchronize_partner_values(registration.partner_id))
 
     @api.depends('partner_id')
-    def _compute_contact_info(self):
+    def _compute_name(self):
         for registration in self:
-            if registration.partner_id:
-                partner_vals = self._synchronize_partner_values(registration.partner_id)
-                registration.update(
-                    dict((fname, fvalue)
-                         for fname, fvalue in partner_vals.items()
-                         if fvalue and not (registration[fname] or registration._origin[fname])
-                         )
-                    )
+            if not registration.name and registration.partner_id:
+                registration.name = registration._synchronize_partner_values(
+                    registration.partner_id,
+                    fnames=['name']
+                ).get('name') or False
+
+    @api.depends('partner_id')
+    def _compute_email(self):
+        for registration in self:
+            if not registration.email and registration.partner_id:
+                registration.email = registration._synchronize_partner_values(
+                    registration.partner_id,
+                    fnames=['email']
+                ).get('email') or False
+
+    @api.depends('partner_id')
+    def _compute_phone(self):
+        for registration in self:
+            if not registration.phone and registration.partner_id:
+                registration.phone = registration._synchronize_partner_values(
+                    registration.partner_id,
+                    fnames=['phone']
+                ).get('phone') or False
+
+    @api.depends('partner_id')
+    def _compute_mobile(self):
+        for registration in self:
+            if not registration.mobile and registration.partner_id:
+                registration.mobile = registration._synchronize_partner_values(
+                    registration.partner_id,
+                    fnames=['mobile']
+                ).get('mobile') or False
 
     @api.depends('state')
     def _compute_date_closed(self):
@@ -108,6 +131,16 @@ class EventRegistration(models.Model):
     def _check_event_ticket(self):
         if any(registration.event_id != registration.event_ticket_id.event_id for registration in self if registration.event_ticket_id):
             raise ValidationError(_('Invalid event / ticket choice'))
+
+    def _synchronize_partner_values(self, partner, fnames=None):
+        if fnames is None:
+            fnames = ['name', 'email', 'phone', 'mobile']
+        if partner:
+            contact_id = partner.address_get().get('contact', False)
+            if contact_id:
+                contact = self.env['res.partner'].browse(contact_id)
+                return dict((fname, contact[fname]) for fname in fnames if contact[fname])
+        return {}
 
     # ------------------------------------------------------------
     # CRUD
@@ -157,14 +190,6 @@ class EventRegistration(models.Model):
                (not registration.event_id.seats_available and registration.event_id.seats_limited) for registration in self):
             return False
         return True
-
-    def _synchronize_partner_values(self, partner):
-        if partner:
-            contact_id = partner.address_get().get('contact', False)
-            if contact_id:
-                contact = self.env['res.partner'].browse(contact_id)
-                return dict((fname, contact[fname]) for fname in ['name', 'email', 'phone', 'mobile'] if contact[fname])
-        return {}
 
     # ------------------------------------------------------------
     # ACTIONS / BUSINESS

--- a/addons/event/tests/test_event_internals.py
+++ b/addons/event/tests/test_event_internals.py
@@ -351,9 +351,9 @@ class TestEventRegistrationData(TestEventCommon):
         self.assertEqual(
             new_reg.email, test_email,
             'Registration should take user input over computed partner value')
-        # self.assertEqual(
-        #     new_reg.phone, customer.phone,
-        #     'Registration should take partner value if not user input')
+        self.assertEqual(
+            new_reg.phone, customer.phone,
+            'Registration should take partner value if not user input')
 
         # already filled information should not be updated
         event.write({

--- a/addons/event/tests/test_event_internals.py
+++ b/addons/event/tests/test_event_internals.py
@@ -128,6 +128,20 @@ class TestEventData(TestEventCommon):
         self.assertEqual(event.event_mail_ids.interval_type, 'before_event')
         self.assertEqual(event.event_mail_ids.template_id, self.env.ref('event.event_reminder'))
         self.assertEqual(len(event.event_ticket_ids), 1)
+
+        # update template, unlink from event -> should not impact event
+        event_type.write({'has_seats_limitation': False})
+        self.assertEqual(event_type.seats_max, 0)
+        self.assertTrue(event.seats_limited)
+        self.assertEqual(event.seats_max, 30)  # original template value
+        event.write({'event_type_id': False})
+        self.assertEqual(event.event_type_id, self.env["event.type"])
+
+        # set template back -> update event
+        event.write({'event_type_id': event_type.id})
+        self.assertFalse(event.seats_limited)
+        self.assertEqual(event.seats_max, 0)
+        self.assertEqual(len(event.event_ticket_ids), 1)
         event_ticket1 = event.event_ticket_ids[0]
         self.assertEqual(event_ticket1.name, 'TestRegistration')
 
@@ -296,6 +310,100 @@ class TestEventData(TestEventCommon):
         self.assertEqual(event.seats_reserved, 5)
         self.assertEqual(event.seats_used, 1)
         self.assertEqual(event.seats_expected, 7)
+
+
+class TestEventRegistrationData(TestEventCommon):
+
+    @users('user_eventmanager')
+    def test_registration_partner_sync(self):
+        """ Test registration computed fields about partner """
+        test_email = '"Nibbler In Space" <nibbler@futurama.example.com>'
+        test_phone = '0456001122'
+
+        event = self.env['event.event'].browse(self.event_0.ids)
+        customer = self.env['res.partner'].browse(self.event_customer.id)
+
+        # take all from partner
+        event.write({
+            'registration_ids': [(0, 0, {
+                'partner_id': customer.id,
+            })]
+        })
+        new_reg = event.registration_ids[0]
+        self.assertEqual(new_reg.partner_id, customer)
+        self.assertEqual(new_reg.name, customer.name)
+        self.assertEqual(new_reg.email, customer.email)
+        self.assertEqual(new_reg.phone, customer.phone)
+
+        # partial update
+        event.write({
+            'registration_ids': [(0, 0, {
+                'partner_id': customer.id,
+                'name': 'Nibbler In Space',
+                'email': test_email,
+            })]
+        })
+        new_reg = event.registration_ids.sorted()[0]
+        self.assertEqual(new_reg.partner_id, customer)
+        self.assertEqual(
+            new_reg.name, 'Nibbler In Space',
+            'Registration should take user input over computed partner value')
+        self.assertEqual(
+            new_reg.email, test_email,
+            'Registration should take user input over computed partner value')
+        # self.assertEqual(
+        #     new_reg.phone, customer.phone,
+        #     'Registration should take partner value if not user input')
+
+        # already filled information should not be updated
+        event.write({
+            'registration_ids': [(0, 0, {
+                'name': 'Nibbler In Space',
+                'phone': test_phone,
+            })]
+        })
+        new_reg = event.registration_ids.sorted()[0]
+        self.assertEqual(new_reg.name, 'Nibbler In Space')
+        self.assertEqual(new_reg.email, False)
+        self.assertEqual(new_reg.phone, test_phone)
+        new_reg.write({'partner_id': customer.id})
+        self.assertEqual(new_reg.partner_id, customer)
+        self.assertEqual(new_reg.name, 'Nibbler In Space')
+        self.assertEqual(new_reg.email, customer.email)
+        self.assertEqual(new_reg.phone, test_phone)
+
+    @users('user_eventmanager')
+    def test_registration_partner_sync_company(self):
+        """ Test synchronization involving companies """
+        event = self.env['event.event'].browse(self.event_0.ids)
+        customer = self.env['res.partner'].browse(self.event_customer.id)
+
+        # create company structure (using sudo as required partner manager group)
+        company = self.env['res.partner'].sudo().create({
+            'name': 'Customer Company',
+            'is_company': True,
+            'type': 'other',
+        })
+        customer.sudo().write({'type': 'invoice', 'parent_id': company.id})
+        contact = self.env['res.partner'].sudo().create({
+            'name': 'ContactName',
+            'parent_id': company.id,
+            'type': 'contact',
+            'email': 'ContactEmail <contact.email@test.example.com>',
+            'phone': '+32456998877',
+        })
+
+        # take all from partner
+        event.write({
+            'registration_ids': [(0, 0, {
+                'partner_id': customer.id,
+            })]
+        })
+        new_reg = event.registration_ids[0]
+        self.assertEqual(new_reg.partner_id, customer)
+        self.assertEqual(new_reg.name, contact.name)
+        self.assertEqual(new_reg.email, contact.email)
+        self.assertEqual(new_reg.phone, contact.phone)
 
 
 class TestEventTicketData(TestEventCommon):

--- a/addons/website_event/tests/common.py
+++ b/addons/website_event/tests/common.py
@@ -107,3 +107,10 @@ class TestEventOnlineCommon(TestEventCommon, EventDtPatcher):
             'date_begin': datetime.combine(cls.reference_now, time(7, 0)) - timedelta(days=1),
             'date_end': datetime.combine(cls.reference_now, time(13, 0)) + timedelta(days=1),
         })
+
+        cls.event_customer.write({
+            'website_description': '<p>I am your best customer, %s</p>' % cls.event_customer.name,
+        })
+        cls.event_customer2.write({
+            'website_description': '<p>I am your best customer, %s</p>' % cls.event_customer2.name,
+        })

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -54,13 +54,13 @@ class Track(models.Model):
     # speaker
     partner_id = fields.Many2one('res.partner', 'Speaker')
     partner_name = fields.Char(
-        string='Name', compute='_compute_partner_info',
+        string='Name', compute='_compute_partner_name',
         readonly=False, store=True, tracking=10)
     partner_email = fields.Char(
-        string='Email', compute='_compute_partner_info',
+        string='Email', compute='_compute_partner_email',
         readonly=False, store=True, tracking=20)
     partner_phone = fields.Char(
-        string='Phone', compute='_compute_partner_info',
+        string='Phone', compute='_compute_partner_phone',
         readonly=False, store=True, tracking=30)
     partner_biography = fields.Html(
         string='Biography', compute='_compute_partner_biography',
@@ -146,11 +146,21 @@ class Track(models.Model):
     # SPEAKER
 
     @api.depends('partner_id')
-    def _compute_partner_info(self):
+    def _compute_partner_name(self):
         for track in self:
-            if track.partner_id:
+            if not track.partner_name or track.partner_id:
                 track.partner_name = track.partner_id.name
+
+    @api.depends('partner_id')
+    def _compute_partner_email(self):
+        for track in self:
+            if not track.partner_email or track.partner_id:
                 track.partner_email = track.partner_id.email
+
+    @api.depends('partner_id')
+    def _compute_partner_phone(self):
+        for track in self:
+            if not track.partner_phone or track.partner_id:
                 track.partner_phone = track.partner_id.phone
 
     @api.depends('partner_id')

--- a/addons/website_event_track/tests/test_track_internals.py
+++ b/addons/website_event_track/tests/test_track_internals.py
@@ -51,9 +51,9 @@ class TestTrackData(TestEventTrackOnlineCommon):
         self.assertEqual(
             new_track.partner_email, test_email,
             'Track should take user input over computed partner value')
-        # self.assertEqual(
-        #     new_track.partner_phone, customer.phone,
-        #     'Track should take partner value if not user input')
+        self.assertEqual(
+            new_track.partner_phone, customer.phone,
+            'Track should take partner value if not user input')
 
         # already filled information should not be updated
         new_track = self.env['event.track'].create({

--- a/addons/website_event_track/tests/test_track_internals.py
+++ b/addons/website_event_track/tests/test_track_internals.py
@@ -7,6 +7,77 @@ from unittest.mock import patch
 from odoo import fields
 from odoo.addons.website.models.website_visitor import WebsiteVisitor
 from odoo.addons.website_event_track.tests.common import TestEventTrackOnlineCommon
+from odoo.tests.common import users
+
+
+class TestTrackData(TestEventTrackOnlineCommon):
+
+    @users('user_eventmanager')
+    def test_track_partner_sync(self):
+        """ Test registration computed fields about partner """
+        test_email = '"Nibbler In Space" <nibbler@futurama.example.com>'
+        test_phone = '0456001122'
+        test_bio = '<p>UserInput</p>'
+        test_bio_void = '<p><br/></p>'
+
+        event = self.env['event.event'].browse(self.event_0.ids)
+        customer = self.env['res.partner'].browse(self.event_customer.id)
+
+        # take all from partner
+        new_track = self.env['event.track'].create({
+            'event_id': event.id,
+            'name': 'Mega Track',
+            'partner_id': customer.id,
+        })
+        self.assertEqual(new_track.partner_id, customer)
+        self.assertEqual(new_track.partner_name, customer.name)
+        self.assertEqual(new_track.partner_email, customer.email)
+        self.assertEqual(new_track.partner_phone, customer.phone)
+        self.assertEqual(new_track.partner_biography, customer.website_description)
+        self.assertIn(customer.name, new_track.partner_biography, 'Low-level test: ensure correctly updated')
+
+        # partial update
+        new_track = self.env['event.track'].create({
+            'event_id': event.id,
+            'name': 'Mega Track',
+            'partner_id': customer.id,
+            'partner_name': 'Nibbler In Space',
+            'partner_email': test_email,
+        })
+        self.assertEqual(new_track.partner_id, customer)
+        self.assertEqual(
+            new_track.partner_name, 'Nibbler In Space',
+            'Track should take user input over computed partner value')
+        self.assertEqual(
+            new_track.partner_email, test_email,
+            'Track should take user input over computed partner value')
+        # self.assertEqual(
+        #     new_track.partner_phone, customer.phone,
+        #     'Track should take partner value if not user input')
+
+        # already filled information should not be updated
+        new_track = self.env['event.track'].create({
+            'event_id': event.id,
+            'name': 'Mega Track',
+            'partner_name': 'Nibbler In Space',
+            'partner_phone': test_phone,
+            'partner_biography': test_bio,
+        })
+        self.assertEqual(new_track.partner_name, 'Nibbler In Space')
+        self.assertEqual(new_track.partner_email, False)
+        self.assertEqual(new_track.partner_phone, test_phone)
+        self.assertEqual(new_track.partner_biography, test_bio)
+        new_track.write({'partner_id': customer.id})
+        self.assertEqual(new_track.partner_id, customer)
+        self.assertEqual(
+            new_track.partner_name, customer.name,
+            'Track customer should take over existing value')
+        self.assertEqual(
+            new_track.partner_email, customer.email,
+            'Track customer should take over existing value')
+        self.assertEqual(
+            new_track.partner_phone, customer.phone,
+            'Track customer should take over existing value')
 
 
 class TestTrackSuggestions(TestEventTrackOnlineCommon):


### PR DESCRIPTION
RATIONALE

Stored editable fields receive their values either from compute either from
user input. If a user input is given to create / write compute method is not
called. If multiple fields are computed through the same method giving one
field value discard call to compute method and other fields are not called.

SPECIFICATIONS

Split ``_compute_contact_info`` compute method on registration model
so that partner related fields are independent.

Split ``_compute_from_event_type`` compute method so that event template
configuration  related fields are independent.

Split ``_compute_from_event_type`` compute method on event model
so that event type related fields are independent.

Add tests related to registration / partner contact fields synchronization. Add
tests with user input and/or partner synchronization to ensure editable stored
fields work as expected on lead model

LINKS

Task ID-2455165
COM PR odoo/odoo#65688
