### PR TITLE
[FIX] point_of_sale: fix doubleclick of validate button

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -971,8 +971,12 @@ exports.PosModel = Backbone.Model.extend({
 
         return new Promise(function (resolve, reject) {
             self.flush_mutex.exec(function () {
-                var flushed = self._flush_orders([self.db.get_order(order_id)], opts);
-
+                var order = self.db.get_order(order_id);
+                if (order){
+                    var flushed = self._flush_orders([order], opts);
+                } else {
+                    var flushed = Promise.resolve([]);
+                }
                 flushed.then(resolve, reject);
 
                 return flushed;


### PR DESCRIPTION
Open POS, add something to the order, go to checkout, add payment,
double click on validate

js error will popup

opw-2429523

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
