### PR TITLE
[FIX] web: fields info for a specific view can be undefined

### DIFF
--- a/addons/web/static/src/js/views/basic/basic_view.js
+++ b/addons/web/static/src/js/views/basic/basic_view.js
@@ -144,7 +144,7 @@ var BasicView = AbstractView.extend({
                             var x2mFieldInfo = record.fieldsInfo[this.viewType][name];
                             var viewType = x2mFieldInfo.viewType || x2mFieldInfo.mode;
                             var knownFields = Object.keys(record.data[name].fieldsInfo[record.data[name].viewType] || {});
-                            var newFields = Object.keys(record.data[name].fieldsInfo[viewType]);
+                            var newFields = Object.keys(record.data[name].fieldsInfo[viewType] || {});
                             if (_.difference(newFields, knownFields).length) {
                                 fieldNames.push(name);
                             }

--- a/addons/web/static/tests/fields/relational_fields/field_one2many_tests.js
+++ b/addons/web/static/tests/fields/relational_fields/field_one2many_tests.js
@@ -7161,7 +7161,7 @@ QUnit.module('fields', {}, function () {
         });
 
         QUnit.test('nested one2manys with no widget in list and as invisible list in form', async function (assert) {
-            assert.expect(4);
+            assert.expect(6);
 
             this.data.partner.records[0].p = [1];
 
@@ -7182,6 +7182,13 @@ QUnit.module('fields', {}, function () {
             assert.containsOnce(form, '.o_data_row');
             assert.strictEqual(form.$('.o_data_row .o_data_cell').text(), '1 record');
 
+            await testUtils.dom.click(form.$('.o_data_row'));
+
+            assert.containsOnce(document.body, '.modal .o_form_view');
+            assert.isNotVisible($('.modal .o_field_one2many'));
+
+            // Test possible caching issues
+            await testUtils.dom.click($('.modal .o_form_button_cancel'));
             await testUtils.dom.click(form.$('.o_data_row'));
 
             assert.containsOnce(document.body, '.modal .o_form_view');


### PR DESCRIPTION
Steps:
- Install mrp
- Go to Manufacturing > Master Data > Bills of Materials
- Create a BoM
  - Components:
    - Add a component
- Save
- Click the component
- Close the modal window
- Click the component once more

Bug:
Traceback here:
https://github.com/odoo/odoo/blob/55a6642a9621fa9683895d5d45a015bb04c3017b/addons/web/static/src/js/views/basic/basic_view.js#L147
Error: can't convert undefined to object

Explanation:
As seen on the line just above:
https://github.com/odoo/odoo/blob/55a6642a9621fa9683895d5d45a015bb04c3017b/addons/web/static/src/js/views/basic/basic_view.js#L146
`fieldsInfo` might not have the view we are looking for.

opw:2452142