### PR TITLE
[FIX] mrp: rename demo data operation records id

### DIFF
--- a/addons/mrp/data/mrp_demo.xml
+++ b/addons/mrp/data/mrp_demo.xml
@@ -304,7 +304,7 @@
             <field name="product_uom_id" ref="uom.product_uom_unit"/>
             <field name="sequence">1</field>
         </record>
-        <record id="mrp_routing_workcenter_0" model="mrp.routing.workcenter">
+        <record id="mrp_routing_workcenter_6" model="mrp.routing.workcenter">
             <field name="bom_id" ref="mrp_bom_table_top"/>
             <field name="workcenter_id" ref="mrp_workcenter_3"/>
             <field name="name">Manual Assembly</field>
@@ -601,7 +601,7 @@
             <field name="sequence">2</field>
             <field name="code">SEC-ASSEM</field>
         </record>
-        <record id="mrp_routing_workcenter_1" model="mrp.routing.workcenter">
+        <record id="mrp_routing_workcenter_7" model="mrp.routing.workcenter">
             <field name="bom_id" ref="mrp_bom_laptop_cust_rout"/>
             <field name="workcenter_id" ref="mrp_workcenter_3"/>
             <field name="name">Long time assembly</field>
@@ -610,7 +610,7 @@
             <field name="worksheet" type="base64" file="mrp/static/img/cutting-worksheet.pdf"/>
         </record>
 
-        <record id="mrp_routing_workcenter_3" model="mrp.routing.workcenter">
+        <record id="mrp_routing_workcenter_8" model="mrp.routing.workcenter">
             <field name="bom_id" ref="mrp_bom_laptop_cust_rout"/>
             <field name="workcenter_id" ref="mrp_workcenter_3"/>
             <field name="name">Testing</field>
@@ -619,7 +619,7 @@
             <field name="worksheet" type="base64" file="mrp/static/img/assebly-worksheet.pdf"/>
         </record>
 
-        <record id="mrp_routing_workcenter_4" model="mrp.routing.workcenter">
+        <record id="mrp_routing_workcenter_9" model="mrp.routing.workcenter">
             <field name="bom_id" ref="mrp_bom_laptop_cust_rout"/>
             <field name="workcenter_id" ref="mrp_workcenter_1"/>
             <field name="name">Packing</field>

--- a/addons/mrp/views/mrp_routing_views.xml
+++ b/addons/mrp/views/mrp_routing_views.xml
@@ -9,6 +9,7 @@
                 <tree string="Routing Work Centers">
                     <field name="sequence" widget="handle"/>
                     <field name="name"/>
+                    <field name="bom_id" optional="show"/>
                     <field name="workcenter_id"/>
                     <field name="time_cycle" widget="float_time" string="Duration (minutes)" sum="Total Duration" width="1.5"/>
                 </tree>


### PR DESCRIPTION
Before this commit, some operations created by the demo data was created with an existing record id. But the purpose of the duplicate demo data was to create an operation for each BOM who previously use the routing
linked to this operation (see c660770ebd84c2c0d9e56ca5897effc6c138b827), not to override the BOM of the operations.

Also, as some demo data operations will now be duplicate, displays the Bill of Materials in the operations list view to be able to discern which operation concerns which BOM.