### PR TITLE
[FIX] hr_contract: Include archived employees on _get_all_contracts

### DIFF
--- a/addons/hr_contract/models/hr_employee.py
+++ b/addons/hr_contract/models/hr_employee.py
@@ -66,7 +66,7 @@ class Employee(models.Model):
         """
         Returns the contracts of all employees between date_from and date_to
         """
-        return self.search([])._get_contracts(date_from, date_to, states=states)
+        return self.search(['|', ('active', '=', True), ('active', '=', False)])._get_contracts(date_from, date_to, states=states)
 
     def write(self, vals):
         res = super(Employee, self).write(vals)


### PR DESCRIPTION
Purpose
=======

When we want to retrieve all the contract (running for instance), we
don't care about the fact that the employee is archived or not.

For example when we generate the work entries to generate the payslips,
we actually pay the employee, even if he's archived (which is the
normal flow).

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
