### PR TITLE
[IMP] website: make maps available without configuration

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -75,6 +75,7 @@
         'views/snippets/s_mega_menu_multi_menus.xml',
         'views/snippets/s_mega_menu_menu_image_menu.xml',
         'views/snippets/s_google_map.xml',
+        'views/snippets/s_map.xml',
         'views/snippets/s_dynamic_snippet.xml',
         'views/snippets/s_dynamic_snippet_carousel.xml',
         'views/website_views.xml',

--- a/addons/website/static/src/img/snippets_thumbs/s_map.svg
+++ b/addons/website/static/src/img/snippets_thumbs/s_map.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="82" height="60" viewBox="0 0 82 60">
+  <defs>
+    <linearGradient id="linearGradient-1" x1="0%" x2="100%" y1="23.231%" y2="76.769%">
+      <stop offset="0%" stop-color="#00A09D"/>
+      <stop offset="100%" stop-color="#00E2FF"/>
+    </linearGradient>
+    <path id="path-2" d="M10 6.5c0-.966-.342-1.791-1.025-2.475A3.372 3.372 0 0 0 6.5 3c-.966 0-1.791.342-2.475 1.025A3.372 3.372 0 0 0 3 6.5c0 .966.342 1.791 1.025 2.475A3.372 3.372 0 0 0 6.5 10c.966 0 1.791-.342 2.475-1.025A3.372 3.372 0 0 0 10 6.5zm3 .167c0 .946-.14 1.723-.419 2.33L7.96 19.076a1.566 1.566 0 0 1-.603.677 1.6 1.6 0 0 1-1.714 0 1.488 1.488 0 0 1-.59-.677L.419 8.997C.139 8.39 0 7.613 0 6.667c0-1.84.635-3.412 1.904-4.714C3.174.651 4.706 0 6.5 0s3.326.651 4.596 1.953S13 4.826 13 6.667z"/>
+    <filter id="filter-4" width="107.7%" height="110%" x="-3.8%" y="-2.5%" filterUnits="objectBoundingBox">
+      <feOffset dy="1" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feComposite in="shadowOffsetOuter1" in2="SourceAlpha" operator="out" result="shadowOffsetOuter1"/>
+      <feColorMatrix in="shadowOffsetOuter1" values="0 0 0 0 1   0 0 0 0 1   0 0 0 0 1  0 0 0 0.4 0"/>
+    </filter>
+  </defs>
+  <g fill="none" fill-rule="evenodd" class="snippets_thumbs" transform="scale(-1, 1) translate(-82, 0)">
+    <g class="s_google_map">
+      <g fill="url(#linearGradient-1)" class="image_1" opacity=".4">
+        <path d="M23.033 36.864L32.38 60H0V44.348l23.033-7.484zM60.346 24.74L74.592 60H55.05L43.071 30.353l17.275-5.613zM82 17.705V60h-4.567L62.858 23.924 82 17.704zM40.56 31.169l11.65 28.83H35.22l-9.677-23.951 15.015-4.88zM27.966-.001L39.57 28.722 0 41.579V0h27.966zM50.35 0l9.006 22.293-17.274 5.613L30.807 0H50.35zM82 0v14.935l-20.132 6.54L53.191 0H82z" class="combined_shape"/>
+      </g>
+      <g class="group" transform="translate(17 14)">
+        <mask id="mask-3" fill="#fff">
+          <use xlink:href="#path-2"/>
+        </mask>
+        <g class="map_marker">
+          <use fill="#000" filter="url(#filter-4)" xlink:href="#path-2"/>
+          <use fill="#FFF" fill-opacity=".95" xlink:href="#path-2"/>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/addons/website/static/src/snippets/s_map/000.scss
+++ b/addons/website/static/src/snippets/s_map/000.scss
@@ -1,0 +1,48 @@
+
+$s-map-desc-bg: theme-color('primary') !default;
+$s-map-desc-alpha: 0.80 !default;
+$s-map-desc-hover-bg: theme-color('primary') !default;
+$s-map-desc-hover-alpha: 0.55 !default;
+
+.s_map {
+    position: relative;
+    min-height: 100px;
+
+    .map_container {
+        @include o-position-absolute(0, 0, 0, 0);
+    }
+    .description {
+        @include o-position-absolute(auto, 0, 0, 0);
+        z-index: 99;
+        padding: 0 1em;
+        background: rgba($s-map-desc-bg, $s-map-desc-alpha);
+        color: color-yiq(rgba($s-map-desc-bg, $s-map-desc-alpha));
+        transition: background-color 250ms ease;
+
+        font {
+            float: left;
+            margin-top: 20px;
+            margin-bottom: 15px;
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+        span {
+            float: left;
+            text-transform: none;
+            font-weight: normal;
+            margin-top: 20px;
+            margin-left: 10px;
+        }
+    }
+    &:hover .description {
+        background: $s-map-desc-hover-bg;
+        background: rgba($s-map-desc-hover-bg, $s-map-desc-hover-alpha);
+        color: color-yiq(rgba($s-map-desc-hover-bg, $s-map-desc-hover-alpha));
+    }
+}
+
+.editor_enable .s_map {
+    iframe {
+        pointer-events: none;
+    }
+}

--- a/addons/website/static/src/snippets/s_map/options.js
+++ b/addons/website/static/src/snippets/s_map/options.js
@@ -1,0 +1,93 @@
+odoo.define('options.s_map_options', function (require) {
+'use strict';
+
+const {_t} = require('web.core');
+const options = require('web_editor.snippets.options');
+
+options.registry.Map = options.Class.extend({
+    /**
+     *
+     * @override
+     */
+    onBuilt: function () {
+        this.updateUI();
+    },
+
+    /**
+     * @override
+     */
+    updateUI() {
+        const dataset = this.$target[0].dataset;
+        const embedded = this.$target.find('.o_embedded');
+        const info = this.$target.find('.missing_option_warning');
+        if (dataset.mapAddress) {
+            const url = 'https://maps.google.com/maps?q=' + encodeURIComponent(dataset.mapAddress)
+                + '&t=' + encodeURIComponent(dataset.mapType)
+                + '&z=' + encodeURIComponent(dataset.mapZoom)
+                + '&ie=UTF8&iwloc=&output=embed';
+            if (url !== embedded.attr('src')) {
+                embedded.attr('src', url);
+            }
+            embedded.removeClass('d-none');
+            info.addClass('d-none');
+        } else {
+            embedded.attr('src', 'about:blank');
+            embedded.addClass('d-none');
+            info.removeClass('d-none');
+        }
+        if (! (this.$target.hasClass('o_half_screen_height') || this.$target.hasClass('o_full_screen_height'))) {
+            this.$target.css('min-height', this.$target[0].dataset.mapMinHeight);
+        }
+        return this._super.apply(this, arguments).then(() => {
+            this.updateUIVisibility();
+        });
+    },
+
+    //--------------------------------------------------------------------------
+    // Options
+    //--------------------------------------------------------------------------
+
+    /**
+     * @see this.selectClass for parameters
+     */
+    async showDescription(previewMode, widgetValue, params) {
+        const descriptionEl = this.$target[0].querySelector('.description');
+        if (widgetValue && !descriptionEl) {
+            this.$target.append($(`
+                <div class="description">
+                    <font>${_t('Visit us:')}</font>
+                    <span>${_t('Our office is open Monday – Friday 8:30 a.m. – 4:00 p.m.')}</span>
+                </div>`)
+            );
+        } else if (!widgetValue && descriptionEl) {
+            descriptionEl.remove();
+        }
+    },
+    /**
+     * @see this.selectClass for parameters
+     */
+    async setHeight(previewMode, widgetValue, params) {
+        if (widgetValue) {
+            this.$target[0].dataset.mapMinHeight = widgetValue;
+            this.$target.css('min-height', widgetValue);
+        }
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    _computeWidgetState(methodName, params) {
+        if (methodName === 'showDescription') {
+            return !!this.$target[0].querySelector('.description');
+        }
+        if (methodName === 'setHeight') {
+            return this.$target[0].dataset.mapMinHeight;
+        }
+        return this._super(...arguments);
+    },
+});
+});

--- a/addons/website/views/assets.xml
+++ b/addons/website/views/assets.xml
@@ -140,6 +140,7 @@
     <script type="text/javascript" src="/website/static/src/snippets/s_timeline/options.js"/>
     <script type="text/javascript" src="/website/static/src/snippets/s_media_list/options.js"/>
     <script type="text/javascript" src="/website/static/src/snippets/s_google_map/options.js"/>
+    <script type="text/javascript" src="/website/static/src/snippets/s_map/options.js"/>
     <script type="text/javascript" src="/website/static/src/snippets/s_dynamic_snippet/options.js"/>
     <script type="text/javascript" src="/website/static/src/snippets/s_dynamic_snippet_carousel/options.js"/>
 

--- a/addons/website/views/snippets/s_map.xml
+++ b/addons/website/views/snippets/s_map.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template name="Map" id="s_map">
+    <section class="s_map" style="min-height: 100px;" data-map-type="m" data-map-zoom="12"  data-map-min-height="100px"
+        t-att-data-map-address="' '.join(filter(None, (user_id.company_id.street, user_id.company_id.city, user_id.company_id.state_id.display_name, user_id.company_id.country_id.display_name)))"
+    >
+        <div class="map_container o_not_editable">
+            <div class="css_non_editable_mode_hidden">
+                <div class="missing_option_warning alert alert-info rounded-0 fade show d-none d-print-none">
+                    An address must be specified for a map to be embedded
+                </div>
+            </div>
+            <iframe class="d-none o_embedded o_not_editable" width="100%" height="100%" src="about:blank" frameborder="0" scrolling="no" marginheight="0" marginwidth="0"></iframe>
+            <div class="o_we_bg_filter" style="background-color: rgba(239, 112, 112, 0) !important;"></div>
+        </div>
+    </section>
+</template>
+
+<!-- Snippet's Options -->
+<template id="s_map_options" inherit_id="website.snippet_options">
+    <xpath expr="//div[@data-js='Box']" position="before">
+        <div data-js="Map" data-selector=".s_map">
+            <we-input class="o_we_large_input" string="Address" data-select-data-attribute="" data-no-preview="true" data-attribute-name="mapAddress" placeholder="e.g. De Brouckere, Brussels, Belgium"/>
+            <we-select string="Type" data-no-preview="true" data-attribute-name="mapType">
+                <we-button data-select-data-attribute="m">Road</we-button>
+                <we-button data-select-data-attribute="k">Satellite</we-button>
+            </we-select>
+            <we-select string="Zoom" data-select-data-attribute="12" data-no-preview="true" data-attribute-name="mapZoom">
+                <we-button data-select-data-attribute="21">2.5 m</we-button>
+                <we-button data-select-data-attribute="20">5 m</we-button>
+                <we-button data-select-data-attribute="19">10 m</we-button>
+                <we-button data-select-data-attribute="18">20 m</we-button>
+                <we-button data-select-data-attribute="17">50 m</we-button>
+                <we-button data-select-data-attribute="16">100 m</we-button>
+                <we-button data-select-data-attribute="15">200 m</we-button>
+                <we-button data-select-data-attribute="14">400 m</we-button>
+                <we-button data-select-data-attribute="13">1 km</we-button>
+                <we-button data-select-data-attribute="12">2 km</we-button>
+                <we-button data-select-data-attribute="11">4 km</we-button>
+                <we-button data-select-data-attribute="10">8 km</we-button>
+                <we-button data-select-data-attribute="9">15 km</we-button>
+                <we-button data-select-data-attribute="8">30 km</we-button>
+                <we-button data-select-data-attribute="7">50 km</we-button>
+                <we-button data-select-data-attribute="6">100 km</we-button>
+                <we-button data-select-data-attribute="5">200 km</we-button>
+                <we-button data-select-data-attribute="4">400 km</we-button>
+                <we-button data-select-data-attribute="3">1000 km</we-button>
+                <we-button data-select-data-attribute="2">2000 km</we-button>
+            </we-select>
+            <we-colorpicker string="Color filter" data-select-style="true"
+                data-css-property="background-color" data-color-prefix="bg-" data-apply-to=".o_we_bg_filter"/>
+            <we-checkbox string="Description" data-no-preview="true" data-show-description="true"/>
+        </div>
+    </xpath>
+    <xpath expr="//div[@data-option-name='minHeight']" position="inside">
+        <div data-js="Map" data-selector=".s_map">
+            <we-input data-name="default_height" data-dependencies="minheight_auto_opt" string="⌙ Default" data-set-height="" data-unit="px" data-no-preview="true"/><!-- &emsp; -->
+        </div>
+    </xpath>
+</template>
+
+<template id="assets_snippet_s_map_css_000" inherit_id="website.assets_frontend">
+    <xpath expr="//link[last()]" position="after">
+        <link rel="stylesheet" type="text/scss" href="/website/static/src/snippets/s_map/000.scss"/>
+    </xpath>
+</template>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -108,6 +108,7 @@
                 <div class="o_panel_header">Dynamic Content</div>
                 <div class="o_panel_body">
                     <t id="form_form_hook"/>
+                    <t t-snippet="website.s_map" t-thumbnail="/website/static/src/img/snippets_thumbs/s_map.svg"/>
                     <t t-snippet="website.s_google_map" t-thumbnail="/website/static/src/img/snippets_thumbs/s_google_map.svg"/>
                     <t t-if="debug" t-snippet="website.s_dynamic_snippet" t-thumbnail="/website/static/src/img/snippets_thumbs/s_dynamic_snippet.svg"/>
                     <t t-if="debug" t-snippet="website.s_dynamic_snippet_carousel" t-thumbnail="/website/static/src/img/snippets_thumbs/s_dynamic_carousel.svg"/>
@@ -451,7 +452,7 @@
     <t t-set="only_bg_image_exclude" t-value="''"/>
 
     <t t-set="both_bg_color_image_selector" t-value="'section, .carousel-item, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .parallax'"/>
-    <t t-set="both_bg_color_image_exclude" t-value="base_only_bg_image_selector + ', .s_carousel_wrapper, .s_color_blocks_2, .s_image_gallery .carousel-item, .s_google_map'"/>
+    <t t-set="both_bg_color_image_exclude" t-value="base_only_bg_image_selector + ', .s_carousel_wrapper, .s_color_blocks_2, .s_image_gallery .carousel-item, .s_google_map, .s_map'"/>
 
     <t t-call="web_editor.snippet_options_background_options">
         <t t-set="selector" t-value="both_bg_color_image_selector"/>
@@ -506,7 +507,7 @@
         t-att-data-selector="so_snippet_addition_selector"
         data-drop-in=":not(p).oe_structure:not(.oe_structure_solo), :not(p)[data-oe-type=html], :not(p).oe_structure.oe_structure_solo:not(:has(> section, > div))"/>
 
-    <t t-set="so_content_addition_selector" t-translation="off">blockquote, .s_card:not(.s_timeline_card), .s_alert, .o_facebook_page, .s_share, .s_rating, .s_hr, .s_google_map, .s_countdown, .s_chart, .s_text_highlight, .s_progress_bar, .s_badge</t>
+    <t t-set="so_content_addition_selector" t-translation="off">blockquote, .s_card:not(.s_timeline_card), .s_alert, .o_facebook_page, .s_share, .s_rating, .s_hr, .s_google_map, .s_map, .s_countdown, .s_chart, .s_text_highlight, .s_progress_bar, .s_badge</t>
     <div id="so_content_addition"
         t-att-data-selector="so_content_addition_selector"
         t-attf-data-drop-near="p, h1, h2, h3, .row > div > img, #{so_content_addition_selector}"
@@ -1008,7 +1009,7 @@
     <!-- Min height of section -->
     <div data-option-name="minHeight" data-selector="section">
         <we-button-group string="Height">
-            <we-button data-select-class="" title="Fit content">Auto</we-button>
+            <we-button data-name="minheight_auto_opt" data-select-class="" title="Fit content">Auto</we-button>
             <we-button data-select-class="o_half_screen_height" title="Half screen">50%</we-button>
             <we-button data-select-class="o_full_screen_height" title="Full screen">100%</we-button>
         </we-button-group>


### PR DESCRIPTION
Before this commit displaying a map on the website required the use of
the Google Maps snippet which requires to configure an API key.

After this commit displaying a map on the website can also be done with
a simpler Maps snippet which requires no configuration.

task-2464422

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
