### PR TITLE
[FIX] mrp: archive operations when deactivating WO

### DIFF
--- a/addons/mrp/models/mrp_routing.py
+++ b/addons/mrp/models/mrp_routing.py
@@ -11,6 +11,7 @@ class MrpRoutingWorkcenter(models.Model):
     _check_company_auto = True
 
     name = fields.Char('Operation', required=True)
+    active = fields.Boolean(default=True)
     workcenter_id = fields.Many2one('mrp.workcenter', 'Work Center', required=True, check_company=True)
     sequence = fields.Integer(
         'Sequence', default=100,

--- a/addons/mrp/models/res_config_settings.py
+++ b/addons/mrp/models/res_config_settings.py
@@ -34,7 +34,10 @@ class ResConfigSettings(models.TransientModel):
         # Work Orders' is deactivated.
         # Long story short: if 'mrp_workorder' is already installed, we don't uninstall it based on
         # group_mrp_routings
+        operations = self.env['mrp.routing.workcenter'].with_context({'active_test': False}).search([('company_id', '=', self.company_id.id)])
         if self.group_mrp_routings:
             self.module_mrp_workorder = True
-        elif not self.env['ir.module.module'].search([('name', '=', 'mrp_workorder'), ('state', '=', 'installed')]):
-            self.module_mrp_workorder = False
+        else:
+            operations.action_archive()  # When deactivating workorders we want to archive all the operations linked to the company
+            if not self.env['ir.module.module'].search([('name', '=', 'mrp_workorder'), ('state', '=', 'installed')]):
+                self.module_mrp_workorder = False


### PR DESCRIPTION
When we deactivate the work orders in the settings, new MOs still
use operations that were assigned to the BoM, it just does not show the
Operations tab. We fix that by archiving the operations when work orders
are deactivated in the settings.

Migration script: odoo/upgrade#2344

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
