### PR TITLE
[FIX] point_of_sale: broken view of the NumberPopup

### DIFF
--- a/addons/point_of_sale/static/src/xml/Popups/NumberPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/NumberPopup.xml
@@ -35,7 +35,7 @@
                         <button class="input-button number-char" t-on-mousedown.prevent="sendInput('7')">7</button>
                         <button class="input-button number-char" t-on-mousedown.prevent="sendInput('8')">8</button>
                         <button class="input-button number-char" t-on-mousedown.prevent="sendInput('9')">9</button>
-                        <button class="input-button number-char" t-on-mousedown.prevent="sendInput('-')">-</button>
+                        <button t-if="!props.isPassword" class="input-button number-char" t-on-mousedown.prevent="sendInput('-')">-</button>
                         <br />
                         <button class="input-button numpad-char" t-on-mousedown.prevent="sendInput('Delete')">C</button>
                         <button class="input-button number-char" t-on-mousedown.prevent="sendInput('0')">0</button>


### PR DESCRIPTION
To reproduce:

1. Activate pos_hr feature.
2. Authorize an employee with pin.
3. Open a pos session and login with that employee.
4. [BUG] The popup to input pin is broken.

This is because of the 'minus' button. In this commit, we make sure
to hide the 'minus' button when the popup is used to ask for pin.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
