### PR TITLE
[IMP] web: boot.js: throw even if not in debug

### DIFF
--- a/addons/web/static/src/js/boot.js
+++ b/addons/web/static/src/js/boot.js
@@ -123,19 +123,17 @@
                 });
         }
 
-        if (odoo.debug) {
-            if (!(deps instanceof Array)) {
-                throw new Error('Dependencies should be defined by an array', deps);
-            }
-            if (typeof factory !== 'function') {
-                throw new Error('Factory should be defined by a function', factory);
-            }
-            if (typeof name !== 'string') {
-                throw new Error("Invalid name definition (should be a string", name);
-            }
-            if (name in factories) {
-                throw new Error("Service " + name + " already defined");
-            }
+        if (!(deps instanceof Array)) {
+            throw new Error('Dependencies should be defined by an array', deps);
+        }
+        if (typeof factory !== 'function') {
+            throw new Error('Factory should be defined by a function', factory);
+        }
+        if (typeof name !== 'string') {
+            throw new Error("Invalid name definition (should be a string", name);
+        }
+        if (name in factories) {
+            throw new Error("Service " + name + " already defined");
         }
 
         factory.deps = deps;

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -640,7 +640,6 @@
         <script type="text/javascript" src="/web/static/lib/nearest/jquery.nearest.js"/>
         <script type="text/javascript" src="/web/static/lib/daterangepicker/daterangepicker.js"></script>
         <script type="text/javascript" src="/web/static/lib/stacktracejs/stacktrace.js"></script>
-        <script type="text/javascript" src="/web/static/src/js/libs/daterangepicker.js"></script>
 
         <script type="text/javascript" src="/web/static/tests/main_tests.js"></script>
 


### PR DESCRIPTION
Before this commit, when a module wasn't correctly defined (e.g.
wrong format for dependencies, wrong format for module name, name
already defined...), an error was thrown but only in debug mode.
In non debug mode, the problem was simply ignored, which is wrong.

An example of harmful consequence would be the following: if
someone defines a new test file and uses an already used module
name, he won't be notified of his mistake unless he runs the suite
in debug mode. If he doesn't, the runbot won't detect it either as
it runs tests in non debug mode. It would then lead to one of the
two test suites not being executed.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
