### PR TITLE
[FIX] stock*: display name should be displayed in user timezone

### DIFF
--- a/addons/stock/wizard/stock_quantity_history.py
+++ b/addons/stock/wizard/stock_quantity_history.py
@@ -3,6 +3,7 @@
 
 from odoo import fields, models, _
 from odoo.osv import expression
+from odoo.tools.misc import format_datetime
 
 
 class StockQuantityHistory(models.TransientModel):
@@ -29,7 +30,7 @@ class StockQuantityHistory(models.TransientModel):
             'type': 'ir.actions.act_window',
             'views': [(tree_view_id, 'tree'), (form_view_id, 'form')],
             'view_mode': 'tree,form',
-            'name': _('Products'),
+            'name': _('Products') + ' (' + format_datetime(self.env, self.inventory_datetime) + ')',
             'res_model': 'product.product',
             'domain': domain,
             'context': dict(self.env.context, to_date=self.inventory_datetime),


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Using the wizard to show stock/products at date will ask for a datetime but then displays nothing for information or the UTC time which is confusing for the users

**Current behavior before PR:**
Wrong displayed date and time of chosen datetime before

**Description of the issue/feature this PR addresses:**
Correctly displayed date and time after chosen datetime in wizard

Info: @wt-io-it

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
