### PR TITLE
[FIX] website_form: user dynamic fields without readonly attribute

### DIFF
--- a/addons/website_form/models/models.py
+++ b/addons/website_form/models/models.py
@@ -70,7 +70,7 @@ class website_form_model(models.Model):
         for field in list(fields_get):
             if 'domain' in fields_get[field] and isinstance(fields_get[field]['domain'], str):
                 del fields_get[field]['domain']
-            if fields_get[field]['readonly'] or field in MAGIC_FIELDS:
+            if fields_get[field].get('readonly') or field in MAGIC_FIELDS:
                 del fields_get[field]
 
         return fields_get


### PR DESCRIPTION
Steps:
- Install studio, website_form
- Go to Settings > Users & Companies > Users
- Click the Studio icon
- On the top bar, click Website
- Click New Form
- In edition mode, click the first label
- Select Customize > Add an Existing Field

Bug:
Traceback here:
https://github.com/odoo/odoo/blob/3ff00944fe6a439bd5d7bddb846206d3d6cac3a0/addons/website_form/models/models.py#L73
KeyError: 'readonly'

Explanation:
Dynamic selection fields don't declare a 'readonly' attribute:
https://github.com/odoo/odoo/blob/3ff00944fe6a439bd5d7bddb846206d3d6cac3a0/odoo/addons/base/models/res_users.py#L1275-L1282

opw:2449356