### PR TITLE
[FIX] account: Set memo to ref if not payment_reference

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -445,10 +445,10 @@ class AccountMove(models.Model):
 
         self._recompute_dynamic_lines(recompute_tax_base_amount=True)
 
-    @api.onchange('payment_reference', 'ref')
+    @api.onchange('payment_reference')
     def _onchange_payment_reference(self):
         for line in self.line_ids.filtered(lambda line: line.account_id.user_type_id.type in ('receivable', 'payable')):
-            line.name = self.payment_reference or self.ref
+            line.name = self.payment_reference
 
     @api.onchange('invoice_vendor_bill_id')
     def _onchange_invoice_vendor_bill(self):

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -115,7 +115,10 @@ class AccountPaymentRegister(models.TransientModel):
         :param batch_result:    A batch returned by '_get_batches'.
         :return:                A string representing a communication to be set on payment.
         '''
-        return ' '.join(label for label in batch_result['lines'].mapped('name') if label)
+        name = ' '.join(label for label in batch_result['lines'].mapped('name') if label)
+        if not name.strip() and batch_result['lines']:
+            name = " ".join(move_id.payment_reference or move_id.ref or move_id.name for move_id in batch_result['lines'].mapped('move_id'))
+        return name
 
     @api.model
     def _get_line_batch_key(self, line):


### PR DESCRIPTION
Issue

	- Install "Accounting" module
	- Create a new bill :
	- Set vendor
	- Set no payment reference
	- Set a bill reference
	- Add products to bill
	- Confirm and click on Register Payment

	Memo field has no value.

Cause

	On move lines update, the lines names are recomputed based
	only on payment_referecence.

Solution

	If no `payment_reference`, fallback on `ref` to set line name.

opw-2440389