### PR TITLE
[FIX] web: ensure o_status is well displayed

### DIFF
--- a/addons/web/static/src/scss/form_view.scss
+++ b/addons/web/static/src/scss/form_view.scss
@@ -619,7 +619,7 @@
             margin-bottom: 0px;
         }
     }
-    td.o_td_label .o_form_label {
+    td.o_td_label .o_form_label:not(.o_status) {
         min-height: 33px;
     }
     td:not(.o_field_cell) .o_form_uri > span:first-child {


### PR DESCRIPTION
Before this commit:

* When a o_status class is set on a label element it is not well displayed
  in project.task_type_edit, event.event_stage_view_form and helpdesk.helpdesk_stage_view_form
  since this commit has been introduced 288b24cbdf54ac0dbee7e012f074fac9a0c68238

After this commit:

* o_status labels are correctly displayed.

task-2453268
Related PR: odoo/enterprise#16173

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
