### PR TITLE
[FIX] sale_project: get only sales order for sale_order_id in project

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -16,7 +16,7 @@ class Project(models.Model):
         help="Sales order item to which the project is linked. Link the timesheet entry to the sales order item defined on the project. "
         "Only applies on tasks without sale order item defined, and if the employee is not in the 'Employee/Sales Order Item Mapping' of the project.")
     sale_order_id = fields.Many2one('sale.order', 'Sales Order',
-        domain="[('order_line.product_id.type', '=', 'service'), ('partner_id', '=', partner_id)]",
+        domain="[('order_line.product_id.type', '=', 'service'), ('partner_id', '=', partner_id), ('state', 'in', ['sale', 'done'])]",
         copy=False, help="Sales order to which the project is linked.")
 
     _sql_constraints = [


### PR DESCRIPTION
Before this commit, the user can select a sales order which is always a
quotation and he cannot select a sales order line because the state of
the sales order is not equal to 'sale' or 'done'.

This commit adds ('state', 'in' ['sale', 'done']) in the domain of the
sale_order_id field in project.project model.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
