### PR TITLE
[FIX] web: fix click on field label

### DIFF
--- a/addons/web/static/src/js/views/form/form_renderer.js
+++ b/addons/web/static/src/js/views/form/form_renderer.js
@@ -1154,10 +1154,8 @@ var FormRenderer = BasicRenderer.extend({
         const entry = Object.entries(this.idsForLabels)
             .find(x => x[1] === idForLabel);
         if (entry) {
-            const fieldWidget = this.allFieldWidgets[this.state.id]
-                .find(field => field[symbol] === entry[0]);
             this.trigger_up('quick_edit', {
-                fieldName: fieldWidget.name,
+                fieldName: this.fieldIdsToNames[entry[0]],
                 target: ev.currentTarget,
                 extraInfo: {},
             });

--- a/addons/web/static/tests/views/form_tests.js
+++ b/addons/web/static/tests/views/form_tests.js
@@ -10319,6 +10319,45 @@ QUnit.module('Views', {
         form.destroy();
     });
 
+    QUnit.test('Quick Edition: Label click (duplicated field)', async function (assert) {
+        assert.expect(8);
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: `
+                <form>
+                    <group>
+                        <div class="o_td_label" invisible="1">
+                            <label for="foo" string="A"/>
+                        </div>
+                        <field name="foo" nolabel="1" invisible="1"/>
+
+                        <div class="o_td_label">
+                            <label for="foo" string="B"/>
+                        </div>
+                        <field name="foo" nolabel="1"/>
+                    </group>
+                </form>`,
+            res_id: 1,
+        });
+
+        assert.containsOnce(form, '.o_form_view.o_form_readonly');
+        assert.containsN(form, '.o_form_label', 2);
+        assert.containsOnce(form, '.o_invisible_modifier .o_form_label');
+
+        await testUtils.dom.click(form.$('.o_form_label')[1]);
+
+        assert.containsOnce(form, '.o_form_view.o_form_editable');
+        assert.containsN(form, '.o_form_label', 2);
+        assert.containsOnce(form, '.o_invisible_modifier .o_form_label');
+        assert.containsOnce(form, 'input.o_field_widget[name="foo"]');
+        assert.strictEqual(document.activeElement, form.$('input.o_field_widget[name="foo"]')[0]);
+
+        form.destroy();
+    });
+
     QUnit.test('Quick Edition: Checkbox click', async function (assert) {
         assert.expect(11);
 


### PR DESCRIPTION
Before this commit, clicking on some field labels threw an error.
This was because we were searching for the associated field by its id
to get the name.
Now, we don't search the associated field anymore, we use
`fieldIdsToNames` to get the name from the id.

task 2456348