### PR TITLE
[IMP] core: colored PID in logs

### DIFF
--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -101,13 +101,17 @@ class DBFormatter(logging.Formatter):
     def format(self, record):
         record.pid = os.getpid()
         record.dbname = getattr(threading.current_thread(), 'dbname', '?')
+        self.color(record)
         return logging.Formatter.format(self, record)
 
+    def color(self, record):
+        pass
+
 class ColoredFormatter(DBFormatter):
-    def format(self, record):
+    def color(self, record):
         fg_color, bg_color = LEVEL_COLOR_MAPPING.get(record.levelno, (GREEN, DEFAULT))
         record.levelname = COLOR_PATTERN % (30 + fg_color, 40 + bg_color, record.levelname)
-        return DBFormatter.format(self, record)
+        record.pid = COLOR_PATTERN % (30 + DEFAULT, 40 + record.pid % 7, record.pid)
 
 _logger_init = False
 def init_logger():


### PR DESCRIPTION
In multiworker mode it is hard to keep track of the log trace of a
particular worker. We now color the PID using a different color per PID,
as there are only 8 color available, we cycle throught them.