### PR TITLE
[FIX] mass_mailing: duplication of mailing list contacts

### DIFF
--- a/addons/mass_mailing/models/mailing_contact.py
+++ b/addons/mass_mailing/models/mailing_contact.py
@@ -140,6 +140,15 @@ class MassMailingContact(models.Model):
 
         return super(MassMailingContact, self.with_context(default_list_ids=False)).create(vals_list)
 
+    @api.returns('self', lambda value: value.id)
+    def copy(self, default=None):
+        """ Cleans the default_list_ids while duplicating mailing contact in context of
+        a mailing list because we already have subscription lists copied over for newly
+        created contact, no need to add the ones from default_list_ids again """
+        if self.env.context.get('default_list_ids'):
+            self = self.with_context(default_list_ids=False)
+        return super().copy(default)
+
     @api.model
     def name_create(self, name):
         name, email = self.get_name_email(name)

--- a/addons/mass_mailing/tests/test_mailing_list.py
+++ b/addons/mass_mailing/tests/test_mailing_list.py
@@ -54,6 +54,18 @@ class TestMailingListMerge(MassMailCommon):
             self.assertFalse(any(contact.opt_out for contact in new))
 
     @users('user_marketing')
+    def test_mailing_list_contact_copy_in_context_of_mailing_list(self):
+        MailingContact = self.env['mailing.contact']
+        contact_1 = MailingContact.create({
+            'name': 'Sam',
+            'email': 'gamgee@shire.com',
+            'subscription_list_ids': [(0, 0, {'list_id': self.mailing_list_3.id})],
+        })
+        # Copy the contact with default_list_ids in context, which should not raise anything
+        contact_2 = contact_1.with_context(default_list_ids=self.mailing_list_3.ids).copy()
+        self.assertEqual(contact_1.list_ids, contact_2.list_ids, 'Should copy the existing mailing list(s)')
+
+    @users('user_marketing')
     def test_mailing_list_merge(self):
         # TEST CASE: Merge A,B into the existing mailing list C
         # The mailing list C contains the same email address than 'Norbert' in list B


### PR DESCRIPTION
PURPOSE:

when anyone tries to duplicate mailing contacts
it will show an user error as follows "a mailing contact
cannot subscribe to the same mailing list multiple times."
the expected behaviour is one should be able to
duplicate mailing contacts.

SPECIFICATION:

when a user duplicates the mailing contact it creates an
exact copy of the one with the similar subscription line, since
the duplication is happening from inside a specific mailing list so
the context tries to re-add the list again, so twice the same list and
It breaks flow.

by this commit we will clean the context while duplicating which will
prevent from passing the same list via context, so it will not add same list
again.
 
LINKS
PR #66827
Task  2431344