### PR TITLE
[FIX] mail, test_mail: correctly send alias name in bounce autoreply

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1019,9 +1019,9 @@ class MailThread(models.AbstractModel):
 
         _generic_bounce_body_html = """<div>
 <p>Hello,</p>
-<p>The following email sent to %s cannot be accepted because this is a private email address.
+<p>The following email sent to {to} cannot be accepted because this is a private email address.
    Only allowed people can contact us at this address.</p>
-</div><blockquote>%s</blockquote>""" % (message.get('to'), message_dict.get('body'))
+</div><blockquote>{body}</blockquote>"""
 
         # Wrong model
         if model and model not in self.env:
@@ -1086,7 +1086,14 @@ class MailThread(models.AbstractModel):
                 check_result = self.env['mail.alias.mixin']._alias_check_contact_on_record(obj, message, message_dict, alias)
             if check_result is not True:
                 self._routing_warn(_('alias %s: %s') % (alias.alias_name, check_result.get('error_message', _('unknown error'))), _('skipping'), message_id, route, False)
-                self._routing_create_bounce_email(email_from, check_result.get('error_template', _generic_bounce_body_html), message)
+                self._routing_create_bounce_email(
+                    email_from,
+                    check_result.get('error_template', _generic_bounce_body_html.format(
+                        to=alias.display_name.lower(),
+                        body=message_dict.get('body')
+                    )),
+                    message
+                )
                 return False
 
         if not model and not thread_id and not alias and not allow_private:

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -173,6 +173,24 @@ class TestMailgateway(BaseFunctionalTest, MockEmails):
     # Alias configuration
     # --------------------------------------------------
 
+    @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
+    def test_message_process_alias_bounce_message_to(self):
+        """ Check bounce message contains the bouncing alias, not a generic "to" """
+        self.alias.write({'alias_contact': 'partners'})
+        bounce_message_with_alias = "The following email sent to %s cannot be accepted because this is a private email address." % self.alias.display_name.lower()
+
+        # Bounce is To
+        self.format_and_process(MAIL_TEMPLATE, to='groups@example.com', cc='other@gmail.com', subject='Should Bounce')
+        self.assertIn(bounce_message_with_alias, self._mails[0].get('body'))
+
+        # Bounce is CC
+        self.format_and_process(MAIL_TEMPLATE, to='other@gmail.com', cc='groups@example.com', subject='Should Bounce')
+        self.assertIn(bounce_message_with_alias, self._mails[1].get('body'))
+
+        # Bounce is part of To
+        self.format_and_process(MAIL_TEMPLATE, to='other@gmail.com, groups@example.com', subject='Should Bounce')
+        self.assertIn(bounce_message_with_alias, self._mails[1].get('body'))
+
     @mute_logger('odoo.addons.mail.models.mail_thread', 'odoo.models')
     def test_message_process_alias_user_id(self):
         """ Test alias ownership """


### PR DESCRIPTION
PURPOSE 
When sending a bounce autoreply it should have correct alias name in mail body.

SPECIFICATION

Current:
When sending mail in cc to the alias which is partner only,
bounce mail body contatins 'to' mail_id rather than 'cc' mail_id.

To Be:
It should contain correct alias name( mail_id ).
It should not be matter that it is send in 'to' or as 'cc'.

LINKS
PR: #66654
TASK ID: 2390310

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
