### PR TITLE
[FIX] hr: Officer Access Right - Gamification

### DIFF
--- a/addons/hr/views/hr_views.xml
+++ b/addons/hr/views/hr_views.xml
@@ -53,7 +53,7 @@
             id="menu_human_resources_configuration"
             name="Configuration"
             parent="menu_hr_root"
-            groups="group_hr_manager"
+            groups="hr.group_hr_user"
             sequence="100"/>
 
             <menuitem


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a user U with employee officer access rights
- Log with U and go to Employee in debug mode

Bug:

The following menus

- Configuration/Challenges
- Configuration/Departments
- Configuration/Goals history

were not accessible

opw:2450931