### PR TITLE
[FIX] web_editor: can set bg position on root editor


### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4342,6 +4342,8 @@ registry.BackgroundPosition = SnippetOptionWidget.extend({
 
         // Create empty clone of $target with same display size, make it draggable and give it a tooltip.
         this.$bgDragger = this.$target.clone().empty();
+        // Prevent clone from being seen as editor if target is editor (eg. background on root tag)
+        this.$bgDragger.removeClass('o_editable');
         // Some CSS child selector rules will not be applied since the clone has a different container from $target.
         // The background-attachment property should be the same in both $target & $bgDragger, this will keep the
         // preview more "wysiwyg" instead of getting different result when bg position saved (e.g. parallax snippet)


### PR DESCRIPTION

Scenario:

- go to /slides and start editing the page
- change the position of background banner
- save

=> traceback

Why:

The code for pan tool duplicates the target element in an overlay. In
the given use case, it means a node with .o_editable class is created
that will cause an error when saving because the code expect the cloned
element to be an editor (in `RTEWidget.save()`) but it is not (and is
eg. missing `.data('options')`).

opw-2427560
