### PR TITLE
[FIX] web_editor: no error background position + ctrl Z


### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4455,7 +4455,7 @@ registry.BackgroundPosition = SnippetOptionWidget.extend({
      * @private
      */
     _onDocumentClicked: function (ev) {
-        if (!ev.target.closest('.o_we_background_position_overlay')) {
+        if (!$(ev.target).closest('.o_we_background_position_overlay')) {
             this._toggleBgOverlay(false);
         }
     },


### PR DESCRIPTION

Scenario:

- start editing background position
- press TAB key
- press CTRL + Z

=> traceback

Why:

Restoring a snapshot with CTRL Z can send a click event with target not
wrapped in a jQuery object which was not expected by the code.

reported in https://github.com/odoo/odoo/pull/66462#issuecomment-782025417

opw-2423445
