### PR TITLE
[FIX] hr: Impossible to create an employee

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -131,7 +131,7 @@
                                                 'form_view_ref': 'base.res_partner_view_form_private'}"
                                             options='{"always_reload": True, "highlight_first_line": True}'/>
                                         <field name="private_email" string="Email"/>
-                                        <field name="phone" class="o_force_ltr" groups="hr.group_hr_user" string="Phone"/>
+                                        <field name="phone" class="o_force_ltr" groups="hr.group_hr_user" string="Phone" readonly="True"/>
                                         <field name="bank_account_id" context="{'default_partner_id': address_home_id}"/>
                                         <field name="km_home_work" groups="hr.group_hr_user"/>
                                     </group>


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a user U with a related partner P
- Log with an internal user IU without Admnistration/Settings and Employee Officer access rights
- Create an employee E with address_home_id = P and save

Bug:

An access right was raised because the mobile of P was written on P and
the error was raised at https://github.com/odoo/odoo/blob/13.0/odoo/addons/base/models/res_partner.py#L531

Due to this bug, only internal user with Admnistration/Settings access rights can create an employee
linked to a contact of an internal user.

opw:2445953