### PR TITLE
[IMP] base : display partner_ids in wizard

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -662,6 +662,8 @@ class Partner(models.Model):
             name = name + "\n" + partner._display_address(without_company=True)
         name = name.replace('\n\n', '\n')
         name = name.replace('\n\n', '\n')
+        if self._context.get('partner_show_db_id'):
+            name = "%s (%s)" % (name, partner.id)
         if self._context.get('address_inline'):
             name = name.replace('\n', ', ')
         if self._context.get('show_email') and partner.email:

--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -40,3 +40,12 @@ class TestPartner(TransactionCase):
 
         with self.assertRaises(UserError, msg="You should not be able to update the company_id of the partner company if the linked user of a child partner is not an allowed to be assigned to that company"), self.cr.savepoint():
             test_partner_company.write({'company_id': company_2.id})
+
+    def test_partner_merge_wizard_dst_partner_id(self):
+        """ Check that dst_partner_id in merge wizard displays id along with partner name """
+        test_partner = self.env['res.partner'].create({'name': 'Radu the Handsome'})
+        expected_partner_name = '%s (%s)' % (test_partner.name, test_partner.id)
+
+        partner_merge_wizard = self.env['base.partner.merge.automatic.wizard'].with_context(
+            {'partner_show_db_id': True, 'default_dst_partner_id': test_partner}).new()
+        self.assertEqual(partner_merge_wizard.dst_partner_id.display_name, expected_partner_name, "'Destination Contact' name should contain db ID in brackets")

--- a/odoo/addons/base/wizard/base_partner_merge_views.xml
+++ b/odoo/addons/base/wizard/base_partner_merge_views.xml
@@ -55,7 +55,11 @@
                                 You can remove contacts from this list to avoid merging them.
                             </p>
                             <group col="2">
-                                <field name="dst_partner_id" domain="[('id', 'in', partner_ids or False)]" attrs="{'required': [('state', '=', 'selection')]}"/>
+                                <field name="dst_partner_id"
+                                    domain="[('id', 'in', partner_ids or False)]"
+                                    attrs="{'required': [('state', '=', 'selection')]}"
+                                    context="{'partner_show_db_id': True}"
+                                    options="{'always_reload': True}"/>
                             </group>
                             <field name="partner_ids" nolabel="1">
                                 <tree string="Partners">


### PR DESCRIPTION
PURPOSE

if we are merging multiple contacts with the same name,
the destination contact field might be confusing as it just
says the name and does not include the id,
or other identifier to make it clear the exact contact you are
setting as the destination.

SPECIFICATIONS

so in this commit we will add the partner ids along with its
name in destination contact field which will avoid the confusion
while merging contacts.

LINKS

PR #66026
Task 2323060
