### PR TITLE
[FIX] hr: Impossible to create an employee

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -95,7 +95,7 @@ class HrEmployeePrivate(models.Model):
     km_home_work = fields.Integer(string="Km Home-Work", groups="hr.group_hr_user", tracking=True)
 
     image_1920 = fields.Image(default=_default_image)
-    phone = fields.Char(related='address_home_id.phone', related_sudo=False, readonly=False, string="Private Phone", groups="hr.group_hr_user")
+    phone = fields.Char(related='address_home_id.phone', related_sudo=False, readonly=True, string="Private Phone", groups="hr.group_hr_user")
     # employee in company
     child_ids = fields.One2many('hr.employee', 'parent_id', string='Direct subordinates')
     category_ids = fields.Many2many(


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a user U with a related partner P
- Log with an internal user IU without Admnistration/Settings and Employee Officer access rights
- Create an employee E with address_home_id = P and save

Bug:

An access right was raised because the mobile of P was written on P and
the error was raised at https://github.com/odoo/odoo/blob/13.0/odoo/addons/base/models/res_partner.py#L531

Due to this bug, only internal user with Admnistration/Settings access rights can create an employee
linked to a contact of an internal user.

opw:2445953