### PR TITLE
[FIX] rating: use website language if full frontend

### DIFF
--- a/addons/rating/controllers/main.py
+++ b/addons/rating/controllers/main.py
@@ -23,8 +23,10 @@ class Rating(http.Controller):
             10: _("satisfied")
         }
         rating.write({'rating': rate, 'consumed': True})
-        lang = rating.partner_id.lang or get_lang(request.env).code
-        return request.env['ir.ui.view'].with_context(lang=lang).render_template('rating.rating_external_page_submit', {
+        additional_context = {}
+        if not getattr(request, 'website', False) and rating.partner_id.lang:
+            additional_context['lang'] = rating.partner_id.lang
+        return request.env['ir.ui.view'].with_context(**additional_context).render_template('rating.rating_external_page_submit', {
             'rating': rating, 'token': token,
             'rate_name': rate_names[rate], 'rate': rate
         })
@@ -36,8 +38,10 @@ class Rating(http.Controller):
             return request.not_found()
         record_sudo = request.env[rating.res_model].sudo().browse(rating.res_id)
         record_sudo.rating_apply(rate, token=token, feedback=kwargs.get('feedback'))
-        lang = rating.partner_id.lang or get_lang(request.env).code
-        return request.env['ir.ui.view'].with_context(lang=lang).render_template('rating.rating_external_page_view', {
+        additional_context = {}
+        if not getattr(request, 'website', False) and rating.partner_id.lang:
+            additional_context['lang'] = rating.partner_id.lang
+        return request.env['ir.ui.view'].with_context(**additional_context).render_template('rating.rating_external_page_view', {
             'web_base_url': request.env['ir.config_parameter'].sudo().get_param('web.base.url'),
             'rating': rating,
         })


### PR DESCRIPTION

The route for customer rating force the customer language.

If website is installed, this overrides the normal language so if
current website language is spanish and customer is english, either:

- we will have a page with two languages mixed with language selector
  set on spanish but showing mostly english

- or if english is not installed, we get an error

With this changeset, if website is intalled we just let it handle
language (previous language used, or if not browser language, ...).

Not necessary in 12.0 since we did not use frontend_layout (e9be0bb178).

opw-2449678
