### PR TITLE
[FIX] web: race condition in crash manager test

### DIFF
--- a/addons/web/static/tests/services/crash_manager_tests.js
+++ b/addons/web/static/tests/services/crash_manager_tests.js
@@ -4,6 +4,7 @@ odoo.define('web.crash_manager_tests', function (require) {
     const Bus = require('web.Bus');
     const testUtils = require('web.test_utils');
     const core = require('web.core');
+    const ajax = require('web.ajax');
     const createActionManager = testUtils.createActionManager;
     
 QUnit.module('Services', {}, function() {
@@ -46,6 +47,7 @@ QUnit.module('Services', {}, function() {
                 ]
             }
         });
+        await ajax.loadJS('/web/static/lib/stacktracejs/stacktrace.js');
         await testUtils.nextTick();
 
         var modal_selector = 'div.modal:contains("crash_manager_tests_warning_modal_text")';


### PR DESCRIPTION
Since commit 2716828f25c5837fff7a90a1cbb9c957b056e853, the error dialog
has an additional JS lib dependency, which means that it may needs to
perform a request before it opens up. However, a test in the
crashmanager was only waiting for a next tick, which is possibly too
short for a network request.

So, depending on the network speed (and on the test order), this test
could fail. To fix it, we simply make sure that the test also wait for
the library to be loaded

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
