### PR TITLE
[FIX] web_tour: Tour does not open

### DIFF
--- a/addons/web_tour/static/src/js/tip.js
+++ b/addons/web_tour/static/src/js/tip.js
@@ -155,6 +155,7 @@ var Tip = Widget.extend({
             this._setupAnchor($anchor, $altAnchor);
         }
         this._bind_anchor_events();
+        this._delegateEvents();
         if (!this.$el) {
             // Ideally this case should not happen but this is still possible,
             // as update may be called before the `start` method is called.


### PR DESCRIPTION
PURPOSE
When hover mouse on tour droplet, it shows tip info, but when click on app name(ex- expenses) and hover on tour droplet, it does not show text.

SPEC
Show tip info even after clicking over App name.

TASK 2376278


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
