### PR TITLE
[IMP] repair: updates to repairs workflow

### DIFF
--- a/addons/repair/__manifest__.py
+++ b/addons/repair/__manifest__.py
@@ -27,6 +27,7 @@ The following topics are covered by this module:
         'security/repair_security.xml',
         'wizard/repair_make_invoice_views.xml',
         'wizard/stock_warn_insufficient_qty_views.xml',
+        'views/stock_move_views.xml',
         'views/repair_views.xml',
         'report/repair_reports.xml',
         'report/repair_templates_repair_order.xml',

--- a/addons/repair/data/ir_sequence_data.xml
+++ b/addons/repair/data/ir_sequence_data.xml
@@ -4,7 +4,7 @@
         <record id="seq_repair" model="ir.sequence">
             <field name="name">Repair Order</field>
             <field name="code">repair.order</field>
-            <field name="prefix">RMA/</field>
+            <field name="prefix">RO/</field>
             <field name="padding">5</field>
             <field name="company_id" eval="False"/>
         </record>

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -8,6 +8,7 @@
         <field name="arch" type="xml">
             <tree string="Repairs order" multi_edit="1" sample="1">
                 <field name="name"/>
+                <field name="description"/>
                 <field name="product_id" readonly="1" optional="show"/>
                 <field name="product_qty" optional="hide" string="Quantity"/>
                 <field name="product_uom" string="Unit of Measure" readonly="1" optional="hide"/>
@@ -44,6 +45,7 @@
                <sheet string="Repairs order">
                     <div class="oe_button_box" name="button_box">
                         <field name="invoice_id" invisible="1"/>
+                        <button name="%(action_repair_move_lines)d" type="action" string="Product Moves" class="oe_stat_button" icon="fa-exchange" attrs="{'invisible': [('state', 'not in', ['done', 'cancel'])]}"/>
                         <button name="action_created_invoice"
                             type="object"
                             class="oe_stat_button"
@@ -56,24 +58,28 @@
                             </div>
                         </button>
                     </div>
-                    <label for="name"/>
-                    <h1>
-                        <field name="name"/>
-                    </h1>
+                    <div class="oe_title">
+                        <label class="o_form_label" for="name"/>
+                        <h1>
+                            <field name="name"/>
+                        </h1>
+                    </div>
                     <group>
                         <group>
+                            <field name="description"/>
                             <field name="invoice_state" invisible="1"/>
                             <field name="tracking" invisible="1" attrs="{'readonly': 1}"/>
                             <field name="product_id" />
+                            <field name="lot_id" context="{'default_product_id': product_id, 'default_company_id': company_id}" groups="stock.group_production_lot" attrs="{'required':[('tracking', 'in', ['serial', 'lot'])], 'invisible': [('tracking', 'not in', ['serial', 'lot'])], 'readonly': ['|', ('state', '=', 'done'), ('tracking', 'not in', ['serial', 'lot'])]}"/>
                             <field name="product_uom_category_id" invisible="1"/>
                             <label for="product_qty"/>
                             <div class="o_row">
                                 <field name="product_qty" attrs="{'readonly':[('tracking', 'in', ['serial'])]}"/>
                                 <field name="product_uom" groups="uom.group_uom"/>
                             </div>
-                            <field name="lot_id" context="{'default_product_id': product_id, 'default_company_id': company_id}" groups="stock.group_production_lot" attrs="{'required':[('tracking', 'in', ['serial', 'lot'])], 'invisible': [('tracking', 'not in', ['serial', 'lot'])], 'readonly': [('state', '=', 'done')]}"/>
                             <field name="partner_id" widget="res_partner_many2one" attrs="{'required':[('invoice_method','!=','none')]}" context="{'res_partner_search_mode': 'customer', 'show_vat': True}"/>
                             <field name="address_id" groups="sale.group_delivery_invoice_address"/>
+                            <field name="sale_order_id"/>
                             <field name="user_id" domain="[('share', '=', False)]"/>
                         </group>
                         <group>
@@ -89,7 +95,7 @@
                     </group>
                 <notebook>
                     <page string="Parts" name="parts">
-                        <field name="operations" context="{'default_product_uom_qty': product_qty, 'default_company_id': company_id}">
+                        <field name="operations" context="{'default_product_uom_qty': product_qty, 'default_company_id': company_id}" attrs="{'readonly':[('state', 'in', ['done', 'cancel'])]}">
                             <form string="Operations">
                                 <group>
                                     <group>
@@ -126,7 +132,8 @@
                                 <field name="product_id"/>
                                 <field name='name' optional="show"/>
                                 <field name="product_uom_category_id" invisible="1"/>
-                                <field name="lot_id" context="{'default_product_id': product_id, 'default_company_id': company_id}" groups="stock.group_production_lot"/>
+                                <field name="tracking" invisible="1"/>
+                                <field name="lot_id" context="{'default_product_id': product_id, 'default_company_id': company_id}" groups="stock.group_production_lot" attrs="{'readonly':[('tracking', 'not in', ['serial', 'lot'])]}"/>
                                 <field name="location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations" optional="show"/>
                                 <field name="location_dest_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations" optional="show"/>
                                 <field name="product_uom_qty" string="Quantity"/>
@@ -150,7 +157,7 @@
                         <div class="oe_clear"/>
                     </page>
                     <page string="Operations" name="operations">
-                        <field name="fees_lines" context="{'default_company_id': company_id}">
+                        <field name="fees_lines" context="{'default_company_id': company_id}" attrs="{'readonly':[('state', 'in', ['done', 'cancel'])]}">
                             <form string="Fees">
                                 <group>
                                     <field name="company_id" invisible="1" force_save="1"/>
@@ -193,8 +200,10 @@
                             </group>
                         </group>
                     </page>
-                    <page string="Notes" name="notes">
+                    <page string="Repair Notes">
                         <field name="internal_notes" placeholder="Add internal notes."/>
+                    </page>
+                    <page string="Quotation Notes">
                         <field name="quotation_notes" placeholder="Add quotation notes."/>
                     </page>
                 </notebook>

--- a/addons/repair/views/stock_move_views.xml
+++ b/addons/repair/views/stock_move_views.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record model="ir.actions.act_window" id="action_repair_move_lines">
+        <field name="name">Inventory Moves</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">stock.move.line</field>
+        <field name="view_mode">tree,form</field>
+        <field name="domain">[('move_id.repair_id', '=', active_id)]</field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
The purpose of this commit is to improve the Repairs module general workflow, to make it more intuitive and more flexible.

1. Change in the way the Repair Reference is created. It is now always auto-generated. A new Repair Description can be used for personalized description.
2. Make the 'Parts' and 'Operations' tabs editable up until (and including) the stage 'Under Repair'.
3. Make the 'Lot/Serial Number' Field non mandatory for tracked products, up to and including to the stage 'Under Repair'. If the user forgot to specify the serial number and clicks on 'End Repair', shows the existing error message.
4. Add product moves related to the repair order in a smart button at the top right of repair, just like for a finished manufacturing order.
5. Add a Sale Order field in the repair form to make it easier to perform return if needed.
6. When a component is not tracked by serial/lot number, leaves lot/serial number read only.
7. Separation of notes and internal notes into 2 separate tabs.
8. Lot/serial field always visible but read-only when there is no tracking.

Task ID-2424420
Migration Script: odoo/upgrade#2327

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
