### PR TITLE
[FIX] sale_coupon: prevent program w/o company (that will miss currency)


### DIFF
--- a/addons/sale_coupon/views/sale_coupon_program_views.xml
+++ b/addons/sale_coupon/views/sale_coupon_program_views.xml
@@ -32,7 +32,7 @@
                                 <field name="rule_minimum_amount" widget='monetary' options="{'currency_field': 'currency_id'}"/>
                                 <field name="rule_minimum_amount_tax_inclusion" required="1"/>
                             </div>
-                            <field name="company_id" placeholder="Select company" groups="base.group_multi_company"></field>
+                            <field name="company_id" placeholder="Select company" groups="base.group_multi_company" required="1"></field>
                         </group>
                         <group name="validity" string="Validity"/>
                     </group>


### PR DESCRIPTION

The company is used to compute currency of:

- discount_fixed_amount
- discount_max_amount
- rule_minimum_amount

If currently we don't set a company, we have an error when using the
company.

opw-2458950
