### PR TITLE
[FIX] base: mail signature CSS inlined for icons etc


### DIFF
--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -217,7 +217,7 @@
                                     </group>
                                 </group>
                                 <group string="Messaging and Social" name="messaging">
-                                    <field name="signature"/>
+                                    <field name="signature" options="{'style-inline': true}"/>
                                 </group>
                             </page>
                         </notebook>
@@ -346,7 +346,7 @@
                         <group name="preference_contact"></group>
                     </group>
                     <group>
-                        <field name="signature" readonly="0"/>
+                        <field name="signature" readonly="0" options="{'style-inline': true}"/>
                     </group>
                     <footer>
                         <button name="preference_save" type="object" string="Save" class="btn-primary"/>

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -51,6 +51,7 @@ safe_attrs = clean.defs.safe_attrs | frozenset(
      'data-o-mail-quote',  # quote detection
      'data-oe-model', 'data-oe-id', 'data-oe-field', 'data-oe-type', 'data-oe-expression', 'data-oe-translation-id', 'data-oe-nodeid',
      'data-publish', 'data-id', 'data-res_id', 'data-interval', 'data-member_id', 'data-scroll-background-ratio', 'data-view-id',
+     'data-class',
      ])
 
 


### PR DESCRIPTION

The mail signature of an user did not inline the CSS like the body of a
message, so for example icons seemed to work but would not be seen
(unless the mail reader had the same font-awesome system).

With this change we inline the signature too.

On edition there was also an issue since the original icon was saved as
data-class which was stripped: so editing a message with working icon on
send, the icons would disappear.

opw-2453912
