### PR TITLE
[FIX] web: TouchEvent doesn't exist in FireFox and Safari

### DIFF
--- a/addons/web/static/tests/helpers/test_utils_dom.js
+++ b/addons/web/static/tests/helpers/test_utils_dom.js
@@ -81,16 +81,20 @@ odoo.define('web.test_utils_dom', function (require) {
         dragover: { constructor: DragEvent, processParameters: onlyBubble },
         drop: { constructor: DragEvent, processParameters: onlyBubble },
 
-        touchstart: { constructor: TouchEvent, processParameters: touchEventMapping },
-        touchend: { constructor: TouchEvent, processParameters: touchEventMapping },
-        touchmove: { constructor: TouchEvent, processParameters: touchEventMapping },
-        touchcancel: { constructor: TouchEvent, processParameters: touchEventCancelMapping },
-
         input: { constructor: InputEvent, processParameters: onlyBubble },
 
         compositionstart: { constructor: CompositionEvent, processParameters: onlyBubble },
         compositionend: { constructor: CompositionEvent, processParameters: onlyBubble },
     };
+
+    if (typeof TouchEvent === 'function') {
+        Object.assign(EVENT_TYPES, {
+            touchstart: {constructor: TouchEvent, processParameters: touchEventMapping},
+            touchend: {constructor: TouchEvent, processParameters: touchEventMapping},
+            touchmove: {constructor: TouchEvent, processParameters: touchEventMapping},
+            touchcancel: {constructor: TouchEvent, processParameters: touchEventCancelMapping},
+        });
+    }
 
     /**
      * Check if an object is an instance of EventTarget.


### PR DESCRIPTION
Since commit odoo/odoo@c96e3b96f307685d03d240fac81fb0e83ca85f1d
the TouchEvent constructor was added to the test utils.

In FireFox (no touch mode) and Safari (desktop) this constructor
doesn't exist and so the test suite won't start anymore.

This commit, inserts TouchEvent constructor only when it's supported by
the browser. So now we can run the tests in FireFox and Safari again.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
