### PR TITLE
[FIX] l10n_fr_pos_cert,point_of_sale: manage return with pricelist price

### DIFF
--- a/addons/l10n_fr_pos_cert/static/src/js/pos.js
+++ b/addons/l10n_fr_pos_cert/static/src/js/pos.js
@@ -71,6 +71,12 @@ models.Orderline = models.Orderline.extend({
 
         return last_id === selectedLine.cid;
     },
+    recompute_unit_price: function(quantity){
+        // when the price is computed via pricelist we need to input the
+        // absolute quantity to get the correct unit price
+        quantity = quantity >= 0 ? quantity : -quantity
+        orderline_super.set_quantity.apply(selected_orderline, [quantity]);
+    },
     set_quantity: function (quantity, keep_price) {
         var current_quantity = this.get_quantity();
         var new_quantity = parseFloat(quantity) || 0;
@@ -101,7 +107,7 @@ models.Orderline = models.Orderline.extend({
                         });
 
                         if(selected_orderline.isLastLine() && current_total_quantity_remaining === 0 && current_total_quantity_remaining < qty_decrease) {
-                            orderline_super.set_quantity.apply(selected_orderline, [-qty_decrease, true]);
+                            orderline_super.set_quantity.apply(selected_orderline, [-qty_decrease]);
                         } else if (qty_decrease > current_total_quantity_remaining) {
                           this.pos.gui.show_popup("error", {
                               'title': _t("Order error"),

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1491,6 +1491,10 @@ exports.Orderline = Backbone.Model.extend({
     get_discount_str: function(){
         return this.discountStr;
     },
+    recompute_unit_price: function(quantity){
+        this.set_unit_price(this.product.get_price(this.order.pricelist, quantity));
+        this.order.fix_tax_included_price(this);
+    },
     // sets the quantity of the product. The quantity will be rounded according to the
     // product's unity of measure properties. Quantities greater than zero will not get
     // rounded to zero
@@ -1520,8 +1524,7 @@ exports.Orderline = Backbone.Model.extend({
 
         // just like in sale.order changing the quantity will recompute the unit price
         if(! keep_price && ! this.price_manually_set){
-            this.set_unit_price(this.product.get_price(this.order.pricelist, this.get_quantity()));
-            this.order.fix_tax_included_price(this);
+            this.recompute_unit_price(this.get_quantity());
         }
         this.trigger('change', this);
     },


### PR DESCRIPTION
Set up a product with sale price A
Set up a pricelist in which the said product has price B
Open POS
Add A
Press delete key (quantity reset to 0)
Press delete key once again (Quantity widget popup show)
Insert 1 or the quantity you want to return
Confirm
The line will update with the negative quantity but price A

This occur because the pricelist computation has a minimum quantity
required to be positive. As the return is processed with quantity
negative the pricelist price is not applied

opw-2419592

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
