### PR TITLE
[FIX] web_editor: shift+enter in editor add direct newline


### DIFF
--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -458,7 +458,7 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
      * @param {OdooEvent} ev
      */
     _onKeydown: function (ev) {
-        if (ev.which === $.ui.keyCode.ENTER && $(ev.target).is('textarea')) {
+        if (ev.which === $.ui.keyCode.ENTER) {
             ev.stopPropagation();
             return;
         }


### PR DESCRIPTION

Enter keypress browser event were removed in 3c372d1da8b.

It was reintroduced in text fields with d2f024d2543 and in source mode
of html field with b10ca1f6094b.

When doing ENTER in the editor, we do our special case of ENTER (eg. it
will split the container in two and have other custom behavior) but when
doing SHIFT+ENTER we let the browser handle it and add a normal newline.

With the "Enter" prevention, SHIFT+ENTER did not work.

opw-2463746
