### PR TITLE
[FIX] mail: profile name changed to administrator in chatter

### DIFF
--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -116,7 +116,7 @@ GROUP BY channel_moderator.res_users_id""", [tuple(self.ids)])
             public channels are mailing list (e-mail based) and so users should always receive
             updates from public channels until they manually un-subscribe themselves.
         """
-        self.mapped('partner_id.channel_ids').filtered(lambda c: c.public != 'public').write({
+        self.mapped('partner_id.channel_ids').filtered(lambda c: c.public != 'public' and c.channel_type == 'channel').write({
             'channel_partner_ids': [(3, pid) for pid in self.mapped('partner_id').ids]
         })
 

--- a/addons/test_mail/tests/test_mail_channel.py
+++ b/addons/test_mail/tests/test_mail_channel.py
@@ -228,22 +228,30 @@ class TestChannelFeatures(common.BaseFunctionalTest, common.MockEmails):
             "name": "Jonas",
         })
         test_partner = test_user.partner_id
+        test_chat = self.env['mail.channel'].with_context(self._test_context).create({
+            'name': 'test',
+            'channel_type': 'chat',
+            'public': 'private',
+            'channel_partner_ids': [(4, self.user_employee.partner_id.id), (4, test_partner.id)],
+        })
 
         self._join_channel(self.test_channel, self.user_employee.partner_id | test_partner)
         self._join_channel(test_channel_private, self.user_employee.partner_id | test_partner)
         self._join_channel(test_channel_group, self.user_employee.partner_id | test_partner)
 
-        # Unsubscribe archived user from the private channels, but not from public channels
+        # Unsubscribe archived user from the private channels, but not from public channels and not from chat
         self.user_employee.active = False
         self.assertEqual(test_channel_private.channel_partner_ids, test_partner)
         self.assertEqual(test_channel_group.channel_partner_ids, test_partner)
         self.assertEqual(self.test_channel.channel_partner_ids, self.user_employee.partner_id | test_partner)
+        self.assertEqual(test_chat.channel_partner_ids, self.user_employee.partner_id | test_partner)
 
-        # Unsubscribe deleted user from the private channels, but not from public channels
+        # Unsubscribe deleted user from the private channels, but not from public channels and not from chat
         test_user.unlink()
         self.assertEqual(test_channel_private.channel_partner_ids, self.env['res.partner'])
         self.assertEqual(test_channel_group.channel_partner_ids, self.env['res.partner'])
         self.assertEqual(self.test_channel.channel_partner_ids, self.user_employee.partner_id | test_partner)
+        self.assertEqual(test_chat.channel_partner_ids, self.user_employee.partner_id | test_partner)
 
     def test_multi_company_chat(self):
         company_A = self.env['res.company'].create({'name': 'Company A'})


### PR DESCRIPTION
**Current behavior before PR:**

When delete/archive any user, the user’s profile name changed to 'Administrator'
on chatWindow.

It happens only in case when the user is ‘Administrator’.

**Desired behavior after PR is merged:**

chat window name should remain the same after archiving/deleting the user.

**LINKS:**
PR #66325
Task-2442235

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
