### PR TITLE
color picker in readonly show default cursor

### DIFF
--- a/addons/web/static/src/scss/form_view.scss
+++ b/addons/web/static/src/scss/form_view.scss
@@ -100,6 +100,10 @@
                 display: inline-block;
             }
         }
+
+        .o_field_color_picker_preview > li > a {
+            cursor: default;
+        }
     }
 
     .o_form_uri {


### PR DESCRIPTION
PURPOSE
The colorpicker widget looks like it could work without being on read mode but it actually can't.

SPEC
Use cursor: default when hovering a readonly colorpicker widget

TASK 2326198


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
