### PR TITLE
[FIX] hr_holidays: Rounding allocation_used_count and allocation_count

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -80,12 +80,12 @@ class HrEmployeeBase(models.AbstractModel):
                 ('holiday_status_id.active', '=', True),
                 ('state', '=', 'validate'),
             ])
-            employee.allocation_count = sum(allocations.mapped('number_of_days'))
+            employee.allocation_count = float_round(sum(allocations.mapped('number_of_days')), precision_digits=2)
             employee.allocation_display = "%g" % employee.allocation_count
 
     def _compute_total_allocation_used(self):
         for employee in self:
-            employee.allocation_used_count = employee.allocation_count - employee.remaining_leaves
+            employee.allocation_used_count = float_round(employee.allocation_count - employee.remaining_leaves, precision_digits=2)
             employee.allocation_used_display = "%g" % employee.allocation_used_count
 
     def _compute_presence_state(self):


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider an employee E with 8.00 hours as Average Hour per Day
- Create an Allocation for E with a Time-off Type in Hours
(be sure the number of hours is different from the average hour per Day)
- Open the form view of E

Bug:

The smart button Time Off(remaining leaves) was completely unreadable

opw:2441019