### PR TITLE
[IMP] web_editor, website: improve image options

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -1469,15 +1469,14 @@ const MediapickerUserValueWidget = UserValueWidget.extend({
      */
     async start() {
         await this._super(...arguments);
-        const iconEl = document.createElement('i');
         if (this.options.dataAttributes.buttonStyle) {
+            const iconEl = document.createElement('i');
             iconEl.classList.add('fa', 'fa-fw', 'fa-camera');
+            $(this.containerEl).prepend(iconEl);
         } else {
-            iconEl.classList.add('fa', 'fa-fw', 'fa-refresh', 'mr-1');
-            this.el.classList.add('o_we_no_toggle');
+            this.el.classList.add('o_we_no_toggle', 'o_we_bg_success');
             this.containerEl.textContent = _t("Replace");
         }
-        $(this.containerEl).prepend(iconEl);
     },
 
     //--------------------------------------------------------------------------

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -2013,9 +2013,7 @@ const RangeUserValueWidget = UnitUserValueWidget.extend({
             [min, max] = [max, min];
             this.input.classList.add('o_we_inverted_range');
         }
-        this.input.setAttribute('min', min);
-        this.input.setAttribute('max', max);
-        this.input.setAttribute('step', step);
+        this._setInputAttributes(min, max, step);
         this.containerEl.appendChild(this.input);
     },
 
@@ -2026,9 +2024,31 @@ const RangeUserValueWidget = UnitUserValueWidget.extend({
     /**
      * @override
      */
+    loadMethodsData(validMethodNames) {
+        this._super(...arguments);
+        for (const methodName of this._methodsNames) {
+            const possibleValues = this._methodsParams.optionsPossibleValues[methodName];
+            if (possibleValues.length > 1) {
+                this._setInputAttributes(0, possibleValues.length - 1, 1);
+                break;
+            }
+        }
+    },
+    /**
+     * @override
+     */
     async setValue(value, methodName) {
         await this._super(...arguments);
-        this.input.value = this._value;
+        const possibleValues = this._methodsParams.optionsPossibleValues[methodName];
+        this.input.value = possibleValues.length > 1 ? possibleValues.indexOf(value) : this._value;
+    },
+    /**
+     * @override
+     */
+    getValue(methodName) {
+        const value = this._super(...arguments);
+        const possibleValues = this._methodsParams.optionsPossibleValues[methodName];
+        return possibleValues.length > 1 ? possibleValues[+value] : value;
     },
 
     //--------------------------------------------------------------------------
@@ -2041,6 +2061,14 @@ const RangeUserValueWidget = UnitUserValueWidget.extend({
     _onInputChange(ev) {
         this._value = ev.target.value;
         this._onUserValueChange(ev);
+    },
+    /**
+     * @private
+     */
+    _setInputAttributes(min, max, step) {
+        this.input.setAttribute('min', min);
+        this.input.setAttribute('max', max);
+        this.input.setAttribute('step', step);
     },
 });
 

--- a/addons/web_editor/static/src/scss/web_editor.variables.scss
+++ b/addons/web_editor/static/src/scss/web_editor.variables.scss
@@ -414,6 +414,27 @@ $o-we-sidebar-content-field-toggle-control-shadow: 0 2px 3px 0 $o-we-bg-darkest 
     }
 }
 
+// ------------------------------------------------------------------
+// Selection wrapper
+// ------------------------------------------------------------------
+
+@mixin o-we-active-wrapper($icon: '\f00c', $top: auto, $right: auto, $bottom: auto, $left: auto) {
+    border: 3px solid $o-brand-primary;
+    &:before {
+        content: $icon;
+        @include o-position-absolute($top, $right, $bottom, $left);
+        width: 19px;
+        height: 19px;
+        background-color: $o-brand-primary;
+        font-family: 'FontAwesome';
+        color: white;
+        border-radius: 50%;
+        text-align: center;
+        z-index: 1;
+        box-shadow: $box-shadow;
+    }
+}
+
 //------------------------------------------------------------------------------
 // Edited content
 //------------------------------------------------------------------------------

--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -296,8 +296,7 @@ body .modal {
             }
 
             .o_we_attachment_selected {
-                border-color: $o-brand-primary;
-                box-shadow: 0px 0px 2px 2px $o-brand-primary;
+                @include o-we-active-wrapper($top: 5px, $left: 5px);
             }
 
             .o_we_attachment_optimized .badge {

--- a/addons/website/static/src/scss/website.backend.scss
+++ b/addons/website/static/src/scss/website.backend.scss
@@ -329,7 +329,7 @@
         }
 
         &.o_theme_installed .o_theme_preview_top {
-            border: 3px solid $o-brand-primary;
+            @include o-we-active-wrapper($top: 7px, $right: 7px);
         }
     }
 

--- a/addons/website/static/src/snippets/s_image_gallery/options.js
+++ b/addons/website/static/src/snippets/s_image_gallery/options.js
@@ -17,9 +17,6 @@ options.registry.gallery = options.Class.extend({
     start: function () {
         var self = this;
 
-        // The snippet should not be editable
-        this.$target.addClass('o_fake_not_editable').attr('contentEditable', false);
-
         // Make sure image previews are updated if images are changed
         this.$target.on('image_changed', 'img', function (ev) {
             var $img = $(ev.currentTarget);

--- a/addons/website/views/snippets/s_image_gallery.xml
+++ b/addons/website/views/snippets/s_image_gallery.xml
@@ -97,12 +97,9 @@
                 <we-button data-columns="6">6</we-button>
                 <we-button data-columns="12">12</we-button>
             </we-select>
-            <we-select string="Images spacing" data-dependencies="!slideshow_mode_opt">
-                <we-button data-select-class="o_spc-none">None</we-button>
-                <we-button data-select-class="o_spc-small">Small</we-button>
-                <we-button data-select-class="o_spc-medium">Medium</we-button>
-                <we-button data-select-class="o_spc-big">Big</we-button>
-            </we-select>
+            <we-range string="Images Spacing"
+                data-dependencies="!slideshow_mode_opt"
+                data-select-class="o_spc-none|o_spc-small|o_spc-medium|o_spc-big"/>
             <we-select string="Styling" data-apply-to="img">
                 <we-button data-select-class="">Standard</we-button>
                 <we-button data-select-class="img-thumbnail">Thumbnails</we-button>

--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -363,10 +363,6 @@
                                     <hr t-if="record.url.value"/>
                                     <button role="button" type="edit" t-if="record.url.value" class="btn btn-secondary">Live Preview</button>
                                 </div>
-                                <i states="installed" t-if="record.is_installed_on_current_website.raw_value"
-                                    class="fa fa-check position-absolute p-1 m-2 rounded-circle bg-primary shadow"
-                                    style="top: 0; right: 0;"
-                                    role="img" aria-label="Installed" title="Installed"/>
                             </div>
                             <div class="o_theme_preview_bottom clearfix">
                                 <h5 t-if="record.display_name.value" class="text-uppercase float-left">


### PR DESCRIPTION
The goal of this PR is to improve UI to ease the understanding of image options:

1- MEDIA DIALOG : 
- Use the same layout as in selected themes for multi image selection (Image Wall, Gallery...).

2- IMAGES WALL:
- Replace "Image Spacing" Selection by a slider.
- Make the "Images Wall" snippet editable to be able to open the media dialog on "double-click" on images.

3- BACKGROUND IMAGES:
- Update style for Media Picker button.

task-2326573

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
