### PR TITLE
[FIX] hw_drivers: Traceback in 'device_changed'

### DIFF
--- a/addons/hw_drivers/event_manager.py
+++ b/addons/hw_drivers/event_manager.py
@@ -44,7 +44,7 @@ class EventManager(object):
             **device.data,
             'device_identifier': device.device_identifier,
             'time': time.time(),
-            'request_data': json.loads(request.params['data']) if request else None,
+            'request_data': json.loads(request.params['data']) if request and 'data' in request.params else None,
         }
         self.events.append(event)
         for session in self.sessions:


### PR DESCRIPTION
Only the 'action' requests have the 'data' parameter set, so any other
request triggering a 'device_changed' failed.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
