### PR TITLE
do not show false on empty url widget

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -1689,12 +1689,17 @@ var UrlWidget = InputField.extend({
 
     /**
      * In readonly, the widget needs to be a link with proper href and proper
-     * support for the design, which is achieved by the added classes.
+     * support for the design, which is achieved by the added classes, it will
+     * display nothing if there is no value as it doesn't make sense to display
+     * link with false value.
      *
      * @override
      * @private
      */
     _renderReadonly: function () {
+        if (!this.value) {
+            return;
+        }
         let href = this.value;
         if (this.value && !this.websitePath) {
             const regex = /^(?:[fF]|[hH][tT])[tT][pP][sS]?:\/\//;

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -1964,7 +1964,7 @@ QUnit.module('basic_fields', {
     QUnit.module('UrlWidget');
 
     QUnit.test('url widget in form view', async function (assert) {
-        assert.expect(9);
+        assert.expect(10);
 
         var form = await createView({
             View: FormView,
@@ -2007,6 +2007,13 @@ QUnit.module('basic_fields', {
             "should have proper new href link");
         assert.strictEqual(form.$('div.o_form_uri.o_field_widget.o_text_overflow.o_field_url > a').text(), 'limbo',
             'the new value should be displayed');
+
+        // switch to edit mode and remove value, save and check the result
+        await testUtils.form.clickEdit(form);
+        testUtils.fields.editInput(form.$('input[type="text"].o_field_widget'), '');
+        await testUtils.form.clickSave(form);
+        assert.containsNone(form, '.o_field_url[name="foo"] > a',
+            "should not have an anchor tag");
 
         form.destroy();
     });


### PR DESCRIPTION
PURPOSE
An empty URL widget should not display 'False'

SPEC
It should be empty if there is no value.

TASK 2462594



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
