### PR TITLE
[FIX] l10n_cl: return a different domain in available document types …

### DIFF
--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -26,7 +26,7 @@ class AccountMove(models.Model):
         self.ensure_one()
         if self.journal_id.company_id.country_id != self.env.ref('base.cl') or not \
                 self.journal_id.l10n_latam_use_documents:
-            return False
+            return super()._get_l10n_latam_documents_domain()
         if self.journal_id.type == 'sale':
             domain = super()._get_l10n_latam_documents_domain()
             document_type_ids = self.journal_id.l10n_cl_sequence_ids.mapped('l10n_latam_document_type_id').ids

--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -24,31 +24,31 @@ class AccountMove(models.Model):
 
     def _get_l10n_latam_documents_domain(self):
         self.ensure_one()
-        domain = super()._get_l10n_latam_documents_domain()
-        if (self.journal_id.l10n_latam_use_documents and
-                self.journal_id.company_id.country_id == self.env.ref('base.cl')):
-            if self.journal_id.type == 'sale':
-                document_type_ids = self.journal_id.l10n_cl_sequence_ids.mapped('l10n_latam_document_type_id').ids
-            else:
-                partner_domain = [
-                    ('country_id.code', '=', 'CL'),
-                    ('internal_type', 'in', ['invoice', 'debit_note', 'credit_note', 'invoice_in'])]
-                if not self.partner_id:
-                    pass
-                elif self.partner_id.l10n_cl_sii_taxpayer_type == '1' and self.partner_id_vat != '60805000-0':
-                    partner_domain += [('code', 'not in', ['39', '70', '71', '914', '911'])]
-                elif self.partner_id.l10n_cl_sii_taxpayer_type == '1' and self.partner_id_vat == '60805000-0':
-                    partner_domain += [('code', 'not in', ['39', '70', '71'])]
-                elif self.partner_id.l10n_cl_sii_taxpayer_type == '2':
-                    partner_domain += [('code', 'in', ['70', '71', '56', '61'])]
-                elif self.partner_id.l10n_cl_sii_taxpayer_type == '3':
-                    partner_domain += [('code', 'in', ['35', '38', '39', '41', '56', '61'])]
-                elif not self.partner_id.l10n_cl_sii_taxpayer_type or self.partner_id.country_id != self.env.ref(
-                        'base.cl') or self.partner_id.l10n_cl_sii_taxpayer_type == '4':
-                    partner_domain += [('code', 'in', [])]
-                document_type_ids = self.env['l10n_latam.document.type'].search(partner_domain).ids
-            domain = expression.AND([domain, [('id', 'in', document_type_ids)]])
+        if self.journal_id.company_id.country_id != self.env.ref('base.cl') or not \
+                self.journal_id.l10n_latam_use_documents:
+            return False
+        if self.journal_id.type == 'sale':
+            domain = super()._get_l10n_latam_documents_domain()
+            document_type_ids = self.journal_id.l10n_cl_sequence_ids.mapped('l10n_latam_document_type_id').ids
+            return expression.AND([domain, [('id', 'in', document_type_ids)]])
+        domain = [
+            ('country_id.code', '=', 'CL'),
+            ('internal_type', 'in', ['invoice', 'debit_note', 'credit_note', 'invoice_in'])]
+        if self.partner_id.l10n_cl_sii_taxpayer_type == '1' and self.partner_id_vat != '60805000-0':
+            domain += [('code', 'not in', ['39', '70', '71', '914', '911'])]
+        elif self.partner_id.l10n_cl_sii_taxpayer_type == '1' and self.partner_id_vat == '60805000-0':
+            domain += [('code', 'not in', ['39', '70', '71'])]
+            if self.type == 'in_invoice':
+                domain += [('internal_type', '!=', 'credit_note')]
+        elif self.partner_id.l10n_cl_sii_taxpayer_type == '2':
+            domain += [('code', 'in', ['70', '71', '56', '61'])]
+        elif self.partner_id.l10n_cl_sii_taxpayer_type == '3':
+            domain += [('code', 'in', ['35', '38', '39', '41', '56', '61'])]
+        elif not self.partner_id.l10n_cl_sii_taxpayer_type or self.partner_id.country_id != self.env.ref(
+                'base.cl') or self.partner_id.l10n_cl_sii_taxpayer_type == '4':
+            domain += [('code', 'in', [])]
         return domain
+
 
     def _check_document_types_post(self):
         for rec in self.filtered(


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fixes the logic changes added in July 2020 to add more document types when using the special partner: "Tesorería de la República" 

Current behavior before PR:
The document type "DIN" (Declaración de Ingreso) is not available in the document type selection when using the special partner "Tesorería de La República", as initially stated in the version of code, previous to July 2020

Desired behavior after PR is merged:
The document type "DIN" is now available for this partner (actually the only document used with them unless the user purchased something from this partner, or sold something to it).


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
