### PR TITLE
[IMP] account: Back 2 Basics improvements

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -80,7 +80,8 @@ class AccountJournal(models.Model):
                "'|', ('user_type_id', '=', default_account_type), ('user_type_id', 'in', type_control_ids),"
                "('user_type_id.type', 'not in', ('receivable', 'payable'))]")
     payment_debit_account_id = fields.Many2one(
-        comodel_name='account.account', check_company=True, copy=False, ondelete='restrict',
+        comodel_name='account.account', check_company=True, ondelete='restrict',
+        compute='_compute_payment_debit_account_id', store=True, readonly=False,
         help="Incoming payments entries triggered by invoices/refunds will be posted on the Outstanding Receipts Account "
              "and displayed as blue lines in the bank reconciliation widget. During the reconciliation process, concerned "
              "transactions will be reconciled with entries on the Outstanding Receipts Account instead of the "
@@ -89,7 +90,8 @@ class AccountJournal(models.Model):
                              ('user_type_id.type', 'not in', ('receivable', 'payable')), \
                              '|', ('user_type_id', '=', %s), ('id', '=', default_account_id)]" % self.env.ref('account.data_account_type_current_assets').id)
     payment_credit_account_id = fields.Many2one(
-        comodel_name='account.account', check_company=True, copy=False, ondelete='restrict',
+        comodel_name='account.account', check_company=True, ondelete='restrict',
+        compute='_compute_payment_credit_account_id', store=True, readonly=False,
         help="Outgoing payments entries triggered by bills/credit notes will be posted on the Outstanding Payments Account "
              "and displayed as blue lines in the bank reconciliation widget. During the reconciliation process, concerned "
              "transactions will be reconciled with entries on the Outstanding Payments Account instead of the "
@@ -256,6 +258,30 @@ class AccountJournal(models.Model):
                 journal.suspense_account_id = journal.company_id.account_journal_suspense_account_id
             else:
                 journal.suspense_account_id = False
+
+    @api.depends('company_id', 'type')
+    def _compute_payment_debit_account_id(self):
+        for journal in self:
+            if journal.type not in ('bank', 'cash'):
+                journal.payment_debit_account_id = False
+            elif journal.payment_debit_account_id:
+                journal.payment_debit_account_id = journal.payment_debit_account_id
+            elif journal.company_id.account_journal_payment_debit_account_id:
+                journal.payment_debit_account_id = journal.company_id.account_journal_payment_debit_account_id
+            else:
+                journal.payment_debit_account_id = False
+
+    @api.depends('company_id', 'type')
+    def _compute_payment_credit_account_id(self):
+        for journal in self:
+            if journal.type not in ('bank', 'cash'):
+                journal.payment_credit_account_id = False
+            elif journal.payment_credit_account_id:
+                journal.payment_credit_account_id = journal.payment_credit_account_id
+            elif journal.company_id.account_journal_payment_credit_account_id:
+                journal.payment_credit_account_id = journal.company_id.account_journal_payment_credit_account_id
+            else:
+                journal.payment_credit_account_id = False
 
     def _compute_alias_domain(self):
         alias_domain = self._default_alias_domain()
@@ -491,7 +517,6 @@ class AccountJournal(models.Model):
 
         if journal_type in ('bank', 'cash'):
             has_liquidity_accounts = vals.get('default_account_id')
-            has_payment_accounts = vals.get('payment_debit_account_id') or vals.get('payment_credit_account_id')
             has_profit_account = vals.get('profit_account_id')
             has_loss_account = vals.get('loss_account_id')
 
@@ -514,21 +539,6 @@ class AccountJournal(models.Model):
                 default_account_code = self.env['account.account']._search_new_account_code(company, digits, liquidity_account_prefix)
                 default_account_vals = self._prepare_liquidity_account_vals(company, default_account_code, vals)
                 vals['default_account_id'] = self.env['account.account'].create(default_account_vals).id
-            if not has_payment_accounts:
-                vals['payment_debit_account_id'] = self.env['account.account'].create({
-                    'name': _("Outstanding Receipts"),
-                    'code': self.env['account.account']._search_new_account_code(company, digits, liquidity_account_prefix),
-                    'reconcile': True,
-                    'user_type_id': current_assets_type.id,
-                    'company_id': company.id,
-                }).id
-                vals['payment_credit_account_id'] = self.env['account.account'].create({
-                    'name': _("Outstanding Payments"),
-                    'code': self.env['account.account']._search_new_account_code(company, digits, liquidity_account_prefix),
-                    'reconcile': True,
-                    'user_type_id': current_assets_type.id,
-                    'company_id': company.id,
-                }).id
             if journal_type == 'cash' and not has_profit_account:
                 vals['profit_account_id'] = company.default_cash_difference_income_account_id.id
             if journal_type == 'cash' and not has_loss_account:

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -52,6 +52,8 @@ class ResCompany(models.Model):
     default_cash_difference_income_account_id = fields.Many2one('account.account', string="Cash Difference Income Account")
     default_cash_difference_expense_account_id = fields.Many2one('account.account', string="Cash Difference Expense Account")
     account_journal_suspense_account_id = fields.Many2one('account.account', string='Journal Suspense Account')
+    account_journal_payment_debit_account_id = fields.Many2one('account.account', string='Journal Outstanding Receipts Account')
+    account_journal_payment_credit_account_id = fields.Many2one('account.account', string='Journal Outstanding Payments Account')
     transfer_account_code_prefix = fields.Char(string='Prefix of the transfer accounts')
     account_sale_tax_id = fields.Many2one('account.tax', string="Default Sale Tax")
     account_purchase_tax_id = fields.Many2one('account.tax', string="Default Purchase Tax")

--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -38,6 +38,31 @@ class ResConfigSettings(models.TransientModel):
     purchase_tax_id = fields.Many2one('account.tax', string="Default Purchase Tax", related='company_id.account_purchase_tax_id', readonly=False)
     tax_calculation_rounding_method = fields.Selection(
         related='company_id.tax_calculation_rounding_method', string='Tax calculation rounding method', readonly=False)
+    account_journal_suspense_account_id = fields.Many2one(
+        comodel_name='account.account',
+        string='Suspense Account',
+        readonly=False,
+        related='company_id.account_journal_suspense_account_id',
+        domain=lambda self: "[('deprecated', '=', False), ('company_id', '=', company_id), ('user_type_id.type', 'not in', ('receivable', 'payable')), ('user_type_id', '=', %s)]" % self.env.ref('account.data_account_type_current_liabilities').id,
+        help='Account used as automatic counterpart to bank/cash transactions')
+    account_journal_payment_debit_account_id = fields.Many2one(
+        comodel_name='account.account',
+        string='Outstanding Receipts Account',
+        readonly=False,
+        related='company_id.account_journal_payment_debit_account_id',
+        domain=lambda self: "[('deprecated', '=', False), ('company_id', '=', company_id), ('user_type_id.type', 'not in', ('receivable', 'payable')), ('user_type_id', '=', %s)]" % self.env.ref('account.data_account_type_current_assets').id,
+        help='Account used as automatic counterpart account to payments received')
+    account_journal_payment_credit_account_id = fields.Many2one(
+        comodel_name='account.account',
+        string='Outstanding Payments Account',
+        readonly=False,
+        related='company_id.account_journal_payment_credit_account_id',
+        domain=lambda self: "[('deprecated', '=', False), ('company_id', '=', company_id), ('user_type_id.type', 'not in', ('receivable', 'payable')), ('user_type_id', '=', %s)]" % self.env.ref('account.data_account_type_current_assets').id,
+        help='Account used as automatic counterpart account to payments sent')
+    transfer_account_id = fields.Many2one('account.account', string="Internal Transfer Account",
+        related='company_id.transfer_account_id', readonly=False,
+        domain=lambda self: [('reconcile', '=', True), ('user_type_id.id', '=', self.env.ref('account.data_account_type_current_assets').id)],
+        help="Intermediary account used to transfer money from one bank/cash account to another bank/cash account")
     module_account_accountant = fields.Boolean(string='Accounting')
     group_analytic_accounting = fields.Boolean(string='Analytic Accounting',
         implied_group='analytic.group_analytic_accounting')

--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -11,8 +11,14 @@
                     <field name='sequence' widget='handle'/>
                     <field name="name"/>
                     <field name="type"/>
-                    <field name="journal_group_ids" widget="many2many_tags" readonly="1"/>
-                    <field name="company_id" groups="base.group_multi_company"/>
+                    <field name="journal_group_ids" widget="many2many_tags" readonly="1" optional="show"/>
+                    <field name="currency_id" groups="base.group_multi_currency" optional="hide"/>
+                    <field name="code" optional="show"/>
+                    <field name="default_account_id" optional="show"/>
+                    <field name="payment_debit_account_id" optional="hide"/>
+                    <field name="payment_credit_account_id" optional="hide"/>
+                    <field name="active" optional="hide"/>
+                    <field name="company_id" groups="base.group_multi_company" optional="hide"/>
                 </tree>
             </field>
         </record>

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -157,25 +157,10 @@
                                     <div class="text-muted">
                                         Record transactions in foreign currencies
                                     </div>
-                                    <div class="content-group" attrs="{'invisible': [('group_multi_currency', '=', False)]}">
-                                        <div class="mt8">
-                                            <button name="%(base.action_currency_all_form)d" icon="fa-arrow-right" type="action" string="Activate Other Currencies" class="btn-link"/>
-                                        </div>
-                                        <div class="mt16">
-                                            <b>Post Exchange difference entries in:</b>
-                                        </div>
-                                        <div class="row mt8">
-                                            <label for="currency_exchange_journal_id" class="col-lg-3 o_light_label" string="Journal" />
-                                            <field name="currency_exchange_journal_id"/>
-                                        </div>
-                                        <div class="row mt8">
-                                            <label for="income_currency_exchange_account_id" class="col-lg-3 o_light_label"/>
-                                            <field name="income_currency_exchange_account_id"/>
-                                        </div>
-                                        <div class="row mt8">
-                                            <label for="expense_currency_exchange_account_id" class="col-lg-3 o_light_label"/>
-                                            <field name="expense_currency_exchange_account_id"/>
-                                        </div>
+                                </div>
+                                <div class="content-group" attrs="{'invisible': [('group_multi_currency', '=', False)]}">
+                                    <div class="mt8">
+                                        <button name="%(base.action_currency_all_form)d" icon="fa-arrow-right" type="action" string="Activate Other Currencies" class="btn-link"/>
                                     </div>
                                 </div>
                             </div>
@@ -460,6 +445,59 @@
                                 </div>
                             </div>
                         </div>
+
+                        <t groups="account.group_account_user" attrs="{'invisible': [('chart_template_id','=',False)]}">
+                            <h2>Default Accounts</h2>
+                            <div class="row mt16 o_settings_container" id="default_accounts">
+                                <div class="col-12 col-lg-6 o_setting_box"
+                                    attrs="{'invisible': [('group_multi_currency', '=', False)]}">
+                                    <div class="o_setting_left_pane"></div>
+                                    <div class="o_setting_right_pane">
+                                        <div class="content-group">
+                                            <div>
+                                                <span class="o_form_label">Post Exchange difference entries in:</span>
+                                            </div>
+                                            <div class="row mt8">
+                                                <label for="currency_exchange_journal_id" class="col-lg-4 o_light_label" string="Journal" />
+                                                <field name="currency_exchange_journal_id"/>
+                                            </div>
+                                            <div class="row mt8">
+                                                <label for="income_currency_exchange_account_id" class="col-lg-4 o_light_label"/>
+                                                <field name="income_currency_exchange_account_id"/>
+                                            </div>
+                                            <div class="row mt8">
+                                                <label for="expense_currency_exchange_account_id" class="col-lg-4 o_light_label"/>
+                                                <field name="expense_currency_exchange_account_id"/>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-12 col-lg-6 o_setting_box">
+                                    <div class="o_setting_left_panel"></div>
+                                    <div class="o_setting_right_pane">
+                                        <span class="o_form_label">Post Payments and Money Transfers in:</span>
+                                        <div class="content-group">
+                                            <div class="row mt8">
+                                                <label for="account_journal_suspense_account_id" class="col-lg-5 o_light_label"/>
+                                                <field name="account_journal_suspense_account_id"/>
+                                            </div>
+                                            <div class="row mt8">
+                                                <label for="account_journal_payment_debit_account_id" class="col-lg-5 o_light_label"/>
+                                                <field name="account_journal_payment_debit_account_id"/>
+                                            </div>
+                                            <div class="row mt8">
+                                                <label for="account_journal_payment_credit_account_id" class="col-lg-5 o_light_label"/>
+                                                <field name="account_journal_payment_credit_account_id"/>
+                                            </div>
+                                            <div class="row mt8">
+                                                <label for="transfer_account_id" class="col-lg-5 o_light_label"/>
+                                                <field name="transfer_account_id"/>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </t>
 
                         <t groups="account.group_account_user">
                             <h2>Bank &amp; Cash</h2>


### PR DESCRIPTION
Now when duplicating a bank or cash journal, the outstanding accounts are
the same as the original journal.

Added a compute method for payment_credit_account_id and payment_debit_account_id
to retrieve the default value from the company. These default accounts can be
changed in the settings.

Change UI for some settings (Default accounts).

Added a smart button on payments to access the linked journal entry.

Changing the tree view of account.journal:
  - Edit journal_group_ids: Optional show
  - Add currency_id: Optional hide
  - Add code: Optional show
  - Add default_account_id
  - Add payment_debit_account_id: Optional hide
  - Add payment_credit_account_id: Optional hide
  - Add active

**Task ID:** #2451842





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
