### PR TITLE
[FIX] project: access to project if follower of folded task


### DIFF
--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -56,7 +56,7 @@
                                         '|','|',
                                             ('message_partner_ids', 'in', [user.partner_id.id]),
                                             ('message_channel_ids', 'in', user.partner_id.channel_ids.ids),
-                                            ('task_ids.message_partner_ids', 'in', [user.partner_id.id]),
+                                            ('tasks.message_partner_ids', 'in', [user.partner_id.id]),
                                     ]</field>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
     </record>


### PR DESCRIPTION

The access rule on a project with invitation only will for example
check if the user is follower of a task inside this project.

Currently it used task_ids to do that, so:

- you would not see a project where you have access to project if the
  tasks you have access to are in folded columns

- there is an odd issue with computation of the field value and the
  domain where is might cause an error and make Project app
  inaccessible (when searching it doesn't filter on task_ids domain,
  so find too many results, when checking security for compute fields
  it filters on it

In any case, we should use tasks which also contains task in folded
stage and not just task_ids.

opw-2455780
