### PR TITLE
[FIX] project: Creating project via service product deletes contact's data

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -161,10 +161,10 @@ class Project(models.Model):
     partner_id = fields.Many2one('res.partner', string='Customer', auto_join=True, tracking=True, domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
     partner_email = fields.Char(
         compute='_compute_partner_email', inverse='_inverse_partner_email',
-        string='Email', readonly=False, store=True)
+        string='Email', readonly=False, store=True, copy=False)
     partner_phone = fields.Char(
         compute='_compute_partner_phone', inverse='_inverse_partner_phone',
-        string="Phone", readonly=False, store=True)
+        string="Phone", readonly=False, store=True, copy=False)
     company_id = fields.Many2one('res.company', string='Company', required=True, default=lambda self: self.env.company)
     currency_id = fields.Many2one('res.currency', related="company_id.currency_id", string="Currency", readonly=True)
     analytic_account_id = fields.Many2one('account.analytic.account', string="Analytic Account", copy=False, ondelete='set null',
@@ -607,10 +607,10 @@ class Task(models.Model):
     commercial_partner_id = fields.Many2one(related='partner_id.commercial_partner_id')
     partner_email = fields.Char(
         compute='_compute_partner_email', inverse='_inverse_partner_email',
-        string='Email', readonly=False, store=True)
+        string='Email', readonly=False, store=True, copy=False)
     partner_phone = fields.Char(
         compute='_compute_partner_phone', inverse='_inverse_partner_phone',
-        string="Phone", readonly=False, store=True)
+        string="Phone", readonly=False, store=True, copy=False)
     ribbon_message = fields.Char('Ribbon message', compute='_compute_ribbon_message')
     partner_city = fields.Char(related='partner_id.city', readonly=False)
     manager_id = fields.Many2one('res.users', string='Project Manager', related='project_id.user_id', readonly=True)


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a customer C1 with email address A1 and phone P1
- Let's consider a project PR with C1 as customer
- Let's consider a service product P with:
   - Milestones (manually set quantities on order) as Service Invoicing Policy
   - Create a new project but no task as service tracking
   - PR as project template
- Create a sale order SO with C2 as customer with A2 as email address and P2 as phone
- Confirm the SO

Bug:

The email address and phone of C2 were changed into A1 and P1 instead of keeping A2 and P2

opw:2439459