### PR TITLE
[FIX] hr_recruitment: display recruitment analysis when no data

### DIFF
--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -309,7 +309,7 @@ class Applicant(models.Model):
         return res
 
     def get_empty_list_help(self, help):
-        if 'active_id' in  self.env.context:
+        if 'active_id' in self.env.context and self.env.context.get('active_model') == 'hr.job':
             alias_id = self.env['hr.job'].browse(self.env.context['active_id']).alias_id
         else:
             alias_id = False


### PR DESCRIPTION
Have an empty database
Install Recruitment
Recruitment>Departments>Administration(3 dots)>Recruitments

Missing record message raise
This occur because of an access to a record that may not exists

opw-2431929

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
