### PR TITLE
Update res_partner.py

### DIFF
--- a/addons/l10n_id_efaktur/models/res_partner.py
+++ b/addons/l10n_id_efaktur/models/res_partner.py
@@ -34,4 +34,4 @@ class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
     l10n_id_tax_address = fields.Char('Tax Address', related='company_id.partner_id.l10n_id_tax_address', readonly=False)
-    l10n_id_tax_name = fields.Char('Tax Name', related='company_id.partner_id.l10n_id_tax_address', readonly=False)
+    l10n_id_tax_name = fields.Char('Tax Name', related='company_id.partner_id.l10n_id_tax_name', readonly=False)


### PR DESCRIPTION
Wrong related field

Description of the issue/feature this PR addresses: Indonesia localization, Updating Tax Address & Name gets a weird behavior as name overriding the address

Current behavior before PR: Unable to update Tax Address on 'Settings' as the value overwritten with Tax Name

Desired behavior after PR is merged: Able to properly update Tax Address on Settings




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
