### PR TITLE
[FIX] web_editor: content under top bar in iframe


### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_iframe.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_iframe.scss
@@ -17,6 +17,10 @@ iframe.wysiwyg_iframe.o_fullscreen {
 body.o_in_iframe {
     background-color: $o-view-background-color;
 
+    &.editor_enable {
+        padding-top: var(--o-we-toolbar-height) !important;
+    }
+
     .note-statusbar {
         display: none;
     }


### PR DESCRIPTION

In ff81fa479 there was some refactoring for change of structure on
frontend, but for the iframe editor (eg. mass mailing), this caused that
the top edition bar was over the content.

opw-2426400
