### PR TITLE
[FIX] web: fix float value representation in export

### DIFF
--- a/addons/test_xlsx_export/models.py
+++ b/addons/test_xlsx_export/models.py
@@ -20,6 +20,8 @@ class GroupOperator(models.Model):
     int_max = fields.Integer(group_operator='max')
     float_min = fields.Float(group_operator='min')
     float_avg = fields.Float(group_operator='avg')
+    float_monetary = fields.Monetary(currency_field='currency_id',group_operator='sum')
+    currency_id = fields.Many2one('res.currency')
     date_max = fields.Date(group_operator='max')
     bool_and = fields.Boolean(group_operator='bool_and')
     bool_or = fields.Boolean(group_operator='bool_or')

--- a/addons/web/static/src/js/widgets/data_export.js
+++ b/addons/web/static/src/js/widgets/data_export.js
@@ -119,6 +119,7 @@ var DataExport = Dialog.extend({
             name: field,
             label: this.record.fields[field].string,
             store: this.record.fields[field].store,
+            type: this.record.fields[field].type,
         }));
         this._exportData(exportedFields, 'xlsx', false);
     },

--- a/addons/web/static/tests/widgets/data_export_tests.js
+++ b/addons/web/static/tests/widgets/data_export_tests.js
@@ -308,9 +308,11 @@ QUnit.module('widgets', {
                         fields: [{
                             name: 'foo',
                             label: 'Foo',
+                            type: 'char',
                         }, {
                             name: 'bar',
                             label: 'Bar',
+                            type: 'char',
                         }]
                     }, "should be called with correct params")
                     args.complete();
@@ -355,9 +357,11 @@ QUnit.module('widgets', {
                         fields: [{
                             name: 'foo',
                             label: 'Foo',
+                            type: 'char',
                         }, {
                             name: 'bar',
                             label: 'Bar',
+                            type: 'char',
                         }]
                     }, "should be called with correct params")
                     args.complete();


### PR DESCRIPTION
- Create a product with:
  Cost: 60.80
  Quantity On Hand: 999.0
- Go to Inventory / Reporting / Inventory Valuation
- Click on export all (little button next to "Inventory at date")

The field "Total value" have too many decimals: 60739.2000000004

This occur because of the multiplication: it yield the correct value
(60739.2), but every rounding attempt done, even in the ORM, will
mess up the representation

https://github.com/odoo/odoo/blob/042298f8c949fba470eda6ad90f94c95ca291030/odoo/fields.py#L1333

opw-2438384

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
