### PR TITLE
[FIX] website: img gallery in tabs block lose thumbnails

### DIFF
--- a/addons/website/static/src/snippets/s_image_gallery/000.js
+++ b/addons/website/static/src/snippets/s_image_gallery/000.js
@@ -86,7 +86,18 @@ const GallerySliderWidget = publicWidget.Widget.extend({
         this.$prev = this.$indicator.find('li.o_indicators_left').css('visibility', ''); // force visibility as some databases have it hidden
         this.$next = this.$indicator.find('li.o_indicators_right').css('visibility', '');
         var $lis = this.$indicator.find('li[data-slide-to]');
-        var nbPerPage = Math.floor(this.$indicator.width() / $lis.first().outerWidth(true)) - 3; // - navigator - 1 to leave some space
+        let indicatorWidth = this.$indicator.width();
+        if (indicatorWidth === 0) {
+            // An ancestor may be hidden so we try to find it and make it
+            // visible just to take the correct width.
+            const $indicatorParent = this.$indicator.parents().not(':visible').last();
+            if (!$indicatorParent[0].style.display) {
+                $indicatorParent[0].style.display = 'block';
+                indicatorWidth = this.$indicator.width();
+                $indicatorParent[0].style.display = '';
+            }
+        }
+        let nbPerPage = Math.floor(indicatorWidth / $lis.first().outerWidth(true)) - 3; // - navigator - 1 to leave some space
         var realNbPerPage = nbPerPage || 1;
         var nbPages = Math.ceil($lis.length / realNbPerPage);
 


### PR DESCRIPTION
Go to the website
Drag a "Tabs" block on the page, by default you will have 3 example tabs
Click on the tab "Contact" and drag in the block "Image Gallery"
Add multiple images to the image gallery
Click on one of the other tabs so that the image gallery is hidden
Save

The image gallery do not have the thumbails anymore
This occur because when the carousel-indicator is hidden, jquery is not
able to fetch its real length, so no icons are added
https://github.com/odoo/odoo/blob/768bcf58e8dc215b96b11bafa632c07dc683e297/addons/website/static/src/snippets/s_image_gallery/000.js#L99

A solution is to give the object a fictional length (i.e. the number of
elements of the list do just fine for the use case)

Other solution require more involved hack on the elements
https://stackoverflow.com/questions/1472303/jquery-get-width-of-element-when-not-visible-display-none

opw-2438513

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
