### PR TITLE
[FIX] mrp: do not use pbm with a pbm configuration

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -116,10 +116,10 @@ class StockRule(models.Model):
             'move_dest_ids': values.get('move_dest_ids') and [(4, x.id) for x in values['move_dest_ids']] or False,
             'user_id': False,
         }
+        # Use the procurement group created in _run_pull mrp override
+        # Preserve the origin from the original stock move, if available
         if location_id.get_warehouse().manufacture_steps == 'pbm_sam':
-            # Use the procurement group created in _run_pull mrp override
-            # Preserve the origin from the original stock move, if available
-            if len(values.get('move_dest_ids', [])) == 1 and values['move_dest_ids'][0].origin and values['group_id']:
+            if values.get('move_dest_ids') and values.get('group_id') and values['move_dest_ids'][0].origin != values['group_id'].name:
                 origin = values['move_dest_ids'][0].origin
                 mo_values.update({
                     'name': values['group_id'].name,


### PR DESCRIPTION
Usecase to reproduce:
- Setup the warehouse in a 3 step manufacturing
- Create a picking type for manufacturing that take components in
virtual/prod and store them in virtual/prod
- Add some route on the product that check in virtual/prod and use
action manufacture
- Do a BoM with multiple levels and with subBom components using the
custom route + replenish on order
- Create a MO for the final product

Error with the constraint of multiple times the same name for different
MO. It's due to commit abf6c0ca88bde077b2b1826596626fbed61d43b3 that
does the hypothesis that a pbm config will use rules that goes through
store finished product location.

Since the run_pull in a store finished location will modify the
procurement group but not the origin, we could compare the procurement
group name and procurement origin to know if the rules went through the
post prod location
