### PR TITLE
[FIX] project: remove chatter glitches in form without sheet tag

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -286,7 +286,6 @@
                     <notebook>
                         <page name="description_page" string="Description">
                             <field name="description" nolabel="1" placeholder="Describe your project..." type="html"/>
-                            <div class="oe_clear"/>
                         </page>
                         <page name="settings" string="Settings">
                             <group>
@@ -716,7 +715,6 @@
                     <notebook>
                         <page name="description_page" string="Description">
                             <field name="description" type="html"/>
-                            <div class="oe_clear"/>
                         </page>
                         <page name="recurrence" string="Recurrence" attrs="{'invisible': [('recurring_task', '=', False)]}">
                             <group>


### PR DESCRIPTION
**Before this commit:**

In edit mode, glitching of chatter is visible in project.project and
project.task's form view(without sheet tag).

**After this commit:**

Removed this glinch of chatter and displaying it with full width in the form
(without sheet tag).

**LINKS**

PR https://github.com/odoo/odoo/pull/66314
Task- 2411632
