### PR TITLE
[FIX] purchase_stock: `on_time_rate` product other company than PO

### DIFF
--- a/addons/purchase_stock/models/res_partner.py
+++ b/addons/purchase_stock/models/res_partner.py
@@ -20,7 +20,7 @@ class ResPartner(models.Model):
             ('partner_id', 'in', self.ids),
             ('date_order', '>', fields.Date.today() - timedelta(365)),
             ('qty_received', '!=', 0),
-        ]).filtered(lambda l: l.product_id.product_tmpl_id.type != 'service' and l.order_id.state in ['done', 'purchase'])
+        ]).filtered(lambda l: l.product_id.sudo().product_tmpl_id.type != 'service' and l.order_id.state in ['done', 'purchase'])
         partner_dict = {}
         for line in order_lines:
             on_time, ordered = partner_dict.get(line.partner_id, (0, 0))


### PR DESCRIPTION
- User in company A,
- Purchase order in company A,
- Product in company B

```
  File "/home/odoo/src/odoo/14.0/addons/purchase_stock/models/res_partner.py", line 23, in _compute_on_time_rate
    ]).filtered(lambda l: l.product_id.product_tmpl_id.type != 'service' and l.order_id.state in ['done', 'purchase'])
  File "/home/odoo/src/odoo/14.0/odoo/models.py", line 5279, in filtered
    return self.browse([rec.id for rec in self if func(rec)])
  File "/home/odoo/src/odoo/14.0/odoo/models.py", line 5279, in <listcomp>
    return self.browse([rec.id for rec in self if func(rec)])
  File "/home/odoo/src/odoo/14.0/addons/purchase_stock/models/res_partner.py", line 23, in <lambda>
    ]).filtered(lambda l: l.product_id.product_tmpl_id.type != 'service' and l.order_id.state in ['done', 'purchase'])
  File "/home/odoo/src/odoo/14.0/odoo/fields.py", line 2483, in __get__
    return super().__get__(records, owner)
  File "/home/odoo/src/odoo/14.0/odoo/fields.py", line 998, in __get__
    record._fetch_field(self)
  File "/home/odoo/src/odoo/14.0/odoo/models.py", line 3072, in _fetch_field
    self._read(fnames)
  File "/home/odoo/src/odoo/14.0/odoo/models.py", line 3183, in _read
    raise self.env['ir.rule']._make_access_error('read', forbidden)
odoo.exceptions.AccessError: Due to security restrictions, you are not allowed to access 'Product' (product.product) records.
```

If you do not share products between companies
(if the multi-company record rule for `product.template` is enabled)
then you are not supposed to use a product from another company in a purchase order.

However, this is possible to land in the case if you enable
the multi-company record rule after you created some purchase orders,
using products from other companies.

Adding `sudo()` just to get the type of product
doesn't cost much to support that case

upg-8277
