### PR TITLE
[mass_mailing] Unsubscribe usability

### DIFF
--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -31,6 +31,7 @@
         'wizard/mailing_list_merge_views.xml',
         'wizard/mailing_mailing_test_views.xml',
         'wizard/mailing_mailing_schedule_date_views.xml',
+        'views/mailing_contact_subscription_views.xml',
         'views/mailing_mailing_views_menus.xml',
         'views/mailing_trace_views.xml',
         'views/link_tracker_views.xml',
@@ -56,7 +57,9 @@
             'mass_mailing/static/src/css/email_template.css',
             'mass_mailing/static/src/js/mass_mailing.js',
             'mass_mailing/static/src/js/mass_mailing_widget.js',
-            'mass_mailing/static/src/js/unsubscribe.js',
+        ],
+        'web.assets_frontend': [
+            'mass_mailing/static/src/js/unsubscribe.js'
         ],
         'mass_mailing.assets_mail_themes': [
             'mass_mailing/static/src/scss/themes/**/*',

--- a/addons/mass_mailing/models/mailing_contact.py
+++ b/addons/mass_mailing/models/mailing_contact.py
@@ -18,6 +18,13 @@ class MassMailingContactListRel(models.Model):
     list_id = fields.Many2one('mailing.list', string='Mailing List', ondelete='cascade', required=True)
     opt_out = fields.Boolean(string='Opt Out',
                              help='The contact has chosen not to receive mails anymore from this list', default=False)
+    opt_out_reason = fields.Selection(string='Opt Out Reason', selection=[
+        ('never_subscribed', 'I never subscribed to this list'),
+        ('changed_mind', 'I changed my mind'),
+        ('too_many_emails', 'I receive too many emails from this list'),
+        ('irrelevant_content', 'The content of these emails is not relevant to me'),
+        ('other', 'Other'),
+    ])
     unsubscription_date = fields.Datetime(string='Unsubscription Date')
     message_bounce = fields.Integer(related='contact_id.message_bounce', store=False, readonly=False)
     is_blacklisted = fields.Boolean(related='contact_id.is_blacklisted', store=False, readonly=False)

--- a/addons/mass_mailing/report/mailing_trace_report_views.xml
+++ b/addons/mass_mailing/report/mailing_trace_report_views.xml
@@ -63,8 +63,8 @@
            <field name="help" type="html"><p>Mass Mailing Statistics allows you to check different mailing related information like number of bounced mails, opened mails, replied mails. You can sort out your analysis by different groups to get accurate grained analysis.</p></field>
        </record>
 
-       <menuitem name="Reporting" id="menu_mass_mailing_report" sequence="99"
-            parent="mass_mailing_menu_root"
+        <menuitem name="Mass Mailing" id="mass_mailing_mass_mailing_report" sequence="89"
+            parent="mass_mailing_menu_report"
             action="mailing_trace_report_action_mail"
             groups="mass_mailing.group_mass_mailing_user"/>
 </odoo>

--- a/addons/mass_mailing/static/src/scss/mass_mailing.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.scss
@@ -66,12 +66,6 @@
     background-color: white;
 }
 
-.o_mass_mailing_unsubscribed {
-    margin-left: 20px;
-    color: #005326;
-    font-size: 90%;
-}
-
 @media only screen and (min-width: 1200px) {
     .o_utm_campaign_mass_mailing_substats {
         padding-right: 210px;

--- a/addons/mass_mailing/views/mailing_contact_subscription_views.xml
+++ b/addons/mass_mailing/views/mailing_contact_subscription_views.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="mailing_contact_subscription_report_view_pivot" model="ir.ui.view">
+        <field name="name">mailing.contact.subscription.view.pivot</field>
+        <field name="model">mailing.contact.subscription</field>
+        <field name="arch" type="xml">
+            <pivot string="Opt Out Statistics" disable_linking="True">
+                <field name="list_id" type="row"/>
+                <field name="opt_out_reason" type="col"/>
+            </pivot>
+        </field>
+    </record>
+
+    <record id="mailing_contact_subscription_report_view_graph" model="ir.ui.view">
+        <field name="name">mailing.contact.subscription.view.graph</field>
+        <field name="model">mailing.contact.subscription</field>
+        <field name="arch" type="xml">
+            <graph string="Opt Out Statistics">
+                <field name="list_id"/>
+                <field name="opt_out_reason"/>
+            </graph>
+        </field>
+    </record>
+
+    <!-- Actions and Menuitems -->
+    <record id="mailing_opt_out_report_action" model="ir.actions.act_window">
+        <field name="name">Opt Out Analysis</field>
+        <field name="res_model">mailing.contact.subscription</field>
+        <field name="view_mode">graph,pivot</field>
+        <field name="domain">[('opt_out', '=', True)]</field>
+    </record>
+</odoo>

--- a/addons/mass_mailing/views/mailing_contact_views.xml
+++ b/addons/mass_mailing/views/mailing_contact_views.xml
@@ -188,9 +188,10 @@
                     </group>
                     <field name="subscription_list_ids">
                         <tree editable="bottom">
-                           <field name="list_id"/>
-                           <field name="unsubscription_date"/>
-                           <field name="opt_out"/>
+                            <field name="list_id"/>
+                            <field name="unsubscription_date"/>
+                            <field name="opt_out"/>
+                            <field name="opt_out_reason"/>
                         </tree>
                     </field>
                 </sheet>

--- a/addons/mass_mailing/views/mailing_mailing_views_menus.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views_menus.xml
@@ -16,6 +16,16 @@
         action="mail.mail_blacklist_action"
         parent="mass_mailing_configuration"/>
 
+    <!-- Reporting -->
+    <menuitem name="Reporting" id="mass_mailing_menu_report" sequence="99"
+        parent="mass_mailing_menu_root"
+        groups="mass_mailing.group_mass_mailing_user"/>
+
+    <menuitem name="Opt Out" id="mass_mailing_opt_out_report" sequence="99"
+        parent="mass_mailing_menu_report"
+        action="mass_mailing.mailing_opt_out_report_action"
+        groups="mass_mailing.group_mass_mailing_user"/>
+
     <!-- Technical / Mass Mailing -->
     <menuitem id="mailing_mailing_menu_technical"
         name="Mass Mailing"

--- a/addons/mass_mailing/views/mass_mailing_templates_portal.xml
+++ b/addons/mass_mailing/views/mass_mailing_templates_portal.xml
@@ -3,53 +3,77 @@
     <template id="unsubscribe">
         <div class="container o_unsubscribe_form">
             <div class="row">
-                <form action="/mail/mailing/unsubscribe" method="POST" id="unsubscribe_form" class="col-lg-6 offset-lg-3 mt-4">
+                <div class="oe_structure w-100"/>
+            </div>
+            <div class="row">
+                <form action="/mail/mailing/unsubscribe" method="POST" id="unsubscribe_form" class="w-100 mx-auto my-3 px-3" style="max-width: 768px">
                     <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
                     <input type="hidden" name="email" t-att-value="email"/>
                     <input type="hidden" name="mailing_id" t-att-value="mailing_id"/>
                     <input type="hidden" name="res_id" t-att-value="res_id"/>
                     <input type="hidden" name="unsubscribed_list" t-att-value="unsubscribed_list"/>
-
+                    <input type="hidden" name="show_blacklist_button" t-att-value="show_blacklist_button"/>
                     <div>
                         <t t-if="contacts">
-                            <div id="info_state" class="alert alert-success" role="status">
-                                <div id="subscription_info"></div>
+                            <div id="info_state" class="mb-4" role="status">
+                                <h1>Successfully Unsubscribed.</h1>
+                                <div id="subscription_info">
+                                    <h2 class="font-weight-light text-muted"></h2>
+                                </div>
                                 <div id="div_feedback">
-                                    <p>We would appreciate if you provide feedback about why you updated<br/>your subscriptions</p>
-                                    <textarea class="form-control"  name="opt_out_feedback" cols="60" rows="3"></textarea>
-                                    <br/>
-                                    <div class="btn btn-primary text-left" id="button_feedback">Send</div>
-                                </div>
-                            </div>
-
-                            <h1 class="o_page_header">Mailing Subscriptions</h1>
-                            <p>Choose your mailing subscriptions</p>
-                            <div id="div_opt_out">
-                                <ul class="list-group">
-                                    <t t-foreach="list_ids" t-as="list_id">
-                                        <t t-if="list_id.is_public == True">
-                                            <li class="list-group-item">
-                                                <input type="checkbox" class="mail_list_checkbox" name="contact_ids"
-                                                    t-att-value="list_id['id']" t-att-checked="None if list_id['id'] in opt_out_list_ids else 'checked'"/>
-                                                <t t-esc="list_id.name"/>
-                                                <span t-if="list_id['id'] in opt_out_list_ids"
-                                                      class="o_mass_mailing_unsubscribed">
-                                                    Unsubscribed
-                                                </span>
-                                            </li>
+                                    <h4>Please let us know why you updated your subscriptions.</h4>
+                                    <span id="opt_out_reason" class="d-none" key="never_subscribed">I never subscribed to this list</span>
+                                    <div class="my-3 pl-3">
+                                        <t t-foreach="opt_out_reasons" t-as="reason">
+                                            <br t-if="reason_index > 0"/>
+                                            <label>
+                                                <input type="radio" class="unsubscribe_reason" name="unsubsribe_reason"
+                                                    t-att-value="reason[0]" t-att-checked="reason[0] == 'never_subscribed'"/>
+                                                <t t-esc="reason[1]" />
+                                            </label>
                                         </t>
-                                    </t>
-                                </ul>
-
-                                <div class="mb64 pt-3">
-                                    <div t-if="show_blacklist_button">
-                                        <div class="btn btn-secondary pull-right" id="button_add_blacklist" style="display:none">Blacklist Me</div>
+                                        <textarea class="form-control mt-1 d-none" name="opt_out_feedback" cols="60" rows="3"></textarea>
                                     </div>
-                                    <div class="btn btn-secondary pull-right" id="button_remove_blacklist" style="display:none">Come Back</div>
-                                    <button type="submit" id="send_form" class="btn btn-primary">Update my subscriptions</button>
+                                    <div class="d-sm-flex flex-row-reverse">
+                                        <div id="feedback_status" class="flex-grow-1 align-self-center mb-3 mb-sm-0"/>
+                                        <div class="align-items-start mr-sm-2">
+                                            <div t-attf-class="btn btn-primary" id="button_feedback">Send</div>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
-
+                            <div class="oe_structure"/>
+                            <div t-if="has_public_list or show_blacklist_button" class="mt-4">
+                                <h3>Mailing Subscriptions</h3>
+                                <p t-if="has_public_list">Choose your mailing subscriptions</p>
+                                <div id="div_opt_out">
+                                    <ul class="list-group">
+                                        <t t-foreach="list_ids" t-as="list_id">
+                                            <t t-if="list_id.is_public == True">
+                                                <li class="list-group-item">
+                                                    <input type="checkbox" class="mail_list_checkbox" name="contact_ids"
+                                                        t-att-value="list_id['id']" t-att-checked="None if list_id['id'] in opt_out_list_ids else 'checked'"/>
+                                                    <t t-esc="list_id.name"/>
+                                                    <span class="text-primary">
+                                                        <t t-if="list_id['id'] in opt_out_list_ids">Not subscribed</t>
+                                                        <t t-else="">Subscribed</t>
+                                                    </span>
+                                                </li>
+                                            </t>
+                                        </t>
+                                    </ul>
+                                    <div class="d-sm-flex flex-row-reverse mt-3">
+                                        <div id="unsubscribe_form_status" class="flex-grow-1 align-self-center mb-3 mb-sm-0" />
+                                        <div class="d-flex align-items-start mr-sm-2">
+                                            <button t-if="has_public_list" type="submit" id="send_form" class="btn btn-primary text-nowrap">Apply Changes</button>
+                                            <div t-if="show_blacklist_button">
+                                                <div t-attf-class="btn btn-link text-nowrap ml-2 ml-sm-0" id="button_add_blacklist" style="display:none">Blacklist Me</div>
+                                                <div t-attf-class="btn btn-link text-nowrap ml-2 ml-sm-0" id="button_remove_blacklist" style="display:none">Come Back</div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
                         </t>
                         <t t-else="">
                             <div class="alert alert-info text-center" role="status">
@@ -58,6 +82,9 @@
                         </t>
                     </div>
                 </form>
+            </div>
+            <div class="row">
+                <div class="oe_structure w-100"/>
             </div>
         </div>
     </template>
@@ -69,14 +96,16 @@
                 <input type="hidden" name="mailing_id" t-att-value="mailing_id"/>
                 <input type="hidden" name="res_id" t-att-value="res_id"/>
                 <div id="div_blacklist" class="col-lg-6 offset-lg-3">
-                    <h1 class="o_page_header">Mailing Subscriptions</h1>
+                    <h1>Mailing Subscriptions</h1>
 
-                    <div id="subscription_info" class="alert alert-success text-center" role="status">
-                        <p>You have been successfully <strong>unsubscribed</strong>!</p>
+                    <div id="subscription_info">
+                        <h2 class="font-weight-light text-muted">
+                            You have been successfully <strong>unsubscribed</strong>!
+                        </h2>
                     </div>
 
-                    <div t-if="list_ids" class="alert alert-warning">
-                        <p class="text-center">You were still subscribed to those newsletters. You will not receive any news from them anymore:</p>
+                    <div t-if="list_ids">
+                        <p>You were still subscribed to those newsletters. You will not receive any news from them anymore:</p>
                         <ul class="list-group mb-4">
                             <t t-foreach="list_ids" t-as="list_id">
                                 <t t-if="list_id.is_public == True">
@@ -89,11 +118,22 @@
                     </div>
 
                     <div t-if="show_blacklist_button" class="mb64">
-                        <div class="btn btn-secondary pull-right" id="button_add_blacklist" style="display:none">Blacklist Me</div>
-                        <div class="btn btn-secondary pull-right" id="button_remove_blacklist" style="display:none">Come Back</div>
+                        <div class="btn btn-link pull-right" id="button_add_blacklist" style="display:none">Blacklist Me</div>
+                        <div class="btn btn-link pull-right" id="button_remove_blacklist" style="display:none">Come Back</div>
                     </div>
                 </div>
             </div>
+        </div>
+    </template>
+
+    <template id="subscription">
+        <div class="container">
+            <h3>Mailing Subscriptions</h3>
+            <ul class="list-group" t-foreach="list_ids" t-as="list_id">
+                <li class="list-group-item" t-if="list_id.is_public == True">
+                    <t t-esc="list_id.name"/>
+                </li>
+            </ul>
         </div>
     </template>
 
@@ -114,37 +154,26 @@
         </t>
     </template>
 
+    <template id="page_subscription" name="Unsubscribed">
+        <t t-call="mass_mailing.layout">
+            <t t-call="mass_mailing.subscription"/>
+        </t>
+    </template>
+
     <!-- new layout for mass_mailing -->
-    <template id="mass_mailing.layout" name="Mass Mailing Layout">
-        <t t-call="web.layout">
-            <t t-set="head">
-                <t t-call-assets="web.assets_common"/>
-                <t t-call-assets="mass_mailing.assets_backend"/>
-            </t>
-            <body class="o_white_body">
-                <header>
-                    <div><title>Odoo</title></div>
-                    <div class="text-center">
-                        <img t-attf-src="/web/binary/company_logo?company={{ res_company.id }}"/>
-                    </div>
-                </header>
-                <div id="wrap" class="oe_structure oe_empty"/>
-                <main>
-                    <t t-out="0"/>
-                </main>
-            </body>
-            <xpath expr="//footer" position="replace">
-                <div class="container mt16 mb8">
-                    <div class="pull-right" t-ignore="true" t-if="not editable">
-                        Create a <a target="_blank" href="https://www.odoo.com/page/website-builder">free website</a> with
-                        <a target="_blank" class="label label-danger" href="https://www.odoo.com/page/website-builder">Odoo</a>
-                    </div>
-                    <div class="pull-left text-muted" itemscope="itemscope" itemtype="https://schema.org/Organization">
-                        <t t-call="web.debug_icon"/>
-                        Copyright &amp;copy; <span t-field="res_company.name" itemprop="name">Company name</span>
-                    </div>
+    <template id="mass_mailing.layout" name="Mass Mailing Layout" inherit_id="web.frontend_layout" primary="True">
+        <xpath expr="//header" position="replace"></xpath>
+        <xpath expr="//footer" position="replace">
+            <footer class="container mt16 mb8">
+                <div class="pull-right" t-ignore="true" t-if="not editable">
+                    Create a <a target="_blank" href="https://www.odoo.com/page/website-builder">free website</a> with
+                    <a target="_blank" class="label label-danger" href="https://www.odoo.com/page/website-builder">Odoo</a>
                 </div>
-            </xpath>
-         </t>
-     </template>
+                <div class="pull-left text-muted" itemscope="itemscope" itemtype="https://schema.org/Organization">
+                    <t t-call="web.debug_icon"/>
+                    Copyright &amp;copy; <span t-field="res_company.name" itemprop="name">Company name</span>
+                </div>
+            </footer>
+        </xpath>
+    </template>
 </odoo>


### PR DESCRIPTION
With these new changes, the end-user will be able to indicate why he/she unsubscribed from a mailing list by selecting on a predefined reason. The end-user can still leave a comment by selecting the reason named 'other'. The reason will then be added to the chatter.

By using predefined reasons, the administrators can quickly do some data analysis and identify why the end-users did unsubscribe without having to read all the comments. To see the reports, the administrators can click on the new "Opt Out" button located in the navbar of the email marketing module.

The layout of the unsubscription page has been improved.