### PR TITLE
[IMP] website_hr_recruitment,google_recaptcha: auto install online job

### DIFF
--- a/addons/website_hr_recruitment/__manifest__.py
+++ b/addons/website_hr_recruitment/__manifest__.py
@@ -8,7 +8,7 @@
     'version': '1.0',
     'summary': 'Manage your online hiring process',
     'description': "This module allows to publish your available job positions on your website and keep track of application submissions easily. It comes as an add-on of *Recruitment* app.",
-    'depends': ['website_partner', 'hr_recruitment', 'website_mail', 'website_form'],
+    'depends': ['hr_recruitment', 'website_mail', 'website_form'],
     'data': [
         'security/ir.model.access.csv',
         'security/website_hr_recruitment_security.xml',
@@ -22,4 +22,5 @@
     ],
     'installable': True,
     'application': True,
+    'auto_install': ['hr_recruitment', 'website_mail'],
 }


### PR DESCRIPTION
Currently, website_hr_recruitment(online job) is not auto installed when hr_recruitment and website is installed.

So in this commit, auto install the online job(website_hr_recruitment) when only website and hr_recruitment is installed.
so removed website_partner dependency from website_hr_recruitment as it's not really needed. also make the website_hr_recruitment and google_recaptcha auto install.

TaskID: 2374617
