### PR TITLE
[FIX] account: wrong batching to compute the name

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1108,7 +1108,11 @@ class AccountMove(models.Model):
         final_batches = []
         for journal_group in grouped.values():
             for date_group in journal_group.values():
-                if not final_batches or final_batches[-1]['format'] != date_group['format']:
+                if (
+                    not final_batches
+                    or final_batches[-1]['format'] != date_group['format']
+                    or final_batches[-1]['format_values'] != date_group['format_values']
+                ):
                     final_batches += [date_group]
                 elif date_group['reset'] == 'never':
                     final_batches[-1]['records'] += date_group['records']

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -475,6 +475,32 @@ class TestAccountMove(AccountTestInvoicingCommon):
         self.assertEqual(refund.name, 'RINV/2016/01/0001')
         self.assertEqual(refund2.name, 'RINV/2016/01/0002')
 
+    def test_journal_sequence_groupby_compute(self):
+        # Setup two journals with a sequence that resets yearly
+        journals = self.env['account.journal'].create([{
+            'name': f'Journal{i}',
+            'code': f'J{i}',
+            'type': 'general',
+        } for i in range(2)])
+        account = self.env['account.account'].search([], limit=1)
+        moves = self.env['account.move'].create([{
+            'journal_id': journals[i].id,
+            'line_ids': [(0, 0, {'account_id': account.id, 'name': 'line'})],
+        } for i in range(2)])._post()
+        year = moves[0].date.year
+        for i in range(2):
+            moves[i].name = f'J{i}/{year}/00001'
+
+        # Check that the moves are correctly batched
+        moves = self.env['account.move'].create([{
+            'journal_id': journals[i].id,
+            'line_ids': [(0, 0, {'account_id': account.id, 'name': 'line'})],
+        } for i in [1, 0, 1]])._post()
+        self.assertEqual(
+            moves.mapped('name'),
+            [f'J1/{year}/00002', f'J0/{year}/00002', f'J1/{year}/00003'],
+        )
+
     def test_journal_override_sequence_regex(self):
         other_moves = self.env['account.move'].search([('journal_id', '=', self.test_move.journal_id.id)]) - self.test_move
         other_moves.unlink()  # Do not interfere when trying to get the highest name for new periods


### PR DESCRIPTION
Reproduce:
* Create one move in a journal
* Create another move in another journal but in the same year
* Both journals should have a yearly sequence reset
* Post both moves at the same time

Bug:
They both are using the same sequence.

Expected:
Both should be using their own sequence.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
