### PR TITLE
[FIX] packaging: add zeep and ofxparse in deb and rpm packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -29,6 +29,7 @@ Depends:
  python3-lxml,
  python3-mako,
  python3-mock,
+ python3-ofxparse,
  python3-passlib,
  python3-polib,
  python3-psutil,
@@ -39,13 +40,13 @@ Depends:
  python3-qrcode,
  python3-reportlab,
  python3-requests,
- python3-suds,
  python3-tz,
  python3-vatnumber,
  python3-vobject,
  python3-werkzeug,
  python3-xlsxwriter,
  python3-xlrd,
+ python3-zeep,
 Conflicts: tinyerp-server, openerp-server, openerp-web, openerp
 Replaces: tinyerp-server, openerp-server, openerp-web, openerp
 Recommends:

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,10 +44,10 @@ requires =
   python3-requests
   python3-six
   python3-stdnum
-  python3-suds
   python3-vatnumber
   python3-vobject
   python3-werkzeug
   python3-xlwt
   python3-xlrd
+  python3-zeep
 

--- a/setup/package.dfdebian
+++ b/setup/package.dfdebian
@@ -48,13 +48,13 @@ RUN apt-get update -qq &&  \
         python3-reportlab \
         python3-requests \
         python3-serial \
-        python3-suds \
         python3-tz \
         python3-usb \
         python3-vatnumber \
         python3-vobject \
         python3-werkzeug \
         python3-xlsxwriter \
+        python3-zeep \
         rsync && \
     rm -rf /var/lib/apt/lists/*
 

--- a/setup/package.dffedora
+++ b/setup/package.dffedora
@@ -33,6 +33,7 @@ RUN dnf update -d 0 -e 0 -y && \
 	  python3-PyPDF2 \
 	  python3-pyserial \
 	  python3-dateutil \
+	  python3-ofxparse \
 	  python3-polib \
 	  python3-pytz \
 	  python3-pyusb \
@@ -40,13 +41,13 @@ RUN dnf update -d 0 -e 0 -y && \
 	  python3-reportlab \
 	  python3-requests \
 	  python3-six \
-	  python3-suds \
 	  python3-vatnumber \
 	  python3-vobject \
 	  python3-werkzeug \
 	  python3-xlwt \
 	  python3-xlrd \
-		python3-xlsxwriter \
+	  python3-xlsxwriter \
+	  python3-zeep \
 		libsass \
 		pytz \
 		postgresql \


### PR DESCRIPTION
Zeep replaced suds but Debian and Rpm packaging were not updated.
Ofxparse is required but did not appear in Debian nor Rpm packaging.
