### PR TITLE
[FIX] stock: variant price on report Product Label (ZPL)


### DIFF
--- a/addons/stock/report/product_templates.xml
+++ b/addons/stock/report/product_templates.xml
@@ -34,11 +34,11 @@
 ^FO100,100
 <t t-if="product.currency_id.position == 'after'">
 ^CI28
-^A0N,44,33^FH^FDPrice: <t t-esc="product.list_price" t-options='{"widget": "float", "precision": 2}'/><t t-esc="product.currency_id.symbol"/>^FS
+^A0N,44,33^FH^FDPrice: <t t-esc="product.lst_price" t-options='{"widget": "float", "precision": 2}'/><t t-esc="product.currency_id.symbol"/>^FS
 </t>
 <t t-if="product.currency_id.position == 'before'">
 ^CI28
-^A0N,44,33^FH^FDPrice: <t t-esc="product.currency_id.symbol"/><t t-esc="product.list_price" t-options='{"widget": "float", "precision": 2}'/>^FS
+^A0N,44,33^FH^FDPrice: <t t-esc="product.currency_id.symbol"/><t t-esc="product.lst_price" t-options='{"widget": "float", "precision": 2}'/>^FS
 </t>
 <t t-if="product.barcode">
 ^FO100,150^BY3


### PR DESCRIPTION

With this change, we show the variant price when printing ZPL
product.product report and not the template as we did before.

This way it is the same as what we see in Odoo as well as when printing
PDF label of the product.

targetting only 14.0 for now (but could be backported in stock_zebra)

opw-2455291
