### PR TITLE
[FIX] web: can show button when changing listview page


### DIFF
--- a/addons/web/static/src/js/views/list/list_editable_renderer.js
+++ b/addons/web/static/src/js/views/list/list_editable_renderer.js
@@ -1038,6 +1038,11 @@ ListRenderer.include({
                     this.columnWidths = false; // columns changed, so forget stored widths
                     break;
                 }
+                if (this.columns[i].tag === 'button' &&
+                    _.isArray(this.columns[i].attrs.modifiers.invisible)) {
+                    this.columnWidths = false; // column might change, so forget stored widths
+                    break;
+                }
             }
         } else {
             this.columnWidths = false; // columns changed, so forget stored widths

--- a/addons/web/static/tests/fields/relational_fields/field_one2many_tests.js
+++ b/addons/web/static/tests/fields/relational_fields/field_one2many_tests.js
@@ -8876,6 +8876,43 @@ QUnit.module('fields', {}, function () {
             form.destroy();
         });
 
+        QUnit.test('column widths are changed if there is a conditionally showed button column in o2m', async function (assert) {
+            assert.expect(3);
+
+            var longLabel = 'very '.repeat(200) + 'long'; // big label to force minimum size on button column
+
+            var form = await createView({
+                View: FormView,
+                model: 'user',
+                data: this.data,
+                arch: '<form>' +
+                          '<field name="partner_ids">' +
+                              '<tree limit="1">' +
+                                  '<field name="display_name" string="'+longLabel+'"/>' +
+                                  '<button name="do_it"'+
+                                      ' string="do it"' +
+                                      ' attrs="{\'invisible\': [(\'display_name\', \'like\', \'first\')]}"' +
+                                  '/>' +
+                              '</tree>' +
+                          '</field>' +
+                      '</form>',
+                res_id: 17,
+            });
+
+            var width = form.$('th[data-name="do_it"]')[0].offsetWidth;
+            assert.ok(width < 10, "column with no visible buttons takes no width");
+
+            await testUtils.dom.click(form.$('.o_field_widget[name="partner_ids"] .o_pager_next'));
+            width = form.$('th[data-name="do_it"]')[0].offsetWidth;
+            assert.ok(width > 20, "column with visible buttons is shown on page change");
+
+            await testUtils.dom.click(form.$('.o_field_widget[name="partner_ids"] .o_pager_previous'));
+            width = form.$('th[data-name="do_it"]')[0].offsetWidth;
+            assert.ok(width < 10, "going to previous page adapts button column with");
+
+            form.destroy();
+        });
+
         QUnit.test('column widths are kept when editing a record in o2m', async function (assert) {
             assert.expect(2);
 


### PR DESCRIPTION

The width of columns when changing list view page is usually kept.

But the width of a column such as:

<button string="do it" attrs="{'invisible': [('name', 'ilike', 'a')]}"/>

might be 0 pixel on one page and 200 pixels on another and this was not
recomputed when changing page.

With this changeset, if we have a button with invisible modifiers, the
column width are not kept.

Without the change, the added test fails with:

 "column with visible buttons is shown on page change"

opw-2381904
