### PR TITLE
[FIX] mail: translate report name field

### DIFF
--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -191,7 +191,7 @@ class MailTemplate(models.Model):
             if template.report_template:
                 for res_id in template_res_ids:
                     attachments = []
-                    report_name = self._render_field('report_name', [res_id])[res_id]
+                    report_name = template._render_field('report_name', [res_id])[res_id]
                     report = template.report_template
                     report_service = report.report_name
 


### PR DESCRIPTION
When genrating an attachment in a mail message (e.g. the pdf attached
to a confirmation email), the filename was not translated into the
language of the recipient (unlink the email content).

The variable `template` has the contact language in the context while
`self` contains the language of the user executing the action.

Fixes odoo/odoo#66420
