### PR TITLE
[FIX] web_editor: prevent traceback when custom color is excluded in colorpicker

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
@@ -274,7 +274,9 @@ const ColorPaletteWidget = Widget.extend({
         }
         this._buildCustomColors();
         this._markSelectedColor();
-        this.colorPicker.setSelectedColor(colorInfo.color);
+        if (this.colorPicker) {
+            this.colorPicker.setSelectedColor(colorInfo.color);
+        }
     },
     /**
      * Mark the selected color


### PR DESCRIPTION

traceback, when you select bg-color for transparent header

TypeError: this.colorPicker is undefined

https://6276834-master.runbot40.odoo.com/web/assets/1537-d789439/1/web_editor.assets_wysiwyg.min.js:608
Traceback:
_selectColor@https://6276834-master.runbot40.odoo.com/web/assets/1537-d789439/1/web_editor.assets_wysiwyg.min.js:608:53
_onColorButtonClick@https://6276834-master.runbot40.odoo.com/web/assets/1537-d789439/1/web_editor.assets_wysiwyg.min.js:608:551
proxy/<@https://6276834-master.runbot40.odoo.com/web/assets/1525-8743097/1/web.assets_common_lazy.min.js:4660:11
dispatch@https://6276834-master.runbot40.odoo.com/web/assets/1525-8743097/1/web.assets_common_lazy.min.js:1617:447
add/elemData.handle@https://6276834-master.runbot40.odoo.com/web/assets/1525-8743097/1/web.assets_common_lazy.min.js:1603:166


task-2464340
Closes 



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
