### PR TITLE
[FIX] pos_restaurant, l10n_fr_pos_cert: fix bill splitting

### DIFF
--- a/addons/l10n_fr_pos_cert/static/src/js/pos.js
+++ b/addons/l10n_fr_pos_cert/static/src/js/pos.js
@@ -77,7 +77,8 @@ models.Orderline = models.Orderline.extend({
         if (
             this.pos.is_french_country() && !this.reward_id &&
             (new_quantity < current_quantity || new_quantity === 0 && current_quantity === 0 && quantity === "remove") &&
-            !(new_quantity === 0 && current_quantity === 1 && this.isLastLine())
+            !(new_quantity === 0 && current_quantity === 1 && this.isLastLine()) &&
+            this._set_quantity_origin_ctx !== "splitbill"
         ) {
             var quantity_to_decrease = current_quantity - new_quantity;
             this.pos.gui.show_popup("number", {

--- a/addons/pos_restaurant/static/src/js/splitbill.js
+++ b/addons/pos_restaurant/static/src/js/splitbill.js
@@ -65,7 +65,9 @@ var SplitbillScreenWidget = screens.ScreenWidget.extend({
                 split.line = line.clone();
                 neworder.add_orderline(split.line);
             }
+            split.line._set_quantity_origin_ctx = 'splitbill';
             split.line.set_quantity(split.quantity, 'do not recompute unit price');
+            split.line._set_quantity_origin_ctx = undefined;
         }else if( split.line ) {
             neworder.remove_orderline(split.line);
             split.line = null;
@@ -102,7 +104,9 @@ var SplitbillScreenWidget = screens.ScreenWidget.extend({
         for(var id in splitlines){
             var split = splitlines[id];
             var line  = order.get_orderline(parseInt(id));
+            line._set_quantity_origin_ctx = 'splitbill';
             line.set_quantity(line.get_quantity() - split.quantity, 'do not recompute unit price');
+            line._set_quantity_origin_ctx = undefined;
             if(Math.abs(line.get_quantity()) < 0.00001){
                 order.remove_orderline(line);
             }


### PR DESCRIPTION
- Configure a Company located in France
- Install l10n_fr_pos_cert
- Create a Bar/Restaurant POS
- Enable Bill Splitting
- Open POS session
- Add n quantities of a Product
- Click on Split button
When clicking on an order line to split the bill, the splitted amount is not computed.
The popup to decrease the quantity (the one preventing to edit an order) is shown instead,
preventing to split the bill.

This popup should not appear on the bill splitting page.

opw-2463872

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
