### PR TITLE
[FIX] mail: prevent traceback on attachment unlink

### DIFF
--- a/addons/mail/static/src/components/attachment/attachment.xml
+++ b/addons/mail/static/src/components/attachment/attachment.xml
@@ -6,7 +6,7 @@
             t-att-class="{
                 'o-downloadable': props.isDownloadable,
                 'o-editable': props.isEditable,
-                'o-has-card-details': detailsMode === 'card',
+                'o-has-card-details': attachment and detailsMode === 'card',
                 'o-temporary': attachment and attachment.isTemporary,
                 'o-viewable': attachment and attachment.isViewable,
             }" t-att-title="attachment ? attachment.displayName : undefined" t-att-data-attachment-local-id="attachment ? attachment.localId : undefined"


### PR DESCRIPTION
Due to asynchronous rendering, the attachment template can be rendered
when its attachment is undefined, this was causing an issue with an
unguarded getter call that was attempting to access the attachment.

This commit fixes this issue.

opw-2457983





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
