### PR TITLE
[FIX] fiscal position calculation is missing product

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2839,6 +2839,7 @@ class AccountMoveLine(models.Model):
             price_subtotal = self._get_price_total_and_subtotal()['price_subtotal']
             self.tax_ids = self.move_id.fiscal_position_id.map_tax(
                 self.tax_ids._origin,
+                product=self.product_id,
                 partner=self.move_id.partner_id)
             accounting_vals = self._get_fields_onchange_subtotal(
                 price_subtotal=price_subtotal,
@@ -3103,7 +3104,7 @@ class AccountMoveLine(models.Model):
             taxes = self._get_computed_taxes()
 
             if taxes and self.move_id.fiscal_position_id:
-                taxes = self.move_id.fiscal_position_id.map_tax(taxes, partner=self.partner_id)
+                taxes = self.move_id.fiscal_position_id.map_tax(taxes, product=self.product_id, partner=self.partner_id)
 
             self.tax_ids = taxes
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Updated map_tax method. The product is missing, but it is needed for the hungarian localization.

Current behavior before PR:
All locatization cannot work, because the product is never given. But we need to know if a product is a service or consumable.

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
