### PR TITLE
[IMP] utm*: Improve utm campaigns filtering

### DIFF
--- a/addons/mass_mailing/views/utm_campaign_views.xml
+++ b/addons/mass_mailing/views/utm_campaign_views.xml
@@ -101,7 +101,7 @@
             Campaigns are the perfect tool to track results across multiple mailings.
             </p>
         </field>
-        <field name="domain">[('is_website', '=', False)]</field>
+        <field name="domain">[('is_auto_campaign', '=', False)]</field>
     </record>
 
     <menuitem name="Campaigns" id="menu_email_campaigns"

--- a/addons/utm/__manifest__.py
+++ b/addons/utm/__manifest__.py
@@ -7,7 +7,7 @@
     'description': """
 Enable management of UTM trackers: campaign, medium, source.
 """,
-    'version': '1.0',
+    'version': '1.1',
     'depends': ['base', 'web'],
     'data': [
         'data/utm_data.xml',

--- a/addons/utm/data/utm_demo.xml
+++ b/addons/utm/data/utm_demo.xml
@@ -19,22 +19,22 @@
         <record model="utm.campaign" id="utm_campaign_fall_drive">
             <field name="name">Sale</field>
             <field name="stage_id" ref="utm.default_utm_stage" />
-            <field name="is_website" eval="True" />
+            <field name="is_auto_campaign" eval="True" />
         </record>
         <record model="utm.campaign" id="utm_campaign_christmas_special">
             <field name="name">Christmas Special</field>
             <field name="stage_id" ref="utm.default_utm_stage" />
-            <field name="is_website" eval="True" />
+            <field name="is_auto_campaign" eval="True" />
         </record>
         <record model="utm.campaign" id="utm_campaign_email_campaign_services">
             <field name="name">Email Campaign - Services</field>
             <field name="stage_id" ref="utm.default_utm_stage" />
-            <field name="is_website" eval="True" />
+            <field name="is_auto_campaign" eval="True" />
         </record>
         <record model="utm.campaign" id="utm_campaign_email_campaign_products">
             <field name="name">Email Campaign - Products</field>
             <field name="stage_id" ref="utm.default_utm_stage" />
-            <field name="is_website" eval="True" />
+            <field name="is_auto_campaign" eval="True" />
         </record>
     </data>
 </odoo>

--- a/addons/utm/models/utm.py
+++ b/addons/utm/models/utm.py
@@ -44,7 +44,7 @@ class UtmCampaign(models.Model):
         'utm.tag', 'utm_tag_rel',
         'tag_id', 'campaign_id', string='Tags')
 
-    is_website = fields.Boolean(default=False, help="Allows us to filter relevant Campaign")
+    is_auto_campaign = fields.Boolean(default=False, string="Automatically Generated Campaign", help="Allows us to filter relevant Campaigns")
     color = fields.Integer(string='Color Index')
 
     @api.model

--- a/addons/utm/models/utm_mixin.py
+++ b/addons/utm/models/utm_mixin.py
@@ -37,8 +37,8 @@ class UtmMixin(models.AbstractModel):
                     Model = self.env[field.comodel_name]
                     records = Model.search([('name', '=', value)], limit=1)
                     if not records:
-                        if 'is_website' in records._fields:
-                            records = Model.create({'name': value, 'is_website': True})
+                        if 'is_auto_campaign' in records._fields:
+                            records = Model.create({'name': value, 'is_auto_campaign': True})
                         else:
                             records = Model.create({'name': value})
                     value = records.id

--- a/addons/utm/views/utm_campaign_views.xml
+++ b/addons/utm/views/utm_campaign_views.xml
@@ -8,6 +8,7 @@
                 <field name="name" string="Campaigns"/>
                 <field name="tag_ids"/>
                 <field name="user_id"/>
+                <field name="is_auto_campaign"/>
                 <group expand="0" string="Group By">
                     <filter string="Stage" name="group_stage_id"
                         context="{'group_by': 'stage_id'}"/>

--- a/addons/utm/views/utm_views.xml
+++ b/addons/utm/views/utm_views.xml
@@ -15,7 +15,7 @@
     <record id="utm_campaign_action" model="ir.actions.act_window">
         <field name="name">Campaigns</field>
         <field name="res_model">utm.campaign</field>
-        <field name="view_mode">kanban,tree,form</field>
+        <field name="view_mode">tree,kanban,form</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Create a campaign

--- a/addons/website_links/static/src/js/website_links.js
+++ b/addons/website_links/static/src/js/website_links.js
@@ -85,7 +85,7 @@ var SelectBox = publicWidget.Widget.extend({
             name: name
         };
         if (this.obj === "utm.campaign"){
-            args.is_website = true;
+            args.is_auto_campaign = true;
         }
         return this._rpc({
             model: this.obj,


### PR DESCRIPTION
This PR renames the field is_website into is_auto_campaign
for clarity purpose.

The is_website field always meant that the campaigns were created automatically
in some instances. Could be created automatically via a link to the website
or even by simply creating a marketing campaign in marketing_automation.

is_auto_campaign is a better name as it does not wrongly imply that only
the website can generate campaigns automatically, while also pointing
out the automatic generation mechanism.

The utm campaigns behaviour rests unchanged.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
