### PR TITLE
[FIX]sales_team: fix the filter for search by display name

### DIFF
--- a/addons/sales_team/views/crm_team_member_views.xml
+++ b/addons/sales_team/views/crm_team_member_views.xml
@@ -6,7 +6,7 @@
         <field name="model">crm.team.member</field>
         <field name="arch" type="xml">
             <search string="Sales Person">
-                <field name="name"/>
+                <field name="user_id"/>
                 <field name="crm_team_id"/>
                 <separator/>
                 <filter name="archived" string="Archived" domain="[('active', '=', False)]"/>


### PR DESCRIPTION
PURPOSE

fix the filter for search by name 

SPECIFICATIONS

in the sales_team -> search view of team members
the filter apply for search by name, it does not working
because in the name filter the field is **name** but 
actually there is no field **name** , so the filter is not 
working properly, if user is trying to search by name it does
not work so it must have to search by user_id, using this 
commit search filter is fixed and we can search team member
easily by its name.

LINKS
PR: #66514
Task Id:2460697

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
