### PR TITLE
[FIX] project: remove subtype description for ratings

### DIFF
--- a/addons/project/data/mail_data.xml
+++ b/addons/project/data/mail_data.xml
@@ -30,7 +30,6 @@
         <field name="name">Task Rating</field>
         <field name="res_model">project.task</field>
         <field name="default" eval="True"/>
-        <field name="description">Ratings</field>
     </record>
     <!-- Project-related subtypes for messaging / Chatter -->
     <record id="mt_project_task_new" model="mail.message.subtype">


### PR DESCRIPTION
**Before this commit:**

For an example, when task is going to 'Done' state at that time mail is sent to
customer for feedback, answering of that mail contain smiley face plus subtype
description in chatter.

**After this commit:**

A subtype description is removed to the smiley face from message.

**Links**

PR https://github.com/odoo/odoo/pull/66137
Task-2373127
