### PR TITLE
[FIX] account: fix counterpart values of Reconciliation Models for St…

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -1159,6 +1159,12 @@ class AccountBankStatementLine(models.Model):
 
                 counterpart_vals['account_id'] = open_balance_account.id
                 counterpart_vals['partner_id'] = partner.id
+            else:
+                if self.amount > 0:
+                    open_balance_account = self.company_id.partner_id.with_company(self.company_id).property_account_receivable_id
+                else:
+                    open_balance_account = self.company_id.partner_id.with_company(self.company_id).property_account_payable_id
+                counterpart_vals['account_id'] = open_balance_account.id
 
             open_balance_vals = self._prepare_counterpart_move_line_vals(counterpart_vals)
         else:


### PR DESCRIPTION
…atement Line with no Partner

- Go to Accounting > Configuration > Reconciliation Models
- Create a Reconciliation Model:
  * Type: Suggest counterpart values
  * Amount Nature: Amount Paid/Received
  * Label: Contains test
  * Counterpart Values: [Add a line with "Percentage of balance" as Amount Type and 100 as Amount, for example]
- Create a Bank Statement of any amount with "test" as Label and no Partner
- Post Bank Statement and Reconcile it
Created Bank Statement matches conditions of Reconciliation Model but Counterpart Values are not suggested.
No counterpart values are suggested if there is no Partner on Bank Statement

During preparation of reconciliation, reconciliation is skipped because an open balance
has to be created but no receivable/payable account is retrieved as there is no Partner
on Bank Statement.

If no Partner is set, receivable/payable account is retrieved from company.

opw-2441484
opw-2442491

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
