### PR TITLE
[FIX] website_event: make allowed_field customizable

### DIFF
--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -320,7 +320,7 @@ class WebsiteEventController(http.Controller):
         :param form_details: posted data from frontend registration form, like
             {'1-name': 'r', '1-email': 'r@r.com', '1-phone': '', '1-event_ticket_id': '1'}
         """
-        allowed_fields = {'name', 'phone', 'email', 'mobile', 'event_id', 'partner_id', 'event_ticket_id'}
+        allowed_fields = request.env['event.registration']._get_website_registration_allowed_fields()
         registration_fields = {key: v for key, v in request.env['event.registration']._fields.items() if key in allowed_fields}
         registrations = {}
         global_values = {}

--- a/addons/website_event/models/event_registration.py
+++ b/addons/website_event/models/event_registration.py
@@ -9,3 +9,6 @@ class EventRegistration(models.Model):
     _inherit = ['event.registration']
 
     visitor_id = fields.Many2one('website.visitor', string='Visitor', ondelete='set null')
+
+    def _get_website_registration_allowed_fields(self):
+        return {'name', 'phone', 'email', 'mobile', 'event_id', 'partner_id', 'event_ticket_id'}


### PR DESCRIPTION
Problem
-------
Since https://github.com/odoo/odoo/commit/d3b18979bfb5496fa4370fdf03a806c469127730,
when a visitor register for an event, the fields in the POST are checked against a list of allowed fields.

The list is hardcoded inside the method _process_attendees_form.

Solution
--------
Move this list in a specific method that can be easily overidden by
another module





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
