### PR TITLE
[IMP] tests: add test_sequence order for tests

### DIFF
--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -269,7 +269,7 @@ def load_module_graph(cr, graph, status=None, perform_checks=True,
         if tools.config.options['test_enable'] and (needs_update or not updating):
             env = api.Environment(cr, SUPERUSER_ID, {})
             loader = odoo.tests.loader
-            suite = loader.make_suite(module_name, 'at_install')
+            suite = loader.make_suite([module_name], 'at_install')
             if suite.countTestCases():
                 if not needs_update:
                     registry.setup_models(cr)

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1265,9 +1265,8 @@ def preload_registries(dbnames):
                 _logger.info("Starting post tests")
                 tests_before = registry._assertion_report.testsRun
                 with odoo.api.Environment.manage():
-                    for module_name in module_names:
-                        result = loader.run_suite(loader.make_suite(module_name, 'post_install'), module_name)
-                        registry._assertion_report.update(result)
+                    result = loader.run_suite(loader.make_suite(module_names, 'post_install'))
+                    registry._assertion_report.update(result)
                 _logger.info("%d post-tests in %.2fs, %s queries",
                              registry._assertion_report.testsRun - tests_before,
                              time.time() - t0,

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -258,6 +258,7 @@ class MetaCase(type):
             cls.test_tags = {'standard', 'at_install'}
             cls.test_module = cls.__module__.split('.')[2]
             cls.test_class = cls.__name__
+            cls.test_sequence = 0
 
 
 class BaseCase(unittest.TestCase, metaclass=MetaCase):

--- a/odoo/tests/loader.py
+++ b/odoo/tests/loader.py
@@ -50,24 +50,25 @@ def _get_tests_modules(path, module):
               if name.startswith('test_')]
     return result
 
-def make_suite(module_name, position='at_install'):
-    mods = get_test_modules(module_name)
-    """ Creates a test suite for all the tests in the specified module,
+def make_suite(module_names, position='at_install'):
+    """ Creates a test suite for all the tests in the specified modules,
     filtered by the provided ``position`` and the current test tags
 
-    :param str module_name: module to load tests from
+    :param list[str] module_names: modules to load tests from
     :param str position: "at_install" or "post_install"
     """
     config_tags = TagsSelector(tools.config['test_tags'])
     position_tag = TagsSelector(position)
-    return OdooSuite(
+    tests = (
         t
-        for m in mods
+        for module_name in module_names
+        for m in get_test_modules(module_name)
         for t in unwrap_suite(unittest.TestLoader().loadTestsFromModule(m))
         if position_tag.check(t) and config_tags.check(t)
     )
+    return OdooSuite(sorted(tests, key=lambda t: t.test_sequence))
 
-def run_suite(suite, module_name):
+def run_suite(suite, module_name=None):
     # avoid dependency hell
     from ..modules import module
     module.current_test = module_name


### PR DESCRIPTION
We have some tests in odoo/upgrade that are sensitive to the order on
which they are executed. Specifically: IntegrityCase tests need to be
run after all UpgradeCase tests across all Odoo modules.

To support this we implemented a sorting mechanism for tests based on
the test_sequence class attribute. This is intended to be used by meta
cases, not by individual tests.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
