### PR TITLE
[FIX] web: display control panel dropdown on top of modal

### DIFF
--- a/addons/web/static/src/js/views/list/list_editable_renderer.js
+++ b/addons/web/static/src/js/views/list/list_editable_renderer.js
@@ -623,6 +623,12 @@ ListRenderer.include({
         var self = this;
         this.currentRow = null;
         return this._super.apply(this, arguments).then(function () {
+            // display the filters,groups and favorites on top of modal
+            var model = self.el.closest('.modal-body');
+            if (model) {
+                var isModalOverflowing = model.clientHeight < model.firstElementChild.clientHeight + model.lastElementChild.clientHeight;
+                model.style.overflow = isModalOverflowing ? 'auto' : 'visible';
+            }
             if (self._isEditable()) {
                 self.$('table').addClass('o_editable_list');
             }

--- a/addons/web/static/src/js/views/view_dialogs.js
+++ b/addons/web/static/src/js/views/view_dialogs.js
@@ -356,6 +356,9 @@ var SelectCreateDialog = ViewDialog.extend({
                         in_DOM: true,
                     });
                     self.set_buttons(self.__buttons);
+
+                    // display the filters,groups and favorites on top of modal
+                    self.el.style.overflow = self.el.scrollHeight > self.el.clientHeight ? 'auto' : 'visible';
                 });
                 _super();
             });

--- a/addons/web/static/tests/views/view_dialogs_tests.js
+++ b/addons/web/static/tests/views/view_dialogs_tests.js
@@ -538,6 +538,63 @@ QUnit.module('Views', {
 
         form.destroy();
     });
+
+    QUnit.test('display filters on top of modal body', async function (assert) {
+        assert.expect(3);
+
+        var records = [];
+        for (let i=1; i<=20; i++) {
+            records.push({ 'id': i,'name': 'display_name' + i });
+        }
+        this.data.partner.records = records;
+
+        const parent = await createParent({
+            data: this.data,
+            archs: {
+                'partner,false,list':
+                    '<tree string="Partner">' +
+                        '<field name="display_name"/>' +
+                        '<field name="foo"/>' +
+                    '</tree>',
+                'partner,false,search':
+                    '<search>' +
+                        '<field name="foo" filter_domain="[(\'display_name\',\'ilike\',self), (\'foo\',\'ilike\',self)]"/>' +
+                        '<group expand="0" string="Group By">' +
+                            '<filter name="groupby_bar" context="{\'group_by\' : \'bar\'}"/>' +
+                            '<filter name="groupby_bar1" context="{\'group_by\' : \'bar\'}"/>' +
+                            '<filter name="groupby_bar2" context="{\'group_by\' : \'bar\'}"/>' +
+                            '<filter name="groupby_bar3" context="{\'group_by\' : \'bar\'}"/>' +
+                            '<filter name="groupby_bar4" context="{\'group_by\' : \'bar\'}"/>' +
+                        '</group>' +
+                    '</search>',
+            },
+        });
+
+        const dialog = new dialogs.SelectCreateDialog(parent, {
+            res_model: 'partner',
+            context: {
+                search_default_groupby_bar: true,
+            },
+        }).open();
+
+        // check that the filter displays on top of modal
+        await testUtils.dom.click(dialog.el.querySelector('.o_search_options .fa.fa-bars'));
+        assert.strictEqual(dialog.el.style.overflow, 'visible',
+            "element should contain visible property");
+
+        // check that removing the groups make content scrollable
+        await testUtils.dom.click(dialog.el.querySelector('.o_group_by_menu a'));
+        assert.strictEqual(dialog.el.style.overflow, 'auto',
+            "element should not contain visible property");
+
+        // check that the filter displays on top of modal
+        await testUtils.dom.click(dialog.el.querySelector('.o_group_by_menu a'));
+        assert.strictEqual(dialog.el.style.overflow, 'visible',
+            "element should contain visible property");
+
+        parent.destroy();
+    });
+
 });
 
 });


### PR DESCRIPTION
Currently, the control panel dropdown hides inside the modal body due to
auto scroll on the modal body.

So this commit fixes the issues by adding overflow property in the
modal body due to that, it will always display on top of the modal.

TaskID: 2443493