### PR TITLE
[FIX] portal & event: portal access errors

### DIFF
--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -17,8 +17,8 @@ class CustomerPortal(CustomerPortal):
 
     def _prepare_portal_layout_values(self):
         values = super(CustomerPortal, self)._prepare_portal_layout_values()
-        values['project_count'] = request.env['project.project'].search_count([])
-        values['task_count'] = request.env['project.task'].search_count([])
+        values['project_count'] = request.env['project.project'].search_count([]) if request.env['project.project'].check_access_rights('read', raise_exception=False) else 0
+        values['task_count'] = request.env['project.task'].search_count([]) if request.env['project.task'].check_access_rights('read', raise_exception=False) else 0
         return values
 
     # ------------------------------------------------------------


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Activate developer mode and create a public user without Application Accesses:
![Selection_112](https://user-images.githubusercontent.com/25005517/108092711-45405900-707d-11eb-8651-b7887fd61406.png)

Then log out, and log in again but as the new user. After log in, you get error message (the same when you click on "My account"). Also you get same error if you click on Events.

![Selection_113](https://user-images.githubusercontent.com/25005517/108093486-0f4fa480-707e-11eb-818a-3d315a54dc7e.png)

**Note:** the portal fix is the same done in many other places (see https://github.com/odoo/odoo/commit/272602193f5647f7f2270ed6ec68777625a139dd).




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr