### PR TITLE
[FIX] account: set noupdate flag on accounting demo data

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -204,6 +204,7 @@ class AccountChartTemplate(models.Model):
                     created = self.env[model]._load_records([{
                         'xml_id': "account.%s" % xml_id if '.' not in xml_id else xml_id,
                         'values': record,
+                        'noupdate': True,
                     } for xml_id, record in data.items()])
                     self._post_create_demo_data(created)
         except Exception:


### PR DESCRIPTION
Demo data is not usually updated. It was also deleting the demo data
when doing a `-i account` when the module was already installed (or
actually the chart of accounts instantiated)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
