### PR TITLE
[FIX] stock: Don't take into account canceled moves to check for back…

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -944,7 +944,9 @@ class Picking(models.Model):
         """
         quantity_todo = {}
         quantity_done = {}
-        for move in self.mapped('move_lines'):
+        # If a preceding move has been canceled and propagated state to its
+        # destination move, we don't take quantities into account
+        for move in self.mapped('move_lines').filtered(lambda m: m.state != "cancel"):
             quantity_todo.setdefault(move.product_id.id, 0)
             quantity_done.setdefault(move.product_id.id, 0)
             quantity_todo[move.product_id.id] += move.product_uom_qty


### PR DESCRIPTION
…order

Description of the issue/feature this PR addresses:

Solve backorder launch when it should not.

Current behavior before PR:

Do a transfer in two steps with several move lines (e.g.: Vendors => Input => Stock).

In the first picking, set quantity = 0 on a single line. Transfer it and say 'No backorder'.

In the second picking, set all quantities (you have two move lines confirmed and one canceled). Validate the
transfer. The backorder wizard is launched. It should not.

Desired behavior after PR is merged:

Do a transfer in two steps with several move lines (e.g.: Vendors => Input => Stock).

In the first picking, set quantity = 0 on a single line. Transfer it and say 'No backorder'.

In the second picking, set all quantities (you have two move lines confirmed and one canceled). Validate the
transfer.

The backorder wizard is not launched


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
