### PR TITLE
[IMP] stock_picking_batch: cancel empty batch

### DIFF
--- a/addons/stock_picking_batch/data/stock_picking_batch_demo.xml
+++ b/addons/stock_picking_batch/data/stock_picking_batch_demo.xml
@@ -1,15 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo><data noupdate="1">
-    <!-- Add batch picking -->
-    <record id="stock_picking_batch_1" model="stock.picking.batch">
-        <field name="picking_type_id" ref="stock.picking_type_out"/>
-        <field name="company_id" ref="base.main_company"/>
-    </record>
-    <record id="stock_picking_batch_2" model="stock.picking.batch">
-        <field name="picking_type_id" ref="stock.picking_type_out"/>
-        <field name="company_id" ref="base.main_company"/>
-    </record>
-
     <!-- Starting inventory -->
     <record id="stock_inventory_batch_1" model="stock.quant">
         <field name="product_id" ref="product.consu_delivery_01"/>
@@ -40,7 +30,6 @@
         <field name="priority">1</field>
         <field name="user_id" eval="False"/>
         <field name="picking_type_id" ref="stock.picking_type_out"/>
-        <field name="batch_id" ref="stock_picking_batch_2"/>
         <field name="location_id" ref="stock.stock_location_stock"/>
         <field name="location_dest_id" ref="stock.stock_location_customers"/>
         <field name="company_id" ref="base.main_company"/>
@@ -50,7 +39,6 @@
         <field name="priority">0</field>
         <field name="user_id" eval="False"/>
         <field name="picking_type_id" ref="stock.picking_type_out"/>
-        <field name="batch_id" ref="stock_picking_batch_2"/>
         <field name="location_id" ref="stock.stock_location_stock"/>
         <field name="location_dest_id" ref="stock.stock_location_customers"/>
         <field name="company_id" ref="base.main_company"/>
@@ -60,7 +48,6 @@
         <field name="priority">0</field>
         <field name="user_id" eval="False"/>
         <field name="picking_type_id" ref="stock.picking_type_out"/>
-        <field name="batch_id" ref="stock_picking_batch_1"/>
         <field name="location_id" ref="stock.stock_location_stock"/>
         <field name="location_dest_id" ref="stock.stock_location_customers"/>
         <field name="company_id" ref="base.main_company"/>
@@ -70,10 +57,21 @@
         <field name="priority">1</field>
         <field name="user_id" eval="False"/>
         <field name="picking_type_id" ref="stock.picking_type_out"/>
-        <field name="batch_id" ref="stock_picking_batch_1"/>
         <field name="location_id" ref="stock.stock_location_stock"/>
         <field name="location_dest_id" ref="stock.stock_location_customers"/>
         <field name="company_id" ref="base.main_company"/>
+    </record>
+
+    <!-- Add batch picking -->
+    <record id="stock_picking_batch_1" model="stock.picking.batch">
+        <field name="picking_type_id" ref="stock.picking_type_out"/>
+        <field name="company_id" ref="base.main_company"/>
+        <field name="picking_ids" eval="[(6, 0, [ref('stock_picking_batch.Picking_C'), ref('stock_picking_batch.Picking_D')])]"/>
+    </record>
+    <record id="stock_picking_batch_2" model="stock.picking.batch">
+        <field name="picking_type_id" ref="stock.picking_type_out"/>
+        <field name="company_id" ref="base.main_company"/>
+        <field name="picking_ids" eval="[(6, 0, [ref('stock_picking_batch.Picking_A'), ref('stock_picking_batch.Picking_B')])]"/>
     </record>
 
     <!-- Add stock move -->

--- a/addons/stock_picking_batch/models/stock_picking.py
+++ b/addons/stock_picking_batch/models/stock_picking.py
@@ -21,8 +21,10 @@ class StockPicking(models.Model):
         return res
 
     def write(self, vals):
+        batches = self.batch_id
         res = super().write(vals)
         if vals.get('batch_id'):
+            batches.filtered(lambda b: not b.picking_ids).state = 'cancel'
             if not self.batch_id.picking_type_id:
                 self.batch_id.picking_type_id = self.picking_type_id[0]
             self.batch_id._sanity_check()


### PR DESCRIPTION
1. allow create batch with picking already in other batch
2. when creating new batch makes an existing batch empty, cancel the empty one.

Task-2464457





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
