### PR TITLE
[FIX] mass_mailing,web_editor: content no under sidebar


### DIFF
--- a/addons/mass_mailing/static/src/scss/mass_mailing.ui.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.ui.scss
@@ -199,10 +199,6 @@ body.editor_enable.o_basic_theme.o_in_iframe {
 
 .oe_structure {
     width: 100%;
-    @media (max-width: map-get($grid-breakpoints, 'lg')) {
-        width: auto;
-        margin-right: $o-we-sidebar-width;
-    }
 }
 
 :root {

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -27,8 +27,6 @@ body.editor_enable.editor_has_snippets {
 // Mobile fix for mass mailing
 @include media-breakpoint-down(md) {
     body.editor_enable.editor_has_snippets {
-        padding-right: inherit !important;
-
         #web_editor-top-edit {
             position: initial !important;
             height: initial !important;


### PR DESCRIPTION

Depdending on situation several fixes (f885202, fc8e446) leads to issue
in small screen size:

- in iframe editor with without snippets => the width of the content is
  decreased of several times the sidebar that is not shown

- in editor with sidebar => the content gets behind the sidebar

With this changeset we remove part of the above commits which seem to
fix both issue.

note: this also fixes that the mass mailing content applied CSS should
not depend on screen size, or what is send would differ dependin on
which screen size clicked on SAVE (on last inlining of CSS).

opw-2426400
