### PR TITLE
[FIX] website_sale: wrap unbreakable product name in td


### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -29,7 +29,9 @@
     }
 
     h1[itemprop="name"], .oe_product_cart form h6, .td-product_name {
+        word-break: break-word;
         word-wrap: break-word;
+        overflow-wrap: break-word;
     }
 
     @include media-breakpoint-down(sm) {


### PR DESCRIPTION

91937764 added new selector to target other location where product name
could break the interface on short screen or with long unbreakable word
in title.

But there is some use case missing where overflow-wrap doesn't work and
word-wrap doesn't. Also adding overflow-wrap since word-wrap is
deprecated.

opw-2451496
