### PR TITLE
[FIX] base, web_editor, website: add missing encoding on etree.tostring


### DIFF
--- a/addons/web_editor/models/ir_ui_view.py
+++ b/addons/web_editor/models/ir_ui_view.py
@@ -343,7 +343,7 @@ class IrUiView(models.Model):
         full_snippet_key = '%s.%s' % (app_name, snippet_key)
 
         # html to xml to add '/' at the end of self closing tags like br, ...
-        xml_arch = etree.tostring(html.fromstring(arch))
+        xml_arch = etree.tostring(html.fromstring(arch), encoding='utf-8')
         new_snippet_view_values = {
             'name': name,
             'key': full_snippet_key,

--- a/addons/website/models/website_snippet_filter.py
+++ b/addons/website/models/website_snippet_filter.py
@@ -60,7 +60,7 @@ class WebsiteSnippetFilter(models.Model):
         records = self._prepare_values(limit, search_domain)
         View = self.env['ir.ui.view'].sudo().with_context(inherit_branding=False)
         content = View._render_template(template_key, dict(records=records)).decode('utf-8')
-        return [ET.tostring(el) for el in ET.fromstring('<root>%s</root>' % content).getchildren()]
+        return [ET.tostring(el, encoding='utf-8') for el in ET.fromstring('<root>%s</root>' % content).getchildren()]
 
     def _prepare_values(self, limit=None, search_domain=None):
         """Gets the data and returns it the right format for render."""

--- a/odoo/addons/base/models/qweb.py
+++ b/odoo/addons/base/models/qweb.py
@@ -367,7 +367,7 @@ class QWeb(object):
 
         if isinstance(document, etree._Element):
             element = document
-            document = etree.tostring(document)
+            document = etree.tostring(document, encoding='utf-8')
         elif not document.strip().startswith('<') and os.path.exists(document):
             element = etree.parse(document).getroot()
         else:


### PR DESCRIPTION

Since lxml 4.5.0 that use now use libxml2 2.9.10, without it, it can crash.

Here sample of content that is broken:
https://drive.google.com/file/d/1gB2-jl4fabHscLjH9OZc4WZgtSEbCVj7/view?usp=sharing

opw-2428617
opw-2428664
