### PR TITLE
[FIX] sale: fix quotation amount in sales team pipelines kanban view

### DIFF
--- a/addons/sale/views/sales_team_views.xml
+++ b/addons/sale/views/sales_team_views.xml
@@ -66,7 +66,7 @@
                             <t t-else="">Quotations</t>
                         </a>
                     </div>
-                    <div class="col-4 text-right">
+                    <div class="col-4 text-right text-truncate">
                         <field name="quotations_amount" widget="monetary"/>
                     </div>
                 </div>

--- a/doc/cla/corporate/forgeflow.md
+++ b/doc/cla/corporate/forgeflow.md
@@ -16,4 +16,5 @@ Aarón Henríquez ahenriquez@forgeflow.com https://github.com/AaronHForgeFlow
 Lois Rilo lois.rilo@forgeflow.com https://github.com/LoisRForgeFlow
 Miquel Raich miquel.raich@forgeflow.com https://github.com/MiquelRForgeFlow
 Jordi Ballester jordi.ballester@forgeflow.com https://github.com/JordiBForgeFlow
+Jordi Masvidal jordi.masvidal@forgeflow.com https://github.com/JordiMForgeFlow
 Hector Villarreal hector.villarreal@forgeflow.com https://github.com/HviorForgeFlow


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Fixes the display of the quotation amount in the sales teams pipeline overview kanban.

Current behavior before PR: The quotation amount is overflowing the kanban card.

Desired behavior after PR is merged: The quotation amount is truncated to prevent overflowing the kanban card.


![image](https://user-images.githubusercontent.com/71635103/108056998-4f009700-7052-11eb-9397-9c3654440198.png)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
