### PR TITLE
[FIX] point_of_sale: Fix pos reload with employee

### DIFF
--- a/addons/pos_hr/static/src/js/models.js
+++ b/addons/pos_hr/static/src/js/models.js
@@ -88,7 +88,7 @@ models.Order = models.Order.extend({
     export_as_JSON: function () {
         const json = super_order_model.export_as_JSON.apply(this, arguments);
         if (this.pos.config.module_pos_hr) {
-            json.employee_id = this.employee.id;
+            json.employee_id = this.employee? this.employee.id : false;
         }
         return json;
     },


### PR DESCRIPTION
Fix the traceback when a session was loaded with the employee feature. If the page was refreshed, there was an undefined employee on the order.
Added a check to see if the employee was set or not.

task-id: 2459761

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
