### PR TITLE
[FIX] point_of_sale: fix variant price in pricelist

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1536,7 +1536,7 @@ exports.Product = Backbone.Model.extend({
     // product.pricelist.item records are loaded with a search_read
     // and were automatically sorted based on their _order by the
     // ORM. After that they are added in this order to the pricelists.
-    get_price: function(pricelist, quantity){
+    get_price: function(pricelist, quantity, price_extra){
         var self = this;
         var date = moment().startOf('day');
 
@@ -1565,6 +1565,9 @@ exports.Product = Backbone.Model.extend({
         });
 
         var price = self.lst_price;
+        if (price_extra){
+            price += price_extra;
+        }
         _.find(pricelist_items, function (rule) {
             if (rule.min_quantity && quantity < rule.min_quantity) {
                 return false;
@@ -1792,7 +1795,7 @@ exports.Orderline = Backbone.Model.extend({
 
         // just like in sale.order changing the quantity will recompute the unit price
         if(! keep_price && ! this.price_manually_set){
-            this.set_unit_price(this.product.get_price(this.order.pricelist, this.get_quantity()) + this.get_price_extra());
+            this.set_unit_price(this.product.get_price(this.order.pricelist, this.get_quantity(), this.get_price_extra()));
             this.order.fix_tax_included_price(this);
         }
         this.trigger('change', this);
@@ -2955,7 +2958,7 @@ exports.Order = Backbone.Model.extend({
             return ! line.price_manually_set;
         });
         _.each(lines_to_recompute, function (line) {
-            line.set_unit_price(line.product.get_price(self.pricelist, line.get_quantity()) + line.get_price_extra());
+            line.set_unit_price(line.product.get_price(self.pricelist, line.get_quantity(), line.get_price_extra()));
             self.fix_tax_included_price(line);
         });
         this.trigger('change');
@@ -2991,7 +2994,7 @@ exports.Order = Backbone.Model.extend({
 
         if (options.price_extra !== undefined){
             line.price_extra = options.price_extra;
-            line.set_unit_price(line.get_unit_price() + options.price_extra);
+            line.set_unit_price(line.product.get_price(this.pricelist, line.get_quantity(), options.price_extra));
             this.fix_tax_included_price(line);
         }
 


### PR DESCRIPTION
Create a product with variants attributes that NEVER create variants.
Configure Variants to add some extra-prices (1$) to some variants.
In POS settings activate "Product Configurator" and
"Advanced Pricelists", add the public pricelist and one that applies 50%
to
the product.

Open a session and select the product created (say price = 1$)
Select the attributes, the extra-price is added to the product (say the
total price now is 2$).
Change pricelist from public to 50% and the order line will show our
product = 1@50% + 1 = 1.50, not applying the pricelist to the extra-price

opw-2439445

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
