### PR TITLE
[FIX] account: break recursion when removing a bank statement

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -132,24 +132,28 @@ class AccountBankStatement(models.Model):
                 # Need default value
                 statement.balance_start = statement.balance_start or 0.0
 
-    @api.depends('previous_statement_id', 'previous_statement_id.balance_end_real')
+    @api.depends('previous_statement_id', 'previous_statement_id.balance_end')
     def _compute_ending_balance(self):
-        latest_statement = self.env['account.bank.statement'].search([('journal_id', '=', self[0].journal_id.id)], limit=1)
         for statement in self:
             # recompute balance_end_real in case we are in a bank journal and if we change the
-            # balance_end_real of previous statement as we don't want
+            # balance_end of previous statement as we don't want
             # holes in case we add a statement in between 2 others statements.
             # We only do this for the bank journal as we use the balance_end_real in cash
             # journal for verification and creating cash difference entries so we don't want
             # to recompute the value in that case
             if statement.journal_type == 'bank':
-                # If we are on last statement and that statement already has a balance_end_real, don't change the balance_end_real
-                # Otherwise, recompute balance_end_real to prevent holes between statement.
-                if latest_statement.id and statement.id == latest_statement.id and not float_is_zero(statement.balance_end_real, precision_digits=statement.currency_id.decimal_places):
-                    statement.balance_end_real = statement.balance_end_real or 0.0
-                else:
-                    total_entry_encoding = sum([line.amount for line in statement.line_ids])
-                    statement.balance_end_real = statement.previous_statement_id.balance_end_real + total_entry_encoding
+                previous_statement = statement.previous_statement_id
+                current_statement = statement
+                while current_statement:
+                    next_statement = self.search([('previous_statement_id', '=', current_statement.id)])
+                    if next_statement or float_is_zero(current_statement.balance_end_real, precision_digits=current_statement.currency_id.decimal_places):
+                        # Recompute balance_end_real to prevent holes between statement.
+                        total_entry_encoding = sum([line.amount for line in current_statement.line_ids])
+                        current_statement.balance_end_real = previous_statement.balance_end_real + total_entry_encoding
+                    else:
+                        # If we are on last statement and that statement already has a balance_end_real, don't change the balance_end_real
+                        statement.balance_end_real = statement.balance_end_real or 0.0
+                    previous_statement, current_statement = current_statement, next_statement
             else:
                 # Need default value
                 statement.balance_end_real = statement.balance_end_real or 0.0

--- a/addons/account/tests/test_account_bank_statement.py
+++ b/addons/account/tests/test_account_bank_statement.py
@@ -207,6 +207,14 @@ class TestAccountBankStatement(TestAccountBankStatementCommon):
             'previous_statement_id': bnk1.id,
         }])
 
+        bnk3.balance_end_real += 1000
+        self.assertRecordValues(bnk4, [{
+            'balance_start': 1175.0,
+            'balance_end_real': 275.0,
+            'balance_end': 1275.0,
+            'previous_statement_id': bnk1.id,
+        }])
+
         # Delete BNK3 and BNK1.
         (bnk3 + bnk1).unlink()
         self.assertRecordValues(bnk2, [{


### PR DESCRIPTION


Steps:
- Have a lot of bank statements
- Try to delete an old bank statement

Bug:
Traceback:
RecursionError: maximum recursion depth exceeded

Explanation:
Unlinking a statement triggers a recursion with this line:
https://github.com/odoo/odoo/blob/0d6332fdbbea996aaae2dd07fb3c20deeb3a53b2/addons/account/models/account_bank_statement.py#L330
This makes the ORM call `_compute_ending_balance()`. If there are too
many statements after the one we just deleted, the stack depth limit is
reached.
With this commit, `_compute_ending_balance()` now depends on
`balance_end` instead of `balance_end_real`. This prevents the recursion
from happening.
Also, a loop has been used to compensate for the lack of recursion.

opw:2427083

