### PR TITLE
[FIX] sale: show popup if first line is display_type

### DIFF
--- a/addons/sale/static/src/js/sale_order_view.js
+++ b/addons/sale/static/src/js/sale_order_view.js
@@ -25,7 +25,7 @@ odoo.define('sale.SaleOrderView', function (require) {
          *  (3) Discount is the same in all sale order line
          */
         _onOpenDiscountWizard(ev) {
-            const orderLines = this.renderer.state.data.order_line.data;
+            const orderLines = this.renderer.state.data.order_line.data.filter(line => !line.data.display_type);
             const recordData = ev.target.recordData;
             const isEqualDiscount = orderLines.slice(1).every(line => line.data.discount === recordData.discount);
             if (orderLines.length >= 3 && recordData.sequence === orderLines[0].data.sequence && isEqualDiscount) {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Before this PR, the popup to update all discount doesn't appear if the first ligne is `display_type == 'line_section' or 'line_note'`.

Go to runbot
- install sale with discount
- create a sale order
- add first section line
- add 4 other lines with products
- add discount on the second line
--> Issue a popup should appear to update all discount. (It works if the first line is not a section).

@simongoffin 


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
