### PR TITLE
[FIX] web: keep null/false/true strings in domains

### DIFF
--- a/addons/web/static/src/js/core/domain.js
+++ b/addons/web/static/src/js/core/domain.js
@@ -224,15 +224,26 @@ var Domain = collections.Tree.extend({
      * representation of the Python prefix-array representation of this domain.
      *
      * @static
-     * @param {Array|string} domain
+     * @param {Array|string|undefined} domain
      * @returns {string}
      */
     arrayToString: function (domain) {
         if (_.isString(domain)) return domain;
-        return JSON.stringify(domain || [])
-            .replace(/null/g, "None")
-            .replace(/false/g, "False")
-            .replace(/true/g, "True");
+        const parts = (domain || []).map(part => {
+            if (_.isArray(part)) { // e.g. ['name', 'ilike', 'foo'] or ['is_active', '=', true]
+                return "[" + part.map(c => {
+                    switch (c) {
+                        case null: return "None";
+                        case true: return "True";
+                        case false: return "False";
+                        default: return JSON.stringify(c);
+                    }
+                }).join(',') + "]";
+            } else { // e.g. '|' or '&'
+                return JSON.stringify(part);
+            }
+        });
+        return "[" + parts.join(',') + "]";
     },
     /*
      * @param {string} fieldName

--- a/addons/web/static/tests/core/domain_tests.js
+++ b/addons/web/static/tests/core/domain_tests.js
@@ -111,5 +111,21 @@ QUnit.module('core', {}, function () {
         assert.strictEqual(typeof(actual),typeof([]));
         assert.strictEqual(actual.length, 0);
     });
+
+    QUnit.test("arrayToString", function (assert) {
+        assert.expect(7);
+
+        const arrayToString = Domain.prototype.arrayToString;
+
+        // domains containing null, false or true
+        assert.strictEqual(arrayToString([['name', '=', null]]), '[["name","=",None]]');
+        assert.strictEqual(arrayToString([['name', '=', false]]), '[["name","=",False]]');
+        assert.strictEqual(arrayToString([['name', '=', true]]), '[["name","=",True]]');
+        assert.strictEqual(arrayToString([['name', '=', 'null']]), '[["name","=","null"]]');
+        assert.strictEqual(arrayToString([['name', '=', 'false']]), '[["name","=","false"]]');
+        assert.strictEqual(arrayToString([['name', '=', 'true']]), '[["name","=","true"]]');
+
+        assert.strictEqual(arrayToString(), '[]');
+    });
 });
 });


### PR DESCRIPTION
Before this commit, occurences of 'null', 'true' and 'false'
strings as autocomplete values in the search view were replaced
respectively by None, True and False.

Fixes #65743

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
