### PR TITLE
remove URLCopyClipboard from user-friendly studio widgets

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -1753,7 +1753,6 @@ var CharCopyClipboard = FieldChar.extend(CopyClipboard, {
 });
 
 var URLCopyClipboard = FieldChar.extend(CopyClipboard, {
-    description: _lt("Copy to Clipboard"),
     clipboardTemplate: 'CopyClipboardChar',
     className: 'o_field_copy o_text_overflow o_field_copy_url',
     events: _.extend({}, FieldChar.prototype.events, {


### PR DESCRIPTION
PURPOSE
There is a new CopyClipboardURL widget that is a variation of the CopyClipboardChar widget, resulting in duplicates from the non-technical user point of view.

SPEC
Do not consider the CopyClipboardURL as 'user-friendly' i.e. it should only appear in debug mode

TaskId: 2458003



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
