### PR TITLE
[IMP] base: add sourcemap support for CSS files.

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1252,7 +1252,7 @@ class DisableCacheMiddleware(object):
             root.setup_session(req)
             if req.session and req.session.debug and not 'wkhtmltopdf' in req.headers.get('User-Agent'):
 
-                if "assets" in req.session.debug and ".js" in req.base_url:
+                if "assets" in req.session.debug and (".js" in req.base_url or ".css" in req.base_url):
                     new_headers = [('Cache-Control', 'no-store')]
                 else:
                     new_headers = [('Cache-Control', 'no-cache')]

--- a/odoo/tools/__init__.py
+++ b/odoo/tools/__init__.py
@@ -22,4 +22,4 @@ from .convert import *
 from .template_inheritance import *
 from . import osutil
 from .js_transpiler import transpile_javascript, is_odoo_module, URL_RE, ODOO_MODULE_RE
-from .js_sourcemap import SourceMapGenerator
+from .sourcemap_generator import SourceMapGenerator

--- a/odoo/tools/sourcemap_generator.py
+++ b/odoo/tools/sourcemap_generator.py
@@ -1,9 +1,10 @@
 from functools import lru_cache
+import json
 
 
 class SourceMapGenerator:
     """
-    The SourceMapGenerator creates the sourcemap maps the asset bundle to the js files.
+    The SourceMapGenerator creates the sourcemap maps the asset bundle to the js/css files.
 
     What is a sourcemap ? (https://developer.mozilla.org/en-US/docs/Tools/Debugger/How_to/Use_a_source_map)
     In brief: a source map is what makes possible to debug your processed/compiled/minified code as if you were
@@ -82,6 +83,14 @@ class SourceMapGenerator:
             mapping["sourceRoot"] = self._source_root
 
         return mapping
+
+    def get_content(self):
+        """Generates the content of the sourcemap.
+
+        :return the content of the sourcemap as a string encoded in UTF-8.
+        """
+        # Store with XSSI-prevention prefix
+        return b")]}'\n" + json.dumps(self.to_json()).encode('utf8')
 
     def add_source(self, source_name, source_content, last_index, start_offset=0):
         """Adds a new source file in the sourcemap. All the lines of the source file will be mapped line by line


### PR DESCRIPTION
[IMP] base: add sourcemap support for CSS files.

Improve the development experience in debug=assets mode by reducing the
number of requests to the server. We are adapting the solution used for
the JS files to the CSS files. This solution consists of no longer
sending all the files separately, but sending only the bundles
associated with their sourcemap. This allows us to keep the same
debugging experience while drastically reducing the number of requests
to the server.

Benchmark:
saas 14.2                   917 requests    domcontentloaded after 3.76s
master (bundling du js)     299 requests    domcontentloaded after 2.03s
branch (bundling js+css)    36  requests    domcontentloaded after 1.01s

Task id : 2463840