### PR TITLE
[FIX] account: when a decoder successfully parse an attachment, ocr i…

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2881,7 +2881,7 @@ class AccountMove(models.Model):
             for attachment in attachments.sorted(lambda x: x != self.message_main_attachment_id):
                 invoice = decoder[1](attachment, self)
                 if invoice:
-                    break
+                    return res
 
         return res
 


### PR DESCRIPTION
…s not called when updating an invoice

see https://github.com/odoo/odoo/pull/65510

Before this commit, even if another attachment decoder managed to parse an attachment into an invoice, all the decoders were called.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
