### PR TITLE
[IMP] website: fa blogpost improvement

### DIFF
--- a/addons/website/views/website_navbar_templates.xml
+++ b/addons/website/views/website_navbar_templates.xml
@@ -122,7 +122,7 @@
                                          t-att-data-module-shortdesc="mod.shortdesc"
                                          class="col-md-4 mb8 o_new_content_element">
                                         <a href="#" data-action="new_blog_post">
-                                            <i class="fa fa-rss"/>
+                                            <i class="fa fa-sticky-note"/>
                                             <p>Blog Post</p>
                                         </a>
                                     </div>


### PR DESCRIPTION
This commit changes the current 'fontawesome' icon, applied to the
'New Blog Post' view, activated after pressing the 'New' button in
the 'User Navbar' of the 'website' module.

This change is made since the current icon does not properly represent
a blog post icon.

--

Task 2448475

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
