### PR TITLE
[IMP] crm - inline email and phone sync warnings on crm lead

### DIFF
--- a/addons/crm/__manifest__.py
+++ b/addons/crm/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'CRM',
-    'version': '1.4',
+    'version': '1.5',
     'category': 'Sales/CRM',
     'sequence': 15,
     'summary': 'Track leads and close opportunities',

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -6,7 +6,6 @@ from odoo.addons.crm.tests.common import TestCrmCommon, INCOMING_EMAIL
 from odoo.addons.phone_validation.tools.phone_validation import phone_format
 from odoo.tests.common import Form, users
 
-
 class TestCRMLead(TestCrmCommon):
 
     @classmethod
@@ -250,7 +249,8 @@ class TestCRMLead(TestCrmCommon):
         lead_form.partner_id = partner
         self.assertEqual(lead_form.email_from, partner_email)
         self.assertEqual(lead_form.phone, partner_phone_formatted)
-        self.assertFalse(lead_form.ribbon_message)
+        self.assertFalse(lead_form.partner_email_update)
+        self.assertFalse(lead_form.partner_phone_update)
 
         lead_form.save()
         self.assertEqual(partner.phone, partner_phone)
@@ -261,12 +261,13 @@ class TestCRMLead(TestCrmCommon):
         new_email = '"John Zoidberg" <john.zoidberg@test.example.com>'
         new_email_normalized = 'john.zoidberg@test.example.com'
         lead_form.email_from = new_email
-        self.assertIn('the customer email will', lead_form.ribbon_message)
+        self.assertTrue(lead_form.partner_email_update)
         new_phone = '+1 202 555 7799'
         new_phone_formatted = phone_format(new_phone, 'US', '1')
         lead_form.phone = new_phone
         self.assertEqual(lead_form.phone, new_phone_formatted)
-        self.assertIn('the customer email and phone number will', lead_form.ribbon_message)
+        self.assertTrue(lead_form.partner_email_update)
+        self.assertTrue(lead_form.partner_phone_update)
 
         lead_form.save()
         self.assertEqual(partner.email, new_email)
@@ -275,7 +276,8 @@ class TestCRMLead(TestCrmCommon):
 
         # resetting lead values also resets partner
         lead_form.email_from, lead_form.phone = False, False
-        self.assertIn('the customer email and phone number will', lead_form.ribbon_message)
+        self.assertTrue(lead_form.partner_email_update)
+        self.assertTrue(lead_form.partner_phone_update)
         lead_form.save()
         self.assertFalse(partner.email)
         self.assertFalse(partner.email_normalized)

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -22,9 +22,6 @@
                             domain="['|', ('team_id', '=', team_id), ('team_id', '=', False)]"
                             attrs="{'invisible': ['|', ('active', '=', False), ('type', '=', 'lead')]}"/>
                     </header>
-                    <div class="text-center alert alert-primary oe_edit_only" role="alert" attrs="{'invisible': ['|', ('ribbon_message', '=', False), ('ribbon_message', '=', '')]}">
-                        <field name="ribbon_message"/>
-                    </div>
                     <sheet>
                         <field name="active" invisible="1"/>
                         <div class="oe_button_box" name="button_box">
@@ -162,6 +159,8 @@
                                 <field name="mobile_blacklisted" invisible="1"/>
                                 <field name="email_state" invisible="1"/>
                                 <field name="phone_state" invisible="1"/>
+                                <field name="partner_email_update" invisible="1"/>
+                                <field name="partner_phone_update" invisible="1"/>
                                 <label for="email_from" class="oe_inline"/>
                                 <div class="o_row o_row_readonly">
                                     <button name="mail_action_blacklist_remove" class="fa fa-ban text-danger"
@@ -169,6 +168,9 @@
                                         type="object" context="{'default_email': email_from}" groups="base.group_user"
                                         attrs="{'invisible': [('is_blacklisted', '=', False)]}"/>
                                     <field name="email_from" string="Email" widget="email"/>
+                                    <span class="fa fa-exclamation-triangle text-warning" 
+                                        title="By saving this change, the customer email will also be updated." 
+                                        attrs="{'invisible': [('partner_email_update', '=', False)]}"/>
                                 </div>
                                 <label for="phone" class="oe_inline"/>
                                 <div class="o_row o_row_readonly">
@@ -177,6 +179,9 @@
                                         type="object" context="{'default_phone': phone}" groups="base.group_user"
                                         attrs="{'invisible': [('phone_blacklisted', '=', False)]}"/>
                                     <field name="phone" widget="phone"/>
+                                    <span class="fa fa-exclamation-triangle text-warning" 
+                                        title="By saving this change, the customer phone number will also be updated." 
+                                        attrs="{'invisible': [('partner_phone_update', '=', False)]}"/>
                                 </div>
                             </group>
                             <group name="lead_info" attrs="{'invisible': [('type', '=', 'opportunity')]}">
@@ -189,6 +194,8 @@
                                 <field name="phone_blacklisted" invisible="1"/>
                                 <field name="email_state" invisible="1"/>
                                 <field name="phone_state" invisible="1"/>
+                                <field name="partner_email_update" invisible="1"/>
+                                <field name="partner_phone_update" invisible="1"/>
                                 <label for="email_from_group_lead_info" class="oe_inline"/>
                                 <div class="o_row o_row_readonly">
                                     <button name="mail_action_blacklist_remove" class="fa fa-ban text-danger"
@@ -196,6 +203,9 @@
                                         type="object" context="{'default_email': email_from}" groups="base.group_user"
                                         attrs="{'invisible': [('is_blacklisted', '=', False)]}"/>
                                     <field name="email_from" id="email_from_group_lead_info" string="Email" widget="email"/>
+                                    <span class="fa fa-exclamation-triangle text-warning" 
+                                        title="By saving this change, the customer email will also be updated." 
+                                        attrs="{'invisible': [('partner_email_update', '=', False)]}"/>
                                 </div>
                                 <field name="email_cc" groups="base.group_no_one"/>
                                 <field name="function"/>
@@ -206,6 +216,9 @@
                                         type="object" context="{'default_phone': phone}" groups="base.group_user"
                                         attrs="{'invisible': [('phone_blacklisted', '=', False)]}"/>
                                     <field name="phone" id="phone_group_lead_info" widget="phone"/>
+                                    <span class="fa fa-exclamation-triangle text-warning" 
+                                        title="By saving this change, the customer phone number will also be updated." 
+                                        attrs="{'invisible': [('partner_phone_update', '=', False)]}"/>
                                 </div>
                                 <label for="mobile" class="oe_inline"/>
                                 <div class="o_row o_row_readonly">


### PR DESCRIPTION
Reduce eye catchiness of warning message when warning the user that
his changes on email and phone will also update customer.

Before, used a ribbon. Now, only displays a red alert sign at the end of
the fields when a change would update the customer profile. Hovering on
the alert sign displays the appropriate message.

Python compute method of ribbon field is split in two compute methods,
one per boolean field will_write_email/phone. Previous compute for ribbon
message is deleted but the field is maintained to ease further ribbon
implementation and extensivity.

Updates ribbon_message tests accordingly

Task Id - 2456105
PR - 66909 