### PR TITLE
[FIX] mrp_subcontracting_account: update inventory valuation 

### DIFF
--- a/addons/mrp_subcontracting_account/models/__init__.py
+++ b/addons/mrp_subcontracting_account/models/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import stock_picking
+from . import stock_location

--- a/addons/mrp_subcontracting_account/models/stock_location.py
+++ b/addons/mrp_subcontracting_account/models/stock_location.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+
+from odoo import models
+
+
+class StockLocation(models.Model):
+    _inherit = "stock.location"
+
+    def _should_be_valued(self):
+        res = super()._should_be_valued()
+        if self.company_id.subcontracting_location_id:
+            res &= self != self.company_id.subcontracting_location_id
+        return res

--- a/addons/mrp_subcontracting_account/tests/test_subcontracting_account.py
+++ b/addons/mrp_subcontracting_account/tests/test_subcontracting_account.py
@@ -53,5 +53,5 @@ class TestAccountSubcontractingFlows(TestMrpSubcontractingCommon):
         picking_receipt.move_lines.quantity_done = 1.0
         picking_receipt.action_done()
 
-        self.assertEqual(picking_receipt.move_lines.stock_valuation_layer_ids.value, 60)
-        self.assertEqual(picking_receipt.move_lines.product_id.value_svl, 60)
+        self.assertEqual(picking_receipt.move_lines.stock_valuation_layer_ids.value, 30)
+        self.assertEqual(picking_receipt.move_lines.product_id.value_svl, 30)


### PR DESCRIPTION
When buying a subcontracted product, if the inventory valuation of the
product category is automated, the product delivery does not create a
new journal entry, i.e. the automated inventory valuation is not done.

To reproduce the error:
(Need account_accountant,purchase)
1. In Settings, enable "Subcontracting"
2. Create a product category PC
    - Parent: All
    - Inventory Valuation: Automated
3. Create a product P
    - Must be storable
    - In category PC
    - Set a positive cost
4. Add a BoM to P
    - Type: Subcontracting
5. Create a RfQ
    - Vendor: BoM's subcontractor
    - Product: P
6. Confirm & Receive Products
7. Go to Accounting > Accounting > Miscellaneous > Journal Entries

Error: There isn't any journal entry about the new product. This is an
error because the inventory valuation for this product is automated, so
there should be a line with the P-product and the cost set on step 3.

When validating the delivery, the server checks the stock move lines
considered as incoming:
https://github.com/odoo/odoo/blob/5098cb25accce91347760cbd2f6427c07265fa00/addons/stock_account/models/stock_move.py#L61-L65
Problem is that `_should_be_valued` for subcontractor's location returns
`True`, therefore the stock move line will not be added.
=> The `mrp_subcontracting` module needs to add a condition:
A location can be valued if it is not subcontractor's location.

OPW-2446298