### PR TITLE
[FIX] web: call do_hide/do_show on a destroyed widget

### DIFF
--- a/addons/web/static/src/js/core/widget.js
+++ b/addons/web/static/src/js/core/widget.js
@@ -181,13 +181,17 @@ var Widget = core.Class.extend(mixins.PropertiesMixin, ServicesMixin, {
      * Hides the widget
      */
     do_hide: function () {
-        this.$el.addClass('o_hidden');
+        if (this.$el) {
+            this.$el.addClass('o_hidden');
+        }
     },
     /**
      * Displays the widget
      */
     do_show: function () {
-        this.$el.removeClass('o_hidden');
+        if (this.$el) {
+            this.$el.removeClass('o_hidden');
+        }
     },
     /**
      * Displays or hides the widget
@@ -196,7 +200,7 @@ var Widget = core.Class.extend(mixins.PropertiesMixin, ServicesMixin, {
     do_toggle: function (display) {
         if (_.isBoolean(display)) {
             display ? this.do_show() : this.do_hide();
-        } else {
+        } else if (this.$el) {
             this.$el.hasClass('o_hidden') ? this.do_show() : this.do_hide();
         }
     },

--- a/addons/web/static/tests/core/widget_tests.js
+++ b/addons/web/static/tests/core/widget_tests.js
@@ -442,6 +442,27 @@ QUnit.module('core', {}, function () {
         parent.destroy();
     });
 
+    QUnit.test("calling do_hide on a widget destroyed before being rendered", async function (assert) {
+        assert.expect(1);
+
+        const MyWidget = Widget.extend({
+            willStart() {
+                return new Promise(() => {});
+            }
+        });
+
+        const widget = new MyWidget();
+        widget.appendTo(document.createDocumentFragment());
+        widget.destroy();
+
+        // those calls should not crash
+        widget.do_hide();
+        widget.do_show();
+        widget.do_toggle(true);
+
+        assert.ok(true);
+    });
+
     QUnit.test('start is not called when widget is destroyed', function (assert) {
         assert.expect(0);
         var slowWillStartDef = $.Deferred();


### PR DESCRIPTION
Before this commit, calling do_hide/do_show/do_toggle on a
widget that had been destroyed before being rendered crashed
(because this.$el was undefined).

Obviously, calling those methods in this situation is useless, but
with asynchronous code, it might happen that you call them in an
handler, and they have been destroyed meanwhile.

This commit checks if this.$el is set before accessing it to avoid
the crash.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
