### PR TITLE
[IMP] website: make refresh routes less visible

### DIFF
--- a/addons/website/views/website_rewrite.xml
+++ b/addons/website/views/website_rewrite.xml
@@ -7,7 +7,7 @@
                 <form string="Website rewrite Settings">
                     <header>
                         <button name="refresh_routes" string="Refresh route's list" type="object"
-                                class="btn-primary"
+                                class="btn-light"
                                 attrs="{'invisible':[('redirect_type', '!=', '308')]}"
                         />
                     </header>


### PR DESCRIPTION
Primary color lets imagine that it is the primary action to be done to update
the routing. While it is just to refresh the url_from list if you have missing
route (new module installed, ...)

Maybe we should just remove this button at the end.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
