### PR TITLE
[FIX] incorrect method called in get balancing pos account

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -382,7 +382,8 @@ class PosSession(models.Model):
         return self._credit_amounts(partial_vals, imbalance_amount_session, imbalance_amount)
 
     def _get_balancing_account(self):
-        return self.company_id.account_default_pos_receivable_account_id or self.env['ir.property'].get('property_account_receivable_id', 'res.partner')
+        propoerty_account = self.env['ir.property']._get('property_account_receivable_id', 'res.partner')
+        return self.company_id.account_default_pos_receivable_account_id or propoerty_account or self.env['account.account']
 
     def _create_account_move(self):
         """ Create account.move and account.move.line records for this session.


### PR DESCRIPTION
When the pos session can't be balanced, a balancing account
is used. First, we take the company balancing account,
but if it is not set, we need to take the property.
Here, it was the wrong method used to get the property.

opw:2439889