### PR TITLE
[FIX] web: list: correctly evaluate groupby modifier with m2o

### DIFF
--- a/addons/web/static/src/js/views/list/list_model.js
+++ b/addons/web/static/src/js/views/list/list_model.js
@@ -180,6 +180,7 @@ odoo.define('web.ListModel', function (require) {
                         viewType: 'groupby',
                     });
                     dp.groupData = groupDp.id;
+                    self._parseServerData(groupFields, groupDp, groupDp.data);
                 });
             });
         },

--- a/addons/web/static/tests/views/list_tests.js
+++ b/addons/web/static/tests/views/list_tests.js
@@ -2299,6 +2299,39 @@ QUnit.module('Views', {
         list.destroy();
     });
 
+    QUnit.test('groupby node with a button with modifiers using a many2one', async function (assert) {
+        assert.expect(5);
+
+        this.data.res_currency.fields.m2o = {string: "Currency M2O", type: "many2one", relation: "bar"};
+        this.data.res_currency.records[0].m2o = 1;
+
+        const list = await createView({
+            View: ListView,
+            model: 'foo',
+            data: this.data,
+            arch: `
+                <tree expand="1">
+                    <field name="foo"/>
+                    <groupby name="currency_id">
+                        <field name="m2o"/>
+                        <button string="Button 1" type="object" name="button_method" attrs='{"invisible": [("m2o", "=", false)]}'/>
+                    </groupby>
+                </tree>`,
+            mockRPC(route, args) {
+                assert.step(args.method);
+                return this._super(...arguments);
+            },
+            groupBy: ['currency_id'],
+        });
+
+        assert.containsOnce(list, '.o_group_header:eq(0) button.o_invisible_modifier');
+        assert.containsOnce(list, '.o_group_header:eq(1) button:not(.o_invisible_modifier)');
+
+        assert.verifySteps(['web_read_group', 'read']);
+
+        list.destroy();
+    });
+
     QUnit.test('reload list view with groupby node', async function (assert) {
         assert.expect(2);
 


### PR DESCRIPTION
Let's assume a <groupby> node in a list view containing a button
with an invisible modifier referencing a many2one field, e.g.

```
 <tree>
   <groupby>
     <field name="m2o" invisible="1"/>
     <button string="do it" attrs="{'invisible': [('m2o', '=',
False)]}"/>
   </groupby>
 </tree>
```

Before this commit, the m2o field was correctly read, but it's
value wasn't processed by the model, so the modifier wasn't
correctly evaluated.

Issue reported on PR https://github.com/odoo/odoo/pull/65316/

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
