### PR TITLE
[IMP] Set the currency of a fixed tax

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -820,6 +820,7 @@ class AccountTaxTemplate(models.Model):
     sequence = fields.Integer(required=True, default=1,
         help="The sequence field is used to define order in which the tax lines are applied.")
     amount = fields.Float(required=True, digits=(16, 4), default=0)
+    currency_id = fields.Many2one('res.currency', string='Currency')
     description = fields.Char(string='Display on Invoices')
     price_include = fields.Boolean(string='Included in Price', default=False,
         help="Check this if the price you use on the product and invoices includes this tax.")

--- a/addons/account/views/account_view.xml
+++ b/addons/account/views/account_view.xml
@@ -1258,6 +1258,8 @@ action = model.setting_init_bank_account_action()
                             <div attrs="{'invisible':[('amount_type','not in', ('fixed', 'percent', 'division'))]}">
                                 <field name="amount" class="oe_inline"/>
                                 <span class="o_form_label oe_inline" attrs="{'invisible':[('amount_type','=','fixed')]}">%</span>
+                                <span class="o_form_label oe_inline" attrs="{'invisible':[('amount_type','!=','fixed')]}">&amp;nbsp;</span>
+                                <field name="currency_id" class="oe_inline" attrs="{'required':[('amount_type','=','fixed')], 'invisible':[('amount_type','!=','fixed')]}"/>
                             </div>
                         </group>
                     </group>

--- a/addons/account_tax_python/models/account_tax.py
+++ b/addons/account_tax_python/models/account_tax.py
@@ -26,16 +26,16 @@ class AccountTaxPython(models.Model):
             ":param product: product.product recordset singleton or None\n"
             ":param partner: res.partner recordset singleton or None")
 
-    def _compute_amount(self, base_amount, price_unit, quantity=1.0, product=None, partner=None):
+    def _compute_amount(self, base_amount, price_unit, quantity=1.0, product=None, partner=None, currency=None, currency_date=None):
         self.ensure_one()
         if product and product._name == 'product.template':
             product = product.product_variant_id
         if self.amount_type == 'code':
             company = self.env.company
-            localdict = {'base_amount': base_amount, 'price_unit':price_unit, 'quantity': quantity, 'product':product, 'partner':partner, 'company': company}
+            localdict = {'base_amount': base_amount, 'price_unit':price_unit, 'quantity': quantity, 'product':product, 'partner':partner, 'company': company, 'currency': currency, 'currency_date': currency_date}
             safe_eval(self.python_compute, localdict, mode="exec", nocopy=True)
             return localdict['result']
-        return super(AccountTaxPython, self)._compute_amount(base_amount, price_unit, quantity, product, partner)
+        return super(AccountTaxPython, self)._compute_amount(base_amount, price_unit, quantity, product, partner, currency, currency_date)
 
     def compute_all(self, price_unit, currency=None, quantity=1.0, product=None, partner=None, is_refund=False, handle_price_include=True):
         taxes = self.filtered(lambda r: r.amount_type != 'code')

--- a/addons/account_tax_python/models/account_tax.py
+++ b/addons/account_tax_python/models/account_tax.py
@@ -32,7 +32,11 @@ class AccountTaxPython(models.Model):
             product = product.product_variant_id
         if self.amount_type == 'code':
             company = self.env.company
-            localdict = {'base_amount': base_amount, 'price_unit':price_unit, 'quantity': quantity, 'product':product, 'partner':partner, 'company': company, 'currency': currency, 'currency_date': currency_date}
+            # mimic the determining of the currency_date to be the same as in the super
+            _currency_date = currency_date
+            if not _currency_date:
+                _currency_date = self._context.get("date", fields.Date.context_today(self))
+            localdict = {'base_amount': base_amount, 'price_unit':price_unit, 'quantity': quantity, 'product':product, 'partner':partner, 'company': company, 'currency': currency, 'currency_date': _currency_date}
             safe_eval(self.python_compute, localdict, mode="exec", nocopy=True)
             return localdict['result']
         return super(AccountTaxPython, self)._compute_amount(base_amount, price_unit, quantity, product, partner, currency, currency_date)


### PR DESCRIPTION
Before this commit you cannot set the currency of a fixed tax, just the
amount. For example if you sell a product and you must pay a 100 HUF
environmental tax no matter which currency you sell the product.

Before this commit if you create a TAX with fixed 100 value, Odoo mean
the currency from the invoice, so if you sell in EUR it will mean 100
EUR.

After this commit if you set the TAX that it is 100 HUF, it will mean
100 HUF no matter which currency you create your invoice with.

The test methodology:

Create 3 currencies:
HUF: 1,00
EUR: 0,01   (=1/100)
USD: 0,0125  (=1/80)

Create two TAX:
"FIX HUF"   with fixed amount 100 HUF
"FIX EUR"   with fixed amount 100 EUR

The company's currency is HUF.
The VAT is 27%

Create three product:
P1  price:100 HUF tax:27%
P2  price:100 HUF tax:27%,"FIX HUF"  
P3  price:100 HUF tax:27%,"FIX EUR"  

Than we created three invoices: HUF, EUR and USD currencies. Than putted every product one-by-one and checked that every amount is correct on the invoice line page and on the journal items page too.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
