### PR TITLE
[FIX] web_editor: stop loading button once ace saved


### DIFF
--- a/addons/web_editor/static/src/js/common/ace.js
+++ b/addons/web_editor/static/src/js/common/ace.js
@@ -914,7 +914,7 @@ var ViewEditor = Widget.extend({
      */
     _onSaveClick: function (ev) {
         const restore = dom.addButtonLoadingEffect(ev.currentTarget);
-        this._saveResources().guardedCatch(restore);
+        this._saveResources().then(restore).guardedCatch(restore);
     },
     /**
      * Called when the user wants to switch from xml to scss or vice-versa ->


### PR DESCRIPTION

When we edit a view with ace in eg. studio, if it works the saved button
would never be enabled again because of missing callback.

Match the behavior of dom.addButtonLoadingEffect other usage (80592abd).

opw-2457046
