### PR TITLE
[FIX] hr_holidays: Display correct number of days

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -84,10 +84,10 @@ class HolidaysRequest(models.Model):
             defaults['state'] = 'confirm' if lt and lt.leave_validation_type != 'no_validation' else 'draft'
 
         now = fields.Datetime.now()
-        defaults.update({
-            'date_from': now,
-            'date_to': now,
-        })
+        if 'date_from' not in defaults:
+            defaults.update({'date_from': now})
+        if 'date_to' not in defaults:
+            defaults.update({'date_to': now})
         return defaults
 
     def _default_get_request_parameters(self, values):


### PR DESCRIPTION
Issue

	- Install `Time Off` module
	- Go to `Time Off` and switch to month calendar view (default view)
	- Select range of date

	In wizard, `duration` is not set.

Cause

	`date_to` and `date_from` are overided on default get request.

Solution

	Do not override default value of `date_from` and
	`date_to` if provided in default get request.

opw-2447931