### PR TITLE
[FIX] stock_account: set unit cost of outgoing stock move

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -266,6 +266,8 @@ class StockMove(models.Model):
                 continue
 
         for svl in stock_valuation_layers.with_context(active_test=False):
+            if svl.stock_move_id in valued_moves['out']:
+                svl.stock_move_id.price_unit = -svl.unit_cost
             if not svl.product_id.valuation == 'real_time':
                 continue
             if svl.currency_id.is_zero(svl.value):


### PR DESCRIPTION
When chekcing the outgoing stock moves, if the costing method of the
product is FIFO, the unit price is always 0.

To reproduce the error:
(Need purchase,sale_management)
1. Enable debug mode
2. Create a product category PC
    - Parent: All
    - Costing Method: FIFO
3. Create a product P
    - Product type: storable
    - Product category: PC
4. Create a RfQ with P
    - Quantity: 1
    - Unit Price: 50
5. Confirm + Receive Product
6. Create+Confirm a SO with P
7. Validate SO's delivery
8. Go to Inventory > Reporting > Stock Moves
    - Set the View Pivot
    - Filters: Done, P-product
    - In Measures, add "Unit Price"

Error: The first column is the source location. Steps 4-5 are
represented by the line "Partner Locations/Vendors": the initial demand
is 1 and the Unit Price is $50 (all ok). However, there is a mistake for
the outgoing stock move (i.e., the second line): the unit price is $0,
it should be -50$ (negative as it is outgoing).

The unit price is correctly computed in the `stock_valuation_layers`,
but nothing copies the value on the stock move.

OPW-2440516