### PR TITLE
[IMP] pos_sale: `pos_order_amount_total` performances using read_group

### DIFF
--- a/addons/pos_sale/models/crm_team.py
+++ b/addons/pos_sale/models/crm_team.py
@@ -34,9 +34,12 @@ class CrmTeam(models.Model):
 
     def _compute_pos_order_amount_total(self):
         for team in self.filtered(lambda t: t.team_type == 'pos'):
-            team.pos_order_amount_total = sum(self.env['report.pos.order'].search(
-                [('session_id', 'in', team.pos_config_ids.mapped('session_ids').filtered(lambda s: s.state == 'opened').ids)]
-            ).mapped('price_total'))
+            res = self.env['report.pos.order'].read_group(
+                [("config_id.crm_team_id", "=", team.id), ("session_id.state", "=", "opened")],
+                ["price_total"],
+                [],
+            )
+            team.pos_order_amount_total = sum(r["price_total"] for r in res if r["price_total"])
 
     def _graph_data(self, start_date, end_date):
         """ If the type of the sales team is point of sale ('pos'), the graph will display the sales data.


### PR DESCRIPTION
Using `read_group` to gather such a sum is always more performant
than a `search` followed by a `mapped`.

In the case of the studied database,
the computation never ended,
while it ends in a few seconds
using `read_group`.

upg-7528
