### PR TITLE
[FIX] pos_cache: load products by batches

### DIFF
--- a/addons/pos_cache/models/pos_cache.py
+++ b/addons/pos_cache/models/pos_cache.py
@@ -42,13 +42,7 @@ class pos_cache(models.Model):
     def get_product_fields(self):
         return literal_eval(self.product_fields)
 
-    @api.model
-    def get_cache(self, domain, fields):
-        if not self.cache or domain != self.get_product_domain() or fields != self.get_product_fields():
-            self.product_domain = str(domain)
-            self.product_fields = str(fields)
-            self.refresh_cache()
-
+    def cache2json(self):
         return json.loads(base64.decodebytes(self.cache).decode('utf-8'))
 
 
@@ -62,34 +56,35 @@ class pos_config(models.Model):
             oldest_cache = pos_cache.search([('config_id', '=', cache.id)], order='write_date', limit=1)
             cache.oldest_cache_time = oldest_cache.write_date
 
-    # Use a related model to avoid the load of the cache when the pos load his config
     cache_ids = fields.One2many('pos.cache', 'config_id')
     oldest_cache_time = fields.Datetime(compute='_get_oldest_cache_time', string='Oldest cache time', readonly=True)
+    limit_products_per_request = fields.Integer(compute='_compute_limit_products_per_request')
 
-    def _get_cache_for_user(self):
-        pos_cache = self.env['pos.cache']
-        cache_for_user = pos_cache.search([('id', 'in', self.cache_ids.ids), ('compute_user_id', '=', self.env.uid)])
-
-        if cache_for_user:
-            return cache_for_user[0]
-        else:
-            return None
+    def _compute_limit_products_per_request(self):
+        limit = self.env['ir.config_parameter'].sudo().get_param('pos_cache.limit_products_per_request', 0)
+        self.update({'limit_products_per_request': int(limit)})
 
     def get_products_from_cache(self, fields, domain):
-        cache_for_user = self._get_cache_for_user()
+        fields_str = str(fields)
+        domain_str = str(domain)
+        pos_cache = self.env['pos.cache']
+        cache_for_user = pos_cache.search([
+            ('id', 'in', self.cache_ids.ids),
+            ('compute_user_id', '=', self.env.uid),
+            ('product_domain', '=', domain_str),
+            ('product_fields', '=', fields_str),
+        ])
 
-        if cache_for_user:
-            return cache_for_user.get_cache(domain, fields)
-        else:
-            pos_cache = self.env['pos.cache']
-            pos_cache.create({
+        if not cache_for_user:
+            cache_for_user = pos_cache.create({
                 'config_id': self.id,
-                'product_domain': str(domain),
-                'product_fields': str(fields),
+                'product_domain': domain_str,
+                'product_fields': fields_str,
                 'compute_user_id': self.env.uid
             })
-            new_cache = self._get_cache_for_user()
-            return new_cache.get_cache(domain, fields)
+            cache_for_user.refresh_cache()
+
+        return cache_for_user.cache2json()
 
     def delete_cache(self):
         # throw away the old caches

--- a/addons/pos_cache/static/src/js/pos_cache.js
+++ b/addons/pos_cache/static/src/js/pos_cache.js
@@ -31,18 +31,56 @@ models.PosModel = models.PosModel.extend({
           // other modules) in js.
           var product_fields =  typeof self.product_model.fields === 'function'  ? self.product_model.fields(self)  : self.product_model.fields;
           var product_domain =  typeof self.product_model.domain === 'function'  ? self.product_model.domain(self)  : self.product_model.domain;
-            var records = rpc.query({
+            var limit_products_per_request = self.config.limit_products_per_request;
+            var cur_request = 0;
+            function next(resolve, reject){
+                var domain = product_domain;
+                if (limit_products_per_request){
+                    domain = domain.slice();
+                    // implement offset-limit via id, because "pos.cache"
+                    // doesn't have such fields and we can add them in master
+                    // branch only
+                    domain.unshift(['id', '>', cur_request * limit_products_per_request],
+                                   ['id', '<=', (cur_request + 1) * limit_products_per_request]);
+                }
+                return rpc.query({
                     model: 'pos.config',
                     method: 'get_products_from_cache',
-                    args: [self.pos_session.config_id[0], product_fields, product_domain],
+                    args: [self.pos_session.config_id[0], product_fields, domain],
+                }).then(function (products) {
+                    self.db.add_products(_.map(products, function (product) {
+                        product.categ = _.findWhere(self.product_categories, {'id': product.categ_id[0]});
+                        product.pos = self;
+                        return new models.Product({}, product);
+                    }));
+                    if (limit_products_per_request) {
+                        cur_request++;
+                        // check that we have more products
+                        domain = product_domain.slice();
+                        domain.unshift(['id', '>', cur_request * limit_products_per_request]);
+                        rpc.query({
+                            model: 'product.product',
+                            method: 'search_read',
+                            args: [domain, ['id']],
+                            kwargs: {
+                                limit: 1,
+                            }
+                        }).then(function (products) {
+                            if (products.length){
+                                next(resolve, reject);
+                            } else {
+                                resolve();
+                            }
+                        });
+                    } else {
+                        resolve();
+                    }
                 });
+            }
             self.setLoadingMessage(_t('Loading') + ' product.product', 1);
-            return records.then(function (products) {
-                self.db.add_products(_.map(products, function (product) {
-                    product.categ = _.findWhere(self.product_categories, {'id': product.categ_id[0]});
-                    product.pos = self;
-                    return new models.Product({}, product);
-                }));
+
+            return new Promise((resolve, reject) => {
+                next(resolve, reject);
             });
         });
     },


### PR DESCRIPTION
pos_cache is used speed up opening POS in databases with large number of
products. In some cases it's not enough and thousands of records cannot be
cached in a single request, because reading information may take more time than
maximum allowed.

As a workaround, this commits adds posibility to split request into few small
requests. To activate the feature set system parameter
``pos_cache.limit_products_per_request`` to appropriate value depending on your
server capacity.

---

opw-2439347

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
