### PR TITLE
[IMP] web_editor: display theme colors at the top of the color picker

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
@@ -69,9 +69,12 @@ const ColorPaletteWidget = Widget.extend({
         const res = this._super.apply(this, arguments);
 
         const $colorSection = this.$('.o_colorpicker_sections[data-color-tab="theme-colors"]');
-        const $clpicker = $(colorpickerArch || `<colorpicker><div class="o_colorpicker_section" data-name="common"></div></colorpicker>`);
+        const $clpicker = $(colorpickerArch || `<colorpicker><div class="o_colorpicker_section" data-name="theme"></div><div class="o_colorpicker_section" data-name="common"></div></colorpicker>`);
         $clpicker.find('button').addClass('o_we_color_btn');
-        $clpicker.appendTo($colorSection);
+        const $clpicker_theme = $clpicker.find('[data-name="theme"]').addClass('o_colorpicker_section_top')
+
+        $clpicker_theme.appendTo($colorSection);
+        $clpicker.insertAfter($clpicker_theme);
 
         // Remove excluded palettes (note: only hide them to still be able
         // to remove their related colors on the DOM target)
@@ -144,7 +147,7 @@ const ColorPaletteWidget = Widget.extend({
             this.colorPicker = new ColorpickerWidget(this, {
                 defaultColor: defaultColor,
             });
-            await this.colorPicker.prependTo($colorSection);
+            await this.colorPicker.insertAfter($clpicker_theme);
         }
 
         return res;

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -1609,6 +1609,10 @@ body.editor_enable.editor_has_snippets {
                 }
             }
         }
+        .o_colorpicker_section_top {
+            padding-top: 0;
+            padding-bottom: $o-we-sidebar-content-field-spacing;
+        }
     }
 }
 


### PR DESCRIPTION
The theme colors are now displayed at the top of the color picker,
helping users to make consistent websites.

The web_editor.colorpicker template was separated with a new
web_editor.colorpicker_theme template that are displayed according
to the new configuration in the color palette widget.

task-2446852

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
