### PR TITLE
[FIX] stock: make package level package consistent pt2

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -268,6 +268,7 @@ class StockMoveLine(models.Model):
                 else:
                     # TODO: make package levels less of a pain and fix this
                     package_level = ml.package_level_id
+                    package_level.move_ids.package_level_id = False
                     ml.package_level_id = False
                     package_level.unlink()
 


### PR DESCRIPTION
The commit b33e72d0bf027fb2c789b1b9476f7edf1a40b0a6
introduced a fix which is not taking into account
the relation between pkg level and stock.move.

**Description of the issue/feature this PR addresses:**

Fix deletion of package levels related to assigned stock moves.

**Current behavior before PR:**

Broken at stock.move.unlink with `You can only delete draft moves.` error.

**Desired behavior after PR is merged:**

Being able to drop package levels and keep related stock.move.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

CC @ticodoo 