### PR TITLE
increase start/end date roundness in daterangepicker

### DIFF
--- a/addons/web/static/src/scss/daterangepicker.scss
+++ b/addons/web/static/src/scss/daterangepicker.scss
@@ -46,6 +46,16 @@
                             background: #FFFFFF;
                             color: #999;
                         }
+                        &.start-date {
+                            border-radius: 8px 0 0 8px;
+                            &.end-date {
+                                border-radius: 8px;
+                            }
+                        }
+                        &.end-date {
+                            border-radius: 0 8px 8px 0;
+                        }
+
                     }
                 }
             }


### PR DESCRIPTION
PURPOSE
Increase the roundness of the start/end dates in the daterange picker for clarity.

SPEC
Increase start/end dates roundness from 4px to 8px.

TASK 2413932



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
