### PR TITLE
[IMP] core: better management of magic and x2many fields

### DIFF
--- a/addons/hr_holidays/tests/test_company_leave.py
+++ b/addons/hr_holidays/tests/test_company_leave.py
@@ -313,8 +313,7 @@ class TestCompanyLeave(TransactionCase):
         })
         company_leave._compute_date_from_to()
 
-        count = 865
-        with self.assertQueryCount(__system__=count, admin=count):
+        with self.assertQueryCount(__system__=735, admin=865):
             # Original query count: 1987
             # Without tracking/activity context keys: 5154
             company_leave.action_validate()

--- a/addons/hr_holidays/tests/test_company_leave.py
+++ b/addons/hr_holidays/tests/test_company_leave.py
@@ -313,7 +313,7 @@ class TestCompanyLeave(TransactionCase):
         })
         company_leave._compute_date_from_to()
 
-        with self.assertQueryCount(__system__=735, admin=865):
+        with self.assertQueryCount(__system__=736, admin=865):
             # Original query count: 1987
             # Without tracking/activity context keys: 5154
             company_leave.action_validate()

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -281,7 +281,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         test_record = self.env['mail.test.ticket'].browse(self.test_record_full.id)
         test_template = self.env['mail.template'].browse(self.test_template_full.id)
         # TODO FIXME non deterministic, last check 25 Mar 2020. Runbot at most +7 compared to local.
-        with self.assertQueryCount(__system__=12, emp=14):
+        with self.assertQueryCount(__system__=11, emp=13):
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -602,7 +602,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         customer_id = self.customer.id
         user_id = self.user_portal.id
 
-        with self.assertQueryCount(__system__=109, emp=110):
+        with self.assertQueryCount(__system__=108, emp=109):
             rec = self.env['mail.test.ticket'].create({
                 'name': 'Test',
                 'container_id': container_id,

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -231,7 +231,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             #voip module read activity_type during create leading to one less query in enterprise on action_feedback
             category = activity.activity_type_id.category
 
-        with self.assertQueryCount(__system__=16, emp=20):
+        with self.assertQueryCount(__system__=16, emp=18):
             activity.action_feedback(feedback='Zizisse Done !')
 
     @users('__system__', 'emp')
@@ -248,7 +248,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
 
         record.write({'name': 'Dupe write'})
 
-        with self.assertQueryCount(__system__=17, emp=20):
+        with self.assertQueryCount(__system__=17, emp=19):
             record.action_close('Dupe feedback')
 
         self.assertEqual(record.activity_ids, self.env['mail.activity'])
@@ -270,7 +270,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 'partner_ids': [(4, customer_id)],
             })
 
-        with self.assertQueryCount(__system__=25, emp=32):
+        with self.assertQueryCount(__system__=24, emp=31):
             composer.send_mail()
 
     @users('__system__', 'emp')
@@ -281,7 +281,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         test_record = self.env['mail.test.ticket'].browse(self.test_record_full.id)
         test_template = self.env['mail.template'].browse(self.test_template_full.id)
         # TODO FIXME non deterministic, last check 25 Mar 2020. Runbot at most +7 compared to local.
-        with self.assertQueryCount(__system__=11, emp=13):
+        with self.assertQueryCount(__system__=11, emp=12):
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -290,7 +290,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             }).create({})
             composer.onchange_template_id_wrapper()
 
-        with self.assertQueryCount(__system__=33, emp=40):
+        with self.assertQueryCount(__system__=32, emp=39):
             composer.send_mail()
 
         # remove created partner to ensure tests are the same each run
@@ -302,7 +302,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_message_assignation_email(self):
         self.user_test.write({'notification_type': 'email'})
         record = self.env['mail.test.track'].create({'name': 'Test'})
-        with self.assertQueryCount(__system__=37, emp=38):
+        with self.assertQueryCount(__system__=36, emp=37):
             record.write({
                 'user_id': self.user_test.id,
             })
@@ -355,7 +355,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_message_post_one_email_notification(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(__system__=28, emp=31):
+        with self.assertQueryCount(__system__=27, emp=30):
             record.message_post(
                 body='<p>Test Post Performances with an email ping</p>',
                 partner_ids=self.customer.ids,
@@ -481,7 +481,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
             'recipient_ids': [(4, pid) for pid in self.partners.ids],
         })
         mail_ids = mail.ids
-        with self.assertQueryCount(__system__=7, emp=7):
+        with self.assertQueryCount(__system__=6, emp=6):
             self.env['mail.mail'].sudo().browse(mail_ids).send()
 
         self.assertEqual(mail.body_html, '<p>Test</p>')
@@ -494,7 +494,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         self.container.message_subscribe(self.user_portal.partner_id.ids)
         record = self.container.with_user(self.env.user)
 
-        with self.assertQueryCount(__system__=63, emp=64):
+        with self.assertQueryCount(__system__=61, emp=62):
             record.message_post(
                 body='<p>Test Post Performances</p>',
                 message_type='comment',
@@ -511,7 +511,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         record = self.container.with_user(self.env.user)
         template_id = self.env.ref('test_mail.mail_test_container_tpl').id
 
-        with self.assertQueryCount(__system__=73, emp=75):
+        with self.assertQueryCount(__system__=70, emp=71):
             record.message_post_with_template(template_id, message_type='comment', composition_mode='comment')
 
         self.assertEqual(record.message_ids[0].body, '<p>Adding stuff on %s</p>' % record.name)
@@ -582,7 +582,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         })
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id)
-        with self.assertQueryCount(__system__=37, emp=38):
+        with self.assertQueryCount(__system__=36, emp=37):
             rec.write({'user_id': self.user_portal.id})
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id | self.user_portal.partner_id)
         # write tracking message
@@ -602,7 +602,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         customer_id = self.customer.id
         user_id = self.user_portal.id
 
-        with self.assertQueryCount(__system__=108, emp=109):
+        with self.assertQueryCount(__system__=105, emp=106):
             rec = self.env['mail.test.ticket'].create({
                 'name': 'Test',
                 'container_id': container_id,
@@ -631,7 +631,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.user_portal.partner_id | self.env.user.partner_id)
         self.assertEqual(len(rec1.message_ids), 1)
-        with self.assertQueryCount(__system__=77, emp=77):
+        with self.assertQueryCount(__system__=75, emp=75):
             rec.write({
                 'name': 'Test2',
                 'container_id': self.container.id,
@@ -668,7 +668,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.user_portal.partner_id | self.env.user.partner_id)
 
-        with self.assertQueryCount(__system__=85, emp=85):
+        with self.assertQueryCount(__system__=83, emp=83):
             rec.write({
                 'name': 'Test2',
                 'container_id': container_id,
@@ -701,7 +701,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id | self.user_portal.partner_id)
 
-        with self.assertQueryCount(__system__=29, emp=30):
+        with self.assertQueryCount(__system__=28, emp=29):
             rec.write({
                 'name': 'Test2',
                 'customer_id': customer_id,
@@ -951,7 +951,7 @@ class TestMailHeavyPerformancePost(BaseMailPerformance):
         ]
         self.attachements = self.env['ir.attachment'].with_user(self.env.user).create(self.vals)
         attachement_ids = self.attachements.ids
-        with self.assertQueryCount(emp=79):
+        with self.assertQueryCount(emp=76):
             self.cr.sql_log = self.warm and self.cr.sql_log_count
             record.with_context({}).message_post(
                 body='<p>Test body <img src="cid:cid1"> <img src="cid:cid2"></p>',

--- a/addons/test_mass_mailing/tests/test_performance.py
+++ b/addons/test_mass_mailing/tests/test_performance.py
@@ -91,7 +91,7 @@ class TestMassMailBlPerformance(TestMassMailPerformanceBase):
         })
 
         # runbot needs +62 compared to local
-        with self.assertQueryCount(__system__=1993, marketing=1994):
+        with self.assertQueryCount(__system__=1992, marketing=1993):
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)

--- a/addons/test_mass_mailing/tests/test_performance.py
+++ b/addons/test_mass_mailing/tests/test_performance.py
@@ -51,7 +51,7 @@ class TestMassMailPerformance(TestMassMailPerformanceBase):
         })
 
         # runbot needs +50 compared to local
-        with self.assertQueryCount(__system__=1714, marketing=1715):
+        with self.assertQueryCount(__system__=1664, marketing=1664):
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)
@@ -91,7 +91,7 @@ class TestMassMailBlPerformance(TestMassMailPerformanceBase):
         })
 
         # runbot needs +62 compared to local
-        with self.assertQueryCount(__system__=1992, marketing=1993):
+        with self.assertQueryCount(__system__=1942, marketing=1942):
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)

--- a/odoo/addons/base/tests/test_ir_actions.py
+++ b/odoo/addons/base/tests/test_ir_actions.py
@@ -510,8 +510,8 @@ class TestCustomFields(common.TransactionCase):
         })
         query_count = self.cr.sql_log_count - query_count
 
-        # create the related field, and assert it only takes 3 extra queries
-        with self.assertQueryCount(query_count + 3):
+        # create the related field, and assert it only takes 1 extra query
+        with self.assertQueryCount(query_count + 1):
             self.env['ir.model.fields'].create({
                 'model_id': self.env['ir.model']._get_id('res.partner'),
                 'name': 'x_oh_boy',

--- a/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
+++ b/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
@@ -706,8 +706,9 @@ class TestAssetsBundleWithIRAMock(FileTouchable):
             # has really been modified. If we do not update the write_date to a posterior date, we are
             # not able to reproduce the case where we compile this bundle again without changing
             # anything.
-            self.env['ir.attachment'].flush(['checksum'])
+            self.env['ir.attachment'].flush(['checksum', 'write_date'])
             self.cr.execute("update ir_attachment set write_date=clock_timestamp() + interval '10 seconds' where id = (select max(id) from ir_attachment)")
+            self.env['ir.attachment'].invalidate_cache(['write_date'])
 
             # Compile a fourth time, without changes
             self._bundle(self._get_asset(), False, False)

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -3115,7 +3115,7 @@ class TestFieldParametersValidation(common.TransactionCase):
 
 def insert(model, *fnames):
     """ Return the expected query string to INSERT the given columns. """
-    columns = ['create_uid', 'create_date', 'write_uid', 'write_date'] + sorted(fnames)
+    columns = sorted(fnames + ('create_uid', 'create_date', 'write_uid', 'write_date'))
     return 'INSERT INTO "{}" ("id", {}) VALUES (nextval(%s), {}) RETURNING id'.format(
         model._table,
         ", ".join('"{}"'.format(column) for column in columns),
@@ -3125,7 +3125,7 @@ def insert(model, *fnames):
 
 def update(model, *fnames):
     """ Return the expected query string to UPDATE the given columns. """
-    columns = sorted(fnames) + ['write_uid', 'write_date']
+    columns = sorted(fnames + ('write_uid', 'write_date'))
     return 'UPDATE "{}" SET {} WHERE id IN %s'.format(
         model._table,
         ", ".join('"{}" = %s'.format(column) for column in columns),

--- a/odoo/addons/test_performance/tests/test_performance.py
+++ b/odoo/addons/test_performance/tests/test_performance.py
@@ -112,37 +112,37 @@ class TestPerformance(SavepointCaseWithUserDemo):
         rec1 = self.env['test_performance.base'].create({'name': 'X'})
 
         # create N lines on rec1: O(N) queries
-        rec1.invalidate_cache()
-        with self.assertQueryCount(2):
+        with self.assertQueryCount(3):
+            rec1.invalidate_cache()
             rec1.write({'line_ids': [Command.create({'value': 0})]})
         self.assertEqual(len(rec1.line_ids), 1)
 
-        rec1.invalidate_cache()
         with self.assertQueryCount(15):
+            rec1.invalidate_cache()
             rec1.write({'line_ids': [Command.create({'value': val}) for val in range(1, 12)]})
         self.assertEqual(len(rec1.line_ids), 12)
 
         lines = rec1.line_ids
 
         # update N lines: O(N) queries
-        rec1.invalidate_cache()
         with self.assertQueryCount(6):
+            rec1.invalidate_cache()
             rec1.write({'line_ids': [Command.update(line.id, {'value': 42}) for line in lines[0]]})
         self.assertEqual(rec1.line_ids, lines)
 
-        rec1.invalidate_cache()
         with self.assertQueryCount(26):
+            rec1.invalidate_cache()
             rec1.write({'line_ids': [Command.update(line.id, {'value': 42 + line.id}) for line in lines[1:]]})
         self.assertEqual(rec1.line_ids, lines)
 
         # delete N lines: O(1) queries
-        rec1.invalidate_cache()
-        with self.assertQueryCount(__system__=14, demo=14):
+        with self.assertQueryCount(14):
+            rec1.invalidate_cache()
             rec1.write({'line_ids': [Command.delete(line.id) for line in lines[0]]})
         self.assertEqual(rec1.line_ids, lines[1:])
 
-        rec1.invalidate_cache()
-        with self.assertQueryCount(__system__=12, demo=12):
+        with self.assertQueryCount(12):
+            rec1.invalidate_cache()
             rec1.write({'line_ids': [Command.delete(line.id) for line in lines[1:]]})
         self.assertFalse(rec1.line_ids)
         self.assertFalse(lines.exists())
@@ -151,13 +151,13 @@ class TestPerformance(SavepointCaseWithUserDemo):
         lines = rec1.line_ids
 
         # unlink N lines: O(1) queries
-        rec1.invalidate_cache()
-        with self.assertQueryCount(__system__=11, demo=11):
+        with self.assertQueryCount(14):
+            rec1.invalidate_cache()
             rec1.write({'line_ids': [Command.unlink(line.id) for line in lines[0]]})
         self.assertEqual(rec1.line_ids, lines[1:])
 
-        rec1.invalidate_cache()
-        with self.assertQueryCount(__system__=12, demo=12):
+        with self.assertQueryCount(12):
+            rec1.invalidate_cache()
             rec1.write({'line_ids': [Command.unlink(line.id) for line in lines[1:]]})
         self.assertFalse(rec1.line_ids)
         self.assertFalse(lines.exists())
@@ -167,36 +167,36 @@ class TestPerformance(SavepointCaseWithUserDemo):
         rec2 = self.env['test_performance.base'].create({'name': 'X'})
 
         # link N lines from rec1 to rec2: O(1) queries
-        rec1.invalidate_cache()
-        with self.assertQueryCount(2):
+        with self.assertQueryCount(7):
+            rec1.invalidate_cache()
             rec2.write({'line_ids': [Command.link(line.id) for line in lines[0]]})
         self.assertEqual(rec1.line_ids, lines[1:])
         self.assertEqual(rec2.line_ids, lines[0])
 
-        rec1.invalidate_cache()
         with self.assertQueryCount(7):
+            rec1.invalidate_cache()
             rec2.write({'line_ids': [Command.link(line.id) for line in lines[1:]]})
         self.assertFalse(rec1.line_ids)
         self.assertEqual(rec2.line_ids, lines)
 
-        rec1.invalidate_cache()
         with self.assertQueryCount(5):
+            rec1.invalidate_cache()
             rec2.write({'line_ids': [Command.link(line.id) for line in lines[0]]})
         self.assertEqual(rec2.line_ids, lines)
 
-        rec1.invalidate_cache()
         with self.assertQueryCount(5):
+            rec1.invalidate_cache()
             rec2.write({'line_ids': [Command.link(line.id) for line in lines[1:]]})
         self.assertEqual(rec2.line_ids, lines)
 
         # empty N lines in rec2: O(1) queries
-        rec1.invalidate_cache()
         with self.assertQueryCount(__system__=13, demo=13):
+            rec1.invalidate_cache()
             rec2.write({'line_ids': [Command.clear()]})
         self.assertFalse(rec2.line_ids)
 
-        rec1.invalidate_cache()
         with self.assertQueryCount(3):
+            rec1.invalidate_cache()
             rec2.write({'line_ids': [Command.clear()]})
         self.assertFalse(rec2.line_ids)
 
@@ -204,18 +204,20 @@ class TestPerformance(SavepointCaseWithUserDemo):
         lines = rec1.line_ids
 
         # set N lines in rec2: O(1) queries
-        rec1.invalidate_cache()
-        with self.assertQueryCount(4):
+        with self.assertQueryCount(8):
+            rec1.invalidate_cache()
             rec2.write({'line_ids': [Command.set(lines[0].ids)]})
         self.assertEqual(rec1.line_ids, lines[1:])
         self.assertEqual(rec2.line_ids, lines[0])
 
-        with self.assertQueryCount(5):
+        with self.assertQueryCount(7):
+            rec1.invalidate_cache()
             rec2.write({'line_ids': [Command.set(lines.ids)]})
         self.assertFalse(rec1.line_ids)
         self.assertEqual(rec2.line_ids, lines)
 
-        with self.assertQueryCount(3):
+        with self.assertQueryCount(5):
+            rec1.invalidate_cache()
             rec2.write({'line_ids': [Command.set(lines.ids)]})
         self.assertEqual(rec2.line_ids, lines)
 
@@ -238,37 +240,37 @@ class TestPerformance(SavepointCaseWithUserDemo):
         rec1 = self.env['test_performance.base'].create({'name': 'X'})
 
         # create N tags on rec1: O(N) queries
-        rec1.invalidate_cache()
         with self.assertQueryCount(4):
+            rec1.invalidate_cache()
             rec1.write({'tag_ids': [Command.create({'name': 0})]})
         self.assertEqual(len(rec1.tag_ids), 1)
 
-        rec1.invalidate_cache()
         with self.assertQueryCount(14):
+            rec1.invalidate_cache()
             rec1.write({'tag_ids': [Command.create({'name': val}) for val in range(1, 12)]})
         self.assertEqual(len(rec1.tag_ids), 12)
 
         tags = rec1.tag_ids
 
         # update N tags: O(N) queries
-        rec1.invalidate_cache()
         with self.assertQueryCount(3):
+            rec1.invalidate_cache()
             rec1.write({'tag_ids': [Command.update(tag.id, {'name': 'X'}) for tag in tags[0]]})
         self.assertEqual(rec1.tag_ids, tags)
 
-        rec1.invalidate_cache()
         with self.assertQueryCount(3):
+            rec1.invalidate_cache()
             rec1.write({'tag_ids': [Command.update(tag.id, {'name': 'X'}) for tag in tags[1:]]})
         self.assertEqual(rec1.tag_ids, tags)
 
         # delete N tags: O(1) queries
-        rec1.invalidate_cache()
         with self.assertQueryCount(__system__=8, demo=8):
+            rec1.invalidate_cache()
             rec1.write({'tag_ids': [Command.delete(tag.id) for tag in tags[0]]})
         self.assertEqual(rec1.tag_ids, tags[1:])
 
-        rec1.invalidate_cache()
         with self.assertQueryCount(__system__=8, demo=8):
+            rec1.invalidate_cache()
             rec1.write({'tag_ids': [Command.delete(tag.id) for tag in tags[1:]]})
         self.assertFalse(rec1.tag_ids)
         self.assertFalse(tags.exists())
@@ -277,13 +279,13 @@ class TestPerformance(SavepointCaseWithUserDemo):
         tags = rec1.tag_ids
 
         # unlink N tags: O(1) queries
-        rec1.invalidate_cache()
         with self.assertQueryCount(3):
+            rec1.invalidate_cache()
             rec1.write({'tag_ids': [Command.unlink(tag.id) for tag in tags[0]]})
         self.assertEqual(rec1.tag_ids, tags[1:])
 
-        rec1.invalidate_cache()
         with self.assertQueryCount(3):
+            rec1.invalidate_cache()
             rec1.write({'tag_ids': [Command.unlink(tag.id) for tag in tags[1:]]})
         self.assertFalse(rec1.tag_ids)
         self.assertTrue(tags.exists())
@@ -291,56 +293,56 @@ class TestPerformance(SavepointCaseWithUserDemo):
         rec2 = self.env['test_performance.base'].create({'name': 'X'})
 
         # link N tags from rec1 to rec2: O(1) queries
-        rec1.invalidate_cache()
         with self.assertQueryCount(3):
+            rec1.invalidate_cache()
             rec2.write({'tag_ids': [Command.link(tag.id) for tag in tags[0]]})
         self.assertEqual(rec2.tag_ids, tags[0])
 
-        rec1.invalidate_cache()
         with self.assertQueryCount(3):
+            rec1.invalidate_cache()
             rec2.write({'tag_ids': [Command.link(tag.id) for tag in tags[1:]]})
         self.assertEqual(rec2.tag_ids, tags)
 
-        rec1.invalidate_cache()
         with self.assertQueryCount(2):
+            rec1.invalidate_cache()
             rec2.write({'tag_ids': [Command.link(tag.id) for tag in tags[1:]]})
         self.assertEqual(rec2.tag_ids, tags)
 
         # empty N tags in rec2: O(1) queries
-        rec1.invalidate_cache()
         with self.assertQueryCount(3):
+            rec1.invalidate_cache()
             rec2.write({'tag_ids': [Command.clear()]})
         self.assertFalse(rec2.tag_ids)
         self.assertTrue(tags.exists())
 
-        rec1.invalidate_cache()
         with self.assertQueryCount(2):
+            rec1.invalidate_cache()
             rec2.write({'tag_ids': [Command.clear()]})
         self.assertFalse(rec2.tag_ids)
 
         # set N tags in rec2: O(1) queries
-        rec1.invalidate_cache()
         with self.assertQueryCount(3):
+            rec1.invalidate_cache()
             rec2.write({'tag_ids': [Command.set(tags.ids)]})
         self.assertEqual(rec2.tag_ids, tags)
 
-        rec1.invalidate_cache()
         with self.assertQueryCount(3):
+            rec1.invalidate_cache()
             rec2.write({'tag_ids': [Command.set(tags[:8].ids)]})
         self.assertEqual(rec2.tag_ids, tags[:8])
 
-        rec1.invalidate_cache()
         with self.assertQueryCount(4):
+            rec1.invalidate_cache()
             rec2.write({'tag_ids': [Command.set(tags[4:].ids)]})
         self.assertEqual(rec2.tag_ids, tags[4:])
 
-        rec1.invalidate_cache()
         with self.assertQueryCount(3):
+            rec1.invalidate_cache()
             rec2.write({'tag_ids': [Command.set(tags.ids)]})
         self.assertEqual(rec2.tag_ids, tags)
 
-        rec1.invalidate_cache()
         with self.assertQueryCount(2):
+            rec1.invalidate_cache()
             rec2.write({'tag_ids': [Command.set(tags.ids)]})
         self.assertEqual(rec2.tag_ids, tags)
 
@@ -412,12 +414,12 @@ class TestPerformance(SavepointCaseWithUserDemo):
         with self.assertQueryCount(__system__=2, demo=2):
             records.mapped('value')
 
-        records.invalidate_cache(['value'])
         with self.assertQueryCount(__system__=2, demo=2):
+            records.invalidate_cache(['value'])
             records.mapped('value')
 
-        records.invalidate_cache(['value'])
         with self.assertQueryCount(__system__=2, demo=2):
+            records.invalidate_cache(['value'])
             new_recs = records.browse(records.new(origin=record).id for record in records)
             new_recs.mapped('value')
 

--- a/odoo/addons/test_performance/tests/test_performance.py
+++ b/odoo/addons/test_performance/tests/test_performance.py
@@ -136,12 +136,12 @@ class TestPerformance(SavepointCaseWithUserDemo):
         self.assertEqual(rec1.line_ids, lines)
 
         # delete N lines: O(1) queries
-        with self.assertQueryCount(15):
+        with self.assertQueryCount(14):
             rec1.invalidate_cache()
             rec1.write({'line_ids': [Command.delete(line.id) for line in lines[0]]})
         self.assertEqual(rec1.line_ids, lines[1:])
 
-        with self.assertQueryCount(13):
+        with self.assertQueryCount(12):
             rec1.invalidate_cache()
             rec1.write({'line_ids': [Command.delete(line.id) for line in lines[1:]]})
         self.assertFalse(rec1.line_ids)
@@ -151,12 +151,12 @@ class TestPerformance(SavepointCaseWithUserDemo):
         lines = rec1.line_ids
 
         # unlink N lines: O(1) queries
-        with self.assertQueryCount(15):
+        with self.assertQueryCount(14):
             rec1.invalidate_cache()
             rec1.write({'line_ids': [Command.unlink(line.id) for line in lines[0]]})
         self.assertEqual(rec1.line_ids, lines[1:])
 
-        with self.assertQueryCount(13):
+        with self.assertQueryCount(12):
             rec1.invalidate_cache()
             rec1.write({'line_ids': [Command.unlink(line.id) for line in lines[1:]]})
         self.assertFalse(rec1.line_ids)
@@ -190,7 +190,7 @@ class TestPerformance(SavepointCaseWithUserDemo):
         self.assertEqual(rec2.line_ids, lines)
 
         # empty N lines in rec2: O(1) queries
-        with self.assertQueryCount(14):
+        with self.assertQueryCount(13):
             rec1.invalidate_cache()
             rec2.write({'line_ids': [Command.clear()]})
         self.assertFalse(rec2.line_ids)

--- a/odoo/addons/test_performance/tests/test_performance.py
+++ b/odoo/addons/test_performance/tests/test_performance.py
@@ -136,12 +136,12 @@ class TestPerformance(SavepointCaseWithUserDemo):
         self.assertEqual(rec1.line_ids, lines)
 
         # delete N lines: O(1) queries
-        with self.assertQueryCount(14):
+        with self.assertQueryCount(15):
             rec1.invalidate_cache()
             rec1.write({'line_ids': [Command.delete(line.id) for line in lines[0]]})
         self.assertEqual(rec1.line_ids, lines[1:])
 
-        with self.assertQueryCount(12):
+        with self.assertQueryCount(13):
             rec1.invalidate_cache()
             rec1.write({'line_ids': [Command.delete(line.id) for line in lines[1:]]})
         self.assertFalse(rec1.line_ids)
@@ -151,12 +151,12 @@ class TestPerformance(SavepointCaseWithUserDemo):
         lines = rec1.line_ids
 
         # unlink N lines: O(1) queries
-        with self.assertQueryCount(14):
+        with self.assertQueryCount(15):
             rec1.invalidate_cache()
             rec1.write({'line_ids': [Command.unlink(line.id) for line in lines[0]]})
         self.assertEqual(rec1.line_ids, lines[1:])
 
-        with self.assertQueryCount(12):
+        with self.assertQueryCount(13):
             rec1.invalidate_cache()
             rec1.write({'line_ids': [Command.unlink(line.id) for line in lines[1:]]})
         self.assertFalse(rec1.line_ids)
@@ -190,7 +190,7 @@ class TestPerformance(SavepointCaseWithUserDemo):
         self.assertEqual(rec2.line_ids, lines)
 
         # empty N lines in rec2: O(1) queries
-        with self.assertQueryCount(__system__=13, demo=13):
+        with self.assertQueryCount(14):
             rec1.invalidate_cache()
             rec2.write({'line_ids': [Command.clear()]})
         self.assertFalse(rec2.line_ids)
@@ -210,13 +210,13 @@ class TestPerformance(SavepointCaseWithUserDemo):
         self.assertEqual(rec1.line_ids, lines[1:])
         self.assertEqual(rec2.line_ids, lines[0])
 
-        with self.assertQueryCount(7):
+        with self.assertQueryCount(6):
             rec1.invalidate_cache()
             rec2.write({'line_ids': [Command.set(lines.ids)]})
         self.assertFalse(rec1.line_ids)
         self.assertEqual(rec2.line_ids, lines)
 
-        with self.assertQueryCount(5):
+        with self.assertQueryCount(4):
             rec1.invalidate_cache()
             rec2.write({'line_ids': [Command.set(lines.ids)]})
         self.assertEqual(rec2.line_ids, lines)

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -204,6 +204,7 @@ class Field(MetaField('DummyField', (object,), {})):
     column_type = None                  # database column type (ident, spec)
     column_format = '%s'                # placeholder for value in queries
     column_cast_from = ()               # column types that may be cast to this
+    write_sequence = 0                  # field ordering for write()
 
     args = None                         # the parameters given to __init__()
     _module = None                      # the field's module name
@@ -1371,6 +1372,8 @@ class Monetary(Field):
         this monetary field is expressed in (default: `\'currency_id\'`)
     """
     type = 'monetary'
+    write_sequence = 10
+
     column_type = ('numeric', 'numeric')
     column_cast_from = ('float8',)
 
@@ -2984,6 +2987,7 @@ class Command(enum.IntEnum):
 
 class _RelationalMulti(_Relational):
     """ Abstract class for relational fields *2many. """
+    write_sequence = 20
 
     # Important: the cache contains the ids of all the records in the relation,
     # including inactive records.  Inactive records are filtered out by


### PR DESCRIPTION
This proposes
* a refactoring that simplifies the hacks dealing with `_log_access` fields, also known as "magic" fields;
* a refactoring that reduces calls to `flush()` when updating x2many fields.