### PR TITLE
[FIX] mrp: avoid settings qty_done before production start

### DIFF
--- a/addons/mrp/models/mrp_abstract_workorder.py
+++ b/addons/mrp/models/mrp_abstract_workorder.py
@@ -330,14 +330,6 @@ class MrpAbstractWorkorderLine(models.AbstractModel):
     qty_reserved = fields.Float('Reserved', digits='Product Unit of Measure')
     company_id = fields.Many2one('res.company', compute='_compute_company_id')
 
-    @api.onchange('lot_id')
-    def _onchange_lot_id(self):
-        """ When the user is encoding a produce line for a tracked product, we apply some logic to
-        help him. This onchange will automatically switch `qty_done` to 1.0.
-        """
-        if self.product_id.tracking == 'serial':
-            self.qty_done = 1
-
     @api.onchange('product_id')
     def _onchange_product_id(self):
         if self.product_id and not self.move_id:

--- a/addons/mrp/wizard/mrp_product_produce.py
+++ b/addons/mrp/wizard/mrp_product_produce.py
@@ -178,3 +178,14 @@ class MrpProductProduceLine(models.TransientModel):
     def _get_production(self):
         product_produce_id = self.raw_product_produce_id or self.finished_product_produce_id
         return product_produce_id.production_id
+
+    @api.onchange('lot_id')
+    def _onchange_lot_id(self):
+        """ When the user is encoding a produce line for a tracked product, we apply some logic to
+        help him. This onchange will automatically switch `qty_done` to 1.0.
+        """
+        if self.product_id.tracking == 'serial':
+            if self.lot_id:
+                self.qty_done = 1
+            else:
+                self.qty_done = 0


### PR DESCRIPTION
- Create a product [Subcomponent1] stored, tracked by SN, with some units
on hand (having 2 units with SN 1 and 2 would do)
- Create a manufactured [Final] product
- Create a BOM for [Final] with component [Subcomponent1] and specify a
routing with include processing in a workcenter (i.e. primary assebly)
- Create a MO for [Final], confirm, check and plan
- On the created workorder, change the lot id for [Subcomponent1] from 1
to 2.
- Now go to processing, the system will still suggest to consume SN 1,
change to 2 and validate.

The user will be blocked because the system already set `qty_done` to 1
when changing SN in the workorder form view, but now the user has no way
to put back the qty_done to 0 or just mark the workorder as complete

opw-2456638

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
