### PR TITLE
[IMP]: point_of_sale: enable margin on orders in pos settings

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -319,6 +319,7 @@ class PosSession(models.Model):
             self._check_if_no_draft_orders()
             if self.update_stock_at_closing:
                 self._create_picking_at_end_of_session()
+                self.order_ids.filtered(lambda o: not o.is_total_cost_computed)._compute_total_cost_at_session_closing(self.picking_ids.move_lines)
             try:
                 data = self.with_company(self.company_id)._create_account_move(balancing_account, amount_to_balance)
             except AccessError as e:

--- a/addons/point_of_sale/report/pos_order_report.py
+++ b/addons/point_of_sale/report/pos_order_report.py
@@ -35,6 +35,7 @@ class PosOrderReport(models.Model):
     pos_categ_id = fields.Many2one('pos.category', string='PoS Category', readonly=True)
     pricelist_id = fields.Many2one('product.pricelist', string='Pricelist', readonly=True)
     session_id = fields.Many2one('pos.session', string='Session', readonly=True)
+    margin = fields.Float(string='Margin', readonly=True)
 
     def _select(self):
         return """
@@ -64,7 +65,8 @@ class PosOrderReport(models.Model):
                 pt.pos_categ_id,
                 s.pricelist_id,
                 s.session_id,
-                s.account_move IS NOT NULL AS invoiced
+                s.account_move IS NOT NULL AS invoiced,
+                SUM(l.price_subtotal - l.total_cost / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END) AS margin
         """
 
     def _from(self):

--- a/addons/point_of_sale/tests/__init__.py
+++ b/addons/point_of_sale/tests/__init__.py
@@ -9,6 +9,7 @@ from . import test_point_of_sale
 from . import test_pos_setup
 from . import test_pos_basic_config
 from . import test_pos_products_with_tax
+from . import test_pos_margin
 from . import test_pos_multiple_sale_accounts
 from . import test_pos_multiple_receivable_accounts
 from . import test_pos_other_currency_config

--- a/addons/point_of_sale/tests/test_pos_margin.py
+++ b/addons/point_of_sale/tests/test_pos_margin.py
@@ -1,0 +1,398 @@
+# -*- coding: utf-8 -*-
+
+import odoo
+from odoo.addons.point_of_sale.tests.common import TestPoSCommon
+
+
+@odoo.tests.tagged('post_install', '-at_install')
+class TestPosMargin(TestPoSCommon):
+    """
+    Test the margin computation on orders with basic configuration
+    The tests contain the base scenarios.
+    """
+
+    def setUp(self):
+        super(TestPosMargin, self).setUp()
+        self.config = self.basic_config
+
+        self.stock_location = self.env['stock.warehouse'].create({
+            'partner_id': self.env.user.partner_id.id,
+            'name': 'Stock location',
+            'code': 'WH'
+        }).lot_stock_id
+        self.customer_location = self.env.ref('stock.stock_location_customers')
+        self.supplier_location = self.env.ref('stock.stock_location_suppliers')
+        self.uom_unit = self.env.ref('uom.product_uom_unit')
+
+
+    def test_positive_margin(self):
+        """
+        Test margin where it should be more than zero
+        """
+
+        product1 = self.create_product('Product 1', self.categ_basic, 10, 5)
+        product2 = self.create_product('Product 2', self.categ_basic, 50, 30)
+
+        # open a session
+        self.open_new_session()
+
+        # create orders
+        orders = [self.create_ui_order_data([(product1, 1)]),
+                  self.create_ui_order_data([(product2, 1)]),
+                  self.create_ui_order_data([(product1, 2), (product2, 2)])]
+
+        # sync orders
+        self.env['pos.order'].create_from_ui(orders)
+
+        # check margins
+        self.assertEqual(self.pos_session.order_ids[0].margin, 5)
+        self.assertEqual(self.pos_session.order_ids[1].margin, 20)
+        self.assertEqual(self.pos_session.order_ids[2].margin, 50)
+
+        # check margins percent
+        self.assertEqual(self.pos_session.order_ids[0].margin_percent, 0.5)
+        self.assertEqual(self.pos_session.order_ids[1].margin_percent, 0.4)
+        self.assertEqual(round(self.pos_session.order_ids[2].margin_percent, 2), 0.42)
+
+        # close session
+        self.pos_session.action_pos_session_validate()
+
+    def test_negative_margin(self):
+        """
+        Test margin where it should be less than zero
+        """
+
+        product1 = self.create_product('Product 1', self.categ_basic, 10, 15)
+        product2 = self.create_product('Product 2', self.categ_basic, 50, 100)
+
+        # open a session
+        self.open_new_session()
+
+        # create orders
+        orders = [self.create_ui_order_data([(product1, 1)]),
+                  self.create_ui_order_data([(product2, 1)]),
+                  self.create_ui_order_data([(product1, 2), (product2, 2)])]
+
+        # sync orders
+        self.env['pos.order'].create_from_ui(orders)
+
+        # check margins
+        self.assertEqual(self.pos_session.order_ids[0].margin, -5)
+        self.assertEqual(self.pos_session.order_ids[1].margin, -50)
+        self.assertEqual(self.pos_session.order_ids[2].margin, -110)
+
+        # check margins percent
+        self.assertEqual(self.pos_session.order_ids[0].margin_percent, -0.5)
+        self.assertEqual(self.pos_session.order_ids[1].margin_percent, -1)
+        self.assertEqual(round(self.pos_session.order_ids[2].margin_percent, 2), -0.92)
+
+        # close session
+        self.pos_session.action_pos_session_validate()
+
+    def test_full_margin(self):
+        """
+        Test margin where the product cost is always 0
+        """
+
+        product1 = self.create_product('Product 1', self.categ_basic, 10)
+        product2 = self.create_product('Product 2', self.categ_basic, 50)
+
+        # open a session
+        self.open_new_session()
+
+        # create orders
+        orders = [self.create_ui_order_data([(product1, 1)]),
+                  self.create_ui_order_data([(product2, 1)]),
+                  self.create_ui_order_data([(product1, 2), (product2, 2)])]
+
+        # sync orders
+        self.env['pos.order'].create_from_ui(orders)
+
+        # check margins
+        self.assertEqual(self.pos_session.order_ids[0].margin, 10)
+        self.assertEqual(self.pos_session.order_ids[1].margin, 50)
+        self.assertEqual(self.pos_session.order_ids[2].margin, 120)
+
+        # check margins percent
+        self.assertEqual(self.pos_session.order_ids[0].margin_percent, 1)
+        self.assertEqual(self.pos_session.order_ids[1].margin_percent, 1)
+        self.assertEqual(self.pos_session.order_ids[2].margin_percent, 1)
+
+        # close session
+        self.pos_session.action_pos_session_validate()
+
+    def test_tax_margin(self):
+        """
+        Test margin with tax on products
+        Product 1 price without tax = 10
+        Product 2 price without tax = 50
+        """
+
+        product1 = self.create_product('Product 1', self.categ_basic, 10, 5, self.taxes['tax7'].ids)
+        product2 = self.create_product('Product 2', self.categ_basic, 55, 30, self.taxes['tax10'].ids)
+
+        # open a session
+        self.open_new_session()
+
+        # create orders
+        orders = [self.create_ui_order_data([(product1, 1)]),
+                  self.create_ui_order_data([(product2, 1)]),
+                  self.create_ui_order_data([(product1, 2), (product2, 2)])]
+
+        # sync orders
+        self.env['pos.order'].create_from_ui(orders)
+
+        # check margins
+        self.assertEqual(self.pos_session.order_ids[0].margin, 5)
+        self.assertEqual(self.pos_session.order_ids[1].margin, 20)
+        self.assertEqual(self.pos_session.order_ids[2].margin, 50)
+
+        # check margins percent
+        self.assertEqual(self.pos_session.order_ids[0].margin_percent, 0.5)
+        self.assertEqual(self.pos_session.order_ids[1].margin_percent, 0.4)
+        self.assertEqual(round(self.pos_session.order_ids[2].margin_percent, 2), 0.42)
+
+        # close session
+        self.pos_session.action_pos_session_validate()
+
+    def test_other_currency_margin(self):
+        """
+        Test margin with tax on products and with different currency
+        The currency rate is 0.5 so the product price is halved in this currency.
+        """
+
+        # change the config
+        current_config = self.config
+        self.config = self.other_currency_config
+
+        # same parameters as test_positive_margin
+        product1 = self.create_product('Product 1', self.categ_basic, 10, 5)
+        product2 = self.create_product('Product 2', self.categ_basic, 50, 30)
+
+        # open a session
+        self.open_new_session()
+
+        # create orders
+        orders = [self.create_ui_order_data([(product1, 1)]),
+                  self.create_ui_order_data([(product2, 1)]),
+                  self.create_ui_order_data([(product1, 2), (product2, 2)])]
+
+        # sync orders
+        self.env['pos.order'].create_from_ui(orders)
+
+        # check margins in the config currency
+        self.assertEqual(self.pos_session.order_ids[0].margin, 2.5)
+        self.assertEqual(self.pos_session.order_ids[1].margin, 10)
+        self.assertEqual(self.pos_session.order_ids[2].margin, 25)
+
+        # check margins percent which should be the same as test_positive_margin
+        self.assertEqual(self.pos_session.order_ids[0].margin_percent, 0.5)
+        self.assertEqual(self.pos_session.order_ids[1].margin_percent, 0.4)
+        self.assertEqual(round(self.pos_session.order_ids[2].margin_percent, 2), 0.42)
+
+        # close session
+        self.pos_session.action_pos_session_validate()
+
+        # set the config back
+        self.config = current_config
+
+    def test_tax_and_other_currency_margin(self):
+        """
+        Test margin with different currency between products and config with taxes.
+        Product 1 price without tax = 10
+        Product 2 price without tax = 50
+        The currency rate is 0.5 so the product price is halved in this currency.
+        """
+
+        # change the config
+        current_config = self.config
+        self.config = self.other_currency_config
+
+        product1 = self.create_product('Product 1', self.categ_basic, 10, 5, self.taxes['tax7'].ids)
+        product2 = self.create_product('Product 2', self.categ_basic, 55, 30, self.taxes['tax10'].ids)
+
+        # open a session
+        self.open_new_session()
+
+        # create orders
+        orders = [self.create_ui_order_data([(product1, 1)]),
+                  self.create_ui_order_data([(product2, 1)]),
+                  self.create_ui_order_data([(product1, 2), (product2, 2)])]
+
+        # sync orders
+        self.env['pos.order'].create_from_ui(orders)
+
+        # check margins in the config currency
+        self.assertEqual(self.pos_session.order_ids[0].margin, 2.5)
+        self.assertEqual(self.pos_session.order_ids[1].margin, 10)
+        self.assertEqual(self.pos_session.order_ids[2].margin, 25)
+
+        # check margins percent which should be the same as test_tax_margin
+        self.assertEqual(self.pos_session.order_ids[0].margin_percent, 0.5)
+        self.assertEqual(self.pos_session.order_ids[1].margin_percent, 0.4)
+        self.assertEqual(self.pos_session.order_ids[2].margin_percent, 0.4167)
+
+        # close session
+        self.pos_session.action_pos_session_validate()
+
+        # set the config back
+        self.config = current_config
+
+    def test_return_margin(self):
+        """
+        Test margin where we return product (negative line quantity)
+        """
+
+        product1 = self.create_product('Product 1', self.categ_basic, 10, 5)
+        product2 = self.create_product('Product 2', self.categ_basic, 50, 30)
+
+        # open a session
+        self.open_new_session()
+
+        # create orders
+        orders = [self.create_ui_order_data([(product1, -1)]),
+                  self.create_ui_order_data([(product2, -1)]),
+                  self.create_ui_order_data([(product1, -2), (product2, -2)])]
+
+        # sync orders
+        self.env['pos.order'].create_from_ui(orders)
+
+        # check margins
+        self.assertEqual(self.pos_session.order_ids[0].margin, -5)
+        self.assertEqual(self.pos_session.order_ids[1].margin, -20)
+        self.assertEqual(self.pos_session.order_ids[2].margin, -50)
+
+        # check margins percent
+        self.assertEqual(self.pos_session.order_ids[0].margin_percent, 0.5)
+        self.assertEqual(self.pos_session.order_ids[1].margin_percent, 0.4)
+        self.assertEqual(round(self.pos_session.order_ids[2].margin_percent, 2), 0.42)
+
+        # close session
+        self.pos_session.action_pos_session_validate()
+
+    def test_fifo_margin_real_time(self):
+        """
+        Test margin where there is product in FIFO with stock update in real time
+        """
+
+        product1 = self.create_product('Product 1', self.categ_anglo, 10, 5)
+        product2 = self.create_product('Product 2', self.categ_basic, 50, 30)
+
+        move1 = self.env['stock.move'].create({
+            'name': 'IN 2 unit @ 3 per unit',
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'product_id': product1.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 2,
+            'price_unit': 3,
+        }).sudo()
+        move1._action_confirm()
+        move1._action_assign()
+        move1.move_line_ids.qty_done = 2
+        move1._action_done()
+
+        move2 = self.env['stock.move'].create({
+            'name': 'IN 1 unit @ 7 per unit',
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'product_id': product1.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 1,
+            'price_unit': 7,
+        }).sudo()
+        move2._action_confirm()
+        move2._action_assign()
+        move2.move_line_ids.qty_done = 1
+        move2._action_done()
+
+        # open a session
+        self.open_new_session()
+
+        # create orders
+        orders = [self.create_ui_order_data([(product1, 1), (product2, 1)]),
+                  self.create_ui_order_data([(product1, 2)])]
+
+        # sync orders
+        self.env['pos.order'].create_from_ui(orders)
+
+        # check margins
+        self.assertEqual(self.pos_session.order_ids[0].margin, 27)
+        self.assertEqual(self.pos_session.order_ids[1].margin, 10)
+
+        # check margins percent
+        self.assertEqual(self.pos_session.order_ids[0].margin_percent, 0.45)
+        self.assertEqual(self.pos_session.order_ids[1].margin_percent, 0.5)
+
+        # close session
+        self.pos_session.action_pos_session_validate()
+
+    def test_avco_margin_closing_time(self):
+        """
+        Test margin where there is product in AVCO with stock update in closing
+        """
+
+        self.categ_anglo.property_cost_method = 'average'
+        product1 = self.create_product('Product 1', self.categ_anglo, 10, 5)
+        product2 = self.create_product('Product 2', self.categ_basic, 50, 30)
+        self.env.company.point_of_sale_update_stock_quantities = 'closing'
+
+
+        move1 = self.env['stock.move'].create({
+            'name': 'IN 2 unit @ 3 per unit',
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'product_id': product1.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 2,
+            'price_unit': 3,
+        }).sudo()
+        move1._action_confirm()
+        move1._action_assign()
+        move1.move_line_ids.qty_done = 2
+        move1._action_done()
+
+        move2 = self.env['stock.move'].create({
+            'name': 'IN 1 unit @ 6 per unit',
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'product_id': product1.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 1,
+            'price_unit': 6,
+        }).sudo()
+        move2._action_confirm()
+        move2._action_assign()
+        move2.move_line_ids.qty_done = 1
+        move2._action_done()
+
+        # open a session
+        self.open_new_session()
+
+        # create orders
+        orders = [self.create_ui_order_data([(product1, 1), (product2, 1)]),
+                  self.create_ui_order_data([(product1, 2)])]
+
+        # sync orders
+        self.env['pos.order'].create_from_ui(orders)
+
+        # check margins which are not really computed so it should be 0
+        self.assertEqual(self.pos_session.order_ids[0].margin, 0)
+        self.assertEqual(self.pos_session.order_ids[1].margin, 0)
+
+        # check margins percent (same as above)
+        self.assertEqual(self.pos_session.order_ids[1].margin_percent, 0)
+        self.assertEqual(self.pos_session.order_ids[1].margin_percent, 0)
+
+        # close session
+        self.pos_session.action_pos_session_validate()
+
+        # check margins
+        self.assertEqual(self.pos_session.order_ids[0].margin, 26)
+        self.assertEqual(self.pos_session.order_ids[1].margin, 12)
+
+        # check margins percent
+        self.assertEqual(self.pos_session.order_ids[0].margin_percent, 0.4333)
+        self.assertEqual(self.pos_session.order_ids[1].margin_percent, 0.6)
+
+        self.env.company.point_of_sale_update_stock_quantities = 'real'

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -51,6 +51,10 @@
                                 <field name="customer_note" optional="hide"/>
                                 <field name="product_uom_id" string="UoM" groups="uom.group_uom"/>
                                 <field name="price_unit" widget="monetary"/>
+                                <field name="is_total_cost_computed" invisible="1"/>
+                                <field name="total_cost" attrs="{'invisible': [('is_total_cost_computed','=', False)]}" optional="hide" widget="monetary"/>
+                                <field name="margin" attrs="{'invisible': [('is_total_cost_computed','=', False)]}" optional="hide" widget="monetary"/>
+                                <field name="margin_percent" attrs="{'invisible': [('is_total_cost_computed','=', False)]}" optional="hide" widget="percentage"/>
                                 <field name="discount" string="Disc.%" widget="monetary"/>
                                 <field name="tax_ids_after_fiscal_position" widget="many2many_tags" string="Taxes"/>
                                 <field name="tax_ids" widget="many2many_tags" invisible="1"/>
@@ -93,6 +97,15 @@
                                 class="oe_subtotal_footer_separator"
                                 widget="monetary"
                                 attrs="{'invisible': [('amount_paid','=', 'amount_total')]}"/>
+                            <label for="margin"/>
+                            <div class="text-nowrap">
+                                <field name="margin" class="oe_inline" attrs="{'invisible': [('is_total_cost_computed','=', False)]}"/>
+                                <span class="oe_inline" attrs="{'invisible': [('is_total_cost_computed','=', False)]}">
+                                    (<field name="margin_percent" nolabel="1" class="oe_inline" widget="percentage"/>)
+                                </span>
+                                <span attrs="{'invisible': [('is_total_cost_computed','=', True)]}">TBD</span>
+                            </div>
+                            <field name="is_total_cost_computed" invisible="1"/>
                             <field name="currency_id" invisible="1"/>
                         </group>
                         <div class="oe_clear"/>
@@ -189,6 +202,8 @@
         <field name="arch" type="xml">
             <pivot string="PoS Orders" sample="1">
                 <field name="date_order" type="row"/>
+                <field name="margin"/>
+                <field name="margin_percent" invisible="1"/>
                 <field name="amount_total" type="measure"/>
             </pivot>
         </field>

--- a/addons/point_of_sale/wizard/pos_payment.py
+++ b/addons/point_of_sale/wizard/pos_payment.py
@@ -57,6 +57,7 @@ class PosMakePayment(models.TransientModel):
         if order._is_pos_order_paid():
             order.action_pos_order_paid()
             order._create_order_picking()
+            order._compute_total_cost_in_real_time()
             return {'type': 'ir.actions.act_window_close'}
 
         return self.launch_payment()


### PR DESCRIPTION
This pull request allows the user to activate the margin on orders in the settings. This gives him a better view on his profitability. Margin has been added to both Order and OrderLine. Margin also has been added to the order report as a measure.