### PR TITLE
[IMP] base: performance improvement when installing a module

### DIFF
--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -390,9 +390,9 @@ class Module(models.Model):
             module_demo = module.demo or update_demo or any(mod.demo for mod in ready_mods)
             demo = demo or module_demo
 
-            # check dependencies and update module itself
-            self.check_external_dependencies(module.name, newstate)
             if module.state in states_to_update:
+                # check dependencies and update module itself
+                self.check_external_dependencies(module.name, newstate)
                 module.write({'state': newstate, 'demo': module_demo})
 
         return demo


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Performance when installing modules with large dependency trees is improved

Current behavior before PR:

Currently, all branches of the dependency tree are traversed and the status is changed accordingly. Especially modules like "web" or "base" may be checked many times.

Desired behavior after PR is merged:

Modules are only checked once and then skipped.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
