### PR TITLE
[IMP] website: use correct groups on field access_token

### DIFF
--- a/addons/website/models/website_visitor.py
+++ b/addons/website/models/website_visitor.py
@@ -31,7 +31,7 @@ class WebsiteVisitor(models.Model):
     _order = 'last_connection_datetime DESC'
 
     name = fields.Char('Name')
-    access_token = fields.Char(required=True, default=lambda x: uuid.uuid4().hex, index=False, copy=False, groups='base.group_website_publisher')
+    access_token = fields.Char(required=True, default=lambda x: uuid.uuid4().hex, index=False, copy=False, groups='website.group_website_publisher')
     active = fields.Boolean('Active', default=True)
     website_id = fields.Many2one('website', "Website", readonly=True)
     partner_id = fields.Many2one('res.partner', string="Contact", help="Partner of the last logged in user.")


### PR DESCRIPTION
Previously, since the group name was wrong, nobody can access this.
Now we let group_website_publisher read it...
Change is not critical, since previous typo make it unreadable for
all.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
