### PR TITLE
[IMP] website_sale: extra_field always visible if one

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1886,23 +1886,25 @@
         </field>
     </record>
 
-    <template id="ecom_show_extra_fields" inherit_id="website_sale.product" active="False" customize_show="True" name="Show Extra Fields">
+    <template id="ecom_show_extra_fields" inherit_id="website_sale.product" active="True" name="Show Extra Fields">
         <xpath expr="//div[@id='product_details']" position="inside">
-            <hr/>
-            <p class="text-muted">
-                <t t-foreach='website.shop_extra_field_ids' t-as='field' t-if='product[field.name]'>
-                    <b><t t-esc='field.label'/>: </b>
-                    <t t-if='field.field_id.ttype != "binary"'>
-                        <span t-esc='product[field.name]' t-options="{'widget': field.field_id.ttype}"/>
+            <t t-if="any([product[field.name] for field in website.shop_extra_field_ids])">
+                <hr/>
+                <p class="text-muted">
+                    <t t-foreach='website.shop_extra_field_ids' t-as='field' t-if='product[field.name]'>
+                        <b><t t-esc='field.label'/>: </b>
+                        <t t-if='field.field_id.ttype != "binary"'>
+                            <span t-esc='product[field.name]' t-options="{'widget': field.field_id.ttype}"/>
+                        </t>
+                        <t t-else=''>
+                            <a target='_blank' t-attf-href='/web/content/product.template/#{product.id}/#{field.name}?download=1'>
+                                <i class='fa fa-file'></i>
+                            </a>
+                        </t>
+                        <br/>
                     </t>
-                    <t t-else=''>
-                        <a target='_blank' t-attf-href='/web/content/product.template/#{product.id}/#{field.name}?download=1'>
-                            <i class='fa fa-file'></i>
-                        </a>
-                    </t>
-                    <br/>
-                </t>
-            </p>
+                </p>
+            </t>
         </xpath>
     </template>
 


### PR DESCRIPTION
Before we need to add extra_field on website AND enable the view.
Now the view is enable for everybody without option, but we only show the extra
field zone if at least one field is set on website.

task-2381327

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
