### PR TITLE
[FIX] website: prevent error on edit mode save for restricted editor

### DIFF
--- a/addons/website/static/src/js/editor/editor_menu.js
+++ b/addons/website/static/src/js/editor/editor_menu.js
@@ -123,7 +123,9 @@ var EditorMenu = Widget.extend({
         return this.wysiwyg.save(false).then(function (result) {
             var $wrapwrap = $('#wrapwrap');
             self.editable($wrapwrap).removeClass('o_editable');
-            if (result.isDirty && reload !== false) {
+            if (!result.isDirty) {
+                self.cancel(reload);
+            } else if (result.isDirty && reload !== false) {
                 // remove top padding because the connected bar is not visible
                 $('body').removeClass('o_connected_user');
                 return self._reload();

--- a/addons/website/static/src/js/editor/wysiwyg_multizone.js
+++ b/addons/website/static/src/js/editor/wysiwyg_multizone.js
@@ -111,7 +111,7 @@ var WysiwygMultizone = Wysiwyg.extend({
                 .then(() => this.editor.save(false))
                 .then(() => ({isDirty: true}));
         } else {
-            return {isDirty: false};
+            return Promise.resolve({isDirty: false});
         }
     },
     /**


### PR DESCRIPTION
**SPECIFICATION**
Enter in edit mode as website restrictor user, and click on save button, you will get the traceback
    https://youtu.be/OR3m5brmHnE

**LINKS**
TaskID: 2379101
Closes: https://github.com/odoo/odoo/pull/66357