### PR TITLE
[FIX] web: add possibility to blacklist menuitems from test_menu.js

### DIFF
--- a/addons/web/static/src/js/tools/test_menus.js
+++ b/addons/web/static/src/js/tools/test_menus.js
@@ -8,6 +8,7 @@
     var viewUpdateCount = 0;
     var testedApps;
     var testedMenus;
+    var blackListedMenus = ['account.menu_action_account_bank_journal_form'];
 
     function createWebClientHooks() {
         var AbstractController = odoo.__DEBUG__.services['web.AbstractController'];
@@ -127,6 +128,7 @@
         var menuDescription = element.innerText.trim() + " " + element.dataset.menuXmlid;
         console.log("Testing menu", menuDescription);
         testedMenus.push(element.dataset.menuXmlid);
+        if (blackListedMenus.includes(element.dataset.menuXmlid)) return Promise.resolve(); // Skip black listed menus
         var startActionCount = clientActionCount;
         _click($(element));
         var isModal = false;


### PR DESCRIPTION
When performing a click-all test on all menus, we may want to skip
some menus that could result in blocking the test.
The functionality already exist in v13 and onward but is now needed in
saas-12.3 as well since the backport of the new
'account_online_synchronization' module.
