### PR TITLE
do not display cover images in sample data

### DIFF
--- a/addons/web/static/src/js/views/sample_server.js
+++ b/addons/web/static/src/js/views/sample_server.js
@@ -251,6 +251,9 @@ odoo.define('web.SampleServer', function (require) {
                     if (field.relation === 'res.currency') {
                         return session.company_currency_id;
                     }
+                    if (field.relation === 'ir.attachment') {
+                        return false;
+                    }
                     return this._getRandomSubRecordId();
                 case "one2many":
                 case "many2many": {

--- a/addons/web/static/tests/views/sample_server_tests.js
+++ b/addons/web/static/tests/views/sample_server_tests.js
@@ -54,6 +54,7 @@ odoo.define('web.sample_server_tests', function (require) {
                     salary: { string: "Salary", type: 'monetary' },
                     currency: { string: "Currency", type: 'many2one', relation: 'res.currency' },
                     manager_id: { string: "Manager", type: 'many2one', relation: 'res.users' },
+                    cover_image_id: { string: "Cover Image", type: 'many2one', relation: 'ir.attachment' },
                     managed_ids: { string: "Managing", type: 'one2many', relation: 'res.users' },
                     tag_ids: { string: "Tags", type: 'many2many', relation: 'tag' },
                     type: { string: "Type", type: 'selection', selection: [
@@ -70,6 +71,9 @@ odoo.define('web.sample_server_tests', function (require) {
                     ] },
                     age: { string: "Age", type: 'integer' },
                 },
+                'ir.attachment': {
+                    display_name: { string: "Name", type: 'char' },
+                }
             };
         },
     }, function () {
@@ -77,7 +81,7 @@ odoo.define('web.sample_server_tests', function (require) {
         QUnit.module("Basic behaviour");
 
         QUnit.test("Sample data: people type + all field names", async function (assert) {
-            assert.expect(25);
+            assert.expect(26);
 
             mock.patch(session, {
                 company_currency_id: 4,
@@ -149,6 +153,8 @@ odoo.define('web.sample_server_tests', function (require) {
 
             assert.strictEqual(typeof rec.manager_id[0], 'number');
             assert.ok(SAMPLE_PEOPLE.includes(rec.manager_id[1]));
+
+            assert.strictEqual(rec.cover_image_id, false);
 
             assert.strictEqual(rec.managed_ids.length, 2);
             assert.ok(rec.managed_ids.every(


### PR DESCRIPTION
PURPOSE
Hide cover images from the sample data of tasks kanban cards, as the pictures are quite random and don't do the view justice

SPEC
Do not return many2one value for cover image field(do not return value if relation of field is ir.attachment)

TASK 2368505


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
