### PR TITLE
[IMP] account: Payments Form View Improvement

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -228,6 +228,8 @@ class AccountMove(models.Model):
         compute='_compute_amount', currency_field='company_currency_id')
     amount_total_signed = fields.Monetary(string='Total Signed', store=True, readonly=True,
         compute='_compute_amount', currency_field='company_currency_id')
+    amount_total_in_currency_signed = fields.Monetary(string='Total in Currency Signed', store=True, readonly=True,
+        compute='_compute_amount', currency_field='currency_id')
     amount_residual_signed = fields.Monetary(string='Amount Due Signed', store=True,
         compute='_compute_amount', currency_field='company_currency_id')
     amount_by_group = fields.Binary(string="Tax amount by group",
@@ -1309,6 +1311,7 @@ class AccountMove(models.Model):
             move.amount_tax_signed = -total_tax
             move.amount_total_signed = abs(total) if move.move_type == 'entry' else -total
             move.amount_residual_signed = total_residual
+            move.amount_total_in_currency_signed = abs(move.amount_total) if move.move_type == 'entry' else -(sign * move.amount_total)
 
             currency = len(currencies) == 1 and currencies.pop() or move.company_id.currency_id
 

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2586,7 +2586,10 @@ class AccountMove(models.Model):
         return action
 
     def action_post(self):
-        self._post(soft=False)
+        if self.payment_id:
+            self.payment_id.action_post()
+        else:
+            self._post(soft=False)
         return False
 
     def js_assign_outstanding_line(self, line_id):

--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -49,12 +49,14 @@ class AccountPayment(models.Model):
         compute='_compute_partner_bank_id',
         domain="[('partner_id', '=', partner_id)]",
         check_company=True)
-    is_internal_transfer = fields.Boolean(string="Is Internal Transfer",
+    is_internal_transfer = fields.Boolean(string="Internal Transfer",
         readonly=False, store=True,
         compute="_compute_is_internal_transfer")
     qr_code = fields.Char(string="QR Code",
         compute="_compute_qr_code",
         help="QR-code report URL to use to generate the QR-code to scan with a banking app to perform this payment.")
+    paired_internal_transfer_payment_id = fields.Many2one('account.payment', help="When an internal transfer is posted, a paired payment is created. "
+        "They cross referenced trough this field")
 
     # == Payment methods fields ==
     payment_method_id = fields.Many2one('account.payment.method', string='Payment Method',
@@ -75,8 +77,8 @@ class AccountPayment(models.Model):
     # == Synchronized fields with the account.move.lines ==
     amount = fields.Monetary(currency_field='currency_id')
     payment_type = fields.Selection([
-        ('outbound', 'Send Money'),
-        ('inbound', 'Receive Money'),
+        ('outbound', 'Send'),
+        ('inbound', 'Receive'),
     ], string='Payment Type', default='inbound', required=True)
     partner_type = fields.Selection([
         ('customer', 'Customer'),
@@ -101,6 +103,12 @@ class AccountPayment(models.Model):
         compute='_compute_destination_account_id',
         domain="[('user_type_id.type', 'in', ('receivable', 'payable')), ('company_id', '=', company_id)]",
         check_company=True)
+    destination_journal_id = fields.Many2one(
+        comodel_name='account.journal',
+        string='Destination Journal',
+        domain="[('type', 'in', ('bank','cash')), ('company_id', '=', company_id), ('id', '!=', journal_id)]",
+        check_company=True,
+    )
 
     # == Stat buttons ==
     reconciled_invoice_ids = fields.Many2many('account.move', string="Reconciled Invoices",
@@ -108,6 +116,10 @@ class AccountPayment(models.Model):
         help="Invoices whose journal items have been reconciled with these payments.")
     reconciled_invoices_count = fields.Integer(string="# Reconciled Invoices",
         compute="_compute_stat_buttons_from_reconciliation")
+    reconciled_invoices_type = fields.Selection(
+        [('credit_note', 'Credit Note'), ('invoice', 'Invoice')],
+        compute='_compute_stat_buttons_from_reconciliation',
+        help="Technical field used to determine label 'invoice' or 'credit note' in view")
     reconciled_bill_ids = fields.Many2many('account.move', string="Reconciled Bills",
         compute='_compute_stat_buttons_from_reconciliation',
         help="Invoices whose journal items have been reconciled with these payments.")
@@ -130,6 +142,12 @@ class AccountPayment(models.Model):
         compute='_compute_show_require_partner_bank',
         help="Technical field used to know whether the field `partner_bank_id` needs to be required or not in the payments form views")
     country_code = fields.Char(related='company_id.account_fiscal_country_id.code')
+    country_code = fields.Char(related='company_id.country_id.code')
+    amount_signed = fields.Monetary(
+        currency_field='currency_id', compute='_compute_amount_signed',
+        help='Negative value of amount field if payment_type is outbound')
+    amount_company_currency_signed = fields.Monetary(
+        currency_field='company_currency_id', compute='_compute_amount_company_currency_signed')
 
     _sql_constraints = [
         (
@@ -315,22 +333,39 @@ class AccountPayment(models.Model):
             payment.show_partner_bank_account = payment.payment_method_code in self._get_method_codes_using_bank_account()
             payment.require_partner_bank_account = payment.state == 'draft' and payment.payment_method_code in self._get_method_codes_needing_bank_account()
 
-    @api.depends('partner_id')
+    @api.depends('amount_total_signed', 'payment_type')
+    def _compute_amount_company_currency_signed(self):
+        for payment in self:
+            if payment.payment_type == 'outbound':
+                payment.amount_company_currency_signed = -payment.amount_total_signed
+            else:
+                payment.amount_company_currency_signed = payment.amount_total_signed
+
+    @api.depends('amount', 'payment_type')
+    def _compute_amount_signed(self):
+        for payment in self:
+            if payment.payment_type == 'outbound':
+                payment.amount_signed = -payment.amount
+            else:
+                payment.amount_signed = payment.amount
+
+    @api.depends('partner_id', 'destination_journal_id', 'is_internal_transfer')
     def _compute_partner_bank_id(self):
         ''' The default partner_bank_id will be the first available on the partner. '''
         for pay in self:
-            available_partner_bank_accounts = pay.partner_id.bank_ids.filtered(lambda x: x.company_id in (False, pay.company_id))
-            if available_partner_bank_accounts:
-                pay.partner_bank_id = available_partner_bank_accounts[0]._origin
+            if pay.is_internal_transfer:
+                pay.partner_bank_id = self.destination_journal_id.bank_account_id
             else:
-                pay.partner_bank_id = False
+                available_partner_bank_accounts = pay.partner_id.bank_ids.filtered(lambda x: x.company_id in (False, pay.company_id))
+                if available_partner_bank_accounts:
+                    pay.partner_bank_id = available_partner_bank_accounts[0]._origin
+                else:
+                    pay.partner_bank_id = False
 
     @api.depends('partner_id', 'destination_account_id', 'journal_id')
     def _compute_is_internal_transfer(self):
         for payment in self:
-            is_partner_ok = payment.partner_id == payment.journal_id.company_id.partner_id
-            is_account_ok = payment.destination_account_id and payment.destination_account_id == payment.journal_id.company_id.transfer_account_id
-            payment.is_internal_transfer = is_partner_ok and is_account_ok
+            payment.is_internal_transfer = payment.partner_id == payment.journal_id.company_id.partner_id
 
     @api.depends('payment_type', 'journal_id')
     def _compute_payment_method_id(self):
@@ -358,8 +393,15 @@ class AccountPayment(models.Model):
                 pay.available_payment_method_ids = pay.journal_id.inbound_payment_method_ids
             else:
                 pay.available_payment_method_ids = pay.journal_id.outbound_payment_method_ids
-
+            to_exclude = self._get_payment_method_codes_to_exclude()
+            if to_exclude:
+                pay.available_payment_method_ids = pay.available_payment_method_ids.filtered(lambda x: x.code not in to_exclude)
             pay.hide_payment_method = len(pay.available_payment_method_ids) == 1 and pay.available_payment_method_ids.code == 'manual'
+
+    def _get_payment_method_codes_to_exclude(self):
+        # can be overriden to exclude payment methods based on the payment charachteristics
+        self.ensure_one()
+        return []
 
     @api.depends('journal_id')
     def _compute_currency_id(self):
@@ -435,6 +477,7 @@ class AccountPayment(models.Model):
         if not stored_payments:
             self.reconciled_invoice_ids = False
             self.reconciled_invoices_count = 0
+            self.reconciled_invoices_type = ''
             self.reconciled_bill_ids = False
             self.reconciled_bills_count = 0
             self.reconciled_statement_ids = False
@@ -514,6 +557,10 @@ class AccountPayment(models.Model):
             statement_ids = query_res.get(pay.id, [])
             pay.reconciled_statement_ids = [(6, 0, statement_ids)]
             pay.reconciled_statements_count = len(statement_ids)
+            if len(pay.reconciled_invoice_ids.mapped('move_type')) == 1 and pay.reconciled_invoice_ids[0].move_type == 'out_refund':
+                pay.reconciled_invoices_type = 'credit_note'
+            else:
+                pay.reconciled_invoices_type = 'invoice'
 
     # -------------------------------------------------------------------------
     # ONCHANGE METHODS
@@ -605,7 +652,7 @@ class AccountPayment(models.Model):
 
     @api.depends('move_id.name')
     def name_get(self):
-        return [(payment.id, payment.move_id.name or _('Draft Payment')) for payment in self]
+        return [(payment.id, payment.move_id.name != '/' and payment.move_id.name or _('Draft Payment')) for payment in self]
 
     # -------------------------------------------------------------------------
     # SYNCHRONIZATION account.payment <-> account.move
@@ -638,32 +685,41 @@ class AccountPayment(models.Model):
                 all_lines = move.line_ids
                 liquidity_lines, counterpart_lines, writeoff_lines = pay._seek_for_lines()
 
-                if len(liquidity_lines) != 1 or len(counterpart_lines) != 1:
+                if len(liquidity_lines) != 1:
                     raise UserError(_(
-                        "The journal entry %s reached an invalid state relative to its payment.\n"
-                        "To be consistent, the journal entry must always contains:\n"
-                        "- one journal item involving the outstanding payment/receipts account.\n"
-                        "- one journal item involving a receivable/payable account.\n"
-                        "- optional journal items, all sharing the same account.\n\n"
-                    ) % move.display_name)
+                        "Journal Entry %s is not valid. In order to proceed, the journal items must "
+                        "include one and only one outstanding payments/receipts account.",
+                        move.display_name,
+                    ))
+
+                if len(counterpart_lines) != 1:
+                    raise UserError(_(
+                        "Journal Entry %s is not valid. In order to proceed, the journal items must "
+                        "include one and only one receivable/payable account (with an exception of "
+                        "internal transfers).",
+                        move.display_name,
+                    ))
 
                 if writeoff_lines and len(writeoff_lines.account_id) != 1:
                     raise UserError(_(
-                        "The journal entry %s reached an invalid state relative to its payment.\n"
-                        "To be consistent, all the write-off journal items must share the same account."
-                    ) % move.display_name)
+                        "Journal Entry %s is not valid. In order to proceed, "
+                        "all optional journal items must share the same account.",
+                        move.display_name,
+                    ))
 
                 if any(line.currency_id != all_lines[0].currency_id for line in all_lines):
                     raise UserError(_(
-                        "The journal entry %s reached an invalid state relative to its payment.\n"
-                        "To be consistent, the journal items must share the same currency."
-                    ) % move.display_name)
+                        "Journal Entry %s is not valid. In order to proceed, the journal items must "
+                        "share the same currency.",
+                        move.display_name,
+                    ))
 
                 if any(line.partner_id != all_lines[0].partner_id for line in all_lines):
                     raise UserError(_(
-                        "The journal entry %s reached an invalid state relative to its payment.\n"
-                        "To be consistent, the journal items must share the same partner."
-                    ) % move.display_name)
+                        "Journal Entry %s is not valid. In order to proceed, the journal items must "
+                        "share the same partner.",
+                        move.display_name,
+                    ))
 
                 if counterpart_lines.account_id.user_type_id.type == 'receivable':
                     partner_type = 'customer'
@@ -746,6 +802,33 @@ class AccountPayment(models.Model):
                 'line_ids': line_ids_commands,
             })
 
+    def _create_paired_internal_transfer_payment(self):
+        ''' When an internal transfer is posted, a paired payment is created
+        with opposite payment_type and swapped journal_id & destination_journal_id.
+        Both payments liquidity transfer lines are then reconciled.
+        '''
+        for payment in self:
+
+            paired_payment = payment.copy({
+                'journal_id': payment.destination_journal_id.id,
+                'destination_journal_id': payment.journal_id.id,
+                'payment_type': payment.payment_type == 'outbound' and 'inbound' or 'outbound',
+                'move_id': None,
+                'ref': payment.ref,
+                'paired_internal_transfer_payment_id': payment.id
+            })
+            paired_payment.move_id._post(soft=False)
+            payment.paired_internal_transfer_payment_id = paired_payment
+
+            body = _('This payment has been created from <a href=# data-oe-model=account.payment data-oe-id=%d>%s</a>') % (payment.id, payment.name)
+            paired_payment.message_post(body=body)
+            body = _('A second payment has been created: <a href=# data-oe-model=account.payment data-oe-id=%d>%s</a>') % (paired_payment.id, paired_payment.name)
+            payment.message_post(body=body)
+
+            lines = (payment.move_id.line_ids + paired_payment.move_id.line_ids).filtered(
+                lambda l: l.account_id == payment.destination_account_id and not l.reconciled)
+            lines.reconcile()
+
     # -------------------------------------------------------------------------
     # BUSINESS METHODS
     # -------------------------------------------------------------------------
@@ -759,6 +842,10 @@ class AccountPayment(models.Model):
     def action_post(self):
         ''' draft -> posted '''
         self.move_id._post(soft=False)
+
+        self.filtered(
+            lambda pay: pay.is_internal_transfer and not pay.paired_internal_transfer_payment_id
+        )._create_paired_internal_transfer_payment()
 
     def action_cancel(self):
         ''' draft -> cancelled '''
@@ -838,4 +925,35 @@ class AccountPayment(models.Model):
                 'view_mode': 'list,form',
                 'domain': [('id', 'in', self.reconciled_statement_ids.ids)],
             })
+        return action
+
+    def button_open_journal_entry(self):
+        ''' Redirect the user to this payment journal.
+        :return:    An action on account.move.
+        '''
+        self.ensure_one()
+        return {
+            'name': _("Journal Entry"),
+            'type': 'ir.actions.act_window',
+            'res_model': 'account.move',
+            'context': {'create': False},
+            'view_mode': 'form',
+            'res_id': self.move_id.id,
+        }
+
+    def action_open_destination_journal(self):
+        ''' Redirect the user to this destination journal.
+        :return:    An action on account.move.
+        '''
+        self.ensure_one()
+
+        action = {
+            'name': _("Destination journal"),
+            'type': 'ir.actions.act_window',
+            'res_model': 'account.journal',
+            'context': {'create': False},
+            'view_mode': 'form',
+            'target': 'new',
+            'res_id': self.destination_journal_id.id,
+        }
         return action

--- a/addons/account/tests/test_account_payment.py
+++ b/addons/account/tests/test_account_payment.py
@@ -190,13 +190,12 @@ class TestAccountPayment(AccountTestInvoicingCommon):
         ])
 
     def test_payment_move_sync_onchange(self):
-        copy_receivable = self.copy_account(self.company_data['default_account_receivable'])
 
         pay_form = Form(self.env['account.payment'].with_context(default_journal_id=self.company_data['default_journal_bank'].id))
         pay_form.amount = 50.0
         pay_form.payment_type = 'inbound'
         pay_form.partner_type = 'customer'
-        pay_form.destination_account_id = copy_receivable
+        pay_form.partner_id = self.partner_a
         payment = pay_form.save()
 
         expected_payment_values = {
@@ -206,13 +205,13 @@ class TestAccountPayment(AccountTestInvoicingCommon):
             'payment_reference': False,
             'is_reconciled': False,
             'currency_id': self.company_data['currency'].id,
-            'partner_id': False,
-            'destination_account_id': copy_receivable.id,
+            'partner_id': self.partner_a.id,
+            'destination_account_id': self.partner_a.property_account_receivable_id.id,
             'payment_method_id': self.env.ref('account.account_payment_method_manual_in').id,
         }
         expected_move_values = {
             'currency_id': self.company_data['currency'].id,
-            'partner_id': False,
+            'partner_id': self.partner_a.id,
         }
         expected_liquidity_line = {
             'debit': 50.0,
@@ -226,7 +225,7 @@ class TestAccountPayment(AccountTestInvoicingCommon):
             'credit': 50.0,
             'amount_currency': -50.0,
             'currency_id': self.company_data['currency'].id,
-            'account_id': copy_receivable.id,
+            'account_id': self.company_data['default_account_receivable'].id,
         }
 
         self.assertRecordValues(payment, [expected_payment_values])
@@ -284,7 +283,7 @@ class TestAccountPayment(AccountTestInvoicingCommon):
         with move_form.line_ids.edit(1) as line_form:
             line_form.currency_id = self.company_data['currency']
             line_form.amount_currency = -75.0
-            line_form.account_id = copy_receivable
+            line_form.account_id = self.company_data['default_account_receivable']
             line_form.partner_id = self.partner_b
         with move_form.line_ids.new() as line_form:
             line_form.currency_id = self.company_data['currency']
@@ -330,6 +329,7 @@ class TestAccountPayment(AccountTestInvoicingCommon):
         payment = self.env['account.payment'].create({
             'amount': 50.0,
             'is_internal_transfer': True,
+            'destination_journal_id': self.company_data['default_journal_cash'].id,
         })
 
         expected_payment_values = {
@@ -412,6 +412,49 @@ class TestAccountPayment(AccountTestInvoicingCommon):
         self.assertRecordValues(payment.line_ids.sorted('balance'), [
             expected_counterpart_line,
             expected_liquidity_line,
+        ])
+
+        # ==== Check creation of paired internal transfer payment ====
+
+        payment = self.env['account.payment'].create({
+            'amount': 50.0,
+            'is_internal_transfer': True,
+            'payment_type': 'inbound',
+            'destination_journal_id': self.company_data['default_journal_cash'].id,
+        })
+        payment.action_post()
+        paired_payment = self.env['account.payment'].search([('payment_type', '=', 'outbound')])
+        expected_payment_values = {
+            'amount': 50.0,
+            'payment_type': 'outbound',
+            'currency_id': self.company_data['currency'].id,
+            'partner_id': self.company_data['company'].partner_id.id,
+            'destination_account_id': self.company_data['company'].transfer_account_id.id,
+        }
+        expected_move_values = {
+            'currency_id': self.company_data['currency'].id,
+            'partner_id': self.company_data['company'].partner_id.id,
+        }
+        expected_liquidity_line = {
+            'debit': 0.0,
+            'credit': 50.0,
+            'amount_currency': -50.0,
+            'currency_id': self.company_data['currency'].id,
+            'account_id': self.company_data['default_journal_cash'].payment_credit_account_id.id,
+        }
+        expected_counterpart_line = {
+            'debit': 50.0,
+            'credit': 0.0,
+            'amount_currency': 50.0,
+            'currency_id': self.company_data['currency'].id,
+            'account_id': self.company_data['company'].transfer_account_id.id,
+        }
+
+        self.assertRecordValues(paired_payment, [expected_payment_values])
+        self.assertRecordValues(paired_payment.move_id, [expected_move_values])
+        self.assertRecordValues(paired_payment.line_ids.sorted('balance'), [
+            expected_liquidity_line,
+            expected_counterpart_line,
         ])
 
     def test_compute_currency_id(self):

--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -67,7 +67,7 @@
                                     <a role="menuitem" type="object" name="open_action_with_context" context="{'action_name': 'action_bank_statement_line', 'search_default_journal': True}">Operations</a>
                                 </div>
                                 <div>
-                                    <a role="menuitem" type="object" name="open_collect_money">Customer Payments</a>
+                                    <a role="menuitem" type="object" name="open_collect_money">Cust. Payments</a>
                                 </div>
                                 <div>
                                     <a role="menuitem" type="object" name="open_spend_money">Vendor Payments</a>
@@ -93,7 +93,7 @@
                                     </t>
                                 </div>
                                 <div>
-                                    <a role="menuitem" type="object" name="create_customer_payment">Customer Payment</a>
+                                    <a role="menuitem" type="object" name="create_customer_payment">Cust. Payment</a>
                                 </div>
                                 <div>
                                     <a role="menuitem" type="object" name="create_supplier_payment">Vendor Payment</a>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -432,18 +432,20 @@
                     <field name="invoice_partner_display_name" invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund','out_receipt')" groups="base.group_user" string="Customer" />
                     <field name="invoice_date" optional="show" invisible="context.get('default_move_type') not in ('in_invoice', 'in_refund','in_receipt')" string="Bill Date"/>
                     <field name="invoice_date" optional="show" invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund','out_receipt')" string="Invoice Date"/>
+                    <field name="date" optional="hide" invisible="context.get('default_move_type') in ('out_invoice', 'out_refund', 'out_receipt')" string="Accounting Date"/>
                     <field name="invoice_date_due" widget="remaining_days" optional="show" attrs="{'invisible': [['payment_state', 'in', ('paid', 'in_payment', 'reversed')]]}"/>
                     <field name="invoice_origin" optional="hide" string="Source Document"/>
                     <field name="payment_reference" optional="hide" invisible="context.get('default_move_type') in ('out_invoice', 'out_refund','out_receipt')"/>
                     <field name="ref" optional="hide"/>
                     <field name="invoice_user_id" optional="hide" invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund','out_receipt')" string="Sales Person" widget="many2one_avatar_user"/>
                     <field name="activity_ids" widget="list_activity" optional="show"/>
-                    <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" optional="show"/>
+                    <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" optional="hide"/>
                     <field name="amount_untaxed_signed" string="Tax Excluded" sum="Total" optional="show"/>
                     <field name="amount_tax_signed" string="Tax" sum="Total" optional="hide"/>
                     <field name="amount_total_signed" string="Total" sum="Total" decoration-bf="1" optional="show"/>
+                    <field name="amount_total_in_currency_signed" string="Total in Currency" groups="base.group_multi_currency"  optional="show"/>
                     <field name="amount_residual_signed" string="Amount Due" sum="Amount Due" optional="hide"/>
-                    <field name="currency_id" invisible="1"/>
+                    <field name="currency_id" groups="base.group_multi_currency" optional="hide"/>
                     <field name="company_currency_id" invisible="1"/>
                     <field name="state" widget="badge" decoration-success="state == 'posted'" decoration-info="state == 'draft'" optional="show"/>
                     <field name="payment_state" widget="badge" decoration-danger="payment_state == 'not_paid'" decoration-warning="payment_state in ('partial', 'in_payment')" decoration-success="payment_state in ('paid', 'reversed')" attrs="{'invisible': [('payment_state', 'in', ('invoicing_legacy'))]}"/>
@@ -462,6 +464,21 @@
                 <xpath expr="//tree" position="attributes">
                     <attribute name="banner_route">/account/account_invoice_onboarding</attribute>
                 </xpath>
+                <field name="currency_id" position="attributes">
+                    <attribute name="string">Invoice Currency</attribute>
+                </field>
+            </field>
+        </record>
+
+        <record id="view_out_credit_note_tree" model="ir.ui.view">
+            <field name="name">account.out.invoice.tree</field>
+            <field name="model">account.move</field>
+            <field name="inherit_id" ref="account.view_invoice_tree"/>
+            <field name="mode">primary</field>
+            <field name="arch" type="xml">
+                <field name="currency_id" position="attributes">
+                    <attribute name="string">Credit Note Currency</attribute>
+                </field>
             </field>
         </record>
 
@@ -478,6 +495,42 @@
                 <xpath expr="//field[@name='payment_state']" position="attributes">
                     <attribute name="optional">hide</attribute>
                 </xpath>
+            </field>
+        </record>
+
+        <record id="view_in_invoice_bill_tree" model="ir.ui.view">
+            <field name="name">account.out.invoice.tree</field>
+            <field name="model">account.move</field>
+            <field name="inherit_id" ref="account.view_in_invoice_tree"/>
+            <field name="mode">primary</field>
+            <field name="arch" type="xml">
+                <field name="currency_id" position="attributes">
+                    <attribute name="string">Bill Currency</attribute>
+                </field>
+            </field>
+        </record>
+
+        <record id="view_in_invoice_refund_tree" model="ir.ui.view">
+            <field name="name">account.out.invoice.tree</field>
+            <field name="model">account.move</field>
+            <field name="inherit_id" ref="account.view_in_invoice_tree"/>
+            <field name="mode">primary</field>
+            <field name="arch" type="xml">
+                <field name="currency_id" position="attributes">
+                    <attribute name="string">Refund Currency</attribute>
+                </field>
+            </field>
+        </record>
+
+        <record id="view_in_invoice_receipt_tree" model="ir.ui.view">
+            <field name="name">account.out.invoice.tree</field>
+            <field name="model">account.move</field>
+            <field name="inherit_id" ref="account.view_in_invoice_tree"/>
+            <field name="mode">primary</field>
+            <field name="arch" type="xml">
+                <field name="currency_id" position="attributes">
+                    <attribute name="string">Receipt Currency</attribute>
+                </field>
             </field>
         </record>
 
@@ -1234,6 +1287,7 @@
                     <filter name="late" string="Overdue" domain="['&amp;', ('invoice_date_due', '&lt;', time.strftime('%%Y-%%m-%%d')), ('state', '=', 'posted'), ('payment_state', 'in', ('not_paid', 'partial'))]" help="Overdue invoices, maturity date passed"/>
                     <separator/>
                     <filter name="invoice_date" string="Invoice Date" date="invoice_date"/>
+                    <filter name="date" invisible="context.get('default_move_type') in ('out_invoice', 'out_refund', 'out_receipt')" string="Accounting Date" date="date"/>
                     <filter name="due_date" string="Due Date" date="invoice_date_due"/>
                     <separator/>
                     <filter invisible="1" string="Late Activities" name="activities_overdue"
@@ -1395,7 +1449,7 @@
             <field name="name">Credit Notes</field>
             <field name="res_model">account.move</field>
             <field name="view_mode">tree,kanban,form</field>
-            <field name="view_id" ref="view_invoice_tree"/>
+            <field name="view_id" ref="view_out_credit_note_tree"/>
             <field name="search_view_id" ref="view_account_invoice_filter"/>
             <field name="domain">[('move_type', '=', 'out_refund')]</field>
             <field name="context">{'default_move_type': 'out_refund'}</field>
@@ -1413,7 +1467,7 @@
             <field name="name">Bills</field>
             <field name="res_model">account.move</field>
             <field name="view_mode">tree,kanban,form</field>
-            <field name="view_id" ref="view_in_invoice_tree"/>
+            <field name="view_id" ref="view_in_invoice_bill_tree"/>
             <field name="search_view_id" ref="view_account_invoice_filter"/>
             <field name="domain">[('move_type', '=', 'in_invoice')]</field>
             <field name="context">{'default_move_type': 'in_invoice'}</field>
@@ -1430,7 +1484,7 @@
             <field name="name">Refunds</field>
             <field name="res_model">account.move</field>
             <field name="view_mode">tree,kanban,form</field>
-            <field name="view_id" ref="view_in_invoice_tree"/>
+            <field name="view_id" ref="view_in_invoice_refund_tree"/>
             <field name="search_view_id" ref="view_account_invoice_filter"/>
             <field name="domain">[('move_type', '=', 'in_refund')]</field>
             <field name="context">{'default_move_type': 'in_refund'}</field>
@@ -1465,7 +1519,7 @@
             <field name="name">Receipts</field>
             <field name="res_model">account.move</field>
             <field name="view_mode">tree,kanban,form</field>
-            <field name="view_id" ref="view_in_invoice_tree"/>
+            <field name="view_id" ref="view_in_invoice_receipt_tree"/>
             <field name="search_view_id" ref="view_account_invoice_filter"/>
             <field name="domain">[('move_type', '=', 'in_receipt')]</field>
             <field name="context">{'default_move_type': 'in_receipt'}</field>

--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -12,15 +12,16 @@
                     <header>
                         <button name="action_post" type="object" string="Confirm"/>
                     </header>
+                    <field name="company_currency_id" invisible="1"/>
                     <field name="date"/>
                     <field name="name"/>
                     <field name="journal_id"/>
                     <field name="payment_method_id"/>
                     <field name="partner_id" string="Customer"/>
-                    <field name="company_id" groups="base.group_multi_company"/>
-                    <field name="amount" sum="Amount"/>
+                    <field name="amount_signed" string="Amount in Currency" groups="base.group_multi_currency" optional="hide"/>
+                    <field name="currency_id" string="Payment Currency" groups="base.group_multi_currency" optional="hide"/>
+                    <field name="amount_company_currency_signed" widget="monetary" string="Amount" sum="Total"/>
                     <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-success="state == 'posted'"/>
-                    <field name="currency_id" groups="base.group_multi_currency"/>
                 </tree>
             </field>
         </record>
@@ -33,6 +34,18 @@
             <field name="arch" type="xml">
                 <field name="partner_id" position="attributes">
                     <attribute name="string">Vendor</attribute>
+                </field>
+            </field>
+        </record>
+
+        <record id="view_account_various_payment_tree" model="ir.ui.view">
+            <field name="name">account.supplier.payment.tree</field>
+            <field name="model">account.payment</field>
+            <field name="inherit_id" ref="account.view_account_payment_tree"/>
+            <field name="mode">primary</field>
+            <field name="arch" type="xml">
+                <field name="partner_id" position="attributes">
+                    <attribute name="string">Partner</attribute>
                 </field>
             </field>
         </record>
@@ -147,7 +160,14 @@
                                 attrs="{'invisible': ['|', '|', ('state', '!=', 'posted'), ('is_move_sent', '=', False), ('payment_method_code', '!=', 'manual')]}"/>
                         <field name="state" widget="statusbar" statusbar_visible="draft,posted"/>
                     </header>
-
+                    <div class="alert alert-info text-center" role="alert" attrs="{'invisible': ['|',('paired_internal_transfer_payment_id','!=',False),('is_internal_transfer','=',False)]}">
+                        A second payment will be created automatically in the destination journal.
+                    </div>
+                    <div class="alert alert-warning text-center" role="alert" attrs="{
+                            'invisible': ['|', '|', ('is_internal_transfer','=',False), ('require_partner_bank_account', '=', False), ('partner_bank_id', '!=', False)]}">
+                        The selected payment method requires a bank account but none is set on 
+                        <button class="oe_link alert-link" type="object" name="action_open_destination_journal" style="padding: 0; vertical-align: baseline;">the destination journal</button>.
+                    </div>
                     <sheet>
                         <!-- Invisible fields -->
                         <field name="id" invisible="1"/>
@@ -160,6 +180,11 @@
                         <field name="available_payment_method_ids" invisible="1"/>
                         <field name="suitable_journal_ids" invisible="1"/>
                         <field name="country_code" invisible="1"/>
+                        <field name="partner_type" invisible="1"/>
+                        <field name="posted_before" invisible="1"/>
+                        <field name="reconciled_invoices_type" invisible="1"/>
+                        <field name="company_id" invisible="1"/>
+                        <field name="paired_internal_transfer_payment_id" invisible="1"/>
 
                         <div class="oe_button_box" name="button_box">
                             <!-- Invoice stat button -->
@@ -167,8 +192,10 @@
                                     class="oe_stat_button" icon="fa-bars"
                                     attrs="{'invisible': [('reconciled_invoices_count','=', 0)]}">
                                 <field name="reconciled_invoices_count"/>
-                                <span attrs="{'invisible': [('reconciled_invoices_count','&gt;', 1)]}">Invoice</span>
-                                <span attrs="{'invisible': [('reconciled_invoices_count','&lt;=', 1)]}">Invoices</span>
+                                <span attrs="{'invisible': ['|',('reconciled_invoices_type','!=','invoice'),('reconciled_invoices_count','&gt;', 1)]}">Invoice</span>
+                                <span attrs="{'invisible': ['|',('reconciled_invoices_type','!=','invoice'),('reconciled_invoices_count','&lt;=', 1)]}">Invoices</span>
+                                <span attrs="{'invisible': ['|',('reconciled_invoices_type','=','invoice'),('reconciled_invoices_count','&gt;', 1)]}">Credit Note</span>
+                                <span attrs="{'invisible': ['|',('reconciled_invoices_type','=','invoice'),('reconciled_invoices_count','&lt;=', 1)]}">Credit Notes</span>
                             </button>
 
                             <!-- Bill stat button -->
@@ -188,6 +215,11 @@
                                 <span attrs="{'invisible': [('reconciled_statements_count','&gt;', 1)]}">Statement</span>
                                 <span attrs="{'invisible': [('reconciled_statements_count','&lt;=', 1)]}">Statements</span>
                             </button>
+
+                            <!-- Journal Entry  button -->
+                            <button name="button_open_journal_entry" type="object" class="oe_stat_button" icon="fa-bars">
+                                Journal Entry
+                            </button>
                         </div>
 
                         <widget name="web_ribbon" text="Invoicing App Legacy"
@@ -196,46 +228,24 @@
                                 tooltip="This payment has been generated through the Invoicing app, before installing Accounting. It has been disabled by the 'Invoicing Switch Threshold Date' setting so that it does not impact your accounting."
                         />
 
-                        <div class="oe_title" attrs="{'invisible': [('state', '=', 'draft')]}">
-                            <h1><field name="name" attrs="{'readonly': [('state', '!=', 'draft')]}"/></h1>
+                        <div class="oe_title">
+                            <h1 attrs="{'invisible': [('state', '!=', 'draft')]}"><span>Draft</span></h1>
+                            <h1 attrs="{'invisible': [('state', '=', 'draft')]}"><field name="name" readonly="1"/></h1>
                         </div>
 
                         <group>
                             <group name="group1">
-                                <field name="payment_type" widget="radio"
-                                       attrs="{'readonly': [('state', '!=', 'draft')]}"/>
-                                <field name="partner_type" widget="selection"
-                                       attrs="{'readonly': [('state', '!=', 'draft')], 'invisible': [('is_internal_transfer', '=', True)]}"/>
-                                <field name="partner_id" context="{'default_is_company': True}"
-                                       attrs="{'readonly': ['|', ('state', '!=', 'draft'), ('is_internal_transfer', '=', True)]}"/>
-                                <field name="destination_account_id"
-                                       options="{'no_create': True}" required="1"
-                                       attrs="{'readonly': ['|', ('state', '!=', 'draft'), ('is_internal_transfer', '=', True)]}"/>
-                                <field name="is_internal_transfer"
-                                       attrs="{'readonly': [('state', '!=', 'draft')]}"/>
-                                <field name="company_id" groups="base.group_multi_company"/>
-                            </group>
-                            <group name="group2">
-                                <field name="journal_id"
-                                       widget="selection"
-                                       domain="[('type', 'in', ('bank', 'cash'))]"
-                                       attrs="{'readonly': [('state', '!=', 'draft')]}"/>
-                                <field name="payment_method_id" widget="radio"
-                                       required="1"
-                                       attrs="{'readonly': [('state', '!=', 'draft')], 'invisible': [('hide_payment_method', '=', True)]}"/>
-                                <field name="partner_bank_id" context="{'default_partner_id': partner_id}"
-                                       attrs="{'invisible': [('show_partner_bank_account', '=', False)], 'required': [('require_partner_bank_account', '=', True)], 'readonly': [('state', '!=', 'draft')]}"/>
-
-                                <!-- /!\ Required due to the _inherits but must not be required when saving a new
-                                record. Using 'required': [('id', '!=', False)] is not working due to the groups set on
-                                the field.
-                                -->
-                                <field name="move_id"
-                                       required="0"
-                                       attrs="{'invisible': [('id', '=', False)]}"
-                                       groups="account.group_account_readonly"/>
-                            </group>
-                            <group name="group3">
+                                <field name="is_internal_transfer" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
+                                <field name="payment_type" widget="radio" options="{'horizontal': True}" 
+                                        attrs="{'readonly': [('state', '!=', 'draft')]}"/>
+                                <field name="partner_id" context="{'default_is_company': True}" string="Customer"
+                                       attrs="{'readonly':[('state', '!=', 'draft')],
+                                             'invisible':['|', ('partner_type','!=','customer'), ('is_internal_transfer', '=', True)],
+                                             'required': [('partner_type','=','customer')]}"/>
+                                <field name="partner_id" context="{'default_is_company': True}" string="Vendor"
+                                       attrs="{'readonly':[('state', '!=', 'draft')],
+                                               'invisible':['|', ('partner_type','!=','supplier'), ('is_internal_transfer', '=', True)],
+                                               'required': [('partner_type','=','supplier')]}"/>
                                 <label for="amount"/>
                                 <div name="amount_div" class="o_row">
                                     <field name="amount"
@@ -250,7 +260,30 @@
                                        attrs="{'readonly': [('state', '!=', 'draft')]}"/>
                                 <field name="ref" string="Memo"/>
                             </group>
+                            <group name="group2">
+                                <field name="journal_id"
+                                       domain="[('type', 'in', ('bank', 'cash'))]"
+                                       attrs="{'readonly': [('state', '!=', 'draft')]}"/>
+                                <field name="payment_method_id" required="1" widget="selection"
+                                       attrs="{'readonly': [('state', '!=', 'draft')], 'invisible': [('hide_payment_method', '=', True)]}"/>
 
+                                <field name="partner_bank_id" context="{'default_partner_id': partner_id}" string="Customer Bank Account"
+                                        attrs="{
+                                            'invisible': ['|', '|', ('show_partner_bank_account', '=', False), ('partner_type','!=','customer'), ('is_internal_transfer', '=', True)],
+                                            'required': [('require_partner_bank_account', '=', True), ('is_internal_transfer', '=', False)],
+                                            'readonly': [('state', '!=', 'draft')]
+                                        }"/>
+
+                                <field name="partner_bank_id" context="{'default_partner_id': partner_id}" string="Vendor Bank Account"
+                                        attrs="{
+                                            'invisible': ['|', '|', ('show_partner_bank_account', '=', False), ('partner_type','!=','supplier'), ('is_internal_transfer', '=', True)],
+                                            'required': [('require_partner_bank_account', '=', True), ('is_internal_transfer', '=', False)],
+                                            'readonly': [('state', '!=', 'draft')]
+                                        }"/>
+                                <field name="destination_journal_id" context="{'default_partner_id': partner_id}"
+                                       attrs="{'invisible': [('is_internal_transfer', '=', False)],
+                                       'readonly': [('state', '!=', 'draft')], 'required': [('is_internal_transfer', '=', True)]}"/>
+                            </group>
                             <group>
                                 <field name="qr_code" invisible="1"/>
                                 <div attrs="{'invisible': [('qr_code', '=', False)]}" colspan="2" class="text-center">

--- a/addons/account_check_printing/views/account_payment_views.xml
+++ b/addons/account_check_printing/views/account_payment_views.xml
@@ -13,7 +13,7 @@
                 <xpath expr="//div[@name='amount_div']" position="after">
                     <field name="check_amount_in_words" attrs="{'invisible': [('payment_method_code', '!=', 'check_printing')]}" groups="base.group_no_one"/>
                 </xpath>
-                <xpath expr="//field[@name='ref']" position="after">
+                <xpath expr="//field[@name='payment_method_id']" position="after">
                     <field name="check_manual_sequencing" invisible="1"/>
                     <field name="check_number" attrs="{'invisible': ['|', ('payment_method_code', '!=', 'check_printing'), ('check_number', '=', False)]}"/>
                 </xpath>

--- a/addons/account_edi/views/account_payment_views.xml
+++ b/addons/account_edi/views/account_payment_views.xml
@@ -51,7 +51,7 @@
                     <field name="edi_document_ids" invisible="1" />
                     <field name="edi_state" attrs="{'invisible': ['|', ('edi_state', '=', False), ('state', '=', 'draft')]}"/>
                 </xpath>
-                <xpath expr="//group[@name='group3']" position="after">
+                <xpath expr="//group[@name='group2']" position="after">
                     <group groups="base.group_no_one">
                         <field name="edi_document_ids" string="EDI Documents" attrs="{'invisible': [('edi_document_ids', '=', [])]}">
                             <tree create="false" delete="false" edit="false" decoration-danger="error">


### PR DESCRIPTION
[IMP] account: Payments Form View Improvement

Improvements of the Payment form view & Allow outgoing payments from Odoo that are neither to a vendor nor to a customer nor internal.
eg. : It should be possible to mention a payment to the VAT administation, the payment of a caution to a third-party, ...

- Add "Various" payment_type
- Always display "Draft" or the sequence
- Hide "Partner Type"
- Turn Label "Customer/ Vendor" into Customer, Vendor or Various depending on the context.
- Hide partner_id when is internal transfer
- Add Journal smart button
- Add "Various Payments" menu item
- Add message in chatter linking paired payments to each other
- Add/fix in currency or not Amount/Total colums for payments and moves
- Prevent reconciling two amount on an account that would be simultaneously
  the Outstanding Payment (Cr) and the Outstanding Receipt one at the same time.
- Other cosmetic changes

Task: 2403336

Enterprise PR: https://github.com/odoo/enterprise/pull/16308