### PR TITLE
[FIX] account_edi: also send template for the payments

### DIFF
--- a/addons/account_edi/models/mail_template.py
+++ b/addons/account_edi/models/mail_template.py
@@ -14,7 +14,7 @@ class MailTemplate(models.Model):
             res_ids = [res_ids]
             multi_mode = False
 
-        if self.model != 'account.move':
+        if self.model not in ['account.move', 'account.payment']:
             return res
 
         records = self.env[self.model].browse(res_ids)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Why not include the edi document with payments as well in the email template?  (big demand in MX)

Current behavior before PR:

No XML included with the payment

Desired behavior after PR is merged: 

XML included with the payment confirmation email to the client


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
