### PR TITLE
[MERGE] sale_timesheet: employee rate for fsm projects

### DIFF
--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -262,15 +262,6 @@ class ProjectTask(models.Model):
             if not self.sale_line_id:
                 self.sale_line_id = self.project_id.sale_line_id
 
-    def write(self, values):
-        res = super(ProjectTask, self).write(values)
-        # Done after super to avoid constraints on field recomputation
-        if values.get('project_id'):
-            project_dest = self.env['project.project'].browse(values['project_id'])
-            if project_dest.pricing_type == 'employee_rate':
-                self.write({'sale_line_id': False})
-        return res
-
     def _get_last_sol_of_customer(self):
         # Get the last SOL made for the customer in the current task where we need to compute
         self.ensure_one()

--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -284,7 +284,7 @@ class ProjectTask(models.Model):
     def _get_timesheet(self):
         # return not invoiced timesheet and timesheet without so_line or so_line linked to task
         timesheet_ids = super(ProjectTask, self)._get_timesheet()
-        return timesheet_ids.filtered(lambda t: (not t.timesheet_invoice_id or t.timesheet_invoice_id.state == 'cancel') and (not t.so_line or t.so_line == t.task_id._origin.sale_line_id))
+        return timesheet_ids.filtered(lambda t: t._is_not_billed())
 
     def _get_action_view_so_ids(self):
         return list(set((self.sale_order_id + self.timesheet_ids.so_line.order_id).ids))

--- a/addons/sale_timesheet/models/project_sale_line_employee_map.py
+++ b/addons/sale_timesheet/models/project_sale_line_employee_map.py
@@ -12,13 +12,6 @@ class ProjectProductEmployeeMap(models.Model):
     employee_id = fields.Many2one('hr.employee', "Employee", required=True)
     sale_line_id = fields.Many2one('sale.order.line', "Sale Order Item", compute="_compute_sale_line_id", store=True, readonly=False, required=True, domain=[('is_service', '=', True)])
     company_id = fields.Many2one('res.company', string='Company', related='project_id.company_id')
-    timesheet_product_id = fields.Many2one(
-        'product.product', string='Service',
-        domain="""[
-            ('type', '=', 'service'),
-            ('invoice_policy', '=', 'delivery'),
-            ('service_type', '=', 'timesheet'),
-            '|', ('company_id', '=', False), ('company_id', '=', company_id)]""")
     price_unit = fields.Float("Unit Price", compute='_compute_price_unit', store=True, readonly=True)
     currency_id = fields.Many2one('res.currency', string="Currency", compute='_compute_price_unit', store=True, readonly=False)
 
@@ -30,25 +23,15 @@ class ProjectProductEmployeeMap(models.Model):
     def _compute_sale_line_id(self):
         self.filtered(lambda map_entry: not map_entry.project_id.sale_order_id and map_entry.sale_line_id).update({'sale_line_id': None})
 
-    @api.depends('sale_line_id', 'sale_line_id.price_unit', 'timesheet_product_id')
+    @api.depends('sale_line_id', 'sale_line_id.price_unit')
     def _compute_price_unit(self):
         for line in self:
             if line.sale_line_id:
                 line.price_unit = line.sale_line_id.price_unit
                 line.currency_id = line.sale_line_id.currency_id
-            elif line.timesheet_product_id:
-                line.price_unit = line.timesheet_product_id.lst_price
-                line.currency_id = line.timesheet_product_id.currency_id
             else:
                 line.price_unit = 0
                 line.currency_id = False
-
-    @api.onchange('timesheet_product_id')
-    def _onchange_timesheet_product_id(self):
-        if self.timesheet_product_id:
-            self.price_unit = self.timesheet_product_id.lst_price
-        else:
-            self.price_unit = 0.0
 
     @api.model
     def create(self, values):

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -153,7 +153,7 @@
                     <field name="timesheet_invoice_id" invisible="1"/>
                     <field name="so_line"
                         attrs="{'column_invisible': [('parent.allow_billable', '=', False)]}"
-                        context="{'with_remaining_hours': True}" options="{'no_create': True, 'no_open': True}"
+                        context="{'with_remaining_hours': True, 'with_price_unit': True}" options="{'no_create': True, 'no_open': True}"
                         domain="[('is_service', '=', True), ('order_partner_id', 'child_of', parent.commercial_partner_id), ('is_expense', '=', False), ('state', 'in', ['sale', 'done']), ('order_id', '=?', parent.project_sale_order_id)]"
                         optional="hide"/>
                 </xpath>
@@ -192,7 +192,7 @@
             <field name="inherit_id" ref="project.view_task_form2"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='sale_line_id']" position="attributes">
-                    <attribute name="context">{'with_remaining_hours': True}</attribute>
+                    <attribute name="context">{'with_remaining_hours': True, 'with_price_unit': True}</attribute>
                     <attribute name="attrs">
                         {'invisible': ['|', ('allow_billable', '=', False), ('partner_id', '=', False)]}
                     </attribute>

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -29,7 +29,7 @@
                         </group>
                     </group>
                     <field name="sale_line_employee_ids" attrs="{'invisible': [('pricing_type', '!=', 'employee_rate')]}">
-                        <tree editable="top">
+                        <tree editable="bottom">
                             <field name="company_id" invisible="1"/>
                             <field name="project_id" invisible="1"/>
                             <field name="employee_id" options="{'no_create': True}"/>

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -23,7 +23,7 @@
                         <group>
                             <field name="display_create_order" invisible="1"/>
                             <field name="pricing_type" attrs="{'invisible': [('allow_billable', '=', False)], 'required': ['&amp;', ('allow_billable', '=', True), ('allow_timesheets', '=', True)]}" widget="radio"/>
-                            <field name="timesheet_product_id" string="Service" invisible="1" context="{'default_type': 'service', 'default_service_policy': 'delivered_timesheet', 'default_service_type': 'timesheet'}"/>
+                            <field name="timesheet_product_id" string="Default Service" invisible="1" context="{'default_type': 'service', 'default_service_policy': 'delivered_timesheet', 'default_service_type': 'timesheet'}"/>
                             <field name="sale_order_id" attrs="{'invisible': [('pricing_type', '=', 'task_rate')], 'readonly': [('sale_order_id', '!=', False)]}" force_save="1" options="{'no_create': True, 'no_edit': True, 'delete': False, 'no_open': True}"/>
                             <field name="sale_line_id" string="Default Sales Order Item" attrs="{'invisible': [('pricing_type', '=', 'task_rate')]}" options="{'no_create': True, 'no_edit': True, 'delete': False, 'no_open': True}"/>
                         </group>


### PR DESCRIPTION
Purpose
======

Currently, the user can configure his field service project to be billed at an employee rate but it just won't work. The rates configured for each employee on the project are not taken into account when the task is marked as done. As a consequence, the only workaround to support this kind of use-case is to create 1 task per employee with a different rate (or to add service products on the task). Those solutions are far from being ideal. We should give more flexibility.

## Details

To reach the goal, some updates are made:
 - Move the timesheet_product field in employee mappings into the fsm sale module, because this field is only used for fsm projects,
 - render _timesheet_determine_sale_line no static to easily override it,
 - fix bug when the user change project on task form view, the project for non billed timesheets is not correctly changed,
 - let the SOL in task when the user wants to change the project of it to a project with pricing type defined as employee rate. Before when the pricing type of the destination project is employee rate, we remove the SOL of the task.

task-2376382

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
