### PR TITLE
[FIX] mail: Don't log unhandled notification

### DIFF
--- a/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -87,9 +87,6 @@ function factory(dependencies) {
                             return;
                         }
                         return this._handleNotificationPartner(Object.assign({}, message));
-                    default:
-                        console.warn(`mail.messaging_notification_handler: Unhandled notification "${model}"`);
-                        return;
                 }
             });
             await this.async(() => Promise.all(proms));


### PR DESCRIPTION
The `mail` module logs bus notifications it does not handle. However, some
notifications are not meant to be handled by `mail` and it's perfectly fine.

This commit removes the log to avoid useless noise in the console.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
