### PR TITLE
[FIX] event_sale: traceback raised when product have blocking message

### DIFF
--- a/addons/event_sale/static/src/js/event_configurator_widget.js
+++ b/addons/event_sale/static/src/js/event_configurator_widget.js
@@ -32,7 +32,7 @@ ProductConfiguratorWidget.include({
     _onProductChange: function (productId, dataPointId) {
       var self = this;
       return this._super.apply(this, arguments).then(function (stopPropagation) {
-          if (stopPropagation) {
+          if (stopPropagation || productId === undefined) {
               return Promise.resolve(true);
           } else {
               return self._checkForEvent(productId, dataPointId);
@@ -56,7 +56,7 @@ ProductConfiguratorWidget.include({
             method: 'read',
             args: [productId, ['event_ok']],
         }).then(function (result) {
-            if (result && result[0].event_ok) {
+            if (Array.isArray(result) && result.length && result[0].event_ok) {
                 self._openEventConfigurator({
                         default_product_id: productId
                     },


### PR DESCRIPTION
- Install event_sale;
- On the Sale's settings check 'Sale Warning';
- Create a blocking message for a product;
- Create a SO;
- Add the product with the blocking message.

Before this commit, a traceback was raised before the blocking message
is shown.

Now, only the blocking message is shown.

opw-2458568
