### PR TITLE
[FIX] account: Set memo to ref if not payment_reference

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -388,10 +388,10 @@ class AccountMove(models.Model):
 
         self._recompute_dynamic_lines(recompute_tax_base_amount=True)
 
-    @api.onchange('invoice_payment_ref')
+    @api.onchange('invoice_payment_ref', 'ref')
     def _onchange_invoice_payment_ref(self):
         for line in self.line_ids.filtered(lambda line: line.account_id.user_type_id.type in ('receivable', 'payable')):
-            line.name = self.invoice_payment_ref
+            line.name = self.invoice_payment_ref or self.ref or ''
 
     @api.onchange('invoice_vendor_bill_id')
     def _onchange_invoice_vendor_bill(self):
@@ -933,7 +933,7 @@ class AccountMove(models.Model):
                     # Create new line.
                     create_method = in_draft_mode and self.env['account.move.line'].new or self.env['account.move.line'].create
                     candidate = create_method({
-                        'name': self.invoice_payment_ref or '',
+                        'name': self.invoice_payment_ref or self.ref or '',
                         'debit': balance < 0.0 and -balance or 0.0,
                         'credit': balance > 0.0 and balance or 0.0,
                         'quantity': 1.0,

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -1789,3 +1789,23 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         })
         move.post()
         self.assertEquals(move.name, 'INV/2019/01/1')
+
+    def test_in_invoice_payment_ref(self):
+        ''' Test the 'name' of the payable line fallbacks on the move's ref if the payment ref is empty. '''
+        ref = 'VENDORBILL123456'
+        with Form(self.invoice) as move_form:
+            move_form.ref = ref
+
+        self.assertInvoiceValues(self.invoice, [
+            self.product_line_vals_1,
+            self.product_line_vals_2,
+            self.tax_line_vals_1,
+            self.tax_line_vals_2,
+            {
+                **self.term_line_vals_1,
+                'name': ref,
+            },
+        ], {
+            **self.move_vals,
+            'ref': ref,
+        })


### PR DESCRIPTION
Issue

	- Install "Accounting" module
	- Create a new bill :
	- Set vendor
	- Set no payment reference
	- Set a bill reference
	- Add products to bill
	- Confirm and click on Register Payment

	Memo field has no value.

Cause

	The memo field is based on lines name.
	Lines name is computed in `_onchange_payment_reference`
	and depends only on payment_referecence.

Solution

	If no `payment_reference`, fallback on `ref` to set line name.

opw-2440389

co-author: nboulif <bon@odoo.com>

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
