### PR TITLE
[IMP] web_editor : add an icon to replace images in edition

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -61,6 +61,7 @@ var SnippetEditor = Widget.extend({
         this.isTargetParentEditable = false;
         this.isTargetMovable = false;
         this.$scrollingElement = $().getScrollingElement();
+        this.displayHandles = false;
 
         this.__isStarted = new Promise(resolve => {
             this.__isStartedResolveFunc = resolve;
@@ -390,11 +391,16 @@ var SnippetEditor = Widget.extend({
             // In preview mode, the sticky classes are left untouched, we only
             // add/remove the preview class when toggling/untoggling
             this.$el.toggleClass('o_we_overlay_preview', show);
+            this.$el.find('.o_handle').removeClass('d-none');
         } else {
             // In non preview mode, the preview class is always removed, and the
             // sticky class is added/removed when toggling/untoggling
             this.$el.removeClass('o_we_overlay_preview');
             this.$el.toggleClass('o_we_overlay_sticky', show);
+            if (!this.displayHandles) {
+                this.$el.find('.o_handle').addClass('d-none');
+                this.$el.find('.o_overlay_options_wrap').addClass('o_inside_parent');
+            }
         }
 
         // Show/hide overlay in preview mode or not
@@ -458,7 +464,6 @@ var SnippetEditor = Widget.extend({
     /**
      * Clones the current snippet.
      *
-     * @private
      * @param {boolean} recordUndo
      */
     clone: async function (recordUndo) {
@@ -571,6 +576,10 @@ var SnippetEditor = Widget.extend({
 
             if (option.forceNoDeleteButton) {
                 this.$el.add($optionsSection).find('.oe_snippet_remove').addClass('d-none');
+            }
+
+            if (option.displayHandles) {
+                this.displayHandles = true;
             }
 
             return option.appendTo(document.createDocumentFragment());
@@ -1518,16 +1527,24 @@ var SnippetsMenu = Widget.extend({
                         editor.toggleOptions(false);
                     }
                 }
-                // ... if no editors are to be enabled, look if any have been
+                // ... then enable the right editor or look if some have been
                 // enabled previously by a click
-                if (!editorToEnable) {
-                     editorToEnable = this.snippetEditors.find(editor => editor.isSticky());
-                     previewMode = false;
-                }
-                // ... then enable the right editor
                 if (editorToEnable) {
                     editorToEnable.toggleOverlay(true, previewMode);
+                    if (!previewMode && !editorToEnable.displayHandles) {
+                        const parentEditor = editorToEnableHierarchy.find(ed => ed.displayHandles);
+                        if (parentEditor) {
+                            parentEditor.toggleOverlay(true, previewMode);
+                        }
+                    }
                     editorToEnable.toggleOptions(true);
+                } else {
+                    this.snippetEditors.forEach(editor => {
+                        if (editor.isSticky()) {
+                            editor.toggleOverlay(true, false);
+                            editor.toggleOptions(true);
+                        }
+                    });
                 }
 
                 this._enabledEditorHierarchy = editorToEnableHierarchy;

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -2443,6 +2443,12 @@ const SnippetOptionWidget = Widget.extend({
      * @type {boolean}
      */
     forceNoDeleteButton: false,
+    /**
+     * The option needs the handles overlay to be displayed on the snippet.
+     *
+     * @type {boolean}
+     */
+    displayHandles: false,
 
     /**
      * The option `$el` is supposed to be the associated DOM UI element.
@@ -3516,6 +3522,8 @@ const registry = {};
 //::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 registry.sizing = SnippetOptionWidget.extend({
+    displayHandles: true,
+
     /**
      * @override
      */

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -1810,6 +1810,9 @@ body.editor_enable.editor_has_snippets {
             > .o_overlay_options_wrap {
                 @include o-position-absolute($o-we-handles-offset-to-hide, $left: 50%);
                 transform: translate(-50%, -110%);
+                &.o_inside_parent {
+                    transform: translate(-50%, 110%);
+                }
 
                 &, > .o_overlay_move_options, .o_overlay_edit_options {
                     display: flex;
@@ -1853,6 +1856,9 @@ body.editor_enable.editor_has_snippets {
             top: auto;
             bottom: -$o-we-handles-offset-to-hide;
             transform: translate(-50%, 110%);
+            &.o_inside_parent {
+                transform: translate(-50%, -110%);
+            }
         }
 
         &.o_we_overlay_preview {

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -1811,21 +1811,20 @@ body.editor_enable.editor_has_snippets {
                 @include o-position-absolute($o-we-handles-offset-to-hide, $left: 50%);
                 transform: translate(-50%, -110%);
 
-                &, > .o_overlay_move_options {
+                &, > .o_overlay_move_options, .o_overlay_edit_options {
                     display: flex;
                 }
-                > .o_overlay_move_options {
-                    > *, + * {
+                > .o_overlay_move_options, .o_overlay_edit_options {
+                    > * {
                         @extend %we-generic-button;
                         margin: 0 1px 0;
                         min-width: 22px;
                         padding: 0 $o-we-sidebar-content-field-button-group-button-spacing * .5;
                         color: $o-we-fg-lighter;
+                        &.oe_snippet_remove {
+                            background-color: mix($o-we-color-danger, $o-we-sidebar-content-field-clickable-bg);
+                        }
                     }
-                }
-                > .oe_snippet_remove {
-                    margin-left: $o-we-sidebar-content-field-button-group-button-spacing;
-                    background-color: mix($o-we-color-danger, $o-we-sidebar-content-field-clickable-bg);;
                 }
                 > .o_overlay_move_options > .o_move_handle {
                     cursor: move;
@@ -1836,8 +1835,8 @@ body.editor_enable.editor_has_snippets {
                     background-repeat: no-repeat;
                 }
                 &:hover {
-                    > .o_overlay_move_options {
-                        > *, + * {
+                    > .o_overlay_move_options, .o_overlay_edit_options {
+                        > * {
                             @include o-hover-opacity(.6);
 
                             &:hover {
@@ -1845,10 +1844,6 @@ body.editor_enable.editor_has_snippets {
                                 background-color: $o-we-sidebar-content-field-pressed-bg;
                             }
                         }
-                    }
-                    > .oe_snippet_remove:hover {
-                        border-color: mix($o-we-color-danger, $o-we-sidebar-content-field-pressed-bg, .4);
-                        background-color: $o-we-color-danger;
                     }
                 }
             }

--- a/addons/web_editor/static/src/xml/snippets.xml
+++ b/addons/web_editor/static/src/xml/snippets.xml
@@ -15,7 +15,9 @@
                         <!-- Button-like handle to drag and drop -->
                         <div class="o_move_handle"/>
                     </div>
-                    <button type="button" class="oe_snippet_remove fa fa-trash"/>
+                    <div class="o_overlay_edit_options">
+                        <button type="button" class="oe_snippet_remove fa fa-trash"/>
+                    </div>
                 </div>
             </div>
         </div>

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -2460,6 +2460,8 @@ options.registry.ContainerWidth = options.Class.extend({
  * Allows snippets to be moved before the preceding element or after the following.
  */
 options.registry.SnippetMove = options.Class.extend({
+    displayHandles: true,
+
     /**
      * @override
      */

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -10,6 +10,7 @@ const weUtils = require('web_editor.utils');
 var options = require('web_editor.snippets.options');
 const wUtils = require('website.utils');
 require('website.s_popup_options');
+const weWidgets = require('wysiwyg.widgets');
 
 var _t = core._t;
 var qweb = core.qweb;
@@ -2585,6 +2586,37 @@ options.registry.ScrollButton = options.Class.extend({
                 return !!this.$button.parent().length;
         }
         return this._super(...arguments);
+    },
+});
+
+/**
+ * Allows for images to be replaced.
+ */
+options.registry.ReplaceImage = options.Class.extend({
+    /**
+     * @override
+     */
+    start: function () {
+        const $button = this.$el.find('we-button');
+        const $overlayArea = this.$overlay.find('.oe_snippet_remove');
+        $button.insertBefore($overlayArea);
+
+        return this._super(...arguments);
+    },
+    
+    //--------------------------------------------------------------------------
+    // Options
+    //--------------------------------------------------------------------------
+
+    /**
+     * Replaces the image.
+     *
+     * @see this.selectClass for parameters
+     */
+    replaceImage: async function () {
+        // TODO: simulates a double click on an image from summernote,
+        // to be refactored when the new editor is merged
+        this.$target.dblclick();
     },
 });
 

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -437,6 +437,11 @@
         <we-button class="fa fa-fw fa-angle-right" data-move-snippet="next" data-no-preview="true" data-name="move_right_opt"/>
     </div>
 
+    <!-- Replace an image -->
+    <div data-js="ReplaceImage" data-selector="img">
+        <we-button class="fa fa-refresh" data-replace-image="true" data-no-preview="true"/>
+    </div>
+
     <!-- Background -->
     <t t-set="only_bg_color_selector" t-value="'section .row > div, .s_text_highlight'"/>
     <t t-set="only_bg_color_exclude" t-value="'.s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .o_mega_menu .row > div, .s_image_gallery .row > div'"/>


### PR DESCRIPTION
From the editor, when clicking on an image there is a new refresh icon
next to the delete icon that will open the media dialog to allow for its
replacement.

task-2431684

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
