### PR TITLE
[FIX] account: make tax_tag_invert's computation correct in case of tax repartition lines with a negative percentage

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3604,16 +3604,19 @@ class AccountMoveLine(models.Model):
     @api.depends('move_id.move_type', 'tax_ids', 'tax_repartition_line_id')
     def _compute_tax_tag_invert(self):
         for record in self:
-            if not record.tax_repartition_line_id and not record.tax_ids :
+            rep_line = record.tax_repartition_line_id
+
+            if not rep_line and not record.tax_ids :
                 # Invoices imported from other softwares might only have kept the tags, not the taxes.
                 record.tax_tag_invert = record.tax_tag_ids and record.move_id.is_inbound()
 
             elif record.move_id.move_type == 'entry':
                 # For misc operations, cash basis entries and write-offs from the bank reconciliation widget
-                rep_line = record.tax_repartition_line_id
                 if rep_line:
                     tax_type = (rep_line.refund_tax_id or rep_line.invoice_tax_id).type_tax_use
                     is_refund = bool(rep_line.refund_tax_id)
+                    if rep_line.factor_percent < 0:
+                        is_refund = not is_refund
                 elif record.tax_ids:
                     tax_type = record.tax_ids[0].type_tax_use
                     is_refund = (tax_type == 'sale' and record.debit) or (tax_type == 'purchase' and record.credit)
@@ -3622,7 +3625,10 @@ class AccountMoveLine(models.Model):
 
             else:
                 # For invoices with taxes
-                record.tax_tag_invert = record.move_id.is_inbound()
+                rslt = record.move_id.is_inbound()
+                if rep_line and rep_line.factor_percent < 0:
+                    rslt = not rslt
+                record.tax_tag_invert = rslt
 
     @api.depends('tax_tag_ids', 'debit', 'credit', 'journal_id', 'tax_tag_invert')
     def _compute_tax_audit(self):


### PR DESCRIPTION
Such repartition lines put their amount in debit for inbound operations (customer invoices, vendor refunds), and credit for outbound (vendor bills, customer refunds) ; so, the opposite of the lines with a positive percentage. However, we expect the tags set on the repartition line to express the way this debit or credit value will impact the tax report, so it means the tax_tag_invert has to be true in case this amount has gone to credit (so that a negative line balance doesn't change the sign in the report).

Before this, we computed the tax_tag_invert in the same way for all the tax lines, whatever the sign of their factor_percent. So, all the inbound stuff had tax_tag_invert=true (because we expected their amount to be in credit), and all the outbound stuff had false instead. So, we totally disregarded negative percentages, which was obviously wrong.
