### PR TITLE
[IMP] core: delegate fields should be auto_join=True

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1128,6 +1128,18 @@ class TestMany2one(TransactionCase):
         ''']):
             self.User.search([('name', 'like', 'foo')])
 
+        # the field supporting the inheritance should be auto_join, too
+        # TODO: use another model, since 'res.users' has explicit auto_join
+        with self.assertQueries(['''
+            SELECT "res_users".id
+            FROM "res_users"
+            LEFT JOIN "res_partner" AS "res_users__partner_id" ON
+                ("res_users"."partner_id" = "res_users__partner_id"."id")
+            WHERE ("res_users__partner_id"."name"::text LIKE %s)
+            ORDER BY "res_users__partner_id"."name", "res_users"."login"
+        ''']):
+            self.User.search([('partner_id.name', 'like', 'foo')])
+
     def test_regular(self):
         self.Partner.search([('company_id.partner_id.name', 'like', self.company.name)])
         self.Partner.search([('country_id.code', 'like', 'BE')])

--- a/odoo/addons/test_inherit/tests/test_inherit.py
+++ b/odoo/addons/test_inherit/tests/test_inherit.py
@@ -12,6 +12,11 @@ class test_inherits(common.TransactionCase):
 
         self.assertEqual(daughter._inherits, {'test.inherit.mother': 'template_id'})
 
+        # the field supporting the inheritance should be auto_join
+        field = daughter._fields['template_id']
+        self.assertTrue(field.delegate)
+        self.assertTrue(field.auto_join, "delegate fields should be auto_join")
+
     def test_10_access_from_child_to_parent_model(self):
         """ check whether added field in model is accessible from children models (_inherits) """
         # This test checks if the new added column of a parent model

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -2586,6 +2586,9 @@ class Many2one(_Relational):
         # determine self.delegate
         if not self.delegate:
             self.delegate = name in model._inherits.values()
+        # self.delegate implies self.auto_join
+        if self.delegate:
+            self.auto_join = True
 
     def _setup_regular_base(self, model):
         super()._setup_regular_base(model)


### PR DESCRIPTION
The field that supports inheritance should be auto_join=True.  This
guarantees that searching on an inherited field (X) or its explicit
related expression (foo_id.X) gives the same query.

Note that adding auto_join=True on that field does not weakens the
model's security, since searching on the model automatically injects the
parent model's security rules into the query (see _apply_ir_rules).