### PR TITLE
[FIX] payment: link to order when not connected

### DIFF
--- a/addons/payment/controllers/portal.py
+++ b/addons/payment/controllers/portal.py
@@ -168,7 +168,13 @@ class WebsitePayment(http.Controller):
         if order_id:
             try:
                 order_id = int(order_id)
-                order = env['sale.order'].browse(order_id)
+                if partner_id:
+                    # `sudo` needed if the user is not connected.
+                    # A public user woudn't be able to read the sale order.
+                    # With `partner_id`, an access_token should be validated, preventing a data breach.
+                    order = env['sale.order'].sudo().browse(order_id)
+                else:
+                    order = env['sale.order'].browse(order_id)
                 values.update({
                     'currency': order.currency_id,
                     'amount': order.amount_total,


### PR DESCRIPTION
Steps:
- Install sales,payment
- Go to Sales
- Create a quotation
- Click Actions > Generate a Payment Link
- Browse the link in a private window
- Pay

Bug:
The transaction is not linked to the sale order in the link table
`sale_order_transaction_rel`

Explanation:
When not connected, the user doesn't have the rights to read the order.
This leads `order_id` to be set to `None`:
https://github.com/odoo/odoo/blob/d2f3c9e7975188753fa17c06db3fc5c73c773944/addons/payment/controllers/portal.py#L177-L178
When paying without `order_id`, the app is not able to make a link
with the transactions:
https://github.com/odoo/odoo/blob/d2f3c9e7975188753fa17c06db3fc5c73c773944/addons/payment/controllers/portal.py#L276-L277
This raises problems such as not being able to capture an amount as seen
here:
https://github.com/odoo/odoo/blob/d2f3c9e7975188753fa17c06db3fc5c73c773944/addons/sale/views/sale_views.xml#L254-L257

If we ensure a `partner_id` is present, using `sudo` here shouldn't be a
problem as the data is protected by the token. Everything we get from
`order_id` should already be in the URL.

opw:2451564