### PR TITLE
[REV] account: revert commit 08f3d2b90e3d48daa26ab48872b9cfd4d8db981f

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3646,19 +3646,16 @@ class AccountMoveLine(models.Model):
     @api.depends('move_id.move_type', 'tax_ids', 'tax_repartition_line_id')
     def _compute_tax_tag_invert(self):
         for record in self:
-            rep_line = record.tax_repartition_line_id
-
-            if not rep_line and not record.tax_ids :
+            if not record.tax_repartition_line_id and not record.tax_ids :
                 # Invoices imported from other softwares might only have kept the tags, not the taxes.
                 record.tax_tag_invert = record.tax_tag_ids and record.move_id.is_inbound()
 
             elif record.move_id.move_type == 'entry':
                 # For misc operations, cash basis entries and write-offs from the bank reconciliation widget
+                rep_line = record.tax_repartition_line_id
                 if rep_line:
                     tax_type = (rep_line.refund_tax_id or rep_line.invoice_tax_id).type_tax_use
                     is_refund = bool(rep_line.refund_tax_id)
-                    if rep_line.factor_percent < 0:
-                        is_refund = not is_refund
                 elif record.tax_ids:
                     tax_type = record.tax_ids[0].type_tax_use
                     is_refund = (tax_type == 'sale' and record.debit) or (tax_type == 'purchase' and record.credit)
@@ -3667,10 +3664,7 @@ class AccountMoveLine(models.Model):
 
             else:
                 # For invoices with taxes
-                rslt = record.move_id.is_inbound()
-                if rep_line and rep_line.factor_percent < 0:
-                    rslt = not rslt
-                record.tax_tag_invert = rslt
+                record.tax_tag_invert = record.move_id.is_inbound()
 
     @api.depends('tax_tag_ids', 'debit', 'credit', 'journal_id', 'tax_tag_invert')
     def _compute_tax_audit(self):


### PR DESCRIPTION
We actually want to keep on computing tax tags this way. Consider the following example:

- configure a sales tax like this
amount : 20%

100% - base : +01
100% - taxe : +02
-10% - taxe: -03

- Make an invoice for 100. It looks like this:

credit 100 - debit 0 - +01
credit  20 - debit 0 - +02
credit   0 - debit 2 - -03

===> Since the repartition line was configured with a negative factor, and because credit lines with + tags do + in the report, we actually expect the tax report to contain +2 in grid 03, since we're applying tag -03 to a negative amount. That's why this fix was a bad idea.

