### PR TITLE
point_of_sale: UI/UX improvements

### DIFF
--- a/addons/point_of_sale/static/src/css/pos.css
+++ b/addons/point_of_sale/static/src/css/pos.css
@@ -2667,6 +2667,7 @@ td {
 
 .pos .popup.popup-password {
     width: 254px;
+    height: 510px;
 }
 .pos .popup-password .mode-button.add,
 .pos .popup-password .input-button.dot {
@@ -2678,6 +2679,9 @@ td {
 .pos .popup-password .popup-input {
     width: 70%;
  }
+.pos .popup-input.value .highlight {
+    background: lightblue;
+}
 
 .pos .popup .body ul,
 .pos .popup ul.body {

--- a/addons/point_of_sale/static/src/js/Chrome.js
+++ b/addons/point_of_sale/static/src/js/Chrome.js
@@ -351,6 +351,8 @@ odoo.define('point_of_sale.Chrome', function(require) {
                 body: this.env._t(
                     'Would you like to load demo data?'
                 ),
+                confirmText: this.env._t('Yes'),
+                cancelText: this.env._t('No')
             });
             if (confirmed) {
                 await this.rpc({

--- a/addons/point_of_sale/static/src/js/Misc/NumberBuffer.js
+++ b/addons/point_of_sale/static/src/js/Misc/NumberBuffer.js
@@ -139,7 +139,7 @@ odoo.define('point_of_sale.NumberBuffer', function(require) {
             onMounted(() => {
                 this.bufferHolderStack.push({
                     component: currentComponent,
-                    state: config.state ? config.state : { buffer: '' },
+                    state: config.state ? config.state : { buffer: '', toStartOver: false },
                     config,
                 });
                 this._setUp();
@@ -227,6 +227,9 @@ odoo.define('point_of_sale.NumberBuffer', function(require) {
             if (input === undefined || input === null) return;
             let isFirstInput = isEmpty(this.state.buffer);
             if (input === this.decimalPoint) {
+                if (this.state.toStartOver) {
+                    this.state.buffer = '';
+                }
                 if (isFirstInput) {
                     this.state.buffer = '0' + this.decimalPoint;
                 } else if (!this.state.buffer.length || this.state.buffer === '-') {
@@ -246,6 +249,9 @@ odoo.define('point_of_sale.NumberBuffer', function(require) {
                     this.state.buffer = '';
                     this.isReset = false;
                     return;
+                }
+                if (this.state.toStartOver) {
+                    this.state.buffer = '';
                 }
                 const buffer = this.state.buffer;
                 if (isEmpty(buffer)) {
@@ -274,6 +280,9 @@ odoo.define('point_of_sale.NumberBuffer', function(require) {
                     inputValue + currentBufferValue
                 );
             } else if (!isNaN(parseInt(input, 10))) {
+                if (this.state.toStartOver) {  // when we want to erase the current buffer for a new value
+                    this.state.buffer = '';
+                }
                 if (isFirstInput) {
                     this.state.buffer = '' + input;
                 } else if (this.state.buffer.length > 12) {
@@ -288,6 +297,8 @@ odoo.define('point_of_sale.NumberBuffer', function(require) {
             // once an input is accepted and updated the buffer,
             // the buffer should not be in reset state anymore.
             this.isReset = false;
+            // it should not be in a start the buffer over state anymore.
+            this.state.toStartOver = false;
 
             this.trigger('buffer-update', this.state.buffer);
         }

--- a/addons/point_of_sale/static/src/js/Popups/NumberPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/NumberPopup.js
@@ -13,6 +13,7 @@ odoo.define('point_of_sale.NumberPopup', function(require) {
          * @param {Object} props
          * @param {Boolean} props.isPassword Show password popup.
          * @param {number|null} props.startingValue Starting value of the popup.
+         * @param {Boolean} props.isInputSelected Input is highlighted and will reset upon a change.
          *
          * Resolve to { confirmed, payload } when used with showPopup method.
          * @confirmed {Boolean}
@@ -26,7 +27,7 @@ odoo.define('point_of_sale.NumberPopup', function(require) {
             if (typeof this.props.startingValue === 'number' && this.props.startingValue > 0) {
                 startingBuffer = this.props.startingValue.toString();
             }
-            this.state = useState({ buffer: startingBuffer });
+            this.state = useState({ buffer: startingBuffer, toStartOver: this.props.isInputSelected });
             NumberBuffer.use({
                 nonKeyboardInputEvent: 'numpad-click-input',
                 triggerAtEnter: 'accept-input',

--- a/addons/point_of_sale/static/src/xml/Popups/NumberPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/NumberPopup.xml
@@ -9,7 +9,7 @@
                         <t t-esc="props.title" />
                     </header>
                     <div class="popup-input value active">
-                        <t t-esc="inputBuffer" />
+                        <span t-att-class="{ 'highlight': state.toStartOver }"><t t-esc="inputBuffer"/></span>
                     </div>
                     <div class="popup-numpad">
                         <button class="input-button number-char" t-on-mousedown.prevent="sendInput('1')">1</button>

--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -43,7 +43,8 @@
                         <h1><field name="name" placeholder="e.g. NYC Shop"/></h1>
                     </div>
                     <div class="o_notification_alert alert alert-warning" attrs="{'invisible':[('has_active_session','=', False)]}" role="alert">
-                      A session is currently opened for this PoS. Some settings can only be changed after the session is closed.
+                        A session is currently opened for this PoS. Some settings can only be changed after the session is closed.
+                        <button class="btn" style="padding:0" name="open_existing_session_cb" type="object">Click here to close the session</button>
                     </div>
                     <div class="row mt16 o_settings_container">
                         <div id="company" class="col-12 col-lg-6 o_setting_box" groups="base.group_multi_company">

--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -373,6 +373,17 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="col-12 col-lg-6 o_setting_box price_control" title="Only users with Manager access rights for PoS app can modify the product prices on orders.">
+                            <div class="o_setting_left_pane">
+                                <field name="restrict_price_control"/>
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label for="restrict_price_control" string="Price Control"/>
+                                <div class="text-muted">
+                                    Restrict price modification to managers
+                                </div>
+                            </div>
+                        </div>
                     </div>
                     <h2>Payments</h2>
                     <div class="row mt16 o_settings_container">

--- a/addons/point_of_sale/views/product_view.xml
+++ b/addons/point_of_sale/views/product_view.xml
@@ -8,6 +8,9 @@
             <filter name="filter_to_sell" position="before">
                <filter name="filter_to_availabe_pos" string="Available in POS" domain="[('available_in_pos', '=', True)]"/>
             </filter>
+            <filter name="categ_id" position="after">
+                <filter string="POS Product Category" name="pos_categ_id" context="{'group_by':'pos_categ_id'}"/>
+            </filter>
         </field>
     </record>
 

--- a/addons/point_of_sale/views/product_view.xml
+++ b/addons/point_of_sale/views/product_view.xml
@@ -111,4 +111,25 @@
         </field>
     </record>
 
+    <record id="product_template_tree_view" model="ir.ui.view">
+        <field name="name">product.template.product.tree.inherit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_tree_view"/>
+        <field name="arch" type="xml">
+            <field name="categ_id" position="before">
+                <field name="pos_categ_id" optional="hide" string="POS Product Category"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="product_product_tree_view" model="ir.ui.view">
+        <field name="name">product.product.product.tree.inherit</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_product_tree_view"/>
+        <field name="arch" type="xml">
+            <field name="categ_id" position="before">
+                <field name="pos_categ_id" optional="hide" string="POS Product Category"/>
+            </field>
+        </field>
+    </record>
 </odoo>

--- a/addons/pos_discount/static/src/js/DiscountButton.js
+++ b/addons/pos_discount/static/src/js/DiscountButton.js
@@ -16,6 +16,7 @@ odoo.define('pos_discount.DiscountButton', function(require) {
             const { confirmed, payload } = await this.showPopup('NumberPopup',{
                 title: this.env._t('Discount Percentage'),
                 startingValue: this.env.pos.config.discount_pc,
+                isInputSelected: true
             });
             if (confirmed) {
                 const val = Math.round(Math.max(0,Math.min(100,parseFloat(payload))));

--- a/addons/pos_hr/views/pos_config.xml
+++ b/addons/pos_hr/views/pos_config.xml
@@ -13,19 +13,6 @@
                     />
                 </div>
             </xpath>
-            <xpath expr="//div[@id='pricing']" position='inside'>
-                <div class="col-12 col-lg-6 o_setting_box price_control" title="Only users with Manager access rights for PoS app can modify the product prices on orders.">
-                    <div class="o_setting_left_pane">
-                        <field name="restrict_price_control"/>
-                    </div>
-                    <div class="o_setting_right_pane">
-                        <label for="restrict_price_control" string="Price Control"/>
-                        <div class="text-muted">
-                            Restrict price modification to managers
-                        </div>
-                    </div>
-                </div>
-            </xpath>
         </field>
     </record>
 </odoo>

--- a/addons/pos_restaurant/static/src/css/restaurant.css
+++ b/addons/pos_restaurant/static/src/css/restaurant.css
@@ -94,16 +94,16 @@
     bottom: 0;
     left: 50%;
     height: 20px;
-    width: 20px;
     line-height: 20px;
     font-size: 16px;
-    border-radius: 50%;
-    margin-left: -10px;
+    border-radius: 5px;
+    margin-left: -16px;
     margin-bottom: 4px;
     background: black;
     color: white;
     opacity: 0.2;
     z-index: 3;
+    padding: 0 4px;
 }
 .floor-map .table .label {
     display: block;
@@ -116,6 +116,9 @@
     outline: solid rgba(255,255,255,0.3);
     cursor: move;
     z-index: 50;
+}
+.floor-map .table.selected .table-seats {
+    margin-left: -12px;
 }
 .floor-map .edit-button.editing {
     position: absolute;

--- a/addons/pos_restaurant/static/src/js/Screens/FloorScreen/FloorScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/FloorScreen/FloorScreen.js
@@ -95,6 +95,7 @@ odoo.define('pos_restaurant.FloorScreen', function (require) {
                 startingValue: selectedTable.seats,
                 cheap: true,
                 title: this.env._t('Number of Seats ?'),
+                isInputSelected: true,
             });
             if (!confirmed) return;
             const newSeatsNum = parseInt(inputNumber, 10) || selectedTable.seats;

--- a/addons/pos_restaurant/static/src/js/Screens/FloorScreen/TableWidget.js
+++ b/addons/pos_restaurant/static/src/js/Screens/FloorScreen/TableWidget.js
@@ -49,6 +49,9 @@ odoo.define('pos_restaurant.TableWidget', function(require) {
                 'notify-skipped': notifications.skipped,
             };
         }
+        get customerCountDisplay() {
+            return `${this.env.pos.get_customer_count(this.props.table)}/${this.props.table.seats}`;
+        }
         _getNotifications() {
             const orders = this.env.pos.get_table_orders(this.props.table);
 

--- a/addons/pos_restaurant/static/src/js/Screens/ProductScreen/ControlButtons/TableGuestsButton.js
+++ b/addons/pos_restaurant/static/src/js/Screens/ProductScreen/ControlButtons/TableGuestsButton.js
@@ -22,6 +22,7 @@ odoo.define('pos_restaurant.TableGuestsButton', function(require) {
                 startingValue: this.nGuests,
                 cheap: true,
                 title: this.env._t('Guests ?'),
+                isInputSelected: true
             });
 
             if (confirmed) {

--- a/addons/pos_restaurant/static/src/xml/Screens/FloorScreen/TableWidget.xml
+++ b/addons/pos_restaurant/static/src/xml/Screens/FloorScreen/TableWidget.xml
@@ -11,7 +11,7 @@
                 <t t-esc="props.table.name" />
             </span>
             <span class="table-seats">
-                <t t-esc="props.table.seats" />
+                <t t-esc="customerCountDisplay" />
             </span>
         </div>
     </t>

--- a/addons/pos_restaurant/static/tests/tours/ControlButtons.tour.js
+++ b/addons/pos_restaurant/static/tests/tours/ControlButtons.tour.js
@@ -2,6 +2,7 @@ odoo.define('pos_restaurant.tour.ControlButtons', function (require) {
     'use strict';
 
     const { TextAreaPopup } = require('pos_restaurant.tour.TextAreaPopupTourMethods');
+    const { NumberPopup } = require('point_of_sale.tour.NumberPopupTourMethods');
     const { Chrome } = require('pos_restaurant.tour.ChromeTourMethods');
     const { FloorScreen } = require('pos_restaurant.tour.FloorScreenTourMethods');
     const { ProductScreen } = require('pos_restaurant.tour.ProductScreenTourMethods');
@@ -43,6 +44,19 @@ odoo.define('pos_restaurant.tour.ControlButtons', function (require) {
     ProductScreen.do.clickPrintBillButton();
     BillScreen.check.isShown();
     BillScreen.do.clickBack();
+
+    // Test GuestButton
+    ProductScreen.do.clickGuestButton();
+    NumberPopup.do.pressNumpad('1 5');
+    NumberPopup.check.inputShownIs('15');
+    NumberPopup.do.clickConfirm();
+    ProductScreen.check.guestNumberIs('15')
+
+    ProductScreen.do.clickGuestButton();
+    NumberPopup.do.pressNumpad('5');
+    NumberPopup.check.inputShownIs('5');
+    NumberPopup.do.clickConfirm();
+    ProductScreen.check.guestNumberIs('5')
 
     Tour.register('ControlButtonsTour', { test: true, url: '/pos/ui' }, getSteps());
 });

--- a/addons/pos_restaurant/static/tests/tours/FloorScreen.tour.js
+++ b/addons/pos_restaurant/static/tests/tours/FloorScreen.tour.js
@@ -87,6 +87,15 @@ odoo.define('pos_restaurant.tour.FloorScreen', function (require) {
     NumberPopup.do.clickConfirm();
     FloorScreen.check.tableSeatIs('T4', '9');
 
+    // change number of seat when the input is already selected
+    FloorScreen.do.clickTable('T4');
+    FloorScreen.check.selectedTableIs('T4');
+    FloorScreen.do.clickSeats();
+    NumberPopup.do.pressNumpad('1 5');
+    NumberPopup.check.inputShownIs('15');
+    NumberPopup.do.clickConfirm();
+    FloorScreen.check.tableSeatIs('T4', '15');
+
     // change shape
     FloorScreen.do.changeShapeTo('round');
 

--- a/addons/pos_restaurant/static/tests/tours/helpers/ProductScreenTourMethods.js
+++ b/addons/pos_restaurant/static/tests/tours/helpers/ProductScreenTourMethods.js
@@ -45,6 +45,14 @@ odoo.define('pos_restaurant.tour.ProductScreenTourMethods', function (require) {
                 },
             ];
         }
+        clickGuestButton() {
+            return [
+                {
+                    content: 'click guest button',
+                    trigger: '.control-buttons .control-button span:contains("Guests")'
+                }
+            ]
+        }
     }
 
     class CheckExt extends Check {
@@ -61,6 +69,15 @@ odoo.define('pos_restaurant.tour.ProductScreenTourMethods', function (require) {
                     run: function () {}, // it's a check
                 },
             ];
+        }
+        guestNumberIs(numberInString) {
+            return [
+                {
+                    content: `guest number is ${numberInString}`,
+                    trigger: `.control-buttons .control-button span.control-button-number:contains(${numberInString})`,
+                    run: function () {}, // it's a check
+                }
+            ]
         }
     }
 


### PR DESCRIPTION
Task ID: 2419637
The UI/UX changes are:
 - The confirm and cancel text buttons of the "Load demo" popup in the POS UI have been changed to `Ok` and `No`
 - The `pos_categ_id` field has been added to the group_by filter 
 - Price control can now be enabled without having to install pos_hr
 - POS Product Category is now in the Product view list and Product variant view list
 - Input field is now selected in the guest number popup (pos_restaurant) and in the global discount number popup. The current value will completely be replaced by the new number.
 - The display of the customer count on the table now shows the ratio between taken seat and max seat
 - Button added in the pos_config form to redirect the user to the closing session page if it's active
 - CSS fix on the size of a popup-password