### PR TITLE
[FIX] mail: notification not sent when using the full composer

### DIFF
--- a/addons/crm/tests/test_performances.py
+++ b/addons/crm/tests/test_performances.py
@@ -174,7 +174,7 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
                 lead.probability = (idx + 1) * 10 * ((int(lead.priority) + 1) / 2)
 
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=6250):  # crm only: 6237
+            with self.assertQueryCount(user_sales_manager=6286):  # crm only: 6250
                 self.env['crm.team'].browse(sales_teams.ids)._action_assign_leads(work_days=30)
 
         self.members.invalidate_cache(fnames=['lead_month_count'])

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1810,7 +1810,7 @@ class MailThread(models.AbstractModel):
         if subtype_xmlid:
             subtype_id = self.env['ir.model.data'].xmlid_to_res_id(subtype_xmlid)
         if not subtype_id:
-            subtype_id = self.env['ir.model.data'].xmlid_to_res_id('mail_mt_note')
+            subtype_id = self.env['ir.model.data'].xmlid_to_res_id('mail.mt_note')
 
         # automatically subscribe recipients if asked to
         if self._context.get('mail_post_autofollow') and partner_ids:

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -951,7 +951,7 @@ class TestMailHeavyPerformancePost(BaseMailPerformance):
         ]
         self.attachements = self.env['ir.attachment'].with_user(self.env.user).create(self.vals)
         attachement_ids = self.attachements.ids
-        with self.assertQueryCount(emp=76):
+        with self.assertQueryCount(emp=77):
             self.cr.sql_log = self.warm and self.cr.sql_log_count
             record.with_context({}).message_post(
                 body='<p>Test body <img src="cid:cid1"> <img src="cid:cid2"></p>',


### PR DESCRIPTION
Current behavior before PR:
mail notification not sent when using the full composer.

Desired behavior after PR is merged:
mail notification will send when using the full composer.

LINKS:
Task-2446855

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
