### PR TITLE
[MERGE] web,hr_timesheet,partner_autocomplete: make multi company timesheet uom work

### DIFF
--- a/addons/hr_timesheet/models/ir_http.py
+++ b/addons/hr_timesheet/models/ir_http.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models
+from odoo import api, models
+from odoo.http import request
 
 
 class Http(models.AbstractModel):
@@ -9,13 +10,35 @@ class Http(models.AbstractModel):
 
     def session_info(self):
         """ The widget 'timesheet_uom' needs to know which UoM conversion factor and which javascript
-            widget to apply, depending on th ecurrent company.
+            widget to apply, depending on the current company.
         """
         result = super(Http, self).session_info()
         if self.env.user.has_group('base.group_user'):
-            company = self.env.company
-            encoding_uom = company.timesheet_encode_uom_id
+            company_ids = request.env.user.company_ids
 
-            result['timesheet_uom'] = encoding_uom.read(['name', 'rounding', 'timesheet_widget'])[0]
-            result['timesheet_uom_factor'] = company.project_time_mode_id._compute_quantity(1.0, encoding_uom, round=False)  # convert encoding uom into stored uom to get conversion factor
+            for company in company_ids:
+                result["user_companies"]["allowed_companies"][company.id].update({
+                    "timesheet_uom_id": company.timesheet_encode_uom_id.id,
+                    "timesheet_uom_factor": company.project_time_mode_id._compute_quantity(
+                        1.0,
+                        company.timesheet_encode_uom_id,
+                        round=False
+                    ),
+                })
+            result["uom_ids"] = self.get_timesheet_uoms()
         return result
+
+    @api.model
+    def get_timesheet_uoms(self):
+        company_ids = request.env.user.company_ids
+        uom_ids = company_ids.mapped('timesheet_encode_uom_id') | \
+                  company_ids.mapped('project_time_mode_id')
+        return {
+            uom.id:
+                {
+                    'id': uom.id,
+                    'name': uom.name,
+                    'rounding': uom.rounding,
+                    'timesheet_widget': uom.timesheet_widget,
+                } for uom in uom_ids
+        }

--- a/addons/hr_timesheet/static/src/js/timesheet_graph.js
+++ b/addons/hr_timesheet/static/src/js/timesheet_graph.js
@@ -12,10 +12,14 @@ odoo.define('hr_timesheet.GraphView', function (require) {
         _processData: function (originIndex, rawData) {
             this._super.apply(this, arguments);
             const session = this.getSession();
-            if (this.chart.measure === 'unit_amount' && session.timesheet_uom_factor !== 1) {
+            const currentCompanyId = session.user_context.allowed_company_ids[0];
+            const currentCompany = session.user_companies.allowed_companies[currentCompanyId];
+            const currentCompanyTimesheetUOMFactor = currentCompany.timesheet_uom_factor || 1;
+
+            if (this.chart.measure === 'unit_amount' && currentCompanyTimesheetUOMFactor !== 1) {
                 // recalculate the Duration values according to the timesheet_uom_factor
                 this.chart.dataPoints.forEach(function (dataPt) {
-                    dataPt.value *= session.timesheet_uom_factor;
+                    dataPt.value *= currentCompanyTimesheetUOMFactor;
                 });
             }
         },

--- a/addons/hr_timesheet/static/src/js/timesheet_uom.js
+++ b/addons/hr_timesheet/static/src/js/timesheet_uom.js
@@ -11,16 +11,26 @@ const fieldRegistry = require('web.field_registry');
 require('web._field_registry');
 
 const session = require('web.session');
+const AbstractWebClient = require('web.AbstractWebClient');
+
+const TimesheetUOMMultiCompanyMixin = {
+    init: function(parent, name, record, options) {
+        this._super(parent, name, record, options);
+        const currentCompanyId = session.user_context.allowed_company_ids[0];
+        const currentCompany = session.user_companies.allowed_companies[currentCompanyId];
+        this.currentCompanyTimesheetUOMFactor = currentCompany.timesheet_uom_factor || 1;
+    }
+};
 
 /**
  * Extend the float factor widget to set default value for timesheet
  * use case. The 'factor' is forced to be the UoM timesheet
  * conversion from the session info.
  **/
-const FieldTimesheetFactor = basicFields.FieldFloatFactor.extend({
+const FieldTimesheetFactor = basicFields.FieldFloatFactor.extend(TimesheetUOMMultiCompanyMixin).extend({
     formatType: 'float_factor',
     /**
-     * Override init to tweak options depending on the session_info
+     * Override init to tweak options depending on the session info
      *
      * @constructor
      * @override
@@ -29,10 +39,8 @@ const FieldTimesheetFactor = basicFields.FieldFloatFactor.extend({
         this._super(parent, name, record, options);
 
         // force factor in format and parse options
-        if (session.timesheet_uom_factor) {
-            this.nodeOptions.factor = session.timesheet_uom_factor;
-            this.parseOptions.factor = session.timesheet_uom_factor;
-        }
+        this.nodeOptions.factor = this.currentCompanyTimesheetUOMFactor;
+        this.parseOptions.factor = this.currentCompanyTimesheetUOMFactor;
     },
 });
 
@@ -43,10 +51,10 @@ const FieldTimesheetFactor = basicFields.FieldFloatFactor.extend({
  * native widget, and the 'factor' is forced to be the UoM timesheet
  * conversion.
  **/
-const FieldTimesheetToggle = basicFields.FieldFloatToggle.extend({
+const FieldTimesheetToggle = basicFields.FieldFloatToggle.extend(TimesheetUOMMultiCompanyMixin).extend({
     formatType: 'float_factor',
     /**
-     * Override init to tweak options depending on the session_info
+     * Override init to tweak options depending on the session info
      *
      * @constructor
      * @override
@@ -66,7 +74,7 @@ const FieldTimesheetToggle = basicFields.FieldFloatToggle.extend({
         if (!hasRange) {
             this.nodeOptions.range = [0.00, 1.00, 0.50];
         }
-        this.nodeOptions.factor = session.timesheet_uom_factor;
+        this.nodeOptions.factor = this.currentCompanyTimesheetUOMFactor;
     },
 });
 
@@ -74,91 +82,92 @@ const FieldTimesheetToggle = basicFields.FieldFloatToggle.extend({
 /**
  * Extend float time widget
  */
-const FieldTimesheetTime = basicFields.FieldFloatTime.extend({
+const FieldTimesheetTime = basicFields.FieldFloatTime.extend(TimesheetUOMMultiCompanyMixin).extend({
     init: function () {
         this._super.apply(this, arguments);
-
-        if (session.timesheet_uom_factor) {
-            this.nodeOptions.factor = session.timesheet_uom_factor;
-            this.parseOptions.factor = session.timesheet_uom_factor;
-        }
+        this.nodeOptions.factor = this.currentCompanyTimesheetUOMFactor;
+        this.parseOptions.factor = this.currentCompanyTimesheetUOMFactor;
     }
 });
 
+AbstractWebClient.include({
+    init: function () {
+        this._super(...arguments);
+        /**
+         * Binding depending on Company Preference
+         *
+         * determine wich widget will be the timesheet one.
+         * Simply match the 'timesheet_uom' widget key with the correct
+         * implementation (float_time, float_toggle, ...). The default
+         * value will be 'float_factor'.
+        **/
+        const widgetName = this.currentCompanyTimesheetUOM &&
+                           this.currentCompanyTimesheetUOM.timesheet_widget ||
+                           'float_factor';
 
-/**
- * Binding depending on Company Preference
- *
- * determine wich widget will be the timesheet one.
- * Simply match the 'timesheet_uom' widget key with the correct
- * implementation (float_time, float_toggle, ...). The default
- * value will be 'float_factor'.
-**/
-const widgetName = 'timesheet_uom' in session ?
-         session.timesheet_uom.timesheet_widget : 'float_factor';
+        let FieldTimesheetUom = null;
 
-let FieldTimesheetUom = null;
+        if (widgetName === 'float_toggle') {
+            FieldTimesheetUom = FieldTimesheetToggle;
+        } else if (widgetName === 'float_time') {
+            FieldTimesheetUom = FieldTimesheetTime;
+        } else {
+            FieldTimesheetUom = (
+                    fieldRegistry.get(widgetName) &&
+                    fieldRegistry.get(widgetName).extend({ })
+                ) || FieldTimesheetFactor;
+        }
+        fieldRegistry.add('timesheet_uom', FieldTimesheetUom);
 
-if (widgetName === 'float_toggle') {
-    FieldTimesheetUom = FieldTimesheetToggle;
-} else if (widgetName === 'float_time') {
-    FieldTimesheetUom = FieldTimesheetTime;
-} else {
-    FieldTimesheetUom = (
-            fieldRegistry.get(widgetName) &&
-            fieldRegistry.get(widgetName).extend({})
-        ) || FieldTimesheetFactor;
-}
-fieldRegistry.add('timesheet_uom', FieldTimesheetUom);
-
-// widget timesheet_uom_no_toggle is the same as timesheet_uom but without toggle.
-// We can modify easly huge amount of days.
-let FieldTimesheetUomWithoutToggle = null;
-if (widgetName === 'float_toggle') {
-    FieldTimesheetUomWithoutToggle = FieldTimesheetFactor;
-} else {
-    FieldTimesheetUomWithoutToggle = FieldTimesheetTime;
-}
-fieldRegistry.add('timesheet_uom_no_toggle', FieldTimesheetUomWithoutToggle);
+        // widget timesheet_uom_no_toggle is the same as timesheet_uom but without toggle.
+        // We can modify easly huge amount of days.
+        let FieldTimesheetUomWithoutToggle = null;
+        if (widgetName === 'float_toggle') {
+            FieldTimesheetUomWithoutToggle = FieldTimesheetFactor;
+        } else {
+            FieldTimesheetUomWithoutToggle = FieldTimesheetTime;
+        }
+        fieldRegistry.add('timesheet_uom_no_toggle', FieldTimesheetUomWithoutToggle);
 
 
-// bind the formatter and parser method, and tweak the options
-const _tweak_options = function(options) {
-    if (!_.contains(options, 'factor')) {
-        options.factor = session.timesheet_uom_factor;
-    }
-    return options;
-};
+        // bind the formatter and parser method, and tweak the options
+        const _tweak_options = (options) => {
+            if (!_.contains(options, 'factor')) {
+                options.factor = this.currentCompanyTimesheetUOMFactor;
+            }
+            return options;
+        };
 
-fieldUtils.format.timesheet_uom = function(value, field, options) {
-    options = _tweak_options(options || {});
-    const formatter = fieldUtils.format[FieldTimesheetUom.prototype.formatType];
-    return formatter(value, field, options);
-};
+        fieldUtils.format.timesheet_uom = function(value, field, options) {
+            options = _tweak_options(options || { });
+            const formatter = fieldUtils.format[FieldTimesheetUom.prototype.formatType];
+            return formatter(value, field, options);
+        };
 
-fieldUtils.parse.timesheet_uom = function(value, field, options) {
-    options = _tweak_options(options || {});
-    const parser = fieldUtils.parse[FieldTimesheetUom.prototype.formatType];
-    return parser(value, field, options);
-};
+        fieldUtils.parse.timesheet_uom = function(value, field, options) {
+            options = _tweak_options(options || { });
+            const parser = fieldUtils.parse[FieldTimesheetUom.prototype.formatType];
+            return parser(value, field, options);
+        };
 
-fieldUtils.format.timesheet_uom_no_toggle = function(value, field, options) {
-    options = _tweak_options(options || {});
-    const formatter = fieldUtils.format[FieldTimesheetUom.prototype.formatType];
-    return formatter(value, field, options);
-};
+        fieldUtils.format.timesheet_uom_no_toggle = function(value, field, options) {
+            options = _tweak_options(options || { });
+            const formatter = fieldUtils.format[FieldTimesheetUom.prototype.formatType];
+            return formatter(value, field, options);
+        };
 
-fieldUtils.parse.timesheet_uom_no_toggle = function(value, field, options) {
-    options = _tweak_options(options || {});
-    const parser = fieldUtils.parse[FieldTimesheetUom.prototype.formatType];
-    return parser(value, field, options);
-};
+        fieldUtils.parse.timesheet_uom_no_toggle = function(value, field, options) {
+            options = _tweak_options(options || { });
+            const parser = fieldUtils.parse[FieldTimesheetUom.prototype.formatType];
+            return parser(value, field, options);
+        };
+    },
+});
 
 return {
-    FieldTimesheetUom,
     FieldTimesheetFactor,
     FieldTimesheetTime,
-    FieldTimesheetToggle
+    FieldTimesheetToggle,
 };
 
 });

--- a/addons/hr_timesheet/static/tests/timesheet_graph_tests.js
+++ b/addons/hr_timesheet/static/tests/timesheet_graph_tests.js
@@ -1,0 +1,73 @@
+odoo.define('hr_timesheet.timesheet_graph_tests', function (require) {
+"use strict";
+
+const session = require('web.session');
+const SetupTimesheetUOMWidgetsTestEnvironment = require('hr_timesheet.timesheet_uom_tests_env');
+const GraphView = require('hr_timesheet.GraphView');
+
+QUnit.module('Timesheet UOM Widgets', function (hooks) {
+    let env;
+    let sessionUserCompaniesBackup;
+    let sessionUserContextBackup;
+    let sessionUOMIdsBackup;
+    let sessionUIDBackup;
+    hooks.before(function (assert) {
+        env = new SetupTimesheetUOMWidgetsTestEnvironment();
+        // Backups session parts that this testing module will alter in order to restore it at the end.
+        sessionUserCompaniesBackup = session.user_companies || false;
+        sessionUserContextBackup = session.user_context || false;
+        sessionUOMIdsBackup = session.uom_ids || false;
+        sessionUIDBackup = session.uid || false;
+    });
+    hooks.after(function (assert) {
+        // Restores the session
+        const sessionToApply = Object.assign(
+            { },
+            sessionUserCompaniesBackup && {
+                user_companies: sessionUserCompaniesBackup,
+            } || { },
+            sessionUserContextBackup && {
+                user_context: sessionUserContextBackup,
+            } || { },
+            sessionUOMIdsBackup && {
+                uom_ids: sessionUOMIdsBackup,
+            } || { },
+            sessionUIDBackup && {
+                uid: sessionUIDBackup,
+            } || { });
+        env.triggerAbstractWebClientInit(sessionToApply, true);
+    });
+    QUnit.module('GraphView', function (hooks) {
+        QUnit.test('the timesheet_graph view data are multiplied by a factor that is company related', async function (assert) {
+            assert.expect(2);
+
+            let options = {
+                View: GraphView,
+                arch: '<graph><field name="unit_amount"/></graph>',
+                viewOptions: {
+                    context: {
+                        graph_measure: 'unit_amount',
+                    },
+                },
+            };
+            let graph = await env.createView(options);
+            let renderedData = graph.renderer.componentRef.comp.chart.data.datasets[0].data[0];
+            assert.strictEqual(renderedData, 8, 'The timesheet_graph is taking the timesheet_uom_factor into account');
+            graph.destroy();
+
+            options = Object.assign(
+                { },
+                options,
+                {
+                    session: {
+                        user_context: env.singleCompanyDayUOMUser,
+                    },
+                });
+            graph = await env.createView(options);
+            renderedData = graph.renderer.componentRef.comp.chart.data.datasets[0].data[0];
+            assert.strictEqual(renderedData, 1, 'The timesheet_graph is taking the timesheet_uom_factor into account');
+            graph.destroy();
+        });
+    });
+});
+});

--- a/addons/hr_timesheet/static/tests/timesheet_uom_common.js
+++ b/addons/hr_timesheet/static/tests/timesheet_uom_common.js
@@ -1,0 +1,191 @@
+odoo.define("hr_timesheet.timesheet_uom_tests_env", function (require) {
+"use strict";
+
+const session = require('web.session');
+const AbstractWebClient = require('web.AbstractWebClient');
+const { createView } = require("web.test_utils");
+const ListView = require('web.ListView');
+
+/**
+ * Sets the timesheet related widgets testing environment up.
+ */
+const SetupTimesheetUOMWidgetsTestEnvironment = function () {
+    this.allowedCompanies = {
+        1: {
+            id: 1,
+            name: 'Company 1',
+            timesheet_uom_id: 1,
+            timesheet_uom_factor: 1,
+        },
+        2: {
+            id: 2,
+            name: 'Company 2',
+            timesheet_uom_id: 2,
+            timesheet_uom_factor: 0.125,
+        },
+        3: {
+            id: 3,
+            name: 'Company 3',
+            timesheet_uom_id: 2,
+            timesheet_uom_factor: 0.125,
+        },
+    };
+    this.uomIds = {
+        1: {
+            id: 1,
+            name: 'hour',
+            rounding: 0.01,
+            timesheet_widget: 'float_time',
+        },
+        2: {
+            id: 2,
+            name: 'day',
+            rounding: 0.01,
+            timesheet_widget: 'float_toggle',
+        },
+    };
+    this.singleCompanyHourUOMUser = {
+        allowed_company_ids: [this.allowedCompanies[1].id],
+    };
+    this.singleCompanyDayUOMUser = {
+        allowed_company_ids: [this.allowedCompanies[2].id],
+    };
+    this.multiCompanyHourUOMUser = {
+        allowed_company_ids: [
+            this.allowedCompanies[1].id,
+            this.allowedCompanies[3].id,
+        ],
+    };
+    this.multiCompanyDayUOMUser = {
+        allowed_company_ids: [
+            this.allowedCompanies[3].id,
+            this.allowedCompanies[1].id,
+        ],
+    };
+    this.session = {
+        uid: 0, // In order to avoid bbqState and cookies to be taken into account in AbstractWebClient.
+        user_companies: {
+            current_company: 1,
+            allowed_companies: this.allowedCompanies,
+        },
+        user_context: this.singleCompanyHourUOMUser,
+        uom_ids: this.uomIds,
+    };
+    this.data = {
+        'account.analytic.line': {
+            fields: {
+                project_id: {
+                    string: "Project",
+                    type: "many2one",
+                    relation: "project.project",
+                },
+                task_id: {
+                    string:"Task",
+                    type: "many2one",
+                    relation: "project.task",
+                },
+                date: {
+                    string: "Date",
+                    type: "date",
+                },
+                unit_amount: {
+                    string: "Unit Amount",
+                    type: "float",
+                },
+            },
+            records: [
+                {
+                    id: 1,
+                    project_id: 1,
+                    task_id: 1,
+                    date: "2021-01-12",
+                    unit_amount: 8,
+                },
+            ],
+        },
+        'project.project': {
+            fields: {
+                name: {
+                    string: "Project Name",
+                    type: "char",
+                },
+            },
+            records: [
+                {
+                    id: 1,
+                    display_name: "P1",
+                },
+            ],
+        },
+        'project.task': {
+            fields: {
+                name: {
+                    string: "Task Name",
+                    type: "char",
+                },
+                project_id: {
+                    string: "Project",
+                    type: "many2one",
+                    relation: "project.project",
+                },
+            },
+            records: [
+                {
+                    id: 1,
+                    display_name: "T1",
+                    project_id: 1,
+                },
+            ],
+        },
+    };
+    this.triggerAbstractWebClientInit = function (sessionToApply, doNotUseEnvSession = false) {
+        /*
+        Adds the timesheet_uom to the fieldRegistry by setting the session and
+        instantiating AbstractWebClient as the process of adding the right widget
+        is included in the init function of AbstractWebClient.
+        */
+        session.user_companies = Object.assign(
+            { },
+            !doNotUseEnvSession && this.session.user_companies || { },
+            sessionToApply && sessionToApply.user_companies);
+        session.user_context = Object.assign(
+            { },
+            !doNotUseEnvSession && this.session.user_context || { },
+            sessionToApply && sessionToApply.user_context);
+        session.uom_ids = Object.assign(
+            { },
+            !doNotUseEnvSession && this.session.uom_ids || { },
+            sessionToApply && sessionToApply.uom_ids);
+        if (!doNotUseEnvSession && 'uid' in this.session) {
+            session.uid = this.session.uid;
+        }
+        if (sessionToApply && 'uid' in sessionToApply) {
+            session.uid = sessionToApply.uid;
+        }
+        if (!this.abstractWebClient) {
+            this.abstractWebClient = new AbstractWebClient();
+        } else {
+            this.abstractWebClient.init();
+        }
+    };
+    this.createView = async function(options) {
+        const sessionToApply = options && options.session || { };
+        this.triggerAbstractWebClientInit(sessionToApply);
+        return await createView(Object.assign(
+            {
+                View: ListView,
+                data: this.data,
+                model: 'account.analytic.line',
+                arch: `
+                    <tree>
+                        <field name="unit_amount" widget="timesheet_uom"/>
+                    </tree>`,
+            },
+            options || { },
+        ));
+    };
+};
+
+return SetupTimesheetUOMWidgetsTestEnvironment;
+
+});

--- a/addons/hr_timesheet/static/tests/timesheet_uom_tests.js
+++ b/addons/hr_timesheet/static/tests/timesheet_uom_tests.js
@@ -1,0 +1,140 @@
+odoo.define("hr_timesheet.timesheet_uom_tests", function (require) {
+"use strict";
+
+const session = require('web.session');
+const SetupTimesheetUOMWidgetsTestEnvironment = require('hr_timesheet.timesheet_uom_tests_env');
+const fieldUtils = require('web.field_utils');
+const TimesheetUOM = require('hr_timesheet.timesheet_uom');
+
+QUnit.module('Timesheet UOM Widgets', function (hooks) {
+    let env;
+    let sessionUserCompaniesBackup;
+    let sessionUserContextBackup;
+    let sessionUOMIdsBackup;
+    let sessionUIDBackup;
+    hooks.before(function (assert) {
+        env = new SetupTimesheetUOMWidgetsTestEnvironment();
+        // Backups session parts that this testing module will alter in order to restore it at the end.
+        sessionUserCompaniesBackup = session.user_companies || false;
+        sessionUserContextBackup = session.user_context || false;
+        sessionUOMIdsBackup = session.uom_ids || false;
+        sessionUIDBackup = session.uid || false;
+    });
+    hooks.after(function (assert) {
+        // Restores the session
+        const sessionToApply = Object.assign(
+            { },
+            sessionUserCompaniesBackup && {
+                user_companies: sessionUserCompaniesBackup,
+            } || { },
+            sessionUserContextBackup && {
+                user_context: sessionUserContextBackup,
+            } || { },
+            sessionUOMIdsBackup && {
+                uom_ids: sessionUOMIdsBackup,
+            } || { },
+            sessionUIDBackup && {
+                uid: sessionUIDBackup,
+            } || { });
+        env.triggerAbstractWebClientInit(sessionToApply, true);
+    });
+    QUnit.module('timesheet_uom', function (hooks) {
+        QUnit.module('fieldRegistry', function (hooks) {
+            let FieldTimesheetTimeBackup;
+            let FieldTimesheetToggleBackup;
+            hooks.before(function (assert) {
+                // Backups the FieldTimesheetTime widget as it will be altered in this testing module
+                // in order to to ease testing.
+                FieldTimesheetTimeBackup = TimesheetUOM.FieldTimesheetTime;
+                TimesheetUOM.FieldTimesheetTime.include({
+                    _render: function () {
+                        const $widgetIdentification = $('<div>').addClass('i_am_a_timesheet_time_widget');
+                        this.$el.append($widgetIdentification);
+                    },
+                });
+                FieldTimesheetToggleBackup = TimesheetUOM.FieldTimesheetToggle;
+                TimesheetUOM.FieldTimesheetToggle.include({
+                    _render: function () {
+                        const $widgetIdentification = $('<div>').addClass('i_am_a_timesheet_toggle_widget');
+                        this.$el.append($widgetIdentification);
+                    },
+                });
+            });
+            hooks.after(function (hooks) {
+                // Restores the widgets and trigger reload in FieldRegistry.
+                TimesheetUOM.FieldTimesheetTime = FieldTimesheetTimeBackup;
+                TimesheetUOM.FieldTimesheetToggle = FieldTimesheetToggleBackup;
+                env.triggerAbstractWebClientInit({ }, true);
+            });
+            QUnit.test('the timesheet_uom widget added to the fieldRegistry is company related', async function (assert) {
+                assert.expect(2);
+
+                let view = await env.createView();
+                assert.ok(view.$('.i_am_a_timesheet_time_widget').length, 'FieldTimesheetTime is rendered when company uom is hour');
+                view.destroy();
+
+                let option = {
+                    session: {
+                        user_context: env.singleCompanyDayUOMUser,
+                    },
+                };
+                view = await env.createView(option);
+                assert.ok(view.$('.i_am_a_timesheet_toggle_widget').length, 'FieldTimesheetToggle is rendered when company uom is day');
+                view.destroy();
+            });
+            QUnit.test('the timesheet_uom widget added to the fieldRegistry in a multi company environment is the current company', async function (assert) {
+                assert.expect(2);
+
+                let option = {
+                    session: {
+                        user_context: env.multiCompanyHourUOMUser,
+                    },
+                };
+                let view = await env.createView(option);
+                assert.ok(view.$('.i_am_a_timesheet_time_widget').length, 'FieldTimesheetTime is rendered when current company uom is hour');
+                view.destroy();
+
+                option = {
+                    session: {
+                        user_context: env.multiCompanyDayUOMUser,
+                    },
+                };
+                view = await env.createView(option);
+                assert.ok(view.$('.i_am_a_timesheet_toggle_widget').length, 'FieldTimesheetToggle is rendered when current company uom is day');
+                view.destroy();
+            });
+        });
+        QUnit.module('timesheet_uom_factor', function (hooks) {
+            QUnit.test('the timesheet_uom_factor usage in formatters and parsers is company related', async function (assert) {
+                assert.expect(4);
+
+                env.triggerAbstractWebClientInit();
+                assert.strictEqual(fieldUtils.format.timesheet_uom(1), '01:00', 'The format is taking the timesheet_uom_factor into account');
+                assert.strictEqual(fieldUtils.parse.timesheet_uom('01:00'), 1, 'The parsing is taking the timesheet_uom_factor into account');
+
+                const sessionToApply = {
+                    user_context: env.singleCompanyDayUOMUser,
+                };
+                env.triggerAbstractWebClientInit(sessionToApply);
+                assert.strictEqual(fieldUtils.format.timesheet_uom(8), '1.00', 'The format is taking the timesheet_uom_factor into account');
+                assert.strictEqual(fieldUtils.parse.timesheet_uom('1.00'), 8, 'The parsing is taking the timesheet_uom_factor into account');
+            });
+            QUnit.test('the timesheet_uom_factor taken into account in a multi company environment is the current company', async function (assert) {
+                assert.expect(4);
+
+                let sessionToApply = {
+                    user_context: env.multiCompanyHourUOMUser,
+                };
+                env.triggerAbstractWebClientInit(sessionToApply);
+                assert.strictEqual(fieldUtils.format.timesheet_uom(1), '01:00', 'The format is taking the timesheet_uom_factor into account');
+                assert.strictEqual(fieldUtils.parse.timesheet_uom('01:00'), 1, 'The parsing is taking the timesheet_uom_factor into account');
+
+                sessionToApply.user_context = env.singleCompanyDayUOMUser;
+                env.triggerAbstractWebClientInit(sessionToApply);
+                assert.strictEqual(fieldUtils.format.timesheet_uom(8), '1.00', 'The format is taking the timesheet_uom_factor into account');
+                assert.strictEqual(fieldUtils.parse.timesheet_uom('1.00'), 8, 'The parsing is taking the timesheet_uom_factor into account');
+            });
+        });
+    });
+});
+});

--- a/addons/hr_timesheet/views/assets.xml
+++ b/addons/hr_timesheet/views/assets.xml
@@ -11,4 +11,11 @@
             <script type="text/javascript" src="/hr_timesheet/static/src/js/timesheet_graph.js"/>
         </xpath>
     </template>
+    <template id="qunit_suite" name="hr tests" inherit_id="web.qunit_suite_tests">
+        <xpath expr="." position="inside">
+            <script type="text/javascript" src="/hr_timesheet/static/tests/timesheet_uom_common.js"/>
+            <script type="text/javascript" src="/hr_timesheet/static/tests/timesheet_uom_tests.js"/>
+            <script type="text/javascript" src="/hr_timesheet/static/tests/timesheet_graph_tests.js"/>
+        </xpath>
+    </template>
 </odoo>

--- a/addons/partner_autocomplete/static/src/js/web_company_autocomplete.js
+++ b/addons/partner_autocomplete/static/src/js/web_company_autocomplete.js
@@ -8,7 +8,7 @@ return AbstractWebClient.include({
 
     start: function () {
         if (session.iap_company_enrich) {
-            const current_company_id = session.user_companies.current_company[0];
+            const current_company_id = session.user_companies.current_company;
             this._rpc({
                 model: 'res.company',
                 method: 'iap_enrich_auto',

--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -60,7 +60,15 @@ class Http(models.AbstractModel):
             }
             session_info.update({
                 # current_company should be default_company
-                "user_companies": {'current_company': (user.company_id.id, user.company_id.name), 'allowed_companies': [(comp.id, comp.name) for comp in user.company_ids]},
+                "user_companies": {
+                    'current_company': user.company_id.id,
+                    'allowed_companies': {
+                        comp.id: {
+                            'id': comp.id,
+                            'name': comp.name,
+                        } for comp in user.company_ids
+                    },
+                },
                 "currencies": self.get_currencies(),
                 "show_effect": True,
                 "display_switch_company_menu": user.has_group('base.group_multi_company') and len(user.company_ids) > 1,

--- a/addons/web/static/src/js/core/session.js
+++ b/addons/web/static/src/js/core/session.js
@@ -362,7 +362,7 @@ var Session = core.Class.extend(mixins.EventDispatcherMixin, {
     },
 
     setCompanies: function (main_company_id, company_ids) {
-        var hash = $.bbq.getState()
+        var hash = $.bbq.getState();
         hash.cids = company_ids.sort(function(a, b) {
             if (a === main_company_id) {
                 return -1;

--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -3710,10 +3710,10 @@ var BasicModel = AbstractModel.extend({
         // in general, the actual "company_id" field of the form should be used for m2o domains, not this fallback
         let current_company_id;
         if (session.user_context.allowed_company_ids) {
-            current_company_id = session.user_context.allowed_company_ids[0];
+            current_company_id = Object.keys(session.user_context.allowed_company_ids)[0];
         } else {
             current_company_id = session.user_companies ?
-                session.user_companies.current_company[0] :
+                session.user_companies.current_company :
                 false;
         }
         return Object.assign(

--- a/addons/web/static/src/js/widgets/switch_company_menu.js
+++ b/addons/web/static/src/js/widgets/switch_company_menu.js
@@ -38,15 +38,12 @@ var SwitchCompanyMenu = Widget.extend({
      * @override
      */
     willStart: function () {
-        var self = this;
         this.allowed_company_ids = String(session.user_context.allowed_company_ids)
                                     .split(',')
                                     .map(function (id) {return parseInt(id);});
         this.user_companies = session.user_companies.allowed_companies;
         this.current_company = this.allowed_company_ids[0];
-        this.current_company_name = _.find(session.user_companies.allowed_companies, function (company) {
-            return company[0] === self.current_company;
-        })[1];
+        this.current_company_name = session.user_companies.allowed_companies[this.current_company]['name'];
         return this._super.apply(this, arguments);
     },
 

--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -1734,11 +1734,11 @@
             </span>
         </a>
         <div class="dropdown-menu dropdown-menu-right" role="menu">
-            <t t-foreach="widget.user_companies" t-as="company">
-                <div class="dropdown-item d-flex py-0 px-0" data-menu="company" t-att-data-company-id="company[0]">
-                    <t t-set="is_allowed" t-value="widget.allowed_company_ids.includes(company[0])"/>
-                    <t t-set="is_current" t-value="company[0] === widget.current_company"/>
-                    <div role="menuitemcheckbox" t-att-aria-checked="is_allowed" t-att-aria-label="company[1]" tabindex="0" class="ml-auto pl-3 pr-3 border border-top-0 border-left-0 border-bottom-0 toggle_company o_py">
+            <t t-foreach="_.values(widget.user_companies)" t-as="company">
+                <div class="dropdown-item d-flex py-0 px-0" data-menu="company" t-att-data-company-id="company.id">
+                    <t t-set="is_allowed" t-value="widget.allowed_company_ids.includes(company.id)"/>
+                    <t t-set="is_current" t-value="company.id === widget.current_company"/>
+                    <div role="menuitemcheckbox" t-att-aria-checked="is_allowed" t-att-aria-label="company.name" tabindex="0" class="ml-auto pl-3 pr-3 border border-top-0 border-left-0 border-bottom-0 toggle_company o_py">
                         <span style="height: 2rem;">
                             <t t-if="is_allowed">
                                 <i class="fa fa-fw fa-check-square pt-2"></i>
@@ -1751,12 +1751,12 @@
                     <div role="button" t-att-aria-pressed="is_current" aria-label="Switch to this company" tabindex="0" class="d-flex flex-grow-1 align-items-center py-0 log_into pl-3 o_py" t-att-style="is_current ? 'background-color: lightgrey;' : ''">
                         <t t-if="is_allowed">
                             <span class='mr-3 company_label'>
-                                <t t-esc="company[1]"/>
+                                <t t-esc="company.name"/>
                             </span>
                         </t>
                         <t t-if="!is_allowed">
                             <span class='mr-3 company_label text-muted'>
-                                <t t-esc="company[1]"/>
+                                <t t-esc="company.name"/>
                             </span>
                         </t>
                     </div>

--- a/addons/web/static/tests/widgets/company_switcher_tests.js
+++ b/addons/web/static/tests/widgets/company_switcher_tests.js
@@ -7,11 +7,11 @@ var testUtils = require('web.test_utils');
 
 async function createSwitchCompanyMenu(params) {
     params = params || {};
-    var target = params.debug ? document.body :  $('#qunit-fixture');
+    var target = params.debug ? document.body : $('#qunit-fixture');
     var menu = new SwitchCompanyMenu();
     await testUtils.mock.addMockEnvironment(menu, params);
-    await menu.appendTo(target)
-    return menu
+    await menu.appendTo(target);
+    return menu;
 }
 
 
@@ -21,12 +21,12 @@ async function initMockCompanyMenu(assert, params) {
             ...params.session,
             setCompanies: function (mainCompanyId, companyIds) {
                 assert.equal(mainCompanyId, params.assertMainCompany[0], params.assertMainCompany[1]);
-                assert.equal(_.intersection(companyIds, params.asserCompanies[0]).length, params.asserCompanies[0].length, params.asserCompanies[1]);
+                assert.equal(_.intersection(companyIds, params.assertCompanies[0]).length, params.assertCompanies[0].length, params.assertCompanies[1]);
             },
         }
-    })
-    await testUtils.dom.click(menu.$('.dropdown-toggle'));  // open company switcher dropdown
-    return menu
+    });
+    await testUtils.dom.click(menu.$('.dropdown-toggle')); // open company switcher dropdown
+    return menu;
 }
 
 async function testSwitchCompany(assert, params) {
@@ -50,15 +50,15 @@ QUnit.module('widgets', {
                 current_company: [1, "Company 1"],
                 allowed_companies: [[1, "Company 1"], [2, "Company 2"], [3, "Company 3"]],
             },
-            user_context: { allowed_company_ids: [1, 3] },
-        },
+            user_context: {allowed_company_ids: [1, 3]},
+        };
         this.session_mock_single = {
             user_companies: {
                 current_company: [1, "Company 1"],
                 allowed_companies: [[1, "Company 1"], [2, "Company 2"], [3, "Company 3"]],
             },
-            user_context: { allowed_company_ids: [1] },
-        }
+            user_context: {allowed_company_ids: [1]},
+        };
     },
 
 }, function () {
@@ -68,13 +68,13 @@ QUnit.module('widgets', {
         QUnit.test("Company switcher basic rendering", async function (assert) {
             assert.expect(6);
             var menu = await createSwitchCompanyMenu({ session: this.session_mock_multi });
-            assert.equal(menu.$('.company_label:contains(Company 1)').length, 1, "it should display Company 1")
-            assert.equal(menu.$('.company_label:contains(Company 2)').length, 1, "it should display Company 2")
-            assert.equal(menu.$('.company_label:contains(Company 3)').length, 1, "it should display Company 3")
+            assert.equal(menu.$('.company_label:contains(Company 1)').length, 1, "it should display Company 1");
+            assert.equal(menu.$('.company_label:contains(Company 2)').length, 1, "it should display Company 2");
+            assert.equal(menu.$('.company_label:contains(Company 3)').length, 1, "it should display Company 3");
 
-            assert.equal(menu.$('div[data-company-id=1] .fa-check-square').length, 1, "Company 1 should be checked")
-            assert.equal(menu.$('div[data-company-id=2] .fa-square-o').length, 1, "Company 2 should not be checked")
-            assert.equal(menu.$('div[data-company-id=3] .fa-check-square').length, 1, "Company 3 should be checked")
+            assert.equal(menu.$('div[data-company-id=1] .fa-check-square').length, 1, "Company 1 should be checked");
+            assert.equal(menu.$('div[data-company-id=2] .fa-square-o').length, 1, "Company 2 should not be checked");
+            assert.equal(menu.$('div[data-company-id=3] .fa-check-square').length, 1, "Company 3 should be checked");
             menu.destroy();
         });
     });
@@ -91,7 +91,7 @@ QUnit.module('widgets', {
                 company: 2,
                 session: this.session_mock_multi,
                 assertMainCompany: [1, "Main company should not have changed"],
-                asserCompanies: [[1, 2, 3], "All companies should be activated"],
+                assertCompanies: [[1, 2, 3], "All companies should be activated"],
             });
         });
 
@@ -105,7 +105,7 @@ QUnit.module('widgets', {
                 company: 3,
                 session: this.session_mock_multi,
                 assertMainCompany: [1, "Main company should not have changed"],
-                asserCompanies: [[1], "Companies 3 should be unactivated"],
+                assertCompanies: [[1], "Companies 3 should be unactivated"],
             });
         });
 
@@ -119,7 +119,7 @@ QUnit.module('widgets', {
                 company: 3,
                 session: this.session_mock_multi,
                 assertMainCompany: [3, "Main company should switch to Company 3"],
-                asserCompanies: [[1, 3], "Companies 1 and 3 should still be active"],
+                assertCompanies: [[1, 3], "Companies 1 and 3 should still be active"],
             });
         });
 
@@ -133,7 +133,7 @@ QUnit.module('widgets', {
                 company: 2,
                 session: this.session_mock_multi,
                 assertMainCompany: [2, "Company 2 should become the main company"],
-                asserCompanies: [[1, 2, 3], "Companies 1 and 3 should still be active"],
+                assertCompanies: [[1, 2, 3], "Companies 1 and 3 should still be active"],
             });
         });
 
@@ -147,7 +147,7 @@ QUnit.module('widgets', {
                 company: 3,
                 session: this.session_mock_single,
                 assertMainCompany: [3, "Main company should switch to Company 3"],
-                asserCompanies: [[3], "Companies 1 should no longer be active"],
+                assertCompanies: [[3], "Companies 1 should no longer be active"],
             });
         });
 
@@ -161,7 +161,7 @@ QUnit.module('widgets', {
                 company: 3,
                 session: this.session_mock_single,
                 assertMainCompany: [1, "Company 1 should still be the main company"],
-                asserCompanies: [[1, 3], "Company 3 should be activated"],
+                assertCompanies: [[1, 3], "Company 3 should be activated"],
             });
         });
     });

--- a/addons/web/static/tests/widgets/company_switcher_tests.js
+++ b/addons/web/static/tests/widgets/company_switcher_tests.js
@@ -47,17 +47,47 @@ QUnit.module('widgets', {
     beforeEach: async function () {
         this.session_mock_multi = {
             user_companies: {
-                current_company: [1, "Company 1"],
-                allowed_companies: [[1, "Company 1"], [2, "Company 2"], [3, "Company 3"]],
+                current_company: 1,
+                allowed_companies: {
+                    1: {
+                        id: 1,
+                        name: 'Company 1',
+                    },
+                    2: {
+                        id: 2,
+                        name: 'Company 2',
+                    },
+                    3: {
+                        id: 3,
+                        name: 'Company 3',
+                    },
+                },
             },
-            user_context: {allowed_company_ids: [1, 3]},
+            user_context: {
+                allowed_company_ids: [1, 3],
+            },
         };
         this.session_mock_single = {
             user_companies: {
-                current_company: [1, "Company 1"],
-                allowed_companies: [[1, "Company 1"], [2, "Company 2"], [3, "Company 3"]],
+                current_company: 1,
+                allowed_companies: {
+                    1: {
+                        id: 1,
+                        name: 'Company 1',
+                    },
+                    2: {
+                        id: 2,
+                        name: 'Company 2',
+                    },
+                    3: {
+                        id: 3,
+                        name: 'Company 3',
+                    },
+                },
             },
-            user_context: {allowed_company_ids: [1]},
+            user_context: {
+                allowed_company_ids: [1],
+            },
         };
     },
 


### PR DESCRIPTION
# Purpose

This PR's primary objective is to ensure that the timesheet uom is working in accordance with the company settings in a multi company environment.

Prior to this PR:

 - The timesheet preferences sent to the front end were always those of the default
   company of the user.
 - The timesheet related widgets initialisation process (adding the correct ones in
   the fieldRegistry) was performed before the front end treatment of cids and coockies
   which prevented applying the front end selected company settings.

After this PR:

 - A dictionnary is used in the session in order to structure the companies info.
 - The company timesheet preferences are sent to the front end through the company dict.
 - The uom info is sent to the front end through the session.
 - The timesheet uom is now managed from the frontend and is now in sync with the settings.
 - Timesheet widgets are initialised during the AbstractWebClient init and are in sync with
   the multicompany front end settings

task-2168337

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
