### PR TITLE
[FIX] web: calendar: avoid rerendering on resize

### DIFF
--- a/addons/web/static/src/js/views/calendar/calendar_renderer.js
+++ b/addons/web/static/src/js/views/calendar/calendar_renderer.js
@@ -524,7 +524,7 @@ return AbstractRenderer.extend({
                 return 'popover';
             },
             windowResize: function () {
-                self._render();
+                self._onWindowResize();
             },
             views: {
                 timeGridDay: {
@@ -980,6 +980,16 @@ return AbstractRenderer.extend({
         if (popover && !popover.contains(e.target)) {
             this._unselectEvent();
         }
+    },
+    /**
+     * Handler for resize event.
+     * As the result it will resize the calendar to fit the window space.
+     *
+     * @private
+     */
+    _onWindowResize: function () {
+        this.$el.height($(window).height() - this.$el.offset().top);
+        this.calendar.updateSize();
     },
     /**
      * @private


### PR DESCRIPTION
Before this commit, when a calendar view was resized the full view was
rendered again to recalculate the resize.

After this commit, we now set manually the new size.
This avoid to lose the current position-y in the calendar.

Steps to reproduce:
* Open a window (not maximized)
* Go to calendar (day/week view)
* Scroll to the end of the calendar
* Resize the window => the calendar returns to the begging.

Note:
By the same way it also fixes a performance issue in TimeOff's render as
it makes an RPC to calculate the popover for the year view.

Task ID: 2200168 (5.a)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
