### PR TITLE
[FIX] mail: fix new message chatwindow issue

### DIFF
--- a/addons/mail/static/src/models/chat_window_manager/chat_window_manager.js
+++ b/addons/mail/static/src/models/chat_window_manager/chat_window_manager.js
@@ -453,7 +453,10 @@ function factory(dependencies) {
         }),
         newMessageChatWindow: one2one('mail.chat_window', {
             compute: '_computeNewMessageChatWindow',
-            dependencies: ['allOrderedThread'],
+            dependencies: [
+                'allOrdered',
+                'allOrderedThread',
+            ],
         }),
         unreadHiddenConversationAmount: attr({
             compute: '_computeUnreadHiddenConversationAmount',


### PR DESCRIPTION
Current behavior before PR:
When looking for a user through the new message chat window, if there is already
a chat open for this user, the new message window is still open on selecting the
user.

Desired behavior after PR is merged:
when opening a chat from a new message, if the chat with this user is already
open then it will close the new message chat window on selecting the user.

LINKS:
Task-2449118
