### PR TITLE
[FIX] mrp, mrp_subcontracting: traceback during unistall

### DIFF
--- a/addons/mrp/__init__.py
+++ b/addons/mrp/__init__.py
@@ -37,12 +37,13 @@ def _create_warehouse_data(cr, registry):
 def uninstall_hook(cr, registry):
     env = api.Environment(cr, SUPERUSER_ID, {})
     warehouses = env["stock.warehouse"].search([])
-    subcontracting_routes = warehouses.mapped("pbm_route_id")
+    pbm_routes = warehouses.mapped("pbm_route_id")
     warehouses.write({"pbm_route_id": False})
     # Fail unlink means that the route is used somewhere (e.g. route_id on stock.rule). In this case
     # we don't try to do anything.
     try:
-        subcontracting_routes.unlink()
+        with env.cr.savepoint():
+            pbm_routes.unlink()
     except:
         pass
 

--- a/addons/mrp_subcontracting/__init__.py
+++ b/addons/mrp_subcontracting/__init__.py
@@ -14,6 +14,7 @@ def uninstall_hook(cr, registry):
     # Fail unlink means that the route is used somewhere (e.g. route_id on stock.rule). In this case
     # we don't try to do anything.
     try:
-        subcontracting_routes.unlink()
+        with env.cr.savepoint():
+            subcontracting_routes.unlink()
     except:
         pass


### PR DESCRIPTION
The unlink fail in __init__.py uninstall hook is managed, however
when it fail, the error is catch but the cursor is not rollback and
do not accept additional transaction. That result in a traceback at
uninstall.

opw-2453939