### PR TITLE
[FIX] Purchase double validation can be circumvented by RPC call

### DIFF
--- a/addons/purchase/tests/test_access_rights.py
+++ b/addons/purchase/tests/test_access_rights.py
@@ -137,3 +137,24 @@ class TestPurchaseInvoice(AccountTestInvoicingCommon):
         purchase_order_user2.invalidate_cache()
         action_user_2 = purchase_order_user2.with_user(purchase_user_2).action_view_invoice()
         self.assertEqual(action_user_1, action_user_2)
+
+    def test_double_validation(self):
+        """Only purchase managers can approve a purchase order when double
+        validation is enabled"""
+        group_purchase_manager = self.env.ref('purchase.group_purchase_manager')
+        order = self.env.ref("purchase.purchase_order_1")
+        company = order.sudo().company_id
+        company.po_double_validation = 'two_step'
+        company.po_double_validation_amount = 0
+        self.purchase_user.write({
+            'company_ids': [(4, company.id)],
+            'company_id': company.id,
+            'groups_id': [(3, group_purchase_manager.id)],
+        })
+        order.with_user(self.purchase_user).button_confirm()
+        self.assertEqual(order.state, 'to approve')
+        order.with_user(self.purchase_user).button_approve()
+        self.assertEqual(order.state, 'to approve')
+        self.purchase_user.groups_id += group_purchase_manager
+        order.with_user(self.purchase_user).button_approve()
+        self.assertEqual(order.state, 'purchase')

--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -221,7 +221,7 @@ class PurchaseOrder(models.Model):
 
     def _create_picking(self):
         StockPicking = self.env['stock.picking']
-        for order in self:
+        for order in self.filtered(lambda po: po.state in ('purchase', 'done')):
             if any(product.type in ['product', 'consu'] for product in order.order_line.product_id):
                 order = order.with_company(order.company_id)
                 pickings = order.picking_ids.filtered(lambda x: x.state not in ('done', 'cancel'))

--- a/addons/purchase_stock/tests/test_create_picking.py
+++ b/addons/purchase_stock/tests/test_create_picking.py
@@ -90,6 +90,7 @@ class TestCreatePicking(common.TestProductCommon):
         self.assertEqual(self.po.state, 'to approve', 'Purchase: PO state should be "to approve".')
 
         # PO approved by manager
+        self.po.env.user.groups_id += self.env.ref("purchase.group_purchase_manager")
         self.po.button_approve()
         self.assertEqual(self.po.state, 'purchase', 'PO state should be "Purchase".')
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When double validation is enabled, purchase orders can still be approved by non-manager purchase users using RPC calls.

Current behavior before PR:
Non-manager purchase users can approve orders under double validation restriction

Desired behavior after PR is merged:
Non-manager purchase users can not approve orders under double validation restriction



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
