### PR TITLE
[FIX] purchase_stock: Dropshipping with subcontracting

### DIFF
--- a/addons/purchase_stock/views/purchase_views.xml
+++ b/addons/purchase_stock/views/purchase_views.xml
@@ -35,7 +35,7 @@
             </xpath>
             <xpath expr="//page[@name='purchase_delivery_invoice']/group/group" position="inside">
                 <field name="picking_type_id" domain="[('code','=','incoming'), '|', ('warehouse_id', '=', False), ('warehouse_id.company_id', '=', company_id)]" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
-                <field name="dest_address_id" groups="stock.group_stock_multi_locations" attrs="{'invisible': [('default_location_dest_id_usage', '!=', 'customer')], 'required': [('default_location_dest_id_usage', '=', 'customer')]}"/>
+                <field name="dest_address_id" groups="stock.group_stock_multi_locations" attrs="{'invisible': [('default_location_dest_id_usage', 'not in', ('customer', 'internal'))], 'required': [('default_location_dest_id_usage', '=', 'customer')]}"/>
                 <field name="default_location_dest_id_usage" invisible="1"/>
                 <field name="incoterm_id"/>
             </xpath>


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a route R with a buy rule from Partner Location/Vendor -> Physical Locations/Subcontracting location
- Let's consider an operation type OT with Partner Location/Vendor as default source location and
Physical Locations/Subcontracting location as default destination location
- Create a PO and set the filed Deliver To with OT

Bug:

It was impossible to set the dropship address of the vendor

opw:2459546