### PR TITLE
[FIX] account: is_valid_balance_start computing

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -188,7 +188,13 @@ class AccountBankStatement(models.Model):
     @api.depends('balance_start', 'previous_statement_id')
     def _compute_is_valid_balance_start(self):
         for bnk in self:
-            bnk.is_valid_balance_start = float_is_zero(bnk.balance_start - bnk.previous_statement_id.balance_end_real, precision_digits=bnk.currency_id.decimal_places)
+            bnk.is_valid_balance_start = (
+                bnk.currency_id.is_zero(
+                    bnk.balance_start - bnk.previous_statement_id.balance_end_real
+                )
+                if bnk.previous_statement_id
+                else True
+            )
 
     @api.depends('date', 'journal_id')
     def _get_previous_statement(self):


### PR DESCRIPTION
According to its description, the field `is_valid_balance_start`
of the `account_bank_statement` model shall be `False` if the starting
balance of the current statement, is different from the previous
ending balance.
That means, it shall be set to `True` when no previous statement has been
set (`previous_statement_id` is NULL), whatever the starting balance value.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
