### PR TITLE
[IMP] web: define calendar slot duration from context

### DIFF
--- a/addons/web/static/src/js/views/calendar/calendar_model.js
+++ b/addons/web/static/src/js/views/calendar/calendar_model.js
@@ -443,7 +443,7 @@ return AbstractModel.extend({
             droppable: true,
             navLinks: false,
             eventLimit: this.eventLimit, // allow "more" link when too many events
-            snapMinutes: 15,
+            snapDuration: this.data.context.calendar_slot_duration || "00:30:00",
             longPressDelay: 500,
             eventResizableFromStart: true,
             nowIndicator: true,


### PR DESCRIPTION
[IMP] web: define calendar slot duration from context

With this patch, an action can define through its context the desired snap duration for calendar views.

This provides a more consistent UX when scheduling needs to be done at specific intervals.

@Tecnativa TT28201

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
