### PR TITLE
[FIX] account: set main attachment only for posted invoices

### DIFF
--- a/addons/account/models/ir_actions_report.py
+++ b/addons/account/models/ir_actions_report.py
@@ -28,6 +28,6 @@ class IrActionsReport(models.Model):
         if self.report_name == 'account.report_original_vendor_bill':
             return None
         res = super(IrActionsReport, self).postprocess_pdf_report(record, buffer)
-        if self.model == 'account.move' and record.is_sale_document(include_receipts=True):
+        if self.model == 'account.move' and record.state == 'posted' and record.is_sale_document(include_receipts=True):
             self.retrieve_attachment(record).register_as_main_attachment(force=False)
         return res


### PR DESCRIPTION
When printing a draft invoice, it raises an error.

The error comes from fix #65320: the latter registers the printed
invoice as main attachment, but this needs to be done only with posted
invoices.

OPW-2427247