### PR TITLE
[FIX] account: reconcile by batches of 1000 lines

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -341,7 +341,14 @@ class AccountBankStatement(models.Model):
 
     def action_bank_reconcile_bank_statements(self):
         self.ensure_one()
-        bank_stmt_lines = self.mapped('line_ids')
+        limit = int(self.env["ir.config_parameter"].get_param("account.reconcile.batch", 1000))
+        bank_stmt_lines = self.env['account.bank.statement.line'].search([
+            ('statement_id', 'in', self.ids),
+            # take not reconciled lines only. See _check_lines_reconciled method
+            ('account_id', '=', False),
+            ('journal_entry_ids', '=', False),
+            ('amount', '!=', 0),
+        ], limit=limit)
         return {
             'type': 'ir.actions.client',
             'tag': 'bank_statement_reconciliation_view',

--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -423,7 +423,15 @@ class account_journal(models.Model):
     def action_open_reconcile(self):
         if self.type in ['bank', 'cash']:
             # Open reconciliation view for bank statements belonging to this journal
-            bank_stmt = self.env['account.bank.statement'].search([('journal_id', 'in', self.ids)]).mapped('line_ids')
+            limit = int(self.env["ir.config_parameter"].get_param("account.reconcile.batch", 1000))
+            bank_stmt = self.env['account.bank.statement.line'].search([
+                ('journal_id', 'in', self.ids),
+                # take not reconciled lines only. See _check_lines_reconciled method
+                ('account_id', '=', False),
+                ('journal_entry_ids', '=', False),
+                ('amount', '!=', 0),
+            ], limit=limit)
+
             return {
                 'type': 'ir.actions.client',
                 'tag': 'bank_statement_reconciliation_view',


### PR DESCRIPTION
Neither server, no browser cannot handle unlimited number of lines at the same
time. On server side it leads to series of heavy sql requests. On client side,
browser will eat all the memory on trying to render all of those lines.

This also prevents loading reconciled lines ids to browser.

Size of the batches can be customized via System Parameter
``account.reconcile.batch``

Details:
* ``action_bank_reconcile_bank_statements`` is used on clicking `[Reconcile]`
button in ``account.bank.statement`` form
* ``action_open_reconcile`` is used on clicking `[Reconcile]` for a journal in
Account Dashboard

---

opw-2424992
opw-2344807