### PR TITLE
[FIX] account: Impossible to change prefix sequence

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1081,10 +1081,14 @@ class AccountMove(models.Model):
         highest_name = self[0]._get_last_sequence() if self else False
 
         # Group the moves by journal and month
+        prefix_change = False
         for move in self:
             if not highest_name and move == self[0] and not move.posted_before:
                 # In the form view, we need to compute a default sequence so that the user can edit
                 # it. We only check the first move as an approximation (enough for new in form view)
+                pass
+            elif highest_name and not highest_name.startswith(move.journal_id.code + '/'):
+                prefix_change = True
                 pass
             elif (move.name and move.name != '/') or move.state != 'posted':
                 try:
@@ -1098,7 +1102,7 @@ class AccountMove(models.Model):
             group = grouped[journal_key(move)][date_key(move)]
             if not group['records']:
                 # Compute all the values needed to sequence this whole group
-                move._set_next_sequence()
+                move.with_context(prefix_change=prefix_change)._set_next_sequence()
                 group['format'], group['format_values'] = move._get_sequence_format_param(move.name)
                 group['reset'] = move._deduce_sequence_number_reset(move.name)
             group['records'] += move

--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -241,7 +241,9 @@ class SequenceMixin(models.AbstractModel):
         self.ensure_one()
         last_sequence = self._get_last_sequence()
         new = not last_sequence
-        if new:
+        if self.env.context.get('prefix_change'):
+            last_sequence = self._get_starting_sequence()
+        elif new:
             last_sequence = self._get_last_sequence(relaxed=True) or self._get_starting_sequence()
 
         format, format_values = self._get_sequence_format_param(last_sequence)


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a journal J with INV as short code and INV/2021/02/0001 as last sequence
- Change the short code of J to INC
- Create a new account.move AM with J as journal and confirm it

Bug:

The name of AM was INV/2021/02/0002 instead of INC/2021/02/0001

opw:2435524