### PR TITLE
[FIX] account: when an attachment is submited and an invoice is suces…

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -589,7 +589,7 @@ class AccountJournal(models.Model):
                     break
             if not invoice:
                 invoice = self.env['account.move'].create({})
-                invoice.with_context(no_new_invoice=True).message_post(attachment_ids=[attachment.id])
+            invoice.with_context(no_new_invoice=True).message_post(attachment_ids=[attachment.id])
             invoices += invoice
 
         action_vals = {


### PR DESCRIPTION
…sfully parsed it is posted in the chatter

Before this commit, the attachment was only posted if no decoder was able to parse the attachment.

See https://github.com/odoo/enterprise/pull/16138

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
