### PR TITLE
[FIX] hr_contract: Could not close contract due to setting date_end to the current date without consider the already specified date_end

### DIFF
--- a/addons/hr_contract/models/hr_contract.py
+++ b/addons/hr_contract/models/hr_contract.py
@@ -165,7 +165,10 @@ class Contract(models.Model):
             self._assign_open_contract()
         if vals.get('state') == 'close':
             for contract in self:
-                contract.date_end = max(date.today(), contract.date_start)
+                date_end = max(date.today(), contract.date_start)
+                if contract.date_end:
+                    date_end = min(date_end, contract.date_end)
+                contract.date_end = date_end
 
         calendar = vals.get('resource_calendar_id')
         if calendar and (self.state == 'open' or (self.state == 'draft' and self.kanban_state == 'done')):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
Can not close new contract which is valid and old contract which has end date in past. System warning: "An employee can only have one contract at the same time. (Excluding Draft and Cancelled contracts)".  Because old contract will set end date to today by new code of Odoo.

Desired behavior after PR is merged:
Can close new contract which is valid and old contract which has end date in past




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
