### PR TITLE
[FIX] stock: make package level package consistent v2

### DIFF
--- a/addons/stock/models/stock_package_level.py
+++ b/addons/stock/models/stock_package_level.py
@@ -145,7 +145,7 @@ class StockPackageLevel(models.Model):
         return result
 
     def unlink(self):
-        self.mapped('move_ids').unlink()
+        self.mapped('move_ids').write({'package_level_id': False})
         self.mapped('move_line_ids').write({'result_package_id': False})
         return super(StockPackageLevel, self).unlink()
 


### PR DESCRIPTION
Commit e5ab8cf missed a use case.

Steps to reproduce:

- Activiate "Packages" setting in Inventory
- Configure an operation type to "Move Entire Packages"
- Create a "Planned Transfer" picking with that operation type and add a
  package to be moved
- Turn off "Move Entire Packages" and try set the destination
  package of the move line to nothing (False).

Expected result:
Move line has no destination package + package level is deleted as
expected.

Another bug will still exist due to the design of package_level where if
in addition to the above use case, if a different package is used instead
of deleting it and "Move Entire Packages" is reactived => final package
shown in the Detailed Operations will show all move lines as being part
of the same package even though they are not. Data appears to be correct
in the database otherwise and a reasonable fix doesn't seem feasible for
now so we leave this bug as is.

Related to Task: 2418907

fixes: odoo/odoo#66542
fixes: odoo/odoo#66517