### PR TITLE
[FIX] hr_contract: Avoid horizontal scroll in contract form on mobile

### DIFF
--- a/addons/hr_contract/static/src/scss/calendar_mismatch.scss
+++ b/addons/hr_contract/static/src/scss/calendar_mismatch.scss
@@ -4,15 +4,15 @@
     }
 
     .o_calendar_warning_tooltip {
-        position: absolute;
+        display: block;
+        height: 0;
         opacity: 0;
-        visibility: hidden;
     }
 
     .o_calendar_warning:hover + .o_calendar_warning_tooltip {
-        position: relative;
-        visibility: visible;
+        display: inline;
+        height: auto;
         opacity: 1;
-        transition: visibility 0s, opacity 0.5s linear;
+        transition: opacity 0.5s linear;
     }
 }


### PR DESCRIPTION
The following warning is very long in absolute position. The following
text: "Calendar Mismatch : The employee's calendar does not match its
current contract calendar. This could lead to unexpected behaviors."
is invisible but takes a lot of width on the same line.

Now, the item is a block of 0px height and doesn't take space.
This avoids the horizontal scroll on mobile.

Note that the item is displayed at the wrong place anyway.
This will be fixed in master.

Steps to reproduce:
- Payroll / Employees / All contracts
- Change "Working Schedule" field

Task-ID: 1929043

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
