### PR TITLE
[FIX] web: m2o extra button misaligned on mobile

### DIFF
--- a/addons/web/static/src/scss/form_view.scss
+++ b/addons/web/static/src/scss/form_view.scss
@@ -562,14 +562,16 @@
             }
         }
 
-        :not(.o_row):not(.o_data_cell) > .o_field_widget,
-        .o_row > .o_field_widget:last-child { // Note: this does not take care
-                                              // of an invisible last-child but
-                                              // it does not really matter
-            // Makes extra buttons (e.g. m2o external button) overflow on the
-            // right padding of the parent element
-            .o_input_dropdown {
-                flex: 1 0 auto;
+        @include media-breakpoint-up(sm) {
+            :not(.o_row):not(.o_data_cell) > .o_field_widget,
+            .o_row > .o_field_widget:last-child { // Note: this does not take care
+                                                // of an invisible last-child but
+                                                // it does not really matter
+                // Makes extra buttons (e.g. m2o external button) overflow on the
+                // right padding of the parent element
+                .o_input_dropdown {
+                    flex: 1 0 auto;
+                }
             }
         }
 


### PR DESCRIPTION
Before this fix, the extra button was out of the right edge of the
screen.

On desktop, m2o external buttons have to overflow over the right padding
of the parent element. This is done to avoid to reduce the size of the
input when the button appears (when a value is set).

But on mobile, there is not enough padding and we therefore prefer to
reduce the size of the field if an extra button should appear.

To fix this, we simply ignore these rules on mobile.
Note that the css selector that really cause this issue was the one
related to '.o_row' and the second one has no effect.

Steps to reproduce:
- Go to "Inventory / Operations / Scrap"
- Click on "Create"
- Choose a product and set UOM field

Related task-ID: 1929043

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
