### PR TITLE
[FIX] uom: prevent deleting referenced UoM

### DIFF
--- a/addons/uom/models/uom_uom.py
+++ b/addons/uom/models/uom_uom.py
@@ -111,6 +111,11 @@ class UoM(models.Model):
         uom_categ_wtime = self.env.ref('uom.uom_categ_wtime')
         if any(uom.category_id.id in (uom_categ_unit + uom_categ_wtime).ids and uom.uom_type == 'reference' for uom in self):
             raise UserError(_("You cannot delete this UoM as it is used by the system. You should rather archive it."))
+        # UoM with external IDs shouldn't be deleted since they will most probably break the app somewhere else.
+        # For example, in addons/product/models/product_template.py, cubic meters are used in `_get_volume_uom_id_from_ir_config_parameter()`,
+        # meters in `_get_length_uom_id_from_ir_config_parameter()`, and so on.
+        if self.env['ir.model.data'].search_count([('model', '=', self._name), ('res_id', 'in', self.ids)]):
+            raise UserError(_("You cannot delete this UoM as it is used by the system. You should rather archive it."))
         return super(UoM, self).unlink()
 
     @api.model


### PR DESCRIPTION
Steps:
- Install Inventory
- Make sure Units of Measure are activated in the settings
- Go to Inventory > Configuration > Units of Measure > UoM
- Delete m³
- Go to Products > Products
- Click any product

Bug:
Traceback here:
https://github.com/odoo/odoo/blob/5324f7a6aa757ff6a728258ea1877ded4a6f86cd/addons/product/models/product_template.py#L315
ValueError: External ID not found in the system:
uom.product_uom_cubic_meter

Explanation:
Products refer to UoM since this commit: https://github.com/odoo/odoo/commit/2c079fcd107caec3a25e2a78d4d0e5af1d8237da
Deleting a referenced UoM will most probably break things in the future.
This commit prevents users from deleting UoM that are referenced by an
external ID.

opw:2457057