### PR TITLE
[FIX] base_vat: not called at all

### DIFF
--- a/addons/base_vat/tests/test_validate_ruc.py
+++ b/addons/base_vat/tests/test_validate_ruc.py
@@ -1,11 +1,20 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo.tests import common
+from odoo.tests.common import SavepointCase, tagged
 from odoo.exceptions import ValidationError
 from unittest.mock import patch
 
-from stdnum.eu import vat
+import stdnum.eu.vat
 
-class TestStructure(common.TransactionCase):
+
+class TestStructure(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        def check_vies(vat_number):
+            return {'valid': vat_number == 'BE0477472701'}
+
+        super().setUpClass()
+        cls.env.user.company_id.vat_check_vies = False
+        cls._vies_check_func = check_vies
 
     def test_peru_ruc_format(self):
         """Only values that has the length of 11 will be checked as RUC, that's what we are proving. The second part
@@ -29,7 +38,7 @@ class TestStructure(common.TransactionCase):
     def test_parent_validation(self):
         """Test the validation with company and contact"""
 
-        # disable the verification to set an invalid vat number
+        # set an invalid vat number
         self.env.user.company_id.vat_check_vies = False
         company = self.env["res.partner"].create({
             "name": "World Company",
@@ -43,11 +52,18 @@ class TestStructure(common.TransactionCase):
             "company_type": "person",
         })
 
-        def mock_check_vies(vat_number):
-            """ Fake vatnumber method that will only allow one number """
-            return vat_number == 'BE0987654321'
-
         # reactivate it and correct the vat number
-        with patch.object(vat, 'check_vies', mock_check_vies):
+        with patch('odoo.addons.base_vat.models.res_partner.check_vies', type(self)._vies_check_func):
             self.env.user.company_id.vat_check_vies = True
-            company.vat = "BE0987654321"
+            with self.assertRaises(ValidationError), self.env.cr.savepoint():
+                company.vat = "BE0987654321"  # VIES refused, don't fallback on other check
+            company.vat = "BE0477472701"
+
+
+@tagged('-standard', 'external')
+class TestStructureVIES(TestStructure):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.user.company_id.vat_check_vies = True
+        cls._vies_check_func = stdnum.eu.vat.check_vies


### PR DESCRIPTION
The function was wrongly imported and used, and it was hidden by a
generic catching of all exceptions.
The return value and some legit exceptions were also badly handled:
* The return value was always thruthy as it returns an object containing
information about the check.
* Exceptions can be raised if the format is not correct. In that case,
we don't want to go to the simple vat check.

Fixes #64897
opw-[2451951](https://www.odoo.com/web#id=2451951&model=project.task&view_type=form&cids=1&menu_id=)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
