### PR TITLE
[FIX] account: Fix use_in_tax_closing on 'base' lines

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -654,12 +654,12 @@ class AccountTaxRepartitionLine(models.Model):
         help="The order in which distribution lines are displayed and matched. For refunds to work properly, invoice distribution lines should be arranged in the same order as the credit note distribution lines they correspond to.")
     use_in_tax_closing = fields.Boolean(string="Tax Closing Entry")
 
-    @api.onchange('account_id')
+    @api.onchange('account_id', 'repartition_type')
     def _on_change_account_id(self):
-        if not self.account_id:
+        if not self.account_id or self.repartition_type == 'base':
             self.use_in_tax_closing = False
         else:
-            self.use_in_tax_closing = not(self.account_id.internal_group == 'income' or self.account_id.internal_group == 'expense')
+            self.use_in_tax_closing = self.account_id.internal_group not in ('income', 'expense')
 
     @api.constrains('invoice_tax_id', 'refund_tax_id')
     def validate_tax_template_link(self):

--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -28,7 +28,9 @@
                     <field name="repartition_type"/>
                     <field name="account_id" attrs="{'invisible': [('repartition_type', '=', 'base')]}" options="{'no_create': True}"/>
                     <field name="tag_ids" widget="many2many_tags" options="{'no_create': True}" domain="[('applicability', '=', 'taxes'), ('country_id', '=', tax_fiscal_country_id)]"/>
-                    <field name="use_in_tax_closing" optional="hidden" />
+                    <field name="use_in_tax_closing"
+                           optional="hidden"
+                           attrs="{'invisible': [('repartition_type', '=', 'base')]}"/>
                     <field name="tax_fiscal_country_id" invisible="1"/>
                     <field name="company_id" invisible="1"/>
                 </tree>


### PR DESCRIPTION
This field shouldn't be visible on the view for 'base' repartition lines.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
