### PR TITLE
[FIX] registry: no name in constraint check

### DIFF
--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -495,7 +495,7 @@ class Registry(Mapping):
             if spec is None:
                 sql.add_foreign_key(cr, table1, column1, table2, column2, ondelete)
                 model.env['ir.model.constraint']._reflect_constraint(model, conname, 'f', None, module)
-            elif spec != (conname, table2, column2, deltype):
+            elif (spec[1], spec[2], spec[3]) != (table2, column2, deltype):
                 sql.drop_constraint(cr, table1, spec[0])
                 sql.add_foreign_key(cr, table1, column1, table2, column2, ondelete)
                 model.env['ir.model.constraint']._reflect_constraint(model, conname, 'f', None, module)


### PR DESCRIPTION
When table name is long enough, the foreign key constraint name computed 
by odoo and the one by PostgreSQL are different, for the same table, 
column and definition. 

As an example, base_partner_merge_automatic_wizard_res_partner_rel(partner_id) foreign 
key is named base_partner_merge_automatic_wizard_res_partner_rel_res_partner_id_fkey 
in Odoo while it's base_partner_merge_automatic_wizard_res_par_res_partner_id_fkey in 
PostgreSQL. This difference trigger a useless foreign key drop/create.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
