### PR TITLE
[13.0] Backport sale coupon expiration cron from version 14.0

### DIFF
--- a/addons/sale_coupon/data/sale_coupon_email_data.xml
+++ b/addons/sale_coupon/data/sale_coupon_email_data.xml
@@ -101,5 +101,17 @@
             <field name="auto_delete" eval="True"/>
             <field name="user_signature" eval="False"/>
       </record>
+
+        <record id="expire_coupon_cron" model="ir.cron">
+            <field name="name">Coupon: expire coupon based on date</field>
+            <field name="model_id" ref="sale_coupon.model_sale_coupon"/>
+            <field name="state">code</field>
+            <field name="code">model.cron_expire_coupon()</field>
+            <field name="active" eval="True"/>
+            <field name="user_id" ref="base.user_root"/>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="numbercall">-1</field>
+        </record>
    </data>
 </odoo>

--- a/addons/sale_coupon/models/sale_coupon.py
+++ b/addons/sale_coupon/models/sale_coupon.py
@@ -108,3 +108,14 @@ class SaleCoupon(models.Model):
             'target': 'new',
             'context': ctx,
         }
+
+    def cron_expire_coupon(self):
+        self._cr.execute("""
+            SELECT C.id FROM SALE_COUPON as C
+            INNER JOIN SALE_COUPON_PROGRAM as P ON C.program_id = P.id
+            WHERE C.STATE in ('reserved', 'new')
+                AND P.validity_duration > 0
+                AND C.create_date + interval '1 day' * P.validity_duration < now()""")
+
+        expired_ids = [res[0] for res in self._cr.fetchall()]
+        self.browse(expired_ids).write({'state': 'expired'})


### PR DESCRIPTION
_**Description of the issue/feature this PR addresses:**_

Backport the `sale.coupon` expiration cron existing in version 14.0, but not in version 13.0:
* https://github.com/odoo/odoo/blob/14.0/addons/coupon/models/coupon.py#L83-L92
* https://github.com/odoo/odoo/blob/14.0/addons/coupon/data/coupon_email_data.xml#L104-L114

_**Current behavior before PR:**_

Expired sale coupons (by expiration date) keep the `Reserved/Valid` status even if the expiration date is lower than today.

_**Desired behavior after PR is merged:**_

When the cron is executed, expired sale coupons (by expiration date) take automatically the `Expired` status.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
