### PR TITLE
[FIX] l10n_cl: in report date, use the invoice_date directly instead …

### DIFF
--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -4,7 +4,6 @@
     <!-- this header can be used on any Chilean report -->
     <template id="custom_header">
 
-        <t t-set="report_date" t-value="o.invoice_date"/>
         <t t-set="report_number" t-value="int(o.l10n_latam_document_number)"/>
         <t t-set="pre_printed_report" t-value="report_type == 'pdf'"/>
         <t t-set="report_name" t-value="o.l10n_latam_document_type_id.name"/>
@@ -83,7 +82,7 @@
                 <strong>
                     <span t-att-style="'color: %s;' % o.company_id.secondary_color">Date:</span>
                 </strong>
-                <span t-esc="report_date" t-options='{"widget": "date"}'/>
+                <span t-esc="o.invoice_date" t-options='{"widget": "date"}'/>
                 <br/>
 
                 <strong>Customer:</strong>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
fix the the invoice date in report
Current behavior before PR:
the invoice date was not printed
Desired behavior after PR is merged:
the date is correctly printed



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
