### PR TITLE
[FIX] hr_skills: All internal users can see resume and skills

### DIFF
--- a/addons/hr_skills/views/hr_views.xml
+++ b/addons/hr_skills/views/hr_views.xml
@@ -55,6 +55,7 @@
         <field name="name">hr.employee.view.form.inherit.resume</field>
         <field name="model">hr.employee</field>
         <field name="inherit_id" ref="hr.view_employee_form"/>
+        <field name="groups_id" eval="[(4, ref('hr.group_hr_user'))]"/>
         <field name="arch" type="xml">
             <xpath expr="//page[@name='public']" position="before">
                 <page name="public" string="Resumé">


### PR DESCRIPTION
Only the users in the group group_hr_user are allowed to see resume and skils
of every employee

opw:2451635