### PR TITLE
[FIX] calendar: Fix access right issue on env.companies

### DIFF
--- a/addons/calendar/models/calendar_alarm_manager.py
+++ b/addons/calendar/models/calendar_alarm_manager.py
@@ -218,7 +218,7 @@ class AlarmManager(models.AbstractModel):
         notifications = []
         users = self.env['res.users'].search([('partner_id', 'in', tuple(partner_ids))])
         for user in users:
-            notif = self.with_user(user).get_next_notif()
+            notif = self.with_user(user).with_context(allowed_company_ids=user.company_ids.ids).get_next_notif()
             notifications.append([(self._cr.dbname, 'calendar.alarm', user.partner_id.id), notif])
         if len(notifications) > 0:
             self.env['bus.bus'].sendmany(notifications)

--- a/addons/calendar/tests/test_calendar.py
+++ b/addons/calendar/tests/test_calendar.py
@@ -315,3 +315,34 @@ class TestCalendar(SavepointCaseWithUserDemo):
 
         # no more email should be sent
         _test_one_mail_per_attendee(self, partners)
+
+    def test_event_creation_sudo_other_company(self):
+        """ Check Access right issue when create event with sudo
+
+            Create a company, a user in that company
+            Create an event for someone else in another company as sudo
+            Should not failed for acces right check
+        """
+        now = fields.Datetime.context_timestamp(self.partner_demo, fields.Datetime.now())
+
+        web_company = self.env['res.company'].sudo().create({'name': "Website Company"})
+        web_user = self.env['res.users'].with_company(web_company).sudo().create({
+            'name': 'web user',
+            'login': 'web',
+            'company_id': web_company.id
+        })
+        self.CalendarEvent.with_user(web_user).with_company(web_company).sudo().create({
+            'name': "Test",
+            'allday': False,
+            'recurrency': False,
+            'partner_ids': [(6, 0, self.partner_demo.ids)],
+            'alarm_ids': [(0, 0, {
+                'name': 'Alarm',
+                'alarm_type': 'notification',
+                'interval': 'minutes',
+                'duration': 30,
+            })],
+            'user_id': self.user_demo.id,
+            'start': fields.Datetime.to_string(now + timedelta(hours=5)),
+            'stop': fields.Datetime.to_string(now + timedelta(hours=6)),
+        })


### PR DESCRIPTION
Context
-------

in the module website_calendar, the controller create
an event with alarm with the Public user and the company of the public
user
and set partner_ids that may belong to a different company

Issue
-----
The company of the user that create the event remains in the context
and _notify_next_alarm check for each user which event should be notify
using with user of the partner that may be notified and check the access
rules to filter the event the partner should actually see.

The check of the acces rules need env.companies that remains the company
of the user that create the event which the current user may not see
which trigger the following error.

"Access to unauthorized or invalid companies."

Solution
--------
Wipe the company in the context when calling get_next_notif


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
