### PR TITLE
[FIX] web: improves small screen display of popovers

### DIFF
--- a/addons/web/static/src/scss/popover.scss
+++ b/addons/web/static/src/scss/popover.scss
@@ -57,6 +57,7 @@
     position: fixed;
     z-index: 1060;
     border: 1px solid $border-color;
+    margin: map-get($spacers, 2);
     background-color: #fff;
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
 


### PR DESCRIPTION
This commit adds a margin to popovers and sets the default position
to 'bottom' to prevent horizontal scrollbars.

opw-2317964