### PR TITLE
[FIX] tools: XML non SVG is application/octet-stream

### DIFF
--- a/odoo/addons/base/tests/test_mimetypes.py
+++ b/odoo/addons/base/tests/test_mimetypes.py
@@ -69,6 +69,10 @@ class test_guess_mimetype(BaseCase):
         mimetype = guess_mimetype(b"   " + content, default='test')
         self.assertNotIn("svg", mimetype)
 
+    def test_mimetype_xml(self):
+        mimetype = guess_mimetype(b'<_/>', default='test')
+        self.assertEqual(mimetype, 'test')
+
 
 
 if __name__ == '__main__':

--- a/odoo/tools/mimetypes.py
+++ b/odoo/tools/mimetypes.py
@@ -112,7 +112,7 @@ def _check_svg(data):
 # for "master" formats with many subformats, discriminants is a list of
 # functions, tried in order and the first non-falsy value returned is the
 # selected mime type. If all functions return falsy values, the master
-# mimetype is returned.
+# mimetype if set is returned.
 _Entry = collections.namedtuple('_Entry', ['mimetype', 'signatures', 'discriminants'])
 _mime_mappings = (
     # pdf
@@ -122,7 +122,7 @@ _mime_mappings = (
     _Entry('image/png', [b'\x89PNG\r\n\x1A\n'], []),
     _Entry('image/gif', [b'GIF87a', b'GIF89a'], []),
     _Entry('image/bmp', [b'BM'], []),
-    _Entry('image/svg+xml', [b'<'], [
+    _Entry(None, [b'<'], [
         _check_svg,
     ]),
     # OLECF files in general (Word, Excel, PPT, default to word because why not?)
@@ -157,7 +157,8 @@ def guess_mimetype(bin_data, default='application/octet-stream'):
                         )
                 # if no discriminant or no discriminant matches, return
                 # primary mime type
-                return entry.mimetype
+                if entry.mimetype:
+                    return entry.mimetype
     return default
 
 


### PR DESCRIPTION

In firefox this change:

 https://hg.mozilla.org/mozilla-central/rev/a3815d601038

forced the extension of filename to mimetype extension.

This has been softened that a little:

 https://hg.mozilla.org/mozilla-central/rev/0a93a065053d

and now the extension is only changed for for 'image/*', 'audio/*',
'video/*' mimetypes.

There is a bug report against that behavior, but currently it seems that
changing extension of WEBP images that wrongly have JPG extension is
more important:

https://bugzilla.mozilla.org/show_bug.cgi?id=1688306

Odoo serves files beginning with '<' character as image/svg+xml so they
will always be saved as .svg in firefox unless we have custom code that
change the mimetype (as done in account_reports).

With this commit, we only set mimetype to image/svg+xml if the file
looks like an SVG file.

opw-2423808
