### PR TITLE
[IMP] registry: Avoid dropping indexes

### DIFF
--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -452,7 +452,7 @@ class Registry(Mapping):
                 except psycopg2.OperationalError:
                     _schema.error("Unable to add index for %s", self)
             elif not index and indexname in existing:
-                sql.drop_index(cr, indexname, tablename)
+                _schema.info("Keep unexpected index %s on table %s", indexname, tablename)
 
     def add_foreign_key(self, table1, column1, table2, column2, ondelete,
                         model, module, force=True):


### PR DESCRIPTION
When an index have as name 'tablename_fieldname_index', this index is 
dropped if the field have index=False. This lead to dropping 
user-created index when performing a module update, or 
dropping/recreating an index during update when index=True is set in a 
sub-module.
A warning is logged instead.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
