### PR TITLE
[FIX] account_fleet: Adding vehicle_id for in_refund.

### DIFF
--- a/addons/account_fleet/views/account_move_views.xml
+++ b/addons/account_fleet/views/account_move_views.xml
@@ -7,11 +7,11 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='line_ids']//field[@name='account_id']" position="after">
                 <field name='need_vehicle' invisible='1'/>
-                <field name='vehicle_id' attrs="{'required': [('need_vehicle', '=', True), ('parent.move_type', '=', 'in_invoice')], 'column_invisible': [('parent.move_type', '!=', 'in_invoice')]}" optional='hidden'/>
+                <field name='vehicle_id' attrs="{'required': [('need_vehicle', '=', True), ('parent.move_type', 'in', ('in_invoice', 'in_refund'))], 'column_invisible': [('parent.move_type', 'not in', ('in_invoice', 'in_refund'))]}" optional='hidden'/>
             </xpath>
             <xpath expr="//field[@name='invoice_line_ids']//field[@name='account_id']" position="after">
                 <field name='need_vehicle' invisible='1'/>
-                <field name='vehicle_id' attrs="{'required': [('need_vehicle', '=', True), ('parent.move_type', '=', 'in_invoice')], 'column_invisible': [('parent.move_type', '!=', 'in_invoice')]}" optional='hidden'/>
+                <field name='vehicle_id' attrs="{'required': [('need_vehicle', '=', True), ('parent.move_type', 'in', ('in_invoice', 'in_refund'))], 'column_invisible': [('parent.move_type', 'not in', ('in_invoice', 'in_refund'))]}" optional='hidden'/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Field `vehicle_id` is missing on the `account.move.line` view of refunds.
This fix updates the domain to make visible the field in `in_refund`.

**Task ID:** #2466914

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
