### PR TITLE
[FIX] hr_work_entry: unit of period not aligned

### DIFF
--- a/addons/hr_work_entry/views/hr_work_entry_views.xml
+++ b/addons/hr_work_entry/views/hr_work_entry_views.xml
@@ -57,7 +57,7 @@
                             <field name="date_start" attrs="{'readonly': [('state', '!=', 'draft')]}" />
                             <field name="date_stop" attrs="{'readonly': [('state', '!=', 'draft')]}" />
                             <label for="duration" string="Period"/>
-                            <div>
+                            <div class="o_row">
                                 <field name="duration" nolabel="1" attrs="{'readonly': [('state', '!=', 'draft')]}" /><span class="ml8">Hours</span>
                             </div>
                             <field name="company_id" invisible="1"/>


### PR DESCRIPTION
Before this commit, 'hours' was on the next row instead of the same line.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
