### PR TITLE
[FIX] packaging: include json files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,6 +14,7 @@ recursive-include odoo *.ico
 recursive-include odoo *.jpeg
 recursive-include odoo *.jpg
 recursive-include odoo *.js
+recursive-include odoo *.json
 recursive-include odoo *.md
 recursive-include odoo *.mp3
 recursive-include odoo *.ogg


### PR DESCRIPTION
Some json files are necessary for some modules but are not included in
packaging.