### PR TITLE
[FIX] account: Fix analytic lines when reconciling a statement line

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -1268,6 +1268,10 @@ class AccountBankStatementLine(models.Model):
             if len(rec_overview_partners) == 1:
                 self.line_ids.write({'partner_id': rec_overview_partners.pop()})
 
+        # Refresh analytic lines.
+        self.move_id.line_ids.analytic_line_ids.unlink()
+        self.move_id.line_ids.create_analytic_lines()
+
     # -------------------------------------------------------------------------
     # BUSINESS METHODS
     # -------------------------------------------------------------------------


### PR DESCRIPTION
When reconciling a statement line from the bank reconciliation widget, the journal entry of the statement line is already posted and then, the analytic lines was never created.
This commit fixes the issue by refreshing the analytic lines at the end of the statement line's reconciliation.

opw: 2466236

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
