### PR TITLE
[FIX] calendar_event: appointment time mismatch

### DIFF
--- a/addons/calendar/data/mail_template_data.xml
+++ b/addons/calendar/data/mail_template_data.xml
@@ -53,16 +53,25 @@
     <table border="0" cellpadding="0" cellspacing="0"><tr>
         <td width="130px;">
             <div style="border-top-left-radius: 3px; border-top-right-radius: 3px; font-size: 12px; border-collapse: separate; text-align: center; font-weight: bold; color: #ffffff; min-height: 18px; background-color: #875A7B; border: 1px solid #875A7B;">
-                ${object.event_id.get_interval('dayname', tz=object.partner_id.tz if not object.event_id.allday else None)}
+                ${format_datetime(dt=object.event_id.start, tz=object.mail_tz if not object.event_id.allday else None, dt_format="EEEE", lang_code=object.env.lang)}
             </div>
             <div style="font-size: 48px; min-height: auto; font-weight: bold; text-align: center; color: #5F5F5F; background-color: #F8F8F8; border: 1px solid #875A7B;">
-                ${object.event_id.get_interval('day', tz=object.partner_id.tz if not object.event_id.allday else None)}
+                ${str(object.event_id.start.day)}
             </div>
             <div style='font-size: 12px; text-align: center; font-weight: bold; color: #ffffff; background-color: #875A7B;'>
-                ${object.event_id.get_interval('month', tz=object.partner_id.tz if not object.event_id.allday else None)}
+                ${format_datetime(dt=object.event_id.start, tz=object.mail_tz if not object.event_id.allday else None, dt_format="MMMM y", lang_code=object.env.lang)}
             </div>
-            <div style="border-collapse: separate; color: #5F5F5F; text-align: center; font-size: 12px; border-bottom-right-radius: 3px; font-weight: bold; border: 1px solid #875A7B; border-bottom-left-radius: 3px;">
-                ${not object.event_id.allday and object.event_id.get_interval('time', tz=object.partner_id.tz) or ''}
+            <div style="border-collapse: separate; color: #5F5F5F; text-align: center; font-size: 12px; border-bottom-right-radius: 3px; font-weight: bold ; border: 1px solid #875A7B; border-bottom-left-radius: 3px;">
+                % if not object.event_id.allday
+                    <div>
+                        ${format_time(time=object.event_id.start, tz=object.mail_tz, time_format="short", lang_code=object.env.lang)}
+                    </div>
+                    % if object.mail_tz
+                    <div style="font-size: 10px; font-weight: normal">
+                        (${object.mail_tz})
+                    </div>
+                    % endif
+                %endif
             </div>
         </td>
         <td width="20px;"/>
@@ -177,16 +186,25 @@
     <table border="0" cellpadding="0" cellspacing="0"><tr>
         <td width="130px;">
             <div style="border-top-left-radius: 3px; border-top-right-radius: 3px; font-size: 12px; border-collapse: separate; text-align: center; font-weight: bold; color: #ffffff; min-height: 18px; background-color: #875A7B; border: 1px solid #875A7B;">
-                ${object.event_id.get_interval('dayname', tz=object.partner_id.tz if not object.event_id.allday else None)}
+                ${format_datetime(dt=object.event_id.start, tz=object.mail_tz if not object.event_id.allday else None, dt_format="EEEE", lang_code=object.env.lang)}
             </div>
             <div style="font-size: 48px; min-height: auto; font-weight: bold; text-align: center; color: #5F5F5F; background-color: #F8F8F8; border: 1px solid #875A7B;">
-                ${object.event_id.get_interval('day', tz=object.partner_id.tz if not object.event_id.allday else None)}
+                ${str(object.event_id.start.day)}
             </div>
             <div style='font-size: 12px; text-align: center; font-weight: bold; color: #ffffff; background-color: #875A7B;'>
-                ${object.event_id.get_interval('month', tz=object.partner_id.tz if not object.event_id.allday else None)}
+                ${format_datetime(dt=object.event_id.start, tz=object.mail_tz if not object.event_id.allday else None, dt_format="MMMM y", lang_code=object.env.lang)}
             </div>
             <div style="border-collapse: separate; color: #5F5F5F; text-align: center; font-size: 12px; border-bottom-right-radius: 3px; font-weight: bold; border: 1px solid #875A7B; border-bottom-left-radius: 3px;">
-                ${not object.event_id.allday and object.event_id.get_interval('time', tz=object.partner_id.tz) or ''}
+                 % if not object.event_id.allday
+                    <div>
+                        ${format_time(time=object.event_id.start, tz=object.mail_tz, time_format="short", lang_code=object.env.lang)}
+                    </div>
+                    % if object.mail_tz
+                    <div style="font-size: 10px; font-weight: normal">
+                        (${object.mail_tz})
+                    </div>
+                    % endif
+                %endif
             </div>
         </td>
         <td width="20px;"/>
@@ -265,7 +283,7 @@
         This is a reminder for the below event :
     </p>
     <div style="text-align: center; margin: 16px 0px 16px 0px;">
-        <a href="/calendar/${'recurrence' if recurrent else 'meeting'}/accept?token=${object.access_token}&amp;id=${object.event_id.id}" 
+        <a href="/calendar/${'recurrence' if recurrent else 'meeting'}/accept?token=${object.access_token}&amp;id=${object.event_id.id}"
             style="padding: 5px 10px; color: #FFFFFF; text-decoration: none; background-color: #875A7B; border: 1px solid #875A7B; border-radius: 3px">
             Accept</a>
         <a href="/calendar/${'recurrence' if recurrent else 'meeting'}/decline?token=${object.access_token}&amp;id=${object.event_id.id}"
@@ -278,16 +296,25 @@
     <table border="0" cellpadding="0" cellspacing="0"><tr>
         <td width="130px;">
             <div style="border-top-left-radius: 3px; border-top-right-radius: 3px; font-size: 12px; border-collapse: separate; text-align: center; font-weight: bold; color: #ffffff; min-height: 18px; background-color: #875A7B; border: 1px solid #875A7B;">
-                ${object.event_id.get_interval('dayname', tz=object.partner_id.tz if not object.event_id.allday else None)}
+                ${format_datetime(dt=object.event_id.start, tz=object.mail_tz if not object.event_id.allday else None, dt_format="EEEE", lang_code=object.env.lang)}
             </div>
             <div style="font-size: 48px; min-height: auto; font-weight: bold; text-align: center; color: #5F5F5F; background-color: #F8F8F8; border: 1px solid #875A7B;">
-                ${object.event_id.get_interval('day', tz=object.partner_id.tz if not object.event_id.allday else None)}
+                ${str(object.event_id.start.day)}
             </div>
             <div style='font-size: 12px; text-align: center; font-weight: bold; color: #ffffff; background-color: #875A7B;'>
-                ${object.event_id.get_interval('month', tz=object.partner_id.tz if not object.event_id.allday else None)}
+                ${format_datetime(dt=object.event_id.start, tz=object.mail_tz if not object.event_id.allday else None, dt_format="MMMM y", lang_code=object.env.lang)}
             </div>
             <div style="border-collapse: separate; color: #5F5F5F; text-align: center; font-size: 12px; border-bottom-right-radius: 3px; font-weight: bold; border: 1px solid #875A7B; border-bottom-left-radius: 3px;">
-                ${not object.event_id.allday and object.event_id.get_interval('time', tz=object.partner_id.tz) or ''}
+                % if not object.event_id.allday
+                    <div>
+                        ${format_time(time=object.event_id.start, tz=object.mail_tz, time_format="short", lang_code=object.env.lang)}
+                    </div>
+                    % if object.mail_tz
+                    <div style="font-size: 10px; font-weight: normal">
+                        (${object.mail_tz})
+                    </div>
+                    % endif
+                %endif
             </div>
         </td>
         <td width="20px;"/>

--- a/addons/calendar/models/calendar_attendee.py
+++ b/addons/calendar/models/calendar_attendee.py
@@ -5,6 +5,7 @@ import base64
 import logging
 
 from odoo import api, fields, models, _
+from odoo.addons.base.models.res_partner import _tz_get
 from odoo.exceptions import UserError
 
 _logger = logging.getLogger(__name__)
@@ -36,6 +37,7 @@ class Attendee(models.Model):
     phone = fields.Char('Phone', related='partner_id.phone', help="Phone number of Invited Person")
     common_name = fields.Char('Common name', compute='_compute_common_name', store=True)
     access_token = fields.Char('Invitation Token', default=_default_access_token)
+    mail_tz = fields.Selection(_tz_get, compute='_compute_mail_tz', help='Timezone used for displaying time in the mail template')
     # state
     state = fields.Selection(STATE_SELECTION, string='Status', readonly=True, default='needsAction',
                              help="Status of the attendee's participation")
@@ -46,6 +48,10 @@ class Attendee(models.Model):
     def _compute_common_name(self):
         for attendee in self:
             attendee.common_name = attendee.partner_id.name or attendee.email
+
+    def _compute_mail_tz(self):
+        for attendee in self:
+            attendee.mail_tz = attendee.partner_id.tz
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -4,7 +4,6 @@
 from datetime import timedelta
 import math
 from uuid import uuid4
-import babel.dates
 import logging
 import pytz
 from werkzeug.urls import url_join
@@ -748,39 +747,6 @@ class Meeting(models.Model):
     def _range(self):
         self.ensure_one()
         return (self.start, self.stop)
-
-    def get_interval(self, interval, tz=None):
-        """ Format and localize some dates to be used in email templates
-            :param string interval: Among 'day', 'month', 'dayname' and 'time' indicating the desired formatting
-            :param string tz: Timezone indicator (optional)
-            :return unicode: Formatted date or time (as unicode string, to prevent jinja2 crash)
-        """
-        self.ensure_one()
-        date = fields.Datetime.from_string(self.start)
-
-        if tz:
-            timezone = pytz.timezone(tz or 'UTC')
-            date = date.replace(tzinfo=pytz.timezone('UTC')).astimezone(timezone)
-
-        if interval == 'day':
-            # Day number (1-31)
-            result = str(date.day)
-
-        elif interval == 'month':
-            # Localized month name and year
-            result = babel.dates.format_date(date=date, format='MMMM y', locale=get_lang(self.env).code)
-
-        elif interval == 'dayname':
-            # Localized day name
-            result = babel.dates.format_date(date=date, format='EEEE', locale=get_lang(self.env).code)
-
-        elif interval == 'time':
-            # Localized time
-            # FIXME: formats are specifically encoded to bytes, maybe use babel?
-            dummy, format_time = self._get_date_formats()
-            result = tools.ustr(date.strftime(format_time + " %Z"))
-
-        return result
 
     def get_display_time_tz(self, tz=False):
         """ get the display_time of the meeting, forcing the timezone. This method is called from email template, to not use sudo(). """

--- a/addons/mail/models/mail_render_mixin.py
+++ b/addons/mail/models/mail_render_mixin.py
@@ -30,6 +30,12 @@ def format_datetime(env, dt, tz=False, dt_format='medium', lang_code=False):
     except babel.core.UnknownLocaleError:
         return dt
 
+def format_time(env, time, tz=False, time_format='medium', lang_code=False):
+    try:
+        return tools.format_time(env, time, tz=tz, time_format=time_format, lang_code=lang_code)
+    except babel.core.UnknownLocaleError:
+        return time
+
 try:
     # We use a jinja2 sandboxed environment to render mako templates.
     # Note that the rendering does not cover all the mako syntax, in particular
@@ -285,6 +291,7 @@ class MailRenderMixin(models.AbstractModel):
         render_context = {
             'format_date': lambda date, date_format=False, lang_code=False: format_date(self.env, date, date_format, lang_code),
             'format_datetime': lambda dt, tz=False, dt_format=False, lang_code=False: format_datetime(self.env, dt, tz, dt_format, lang_code),
+            'format_time': lambda time, tz=False, time_format=False, lang_code=False: format_time(self.env, time, tz, time_format, lang_code),
             'format_amount': lambda amount, currency, lang_code=False: tools.format_amount(self.env, amount, currency, lang_code),
             'format_duration': lambda value: tools.format_duration(value),
             'user': self.env.user,

--- a/odoo/addons/base/tests/test_misc.py
+++ b/odoo/addons/base/tests/test_misc.py
@@ -268,6 +268,10 @@ class TestFormatLangDate(TransactionCase):
         self.assertIn(misc.format_time(lang.with_context(lang='fr_FR').env, time_part_tz, time_format='long'), ['16:30:22 -0504', '16:30:22 HNE'])
         self.assertEqual(misc.format_time(lang.with_context(lang='zh_CN').env, time_part_tz, time_format='full'), '\u5317\u7f8e\u4e1c\u90e8\u6807\u51c6\u65f6\u95f4\u0020\u4e0b\u53484:30:22')
 
+        #Check timezone conversion in format_time
+        self.assertEqual(misc.format_time(lang.with_context(lang='fr_FR').env, datetime_str, 'Europe/Brussels', time_format='long'), '11:33:00 +0100')
+        self.assertEqual(misc.format_time(lang.with_context(lang='fr_FR').env, datetime_str, 'US/Eastern', time_format='long'), '05:33:00 HNE')
+
         # Check given `lang_code` overwites context lang
         self.assertEqual(misc.format_time(lang.with_context(lang='fr_FR').env, time_part, time_format='short', lang_code='zh_CN'), '\u4e0b\u53484:30')
         self.assertEqual(misc.format_time(lang.with_context(lang='zh_CN').env, time_part, time_format='medium', lang_code='fr_FR'), '16:30:22')


### PR DESCRIPTION
add a mail_template_id field in order to make it
easier to change the mail template of the emails
that are sent to attendees so that we can use it
to make the appointment time shown on the invitation email
sent to the attendees consistent with the time shown on the
website page, see: odoo/enterprise#16204

Task-2451154

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
