### PR TITLE
[FIX] web_editor: prevent crash on link edit

### DIFF
--- a/addons/web_editor/static/lib/summernote/src/js/module/Editor.js
+++ b/addons/web_editor/static/lib/summernote/src/js/module/Editor.js
@@ -680,7 +680,9 @@ define([
      * @return {String} [return.url=""]
      */
     this.getLinkInfo = function ($editable) {
-      this.focus($editable);
+      // ODOO: modification
+      // this.focus($editable);
+      this.focus($editable.closest(':not(form)'));
 
       var rng = range.create().expand(dom.isAnchor);
 


### PR DESCRIPTION
Go to Website
Go to conatct us form
Switch in Edit mode
Click on “send” (or "submit")
click on edit link

A js traceback will apper. This occur because we refocus an elements
which may not be the correct one. In this case $editable will contain
all the contact form instead of just the relevant div of the submit
button

opw-2439090

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
