### PR TITLE
[FIX] calendar: cannot send mail if current user not in the loop

### DIFF
--- a/addons/calendar/models/calendar.py
+++ b/addons/calendar/models/calendar.py
@@ -211,7 +211,8 @@ class Attendee(models.Model):
                                 'mimetype': 'text/calendar',
                                 'datas': base64.b64encode(ics_file)})
                     ]
-                    mail_ids.append(invitation_template.with_context(no_document=True).send_mail(attendee.id, email_values=email_values, notif_layout='mail.mail_notification_light'))
+                    # sudo is needed when the current user hasn't been added to the loop (i.e. neither in attendees, nor in owner)
+                    mail_ids.append(invitation_template.with_context(no_document=True).sudo().send_mail(attendee.id, email_values=email_values, notif_layout='mail.mail_notification_light'))
                 else:
                     mail_ids.append(invitation_template.send_mail(attendee.id, email_values=email_values, notif_layout='mail.mail_notification_light'))
 

--- a/addons/calendar/tests/test_calendar.py
+++ b/addons/calendar/tests/test_calendar.py
@@ -452,3 +452,31 @@ class TestCalendar(TransactionCase):
         # since the detach actually create an event in the backend
         # we check that no mail notifications are sent to the attendees
         _test_one_mail_per_attendee(self, m, partners)
+
+    def test_event_creation_mail_with_different_owner(self):
+        admin = self.env.ref('base.user_admin')
+        demo = self.env.ref('base.user_demo')
+        now = fields.Datetime.now()
+        partners = [
+           self.env['res.partner'].create({'name': 'testuser0', 'email': u'bob@example.com'}),
+           self.env['res.partner'].create({'name': 'testuser1', 'email': u'alice@example.com'}),
+           ]
+        partner_ids = [(6, False, [p.id for p in partners]), ]
+
+        m = self.CalendarEvent.with_user(admin).create({
+            'name': "mailTest1",
+            'partner_ids': partner_ids,
+            'allday': False,
+            'duration': 0.5,
+            'user_id': demo.id,
+            'start': fields.Datetime.to_string(now + timedelta(days=10)),
+            'stop': fields.Datetime.to_string(now + timedelta(days=15)),
+            })
+
+        for partner in partners:
+            mail = self.env['mail.mail'].search([
+                ('recipient_ids', 'in', partner.id),
+                ('subject', 'like', m.name),
+                ])
+            self.assertEqual(len(mail), 1)
+            self.assertEqual(mail.author_id.id, demo.partner_id.id)


### PR DESCRIPTION


Steps:
- Log in as admin
- Install calendar
- Activate the developer mode
- Go to Calendar
- Create a new event:
  - Attendee: demo (1)
  - Misc tab:
    - Owner: demo (1)

Bug:
Access Denied:
(Document type: Message, Operation: read) - (Records: [84], User: 2)

Explanation:
The author of the message is not the current user from this commit
onward: 160d321
The access denial appears when trying to add the ICS file to the
message. The current user is not allowed to read the old attachments
since they are not a part of the discussion.

opw:2454395

