### PR TITLE
date options are not displayed in dropdown

### DIFF
--- a/addons/web/static/src/scss/dropdown_menu.scss
+++ b/addons/web/static/src/scss/dropdown_menu.scss
@@ -4,6 +4,8 @@
     }
 
     min-width: 150px;
+    max-height: calc(100vh - 140px); // FIXME
+    overflow: auto;
 
     .o_menu_item {
         position: relative;
@@ -16,11 +18,6 @@
             }
         }
     }
-}
-
-.o_dropdown_menu, .dropdown-menu {
-    max-height: calc(100vh - 140px); // FIXME
-    overflow: auto;
 }
 
 .dropdown-item {


### PR DESCRIPTION
PURPOSE
The 'date picker' of date(time) fields does not unfold in the pivot groupby dropdown

SPEC
The 'date picker' of date(time) fields should be unfolded in the pivot groupby dropdown

TASK 2452033


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
