### PR TITLE
[FIX] web_editor: bgOptimize+parallax=bg no kaput


### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -3528,7 +3528,10 @@ registry.BackgroundOptimize = ImageHandlerOption.extend({
      */
     async _loadImageInfo() {
         this.img = new Image();
-        Object.entries(this.$target[0].dataset).forEach(([key, value]) => {
+        Object.entries(this.$target[0].dataset).filter(([key]) =>
+            // Avoid copying dynamic editor attributes
+            !['oeId','oeModel', 'oeField', 'oeXpath', 'noteId'].includes(key)
+        ).forEach(([key, value]) => {
             this.img.dataset[key] = value;
         });
         const src = getBgImageURL(this.$target[0]);


### PR DESCRIPTION

Scenario:

- set new background image
- set parallax
- save

=> on next edition, the editor doesn't work on background anymore

Why:

- backgroundOptimize copy attributes of the original image to the real
  target element on save
- parallax change the real target element to a new child

=> so if the original element was an editor (with data-oe-model, ...)
   attributes, with the combination of the two options we will save
   these editing attribute on the child element which is wrong (the
   editing attributes are added dynamically and should not be saved).

With this changeset, we don't copy the editing attributes in
backgroundOptimize when we copy the original target image.

opw-2427560
opw-2429340
