### PR TITLE
[IMP] hr_timesheet, sale_timesheet: group by inv/so in portal

### DIFF
--- a/addons/sale_timesheet/controllers/portal.py
+++ b/addons/sale_timesheet/controllers/portal.py
@@ -54,7 +54,10 @@ class SaleTimesheetCustomerPortal(TimesheetCustomerPortal):
 
     def _get_searchbar_groupby(self):
         searchbar_groupby = super()._get_searchbar_groupby()
-        searchbar_groupby.update(sol={'input': 'sol', 'label': _('Sales Order Item')})
+        searchbar_groupby.update(
+            sol={'input': 'sol', 'label': _('Sales Order Item')},
+            so={'input': 'so', 'label': _('Sales Order')},
+            invoice={'input': 'invoice', 'label': _('Invoice')})
         return searchbar_groupby
 
     def _get_search_domain(self, search_in, search):
@@ -71,7 +74,10 @@ class SaleTimesheetCustomerPortal(TimesheetCustomerPortal):
 
     def _get_groupby_mapping(self):
         groupby_mapping = super()._get_groupby_mapping()
-        groupby_mapping.update(sol='so_line')
+        groupby_mapping.update(
+            sol='so_line',
+            so='order_id',
+            invoice='timesheet_invoice_id')
         return groupby_mapping
 
     @http.route(['/my/timesheets', '/my/timesheets/page/<int:page>'], type='http', auth="user", website=True)

--- a/addons/sale_timesheet/models/account.py
+++ b/addons/sale_timesheet/models/account.py
@@ -21,6 +21,8 @@ class AccountAnalyticLine(models.Model):
         ('non_billable_project', 'No task found')], string="Billable Type", compute='_compute_timesheet_invoice_type', compute_sudo=True, store=True, readonly=True)
     timesheet_invoice_id = fields.Many2one('account.move', string="Invoice", readonly=True, copy=False, help="Invoice created from the timesheet")
     so_line = fields.Many2one(compute="_compute_so_line", store=True, readonly=False)
+    # we needed to store it only in order to be able to groupby in the portal
+    order_id = fields.Many2one(related='so_line.order_id', store=True, readonly=False)
     is_so_line_edited = fields.Boolean("Is Sales Order Item Manually Edited")
 
     # TODO: [XBO] Since the task_id is not required in this model,  then it should more efficient to depends to pricing_type of project (See in master)

--- a/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
+++ b/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
@@ -7,9 +7,15 @@
         </xpath>
     </template>
 
-    <template id="sale_order_portal_content_inherit" inherit_id="sale.sale_order_portal_content">
-        <xpath expr="//td[@id='product_name']" position="inside">
-            <a t-if="timesheets and len(timesheets.filtered(lambda t: t.so_line == line)) > 0" t-att-href="'/my/timesheets?search_in=so&amp;search=%s' % line.order_id.name">View Timesheets</a>
+    <template id="sale_order_portal_content_inherit" inherit_id="sale.sale_order_portal_template">
+        <xpath expr="//li[.//a[@id='print_invoice_report']]" position="after">
+            <li t-if="sale_order.timesheet_count > 0 and sale_order.state in ('sale', 'done')" class="list-group-item flex-grow-1">
+                <div class="btn-toolbar flex-sm-nowrap justify-content-center">
+                    <div class="btn-group">
+                        <a t-att-href="'/my/timesheets?search_in=so&amp;search=%s' % sale_order.name">View Timesheets</a>
+                    </div>
+                </div>
+            </li>
         </xpath>
     </template>
 
@@ -27,6 +33,40 @@
                     </t>
                 </th>
                 <th colspan="1" class="text-right text-muted font-weight-normal">
+                    <t t-if="is_uom_day">
+                        Total: <span t-esc="timesheets[0]._convert_hours_to_days(hours_spent)" t-options='{"widget": "timesheet_uom"}'/>
+                    </t>
+                    <t t-else="">
+                        Total: <span t-esc="hours_spent" t-options='{"widget": "float_time"}'/>
+                    </t>
+                </th>
+            </t>
+            <t t-elif="groupby == 'so'">
+                <t t-set="so" t-value="timesheets[0].order_id"/>
+                <th colspan="6">
+                    <t t-if="so">
+                        <em class="font-weight-normal text-muted">Timesheets for sales order:</em>
+                        <span t-field="so.display_name"/>
+                    </t>
+                </th>
+                <th colspan="1" class="text-right text-muted">
+                    <t t-if="is_uom_day">
+                        Total: <span t-esc="timesheets[0]._convert_hours_to_days(hours_spent)" t-options='{"widget": "timesheet_uom"}'/>
+                    </t>
+                    <t t-else="">
+                        Total: <span t-esc="hours_spent" t-options='{"widget": "float_time"}'/>
+                    </t>
+                </th>
+            </t>
+            <t t-elif="groupby == 'invoice'">
+                <t t-set="invoice" t-value="timesheets[0].timesheet_invoice_id"/>
+                <th colspan="6">
+                    <t t-if="invoice">
+                        <em class="font-weight-normal text-muted">Timesheets for Invoice:</em>
+                        <span t-field="invoice.display_name"/>
+                    </t>
+                </th>
+                <th colspan="1" class="text-right text-muted">
                     <t t-if="is_uom_day">
                         Total: <span t-esc="timesheets[0]._convert_hours_to_days(hours_spent)" t-options='{"widget": "timesheet_uom"}'/>
                     </t>


### PR DESCRIPTION
The purpose of this task is to ease the analysis of timesheets
by allowing the customer to group the timesheets by invoice
or sales order in his portal.

In this commit, we make the following changes:
  - add a group by 'sales order' and 'invoice'
  - add a search on 'date'
  - move the 'view timesheets' button next to each SOL to the top
    left panel

Task-Id: 2451359
PR:  #65932

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
