### PR TITLE
[FIX] calendar: Add start week day to weekly recurrence rrule generator + unit test

### DIFF
--- a/addons/calendar/models/calendar_recurrence.py
+++ b/addons/calendar/models/calendar_recurrence.py
@@ -345,11 +345,14 @@ class RecurrenceRule(models.Model):
             data['end_type'] = 'forever'
         return data
 
+    def _get_lang_week_start(self):
+        lang = self.env['res.lang']._lang_get(self.env.user.lang)
+        week_start = int(lang.week_start)  # lang.week_start ranges from '1' to '7'
+        return rrule.weekday(week_start - 1) # rrule expects an int from 0 to 6
+
     def _get_start_of_period(self, dt):
         if self.rrule_type == 'weekly':
-            lang = self.env['res.lang']._lang_get(self.env.user.lang)
-            week_start = int(lang.week_start)  # lang.week_start ranges from '1' to '7'
-            week_start = rrule.weekday(week_start - 1)  # expects an int from 0 to 6
+            week_start = self._get_lang_week_start()
             start = dt + relativedelta(weekday=week_start(-1))
         elif self.rrule_type == 'monthly':
             start = dt + relativedelta(day=1)
@@ -461,6 +464,7 @@ class RecurrenceRule(models.Model):
             if not weekdays:
                 raise UserError(_("You have to choose at least one day in the week"))
             rrule_params['byweekday'] = weekdays
+            rrule_params['wkst'] = self._get_lang_week_start()
 
         if self.end_type == 'count':  # e.g. stop after X occurence
             rrule_params['count'] = min(self.count, MAX_RECURRENT_EVENT)

--- a/addons/calendar/tests/test_event_recurrence.py
+++ b/addons/calendar/tests/test_event_recurrence.py
@@ -74,6 +74,25 @@ class TestCreateRecurrentEvents(TestRecurrentEvents):
             (datetime(2019, 11, 5, 8, 0), datetime(2019, 11, 7, 18, 0)),
         ])
 
+    def test_weekly_interval_2_week_start_sunday(self):
+        lang = self.env['res.lang']._lang_get(self.env.user.lang)
+        lang.week_start = '7'  # Sunday
+
+        self.event._apply_recurrence_values({
+            'interval': 2,
+            'rrule_type': 'weekly',
+            'tu': True,
+            'count': 2,
+            'event_tz': 'UTC',
+        })
+        recurrence = self.env['calendar.recurrence'].search([('base_event_id', '=', self.event.id)])
+        events = recurrence.calendar_event_ids
+        self.assertEventDates(events, [
+            (datetime(2019, 10, 22, 8, 0), datetime(2019, 10, 24, 18, 0)),
+            (datetime(2019, 11, 5, 8, 0), datetime(2019, 11, 7, 18, 0)),
+        ])
+        lang.week_start = '1'  # Monday
+
     def test_weekly_until(self):
         self.event._apply_recurrence_values({
             'rrule_type': 'weekly',


### PR DESCRIPTION
Issue

	- Install 'Calendar' module
	- Create new event from Calendar view
	- Edit event
	- Set True to 'Recurrent' in options tab
	- Repeat every 2 weeks
	- Until : Number of repetitions 2
	- Save and go back to calendar view

	- Events are shifted (+ 1 week)

Cause

	The rrule.rrule (who create the generator with the recurrence ranges dates) use
	by default `calendar.firstweekday()` as first week day ('wkst').

Solution

	If recurrence frequency is 'weekly', get first week day based on user language,
	and add it as param ('wkst') to the rrule.rrule.

https://dateutil.readthedocs.io/en/stable/rrule.html#classes

opw-2448325

Co-authored-by: LucasLefevre (lul) <lul@odoo.com>