### PR TITLE
[FIX]stock_account: don't show consumable in valuation report

### DIFF
--- a/addons/stock_account/wizard/stock_quantity_history.py
+++ b/addons/stock_account/wizard/stock_quantity_history.py
@@ -10,7 +10,7 @@ class StockQuantityHistory(models.TransientModel):
         active_model = self.env.context.get('active_model')
         if active_model == 'stock.valuation.layer':
             action = self.env.ref('stock_account.stock_valuation_layer_action').read()[0]
-            action['domain'] = [('create_date', '<=', self.inventory_datetime)]
+            action['domain'] = [('create_date', '<=', self.inventory_datetime), ('product_id.type', '=', 'product')]
             action['display_name'] = str(self.inventory_datetime)
             return action
 


### PR DESCRIPTION
In "Inventory Valuation", when click "Inventory at Date" then "confirm".
Record for consumable products will be shown in the report.

Previously fix in #62622 which disabled svl for consumable products,
then rolled back in #63386 due to mrp need to create svl for consumables
to analyse cost.

In this commit, we add a domian filter to not show consumables in
"Inventory Valuation"

Task 2449211





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
