### PR TITLE
[FIX] account: wrong sequence number reset for refund type moves

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1154,6 +1154,9 @@ class AccountMove(models.Model):
 
         if not relaxed:
             domain = [('journal_id', '=', self.journal_id.id), ('id', '!=', self.id or self._origin.id), ('name', 'not in', ('/', False))]
+            if self.journal_id.refund_sequence:
+                refund_types = ('out_refund', 'in_refund')
+                domain += [('move_type', 'in' if self.move_type in refund_types else 'not in', refund_types)]
             reference_move_name = self.search(domain + [('date', '<=', self.date)], order='date desc', limit=1).name
             if not reference_move_name:
                 reference_move_name = self.search(domain, order='date asc', limit=1).name

--- a/addons/account/tests/test_reconciliation_matching_rules.py
+++ b/addons/account/tests/test_reconciliation_matching_rules.py
@@ -743,7 +743,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
         move = self.env['account.move'].create({
             'move_type': 'entry',
             'date': '2017-01-01',
-            'journal_id': self.company_data['default_journal_sale'].id,
+            'journal_id': self.company_data['default_journal_misc'].id,
             'line_ids': [
                 # Rate is 2 GOL = 1 USD in 2017.
                 # The statement line will consider this line equivalent to 600 DAR.


### PR DESCRIPTION
In case a yearly sequence is set for out_invoice/in_invoice types and if we set
a monthly sequence on the corresponding out_refund/in_refund type, we will not be
able to validate the refund the next month as it will be wrongly identified as a
yearly sequence.

Therefore, the constraint on date sequence is preventing to validate it. We should
include the move type when retrieving the last sequence name to solve it.

Description of the issue/feature this PR addresses:
opw-2456008

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
