### PR TITLE
[FIX] account: reconcile two different rate values

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -916,8 +916,12 @@ class AccountMoveLine(models.Model):
             credit_move = credit_moves[0]
             company_currency = debit_move.company_id.currency_id
             # We need those temporary value otherwise the computation might be wrong below
-            temp_amount_residual = min(debit_move.amount_residual, -credit_move.amount_residual)
-            temp_amount_residual_currency = min(debit_move.amount_residual_currency, -credit_move.amount_residual_currency)
+            if debit_move[field] < -credit_move[field]:
+                temp_amount_residual = debit_move.amount_residual
+                temp_amount_residual_currency = debit_move.amount_residual_currency
+            else:
+                temp_amount_residual = -credit_move.amount_residual
+                temp_amount_residual_currency = -credit_move.amount_residual_currency
             dc_vals[(debit_move.id, credit_move.id)] = (debit_move, credit_move, temp_amount_residual_currency)
             amount_reconcile = min(debit_move[field], -credit_move[field])
 


### PR DESCRIPTION
When registering a partial payment for an invoice, if the exchange rate
on the invoice date is different from exchange rate on the day of the
payment, the reconciliation will use inconsistent values and partial
payment's account move line will not be reconciled.

To reproduce the error:
(Need account_accountant)
1. In Settings, activate Multi-Currencies
	- Let C_company be current company's currency
2. Go to "Activate Other Currencies"
3. Make sure C_company's rate is 1.00
4. Activate another currency C_other
5. Update C_other's rate:
	- Date: in the past (D_past), Rate: 0.9
	- Date: today, Rate: 0.7
6. Create an invoice + Validate
	- Invoice Date: D_past
	- Currency: C_other
	- Total must be 4050 C_other
7. Register Payment
	- Amount: 4000 C_other
	- Payment date: today
8. Go to follow-up report of invoice's customer

Error: There is a line with Total Due equals to 0. The line is the bank
statement of the payment registered on step 7.

When registering a payment, the `account` module tries to reconcile the
payment with the invoice. At some point, we have:
https://github.com/odoo/odoo/blob/23d7cb7bf8249560434fa0727858feb746efe519/addons/account/models/account_move.py#L919-L922
With these data:
| Variable    | amount_residual | amount_residual_currency | (Rate used) |
|-------------|:---------------:|:------------------------:|:-----------:|
| debit_move  |       4500      |           4050           |     0.9     |
| credit_move |     -5714.29    |           -4000          |     0.7     |

Since it computes the minimum of each column (using absolute values), we
have:
`temp_amount_residual` = 4500
`temp_amount_residual_currency` = 4000
This does not make sense: it should use either the debit or the credit
for both values. As a result, the module then tries to create a partial
reconciliation:
https://github.com/odoo/odoo/blob/23d7cb7bf8249560434fa0727858feb746efe519/addons/account/models/account_move.py#L959-L965
Where
```python
amount_reconcile_currency = temp_amount_residual_currency
amount_reconcile = temp_amount_residual
```
But these variables are a mix between the credit value and the debit
value, therefore none of the two is reconciled. This is an error: at the
end of the partial reconciliation, `credit_move.reconciled` should be
`True`.

OPW-2425251