### PR TITLE
[IMP] crm: Use flanker to check email correctness

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -8,6 +8,7 @@ from datetime import date, datetime, timedelta
 from psycopg2 import sql
 
 from odoo import api, fields, models, tools, SUPERUSER_ID
+from odoo.addons.mail.tools import mail_validation
 from odoo.addons.phone_validation.tools import phone_validation
 from odoo.exceptions import UserError, AccessError
 from odoo.osv import expression
@@ -17,6 +18,8 @@ from odoo.tools import email_re, email_split
 from . import crm_stage
 
 _logger = logging.getLogger(__name__)
+
+
 
 CRM_LEAD_FIELDS_TO_MERGE = [
     # UTM mixin
@@ -451,7 +454,7 @@ class Lead(models.Model):
             if lead.email_from:
                 email_state = 'incorrect'
                 for email in email_split(lead.email_from):
-                    if tools.email_normalize(email):
+                    if mail_validation.mail_validate(email):
                         email_state = 'correct'
                         break
             lead.email_state = email_state

--- a/addons/mail/__init__.py
+++ b/addons/mail/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
 from . import models
+from . import tools
 from . import wizard
 from . import controllers

--- a/addons/mail/tools/__init__.py
+++ b/addons/mail/tools/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import mail_validation

--- a/addons/mail/tools/mail_validation.py
+++ b/addons/mail/tools/mail_validation.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import logging
+
+from odoo import tools
+
+_logger = logging.getLogger(__name__)
+
+_flanker_lib_warning = False
+
+try:
+    from flanker.addresslib import address
+    # Avoid warning each time a mx server is not reachable by flanker
+    logging.getLogger("flanker.addresslib.validate").setLevel(logging.ERROR)
+
+    def mail_validate(email):
+        return bool(address.validate_address(email))
+
+except ImportError:
+
+    def mail_validate(email):
+        global _flanker_lib_warning
+        if not _flanker_lib_warning:
+            _flanker_lib_warning = True
+            _logger.info("The `flanker` Python module is not installed,"
+                           "so email validation fallback to email_normalize. Use 'pip install flanker' to install it")
+        return tools.email_normalize(email)


### PR DESCRIPTION
Context
-------
Lead assignement is now based on PLS probability.
We want to avoid giving the same score to real email addresses
and email addresses that are just well formed

Flanker try to acheive that be checking specific
criteria according to the domain, check the dns and mx record

Improvement
-----------
If flanker is installed, use flanker to check correctness of
email addresses.
It should help the PLS to give a bad score to well formed addresses
that flanker suspect to be wrong.

Setup
-----
NB: flanker is not available as debian package, we make it optional

To install flanker
```
pip install flanker
pip install redis
pip install dnsq
```

If you have installed it as root you may need to run
```py
from flanker.addresslib import address
```
as root for the first initialisation

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
