### PR TITLE
[FIX] mail: use current user company in notification

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2358,7 +2358,9 @@ class MailThread(models.AbstractModel):
             if add_sign:
                 signature = "<p>-- <br/>%s</p>" % author.name
 
-        company = self.company_id.sudo() if self and 'company_id' in self else user.company_id
+        # use company switcher company if author is current user
+        user_company = self.env.company if self.env.user == user else user.company_id
+        company = self.company_id.sudo() if self and 'company_id' in self else user_company
         if company.website:
             website_url = 'http://%s' % company.website if not company.website.lower().startswith(('http:', 'https:')) else company.website
         else:


### PR DESCRIPTION
When sending a notification, the company used is:

- company_id of current record or if not available,
- company_id of author or if no author,
- company_id of user

This can seem unexpected if the author is the current user and the
company_id of our user is different than the current company switcher
company.

With this changeset, the company used is:

- company_id of current record or if not available,
- company_id of author if author is different than user or,
- current company in company switcher or if not,
- company_id of user

opw-2472622