### PR TITLE
[FIX] hr_contract: update date_end when closing contract

### DIFF
--- a/addons/hr_contract/models/hr_contract.py
+++ b/addons/hr_contract/models/hr_contract.py
@@ -164,7 +164,7 @@ class Contract(models.Model):
         if vals.get('state') == 'open':
             self._assign_open_contract()
         if vals.get('state') == 'close':
-            for contract in self.filtered(lambda c: not c.date_end):
+            for contract in self:
                 contract.date_end = max(date.today(), contract.date_start)
 
         calendar = vals.get('resource_calendar_id')


### PR DESCRIPTION
When changing a contract's state to "Expired", if the contract has an
end date, the latter is not updated. As a result, contracts' reporting
contains some error.

To reproduce the error:
1. Create an employee E
2. Create a contract C
    - Employee: E
    - Start date: in the past
    - End Date: in the future (! at least after the current month)
3. Set contract's state to "Expired"
4. Go to Employee > Reporting > Contracts
5. On pivot view, change the rows:
    - Total must be split into "Date > Month"
    - Current month must be split into "Employee"

Error: on current month, "# Departure Employee" of E-employee is 0. It
should be 1. This value's computation is based on `contract.date_end`,
but when changing the state to "Expired", the variable will not be
updated if it already has a value. So "# Departure Employee" will be
equal to 1 for the month of end date defined on step 2, instead of
current month.

Note: The fix result can not be directly tested. The end date must be
done for the departure to be effective (`contract.date_end` < 'today').
Since this fix updates `contract.date_end` to 'today', "# Departure
Employee" will not count this contract until the following day.

OPW-2445504