### PR TITLE
[FIX] survey : fix the function extract comment from the answers

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -535,7 +535,7 @@ class Survey(http.Controller):
                 if not isinstance(answers, list):
                     answers = [answers]
                 for answer in answers:
-                    if 'comment' in answer:
+                    if isinstance(answer, dict) and 'comment' in answer:
                         comment = answer['comment'].strip()
                     else:
                         answers_no_comment.append(answer)


### PR DESCRIPTION
[FIX] survey : fix the function extract comment from the answers

Steps to follow to reproduce the bug:
	-Go to survey
	-Choose any survey with at least one "single text box" question
	-In the survey form
	-Click on the button test
	-Complete the survey, but in a "single text box" question, write the word "comment"
	-Validate the survey
	-An error is triggered.

Problem :
In the function which extracts comments from answers, it doesn't check the type in which the answer is stored.
When there is a comment, it is stored in a dict under the key: "comment".
To find the comment, the function checks if "comment"(key) is in the answer.
But in the case of "single text box" question, the answer is stored in a string.
If the word "comment" is present in the answer, the function looking for the key "comment" will return True and try to extract the comment.

Solution :
Add a check to ensure that we are looking for the key "comment" in dict type.

opw-2446194

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
