### PR TITLE
[FIX] website: o_cp_top_left class doesn't exist on mobile

### DIFF
--- a/addons/website/static/src/js/theme_preview_kanban.js
+++ b/addons/website/static/src/js/theme_preview_kanban.js
@@ -28,9 +28,9 @@ var ThemePreviewKanbanController = KanbanController.extend(ThemePreviewControlle
             className: 'mx-2 text-muted',
             innerHTML: _lt("Don't worry, you can switch later."),
         });
-        this._controlPanelWrapper.el.querySelector('.o_cp_top .o_cp_top_left .breadcrumb li.active').classList.add('text-black-75');
+        this._controlPanelWrapper.el.querySelector('.o_cp_top .breadcrumb li.active').classList.add('text-black-75');
         this._controlPanelWrapper.el.querySelector('.o_cp_top').appendChild(websiteLink);
-        this._controlPanelWrapper.el.querySelector('div.o_cp_top_left li').appendChild(smallBreadcumb);
+        this._controlPanelWrapper.el.querySelector('.o_cp_top li').appendChild(smallBreadcumb);
     },
     /**
      * Called when user click on any button in kanban view.


### PR DESCRIPTION
Before this commit, the selector 'o_cp_top_left' was used to target
a descendent element. The 'o_cp_top_left' class was added in this commit
odoo/odoo@533db5991a5bb871198485cd71a63f75a8c6becf
But 'o_cp_top_left' class is only available on desktop.
On mobile the layout of the control panel is different.
This produce a bug on Mobile.

After this commit, we use a less restrictive querySelector to match
the element in mobile too.

Note: we remove the 'div' for clarity/consistency

Steps to reproduce:
* Open Odoo in "Mobile mode" (small screen)
* Go to Apps
* Install a module that need website or website it self
* You are redirect to the "chose theme" => Bug

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
