### PR TITLE
[FIX] account: journal sequence no reset on change of period

### DIFF
--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -169,7 +169,11 @@ class SequenceMixin(models.AbstractModel):
         self.ensure_one()
         if self._sequence_field not in self._fields or not self._fields[self._sequence_field].store:
             raise ValidationError(_('%s is not a stored field', self._sequence_field))
-        where_string, param = self._get_last_sequence_domain(relaxed)
+        # (?P<no_reset>) can be used on the journal regex override to not reset the
+        # sequence on change of period, in that case all the sequences point to the
+        # journal override, so it's OK to only check with the monthly one
+        no_reset = "(?P<no_reset>)" in self._sequence_monthly_regex
+        where_string, param = self._get_last_sequence_domain(relaxed=(no_reset or relaxed))
         if self.id or self.id.origin:
             where_string += " AND id != %(id)s "
             param['id'] = self.id or self.id.origin


### PR DESCRIPTION
Add support for not resetting a sequence on change of period by means of a _shadow_ group `(:P<no_reset>)` on the journal override regex. This allows to setup no reset per journal.

Add some tests.

Description of the issue/feature this PR addresses: 
Currently the period is detected by the presence of 'year' or 'month' keyword on the regex. This period is then used to reset the sequence. Even when the period is not correctly detected, i.e. when it's taken as 'never', the sequence is not reset correctly since then the year or month won't be computed correctly.
This is a limitation of the new sequencing implementation which assumes resetting of the sequence when the period changes. 

Current behavior before PR:
For example, a sequence having `PREF/2020/15` as last sequence of 2020 will have `PREF/2021/00` as new sequence on 2021.

Desired behavior after PR is merged:
If the `no_reset` group is used the sequence will not reset on change of period.
As per previous example: `PREF/2021/16` will be the first sequence of 2021 as expected.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
