### PR TITLE
[FIX] sale_timesheet: fix (re-)invoiced amount computed as other revenue

### DIFF
--- a/addons/sale_timesheet/models/project_overview.py
+++ b/addons/sale_timesheet/models/project_overview.py
@@ -115,6 +115,7 @@ class Project(models.Model):
             profit['expense_cost'] += data.get('expense_cost', 0.0)
             profit['expense_amount_untaxed_invoiced'] += data.get('expense_amount_untaxed_invoiced', 0.0)
         profit['other_revenues'] = other_revenues - data.get('amount_untaxed_invoiced', 0.0) if other_revenues else 0.0
+        profit['other_revenues'] = profit['other_revenues'] - data.get('expense_amount_untaxed_invoiced', 0.0) if profit['other_revenues'] else 0.0
         profit['total'] = sum([profit[item] for item in profit.keys()])
         dashboard_values['profit'] = profit
 

--- a/addons/sale_timesheet/report/project_profitability_report_analysis.py
+++ b/addons/sale_timesheet/report/project_profitability_report_analysis.py
@@ -178,6 +178,14 @@ class ProfitabilityAnalysis(models.Model):
                                     LEFT JOIN account_analytic_account AA ON P.analytic_account_id = AA.id
                                     LEFT JOIN account_analytic_line AAL ON AAL.account_id = AA.id
                                 WHERE AAL.amount > 0.0 AND AAL.project_id IS NULL AND P.active = 't' AND P.allow_timesheets = 't'
+                                    AND NOT EXISTS (
+                                        SELECT SOL.id
+                                        FROM sale_order_line SOL
+                                        JOIN sale_order_line_invoice_rel SOINV ON SOINV.order_line_id = SOL.id
+                                        JOIN account_move_line AML ON SOINV.invoice_line_id = AAL.move_id
+                                        WHERE SOL.qty_delivered_method IN ('timesheet', 'manual')
+                                            OR (SOL.qty_delivered_method = 'analytic' AND SOL.invoice_status != 'no')
+                                    )
 
                                 UNION ALL
 


### PR DESCRIPTION
- Install sale_timesheet and hr_expense
- Create a Service Product with "Create a task in sales order's project" as Service Tracking (i.e. Service X)
- Create a Product with "Can be Expensed" and "At cost" as "Re-Invoice Expenses" (i.e. Expense X)
- Create a SO with Service X (i.e. Unit Price: 50.0) and confirm it
- Go to Expenses and create an Expense:
  * Product: Expense Y
  * Unit Price: 25.0
  * Customer to Reinvoice: [select the created SO]
- Create Report, Approve and Post journal entries
- From SO, create an Invoice (Service Y + Expense Y) and confirm it
In Project Overview, the expense is computed in Other Revenues and
Re-invoiced costs. Therefore, the amount of the expense is added twice
in the Profitability total.
In Project > Reporting > Project Costs and Revenues, for Project linked
to SO, Untaxed Amount Invoiced and Untaxed Amount Re-Invoiced are also
computed in Other Revenues.

opw-2444237

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
