### PR TITLE
[FIX] google_calendar: Fix access to ICP

### DIFF
--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -48,7 +48,7 @@ class Meeting(models.Model):
 
     def _get_sync_domain(self):
         # in case of full sync, limit to a range of 1y in past and 1y in the future by default
-        ICP = self.env['ir.config_parameter']
+        ICP = self.env['ir.config_parameter'].sudo()
         day_range = int(ICP.get_param('google_calendar.sync.range_days', default=365))
         lower_bound = fields.Datetime.subtract(fields.Datetime.now(), days=day_range)
         upper_bound = fields.Datetime.add(fields.Datetime.now(), days=day_range)

--- a/addons/google_calendar/utils/google_calendar.py
+++ b/addons/google_calendar/utils/google_calendar.py
@@ -38,7 +38,7 @@ class GoogleCalendarService():
             params['syncToken'] = sync_token
         else:
             # full sync, limit to a range of 1y in past to 1y in the futur by default
-            ICP = self.google_service.env['ir.config_parameter']
+            ICP = self.google_service.env['ir.config_parameter'].sudo()
             day_range = int(ICP.get_param('google_calendar.sync.range_days', default=365))
             _logger.info("Full cal sync, restricting to %s days range", day_range)
             lower_bound = fields.Datetime.subtract(fields.Datetime.now(), days=day_range)


### PR DESCRIPTION
Issue
-----
An access right error on ir.config.parameter can be raised
if the user need to do a full sync and don't have
admin access right. This may happen a lot

Solution
--------
Sudo to get the ICP




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
