### PR TITLE
[IMP] crm: add recurring revenue total in progress bar

### DIFF
--- a/addons/crm/__manifest__.py
+++ b/addons/crm/__manifest__.py
@@ -72,6 +72,7 @@
     'application': True,
     'assets': {
         'web.assets_qweb': [
+            'crm/static/src/xml/crm_kanban.xml',
             'crm/static/src/xml/forecast_kanban.xml',
         ],
         'web.assets_backend': [
@@ -87,6 +88,7 @@
             'crm/static/tests/tours/**/*',
         ],
         'web.qunit_suite_tests': [
+            'crm/static/tests/crm_kanban_progress_bar_mrr_sum_field_tests.js',
             'crm/static/tests/mock_server.js',
             'crm/static/tests/forecast_kanban_tests.js',
             'crm/static/tests/forecast_view_tests.js',

--- a/addons/crm/static/src/js/crm_kanban.js
+++ b/addons/crm/static/src/js/crm_kanban.js
@@ -4,11 +4,161 @@
      * This Kanban Model make sure we display a rainbowman
      * message when a lead is won after we moved it in the
      * correct column and when it's grouped by stage_id (default).
+     * Apart from that, in the KanbanColumnProgressBar, we add
+     * support for showing sum of the expected MRR (after the regular
+     * sum field) if the logged user has the enough rights.
      */
 
+    import KanbanColumn from 'web.KanbanColumn';
+    import KanbanColumnProgressBar from 'web.KanbanColumnProgressBar';
     import KanbanModel from 'web.KanbanModel';
+    import KanbanRenderer from 'web.KanbanRenderer';
     import KanbanView from 'web.KanbanView';
+    import utils from 'web.utils';
     import viewRegistry from 'web.view_registry';
+
+    const CrmKanbanColumnProgressBar = KanbanColumnProgressBar.extend({
+
+        /**
+         * @constructor
+         * @override
+         */
+        init(parent, options, columnState) {
+            this._super.apply(this, arguments);
+            this.recurringRevenueSumField = columnState.progressBarValues.recurring_revenue_sum_field;
+            // Check whether the given MRR sum field is valid or not
+            this.isRecurringRevenueSumFieldValid = Object.keys(columnState.fields).includes(columnState.progressBarValues.recurring_revenue_sum_field);
+            this.recurringRevenueSumFieldLabel = this.isRecurringRevenueSumFieldValid ? columnState.fields[this.recurringRevenueSumField].string : false;
+            // Previous progressBar state
+            const state = options.progressBarStates[this.columnID];
+            if (state) {
+                this.totalRecurringRevenue = state.totalRecurringRevenue;
+            }
+        },
+
+        /**
+         * @override
+         */
+        willStart() {
+            const userHasGroup = this.getSession().user_has_group('crm.group_use_recurring_revenues')
+                .then((useRecurringRevenues) => {
+                    // only show MRR related info if 'Recurring Revenues' is enabled, and provided MRR sum field is valid
+                    this.showRecurringRevenue = useRecurringRevenues && this.isRecurringRevenueSumFieldValid;
+                });
+            return Promise.all([this._super(...arguments), userHasGroup]);
+        },
+
+        /**
+         * @override
+         */
+        start() {
+            const def = this._super.apply(this, arguments);
+
+            if (!this.showRecurringRevenue) {
+                return def;
+            }
+
+            this.$mrrCounter = this.$counter.filter('.o_crm_kanban_mrr_counter_side');
+            this.$recurringRevenueNumber = this.$mrrCounter.find('.o_crm_kanban_mrr_sum');
+            // the MRR counter has it's own width, and so if we put the '+' symbol outside it,
+            // '+' will be more close to the actual sum field and far from MRR, especially if
+            //  MRR has single digit value and text is aligned right, so we put it within MRR.
+            let $plus = $('<strong/>', {
+                text: '+',
+            });
+            this.$('.o_kanban_counter_progress').addClass('o_crm_kanban_counter_progress_mrr w-50');
+            this.$mrrCounter.prepend($plus);
+            return def;
+        },
+
+        /**
+         * @override
+         */
+        computeCounters() {
+            this._super.apply(this, arguments);
+            if (this.showRecurringRevenue) {
+                this.prevTotalRecurringRevenue = this.totalRecurringRevenue;
+                this.totalRecurringRevenue = this.columnState.aggregateValues[this.recurringRevenueSumField] || 0;
+            }
+        },
+
+        //--------------------------------------------------------------------------
+        // Private
+        //--------------------------------------------------------------------------
+
+        /**
+         * @private
+         * @override
+         */
+        _render() {
+            const self = this;
+            const res = this._super.apply(this, arguments);
+
+            if (!this.showRecurringRevenue) {
+                return res;
+            }
+
+            const startMRR = this.prevTotalRecurringRevenue;
+            let endMRR = this.totalRecurringRevenue;
+
+            if (this.activeFilter.value) {
+                endMRR = 0;
+                this.columnState.data.forEach((record) => {
+                    if (this.activeFilter.value === record.data[this.fieldName] ||
+                        (this.activeFilter.value === '__false' && !record.data[this.fieldName])) {
+                        endMRR += parseFloat(record.data[this.recurringRevenueSumField]);
+                    }
+                });
+            }
+
+            this.prevTotalRecurringRevenue = endMRR;
+
+            if (startMRR !== undefined && (endMRR > startMRR || this.activeFilter.value) && this.ANIMATE) {
+                $({currentValue: startMRR}).animate({currentValue: endMRR}, {
+                    duration: 1000,
+                    start: function () {
+                        // always use 'o_kanban_grow' class due to limited length
+                        self.$counter.removeClass('o_kanban_grow_huge');
+                        self.$counter.addClass('o_kanban_grow');
+                        self.$mrrCounter.addClass('o_kanban_grow');
+                    },
+                    step: function () {
+                        self.$recurringRevenueNumber.text(utils.human_number(this.currentValue));
+                    },
+                    complete: function () {
+                        self.$recurringRevenueNumber.text(utils.human_number(this.currentValue));
+                        self.$counter.removeClass('o_kanban_grow');
+                        self.$mrrCounter.removeClass('o_kanban_grow');
+                    },
+                });
+            } else {
+                this.$recurringRevenueNumber.text(utils.human_number(endMRR));
+            }
+            return res;
+        },
+
+        /**
+         * @private
+         * @override
+         */
+        _getNotifyStateValues: function() {
+            const res = this._super.apply(this, arguments);
+            if (this.showRecurringRevenue) {
+                res.totalRecurringRevenue = this.totalRecurringRevenue;
+            }
+            return res;
+        },
+    });
+
+    const CrmKanbanColumn = KanbanColumn.extend({
+        /**
+         * @private
+         * @override
+         */
+        _getKanbanColumnProgressBar: function () {
+            return new CrmKanbanColumnProgressBar(this, this.barOptions, this.data);
+        },
+    });
 
     var CrmKanbanModel = KanbanModel.extend({
         /**
@@ -35,15 +185,25 @@
         },
     });
 
+    const CrmKanbanRenderer = KanbanRenderer.extend({
+        config: Object.assign({}, KanbanRenderer.prototype.config, {
+            KanbanColumn: CrmKanbanColumn,
+        }),
+    });
+
     var CrmKanbanView = KanbanView.extend({
         config: _.extend({}, KanbanView.prototype.config, {
             Model: CrmKanbanModel,
+            Renderer: CrmKanbanRenderer,
         }),
     });
 
     viewRegistry.add('crm_kanban', CrmKanbanView);
 
     export default {
+        CrmKanbanColumn: CrmKanbanColumn,
+        CrmKanbanColumnProgressBar: CrmKanbanColumnProgressBar,
         CrmKanbanModel: CrmKanbanModel,
-        CrmKanbanView: CrmKanbanView,
+        CrmKanbanRenderer: CrmKanbanRenderer,
+        CrmKanbanView: CrmKanbanView
     };

--- a/addons/crm/static/src/xml/crm_kanban.xml
+++ b/addons/crm/static/src/xml/crm_kanban.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<template>
+    <t t-extend="KanbanView.ColumnProgressBar">
+        <t t-jquery="div.o_kanban_counter_side" t-operation="after">
+            <t t-if="widget.showRecurringRevenue">
+                <div class="o_kanban_counter_side o_crm_kanban_mrr_counter_side">
+                    <strong class="o_crm_kanban_mrr_sum" t-esc="widget.totalRecurringRevenue" t-att-title="widget.recurringRevenueSumFieldLabel"/>
+                </div>
+            </t>
+        </t>
+    </t>
+</template>

--- a/addons/crm/static/tests/crm_kanban_progress_bar_mrr_sum_field_tests.js
+++ b/addons/crm/static/tests/crm_kanban_progress_bar_mrr_sum_field_tests.js
@@ -1,0 +1,196 @@
+/** @odoo-module */
+import CrmKanban from '../src/js/crm_kanban';
+import KanbanColumnProgressBar from 'web.KanbanColumnProgressBar';
+import testUtils from 'web.test_utils';
+
+const createView = testUtils.createView;
+const CrmKanbanView = CrmKanban.CrmKanbanView;
+
+QUnit.module('Crm Kanban Progressbar', {
+    before: function () {
+        this._initialKanbanProgressBarAnimate = KanbanColumnProgressBar.prototype.ANIMATE;
+        KanbanColumnProgressBar.prototype.ANIMATE = false;
+    },
+    after: function () {
+        KanbanColumnProgressBar.prototype.ANIMATE = this._initialKanbanProgressBarAnimate;
+    },
+    beforeEach: function () {
+        this.data = {
+            'res.users': {
+                fields: {
+                    display_name: { string: 'Name', type: 'char' },
+                },
+                records: [
+                    { id: 1, name: 'Dhvanil' },
+                    { id: 2, name: 'Trivedi' },
+                ],
+            },
+            'crm.stage': {
+                fields: {
+                    display_name: { string: 'Name', type: 'char' },
+                },
+                records: [
+                    { id: 1, name: 'New' },
+                    { id: 2, name: 'Qualified' },
+                    { id: 3, name: 'Won' },
+                ],
+            },
+            'crm.lead': {
+                fields: {
+                    display_name: { string: 'Name', type: 'char' },
+                    bar: {string: "Bar", type: "boolean"},
+                    activity_state: {string: "Activity State", type: "char"},
+                    expected_revenue: { string: 'Revenue', type: 'integer', sortable: true },
+                    recurring_revenue_monthly: { string: 'Recurring Revenue', type: 'integer',  sortable: true },
+                    stage_id: { string: 'Stage', type: 'many2one', relation: 'crm.stage' },
+                    user_id: { string: 'Salesperson', type: 'many2one', relation: 'res.users' },
+                },
+                records : [
+                    { id: 1, bar: false, name: 'Lead 1', activity_state: 'planned', expected_revenue: 125, recurring_revenue_monthly: 5, stage_id: 1, user_id: 1 },
+                    { id: 2, bar: true, name: 'Lead 2', activity_state: 'today', expected_revenue: 5, stage_id: 2, user_id: 2 },
+                    { id: 3, bar: true, name: 'Lead 3', activity_state: 'planned', expected_revenue: 13, recurring_revenue_monthly: 20, stage_id: 3, user_id: 1 },
+                    { id: 4, bar: true, name: 'Lead 4', activity_state: 'today', expected_revenue: 4, stage_id: 2, user_id: 2 },
+                    { id: 5, bar: false, name: 'Lead 5', activity_state: 'overdue', expected_revenue: 8, recurring_revenue_monthly: 25, stage_id: 3, user_id: 1 },
+                    { id: 6, bar: true, name: 'Lead 4', activity_state: 'today', expected_revenue: 4, recurring_revenue_monthly: 15, stage_id: 1, user_id: 2 },
+                ],
+            },
+        };
+    },
+}, function () {
+    QUnit.test("Progressbar: do not show sum of MRR if recurring revenues is not enabled", async function (assert) {
+        assert.expect(1);
+
+        const kanban = await createView({
+            data: this.data,
+            model: 'crm.lead',
+            View: CrmKanbanView,
+            groupBy: ['stage_id'],
+            session: {
+                async user_has_group(group) {
+                    if (group === 'crm.group_use_recurring_revenues') {
+                        return false;
+                    }
+                    return this._super(...arguments);
+                },
+            },
+            arch: `
+                <kanban js_class="crm_kanban">
+                    '<field name="stage_id"/>' +
+                    '<field name="expected_revenue"/>' +
+                    '<field name="recurring_revenue_monthly"/>' +
+                    '<field name="activity_state"/>' +
+                    <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}' sum_field="expected_revenue" recurring_revenue_sum_field="recurring_revenue_monthly"/>
+                    <templates>
+                        <t t-name="kanban-box">
+                            <div><field name="name"/></div>
+                            <div><field name="recurring_revenue_monthly"/></div>
+                        </t>
+                    </templates>
+                </kanban>`,
+        });
+
+        const reccurringRevenueNoValues = [...kanban.el.querySelectorAll('.o_crm_kanban_mrr_counter_side')].map((elem) => elem.textContent)
+        assert.deepEqual(reccurringRevenueNoValues, [],
+            "counter should not display recurring_revenue_monthly content");
+        kanban.destroy();
+    });
+
+    QUnit.test("Progressbar: ensure correct MRR sum is displayed if recurring revenues is enabled", async function (assert) {
+        assert.expect(1);
+
+        const kanban = await createView({
+            data: this.data,
+            model: 'crm.lead',
+            View: CrmKanbanView,
+            groupBy: ['stage_id'],
+            session: {
+                async user_has_group(group) {
+                    if (group === 'crm.group_use_recurring_revenues') {
+                        return true;
+                    }
+                    return this._super(...arguments);
+                },
+            },
+            arch: `
+                <kanban js_class="crm_kanban">
+                    '<field name="stage_id"/>' +
+                    '<field name="expected_revenue"/>' +
+                    '<field name="recurring_revenue_monthly"/>' +
+                    '<field name="activity_state"/>' +
+                    <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}' sum_field="expected_revenue" recurring_revenue_sum_field="recurring_revenue_monthly"/>
+                    <templates>
+                        <t t-name="kanban-box">
+                            <div><field name="name"/></div>
+                            <div><field name="recurring_revenue_monthly"/></div>
+                        </t>
+                    </templates>
+                </kanban>`,
+        });
+
+        const reccurringRevenueValues = [...kanban.el.querySelectorAll('.o_crm_kanban_mrr_sum')].map((elem) => elem.textContent);
+
+        // When no values are given in column it should return 0 and counts value if given.
+        assert.deepEqual(reccurringRevenueValues, ["20", "0", "45"],
+            "counter should display the sum of recurring_revenue_monthly values if values are given else display 0");
+        kanban.destroy();
+    });
+
+    QUnit.test("Progressbar: ensure correct MRR updation after state change", async function (assert) {
+        assert.expect(3);
+
+        const kanban = await createView({
+            data: this.data,
+            model: 'crm.lead',
+            View: CrmKanbanView,
+            groupBy: ['bar'],
+            session: {
+                async user_has_group(group) {
+                    if (group === 'crm.group_use_recurring_revenues') {
+                        return true;
+                    }
+                    return this._super(...arguments);
+                },
+            },
+            arch: `
+                <kanban js_class="crm_kanban">
+                    '<field name="stage_id"/>' +
+                    '<field name="expected_revenue"/>' +
+                    '<field name="recurring_revenue_monthly"/>' +
+                    '<field name="activity_state"/>' +
+                    <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}' sum_field="expected_revenue" recurring_revenue_sum_field="recurring_revenue_monthly"/>
+                    <templates>
+                        <t t-name="kanban-box">
+                            <div><field name="name"/></div>
+                            <div><field name="recurring_revenue_monthly"/></div>
+                        </t>
+                    </templates>
+                </kanban>`,
+        });
+
+        //MRR before state change
+        let reccurringRevenueNoValues = [...kanban.el.querySelectorAll('.o_crm_kanban_mrr_sum')].map((elem) => elem.textContent);
+        assert.deepEqual(reccurringRevenueNoValues, ['30','35'],
+            "counter should display the sum of recurring_revenue_monthly values");
+
+        // Drag the first kanban record from 1st column to the top of the last column
+        await testUtils.dom.dragAndDrop(
+            [...kanban.el.querySelectorAll('.o_kanban_record')].shift(),
+            [...kanban.el.querySelectorAll('.o_kanban_record')].pop(),
+            { position: 'bottom' }
+        );
+
+        //check MRR after drag&drop
+        reccurringRevenueNoValues = [...kanban.el.querySelectorAll('.o_crm_kanban_mrr_sum')].map((elem) => elem.textContent)
+        assert.deepEqual(reccurringRevenueNoValues, ['25', '40'],
+            "counter should display the sum of recurring_revenue_monthly correctly after drag and drop");
+
+        //Activate "planned" filter on first column
+        await testUtils.dom.click(kanban.el.querySelector('.o_kanban_group:nth-child(2) .progress-bar[data-filter="planned"]'));
+
+        //check MRR after applying filter
+        reccurringRevenueNoValues = [...kanban.el.querySelectorAll('.o_crm_kanban_mrr_sum')].map((elem) => elem.textContent);
+        assert.deepEqual(reccurringRevenueNoValues, ['25','25'],
+            "counter should display the sum of recurring_revenue_monthly only of overdue filter in 1st column");
+        kanban.destroy();
+    });
+});

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -562,7 +562,10 @@
                     <field name="company_currency"/>
                     <field name="activity_state" />
                     <field name="activity_ids" />
-                    <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}' sum_field="expected_revenue" help="This bar allows to filter the opportunities based on scheduled activities."/>
+                    <field name="recurring_revenue_monthly"/>
+                    <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'
+                        sum_field="expected_revenue" recurring_revenue_sum_field="recurring_revenue_monthly"
+                        help="This bar allows to filter the opportunities based on scheduled activities."/>
                     <templates>
                         <t t-name="kanban-box">
                             <t t-set="lost_ribbon" t-value="!record.active.raw_value and record.probability and record.probability.raw_value == 0"/>

--- a/addons/web/static/src/legacy/js/views/kanban/kanban_column.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_column.js
@@ -154,7 +154,7 @@ var KanbanColumn = Widget.extend({
         });
         if (this.barOptions) {
             this.$el.addClass('o_kanban_has_progressbar');
-            this.progressBar = new KanbanColumnProgressBar(this, this.barOptions, this.data);
+            this.progressBar = this._getKanbanColumnProgressBar();
             defs.push(this.progressBar.appendTo(this.$header));
         }
 
@@ -286,6 +286,15 @@ var KanbanColumn = Widget.extend({
             ids.push($(r).data('record').id);
         });
         return ids;
+    },
+    /**
+     * This method can be over-ridden when custom ColumnProgressbar is to be used
+     *
+     * @private
+     * @returns {Widget} the instance of 'KanbanColumnProgressBar'
+     */
+    _getKanbanColumnProgressBar: function () {
+        return new KanbanColumnProgressBar(this, this.barOptions, this.data);
     },
 
     //--------------------------------------------------------------------------

--- a/addons/web/static/src/legacy/js/views/kanban/kanban_column_progressbar.js
+++ b/addons/web/static/src/legacy/js/views/kanban/kanban_column_progressbar.js
@@ -236,6 +236,17 @@ var KanbanColumnProgressBar = Widget.extend({
         }
     },
     /**
+     * @private
+     */
+    _getNotifyStateValues: function() {
+        return {
+            groupCount: this.groupCount,
+            subgroupCounts: this.subgroupCounts,
+            totalCounterValue: this.totalCounterValue,
+            activeFilter: this.activeFilter,
+        };
+    },
+    /**
      * Notifies the new progressBar state so that if a full rerender occurs, the
      * new progressBar that would replace this one will be initialized with
      * current state, so that animations are correct.
@@ -245,12 +256,7 @@ var KanbanColumnProgressBar = Widget.extend({
     _notifyState: function () {
         this.trigger_up('set_progress_bar_state', {
             columnID: this.columnID,
-            values: {
-                groupCount: this.groupCount,
-                subgroupCounts: this.subgroupCounts,
-                totalCounterValue: this.totalCounterValue,
-                activeFilter: this.activeFilter,
-            },
+            values: this._getNotifyStateValues(),
         });
     },
     /**


### PR DESCRIPTION
PURPOSE
Take recurring revenues into account in the kanban stage counts.

CURRENT
Currently we only display expected_revenue total in kanban progress bar.

 TO BE
Display Recurring revenue total next  to expected_revenue total in kanban progress bar in crm.

PR
TASK ID: 2414576

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
