### PR TITLE
[FIX] website_sale: send quotation with current website in links

### DIFF
--- a/addons/website_sale/models/mail_compose_message.py
+++ b/addons/website_sale/models/mail_compose_message.py
@@ -10,11 +10,16 @@ class MailComposeMessage(models.TransientModel):
     def send_mail(self, auto_commit=False):
         context = self._context
         # TODO TDE: clean that brole one day
-        if context.get('website_sale_send_recovery_email') and self.model == 'sale.order' and context.get('active_ids'):
+        if self.model == 'sale.order' and context.get('active_ids'):
             self.env['sale.order'].search([
                 ('id', 'in', context.get('active_ids')),
-                ('cart_recovery_email_sent', '=', False),
-                ('is_abandoned_cart', '=', True)
-            ]).write({'cart_recovery_email_sent': True})
-            self = self.with_context(mail_post_autofollow=True)
+                ('website_id', '=', False),
+            ]).write({'website_id': self.env['website'].get_current_website()})
+            if context.get('website_sale_send_recovery_email'):
+                self.env['sale.order'].search([
+                    ('id', 'in', context.get('active_ids')),
+                    ('cart_recovery_email_sent', '=', False),
+                    ('is_abandoned_cart', '=', True)
+                ]).write({'cart_recovery_email_sent': True})
+                self = self.with_context(mail_post_autofollow=True)
         return super(MailComposeMessage, self).send_mail(auto_commit=auto_commit)


### PR DESCRIPTION
Issue

	- Set website A to Company A with domain A
	- Set website B to Company B with domain B
	- Log in on website A
	- Log in (in an other tab) on website B
	- With logged user on website A:
	- Create a quotation and send it

	In mail content, the link redirect to website B

Cause

	Since no website_id is linked to the order, the url is based
	on the system param 'web.base.url' who have the domain of the
	last logged user.

Solution

	If not website_id is set on Order when "Sent by mail", then
	set it (so.website_id) to the current website.

opw-2449793