### PR TITLE
[FIX] mrp: Existing operations cannot be added to BOM

### DIFF
--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -331,6 +331,24 @@ class TestBoM(TestMrpCommon):
             'name': 'Deserts Table'
         })
 
+        operation_1 = self.env['mrp.routing.workcenter'].create({
+            'workcenter_id': workcenter.id,
+            'name': 'Prepare biscuits',
+            'time_cycle_manual': 5
+        })
+
+        operation_2 = self.env['mrp.routing.workcenter'].create({
+            'workcenter_id': workcenter.id,
+            'name': 'Prepare butter',
+            'time_cycle_manual': 3
+        })
+
+        operation_3 = self.env['mrp.routing.workcenter'].create({
+            'workcenter_id': workcenter.id,
+            'name': 'Mix manually',
+            'time_cycle_manual': 5
+        })
+
         with Form(bom_crumble) as bom:
             with bom.bom_line_ids.new() as line:
                 line.product_id = butter
@@ -340,18 +358,9 @@ class TestBoM(TestMrpCommon):
                 line.product_id = biscuit
                 line.product_uom_id = uom_kg
                 line.product_qty = 6
-            with bom.operation_ids.new() as operation:
-                operation.workcenter_id = workcenter
-                operation.name = 'Prepare biscuits'
-                operation.time_cycle_manual = 5
-            with bom.operation_ids.new() as operation:
-                operation.workcenter_id = workcenter
-                operation.name = 'Prepare butter'
-                operation.time_cycle_manual = 3
-            with bom.operation_ids.new() as operation:
-                operation.workcenter_id = workcenter
-                operation.name = 'Mix manually'
-                operation.time_cycle_manual = 5
+            bom.operation_ids.add(operation_1)
+            bom.operation_ids.add(operation_2)
+            bom.operation_ids.add(operation_3)
 
         # TEST BOM STRUCTURE VALUE WITH BOM QUANTITY
         report_values = self.env['report.mrp.report_bom_structure']._get_report_data(bom_id=bom_crumble.id, searchQty=11, searchVariant=False)
@@ -428,6 +437,18 @@ class TestBoM(TestMrpCommon):
             'time_stop': 15
         })
 
+        operation_4 = self.env['mrp.routing.workcenter'].create({
+            'workcenter_id': workcenter.id,
+            'name': 'Mix cheese and crumble',
+            'time_cycle_manual': 10
+        })
+
+        operation_5 = self.env['mrp.routing.workcenter'].create({
+            'workcenter_id': workcenter_2.id,
+            'name': 'Cake mounting',
+            'time_cycle_manual': 5
+        })
+
         with Form(bom_cheese_cake) as bom:
             with bom.bom_line_ids.new() as line:
                 line.product_id = cream
@@ -437,14 +458,8 @@ class TestBoM(TestMrpCommon):
                 line.product_id = crumble
                 line.product_uom_id = uom_kg
                 line.product_qty = 5.4
-            with bom.operation_ids.new() as operation:
-                operation.workcenter_id = workcenter
-                operation.name = 'Mix cheese and crumble'
-                operation.time_cycle_manual = 10
-            with bom.operation_ids.new() as operation:
-                operation.workcenter_id = workcenter_2
-                operation.name = 'Cake mounting'
-                operation.time_cycle_manual = 5
+            bom.operation_ids.add(operation_4)
+            bom.operation_ids.add(operation_5)
 
 
         # TEST CHEESE BOM STRUCTURE VALUE WITH BOM QUANTITY

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -101,6 +101,7 @@
                             attrs="{'invisible': [('type', 'not in',('normal','phantom'))]}"
                             groups="mrp.group_mrp_routings">
                                 <field name="operation_ids"
+                                    widget="many2many"
                                     attrs="{'invisible': [('type','not in',('normal','phantom'))]}"
                                     groups="mrp.group_mrp_routings"
                                     context="{'default_company_id': company_id, 'default_product_tmpl_ids': [product_tmpl_id]}"/>


### PR DESCRIPTION
Steps to reproduce the bug:

- Go to an existing BOM B
- Edit B and try to add an existing operation O in operations tab

Bug:

It was impossible to add an existing operation

opw:2458974