### PR TITLE
[FIX] sale: fix order line amount update after downpayment invoice

### DIFF
--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -16,9 +16,12 @@ class AccountMove(models.Model):
         for line in line_ids:
             try:
                 line.sale_line_ids.tax_id = line.tax_ids
-                #To keep positive amount on the sale order and to have the right price for the invoice
-                #We need the - before our untaxed_amount_to_invoice
-                line.sale_line_ids.price_unit = -line.sale_line_ids.untaxed_amount_to_invoice
+                if all(line.tax_ids.mapped('price_include')):
+                    line.sale_line_ids.price_unit = line.price_unit
+                else:
+                    #To keep positive amount on the sale order and to have the right price for the invoice
+                    #We need the - before our untaxed_amount_to_invoice
+                    line.sale_line_ids.price_unit = -line.sale_line_ids.untaxed_amount_to_invoice
             except UserError:
                 # a UserError here means the SO was locked, which prevents changing the taxes
                 # just ignore the error - this is a nice to have feature and should not be blocking


### PR DESCRIPTION
Create a standard tax included in the product price.
Add that tax to a product and the down payment product.
Create a sales order (i.e. 1 line, 100$ total, 15% tax incl).
Create a percentage down payment invoice, i.e. 50%.
Post the downpayment invoice.
Go back to the sale order

The sale order line relative to the downpayment was asjusted to remove
the tax amout while this should not occur when dealing with tax included
in price

Added test

opw-2426294

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
