### PR TITLE
[FIX] stock_account: display datetime with user timezone

### DIFF
--- a/addons/stock_account/wizard/stock_quantity_history.py
+++ b/addons/stock_account/wizard/stock_quantity_history.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models
+from odoo.tools.misc import format_datetime
 
 
 class StockQuantityHistory(models.TransientModel):
@@ -11,7 +12,7 @@ class StockQuantityHistory(models.TransientModel):
         if active_model == 'stock.valuation.layer':
             action = self.env.ref('stock_account.stock_valuation_layer_action').read()[0]
             action['domain'] = [('create_date', '<=', self.inventory_datetime), ('product_id.type', '=', 'product')]
-            action['display_name'] = str(self.inventory_datetime)
+            action['display_name'] = format_datetime(self.env, self.inventory_datetime)
             return action
 
         return super(StockQuantityHistory, self).open_at_date()


### PR DESCRIPTION
Issue

	- Install Inventory module
	- Go to Inventory -> Reporting -> Inventory Valuation
	- Click on "Inventory At Date" button
	- Select any date

	The datetime in breadcrumb is displayed in UTC.

Solution

	Display datetime in current user timezone.

opw-2464744