### PR TITLE
[FIX] website_event: registration template show sale end date

### DIFF
--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -215,6 +215,7 @@
                             <span t-if="tickets" t-field="tickets.name"/>
                             <span t-else="">Registration</span>
                         </h6>
+                        <small t-if="tickets.end_sale_date and tickets.sale_available and not tickets.is_expired" class="text-muted mr-3" itemprop="availabilityEnds">Sales end on <span itemprop="priceValidUntil" t-field="tickets.end_sale_date"/></small>
                         <div class="ml-auto o_wevent_nowrap">
                             <t t-if="event.event_registrations_open">
                                 <span class="text-dark font-weight-bold align-middle pr-2">Qty</span>


### PR DESCRIPTION
Steps:
- Install website_event_sale
- Go to Events
- Create a new event:
  - Add a line:
    - Sales Start: yesterday
    - Sales End: tomorrow
- Click the "Go to Website" smart button

Bug:
The sales end date is not displayed. It's displayed when there are more
items.

Explanation:
When there is only one item, the layout is not the same.
This commit adds "Sales end on" next to the price.

opw:2449080