### PR TITLE
Master mrp mo consumption yhu

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -976,7 +976,7 @@ class MrpProduction(models.Model):
             moves_to_confirm |= additional_byproducts
 
         if moves_to_confirm:
-            moves_to_confirm._action_confirm()
+            moves_to_confirm = moves_to_confirm._action_confirm()
             # run scheduler for moves forecasted to not have enough in stock
             moves_to_confirm._trigger_scheduler()
 

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1326,7 +1326,7 @@ class MrpProduction(models.Model):
                 move.product_uom_qty = move.quantity_done
             # MRP do not merge move, catch the result of _action_done in order
             # to get extra moves.
-            moves_to_do = moves_to_do._action_done()
+            moves_to_do = moves_to_do._action_done(cancel_backorder=cancel_backorder)
             moves_to_do = order.move_raw_ids.filtered(lambda x: x.state == 'done') - moves_not_to_do
 
             finish_moves = order.move_finished_ids.filtered(lambda m: m.product_id == order.product_id and m.state not in ('done', 'cancel'))

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -401,3 +401,10 @@ class StockMove(models.Model):
             self.move_line_ids = self._set_quantity_done_prepare_vals(new_qty)
         else:
             self.quantity_done = new_qty
+
+    def _update_candidate_moves_list(self, candidate_moves_list):
+        super()._update_candidate_moves_list(candidate_moves_list)
+        for production in self.mapped('raw_material_production_id'):
+            candidate_moves_list.append(production.move_raw_ids)
+        for production in self.mapped('production_id'):
+            candidate_moves_list.append(production.move_finished_ids)

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -149,11 +149,10 @@ class TestMrpOrder(TestMrpCommon):
         # check sub product availability state is assigned
         self.assertEqual(production_2.reservation_state, 'assigned', 'Production order should be availability for assigned state')
 
-    def test_split_move_line(self):
-        """ Consume more component quantity than the initial demand.
-        It should create extra move and share the quantity between the two stock
-        moves """
-        mo, bom, p_final, p1, p2 = self.generate_mo(qty_base_1=10, qty_final=1, qty_base_2=1)
+    def test_over_consumption(self):
+        """ Consume more component quantity than the initial demand. No split on moves.
+        """
+        mo, _bom, _p_final, _p1, _p2 = self.generate_mo(qty_base_1=10, qty_final=1, qty_base_2=1)
         mo.action_assign()
         # check is_quantity_done_editable
         mo_form = Form(mo)
@@ -175,10 +174,10 @@ class TestMrpOrder(TestMrpCommon):
         self.assertEqual(mo.move_raw_ids[0].quantity_done, 2)
         self.assertEqual(mo.move_raw_ids[1].quantity_done, 11)
         mo.button_mark_done()
-        self.assertEqual(len(mo.move_raw_ids), 4)
-        self.assertEqual(len(mo.move_raw_ids.mapped('move_line_ids')), 4)
-        self.assertEqual(mo.move_raw_ids.mapped('quantity_done'), [1, 10, 1, 1])
-        self.assertEqual(mo.move_raw_ids.mapped('move_line_ids.qty_done'), [1, 10, 1, 1])
+        self.assertEqual(len(mo.move_raw_ids), 2)
+        self.assertEqual(len(mo.move_raw_ids.mapped('move_line_ids')), 2)
+        self.assertEqual(mo.move_raw_ids.mapped('quantity_done'), [2, 11])
+        self.assertEqual(mo.move_raw_ids.mapped('move_line_ids.qty_done'), [2, 11])
 
     def test_update_quantity_1(self):
         """ Build 5 final products with different consumed lots,

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -238,12 +238,14 @@
                                         </tree>
                                     </field>
 
+                                    <field name="propagate_cancel" invisible="1"/>
+                                    <field name="price_unit" invisible="1"/>
                                     <field name="company_id" invisible="1"/>
                                     <field name="product_uom_category_id" invisible="1"/>
                                     <field name="name" invisible="1"/>
                                     <field name="allowed_operation_ids" invisible="1"/>
                                     <field name="unit_factor" invisible="1"/>
-                                    <field name="date_deadline" invisible="1"/>
+                                    <field name="date_deadline" invisible="1" force_save="1"/>
                                     <field name="date" invisible="1"/>
                                     <field name="additional" invisible="1"/>
                                     <field name="picking_type_id" invisible="1"/>

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -797,6 +797,10 @@ class StockMove(models.Model):
         """Cleanup hook used when merging moves"""
         self.write({'propagate_cancel': False})
 
+    def _update_candidate_moves_list(self, candidate_moves_list):
+        for picking in self.mapped('picking_id'):
+            candidate_moves_list.append(picking.move_lines)
+
     def _merge_moves(self, merge_into=False):
         """ This method will, for each move in `self`, go up in their linked picking and try to
         find in their existing moves a candidate into which we can merge the move.
@@ -807,8 +811,7 @@ class StockMove(models.Model):
 
         candidate_moves_list = []
         if not merge_into:
-            for picking in self.mapped('picking_id'):
-                candidate_moves_list.append(picking.move_lines)
+            self._update_candidate_moves_list(candidate_moves_list)
         else:
             candidate_moves_list.append(merge_into | self)
 


### PR DESCRIPTION
Make MO under/over consumption consistent with picking

when over consumption:
    to consume = 2, Consumed = 3
after done, show 1 line:
   to consume = 3, Consumed = 3

when under consumption:
    to consume = 2, Consumed = 1
after done, show 2 lines:
    to consume = 1, Consumed = 1
    to consume = 1, consumed = 0 (cancelled)





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
