### PR TITLE
[13.0] [IMP] point_of_sale: do not require unlink access on account.move for empty sessions

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -307,7 +307,7 @@ class PosSession(models.Model):
             # made thru cash in/out when sesion is in cash_control.
             if self.config_id.cash_control:
                 self.cash_register_id.button_confirm_bank()
-            self.move_id.unlink()
+            self.move_id.sudo().unlink()
         self.write({'state': 'closed'})
         return {
             'type': 'ir.actions.client',


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Unlink access on account moves should not be required to validate an empty PoS session.

**Current behavior before PR:**
A user with no unlink access on account.move can't validate an empty PoS session.

**Desired behavior after PR is merged:**
Unlink the account move with sudo() to allow the user to validate the PoS session.



----------
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
