### PR TITLE
[FIX] base: @odoo-module alias ending with **/

### DIFF
--- a/odoo/addons/test_assetsbundle/tests/test_js_transpiler_regex.py
+++ b/odoo/addons/test_assetsbundle/tests/test_js_transpiler_regex.py
@@ -19,17 +19,21 @@ class TestJsTranspiler(TransactionCase):
             '// @odoo-module alias=web.test',
             '/* @odoo-module  alias=web.test',
             '/** @odoo-module  alias=web.test',
+            '/** @odoo-module  alias=web.test**/',
             '/* @odoo-module  alias=web.test ',
             '/* @odoo-module alias=web.test default=false',
             '/* @odoo-module alias=web.test default=false ',
+            '/* @odoo-module alias=web.test default=false**/',
         ]
 
         for case in cases:
             assert ODOO_MODULE_RE.match(case), "URL_RE is failing... >%s<" % case
             if "alias" in case:
                 assert ODOO_MODULE_RE.match(case).groupdict().get('alias'), "URL_RE is failing for alias... >%s<" % case
+                assert ODOO_MODULE_RE.match(case).groupdict().get('alias') == "web.test", "URL_RE does not get the right alias for ... >%s<" % case
             if "default" in case:
                 assert ODOO_MODULE_RE.match(case).groupdict().get('default'), "URL_RE is failing for default... >%s<" % case
+                assert ODOO_MODULE_RE.match(case).groupdict().get('default') == "false", "URL_RE does not get the right default for ... >%s<" % case
 
     def test_incorrect_ODOO_MODULE_RE(self):
         cases = [

--- a/odoo/tools/js_transpiler.py
+++ b/odoo/tools/js_transpiler.py
@@ -537,10 +537,10 @@ def relative_path_to_module_path(url, path_rel):
 
 
 ODOO_MODULE_RE = re.compile(r"""
-    \s*                                       # some starting space  
+    \s*                                       # some starting space
     \/(\*|\/).*\s*                            # // or /*
     @odoo-module                              # @odoo-module
-    (\s+alias=(?P<alias>\S+))?                # alias=web.AbstractAction (optional)
+    (\s+alias=(?P<alias>[\w.]+))?             # alias=web.AbstractAction (optional)
     (\s+default=(?P<default>False|false|0))?  # default=False or false or 0 (optional)
 """, re.VERBOSE)
 


### PR DESCRIPTION
When you define an @odoo-module with an alias without any space between
the alias and the **/, the alias contains the **/.
The purpose of this commit is to no longer add the **/ to the alias.

Example:
/** @odoo-module alias=web.base**/

Before:
  odoo.define(`web.base**/`, function(require) {
After:
  odoo.define(`web.base`, function(require) {

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
