### PR TITLE
[FIX] packaging: fix typo in control file

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -34,7 +34,7 @@ Depends:
  python3-libsass,
  python3-lxml,
  python3-mako,
- python3-ofxparse
+ python3-ofxparse,
  python3-passlib,
  python3-polib,
  python3-psutil,


### PR DESCRIPTION
During the resolution of conflicts in odoo/odoo#66784, a typo was
introduced in debian/control file.

sad but true.