### PR TITLE
[FIX] event_crm: prevent access rights issues on leads

### DIFF
--- a/addons/event_crm/views/crm_lead_views.xml
+++ b/addons/event_crm/views/crm_lead_views.xml
@@ -22,7 +22,7 @@
             <xpath expr="//div[@name='button_box']" position="inside">
                 <field name="registration_ids" invisible="1"/>
                 <button name="%(event_registration_action_from_lead)d" type="action" class="oe_stat_button" icon="fa-ticket"
-                    attrs="{'invisible': [('registration_count', '=', 0)]}">
+                    attrs="{'invisible': [('registration_count', '=', 0)]}" groups="event.group_event_user">
                     <div class="o_stat_info">
                         <field name="registration_count"/>
                         <span class="o_stat_text"> Attendees</span>


### PR DESCRIPTION
Steps:
- Login as an admin user
- On a fresh branch install event_crm
- Give a "test" user access rights of "Own Document only" in the "Sales"
  app, nothing in "Events"
- Assign any lead to "test" user
- Login as "test" user and try to access your own leads

Bug:
Error: While parsing modifiers for button: for modifier "invisible":
Unknown field registration_count in domain

Explanation:
The button `event_registration_action_from_lead` tries to access event
registrations even if the user doesn't have access to events.

opw:2462127