### PR TITLE
[IMP] base: check fallback on AccessDenied

### DIFF
--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -191,7 +191,8 @@ class IrHttp(models.AbstractModel):
 
         # This is done first as the attachment path may
         # not match any HTTP controller
-        if isinstance(exception, werkzeug.exceptions.HTTPException) and exception.code == 404:
+        if (isinstance(exception, werkzeug.exceptions.HTTPException) and exception.code == 404) or \
+           (isinstance(exception, odoo.exceptions.AccessError)):
             serve = cls._serve_fallback(exception)
             if serve:
                 return serve


### PR DESCRIPTION
Before this commit, we only check if another endpoint can be serve in case of
404 not found. Idea was that each url has only one endpoint.

Fun effect is that if record doesn't exist, route doesn't match, so in reality
we had one endpoint but we fallback too to check if another match.

But it doesn't match a recurring case, when you archive a record, and want to
create a redirect for your seo and customer to another record, it is just
ignored because the url math a controller (that return 403 since you don't have
anymore the access right)

Since ask to the customer to delete the record is not always possible
(e.g. a product already sold) now we check if a fallback match for 403.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
