### PR TITLE
[IMP] mass_mailing: create add to mailing list button

### DIFF
--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -27,6 +27,7 @@
         'data/mailing_data_templates.xml',
         'data/mass_mailing_data.xml',
         'wizard/mail_compose_message_views.xml',
+        'wizard/mailing_contact_to_list_views.xml',
         'wizard/mailing_list_merge_views.xml',
         'wizard/mailing_mailing_test_views.xml',
         'views/mailing_mailing_views_menus.xml',

--- a/addons/mass_mailing/models/mailing_contact.py
+++ b/addons/mass_mailing/models/mailing_contact.py
@@ -174,3 +174,12 @@ class MassMailingContact(models.Model):
             'email_cc': False}
             for r in self
         }
+
+    def action_add_to_mailing_list(self):
+        ctx = dict(self.env.context, default_contact_ids=self.ids)
+        action = self.env["ir.actions.actions"]._for_xml_id("mass_mailing.mailing_contact_to_list_action")
+        action['view_mode'] = 'form'
+        action['target'] = 'new'
+        action['context'] = ctx
+
+        return action

--- a/addons/mass_mailing/security/ir.model.access.csv
+++ b/addons/mass_mailing/security/ir.model.access.csv
@@ -17,3 +17,4 @@ access_mail_blacklist_remove_mass_mailing_user,acesss.mail.blacklist.remove.mass
 access_link_tracker_mailing,access.link.tracker.mailing,link_tracker.model_link_tracker,mass_mailing.group_mass_mailing_user,1,1,1,1
 access_mailing_list_merge,access.mailing.list.merge,model_mailing_list_merge,mass_mailing.group_mass_mailing_user,1,1,1,0
 access_mailing_mailing_test,access.mailing.mailing.test,model_mailing_mailing_test,mass_mailing.group_mass_mailing_user,1,1,1,0
+access_mailing_contact_to_list,access.mailing.contact.to.list,model_mailing_contact_to_list,mass_mailing.group_mass_mailing_user,1,1,1,1

--- a/addons/mass_mailing/views/mailing_contact_views.xml
+++ b/addons/mass_mailing/views/mailing_contact_views.xml
@@ -94,6 +94,9 @@
         <field name="priority">10</field>
         <field name="arch" type="xml">
             <tree string="Mailing List Contacts" sample="1">
+                <header>
+                    <button name="action_add_to_mailing_list" string="Add to List" type="object"/>
+                </header>
                 <field name="create_date"/>
                 <field name="name"/>
                 <field name="company_name"/>

--- a/addons/mass_mailing/wizard/__init__.py
+++ b/addons/mass_mailing/wizard/__init__.py
@@ -2,5 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import mail_compose_message
+from . import mailing_contact_to_list
 from . import mailing_list_merge
 from . import mailing_mailing_test

--- a/addons/mass_mailing/wizard/mailing_contact_to_list.py
+++ b/addons/mass_mailing/wizard/mailing_contact_to_list.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, _
+
+class MailingContactToList(models.TransientModel):
+    _name = "mailing.contact.to.list"
+    _description = "Add Contacts to Mailing List"
+
+    contact_ids = fields.Many2many('mailing.contact', string='Contacts')
+    mailing_list_id = fields.Many2one('mailing.list', string='Mailing List', required=True)
+
+    def action_add_contacts(self):
+        """ Simply add contacts to the mailing list and close wizard. """
+        return self._add_contacts_to_mailing_list({'type': 'ir.actions.act_window_close'})
+
+    def action_add_contacts_and_send_mailing(self):
+        """ Add contacts to the mailing list and redirect to a new mailing on
+        this list. """
+        self.ensure_one()
+
+        action = self.env["ir.actions.actions"]._for_xml_id("mass_mailing.mailing_mailing_action_mail")
+        action['views'] = [[False, "form"]]
+        action['target'] = 'current'
+        action['context'] = {
+            'default_contact_list_ids': [self.mailing_list_id.id]
+        }
+        return self._add_contacts_to_mailing_list(action)
+
+    def _add_contacts_to_mailing_list(self, action):
+        self.ensure_one()
+
+        previous_count = len(self.mailing_list_id.contact_ids)
+        self.mailing_list_id.write({
+            'contact_ids': [
+                (4, contact.id)
+                for contact in self.contact_ids
+                if contact not in self.mailing_list_id.contact_ids]
+            })
+
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'type': 'info',
+                'message': _("%s Mailing Contacts have been added. ",
+                             len(self.mailing_list_id.contact_ids) - previous_count
+                            ),
+                'sticky': False,
+                'next': action,
+            }
+        }

--- a/addons/mass_mailing/wizard/mailing_contact_to_list_views.xml
+++ b/addons/mass_mailing/wizard/mailing_contact_to_list_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<odoo>
+
+    <record id="mailing_contact_to_list_view_form" model="ir.ui.view" >
+        <field name="name">mailing.contact.to.list.view.form</field>
+            <field name="model">mailing.contact.to.list</field>
+            <field name="arch" type="xml">
+                <form string="Send a Sample Mail">
+                    <group>
+                        <field name="mailing_list_id" options="{'no_create_edit': True, 'no_open': True}"/>
+                        <field name="contact_ids" invisible="1"/>
+                    </group>
+                    <footer>
+                        <button string="Add" name="action_add_contacts" type="object" class="btn-primary"/>
+                        <button string="Add and Send Mailing" name="action_add_contacts_and_send_mailing" type="object" class="btn-primary"/>
+                        <button string="Cancel" class="btn-secondary" special="cancel" />
+                    </footer>
+                </form>
+            </field>
+    </record>
+
+    <record id="mailing_contact_to_list_action" model="ir.actions.act_window">
+        <field name="name">Add Selected Contacts to a Mailing List</field>
+        <field name="res_model">mailing.contact.to.list</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
create a button that allows users to add selected
mailing list contacts to a mailing list, the purpose
is to allow users to handle their mailing contacts by:
- letting them create populated mailing lists on the fly
- letting them add contacts to existing lists

Task-2453990

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
