### PR TITLE
[FIX] web: correctly close confirm dialog

### DIFF
--- a/addons/web/static/src/js/views/form/form_controller.js
+++ b/addons/web/static/src/js/views/form/form_controller.js
@@ -509,7 +509,7 @@ var FormController = BasicController.extend({
         var attrs = ev.data.attrs;
         if (attrs.confirm) {
             def = new Promise(function (resolve, reject) {
-                Dialog.confirm(this, attrs.confirm, {
+                Dialog.confirm(self, attrs.confirm, {
                     confirm_callback: saveAndExecuteAction,
                 }).on("closed", null, resolve);
             });

--- a/addons/web/static/tests/chrome/action_manager_tests.js
+++ b/addons/web/static/tests/chrome/action_manager_tests.js
@@ -3540,6 +3540,57 @@ QUnit.module('ActionManager', {
         actionManager.destroy();
     });
 
+    QUnit.test('can execute act_window actions in target="new"', async function (assert) {
+        assert.expect(5);
+
+        this.actions.push({
+            id: 999,
+            name: 'A window action',
+            res_model: 'partner',
+            target: 'new',
+            type: 'ir.actions.act_window',
+            views: [[999, 'form']],
+        });
+        this.archs['partner,999,form'] = `
+            <form>
+                <button name="method" string="Call method" type="object" confirm="Are you sure?"/>
+            </form>`;
+        this.archs['partner,1000,form'] = `<form>Another action</form>`;
+
+        const actionManager = await createActionManager({
+            actions: this.actions,
+            archs: this.archs,
+            data: this.data,
+            mockRPC: function (route, args) {
+                if (args.method === 'method') {
+                    return Promise.resolve({
+                        id: 1000,
+                        name: 'Another window action',
+                        res_model: 'partner',
+                        target: 'new',
+                        type: 'ir.actions.act_window',
+                        views: [[1000, 'form']],
+                    });
+                }
+                return this._super.apply(this, arguments);
+            },
+        });
+        await actionManager.doAction(999);
+
+        assert.containsOnce(document.body, '.modal button[name=method]');
+
+        await testUtils.dom.click($('.modal button[name=method]'));
+
+        assert.containsN(document.body, '.modal', 2);
+        assert.strictEqual($('.modal:last .modal-body').text(), 'Are you sure?');
+
+        await testUtils.dom.click($('.modal:last .modal-footer .btn-primary'));
+        assert.containsOnce(document.body, '.modal');
+        assert.strictEqual($('.modal:last .modal-body').text().trim(), 'Another action');
+
+        actionManager.destroy();
+    });
+
     QUnit.test('on_attach_callback is called for actions in target="new"', async function (assert) {
         assert.expect(4);
 


### PR DESCRIPTION
Let's assume the following scenario:
 - have an action in target new (e.g. a form view)
 - in the dialog, have an action/object button with confirm
   attribute
 - when clicking on that button, a confirm dialog opens
 - if validated, the following action returned by the server
   is again an action in target new

Before this commit, the confirm dialog remained in the DOM.

This issue occurred because it's parent wasn't correctly set (wrong
use of `this`), so when the first dialog was destroyed, the confirm
dialog wasn't automatically destroyed in turn.

OPW~2440712

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
