### PR TITLE
[FIX] web_editor: don't save cropping tool on CTRL+Z


### DIFF
--- a/addons/web_editor/static/src/js/editor/rte.summernote.js
+++ b/addons/web_editor/static/src/js/editor/rte.summernote.js
@@ -1208,7 +1208,7 @@ var SummernoteManager = Class.extend(mixins.EventDispatcherMixin, ServicesMixin,
         }
         data.__alreadyDone = true;
         new weWidgets.ImageCropWidget(this, data.media)
-            .appendTo(data.$editable);
+            .appendTo(data.$editable.parent());
     },
     /**
      * Called when a demand to open a link dialog is received on the bus.


### PR DESCRIPTION

Scenario:

- start cropping of an image
- press TAB key
- do CTRL + Z

=> now the image cropping tool are inside the page and there is no way
to remove them.

Why:

The image crop tool was added inside the editable elemnt, so if we did
an action that changed history the cropping tools are saved in the
snapshot and going back to it will add them without any code handling
their removal.

opw-2394877
opw-2423445
