### PR TITLE
[IMP] im_livechat: disable composer text box on channel session close

### DIFF
--- a/addons/im_livechat/models/mail_channel.py
+++ b/addons/im_livechat/models/mail_channel.py
@@ -87,6 +87,7 @@ class MailChannel(models.Model):
                     channel_infos_dict[channel.id]['operator_pid'] = (res[0], res[1].replace(',', ''))
                 # add the anonymous or partner name
                 channel_infos_dict[channel.id]['livechat_visitor'] = channel._channel_get_livechat_visitor_info()
+                channel_infos_dict[channel.id]['livechat_active'] = channel.livechat_active
         return list(channel_infos_dict.values())
 
     @api.model
@@ -190,6 +191,7 @@ class MailChannel(models.Model):
             # Notify that the visitor has left the conversation
             self.message_post(author_id=self.env.ref('base.partner_root').id,
                               body=self._get_visitor_leave_message(**kwargs), message_type='comment', subtype_xmlid='mail.mt_comment')
+            self.env['bus.bus'].sendmany([[(self._cr.dbname, 'mail.channel', self.id), {'info': 'close_livechat_session',}]])
 
     # Rating Mixin
 

--- a/addons/im_livechat/static/src/components/composer/composer.js
+++ b/addons/im_livechat/static/src/components/composer/composer.js
@@ -1,0 +1,19 @@
+odoo.define('im_livechat/static/src/components/composer/composer.js', function (require) {
+'use strict';
+
+const components = {
+    Composer: require('mail/static/src/components/composer/composer.js'),
+};
+
+const { patch } = require('web.utils');
+
+patch(components.Composer, 'im_livechat/static/src/components/composer/composer.js', {
+    _update() {
+        this._super.apply(this, arguments);
+        if (this.composer.thread && !this.composer.thread.isLiveChatActive) {
+            this.composer.thread.disableComposer();
+        }
+    },
+});
+
+});

--- a/addons/im_livechat/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/im_livechat/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -37,6 +37,39 @@ registerInstancePatchModel('mail.messaging_notification_handler', 'im_livechat/s
             partner_name: partnerName,
         }));
     },
+
+    /**
+     * @private
+     * @param {integer} channelId
+     * @param {Object} data
+     * @param {string} [data.info]
+     * @param {boolean} [data.is_typing]
+     * @param {integer} [data.last_message_id]
+     * @param {integer} [data.partner_id]
+     */
+    async _handleNotificationChannel(channelId, data) {
+        if (data.info && data.info === 'close_livechat_session') {
+            return this._handleNotificationChannelCloseLivechatSession(channelId);
+        } else {
+            this._super.apply(this, arguments)
+        }
+    },
+
+    /**
+     * @private
+     * @param {integer} channelId
+     */
+    _handleNotificationChannelCloseLivechatSession(channelId) {
+        const channel = this.env.models['mail.thread'].findFromIdentifyingData({
+            id: channelId,
+            model: 'mail.channel',
+        });
+        if (!channel) {
+            return;
+        }
+        channel.disableComposer();
+    },
+
 });
 
 });

--- a/addons/im_livechat/static/src/models/thread/thread.js
+++ b/addons/im_livechat/static/src/models/thread/thread.js
@@ -3,8 +3,10 @@ odoo.define('im_livechat/static/src/models/thread/thread.js', function (require)
 
 const {
     registerClassPatchModel,
+    registerFieldPatchModel,
     registerInstancePatchModel,
 } = require('mail/static/src/model/model_core.js');
+const { attr } = require('mail/static/src/model/model_field.js');
 
 registerClassPatchModel('mail.thread', 'im_livechat/static/src/models/thread/thread.js', {
 
@@ -54,6 +56,9 @@ registerClassPatchModel('mail.thread', 'im_livechat/static/src/models/thread/thr
                 data2.correspondent = [['insert', partnerData]];
             }
         }
+        if ('livechat_active' in data) {
+            data2.livechatActive = data.livechat_active;
+        }
         return data2;
     },
 });
@@ -92,6 +97,25 @@ registerInstancePatchModel('mail.thread', 'im_livechat/static/src/models/thread/
     _computeIsChatChannel() {
         return this.channel_type === 'livechat' || this._super();
     },
+    /**
+     * @private
+     * @returns {boolean}
+     */
+    _computeisLiveChatActive() {
+        return (this.channel_type === 'livechat' && this.livechatActive !== undefined) ? this.livechatActive : true;
+    }
 });
 
+registerFieldPatchModel('mail.thread', 'im_livechat/static/src/models/thread/thread.js', {
+    livechatActive: attr({
+        'default': true
+    }),
+    isLiveChatActive: attr({
+        compute: '_computeisLiveChatActive',
+        dependencies: [
+            'channel_type',
+            'livechatActive',
+        ],
+    }),
+});
 });

--- a/addons/im_livechat/static/tests/helpers/mock_models.js
+++ b/addons/im_livechat/static/tests/helpers/mock_models.js
@@ -26,7 +26,7 @@ MockModels.patch('im_livechat/static/tests/helpers/mock_models.js', T =>
             Object.assign(data['mail.channel'].fields, {
                 anonymous_name: { string: "Anonymous Name", type: 'char' },
                 country_id: { string: "Country", type: 'many2one', relation: 'res.country' },
-                livechat_active: { string: "Is livechat ongoing?", type: 'boolean', default: false },
+                livechat_active: { string: "Is livechat ongoing?", type: 'boolean', default: true },
                 livechat_channel_id: { string: "Channel", type: 'many2one', relation: 'im_livechat.channel' },
                 livechat_operator_id: { string: "Operator", type: 'many2one', relation: 'res.partner' },
             });

--- a/addons/im_livechat/views/im_livechat_channel_templates.xml
+++ b/addons/im_livechat/views/im_livechat_channel_templates.xml
@@ -10,6 +10,7 @@
                 <script type="text/javascript" src="/im_livechat/static/src/js/im_livechat_channel_form_view.js"></script>
                 <script type="text/javascript" src="/im_livechat/static/src/js/im_livechat_channel_form_controller.js"></script>
                 <script type="text/javascript" src="/im_livechat/static/src/bugfix/bugfix.js"></script>
+                <script type="text/javascript" src="/im_livechat/static/src/components/composer/composer.js"></script>
                 <script type="text/javascript" src="/im_livechat/static/src/components/discuss/discuss.js"></script>
                 <script type="text/javascript" src="/im_livechat/static/src/components/discuss_sidebar/discuss_sidebar.js"></script>
                 <script type="text/javascript" src="/im_livechat/static/src/components/discuss_sidebar_item/discuss_sidebar_item.js"></script>

--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -6463,6 +6463,13 @@ msgstr ""
 
 #. module: mail
 #. openerp-web
+#: code:addons/mail/static/src/components/composer_text_input/composer_text_input.js:0
+#, python-format
+msgid "Conversation Closed"
+msgstr ""
+
+#. module: mail
+#. openerp-web
 #: code:addons/mail/static/src/components/message_list/message_list.js:0
 #: code:addons/mail/static/src/js/activity.js:0
 #, python-format

--- a/addons/mail/static/src/components/chat_window_header/chat_window_header.js
+++ b/addons/mail/static/src/components/chat_window_header/chat_window_header.js
@@ -27,6 +27,7 @@ class ChatWindowHeader extends Component {
                 chatWindowName: chatWindow && chatWindow.name,
                 isDeviceMobile: this.env.messaging.device.isMobile,
                 thread,
+                threadIsDisabled: thread && thread.isDisabled,
                 threadLocalMessageUnreadCounter: thread && thread.localMessageUnreadCounter,
                 threadMassMailing: thread && thread.mass_mailing,
             };

--- a/addons/mail/static/src/components/chat_window_header/chat_window_header.xml
+++ b/addons/mail/static/src/components/chat_window_header/chat_window_header.xml
@@ -21,7 +21,7 @@
                 <t t-if="chatWindow.thread and chatWindow.thread.mass_mailing">
                     <i class="fa fa-envelope-o" title="Messages are sent by email" role="img"/>
                 </t>
-                <t t-if="chatWindow.thread and chatWindow.thread.localMessageUnreadCounter > 0">
+                <t t-if="chatWindow.thread and chatWindow.thread.localMessageUnreadCounter > 0 and !chatWindow.thread.isDisabled">
                     <div class="o_ChatWindowHeader_counter o_ChatWindowHeader_item">
                         (<t t-esc="chatWindow.thread.localMessageUnreadCounter"/>)
                     </div>

--- a/addons/mail/static/src/components/composer/composer.js
+++ b/addons/mail/static/src/components/composer/composer.js
@@ -47,6 +47,7 @@ class Composer extends Component {
                 composerSubjectContent: composer && composer.subjectContent,
                 isDeviceMobile: this.env.messaging.device.isMobile,
                 thread,
+                threadIsDisabled: thread && thread.isDisabled,
                 threadChannelType: thread && thread.channel_type, // for livechat override
                 threadDisplayName: thread && thread.displayName,
                 threadMassMailing: thread && thread.mass_mailing,

--- a/addons/mail/static/src/components/composer/composer.xml
+++ b/addons/mail/static/src/components/composer/composer.xml
@@ -13,7 +13,7 @@
             t-on-keydown="_onKeydown"
         >
             <t t-if="composer">
-                <t t-if="isDropZoneVisible.value">
+                <t t-if="isDropZoneVisible.value and !composer.isDisabled">
                     <DropZone
                         class="o_Composer_dropZone"
                         t-on-o-dropzone-files-dropped="_onDropZoneFilesDropped"
@@ -88,6 +88,7 @@
                     />
                     <div class="o_Composer_buttons" t-att-class="{ 'o-composer-is-compact': props.isCompact, 'o-mobile': env.messaging.device.isMobile }">
                         <div class="o_Composer_toolButtons"
+                            t-if="!composer.isDisabled"
                             t-att-class="{
                                 'o-composer-has-current-partner-avatar': props.hasCurrentPartnerAvatar,
                                 'o-composer-is-compact': props.isCompact,
@@ -161,7 +162,7 @@
                         'o-composer-is-compact': props.isCompact,
                         'o-has-current-partner-avatar': props.hasCurrentPartnerAvatar,
                     }"
-                    t-att-disabled="!composer.canPostMessage ? 'disabled' : ''"
+                    t-att-disabled="!composer.canPostMessage || composer.isDisabled ? 'disabled' : ''"
                     type="button"
                     t-on-click="_onClickSend"
                 >

--- a/addons/mail/static/src/components/composer_text_input/composer_text_input.js
+++ b/addons/mail/static/src/components/composer_text_input/composer_text_input.js
@@ -37,6 +37,7 @@ class ComposerTextInput extends Component {
                 composerTextInputCursorStart: composer && composer.textInputCursorStart,
                 composerTextInputSelectionDirection: composer && composer.textInputSelectionDirection,
                 isDeviceMobile: this.env.messaging.device.isMobile,
+                threadIsDisabled: thread && thread.isDisabled,
                 threadModel: thread && thread.model,
             };
         });
@@ -79,6 +80,9 @@ class ComposerTextInput extends Component {
     get textareaPlaceholder() {
         if (!this.composer) {
             return "";
+        }
+        if (this.composer.thread && this.composer.thread.isDisabled) {
+            return this.env._t("Conversation Closed");
         }
         if (this.composer.thread && this.composer.thread.model !== 'mail.channel') {
             if (this.composer.isLog) {

--- a/addons/mail/static/src/components/composer_text_input/composer_text_input.xml
+++ b/addons/mail/static/src/components/composer_text_input/composer_text_input.xml
@@ -10,7 +10,7 @@
                         isBelow="props.hasMentionSuggestionsBelowPosition"
                     />
                 </t>
-                <textarea class="o_ComposerTextInput_textarea o_ComposerTextInput_textareaStyle" t-att-class="{ 'o-composer-is-compact': props.isCompact }" t-esc="composer.textInputContent" t-att-placeholder="textareaPlaceholder" t-on-focusin="_onFocusinTextarea" t-on-focusout="_onFocusoutTextarea" t-on-keydown="_onKeydownTextarea" t-on-keyup="_onKeyupTextarea" t-on-input="_onInputTextarea" t-ref="textarea"/>
+                <textarea class="o_ComposerTextInput_textarea o_ComposerTextInput_textareaStyle" t-att-class="{ 'o-composer-is-compact': props.isCompact }" t-esc="composer.textInputContent" t-att-placeholder="textareaPlaceholder" t-att-disabled="composer.isDisabled ? 'disabled' : ''" t-on-focusin="_onFocusinTextarea" t-on-focusout="_onFocusoutTextarea" t-on-keydown="_onKeydownTextarea" t-on-keyup="_onKeyupTextarea" t-on-input="_onInputTextarea" t-ref="textarea"/>
                 <!--
                      This is an invisible textarea used to compute the composer
                      height based on the text content. We need it to downsize

--- a/addons/mail/static/src/models/composer/composer.js
+++ b/addons/mail/static/src/models/composer/composer.js
@@ -1123,6 +1123,9 @@ function factory(dependencies) {
         thread: one2one('mail.thread', {
             inverse: 'composer',
         }),
+        isDisabled: attr({
+            related: 'thread.isDisabled',
+        }),
     };
 
     Composer.modelName = 'mail.composer';

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -1632,6 +1632,15 @@ function factory(dependencies) {
             this.unregisterOtherMemberTypingMember(partner);
         }
 
+        /**
+         * Disable composer input and buttons based on the chat sessions.
+         *
+         * @private
+         * */
+        disableComposer() {
+            this.update({ isDisabled: true });
+        }
+
     }
 
     Thread.fields = {
@@ -2191,6 +2200,9 @@ function factory(dependencies) {
             ]
         }),
         uuid: attr(),
+        isDisabled: attr({
+            default: false,
+        }),
     };
 
     Thread.modelName = 'mail.thread';


### PR DESCRIPTION
**PURPOSE**

Currently, When live chat session closed by any of the visitor, we are only
notifying the operator that the visitor has closed the conversation.
but still, the operator can send the messages which is not the case because when
the visitor click on "close conversation Icon", it is redirecting to the rating
window so the visitor is unable to see the messages those are sent by the admin
after closing the conversion.

**SPECIFICATION**

we are now disabling the composer input once the chat closed.
So operator will not able to send the messages to the visitor after chat closed.

**Task : 2210040**