### PR TITLE
boolean_favorite widget design improvements

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -2666,7 +2666,7 @@ var FavoriteWidget = AbstractField.extend({
     _render: function () {
         var tip = this.value ? _t('Remove from Favorites') : _t('Add to Favorites');
         var template = this.attrs.nolabel ? '<a href="#"><i class="fa %s" title="%s" aria-label="%s" role="img"></i></a>' : '<a href="#"><i class="fa %s" role="img" aria-label="%s"></i> %s</a>';
-        this.$el.empty().append(_.str.sprintf(template, this.value ? 'fa-star' : 'fa-star-o', tip, tip));
+        this.$el.empty().append(_.str.sprintf(template, this.value ? 'fa-bookmark' : 'fa-bookmark-o', tip, tip));
     },
 
     //--------------------------------------------------------------------------

--- a/addons/web/static/src/scss/fields.scss
+++ b/addons/web/static/src/scss/fields.scss
@@ -276,14 +276,14 @@
         i.fa {
             font-size: 16px;
         }
-        i.fa-star-o {
+        i.fa-bookmark-o {
             color: $o-main-color-muted;
             &:hover {
-                color: gold;
+                color: $o-brand-primary;
             }
         }
-        i.fa-star {
-            color: gold;
+        i.fa-bookmark {
+            color: $o-brand-primary;
         }
     }
 

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -6340,14 +6340,14 @@ QUnit.module('basic_fields', {
             domain: [['id', '=', 1]],
         });
 
-        assert.containsOnce(kanban, '.o_kanban_record .o_field_widget.o_favorite > a i.fa.fa-star',
+        assert.containsOnce(kanban, '.o_kanban_record .o_field_widget.o_favorite > a i.fa.fa-bookmark',
             'should be favorite');
         assert.strictEqual(kanban.$('.o_kanban_record .o_field_widget.o_favorite > a').text(), ' Remove from Favorites',
             'the label should say "Remove from Favorites"');
 
         // click on favorite
         await testUtils.dom.click(kanban.$('.o_field_widget.o_favorite'));
-        assert.containsNone(kanban, '.o_kanban_record  .o_field_widget.o_favorite > a i.fa.fa-star',
+        assert.containsNone(kanban, '.o_kanban_record  .o_field_widget.o_favorite > a i.fa.fa-bookmark',
             'should not be favorite');
         assert.strictEqual(kanban.$('.o_kanban_record  .o_field_widget.o_favorite > a').text(), ' Add to Favorites',
             'the label should say "Add to Favorites"');
@@ -6372,35 +6372,35 @@ QUnit.module('basic_fields', {
             res_id: 1,
         });
 
-        assert.containsOnce(form, '.o_field_widget.o_favorite > a i.fa.fa-star',
+        assert.containsOnce(form, '.o_field_widget.o_favorite > a i.fa.fa-bookmark',
             'should be favorite');
         assert.strictEqual(form.$('.o_field_widget.o_favorite > a').text(), ' Remove from Favorites',
             'the label should say "Remove from Favorites"');
 
         // click on favorite
         await testUtils.dom.click(form.$('.o_field_widget.o_favorite'));
-        assert.containsNone(form, '.o_field_widget.o_favorite > a i.fa.fa-star',
+        assert.containsNone(form, '.o_field_widget.o_favorite > a i.fa.fa-bookmark',
             'should not be favorite');
         assert.strictEqual(form.$('.o_field_widget.o_favorite > a').text(), ' Add to Favorites',
             'the label should say "Add to Favorites"');
 
         // switch to edit mode
         await testUtils.form.clickEdit(form);
-        assert.containsOnce(form, '.o_field_widget.o_favorite > a i.fa.fa-star-o',
+        assert.containsOnce(form, '.o_field_widget.o_favorite > a i.fa.fa-bookmark-o',
             'should not be favorite');
         assert.strictEqual(form.$('.o_field_widget.o_favorite > a').text(), ' Add to Favorites',
             'the label should say "Add to Favorites"');
 
         // click on favorite
         await testUtils.dom.click(form.$('.o_field_widget.o_favorite'));
-        assert.containsOnce(form, '.o_field_widget.o_favorite > a i.fa.fa-star',
+        assert.containsOnce(form, '.o_field_widget.o_favorite > a i.fa.fa-bookmark',
             'should be favorite');
         assert.strictEqual(form.$('.o_field_widget.o_favorite > a').text(), ' Remove from Favorites',
             'the label should say "Remove from Favorites"');
 
         // save
         await testUtils.form.clickSave(form);
-        assert.containsOnce(form, '.o_field_widget.o_favorite > a i.fa.fa-star',
+        assert.containsOnce(form, '.o_field_widget.o_favorite > a i.fa.fa-bookmark',
             'should be favorite');
         assert.strictEqual(form.$('.o_field_widget.o_favorite > a').text(), ' Remove from Favorites',
             'the label should say "Remove from Favorites"');
@@ -6420,22 +6420,22 @@ QUnit.module('basic_fields', {
                   '</tree>',
         });
 
-        assert.containsOnce(list, '.o_data_row:first .o_field_widget.o_favorite > a i.fa.fa-star',
+        assert.containsOnce(list, '.o_data_row:first .o_field_widget.o_favorite > a i.fa.fa-bookmark',
             'should be favorite');
 
         // switch to edit mode
         await testUtils.dom.click(list.$('tbody td:not(.o_list_record_selector)').first());
-        assert.containsOnce(list, '.o_data_row:first .o_field_widget.o_favorite > a i.fa.fa-star',
+        assert.containsOnce(list, '.o_data_row:first .o_field_widget.o_favorite > a i.fa.fa-bookmark',
             'should be favorite');
 
         // click on favorite
         await testUtils.dom.click(list.$('.o_data_row:first .o_field_widget.o_favorite'));
-        assert.containsNone(list, '.o_data_row:first .o_field_widget.o_favorite > a i.fa.fa-star',
+        assert.containsNone(list, '.o_data_row:first .o_field_widget.o_favorite > a i.fa.fa-bookmark',
             'should not be favorite');
 
         // save
         await testUtils.dom.click(list.$buttons.find('.o_list_button_save'));
-        assert.containsOnce(list, '.o_data_row:first .o_field_widget.o_favorite > a i.fa.fa-star-o',
+        assert.containsOnce(list, '.o_data_row:first .o_field_widget.o_favorite > a i.fa.fa-bookmark-o',
             'should not be favorite');
 
         list.destroy();


### PR DESCRIPTION
PURPOSE
Currently, the fa-star icon expresses two different things in Odoo:
    an user-specific favorite/bookmark field (in project, accounting dashboard) > this is the 'boolean_favorite' widget
    a priority field common to all users (3 levels on leads, 1 level on tasks) > this is the 'priority' widget

The goal of this task is to differentiate the boolean_favorite widget simply by changing its icon to that of a bookmark.
This is to prevent confusion and have a dedicated icon for 'personal favoriting'.

SPEC
    change the icons of the boolean_favorite widget to fa-bookmark/fa-bookmark-o
    use the primary green for those icons

TASK 2449047


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
