### PR TITLE
[FIX] mail: channel not automatically switched to a mailing channel on save

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -256,6 +256,18 @@ class Channel(models.Model):
                 ('res_id', 'in', self.ids)
             ])._moderate_accept()
 
+        # Reflect changes when switching a channel to a mailing one or vice versa
+        if 'email_send' in vals:
+            notifications = []
+            for channel in self:
+                notifications.append([(self._cr.dbname, 'mail.channel', channel.id), {
+                    'info': 'channel_updated',
+                    'channel': {
+                        'mass_mailing': channel.email_send,
+                    },
+                }])
+            self.env['bus.bus'].sendmany(notifications)
+
         return result
 
     def init(self):

--- a/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -129,6 +129,8 @@ function factory(dependencies) {
                         partner_id,
                         partner_name,
                     });
+                case 'channel_updated':
+                    return this._handleNotificationChannelUpdated(channelId, data);
                 default:
                     return this._handleNotificationChannelMessage(channelId, data);
             }
@@ -680,6 +682,23 @@ function factory(dependencies) {
                 message,
                 type: 'info',
             });
+        }
+
+        /**
+         * @private
+         * @param {integer} channelId
+         * @param {Object} messageData
+         */
+        _handleNotificationChannelUpdated(channelId, messageData) {
+            const convertedData = this.env.models['mail.thread'].convertData(messageData.channel);
+            const channel = this.env.models['mail.thread'].findFromIdentifyingData({
+                id: channelId,
+                model: 'mail.channel',
+            });
+            if (!channel) {
+                return;
+            }
+            channel.update(convertedData);
         }
 
         /**


### PR DESCRIPTION
**PURPOSE**

When we change the channel to the mailing one by setting the Send messages 
by email boolean field, it is not reflecting in the Discuss and chat window.
The user needs to refresh the page in order to see his changes.
once he refresh, the channel is having the subject and body composer inputs 
and vice versa.

**SPECIFICATION**

once you change any channel to mailing one then the changes
would be reflected for each member using bus notification passed to each and every channel
members and notify it with changed type.

**Task :  2363099**