### PR TITLE
[FIX] mail: missing discard button if next activity flow

### DIFF
--- a/addons/mail/static/src/xml/activity.xml
+++ b/addons/mail/static/src/xml/activity.xml
@@ -100,13 +100,13 @@
                         Done &amp; Schedule Next</button>
                     <button type="button" class="btn btn-sm btn-primary o_activity_popover_done">
                         Done</button>
-                    <button type="button" class="btn btn-sm btn-link o_activity_popover_discard">
-                        Discard</button>
                 </t>
                 <t t-else="">
                     <button type="button" class="btn btn-sm btn-primary o_activity_popover_done_next">
                         Done &amp; Launch Next</button>
                 </t>
+                <button type="button" class="btn btn-sm btn-link o_activity_popover_discard">
+                    Discard</button>
             </div>
         </div>
     </t>


### PR DESCRIPTION
**Current behavior before PR:**

If a next activity is "triggered", the discard button is not visible.

**Desired behavior after PR is merged:**

Even if a next activity is "triggered", the discard button will visible.

**LINKS:**
PR #66168
Task-2459645

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
