### PR TITLE
[IMP] hr_recruitment : add a hired_stage boolean to recruitment stages

### DIFF
--- a/addons/hr_recruitment/data/hr_recruitment_data.xml
+++ b/addons/hr_recruitment/data/hr_recruitment_data.xml
@@ -62,6 +62,7 @@
         <field name="name">Contract Signed</field>
         <field name="sequence">5</field>
         <field name="fold" eval="True"/>
+        <field name="hired_stage">True</field>
     </record>
 
     <!-- applicant refuse reason -->

--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -63,12 +63,15 @@ class RecruitmentStage(models.Model):
     fold = fields.Boolean(
         "Folded in Kanban",
         help="This stage is folded in the kanban view when there are no records in that stage to display.")
+    hired_stage = fields.Boolean('Hired Stage',
+        help="If checked, this stage is used to determine the hire date of an applicant")
     legend_blocked = fields.Char(
         'Red Kanban Label', default=lambda self: _('Blocked'), translate=True, required=True)
     legend_done = fields.Char(
         'Green Kanban Label', default=lambda self: _('Ready for Next Stage'), translate=True, required=True)
     legend_normal = fields.Char(
         'Grey Kanban Label', default=lambda self: _('In Progress'), translate=True, required=True)
+    is_warning_visible = fields.Boolean(compute='_compute_is_warning_visible')
 
     @api.model
     def default_get(self, fields):
@@ -78,6 +81,15 @@ class RecruitmentStage(models.Model):
             self = self.with_context(context)
         return super(RecruitmentStage, self).default_get(fields)
 
+    @api.depends('hired_stage')
+    def _compute_is_warning_visible(self):
+        applicant_data = self.env['hr.applicant'].read_group([('stage_id', 'in', self.ids)], ['stage_id'], 'stage_id')
+        applicants = dict((data['stage_id'][0], data['stage_id_count']) for data in applicant_data)
+        for stage in self:
+            if stage._origin.hired_stage and not stage.hired_stage and applicants.get(stage._origin.id):
+                stage.is_warning_visible = True
+            else:
+                stage.is_warning_visible = False
 
 class RecruitmentDegree(models.Model):
     _name = "hr.recruitment.degree"
@@ -117,7 +129,7 @@ class Applicant(models.Model):
     user_id = fields.Many2one(
         'res.users', "Recruiter", compute='_compute_user',
         tracking=True, store=True, readonly=False)
-    date_closed = fields.Datetime("Closed", compute='_compute_date_closed', store=True, index=True)
+    date_closed = fields.Datetime("Hire Date", compute='_compute_date_closed', store=True, index=True, readonly=False, tracking=True)
     date_open = fields.Datetime("Assigned", readonly=True, index=True)
     date_last_stage_update = fields.Datetime("Last Stage Update", index=True, default=fields.Datetime.now)
     priority = fields.Selection(AVAILABLE_PRIORITIES, "Appreciation", default='0')
@@ -273,12 +285,12 @@ class Applicant(models.Model):
         for applicant in self.filtered(lambda a: a.partner_id and a.partner_mobile and not a.partner_id.mobile):
             applicant.partner_id.mobile = applicant.partner_mobile
 
-    @api.depends('stage_id')
+    @api.depends('stage_id.hired_stage')
     def _compute_date_closed(self):
         for applicant in self:
-            if applicant.stage_id and applicant.stage_id.fold:
+            if applicant.stage_id and applicant.stage_id.hired_stage and not applicant.date_closed:
                 applicant.date_closed = fields.datetime.now()
-            else:
+            if not applicant.stage_id.hired_stage:
                 applicant.date_closed = False
 
     @api.model

--- a/addons/hr_recruitment/static/src/scss/hr_job.scss
+++ b/addons/hr_recruitment/static/src/scss/hr_job.scss
@@ -89,6 +89,32 @@
     }
 }
 
+.o_kanban_view {
+    &.o_kanban_applicant {
+        .ribbon {
+            &::before, &::after {
+                display: none;
+            }
+
+            span {
+                background-color: $o-brand-odoo;
+                padding: 5px;
+                font-size: x-small;
+                z-index: unset;
+                height: auto;
+            }
+        }
+        .ribbon-top-right {
+            margin-top: -$o-kanban-dashboard-vpadding;
+
+            span {
+                top: 10px;
+                left: 20px;
+            }
+        }
+    }
+}
+
 .o_kanban_view .oe_kanban_card {
     .o_kanban_state_with_padding {
         padding-left:7%;

--- a/addons/hr_recruitment/views/hr_recruitment_views.xml
+++ b/addons/hr_recruitment/views/hr_recruitment_views.xml
@@ -95,6 +95,7 @@
                     </button>
                 </div>
                 <widget name="web_ribbon" title="Refused" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                <widget name="web_ribbon" title="Hired" attrs="{'invisible': [('date_closed', '=', False)]}" />
                 <field name="kanban_state" widget="kanban_state_selection"/>
                 <field name="active" invisible="1"/>
                 <field name="legend_normal" invisible="1"/>
@@ -123,6 +124,7 @@
                     <group>
                         <field name="categ_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
                         <field name="user_id" domain="[('share', '=', False)]"/>
+                        <field name="date_closed" attrs="{'invisible': [('date_closed', '=', False)]}" />
                         <field name="priority" widget="priority"/>
                         <field name="medium_id" groups="base.group_no_one" />
                         <field name="source_id"/>
@@ -282,6 +284,7 @@
         <field name="arch" type="xml">
             <kanban default_group_by="stage_id" class="o_kanban_applicant" quick_create_view="hr_recruitment.quick_create_applicant_form" sample="1">
                 <field name="stage_id" options='{"group_by_tooltip": {"requirements": "Requirements"}}'/>
+                <field name="date_closed"/>
                 <field name="color"/>
                 <field name="priority"/>
                 <field name="user_id"/>
@@ -299,6 +302,10 @@
                 <templates>
                     <t t-name="kanban-box">
                         <div t-attf-class="{{!selection_mode ? 'oe_kanban_color_' + kanban_getcolor(record.color.raw_value) : ''}} oe_kanban_card oe_kanban_global_click oe_applicant_kanban oe_semantic_html_override">
+                            <field name="date_closed" invisible="1"/>
+                            <div class="ribbon ribbon-top-right" attrs="{'invisible': [('date_closed', '=', False)]}">
+                                <span class="bg-success">Hired</span>
+                            </div>
                             <span class="badge badge-pill badge-danger pull-right mr-4" attrs="{'invisible': [('active', '=', True)]}">Refused</span>
                             <div class="o_dropdown_kanban dropdown">
                                 <a class="dropdown-toggle o-no-caret btn" role="button" data-toggle="dropdown" href="#" aria-label="Dropdown menu" title="Dropdown menu" data-display="static">
@@ -691,6 +698,7 @@ action = act
                 <field name="sequence" widget="handle"/>
                 <field name="name"/>
                 <field name="fold"/>
+                <field name="hired_stage"/>
             </tree>
         </field>
     </record>
@@ -735,6 +743,16 @@ action = act
                     </group>
                     <group name="stage_details">
                         <field name="fold"/>
+                        <field name="hired_stage"/>
+                        <field name="is_warning_visible" invisible="1"/>
+                        <span attrs="{'invisible': [('is_warning_visible', '=', False)]}">
+                            <span
+                                class="fa fa-exclamation-triangle text-danger pl-3">
+                            </span>
+                            <span class="text-danger">
+                                All applications will lose their hired date and hired status.
+                            </span>
+                        </span>
                         <field name="job_ids" widget="many2many_tags"/>
                     </group>
                 </group>


### PR DESCRIPTION
Previously the number of hired people in the reporting was based on
if they were in a folded stage or not. Adding this boolean allows the user
to decide which stage should be used for the computation of the number
of hired people.

Task-2462536