### PR TITLE
[IMP] website_event_exhibitor: speed up sponsors retrieval

### DIFF
--- a/addons/website_event_exhibitor/models/event_sponsor.py
+++ b/addons/website_event_exhibitor/models/event_sponsor.py
@@ -40,7 +40,7 @@ class Sponsor(models.Model):
         sanitize_attributes=False, sanitize_form=True, translate=html_translate,
         readonly=False, store=True)
     # contact information
-    partner_id = fields.Many2one('res.partner', 'Partner', required=True)
+    partner_id = fields.Many2one('res.partner', 'Partner', required=True, auto_join=True)
     partner_name = fields.Char('Name', related='partner_id.name')
     partner_email = fields.Char('Email', related='partner_id.email')
     partner_phone = fields.Char('Phone', related='partner_id.phone')


### PR DESCRIPTION
The filters for sponsor countries works by adding a domain term on `partner_id.country_id`. Currently this is evaluated by the ORM by first searching for all partners in those countries, and then substituting the IDs in the final query (`partner_id in <ids>`).

On large databases with many partners, this makes the filtering really slow (e.g. 3 seconds with 1M partners), even though only a few sponsors actually match.

From a security standpoint, most of the data on the linked partner is already available on the sponsor through related fields, and those partners are only visible when they are already published anyway.  Besides, the calls in `_event_exhibitors_get_values` are performed in `sudo` mode.

It should be noted that `res.partner.country_id` is not currently indexed, and doing so help marginally: the query goes from 3000ms to 800ms. It is still much slower than with `auto_join`, which makes it go down to about 1-2 ms.

Indexing `country_id` does not help make the `auto_join` version faster, as it only requires the primary key index to find the records.
