### PR TITLE
[FIX] point_of_sale: select employee with pin by barcode

### DIFF
--- a/addons/point_of_sale/static/src/js/Popups/NumberPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/NumberPopup.js
@@ -47,6 +47,12 @@ odoo.define('point_of_sale.NumberPopup', function(require) {
                 return this.state.buffer;
             }
         }
+        confirm(event) {
+            const bufferState = event.detail;
+            if (bufferState.buffer !== '') {
+                super.confirm();
+            }
+        }
         sendInput(key) {
             this.trigger('numpad-click-input', { key });
         }


### PR DESCRIPTION
When switching employee on point of sale, we may have a PIN to enter.

If we enter the barcode and there is a PIN, we get an "Invalid Password"
error.

Why:
====

When we switch with a barcode 12, the barcode system will catch events
and prevent their propagation:

- {'type': 'keypress', 'key': 49}
- {'type': 'keypress', 'key': 50}
- {'type': 'keypress', 'key': 13}

For respectively '1', '2', 'Newline'.

If it match an employee, the PIN number modal is opened which will
listen to KEYUP events => it receives very shortly:

- {'type': 'KEYUP', 'key': 13}

which is the newline character which follows the KEYPRESS.

With a "Return" key received, the PIN modale closes with empty value
and an error "Invalid Password" is shown.

Solution:
=========

Ignore the newline character if no number has been selected.

opw-2448585
