### PR TITLE
[FIX] l10n_in_sale: place of supply base on delivery address

### DIFF
--- a/addons/l10n_in_sale/report/account_invoice_report.py
+++ b/addons/l10n_in_sale/report/account_invoice_report.py
@@ -7,6 +7,16 @@ from odoo import models
 class L10nInAccountInvoiceReport(models.Model):
     _inherit = "l10n_in.account.invoice.report"
 
+    def _from(self):
+        from_str = super(L10nInAccountInvoiceReport, self)._from()
+        return from_str.replace(
+            "LEFT JOIN res_country_state ps ON ps.id = p.state_id",
+            """
+            LEFT JOIN res_partner dp ON dp.id = am.partner_shipping_id
+            LEFT JOIN res_country_state ps ON ps.id = dp.state_id
+            """
+        )
+
     def _where(self):
         where_str = super(L10nInAccountInvoiceReport, self)._where()
         where_str += """ AND (aml.product_id IS NULL or aml.product_id != COALESCE(


### PR DESCRIPTION
Before this commit:

place of supply always set from customer address.

After this commit:

place of supply is set by delivery address

opw: 2456095

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
