### PR TITLE
[FIX] membership: prevent excessive field recomputations

### DIFF
--- a/addons/membership/models/partner.py
+++ b/addons/membership/models/partner.py
@@ -57,13 +57,7 @@ class Partner(models.Model):
         if parent_members:
             parent_members._recompute_todo(self._fields['membership_state'])
 
-    @api.depends('member_lines.account_invoice_line.invoice_id.state',
-                 'member_lines.account_invoice_line.invoice_id.invoice_line_ids',
-                 'member_lines.account_invoice_line.invoice_id.payment_ids',
-                 'free_member',
-                 'member_lines.date_to', 'member_lines.date_from', 'member_lines.date_cancel',
-                 'membership_state',
-                 'associate_member.membership_state')
+    @api.depends('associate_member', 'member_lines.date_from', 'member_lines.date_cancel')
     def _compute_membership_start(self):
         """Return  date of membership"""
         for partner in self:
@@ -71,13 +65,7 @@ class Partner(models.Model):
                 ('partner', '=', partner.associate_member.id or partner.id), ('date_cancel','=',False)
             ], limit=1, order='date_from').date_from
 
-    @api.depends('member_lines.account_invoice_line.invoice_id.state',
-                 'member_lines.account_invoice_line.invoice_id.invoice_line_ids',
-                 'member_lines.account_invoice_line.invoice_id.payment_ids',
-                 'free_member',
-                 'member_lines.date_to', 'member_lines.date_from', 'member_lines.date_cancel',
-                 'membership_state',
-                 'associate_member.membership_state')
+    @api.depends('associate_member', 'member_lines.date_to', 'member_lines.date_cancel')
     def _compute_membership_stop(self):
         MemberLine = self.env['membership.membership_line']
         for partner in self:
@@ -85,13 +73,7 @@ class Partner(models.Model):
                 ('partner', '=', partner.associate_member.id or partner.id),('date_cancel','=',False)
             ], limit=1, order='date_to desc').date_to
 
-    @api.depends('member_lines.account_invoice_line.invoice_id.state',
-                 'member_lines.account_invoice_line.invoice_id.invoice_line_ids',
-                 'member_lines.account_invoice_line.invoice_id.payment_ids',
-                 'free_member',
-                 'member_lines.date_to', 'member_lines.date_from', 'member_lines.date_cancel',
-                 'membership_state',
-                 'associate_member.membership_state')
+    @api.depends('member_lines.date_cancel')
     def _compute_membership_cancel(self):
         for partner in self:
             partner.membership_cancel = self.env['membership.membership_line'].search([


### PR DESCRIPTION
STEPS:
* add logs printing
* create a tree of associated members
* create membership invoice
* validate the invoice

Below is printing for the following tree

```
45
 \---- 51
  \
   \--- 50
    \
     \-- 46 -- 49
          \ -- 48
           \-- 47
```

BEFORE

Create invoice:

_compute_membership_state: res.partner(45,)
_compute_membership_cancel: res.partner(45,)
_compute_membership_stop: res.partner(45,)
_compute_membership_state: res.partner(46, 50, 51)
_compute_membership_cancel: res.partner(45, 46, 50, 51)
_compute_membership_stop: res.partner(45, 46, 50, 51)
_compute_membership_state: res.partner(47, 48, 49)
_compute_membership_cancel: res.partner(45, 46, 50, 51, 47, 48, 49)
_compute_membership_stop: res.partner(45, 46, 50, 51, 47, 48, 49)
_compute_membership_cancel: res.partner(45, 46, 50, 51, 47, 48, 49)
_compute_membership_start: res.partner(45, 46, 50, 51, 47, 48, 49)
_compute_membership_stop: res.partner(45, 46, 50, 51, 47, 48, 49)
_compute_membership_state: res.partner(45,)
_compute_membership_cancel: res.partner(45,)
_compute_membership_stop: res.partner(45,)
_compute_membership_state: res.partner(46, 50, 51)
_compute_membership_cancel: res.partner(45, 46, 50, 51)
_compute_membership_stop: res.partner(45, 46, 50, 51)
_compute_membership_state: res.partner(47, 48, 49)
_compute_membership_cancel: res.partner(45, 46, 50, 51, 47, 48, 49)
_compute_membership_stop: res.partner(45, 46, 50, 51, 47, 48, 49)
_compute_membership_cancel: res.partner(45, 46, 50, 51, 47, 48, 49)
_compute_membership_start: res.partner(45, 46, 50, 51, 47, 48, 49)
_compute_membership_stop: res.partner(45, 46, 50, 51, 47, 48, 49)

Validate invoice:

_compute_membership_state: res.partner(45,)
_compute_membership_state: res.partner(46, 50, 51)
_compute_membership_cancel: res.partner(46, 50, 51, 45)
_compute_membership_stop: res.partner(46, 50, 51, 45)
_compute_membership_state: res.partner(47, 48, 49)
_compute_membership_cancel: res.partner(46, 50, 51, 45, 47, 48, 49)
_compute_membership_stop: res.partner(46, 50, 51, 45, 47, 48, 49)
_compute_membership_cancel: res.partner(46, 50, 51, 45, 47, 48, 49)
_compute_membership_start: res.partner(46, 50, 51, 45, 47, 48, 49)
_compute_membership_stop: res.partner(46, 50, 51, 45, 47, 48, 49)
_compute_membership_state: res.partner(45,)
_compute_membership_cancel: res.partner(45,)
_compute_membership_stop: res.partner(45,)
_compute_membership_state: res.partner(46, 50, 51)
_compute_membership_cancel: res.partner(45, 46, 50, 51)
_compute_membership_stop: res.partner(45, 46, 50, 51)
_compute_membership_state: res.partner(47, 48, 49)
_compute_membership_cancel: res.partner(45, 46, 50, 51, 47, 48, 49)
_compute_membership_stop: res.partner(45, 46, 50, 51, 47, 48, 49)
_compute_membership_cancel: res.partner(45, 46, 50, 51, 47, 48, 49)
_compute_membership_start: res.partner(45, 46, 50, 51, 47, 48, 49)
_compute_membership_stop: res.partner(45, 46, 50, 51, 47, 48, 49)

AFTER

Create invoice:

_compute_membership_cancel: res.partner(45,)
_compute_membership_stop: res.partner(45,)
_compute_membership_start: res.partner(45,)
_compute_membership_state: res.partner(45,)
_compute_membership_state: res.partner(46, 50, 51)
_compute_membership_state: res.partner(47, 48, 49)
_compute_membership_state: res.partner(45,)
_compute_membership_state: res.partner(46, 50, 51)
_compute_membership_state: res.partner(47, 48, 49)

Validate invoice:

_compute_membership_state: res.partner(45,)
_compute_membership_state: res.partner(46, 50, 51)
_compute_membership_state: res.partner(47, 48, 49)
_compute_membership_state: res.partner(45,)
_compute_membership_state: res.partner(46, 50, 51)
_compute_membership_state: res.partner(47, 48, 49)

---

opw-2390394

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
