### PR TITLE
[FIX] web: show more text of short calendar event


### DIFF
--- a/addons/web/static/src/scss/web_calendar.scss
+++ b/addons/web/static/src/scss/web_calendar.scss
@@ -51,6 +51,11 @@ $o-cw-filter-avatar-size: 20px;
             font-weight: 500;
         }
 
+        // Try to show one full lien for short event
+        &.fc-short .fc-content {
+            margin-top: 2px;
+        }
+
         &.o_cw_custom_highlight {
             z-index: 10!important;
 


### PR DESCRIPTION

In a4d170ad9 there were some improvment to not show event totally empty
on the day calendar view because of different style (font + padding).

The lower part of the text was still a little cut, this commit try to
improve this for week and day view mode by removing 5 additional pixels.

opw-2422700
