### PR TITLE
Color Picker adjustment

### DIFF
--- a/addons/web/static/src/legacy/scss/color_picker.scss
+++ b/addons/web/static/src/legacy/scss/color_picker.scss
@@ -2,6 +2,7 @@
     display: flex;
     float: right;
     margin-right: 7px;
+    width: 100%;
     ul {
         display: flex;
         justify-content: flex-end;
@@ -15,6 +16,7 @@
         > li {
             border: 2px solid white;
             box-shadow: 0 0 0 1px gray('300');
+            margin: $o-kanban-inner-hmargin 4px 0 0;
             > a:focus {
                 outline: none;
             }


### PR DESCRIPTION
PURPOSE
On smaller screens, one of the colors is sent to the line below while they could all fit on the same line

SPEC
It would be great to "align" the first color to the left so that all square can fit.

TaskId: 2454346


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
