### PR TITLE
[FIX] stock: while fixing the date/date_expected field the operator was corrupted

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -145,10 +145,10 @@ class Product(models.Model):
                 '|',
                     '&',
                         ('state', '=', 'done'),
-                        ('date', '<=', from_date),
+                        ('date', '>=', from_date),
                     '&',
                         ('state', '!=', 'done'),
-                        ('date_expected', '<=', from_date),
+                        ('date_expected', '>=', from_date),
             ]
             domain_move_in += date_date_expected_domain_from
             domain_move_out += date_date_expected_domain_from


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
`date_from` was destroyed during a bug fix about two years ago.

**Current behavior before PR:**
`date_from` is acting like `date_to`

**Desired behavior after PR is merged:**
original logic resurrected with the proper bug fix intend of https://github.com/odoo/odoo/commit/c2c9d6d143af7f00bb07e391fe494c2496cdad88

Info:@wt-io-it

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
