### PR TITLE
[FIX] google_(account|calendar): Improve google sync for heavier usage

### DIFF
--- a/addons/google_account/models/google_service.py
+++ b/addons/google_account/models/google_service.py
@@ -146,14 +146,14 @@ class GoogleService(models.AbstractModel):
             res.raise_for_status()
             status = res.status_code
 
-            if int(status) in (204, 404):  # Page not found, no response
+            if int(status) == 204:  # Page not found, no response
                 response = False
             else:
                 response = res.json()
 
             try:
-                ask_time = datetime.strptime(res.headers.get('date'), "%a, %d %b %Y %H:%M:%S %Z")
-            except:
+                ask_time = datetime.strptime(res.headers.get('date', ''), "%a, %d %b %Y %H:%M:%S %Z")
+            except ValueError:
                 pass
         except requests.HTTPError as error:
             if error.response.status_code in (204, 404):


### PR DESCRIPTION
Issue 1: Concurrent synchro
---------------------------
Each time the calendar view of event.calendar is loaded,
the synchronization with google calendar was launched
and if a user open many tabs, it can lead to deadlock

Solution: Check for lock before launching the synchro,
if the transaction cannot acquire the lock, it's probably
because another synchro already started

Issue 2: Write on deleted record
--------------------------------
The delete operation, like other operation, set need_sync = False
Obviously, when the record are already deleted in odoo it's not
needed and possible anymore and thus raise an exception





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
