### PR TITLE
[FIX] website, website_mass_mailing: correctly load newsletter snippet

### DIFF
--- a/addons/website_mass_mailing/__manifest__.py
+++ b/addons/website_mass_mailing/__manifest__.py
@@ -21,5 +21,5 @@ On a simple click, your visitors can subscribe to mailing lists managed in the E
     'qweb': [
         'static/src/xml/*.xml',
     ],
-    'auto_install': True,
+    'auto_install': ['website', 'mass_mailing'],
 }


### PR DESCRIPTION
Since d4984b81e6b24, the `website_mass_mailing` module would not auto install
itself if the `mass_mailing` module would be installed since a new dependency
was added: `google_recaptcha`.

Step to reproduce:
  - Enter edit mode & install newsletter popup snippet
  - It will reload the page after having install `mass_mailing` module
  - The newsletter popup snippet is not found anymore, it is considered
    installed so it is not visible anymore, but the correct module was not
    installed.

task-2455069
