### PR TITLE
[FIX] snailmail: avoid a traceback when validating addresses

### DIFF
--- a/addons/snailmail_account/wizard/account_invoice_send.py
+++ b/addons/snailmail_account/wizard/account_invoice_send.py
@@ -19,7 +19,7 @@ class AccountInvoiceSend(models.TransientModel):
     @api.depends('invoice_ids')
     def _compute_invalid_addresses(self):
         for wizard in self:
-            invalid_invoices = wizard.invoice_ids.filtered(lambda i: not self.env['snailmail.letter']._is_valid_address(i.partner_id))
+            invalid_invoices = wizard.invoice_ids.filtered(lambda i: not i.partner_id or not self.env['snailmail.letter']._is_valid_address(i.partner_id))
             wizard.invalid_invoice_ids = invalid_invoices
             wizard.invalid_addresses = len(invalid_invoices)
 

--- a/addons/snailmail_account/wizard/account_invoice_send_views.xml
+++ b/addons/snailmail_account/wizard/account_invoice_send_views.xml
@@ -23,7 +23,7 @@
                                     <i class="fa fa-info-circle" role="img" aria-label="Warning" title="Make sure you have enough Stamps on your account."/>
                                 )</b>
                             </span>
-                            <span attrs="{'invisible': ['|', ('composition_mode', '=', 'mass_mail'), ('partner_id', '=', False)]}">
+                            <span attrs="{'invisible': [('composition_mode', '=', 'mass_mail')]}">
                                 <span attrs="{'invisible': [('invalid_addresses', '!=', 0)]}">
                                     <div class="text-right text-muted d-inline-block" name="address">
                                         <span> to: </span>


### PR DESCRIPTION
When trying to send&print a move without partner_id, which can be done
from the tree view of the account moves, a traceback will be raised when
 the address is being validated.

This change will add support for empty recordsets into _is_valid_address
and thus ensure that no traceback happens.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
