### PR TITLE
[FIX] l10n_id_efaktur: type -> move_type in onchange

### DIFF
--- a/addons/l10n_id_efaktur/models/account_move.py
+++ b/addons/l10n_id_efaktur/models/account_move.py
@@ -45,7 +45,7 @@ class AccountMove(models.Model):
     @api.onchange('l10n_id_tax_number')
     def _onchange_l10n_id_tax_number(self):
         for record in self:
-            if record.l10n_id_tax_number and record.type not in self.get_purchase_types():
+            if record.l10n_id_tax_number and record.move_type not in self.get_purchase_types():
                 raise UserError(_("You can only change the number manually for a Vendor Bills and Credit Notes"))
 
     @api.depends('l10n_id_attachment_id')


### PR DESCRIPTION
Wrong variable name as account.move doesn't have 'type' but 'move_type'

Description of the issue/feature this PR addresses: Unable to fill tax number for purchase invoice on 'Indonesia' localization

Current behavior before PR: Unable save a purchase invoice with filled tax number (l10n_id_tax_number) on 'Indonesia' localization as onchange get an error

Desired behavior after PR is merged: Unable save a purchase invoice with filled tax number (l10n_id_tax_number) on 'Indonesia' localization 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
