### PR TITLE
[FIX] sale_stock: consider state on qty_at_date widget update

### DIFF
--- a/addons/sale_stock/static/src/js/qty_at_date_widget.js
+++ b/addons/sale_stock/static/src/js/qty_at_date_widget.js
@@ -40,7 +40,8 @@ var QtyAtDateWidget = Widget.extend({
         // add some data to simplify the template
         if (this.data.scheduled_date) {
             // The digit info need to get from free_qty_today in master (instead of virtual_available_at_date)
-            this.data.will_be_fulfilled = utils.round_decimals(this.data.free_qty_today, this.fields.virtual_available_at_date.digits[1]) >= utils.round_decimals(this.data.qty_to_deliver, this.fields.qty_to_deliver.digits[1]);
+            var qty_considered = this.data.state === 'sale' ? this.data.free_qty_today : this.data.virtual_available_at_date;
+            this.data.will_be_fulfilled = utils.round_decimals(qty_considered, this.fields.virtual_available_at_date.digits[1]) >= utils.round_decimals(this.data.qty_to_deliver, this.fields.qty_to_deliver.digits[1]);
             this.data.will_be_late = this.data.forecast_expected_date && this.data.forecast_expected_date > this.data.scheduled_date;
             if (['draft', 'sent'].includes(this.data.state)){
                 // Moves aren't created yet, then the forecasted is only based on virtual_available of quant


### PR DESCRIPTION
When adding a line to a new SO, if the delivery date is in the future,
and even though the quantity will be sufficient at that time, the
symbol of the quantity remains red ("Not available").

To reproduce the error:
1. Create a storable product P
2. Create + Confirm a RfQ
    - Add 1 x P
    - Set the receipt date in the future (e.g., today + 7 days)
    - (! Do not receive the product)
3. Create a SO
    - Add 1 x P
    - (In Other Info) Set the delivery date after the receipt date
(e.g., today + 8 days)
4. Save & Go back to order lines

Error: The chart next to the requested quantity is always red. This is
not true since the delivery is scheduled after the product reception. If
you click on the chart, the forecasted stock on delivery date is 1.
Therefore, the chart should be green.

This fix improves #60054: the latter updates the computation of
`will_be_fulfilled` using `free_qty_today` because there was an issue
when the SO is confirmed. However, the initial widget behaviour was
correct when the SO is not confirmed.

OPW-2440724