### PR TITLE
[FIX] account_analytic_default: keep new account analytic

### DIFF
--- a/addons/account_analytic_default/models/account_analytic_default.py
+++ b/addons/account_analytic_default/models/account_analytic_default.py
@@ -75,8 +75,8 @@ class AccountMoveLine(models.Model):
     @api.depends('product_id', 'account_id', 'partner_id', 'date_maturity')
     def _compute_analytic_account(self):
         for record in self:
-            record.analytic_account_id = (record._origin or record).analytic_account_id
-            record.analytic_tag_ids = (record._origin or record).analytic_tag_ids
+            record.analytic_account_id = record.analytic_account_id
+            record.analytic_tag_ids = record.analytic_tag_ids
             rec = self.env['account.analytic.default'].account_get(
                 product_id=record.product_id.id,
                 partner_id=record.partner_id.commercial_partner_id.id or record.move_id.partner_id.commercial_partner_id.id,


### PR DESCRIPTION
When importing some invoice lines, if the analytic account field of a
line has changed, the new invoice line will still keep the initial
analytic account value.

To reproduce the error:
(use demo data)
1. Create an invoice I01
    - Add one line with one analytic account (e.g., "Administrative")
2. Save
3. Go to Accounting > Customers > Invoices
4. Export I01:
    - Enable "I want to update data (import-compatible export)"
    - Fields to export:
        - Invoice lines
        - Invoice lines/External ID
        - Invoice lines/Analytic Account
        - Invoice lines/Analytic Account/Analytic Account
5. On exported file:
    - Delete column "invoice_line_ids"
    - Change the analytic account (e.g., "Operating Costs")
6. Import the file
7. Open I01

Error: The analytic account is still "Administrative". It should be
"Operating Costs".

The issue comes from both `._origin`: the module keeps the initial
values. Both `_origin` were introduced to fix an issue (see #49110), but
they are not useful anymore.

OPW-2452428