### PR TITLE
[13.0] [IMP] Stock: allow stock inventory validation call with sudo

### DIFF
--- a/addons/stock/models/stock_inventory.py
+++ b/addons/stock/models/stock_inventory.py
@@ -84,7 +84,7 @@ class Inventory(models.Model):
         if not self.exists():
             return
         self.ensure_one()
-        if not self.user_has_groups('stock.group_stock_manager'):
+        if not self.user_has_groups('stock.group_stock_manager') and not self.env.su:
             raise UserError(_("Only a stock manager can validate an inventory adjustment."))
         if self.state != 'confirm':
             raise UserError(_(


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Stock inventory validation.

**Current behavior before PR:**
A call to action_validate with sudo doesn't allow to bypass the security check.

**Desired behavior after PR is merged:**
A call to action_validate with sudo allows to bypass the security check.




--------------
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
