### PR TITLE
[FIX] l10n_mx: allow MX to print receipts

### DIFF
--- a/addons/l10n_mx/i18n/l10n_mx.pot
+++ b/addons/l10n_mx/i18n/l10n_mx.pot
@@ -128,6 +128,12 @@ msgid "Nature"
 msgstr ""
 
 #. module: l10n_mx
+#: code:addons/l10n_mx/models/account_move.py:0
+#, python-format
+msgid "Only invoices can be printed."
+msgstr ""
+
+#. module: l10n_mx
 #: model:ir.model.fields,help:l10n_mx.field_account_setup_bank_manual_config__l10n_mx_edi_clabe
 #: model:ir.model.fields,help:l10n_mx.field_res_partner_bank__l10n_mx_edi_clabe
 msgid ""

--- a/addons/l10n_mx/models/__init__.py
+++ b/addons/l10n_mx/models/__init__.py
@@ -6,3 +6,4 @@ from . import account
 from . import res_bank
 from . import res_config_settings
 from . import chart_template
+from . import account_move

--- a/addons/l10n_mx/models/account_move.py
+++ b/addons/l10n_mx/models/account_move.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models, _
+from odoo.exceptions import UserError
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    def _get_report_base_filename(self):
+        self.ensure_one()
+        if (self.company_id.country_id and self.company_id.country_id.code) == 'MX':
+            if not self.is_invoice(include_receipts=True):
+                raise UserError(_("Only invoices can be printed."))
+            return self._get_move_display_name()
+        return super()._get_report_base_filename()


### PR DESCRIPTION
To reproduce the error:
(Need MX configuration)
1. Go to Accounting > Customers > Receipts
2. Create a Receipt
3. Post and Print it

Error: An error message is displayed: "Only invoices could be printed."
However, MX should be allowed to print the receipts.

OPW-2456374