### PR TITLE
[IMP] codeowner: disable codeowner for accounting in master

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,8 +30,8 @@
 
 # Generic fallback rules
 
-/addons/account*/ @odoo/rd-accounting
-/addons/l10n_*/ @odoo/rd-accounting
+# /addons/account*/ @odoo/rd-accounting
+# /addons/l10n_*/ @odoo/rd-accounting
 /addons/*/models/ir_http.py @odoo/rd-website
 /addons/*/models/ir_qweb.py @odoo/rd-website
 /addons/*/models/ir_qweb_fields.py @odoo/rd-website


### PR DESCRIPTION
We keep the codeownership in stable versions but disable it in master to
reduce the spam.
Will be added back at each freeze.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
