### PR TITLE
[FIX] tools: preload PIL with all image formats

### DIFF
--- a/odoo/tools/image.py
+++ b/odoo/tools/image.py
@@ -14,10 +14,6 @@ from odoo.exceptions import UserError
 from odoo.tools.translate import _
 
 
-# Preload PIL with the minimal subset of image formats we need
-Image.preinit()
-Image._initialized = 2
-
 # Maps only the 6 first bits of the base64 data, accurate enough
 # for our purpose and faster than decoding the full blob first
 FILETYPE_BASE64_MAGICWORD = {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

I'm developing an addon which uses the PIL library to convert images in the WebP format but the current implementation restricts PIL from preloading all the available formats.

Current behavior before PR:

PIL is initialized with only a few formats (BMP, GIF, PNG, JPEG, TIFF and PPM) 

Desired behavior after PR is merged:

PIL preloads all the supported formats of the library


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr