### PR TITLE
[FIX] web: mock active_test for search and search_read

### DIFF
--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -1641,7 +1641,10 @@ var MockServer = Class.extend({
      */
     _mockSearch: function (model, args, kwargs) {
         const limit = kwargs.limit || Number.MAX_VALUE;
-        return this._getRecords(model, args[0]).map(r => r.id).slice(0, limit);
+        const { context } = kwargs;
+        const active_test =
+          context && "active_test" in context ? context.active_test : true;
+        return this._getRecords(model, args[0], { active_test }).map(r => r.id).slice(0, limit);
     },
     /**
      * Simulate a 'search_count' operation
@@ -1695,7 +1698,12 @@ var MockServer = Class.extend({
      */
     _mockSearchReadController: function (args) {
         var self = this;
-        var records = this._getRecords(args.model, args.domain || []);
+        const { context } = args;
+        const active_test =
+          context && "active_test" in context ? context.active_test : true;
+        var records = this._getRecords(args.model, args.domain || [], {
+          active_test,
+        });
         var fields = args.fields && args.fields.length ? args.fields : _.keys(this.data[args.model].fields);
         var nbRecords = records.length;
         var offset = args.offset || 0;

--- a/addons/web/static/tests/mockserver_tests.js
+++ b/addons/web/static/tests/mockserver_tests.js
@@ -16,8 +16,16 @@ QUnit.module("MockServer", {
                         string: "Email",
                         type: "string",
                     },
+                    active: {
+                        string: "Active",
+                        type: "bool",
+                        default: true,
+                    },
                 },
-                records: [{ id: 1, name: "Jean-Michel", email: "jean.michel@example.com" }],
+                records: [
+                    { id: 1, name: "Jean-Michel", email: "jean.michel@example.com" },
+                    { id: 2, name: "Raoul", email: "raoul@example.com", active: false },
+                ],
             },
         };
     },
@@ -130,6 +138,64 @@ QUnit.module("MockServer", {
             kwargs: {},
         });
         assert.deepEqual(result, [[null, "False"], [1, "Jean-Michel"]]);
+    });
+
+    QUnit.test("performRpc: search with active_test=false", async function (assert) {
+        assert.expect(1);
+        const server = new MockServer(this.data, {});
+        const result = await server.performRpc("", {
+            model: "res.partner",
+            method: "search",
+            args: [[]],
+            kwargs: {
+                context: { active_test: false },
+            },
+        });
+        assert.deepEqual(result, [1, 2]);
+    });
+
+    QUnit.test("performRpc: search with active_test=true", async function (assert) {
+        assert.expect(1);
+        const server = new MockServer(this.data, {});
+        const result = await server.performRpc("", {
+            model: "res.partner",
+            method: "search",
+            args: [[]],
+            kwargs: {
+                context: { active_test: true },
+            },
+        });
+        assert.deepEqual(result, [1]);
+    });
+
+    QUnit.test("performRpc: search_read with active_test=false", async function (assert) {
+        assert.expect(1);
+        const server = new MockServer(this.data, {});
+        const result = await server.performRpc("", {
+            model: "res.partner",
+            method: "search_read",
+            args: [[]],
+            kwargs: {
+                fields: ["name"],
+                context: { active_test: false },
+            },
+        });
+        assert.deepEqual(result, [{id: 1, name: "Jean-Michel"}, {id: 2, name: "Raoul"}]);
+    });
+
+    QUnit.test("performRpc: search_read with active_test=true", async function (assert) {
+        assert.expect(1);
+        const server = new MockServer(this.data, {});
+        const result = await server.performRpc("", {
+            model: "res.partner",
+            method: "search_read",
+            args: [[]],
+            kwargs: {
+                fields: ["name"],
+                context: { active_test: true },
+            },
+        });
+        assert.deepEqual(result, [{id: 1, name: "Jean-Michel"}]);
     });
 });
 });


### PR DESCRIPTION
The support for "active_test" context key has been introduced in the mock server with c2918c1
However, the context key is ignored in many mocked ORM methods (if not all).

This commit adds support for the `search` and `search_read` methods.

Note: this is done to easily write some tests in odoo/enterprise#16363
and it might be usefull to test futures features (or fixes) using this
context key.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
