### PR TITLE
[FIX] web: prevent quick edit in non-editable forms

### DIFF
--- a/addons/web/static/src/js/views/form/form_controller.js
+++ b/addons/web/static/src/js/views/form/form_controller.js
@@ -691,8 +691,10 @@ var FormController = BasicController.extend({
      */
     _onQuickEdit: async function (ev) {
         ev.stopPropagation();
-        await this._setEditMode();
-        this.renderer.quickEdit(ev.data);
+        if (this.activeActions.edit) {
+            await this._setEditMode();
+            this.renderer.quickEdit(ev.data);
+        }
     },
     /**
      * Called when the user wants to save the current record -> @see saveRecord

--- a/addons/web/static/tests/views/form_tests.js
+++ b/addons/web/static/tests/views/form_tests.js
@@ -10825,6 +10825,32 @@ QUnit.module('Views', {
 
         form.destroy();
     });
+
+    QUnit.test('Quick Edition: non-editable form', async function (assert) {
+        assert.expect(3);
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: `
+                <form edit="0">
+                    <group>
+                        <field name="foo"/>
+                    </group>
+                </form>`,
+            res_id: 1,
+        });
+
+        assert.containsOnce(form, '.o_form_view.o_form_readonly');
+        await testUtils.dom.click(form.$('.o_form_label'));
+        assert.containsOnce(form, '.o_form_view.o_form_readonly');
+
+        await testUtils.dom.click(form.$('.o_field_widget'));
+        assert.containsOnce(form, '.o_form_view.o_form_readonly');
+
+        form.destroy();
+    });
 });
 
 });


### PR DESCRIPTION
Before this commit, non-editable forms could switch to edit mode
when clicking on a field or a label.
Now, the edit right is checked when the quick edit is triggered.

task 2456324