### PR TITLE
[FIX] mrp_subcontracting: Updat quantity on confirmed PO

### DIFF
--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -196,7 +196,7 @@ operations.""") % ('\n'.join(overprocessed_moves.mapped('product_id.display_name
     def _update_subcontract_order_qty(self, quantity):
         for move in self:
             quantity_change = quantity - move.product_uom_qty
-            production = move.move_orig_ids.production_id
+            production = move.move_orig_ids.production_id.filtered(lambda p: p.state != 'cancel')
             if production:
                 self.env['change.production.qty'].with_context(skip_activity=True).create({
                     'mo_id': production.id,


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a product P with a subcontracting BOM B and subcontractor S
- Create a purchase order PO with S as vendor
- Add P on PO and confirm it
- Change quantity of P two times

Bug:

A traceback was raised

opw:2419222