### PR TITLE
[FIX] pad: make pad quick editable

### DIFF
--- a/addons/pad/static/src/js/pad.js
+++ b/addons/pad/static/src/js/pad.js
@@ -10,9 +10,13 @@ var _t = core._t;
 var FieldPad = AbstractField.extend({
     template: 'FieldPad',
     content: "",
-    events: {
+    events: _.extend({}, AbstractField.prototype.events, {
         'click .oe_pad_switch': '_onToggleFullScreen',
-    },
+    }),
+    isQuickEditable: true,
+    quickEditExclusion: [
+        '[href]',
+    ],
 
     /**
      * @override
@@ -174,6 +178,13 @@ var FieldPad = AbstractField.extend({
     // Handlers
     //--------------------------------------------------------------------------
 
+    /**
+     * @override
+     * @private
+     */
+    _onKeydown: function () {
+        // managed by the pad.
+    },
     /**
      * @override
      * @private

--- a/addons/pad/static/tests/pad_tests.js
+++ b/addons/pad/static/tests/pad_tests.js
@@ -307,4 +307,63 @@ QUnit.module('pad widget', {
         delete FieldPad.prototype.isPadConfigured;
     });
 
+    QUnit.test('Quick Edition: click on the pad', async function (assert) {
+        assert.expect(2);
+
+        const form = await createView({
+            View: FormView,
+            model: 'task',
+            data: this.data,
+            arch: `
+                <form>
+                    <sheet>
+                        <group>
+                            <field name="description" widget="pad"/>
+                        </group>
+                    </sheet>
+                </form>`,
+            res_id: 2,
+        });
+
+        assert.containsOnce(form, '.o_form_readonly');
+
+        await testUtils.dom.click(form.$('.o_field_widget[name="description"]'));
+
+        assert.containsOnce(form, '.o_form_editable');
+
+        form.destroy();
+        delete FieldPad.prototype.isPadConfigured;
+    });
+
+    QUnit.test('Quick Edition: click on a link', async function (assert) {
+        assert.expect(2);
+
+        this.data.task.pad_get_content = function () {
+            return '<a href="https://www.example.com/">link</a>';
+        };
+
+        const form = await createView({
+            View: FormView,
+            model: 'task',
+            data: this.data,
+            arch: `
+                <form>
+                    <sheet>
+                        <group>
+                            <field name="description" widget="pad"/>
+                        </group>
+                    </sheet>
+                </form>`,
+            res_id: 2,
+        });
+
+        assert.containsOnce(form, '.o_form_readonly');
+
+        await testUtils.dom.click(form.$('.o_field_widget[name="description"] a'));
+
+        assert.containsOnce(form, '.o_form_readonly');
+
+        form.destroy();
+        delete FieldPad.prototype.isPadConfigured;
+    });
 });


### PR DESCRIPTION
This commit makes the pad quick editable like a html field.
When we click on the pad, the form switches to edit mode but
not if we click on a link. A link has the priority over the quick edit.