### PR TITLE
[FIX]sales_team: fix the filter for search by display name

### DIFF
--- a/addons/sales_team/views/crm_team_member_views.xml
+++ b/addons/sales_team/views/crm_team_member_views.xml
@@ -6,7 +6,7 @@
         <field name="model">crm.team.member</field>
         <field name="arch" type="xml">
             <search string="Sales Person">
-                <field name="name"/>
+                <field name="user_id"/>
                 <field name="crm_team_id"/>
                 <separator/>
                 <filter name="archived" string="Archived" domain="[('active', '=', False)]"/>


### PR DESCRIPTION
PURPOSE

in the sales_team -> search view of team members, search by name 
filter is not correctly working.

Task Id:2460697

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
