### PR TITLE
[REF] logistics: improve performance of some highly used method/code

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -540,7 +540,7 @@ class MrpProduction(models.Model):
         if not self.product_id:
             self.bom_id = False
         elif not self.bom_id or self.bom_id.product_tmpl_id != self.product_tmpl_id or (self.bom_id.product_id and self.bom_id.product_id != self.product_id):
-            bom = self.env['mrp.bom']._bom_find(product=self.product_id, picking_type=self.picking_type_id, company_id=self.company_id.id, bom_type='normal')
+            bom = self.env['mrp.bom']._bom_find(self.product_id, picking_type=self.picking_type_id, company_id=self.company_id.id, bom_type='normal')[self.product_id]
             if bom:
                 self.bom_id = bom.id
                 self.product_qty = self.bom_id.product_qty

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -509,7 +509,7 @@ class MrpProduction(models.Model):
     @api.depends('product_uom_qty', 'date_planned_start')
     def _compute_forecasted_issue(self):
         for order in self:
-            warehouse = order.location_dest_id.get_warehouse()
+            warehouse = order.location_dest_id.warehouse_id
             order.forecasted_issue = False
             if order.product_id:
                 virtual_available = order.product_id.with_context(warehouse=warehouse.id, to_date=order.date_planned_start).virtual_available
@@ -631,7 +631,7 @@ class MrpProduction(models.Model):
     def _onchange_location(self):
         source_location = self.location_src_id
         self.move_raw_ids.update({
-            'warehouse_id': source_location.get_warehouse().id,
+            'warehouse_id': source_location.warehouse_id.id,
             'location_id': source_location.id,
         })
 
@@ -641,7 +641,7 @@ class MrpProduction(models.Model):
         update_value_list = []
         for move in self.move_finished_ids:
             update_value_list += [(1, move.id, ({
-                'warehouse_id': destination_location.get_warehouse().id,
+                'warehouse_id': destination_location.warehouse_id.id,
                 'location_dest_id': destination_location.id,
             }))]
         self.move_finished_ids = update_value_list
@@ -834,7 +834,7 @@ class MrpProduction(models.Model):
             'location_dest_id': self.location_dest_id.id,
             'company_id': self.company_id.id,
             'production_id': self.id,
-            'warehouse_id': self.location_dest_id.get_warehouse().id,
+            'warehouse_id': self.location_dest_id.warehouse_id.id,
             'origin': self.name,
             'group_id': self.procurement_group_id.id,
             'propagate_cancel': self.propagate_cancel,
@@ -895,7 +895,7 @@ class MrpProduction(models.Model):
             'procure_method': 'make_to_stock',
             'origin': self.name,
             'state': 'draft',
-            'warehouse_id': source_location.get_warehouse().id,
+            'warehouse_id': source_location.warehouse_id.id,
             'group_id': self.procurement_group_id.id,
             'propagate_cancel': self.propagate_cancel,
         }

--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -257,7 +257,7 @@ class MrpUnbuild(models.Model):
             'procure_method': 'make_to_stock',
             'location_dest_id': location_dest_id.id,
             'location_id': location_id.id,
-            'warehouse_id': location_dest_id.get_warehouse().id,
+            'warehouse_id': location_dest_id.warehouse_id.id,
             'unbuild_id': self.id,
             'company_id': move.company_id.id,
         })
@@ -266,7 +266,7 @@ class MrpUnbuild(models.Model):
         product_prod_location = product.with_company(self.company_id).property_stock_production
         location_id = bom_line_id and product_prod_location or self.location_id
         location_dest_id = bom_line_id and self.location_dest_id or product_prod_location
-        warehouse = location_dest_id.get_warehouse()
+        warehouse = location_dest_id.warehouse_id
         return self.env['stock.move'].create({
             'name': self.name,
             'date': self.create_date,

--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -119,7 +119,7 @@ class MrpUnbuild(models.Model):
     @api.onchange('product_id')
     def _onchange_product_id(self):
         if self.product_id:
-            self.bom_id = self.env['mrp.bom']._bom_find(product=self.product_id, company_id=self.company_id.id)
+            self.bom_id = self.env['mrp.bom']._bom_find(self.product_id, company_id=self.company_id.id)[self.product_id]
             self.product_uom_id = self.product_id.uom_id.id
 
     @api.constrains('product_qty')

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -219,7 +219,7 @@ class StockMove(models.Model):
             if not move.picking_type_id or (move.production_id and move.production_id.product_id == move.product_id):
                 moves_ids_to_return.add(move.id)
                 continue
-            bom = self.env['mrp.bom'].sudo()._bom_find(product=move.product_id, company_id=move.company_id.id, bom_type='phantom')
+            bom = self.env['mrp.bom'].sudo()._bom_find(move.product_id, company_id=move.company_id.id, bom_type='phantom')[move.product_id]
             if not bom:
                 moves_ids_to_return.add(move.id)
                 continue

--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -7,6 +7,7 @@ from dateutil.relativedelta import relativedelta
 from odoo import api, fields, models, SUPERUSER_ID, _
 from odoo.osv import expression
 from odoo.addons.stock.models.stock_rule import ProcurementException
+from odoo.tools import OrderedSet
 
 
 class StockRule(models.Model):
@@ -80,8 +81,7 @@ class StockRule(models.Model):
     def _get_matching_bom(self, product_id, company_id, values):
         if values.get('bom_id', False):
             return values['bom_id']
-        return self.env['mrp.bom']._bom_find(
-            product=product_id, picking_type=self.picking_type_id, bom_type='normal', company_id=company_id.id)
+        return self.env['mrp.bom']._bom_find(product_id, picking_type=self.picking_type_id, bom_type='normal', company_id=company_id.id)[product_id]
 
     def _prepare_mo_vals(self, product_id, product_qty, product_uom, location_id, name, origin, company_id, values, bom):
         date_planned = self._get_date_planned(product_id, company_id, values)
@@ -148,12 +148,15 @@ class ProcurementGroup(models.Model):
         the original 'run' method with the values of the components of that kit.
         """
         procurements_without_kit = []
+        product_by_company = defaultdict(OrderedSet)
         for procurement in procurements:
-            bom_kit = self.env['mrp.bom']._bom_find(
-                product=procurement.product_id,
-                company_id=procurement.company_id.id,
-                bom_type='phantom',
-            )
+            product_by_company[procurement.company_id].add(procurement.product_id.id)
+        kits_by_company = {
+            company: self.env['mrp.bom']._bom_find(self.env['product.product'].browse(product_ids), company_id=company.id, bom_type='phantom')
+            for company, product_ids in product_by_company.items()
+        }
+        for procurement in procurements:
+            bom_kit = kits_by_company[procurement.company_id].get(procurement.product_id)
             if bom_kit:
                 order_qty = procurement.product_uom._compute_quantity(procurement.product_qty, bom_kit.product_uom_id, round=False)
                 qty_to_produce = (order_qty / bom_kit.product_qty)

--- a/addons/mrp/populate/mrp.py
+++ b/addons/mrp/populate/mrp.py
@@ -85,7 +85,7 @@ class MrpBomLine(models.Model):
 
     def _populate_factories(self):
         # TODO: tree of product by company to be more closer to the reality
-        boms = self.env['mrp.bom'].search([('id', 'in', self.env.registry.populated_models['mrp.bom'])], order='sequence, product_id')
+        boms = self.env['mrp.bom'].search([('id', 'in', self.env.registry.populated_models['mrp.bom'])], order='sequence, product_id, id')
 
         product_manu_ids = OrderedSet()
         for bom in boms:
@@ -236,7 +236,7 @@ class MrpBomByproduct(models.Model):
         boms_ids = self.env.registry.populated_models['mrp.bom']
         boms_ids = random.sample(boms_ids, int(len(boms_ids) * 0.5))
 
-        boms = self.env['mrp.bom'].search([('id', 'in', self.env.registry.populated_models['mrp.bom'])], order='sequence, product_id')
+        boms = self.env['mrp.bom'].search([('id', 'in', self.env.registry.populated_models['mrp.bom'])], order='sequence, product_id, id')
 
         product_manu_ids = OrderedSet()
         for bom in boms:

--- a/addons/mrp_account/models/product.py
+++ b/addons/mrp_account/models/product.py
@@ -36,7 +36,7 @@ class ProductProduct(models.Model):
 
     def _set_price_from_bom(self, boms_to_recompute=False):
         self.ensure_one()
-        bom = self.env['mrp.bom']._bom_find(product=self)
+        bom = self.env['mrp.bom']._bom_find(self)[self]
         if bom:
             self.standard_price = self._compute_bom_price(bom, boms_to_recompute=boms_to_recompute)
 
@@ -44,7 +44,7 @@ class ProductProduct(models.Model):
         self.ensure_one()
         if stock_moves.product_id == self:
             return super()._compute_average_price(qty_invoiced, qty_to_invoice, stock_moves)
-        bom = self.env['mrp.bom']._bom_find(product=self, company_id=stock_moves.company_id.id, bom_type='phantom')
+        bom = self.env['mrp.bom']._bom_find(self, company_id=stock_moves.company_id.id, bom_type='phantom')[self]
         if not bom:
             return super()._compute_average_price(qty_invoiced, qty_to_invoice, stock_moves)
         dummy, bom_lines = bom.explode(self, 1)

--- a/addons/mrp_subcontracting/models/mrp_bom.py
+++ b/addons/mrp_subcontracting/models/mrp_bom.py
@@ -12,10 +12,10 @@ class MrpBom(models.Model):
     ], ondelete={'subcontract': lambda recs: recs.write({'type': 'normal', 'active': False})})
     subcontractor_ids = fields.Many2many('res.partner', 'mrp_bom_subcontractor', string='Subcontractors', check_company=True)
 
-    def _bom_subcontract_find(self, product_tmpl=None, product=None, picking_type=None, company_id=False, bom_type='subcontract', subcontractor=False):
-        domain = self._bom_find_domain(product_tmpl=product_tmpl, product=product, picking_type=picking_type, company_id=company_id, bom_type=bom_type)
+    def _bom_subcontract_find(self, product, picking_type=None, company_id=False, bom_type='subcontract', subcontractor=False):
+        domain = self._bom_find_domain(product, picking_type=picking_type, company_id=company_id, bom_type=bom_type)
         if subcontractor:
             domain = AND([domain, [('subcontractor_ids', 'parent_of', subcontractor.ids)]])
-            return self.search(domain, order='sequence, product_id', limit=1)
+            return self.search(domain, order='sequence, product_id, id', limit=1)
         else:
             return self.env['mrp.bom']

--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -155,7 +155,7 @@ class StockMove(models.Model):
     def _get_subcontract_bom(self):
         self.ensure_one()
         bom = self.env['mrp.bom'].sudo()._bom_subcontract_find(
-            product=self.product_id,
+            self.product_id,
             picking_type=self.picking_type_id,
             company_id=self.company_id.id,
             bom_type='subcontract',

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -345,8 +345,7 @@ class ProductTemplate(models.Model):
     @api.depends('product_variant_ids.product_tmpl_id')
     def _compute_product_variant_count(self):
         for template in self:
-            # do not pollute variants to be prefetched when counting variants
-            template.product_variant_count = len(template.with_prefetch().product_variant_ids)
+            template.product_variant_count = len(template.product_variant_ids)
 
     @api.depends('product_variant_ids', 'product_variant_ids.default_code')
     def _compute_default_code(self):

--- a/addons/purchase_stock/models/product.py
+++ b/addons/purchase_stock/models/product.py
@@ -67,5 +67,5 @@ class ProductProduct(models.Model):
             uom = self.env['uom.uom'].browse(group['product_uom'][0])
             product_qty = uom._compute_quantity(group['product_qty'], product.uom_id, round=False)
             qty_by_product_location[(product.id, location.id)] += product_qty
-            qty_by_product_wh[(product.id, location.get_warehouse().id)] += product_qty
+            qty_by_product_wh[(product.id, location.warehouse_id.id)] += product_qty
         return qty_by_product_location, qty_by_product_wh

--- a/addons/sale_mrp/models/sale.py
+++ b/addons/sale_mrp/models/sale.py
@@ -51,7 +51,7 @@ class SaleOrderLine(models.Model):
             if line.state == 'sale':
                 boms = line.move_ids.mapped('bom_line_id.bom_id')
             elif line.state in ['draft', 'sent'] and line.product_id:
-                boms = boms._bom_find(product=line.product_id, company_id=line.company_id.id, bom_type='phantom')
+                boms = boms._bom_find(line.product_id, company_id=line.company_id.id, bom_type='phantom')[line.product_id]
             relevant_bom = boms.filtered(lambda b: b.type == 'phantom' and
                     (b.product_id == line.product_id or
                     (b.product_tmpl_id == line.product_id.product_tmpl_id and not b.product_id)))
@@ -70,7 +70,7 @@ class SaleOrderLine(models.Model):
                 boms = order_line.move_ids.mapped('bom_line_id.bom_id')
                 dropship = False
                 if not boms and any(m._is_dropshipped() for m in order_line.move_ids):
-                    boms = boms._bom_find(product=order_line.product_id, company_id=order_line.company_id.id, bom_type='phantom')
+                    boms = boms._bom_find(order_line.product_id, company_id=order_line.company_id.id, bom_type='phantom')[order_line.product_id]
                     dropship = True
                 # We fetch the BoMs of type kits linked to the order_line,
                 # the we keep only the one related to the finished produst.
@@ -137,7 +137,7 @@ class SaleOrderLine(models.Model):
         # We don't try to be too smart and keep a simple approach: we compare the quantity before
         # and after update, and return the difference. We don't take into account what was already
         # sent, or any other exceptional case.
-        bom = self.env['mrp.bom']._bom_find(product=self.product_id, bom_type='phantom')
+        bom = self.env['mrp.bom']._bom_find(self.product_id, bom_type='phantom')[self.product_id]
         if bom and previous_product_uom_qty:
             return previous_product_uom_qty and previous_product_uom_qty.get(self.id, 0.0)
         return super(SaleOrderLine, self)._get_qty_procurement(previous_product_uom_qty=previous_product_uom_qty)

--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -734,7 +734,7 @@ class TestSaleMrpFlow(ValuationReconciliationTestCommon):
         self.assertEqual(len(move_lines), 3)
 
         # Check if BoM is created and is for a 'Kit'
-        bom_from_k1 = self.env['mrp.bom']._bom_find(product=self.kit_1)
+        bom_from_k1 = self.env['mrp.bom']._bom_find(self.kit_1)[self.kit_1]
         self.assertEqual(self.bom_kit_1.id, bom_from_k1.id)
         self.assertEqual(bom_from_k1.type, 'phantom')
 

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -574,7 +574,7 @@ class Product(models.Model):
             seen_rules = self.env['stock.rule']
         rule = self.env['procurement.group']._get_rule(self, location, {
             'route_ids': route_ids,
-            'warehouse_id': location.get_warehouse()
+            'warehouse_id': location.warehouse_id
         })
         if not rule:
             return seen_rules

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -409,7 +409,7 @@ class StockMove(models.Model):
             move.forecast_availability = move.product_qty
 
         product_moves = (self - not_product_moves)
-        warehouse_by_location = {loc: loc.get_warehouse() for loc in product_moves.location_id}
+        warehouse_by_location = {loc: loc.warehouse_id for loc in product_moves.location_id}
 
         outgoing_unreserved_moves_per_warehouse = defaultdict(lambda: self.env['stock.move'])
         for move in product_moves:
@@ -670,9 +670,9 @@ class StockMove(models.Model):
             'move_to_match_ids': self.ids,
         }
         if self.picking_type_id.code == 'outgoing':
-            warehouse = self.location_id.get_warehouse()
+            warehouse = self.location_id.warehouse_id
         else:
-            warehouse = self.location_dest_id.get_warehouse()
+            warehouse = self.location_dest_id.warehouse_id
 
         if warehouse:
             action['context']['warehouse'] = warehouse.id
@@ -880,7 +880,7 @@ class StockMove(models.Model):
 
     def _get_forecast_availability_incoming(self):
         self.ensure_one()
-        warehouse = self.location_dest_id.get_warehouse()
+        warehouse = self.location_dest_id.warehouse_id
         self.forecast_availability = self.product_id.with_context(warehouse=warehouse.id, to_date=self.date).virtual_available
         if self.state == 'draft':
             self.forecast_availability += self.product_uom_qty

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -242,7 +242,9 @@ class StockWarehouseOrderpoint(models.Model):
             product_context = frozendict({**self.env.context, **orderpoint_context})
             orderpoints_contexts[product_context] |= orderpoint
         for orderpoint_context, orderpoints_by_context in orderpoints_contexts.items():
-            products_qty = orderpoints_by_context.product_id.with_context(orderpoint_context)._product_available()
+            products_qty = {
+                p['id']: p for p in orderpoints_by_context.product_id.with_context(orderpoint_context).read(['qty_available', 'virtual_available'])
+            }
             products_qty_in_progress = orderpoints_by_context._quantity_in_progress()
             for orderpoint in orderpoints_by_context:
                 orderpoint.qty_on_hand = products_qty[orderpoint.product_id.id]['qty_available']

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -176,7 +176,7 @@ class StockWarehouseOrderpoint(models.Model):
 
     @api.onchange('location_id')
     def _onchange_location_id(self):
-        warehouse = self.location_id.get_warehouse().id
+        warehouse = self.location_id.warehouse_id.id
         if warehouse:
             self.warehouse_id = warehouse
 

--- a/addons/stock/populate/stock.py
+++ b/addons/stock/populate/stock.py
@@ -380,7 +380,7 @@ class PickingType(models.Model):
                 locations_company = locations_by_company[values['company_id']]
                 # TODO : choice only location child of warehouse.lot_stock_id
                 inter_location = random.choice(locations_company)
-                values['warehouse_id'] = inter_location.get_warehouse().id
+                values['warehouse_id'] = inter_location.warehouse_id.id
                 if values['code'] == 'internal':
                     values['default_location_src_id'] = inter_location.id
                     values['default_location_dest_id'] = random.choice(locations_company - inter_location).id

--- a/addons/stock/report/report_stock_rule.py
+++ b/addons/stock/report/report_stock_rule.py
@@ -96,7 +96,7 @@ class ReportStockRule(models.AbstractModel):
         ordered_locations = self.env['stock.location']
         locations = all_locations.filtered(lambda l: l.usage in ('supplier', 'production'))
         for warehouse_id in warehouses:
-            all_warehouse_locations = all_locations.filtered(lambda l: l.get_warehouse() == warehouse_id)
+            all_warehouse_locations = all_locations.filtered(lambda l: l.warehouse_id == warehouse_id)
             starting_rules = [d for d in rules_and_loc if d['source'] not in all_warehouse_locations]
             if starting_rules:
                 start_locations = self.env['stock.location'].concat(*([r['destination'] for r in starting_rules]))
@@ -116,7 +116,7 @@ class ReportStockRule(models.AbstractModel):
     def _sort_locations_by_warehouse(self, rules_and_loc, used_rules, start_locations, ordered_locations, warehouse_id):
         """ We order locations by putting first the locations that are not the destination of others and do it recursively.
         """
-        start_locations = start_locations.filtered(lambda l: l.get_warehouse() == warehouse_id)
+        start_locations = start_locations.filtered(lambda l: l.warehouse_id == warehouse_id)
         ordered_locations |= start_locations
         rules_start = []
         for rule in rules_and_loc:


### PR DESCRIPTION
[REF] stock: remove `_product_available` method

This method is useless and it bypass the computation of some fields
(qty_available, virtual_available, incoming_qty, outgoing_qty). Then
this method is not cache-friendly, and we should use `read` instead.

[REF] stock: cache the `get_warehouse` of `stock.location`

To avoid multiple search of the get_warehouse for the same location
and extra SQL request (it happens a lot for complicate flow, e.g.
mrp_mps, replenishment report).
Translate it into a standard compute to use the cache of
the ORM for no-store compute field (`warehouse_id`) and put
some depends to be always correct (even if `warehouse_id` shouldn't
change in the same request).

[REF] *mrp*: batch `_bom_find`

Some usage of `_bom_find` are performance bottleneck (one request by
product). By example, when the mrp is installed, search products
with fields compute by `_compute_quantities` (e.g. 'Negative forecasted
quantity'). it is due to the override of `_compute_quantities`
in mrp which will make (in the worst case) a `_bom_find` for each
product in the DB.
To avoid this situation the `_bom_find` method become batched
which can handle several products in once. The signature of the method
has changed and uniformize in all module.

Example performance Gain:
------------------------
In a DB with 7000 products (type 'product'), 500 locations, 1800 BoM,
9000 Stock moves, etc. Search in the tree view with filter "Negative
forecasted quantity":
Before: 10879 (nb SQL request) 12.67 +- 0.11 sec (Total RPC Time)
After: 159 (nb SQL request) 1.82 +- 0.03 sec (Total RPC Time)

[FIX] product: fix performance tree/kanban views product

The compute of `product_variant_count` was highly inefficient
in batch. It is due to `with_prefetch` which remove the prefetch
(reset _prefetch_ids = _ids) of the for loop.
It was added by 05a00fa9d4f001cef6d31a5b8d20a847de4f455b
which fixed performance issue for the 11.0 about
`sales_count`. But with the new ORM (13.0) compute fields are lazy.

Performance improvements:
For the search_read of the kanban view (Menu: Sale/Products/Products)
with the default pagination (80 items):
Before: 347 SQL request and 0.31 +- 0.2 sec (Python and SQL time)
After: 110 SQL request and 0.14 +- 0.2 sec (Python and SQL time)

task-2439019

odoo/enterprise#16584