### PR TITLE
[FIX] l10n_fr_pos_cert: hide bill splitting button

### DIFF
--- a/addons/l10n_fr_pos_cert/static/src/js/pos.js
+++ b/addons/l10n_fr_pos_cert/static/src/js/pos.js
@@ -212,6 +212,15 @@ screens.NumpadWidget.include({
     },
 });
 
+screens.ActionButtonWidget.include({
+    start: function(event) {
+        this._super(event);
+        if (this.pos.is_french_country() && this.$el.hasClass('order-split')) {
+            this.$el.prop("hidden", true);
+            this.$el.hide();
+        }
+    },
+});
 
 
 });


### PR DESCRIPTION
- Configure a Company located in France
- Install l10n_fr_pos_cert
- Create a Bar/Restaurant POS
- Enable Bill Splitting
- Open POS session
- Add n quantities of a Product
- Click on Split button
On the bill splitting screen, it is not possible to split the bill as l10n_fr_pos_cert
prevents to modify quantity on order lines, making the feature useless.

The Split button can be hidden for FR localization.

opw-2463872

See https://github.com/odoo/odoo/pull/66852

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
