### PR TITLE
[FIX] mrp: require consumption qty for MOs

### DIFF
--- a/addons/mrp/i18n/mrp.pot
+++ b/addons/mrp/i18n/mrp.pot
@@ -4798,6 +4798,14 @@ msgid "You have to produce at least one %s."
 msgstr ""
 
 #. module: mrp
+#: code:addons/mrp/models/mrp_production.py:0
+#, python-format
+msgid ""
+"You must indicate a non-zero amount consumed for at least one of your "
+"components"
+msgstr ""
+
+#. module: mrp
 #: code:addons/mrp/models/mrp_workorder.py:0
 #, python-format
 msgid ""

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -943,6 +943,9 @@ class MrpProduction(models.Model):
                     )
                 )
 
+            if not any(order.move_raw_ids.mapped('quantity_done')):
+                raise UserError(_("You must indicate a non-zero amount consumed for at least one of your components"))
+
             moves_not_to_do = order.move_raw_ids.filtered(lambda x: x.state == 'done')
             moves_to_do = order.move_raw_ids.filtered(lambda x: x.state not in ('done', 'cancel'))
             for move in moves_to_do.filtered(lambda m: m.product_qty == 0.0 and m.quantity_done > 0):

--- a/addons/mrp/tests/test_stock.py
+++ b/addons/mrp/tests/test_stock.py
@@ -194,13 +194,12 @@ class TestWarehouse(common.TestMrpCommon):
         mo_laptop = self.new_mo_laptop()
         serial = self.env['stock.production.lot'].create({'product_id': self.laptop.id, 'company_id': self.env.company.id})
 
-        product_produce = self.env['mrp.product.produce'].with_context({
+        produce_form = Form(self.env['mrp.product.produce'].with_context({
             'active_id': mo_laptop.id,
             'active_ids': [mo_laptop.id],
-        }).create({
-            "qty_producing": 1.0,
-            "finished_lot_id": serial.id,
-        })
+        }))
+        produce_form.finished_lot_id = serial
+        product_produce = produce_form.save()
         product_produce.do_produce()
         mo_laptop.button_mark_done()
 


### PR DESCRIPTION
Previous to this commit, there is a check to prevent MOs from having
no components, but there is no check to make sure any of the components
were actually consumed. This lead to a situation where you can have a
completed MO that has a state of "Cancelled" due to all quantity_done=0
moves being cancelled by stock_move.action_done() even though the MO is
"Done".

Steps to reproduce:
1. Create a MO for a product with a BOM with no components
2. Add a component with 0 to Consume
3. Complete (Validate/Mark as Done) the MO

Expected result: cannot validate the MO

Actual Result: MO is completed but state = Cancelled

Also fixes an out-of-date test that incorrectly fails due to its
component usage not being properly updated.

Task: 2463893
ENT PR: odoo/enterprise#16601

Description of the issue/feature this PR addresses:

Current behavior before PR :odoo/enterprise#16601

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
