### PR TITLE
[FIX] mail: this.env.services.bus_service is undefined

### DIFF
--- a/addons/mail/static/src/models/messaging/messaging.js
+++ b/addons/mail/static/src/models/messaging/messaging.js
@@ -12,7 +12,9 @@ function factory(dependencies) {
          * @override
          */
         _willDelete() {
-            this.env.services['bus_service'].off('window_focus', null, this._handleGlobalWindowFocus);
+            if (this.env.services['bus_service']) {
+                this.env.services['bus_service'].off('window_focus', null, this._handleGlobalWindowFocus);
+            }
             return super._willDelete(...arguments);
         }
 

--- a/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
+++ b/addons/mail/static/src/models/messaging_notification_handler/messaging_notification_handler.js
@@ -16,8 +16,10 @@ function factory(dependencies) {
          * @override
          */
         _willDelete() {
-            this.env.services['bus_service'].off('notification');
-            this.env.services['bus_service'].stopPolling();
+            if (this.env.services['bus_service']) {
+                this.env.services['bus_service'].off('notification');
+                this.env.services['bus_service'].stopPolling();
+            }
             return super._willDelete(...arguments);
         }
 


### PR DESCRIPTION
Before this commit, a page reload or a redirect could raise following
error:

```
Uncaught (in promise) TypeError: this.env.services.bus_service is undefined
```

This happens due to `Messaging` model relying on `bus_service` in its
teardown method `_willDelete`. This is sometimes unsafe because the
bus service may not have been deployed yet.

Task-2468469