### PR TITLE
Fixes bug introduced by commit 84d668ed3a1ba8ba4f61302dea011c596a07f493

### DIFF
--- a/addons/pos_hr/static/src/js/models.js
+++ b/addons/pos_hr/static/src/js/models.js
@@ -87,7 +87,7 @@ models.Order = models.Order.extend({
     },
     export_as_JSON: function () {
         const json = super_order_model.export_as_JSON.apply(this, arguments);
-        if (this.pos.config.module_pos_hr) {
+        if (this.pos.config.module_pos_hr && this.employee) {
             json.employee_id = this.employee.id;
         }
         return json;


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
A variable undefined error is triggered when the pos_restaurant module is installed and the point of sale is configured to only allow certain employees open a session and there is a table map configured for that point of sale. If you add an order in a table, go back to the map and then try to open that table again, an error is triggered and the sync error(red) icon appears at the top right.

Opening a table triggers the sync_to_server in the pos_restaurant module to be called.
https://github.com/odoo/odoo/blob/14.0/addons/pos_restaurant/static/src/js/floors.js#L220

This in turns calls the initialize of the order object
https://github.com/odoo/odoo/blob/14.0/addons/pos_hr/static/src/js/models.js#L76

And then that calls the export_as_JSON
https://github.com/odoo/odoo/blob/14.0/addons/pos_hr/static/src/js/models.js#L88

But this method is called before the this.employee attribute has been assigned in this line, 
https://github.com/odoo/odoo/blob/14.0/addons/pos_hr/static/src/js/models.js#L79

Causing an error.

Current behavior before PR:
An error is triggered when you open a table with un-paid orders saved. Rendering the point of sale unusable.

Desired behavior after PR is merged:
Opening tables should load the saved and un-paid orders.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
