### PR TITLE
14.0 fix misc las

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -1248,7 +1248,7 @@ class AccountBankStatementLine(models.Model):
         # Assign partner if needed (for example, when reconciling a statement
         # line with no partner, with an invoice; assign the partner of this invoice)
         if not self.partner_id:
-            rec_overview_partners = set(overview['counterpart_line'].partner_id
+            rec_overview_partners = set(overview['counterpart_line'].partner_id.id
                                         for overview in reconciliation_overview
                                         if overview.get('counterpart_line') and overview['counterpart_line'].partner_id)
             if len(rec_overview_partners) == 1:

--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -706,7 +706,7 @@ class AccountBankStatementLine(models.Model):
             **counterpart_vals,
             'name': counterpart_vals.get('name', move_line.name if move_line else ''),
             'move_id': self.move_id.id,
-            'partner_id': self.partner_id.id,
+            'partner_id': self.partner_id.id or (move_line.partner_id.id if move_line else False),
             'currency_id': currency_id,
             'account_id': counterpart_vals.get('account_id', move_line.account_id.id if move_line else False),
             'debit': balance if balance > 0.0 else 0.0,

--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -404,8 +404,9 @@ class AccountJournal(models.Model):
         result = super(AccountJournal, self).write(vals)
 
         # Ensure the liquidity accounts are sharing the same foreign currency.
-        for journal in self.filtered(lambda journal: journal.type in ('bank', 'cash')):
-            journal.default_account_id.currency_id = journal.currency_id
+        if 'currency_id' in vals:
+            for journal in self.filtered(lambda journal: journal.type in ('bank', 'cash')):
+                journal.default_account_id.currency_id = journal.currency_id
 
         # Create the bank_account_id if necessary
         if 'bank_acc_number' in vals:


### PR DESCRIPTION
**[FIX] account: Don't write currency on journal's accounts everytime**

The currency is not always consistent between the journal and their accounts when coming from migrations.
It leads to some traceback when installing l10n_us_nacha or account_sepa writing a payment method at the installation of the module in case of the journal has a foreign currency but not the account.

**[FIX] account: Keep counterpart partner when reconciling a statement line**

When reconciling a statement line that has no partner with multiple lines having different partners, the partner wasn't set on the auto-generated lines during the reconciliation.

**[FIX] account: Fix 'Comparing apples and oranges' during statement line reconciliation**

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
