### PR TITLE
[FIX] mail: do not show typing on command

### DIFF
--- a/addons/mail/static/src/components/composer_text_input/composer_text_input.js
+++ b/addons/mail/static/src/components/composer_text_input/composer_text_input.js
@@ -220,12 +220,12 @@ class ComposerTextInput extends Component {
      * @private
      */
     _onInputTextarea() {
+        this.saveStateInStore();
         if (this._textareaLastInputValue !== this._textareaRef.el.value) {
             this.composer.handleCurrentPartnerIsTyping();
         }
         this._textareaLastInputValue = this._textareaRef.el.value;
         this._updateHeight();
-        this.saveStateInStore();
     }
 
     /**

--- a/addons/mail/static/src/models/composer/composer.js
+++ b/addons/mail/static/src/models/composer/composer.js
@@ -311,6 +311,12 @@ function factory(dependencies) {
             if (!this.thread) {
                 return;
             }
+            if (
+                this.suggestionModelName === 'mail.channel_command' ||
+                this._getCommandFromText(this.textInputContent)
+            ) {
+                return;
+            }
             if (this.thread.typingMembers.includes(this.env.messaging.currentPartner)) {
                 this.thread.refreshCurrentPartnerIsTyping();
             } else {


### PR DESCRIPTION
PURPOSE:

Currently typing status is sent when typing a command.

SPECIFICATION:

Typing status should not be sent when typing a command.

Task-2363267