### PR TITLE
[FIX] sale: allow 2+ taxes on downpayment product

### DIFF
--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -106,7 +106,7 @@ class SaleAdvancePaymentInv(models.TransientModel):
     def _get_advance_details(self, order):
         context = {'lang': order.partner_id.lang}
         if self.advance_payment_method == 'percentage':
-            if self.product_id.taxes_id.price_include:
+            if all(self.product_id.taxes_id.mapped('price_include')):
                 amount = order.amount_total * self.amount / 100
             else:
                 amount = order.amount_untaxed * self.amount / 100

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -128,7 +128,7 @@ class TestSaleStock(TestSale):
         })
         act = adv_wiz.with_context(open_invoices=True).create_invoices()
         inv = self.env['account.move'].browse(act['res_id'])
-        self.assertEqual(inv.amount_untaxed, self.so.amount_untaxed * 5.0 / 100.0, 'Sale Stock: deposit invoice is wrong')
+        self.assertEqual(inv.amount_total, self.so.amount_total * 5.0 / 100.0, 'Sale Stock: deposit invoice is wrong')
         self.assertEqual(self.so.invoice_status, 'to invoice', 'Sale Stock: so should be to invoice after invoicing deposit')
         # invoice on order: everything should be invoiced
         self.so._create_invoices(final=True)


### PR DESCRIPTION
Create a product with mor than one tax > Create a down payment with %
Traceback

opw-2464291

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
