### PR TITLE
[FW][FIX] web_editor: have video button even if sanitized

### DIFF
--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -226,7 +226,7 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
                         toolbar.splice(-1, 0, ['view', ['codeview']]);
                     }
                 }
-                if (self.field.sanitize && self.field.sanitize_tags) {
+                if (self.model === "mail.compose.message" || self.model === "mailing.mailing") {
                     options.noVideos = true;
                 }
                 options.prettifyHtml = false;


### PR DESCRIPTION
If a field is sanitized, a6e2b48 would hide the video button because
the video does not show in backend. It is better for the consistency but
if the field appear in frontend, the video would still show so we
prevent something that worked (but is very not user friendly when
editing in backend).

This changeset go back to the previous behavior (keeping the code
simplification), at one point there should be a fix so at least when
editing we see the video (currently we see an empty div in given
conditions).

opw-2463746

X-original-commit: 73f5781
Forward-Port-Of: #66434