### PR TITLE
[FIX] mail: prevent message separator for new conversations

### DIFF
--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -1344,6 +1344,9 @@ function factory(dependencies) {
             const index = this.orderedMessages.findIndex(message =>
                 message.id === this.lastSeenByCurrentPartnerMessageId
             );
+            if (index === -1) {
+                return [['unlink']];
+            }
             const message = this.orderedMessages[index + 1];
             if (!message) {
                 return [['unlink']];


### PR DESCRIPTION
**Before this commit:**

When a new conversation is initiated, the 'new messages' separator is displayed.
This looks a bit weird as there is no history of conversation and thus no older
messages from which new messages should be separated.

**After this commit:**

The 'new messages' separator will not be displayed in new conversations.

**LINKS**

PR https://github.com/odoo/odoo/pull/65952
Task-2453511
