### PR TITLE
[FIX] account: can refresh tax audit action


### DIFF
--- a/addons/account/views/account_view.xml
+++ b/addons/account/views/account_view.xml
@@ -1390,7 +1390,6 @@
         <act_window
             id="action_move_line_select_tax_audit"
             name="Journal Items for Tax Audit"
-            context="{'search_default_account_id': [active_id]}"
             res_model="account.move.line"
             src_model="account.account"
             view_id="account.view_move_line_tax_audit_tree"/>


### PR DESCRIPTION
Because of context:

{'search_default_account_id': [active_id]}

refreshing on the tax audit action could cause an error because in normal
use case we have active_id that is never an account.account id.

There doesn't seem to be any use case where that context is useful since
it was introduced in 2017 (81089042), this action is always used with an
overriden context. So this commit is removing it.

opw-2388448
