### PR TITLE
[FIX] website_sale_digital: ignore Note/Section

### DIFF
--- a/addons/website_sale_digital/models/account_invoice.py
+++ b/addons/website_sale_digital/models/account_invoice.py
@@ -23,7 +23,7 @@ class AccountInvoiceLine(models.Model):
 
         # Get free products
         purchases += self.env['sale.order.line'].sudo().search_read(
-            domain=[('order_id.partner_id', '=', partner.id), '|', ('price_subtotal', '=', 0.0), ('order_id.amount_total', '=', 0.0)],
+            domain=[('display_type', '=', False), ('order_id.partner_id', '=', partner.id), '|', ('price_subtotal', '=', 0.0), ('order_id.amount_total', '=', 0.0)],
             fields=['product_id'],
         )
 


### PR DESCRIPTION
When downloading the digital file, if there exists one SO linked to the
current customer and that contains a Note/Section, the web page will be
redirected to the "Internal Server Error" web page.

To reproduce the error:
(Need sale_management)
1. Create a customer C
2. Grant C portal access
3. Create a product P
    - Add a digital attachment
4. Create a SO
    - Customer: C
    - Add product P
    - Add a note
5. Save, Confirm, Create Invoice, Register Payment
6. Sign in with P
7. Consult the SO web page
8. Download the file attached to the SO line

Error: The page is redirected to the "Internal Server Error" web page.

When downloading the document, the module checks the customer's access.
To do so, it gets all relevant invoices and free products. Here is the
problem, when getting the free products, the domain includes the SO
lines used for Section and Note. As a result, when it tries to read the
product of such a line, this will raise an error.

OPW-2419478