### PR TITLE
[FIX] mail: missing discard button if next activity flow

### DIFF
--- a/addons/mail/static/src/components/activity_mark_done_popover/activity_mark_done_popover.xml
+++ b/addons/mail/static/src/components/activity_mark_done_popover/activity_mark_done_popover.xml
@@ -11,10 +11,10 @@
                         <button type="button" class="o_ActivityMarkDonePopover_doneButton btn btn-sm btn-primary" t-on-click="_onClickDone">
                             Done
                         </button>
-                        <button type="button" class="o_ActivityMarkDonePopover_discardButton btn btn-sm btn-link" t-on-click="_onClickDiscard">
-                            Discard
-                        </button>
                     </t>
+                    <button type="button" class="o_ActivityMarkDonePopover_discardButton btn btn-sm btn-link" t-on-click="_onClickDiscard">
+                        Discard
+                    </button>
                 </div>
             </t>
         </div>

--- a/addons/mail/static/src/components/activity_mark_done_popover/activity_mark_done_popover_tests.js
+++ b/addons/mail/static/src/components/activity_mark_done_popover/activity_mark_done_popover_tests.js
@@ -124,10 +124,10 @@ QUnit.test('activity with force next mark done popover simplest layout', async f
         '.o_ActivityMarkDonePopover_doneButton',
         "Popover component should NOT contain the done button"
     );
-    assert.containsNone(
+    assert.containsOnce(
         document.body,
         '.o_ActivityMarkDonePopover_discardButton',
-        "Popover component should NOT contain the discard button"
+        "Popover component should contain the discard button"
     );
 });
 


### PR DESCRIPTION
**Current behavior before PR:**

If a next activity is "triggered", the discard button is not visible.

**Desired behavior after PR is merged:**

Even if a next activity is "triggered", the discard button will visible.

**LINKS:**
PR #66164
Task-2459645


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
