### PR TITLE
[FIX] website_form: display attachment on form web page

### DIFF
--- a/addons/website_form/controllers/main.py
+++ b/addons/website_form/controllers/main.py
@@ -246,6 +246,7 @@ class WebsiteForm(http.Controller):
                     'no_auto_thread': False,
                     'res_id': id_record,
                     'attachment_ids': [(6, 0, orphan_attachment_ids)],
+                    'subtype_id': request.env['ir.model.data'].xmlid_to_res_id('mail.mt_comment'),
                 }
                 mail_id = request.env['mail.message'].sudo().create(values)
         else:


### PR DESCRIPTION
When submitting a ticket, if the user adds an attachement, he will not
be able to see it on the ticket web page.

To reproduce the error:
(Need helpdesk,contacts)
1. Go to the settings of a Helpdesk Team (e.g., "Customer Care")
2. Enable "Website Form", Refresh
3. Go on Helpdesk web page and Publish the form
4. Create a partner P and grant him the portal access
5. Sign in with P
6. Submit a ticket with one attachment
7. Consult the ticket's web page

Error: in "Message and communication history", OdooBot's message with
the attachment is not displayed. However, when consulting the
same page with the admin account, this message is considered as
"Published". Thus, P should see the message and the attachment.

When getting the messages, if the user is not an employee, the domain is
restricted:
https://github.com/odoo/odoo/blob/e92ac60a75462dfd830254a3d0dd5d7effe1528e/addons/portal/controllers/mail.py#L128-L130
with
https://github.com/odoo/odoo/blob/cc32b7d1b396a42dd4575c681ceb422f99b6015a/addons/portal/models/mail_message.py#L30-L32
Problem is that, when creating the message with the attachement,
`subtype_id` is not defined.

OPW-2440069