### PR TITLE
[FIX] l10n_ch: human readable ISR number set to False

### DIFF
--- a/addons/l10n_ch/models/account_invoice.py
+++ b/addons/l10n_ch/models/account_invoice.py
@@ -151,7 +151,7 @@ class AccountMove(models.Model):
             return res
 
         for record in self:
-            if record.name and record.invoice_partner_bank_id and record.invoice_partner_bank_id.l10n_ch_postal:
+            if record.l10n_ch_isr_number:
                 record.l10n_ch_isr_number_spaced = _space_isr_number(record.l10n_ch_isr_number)
             else:
                 record.l10n_ch_isr_number_spaced = False

--- a/addons/l10n_ch/tests/test_gen_isr_reference.py
+++ b/addons/l10n_ch/tests/test_gen_isr_reference.py
@@ -44,8 +44,10 @@ class TestGenISRReference(AccountTestInvoicingCommon):
         self.invoice.name = "INV/01234567890"
 
         expected_isr = "000000000000000012345678903"
+        expected_isr_spaced = "00 00000 00000 00001 23456 78903"
         expected_optical_line = "0100001307807>000000000000000012345678903+ 010001628>"
         self.assertEqual(self.invoice.l10n_ch_isr_number, expected_isr)
+        self.assertEqual(self.invoice.l10n_ch_isr_number_spaced, expected_isr_spaced)
         self.assertEqual(self.invoice.l10n_ch_isr_optical_line, expected_optical_line)
 
     def test_qrr(self):
@@ -54,7 +56,9 @@ class TestGenISRReference(AccountTestInvoicingCommon):
         self.invoice.name = "INV/01234567890"
 
         expected_isr = "000000000000000012345678903"
+        expected_isr_spaced = "00 00000 00000 00001 23456 78903"
         self.assertEqual(self.invoice.l10n_ch_isr_number, expected_isr)
+        self.assertEqual(self.invoice.l10n_ch_isr_number_spaced, expected_isr_spaced)
         # No need to check optical line, we have no use for it with QR-bill
 
     def test_isr_long_reference(self):
@@ -63,8 +67,10 @@ class TestGenISRReference(AccountTestInvoicingCommon):
         self.invoice.name = "INV/123456789012345678901234567890"
 
         expected_isr = "567890123456789012345678901"
+        expected_isr_spaced = "56 78901 23456 78901 23456 78901"
         expected_optical_line = "0100001307807>567890123456789012345678901+ 010001628>"
         self.assertEqual(self.invoice.l10n_ch_isr_number, expected_isr)
+        self.assertEqual(self.invoice.l10n_ch_isr_number_spaced, expected_isr_spaced)
         self.assertEqual(self.invoice.l10n_ch_isr_optical_line, expected_optical_line)
 
     def test_missing_isr_subscription_num(self):
@@ -73,6 +79,7 @@ class TestGenISRReference(AccountTestInvoicingCommon):
         self.invoice.invoice_partner_bank_id = self.bank_acc_isr
 
         self.assertFalse(self.invoice.l10n_ch_isr_number)
+        self.assertFalse(self.invoice.l10n_ch_isr_number_spaced)
         self.assertFalse(self.invoice.l10n_ch_isr_optical_line)
 
     def test_missing_isr_subscription_num_in_wrong_field(self):
@@ -82,12 +89,14 @@ class TestGenISRReference(AccountTestInvoicingCommon):
         self.invoice.invoice_partner_bank_id = self.bank_acc_isr
 
         self.assertFalse(self.invoice.l10n_ch_isr_number)
+        self.assertFalse(self.invoice.l10n_ch_isr_number_spaced)
         self.assertFalse(self.invoice.l10n_ch_isr_optical_line)
 
     def test_no_bank_account(self):
         self.invoice.invoice_partner_bank_id = False
 
         self.assertFalse(self.invoice.l10n_ch_isr_number)
+        self.assertFalse(self.invoice.l10n_ch_isr_number_spaced)
         self.assertFalse(self.invoice.l10n_ch_isr_optical_line)
 
     def test_wrong_currency(self):
@@ -95,4 +104,5 @@ class TestGenISRReference(AccountTestInvoicingCommon):
         self.invoice.currency_id = self.env.ref("base.BTN")
 
         self.assertFalse(self.invoice.l10n_ch_isr_number)
+        self.assertFalse(self.invoice.l10n_ch_isr_number_spaced)
         self.assertFalse(self.invoice.l10n_ch_isr_optical_line)


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

The condition on computation of `l10n_ch_isr_number_spaced` was not in line anymore with
`l10n_ch_isr_number` computation.
With fixes on the ISR number the use of `l10n_ch_isr_postal` is rightly not
mandatory anymore.

This lead to an empty field, visible on the ISR report.


**Current behavior before PR:**

On the print of the ISR, Reference is empty.

![isr_missing_ref_before](https://user-images.githubusercontent.com/4158438/109186722-84fbf480-7791-11eb-999c-4a6583085878.png)


**Desired behavior after PR is merged:**

On the print of the ISR, Reference is shown.

![isr_missing_ref_after](https://user-images.githubusercontent.com/4158438/109186736-888f7b80-7791-11eb-9589-4ad24f662bee.png)


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
