### PR TITLE
[FIX] account: register attachment only if it exists

### DIFF
--- a/addons/account/models/ir_actions_report.py
+++ b/addons/account/models/ir_actions_report.py
@@ -29,5 +29,7 @@ class IrActionsReport(models.Model):
             return None
         res = super(IrActionsReport, self).postprocess_pdf_report(record, buffer)
         if self.model == 'account.move' and record.state == 'posted' and record.is_sale_document(include_receipts=True):
-            self.retrieve_attachment(record).register_as_main_attachment(force=False)
+            attachment = self.retrieve_attachment(record)
+            if attachment:
+                attachment.register_as_main_attachment(force=False)
         return res


### PR DESCRIPTION
When printing an invoice, the server tries to register one attachment as
main one (see #65320). However, if there is not any attachment, this
will raise an error.

OPW-2465995