### PR TITLE
[12.0][FIX] production with sub bom of type phantom and routing will …

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -619,7 +619,8 @@ class MrpProduction(models.Model):
             moves_raw.mapped('move_line_ids').write({'workorder_id': workorder.id})
             (moves_finished + moves_raw).write({'workorder_id': workorder.id})
 
-            workorder._generate_lot_ids()
+            if bom.type != 'phantom':
+                workorder._generate_lot_ids()
         return workorders
 
     def _check_lots(self):


### PR DESCRIPTION
…generate duplicated lines of product lot to be removed from stock

Description of the issue/feature this PR addresses: created a production with bom with routing and products to be consumed with lot tracking and with sub-bom of type phantom with routing.

Current behavior before PR: duplicated lines of product to be consumed with lot are created

Desired behavior after PR is merged: duplicated lines of product to be consumed with lot are not created




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
