### PR TITLE
crm customer consistency

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -567,9 +567,13 @@ class Lead(models.Model):
         return {'contact_name': contact_name or self.contact_name}
 
     def _prepare_partner_name_from_partner(self, partner):
+        """ Company name: name of partner parent (if set) or name of partner
+        (if company) or company_name of partner (if not a company). """
         partner_name = partner.parent_id.name
         if not partner_name and partner.is_company:
             partner_name = partner.name
+        elif not partner_name and partner.company_name:
+            partner_name = partner.company_name
         return {'partner_name': partner_name or self.partner_name}
 
     # ------------------------------------------------------------

--- a/addons/crm/tests/common.py
+++ b/addons/crm/tests/common.py
@@ -107,6 +107,8 @@ class TestCrmCommon(TestSalesCommon, MailCase):
             'is_won': True,
         })
 
+        base_us = cls.env.ref('base.us')
+
         cls.lead_1 = cls.env['crm.lead'].create({
             'name': 'Nibbler Spacecraft Request',
             'type': 'lead',
@@ -169,9 +171,19 @@ class TestCrmCommon(TestSalesCommon, MailCase):
             'is_company': False,
             'street': 'Cookieville Minimum-Security Orphanarium',
             'city': 'New New York',
-            'country_id': cls.env.ref('base.us').id,
+            'country_id': base_us.id,
             'mobile': '+1 202 555 0999',
             'zip': '97648',
+        })
+        cls.contact_company = cls.env['res.partner'].create({
+            'name': 'Mom',
+            'company_name': 'MomCorp',
+            'is_company': True,
+            'street': 'Mom Friendly Robot Street',
+            'city': 'New new York',
+            'country_id': base_us.id,
+            'mobile': '+1 202 555 0888',
+            'zip': '87654',
         })
 
     def _create_leads_batch(self, lead_type='lead', count=10, email_dup_count=0,

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -139,6 +139,28 @@ class TestCRMLead(TestCrmCommon):
         self.assertEqual(lead.state_id, empty_partner.state_id, "State should be sync from the Partner")
         self.assertEqual(lead.country_id, empty_partner.country_id, "Country should be sync from the Partner")
 
+    def test_crm_lead_creation_partner_company(self):
+        """ Test lead / partner synchronization involving company details """
+        # Test that partner_name (company name) is the partner name if partner is company
+        lead = self.env['crm.lead'].create({
+            'name': 'TestLead',
+            'partner_id': self.contact_company.id,
+        })
+        self.assertEqual(lead.contact_name, False,
+                         "Lead contact name should be Falsy when dealing with companies")
+        self.assertEqual(lead.partner_name, self.contact_company.name,
+                         "Lead company name should be set to partner name if partner is a company")
+        # Test that partner_name (company name) is the partner company name if partner is an individual
+        self.contact_company.write({'is_company': False})
+        lead = self.env['crm.lead'].create({
+            'name': 'TestLead',
+            'partner_id': self.contact_company.id,
+        })
+        self.assertEqual(lead.contact_name, self.contact_company.name,
+                         "Lead contact name should be set to partner name if partner is not a company")
+        self.assertEqual(lead.partner_name, self.contact_company.company_name,
+                         "Lead company name should be set to company name if partner is not a company")
+
     def test_crm_lead_creation_partner_no_address(self):
         """ Test that an empty address on partner does not void its lead values """
         empty_partner = self.env['res.partner'].create({

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -428,6 +428,8 @@
                             'default_company_name': type == 'opportunity' and partner_name,
                             'default_phone': phone,
                             'default_email': email_from,
+                            'default_user_id': user_id,
+                            'default_team_id': team_id,
                             'show_vat': True}"/>
                         <field name="name" placeholder="e.g. Product Pricing" />
                         <field name="email_from" string="Email" />


### PR DESCRIPTION

a customer created through the form view automatically gets
assigned to the user (salesperson) but customer-created
through the kanban quick create does not add the user

after this commit, the salesperson will be assigned upon
creating a customer from kanban quick create

Task: https://www.odoo.com/web#id=2446969&action=4043&model=project.task&view_type=form&cids=2&menu_id=4720


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
