### PR TITLE
[FIX] mail: messaging start when bus service is deployed

### DIFF
--- a/addons/mail/static/src/js/main.js
+++ b/addons/mail/static/src/js/main.js
@@ -2,8 +2,10 @@ odoo.define('mail/static/src/js/main.js', function (require) {
 'use strict';
 
 const ModelManager = require('mail/static/src/model/model_manager.js');
+const MessagingService = require('@mail/services/messaging/messaging')[Symbol.for("default")];
 
 const env = require('web.commonEnv');
+const { serviceRegistry } = require('web.core');
 
 const { Store } = owl;
 const { EventBus } = owl.core;
@@ -121,6 +123,6 @@ env.bus.on(
     () => env.messagingBus.trigger('will_show_home_menu')
 );
 
-env.messagingCreatedPromise.then(() => env.messaging.start());
+serviceRegistry.add('messaging', MessagingService);
 
 });

--- a/addons/mail/static/src/services/messaging/messaging.js
+++ b/addons/mail/static/src/services/messaging/messaging.js
@@ -1,0 +1,14 @@
+/** @odoo-module **/
+
+import AbstractService from 'web.AbstractService';
+
+export default AbstractService.extend({
+    dependencies: ['bus_service'],
+    /**
+     * @override {web.AbstractService}
+     */
+    start() {
+        this._super(...arguments);
+        this.env.messagingCreatedPromise.then(() => this.env.messaging.start());
+    },
+});

--- a/addons/mail/views/assets.xml
+++ b/addons/mail/views/assets.xml
@@ -166,6 +166,7 @@
                 <script type="text/javascript" src="/mail/static/src/models/user/user.js"></script>
                 <script type="text/javascript" src="/mail/static/src/services/chat_window_service/chat_window_service.js"></script>
                 <script type="text/javascript" src="/mail/static/src/services/dialog_service/dialog_service.js"></script>
+                <script type="text/javascript" src="/mail/static/src/services/messaging/messaging.js"/>
                 <script type="text/javascript" src="/mail/static/src/utils/deferred/deferred.js"></script>
                 <script type="text/javascript" src="/mail/static/src/utils/throttle/throttle.js"></script>
                 <script type="text/javascript" src="/mail/static/src/utils/timer/timer.js"></script>


### PR DESCRIPTION
Before this commit, messaging.start() may crash due to bus service
not yet deployed.

This commit fixes the issue by ensuring `start()` is always called
when the bus service is deployed. To do so, we introduce a new
service (Messaging) that simply waits for bus service deployment
before invoking messaging start.

Task-2468483