### PR TITLE
[FIX] base_iban: The bank number validated correctly for Costa Rica

### DIFF
--- a/addons/base_iban/models/res_partner_bank.py
+++ b/addons/base_iban/models/res_partner_bank.py
@@ -114,7 +114,7 @@ _map_iban_template = {
     'br': 'BRkk BBBB BBBB SSSS SCCC CCCC CCCT N',  # Brazil
     'by': 'BYkk BBBB AAAA CCCC CCCC CCCC CCCC',  # Belarus
     'ch': 'CHkk BBBB BCCC CCCC CCCC C',  # Switzerland
-    'cr': 'CRkk BBBC CCCC CCCC CCCC C',  # Costa Rica
+    'cr': 'CRkk BBBC CCCC CCCC CCCC CC',  # Costa Rica
     'cy': 'CYkk BBBS SSSS CCCC CCCC CCCC CCCC',  # Cyprus
     'cz': 'CZkk BBBB SSSS SSCC CCCC CCCC',  # Czech Republic
     'de': 'DEkk BBBB BBBB CCCC CCCC CC',  # Germany


### PR DESCRIPTION
- The format correspond to the standard following the format:
https://en.wikipedia.org/wiki/International_Bank_Account_Number#IBAN_formats_by_country

- It does not allows you to save account numbers that do not meet the standard

OPW# 2477541
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
