### PR TITLE
[FIX] account:Auto Post scheduler action threads killed by timeout.

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2574,7 +2574,10 @@ class AccountMove(models.Model):
             ('date', '<=', fields.Date.today()),
             ('auto_post', '=', True),
         ])
-        records.post()
+        for ids in self._cr.split_for_in_conditions(records.ids, size=1000):
+            self.browse(ids).post()
+            if not self.env.registry.in_test_mode():
+                self._cr.commit()
 
     # offer the possibility to duplicate thanks to a button instead of a hidden menu, which is more visible
     def action_duplicate(self):


### PR DESCRIPTION
Before this commit:

  When there is too many records to post, and it's to take time more than 15 minutes then the server was restarted.
  So scheduler action will do the process with the same records again and again.

After this commit:

  post record in batch of 1000

opw-2451446


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
