### PR TITLE
[FIX] crm_iap_lead: Traceback on select Sales Team in Lead Mining Request

### DIFF
--- a/addons/crm_iap_lead/views/crm_iap_lead_views.xml
+++ b/addons/crm_iap_lead/views/crm_iap_lead_views.xml
@@ -67,7 +67,7 @@
                         </group>
                         <group name="lead_info">
                             <field name="lead_type" groups="crm.group_use_lead" invisible="context.get('is_modal')" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
-                            <field name="team_id" no_create="1" no_open="1" attrs="{'readonly': [('state', '!=', 'draft')]}" kanban_view_ref="812"/>
+                            <field name="team_id" no_create="1" no_open="1" attrs="{'readonly': [('state', '!=', 'draft')]}" kanban_view_ref="%(sales_team.crm_team_view_kanban)s"/>
                             <field name="user_id" no_create="1" no_open="1" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
                             <field name="tag_ids" string="Default Tags" widget="many2many_tags" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
                         </group>


### PR DESCRIPTION
Issue

	- Install CRM module
	- Go to CRM -> Configuration -> Lead Generation -> Lead Mining Requests
	- Click on create and select a Sales Team

	Traceback is raised.

Cause

	`kanban_view_ref` attribute on sales team field is hardcoded.

Solution

	Replace value to `%(sales_team.crm_team_view_kanban)s`.

opw-2444553