### PR TITLE
[FIX] pos_hr: loading crash when employee record is deleted

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
@@ -107,7 +107,7 @@ odoo.define('point_of_sale.TicketScreen', function (require) {
             return order.get_cardholder_name();
         }
         getEmployee(order) {
-            return order.employee.name;
+            return order.employee ? order.employee.name : '';
         }
         getStatus(order) {
             const screen = order.get_screen_data();

--- a/addons/pos_hr/static/src/js/models.js
+++ b/addons/pos_hr/static/src/js/models.js
@@ -88,7 +88,7 @@ models.Order = models.Order.extend({
     export_as_JSON: function () {
         const json = super_order_model.export_as_JSON.apply(this, arguments);
         if (this.pos.config.module_pos_hr) {
-            json.employee_id = this.employee.id;
+            json.employee_id = this.employee ? this.employee.id : false;
         }
         return json;
     },


### PR DESCRIPTION
To reproduce:

0. Login as admin.
1. Install pos_hr.
2. Open a pos session without activating the Authorized employees feature.
3. Make an order as Mitchell admin but **don't** validate, order is just
in the localStorage.
4. Go back to the backend (without closing the browser).
5. Close the session.
6. Edit the pos config and activate authorized employees.
7. Delete the employee record linked to the admin user.
8. Open a new session using the modified pos config.
9. [Crash] Because of missing employee.

Solution:

We just make sure to prevent field access on missing undefined object.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
