### PR TITLE
[FIX] website_sale: wrap unbreakable product name


### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -28,7 +28,7 @@
         }
     }
 
-    h1[itemprop="name"], .oe_product_cart form h5 {
+    h1[itemprop="name"], .oe_product_cart form h6, .td-product_name {
         word-wrap: break-word;
     }
 


### PR DESCRIPTION

In some location, a long unbreakable word would cause following columns
to be hidden (depending on size of unbreakable word, font, font size,
...). For example, this happened in the cart summary on payment page.

With this changeset, if not possible otherwise, line break happen inside
the word.

opw-2451496
