### PR TITLE
[FIX]crm: do not propagate lead email to partner if formatting differs

### DIFF
--- a/addons/crm/tests/common.py
+++ b/addons/crm/tests/common.py
@@ -118,9 +118,32 @@ class TestCrmCommon(TestSalesCommon, MailCase):
         cls.lead_team_1_lost.action_set_lost()
         (cls.lead_team_1_won | cls.lead_team_1_lost).flush()
 
+        # email / phone data
+        cls.test_email_data = [
+            '"Planet Express" <planet.express@test.example.com>',
+            '"Philip, J. Fry" <philip.j.fry@test.example.com>',
+            '"Turanga Leela" <turanga.leela@test.example.com>',
+        ]
+        cls.test_email_data_normalized = [
+            'planet.express@test.example.com',
+            'philip.j.fry@test.example.com',
+            'turanga.leela@test.example.com',
+        ]
+        cls.test_pĥone_data = [
+            '+1 202 555 0122',  # formatted US number
+            '202 555 0999',  # local US number
+            '202 555 0888',  # local US number
+        ]
+        cls.test_pĥone_data_sanitized = [
+            '+12025550122',
+            '+12025550999',
+            '+12025550888',
+        ]
+
+        # create some test contact and companies
         cls.contact_company_1 = cls.env['res.partner'].create({
             'name': 'Planet Express',
-            'email': 'planet.express@test.example.com',
+            'email': cls.test_email_data[0],
             'is_company': True,
             'street': '57th Street',
             'city': 'New New York',
@@ -129,8 +152,8 @@ class TestCrmCommon(TestSalesCommon, MailCase):
         })
         cls.contact_1 = cls.env['res.partner'].create({
             'name': 'Philip J Fry',
-            'email': 'philip.j.fry@test.example.com',
-            'mobile': '+1 202 555 0122',
+            'email': cls.test_email_data[1],
+            'mobile': cls.test_pĥone_data[0],
             'title': cls.env.ref('base.res_partner_title_mister').id,
             'function': 'Delivery Boy',
             'phone': False,
@@ -143,13 +166,14 @@ class TestCrmCommon(TestSalesCommon, MailCase):
         })
         cls.contact_2 = cls.env['res.partner'].create({
             'name': 'Turanga Leela',
-            'email': 'turanga.leela@test.example.com',
+            'email': cls.test_email_data[2],
+            'mobile': cls.test_pĥone_data[1],
+            'phone': cls.test_pĥone_data[2],
             'parent_id': False,
             'is_company': False,
             'street': 'Cookieville Minimum-Security Orphanarium',
             'city': 'New New York',
             'country_id': cls.env.ref('base.us').id,
-            'mobile': '+1 202 555 0999',
             'zip': '97648',
         })
 

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -256,6 +256,13 @@ class TestCRMLead(TestCrmCommon):
         self.assertEqual(lead.phone_sanitized, partner_mobile_sanitized,
                          'Lead: phone_sanitized computed field on mobile')
 
+        # for email_from, if only formatting differs, warning ribbon should
+        # not appear and email on partner should not be updated
+        lead_form.email_from = '"Hermes Conrad" <%s>' % partner_email_normalized
+        self.assertFalse(lead_form.ribbon_message)
+        lead_form.save()
+        self.assertEqual(lead_form.partner_id.email, partner_email)
+
         # LEAD/PARTNER SYNC: lead updates partner
         new_email = '"John Zoidberg" <john.zoidberg@test.example.com>'
         new_email_normalized = 'john.zoidberg@test.example.com'

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -216,26 +216,47 @@ class TestCRMLead(TestCrmCommon):
         lead, partner = self.lead_1.with_user(self.env.user), self.contact_2
         lead_form = Form(lead)
 
-        # reset partner phone to a local number
-        partner_phone, partner_email = '202 555 0999', partner.email
+        # reset partner phone to a local number and prepare formatted / sanitized values
+        partner_phone, partner_mobile = self.test_pĥone_data[2], self.test_pĥone_data[1]
         partner_phone_formatted = phone_format(partner_phone, 'US', '1')
         partner_phone_sanitized = phone_format(partner_phone, 'US', '1', force_format='E164')
-        self.assertEqual(partner_phone_formatted, '+1 202-555-0999')
-        self.assertEqual(partner_phone_sanitized, '+12025550999')
-        partner.phone = partner_phone
+        partner_mobile_formatted = phone_format(partner_mobile, 'US', '1')
+        partner_mobile_sanitized = phone_format(partner_mobile, 'US', '1', force_format='E164')
+        partner_email, partner_email_normalized = self.test_email_data[2], self.test_email_data_normalized[2]
+        self.assertEqual(partner_phone_formatted, '+1 202-555-0888')
+        self.assertEqual(partner_phone_sanitized, self.test_pĥone_data_sanitized[2])
+        self.assertEqual(partner_mobile_formatted, '+1 202-555-0999')
+        self.assertEqual(partner_mobile_sanitized, self.test_pĥone_data_sanitized[1])
+        # ensure initial data
+        self.assertEqual(partner.phone, partner_phone)
+        self.assertEqual(partner.mobile, partner_mobile)
+        self.assertEqual(partner.email, partner_email)
 
-        # email & phone must be automatically set on the lead
+        # LEAD/PARTNER SYNC: email and phone are propagated to lead
+        # as well as mobile (who does not trigger the reverse sync)
         lead_form.partner_id = partner
         self.assertEqual(lead_form.email_from, partner_email)
-        self.assertEqual(lead_form.phone, partner_phone_formatted)
+        self.assertEqual(lead_form.phone, partner_phone_formatted,
+                         'Lead: form automatically formats numbers')
+        self.assertEqual(lead_form.mobile, partner_mobile_formatted,
+                         'Lead: form automatically formats numbers')
         self.assertFalse(lead_form.ribbon_message)
 
         lead_form.save()
-        self.assertEqual(partner.phone, partner_phone)
-        self.assertEqual(lead.phone, partner_phone_formatted)
-        self.assertEqual(lead.phone_sanitized, partner_phone_sanitized)
+        self.assertEqual(partner.phone, partner_phone,
+                         'Lead / Partner: partner values sent to lead')
+        self.assertEqual(lead.email_from, partner_email,
+                         'Lead / Partner: partner values sent to lead')
+        self.assertEqual(lead.email_normalized, partner_email_normalized,
+                         'Lead / Partner: equal emails should lead to equal normalized emails')
+        self.assertEqual(lead.phone, partner_phone_formatted,
+                         'Lead / Partner: partner values (formatted) sent to lead')
+        self.assertEqual(lead.mobile, partner_mobile_formatted,
+                         'Lead / Partner: partner values (formatted) sent to lead')
+        self.assertEqual(lead.phone_sanitized, partner_mobile_sanitized,
+                         'Lead: phone_sanitized computed field on mobile')
 
-        # writing on the lead field must change the partner field
+        # LEAD/PARTNER SYNC: lead updates partner
         new_email = '"John Zoidberg" <john.zoidberg@test.example.com>'
         new_email_normalized = 'john.zoidberg@test.example.com'
         lead_form.email_from = new_email
@@ -251,13 +272,28 @@ class TestCRMLead(TestCrmCommon):
         self.assertEqual(partner.email_normalized, new_email_normalized)
         self.assertEqual(partner.phone, new_phone_formatted)
 
-        # resetting lead values also resets partner
-        lead_form.email_from, lead_form.phone = False, False
+        # LEAD/PARTNER SYNC: mobile does not update partner
+        new_mobile = '+1 202 555 6543'
+        new_mobile_formatted = phone_format(new_mobile, 'US', '1')
+        lead_form.mobile = new_mobile
+        lead_form.save()
+        self.assertEqual(lead.mobile, new_mobile_formatted)
+        self.assertEqual(partner.mobile, partner_mobile)
+
+        # LEAD/PARTNER SYNC: reseting lead values also resets partner for email
+        # and phone, but not for mobile
+        lead_form.email_from, lead_form.phone, lead.mobile = False, False, False
         self.assertIn('the customer email and phone number will', lead_form.ribbon_message)
         lead_form.save()
         self.assertFalse(partner.email)
         self.assertFalse(partner.email_normalized)
         self.assertFalse(partner.phone)
+        self.assertFalse(lead.phone)
+        self.assertFalse(lead.mobile)
+        self.assertFalse(lead.phone_sanitized)
+        self.assertEqual(partner.mobile, partner_mobile)
+        self.assertEqual(partner.phone_sanitized, partner_mobile_sanitized,
+                         'Partner sanitized should be computed on mobile')
 
     @users('user_sales_manager')
     def test_crm_lead_stages(self):

--- a/addons/crm/tests/test_crm_lead_convert.py
+++ b/addons/crm/tests/test_crm_lead_convert.py
@@ -31,6 +31,7 @@ class TestLeadConvert(crm_common.TestLeadConvertCommon):
     @users('user_sales_manager')
     def test_lead_convert_base(self):
         """ Test base method ``convert_opportunity`` or crm.lead model """
+        self.contact_2.phone = False  # force Falsy to compare with mobile
         self.assertFalse(self.contact_2.phone)
         lead = self.lead_1.with_user(self.env.user)
         lead.write({


### PR DESCRIPTION
PURPOSE

    in the crm lead if only formating different in email
    the email is updating in the partner also, but the
    email is same and it has only formatting difference
    than we don't have to update that email in partner,
    if the email is change than and only than we have
    to update that email

    Right way to detect the email change is:
        * lead email is difference from partner email
        * lead formatted email is different from partner formatted email

    if this both conditions are match than we are quit sure the email
    are different and not only formatting different.

SPECIFICATION

    in this commit we are fix the inverse of email, email in the crm lead
    has a two parts one is email header and one is email, if the we change
    the header of the email it consider as a only formatting difference
    and if we change in the email it consider as a email is change,
    and if email is change than it also update the partner email.

    Tests are added to ensure new behavior and that ribbon message is effectively
    trig erred with correct content.

    LINKS

    Task ID-2461308
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
