### PR TITLE
[FIX] mail: prevent use of private addresses for followers, recipients,...

### DIFF
--- a/addons/mail/models/mail_followers.py
+++ b/addons/mail/models/mail_followers.py
@@ -29,7 +29,7 @@ class Followers(models.Model):
     res_id = fields.Many2oneReference(
         'Related Document ID', index=True, help='Id of the followed resource', model_field='res_model')
     partner_id = fields.Many2one(
-        'res.partner', string='Related Partner', ondelete='cascade', index=True)
+        'res.partner', string='Related Partner', ondelete='cascade', index=True, domain=[('type', '!=', 'private')])
     channel_id = fields.Many2one(
         'mail.channel', string='Listener', ondelete='cascade', index=True)
     subtype_ids = fields.Many2many(

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2666,9 +2666,9 @@ class MailThread(models.AbstractModel):
             self.check_access_rights('write')
             self.check_access_rule('write')
 
-        # filter inactive
+        # filter inactive and private addresses
         if partner_ids and not adding_current:
-            partner_ids = self.env['res.partner'].sudo().search([('id', 'in', partner_ids), ('active', '=', True)]).ids
+            partner_ids = self.env['res.partner'].sudo().search([('id', 'in', partner_ids), ('active', '=', True), ('type', '!=', 'private')]).ids
 
         return self._message_subscribe(partner_ids, channel_ids, subtype_ids, customer_ids=customer_ids)
 

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -130,7 +130,7 @@ class Partner(models.Model):
             If channel_id is given, only members of this channel are returned.
         """
         search_dom = expression.OR([[('name', 'ilike', search)], [('email', 'ilike', search)]])
-        search_dom = expression.AND([[('active', '=', True)], search_dom])
+        search_dom = expression.AND([[('active', '=', True), ('type', '!=', 'private')], search_dom])
         if channel_id:
             search_dom = expression.AND([[('channel_ids', 'in', channel_id)], search_dom])
 

--- a/addons/mail/wizard/invite.py
+++ b/addons/mail/wizard/invite.py
@@ -41,7 +41,8 @@ class Invite(models.TransientModel):
 
     res_model = fields.Char('Related Document Model', required=True, index=True, help='Model of the followed resource')
     res_id = fields.Integer('Related Document ID', index=True, help='Id of the followed resource')
-    partner_ids = fields.Many2many('res.partner', string='Recipients', help="List of partners that will be added as follower of the current document.")
+    partner_ids = fields.Many2many('res.partner', string='Recipients', help="List of partners that will be added as follower of the current document.",
+                                   domain=[('type', '!=', 'private')])
     channel_ids = fields.Many2many('mail.channel', string='Channels', help='List of channels that will be added as listeners of the current document.',
                                    domain=[('channel_type', '=', 'channel')])
     message = fields.Html('Message')

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -131,7 +131,8 @@ class MailComposer(models.TransientModel):
                             help='Whether the message is an internal note (comment mode only)')
     partner_ids = fields.Many2many(
         'res.partner', 'mail_compose_message_res_partner_rel',
-        'wizard_id', 'partner_id', 'Additional Contacts')
+        'wizard_id', 'partner_id', 'Additional Contacts',
+        domain=[('type', '!=', 'private')])
     # mass mode options
     notify = fields.Boolean('Notify followers', help='Notify followers of the document (mass post only)')
     auto_delete = fields.Boolean('Delete Emails',

--- a/addons/test_mail/tests/test_mail_followers.py
+++ b/addons/test_mail/tests/test_mail_followers.py
@@ -174,6 +174,21 @@ class BaseFollowersTest(TestMailCommon):
         self.assertEqual(document.message_partner_ids, self.partner_portal, 'No active test: customer not visible')
         self.assertEqual(document.message_follower_ids.partner_id, self.partner_portal | customer)
 
+    @users('employee')
+    def test_followers_private_address(self):
+        """ Test standard API does not subscribe private addresses """
+        private_address = self.env['res.partner'].sudo().create({
+            'name': 'Private Address',
+            'type': 'private',
+        })
+        document = self.env['mail.test.simple'].browse(self.test_record.id)
+        document.message_subscribe(partner_ids=(self.partner_portal | private_address).ids)
+        self.assertEqual(document.message_follower_ids.partner_id, self.partner_portal)
+
+        # works through low-level API
+        document._message_subscribe(partner_ids=(self.partner_portal | private_address).ids)
+        self.assertEqual(document.message_follower_ids.partner_id, self.partner_portal | private_address)
+
 
 @tagged('mail_followers')
 class AdvancedFollowersTest(TestMailCommon):


### PR DESCRIPTION
- Connect with Admin
- Go to Contacts, edit himself by adding a Private Address
- Create an Internal User without "Access to Private Addresses" right (i.e. User X)
- Go to any app implementing chatter (i.e. Sales)
- Create a SO
- Add the created Private Address as follower
- Make sure User X can access the record (i.e. Sales: Administrator)
- Connect with User X and open the SO
An Access Error is raised while trying to fetch data about the followers.

This commit prevents to:
- add a private address as follower of a record
- add a private address as Recipient in full composer
- propose private addresses when adding a mention to a partner

opw-2428936
Task-ID: 2463622

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
