### PR TITLE
[IMP] core: avoid flushing fields to read

### DIFF
--- a/addons/account/tests/test_account_account.py
+++ b/addons/account/tests/test_account_account.py
@@ -61,7 +61,7 @@ class TestAccountAccount(AccountTestInvoicingCommon):
 
         # Set the account as reconcile and fully reconcile something.
         account.reconcile = True
-        self.env['account.move.line'].invalidate_model()
+        self.env.invalidate_all()
 
         self.assertRecordValues(move.line_ids, [
             {'reconciled': False, 'amount_residual': 100.0, 'amount_residual_currency': 200.0},
@@ -77,7 +77,7 @@ class TestAccountAccount(AccountTestInvoicingCommon):
         # Set back to a not reconcile account and check the journal items.
         move.line_ids.remove_move_reconcile()
         account.reconcile = False
-        self.env['account.move.line'].invalidate_model()
+        self.env.invalidate_all()
 
         self.assertRecordValues(move.line_ids, [
             {'reconciled': False, 'amount_residual': 0.0, 'amount_residual_currency': 0.0},
@@ -119,7 +119,7 @@ class TestAccountAccount(AccountTestInvoicingCommon):
 
         # Set the account as reconcile and partially reconcile something.
         account.reconcile = True
-        self.env['account.move.line'].invalidate_model()
+        self.env.invalidate_all()
 
         move.line_ids.filtered(lambda line: line.account_id == account).reconcile()
 

--- a/addons/calendar/models/calendar_alarm_manager.py
+++ b/addons/calendar/models/calendar_alarm_manager.py
@@ -15,6 +15,10 @@ class AlarmManager(models.AbstractModel):
     _description = 'Event Alarm Manager'
 
     def _get_next_potential_limit_alarm(self, alarm_type, seconds=None, partners=None):
+        # flush models before making queries
+        for model_name in ('calendar.alarm', 'calendar.event', 'calendar.recurrence'):
+            self.env[model_name].flush_model()
+
         result = {}
         delta_request = """
             SELECT

--- a/addons/calendar/tests/test_calendar.py
+++ b/addons/calendar/tests/test_calendar.py
@@ -161,6 +161,7 @@ class TestCalendar(SavepointCaseWithUserDemo):
             'stop_date': "2018-10-18",
             'allday': True,
         })
+        self.env.invalidate_all()
         self.assertEqual(str(event.start), '2018-10-16 08:00:00')
         self.assertEqual(str(event.stop), '2018-10-18 18:00:00')
 

--- a/addons/crm/tests/test_crm_pls.py
+++ b/addons/crm/tests/test_crm_pls.py
@@ -191,6 +191,9 @@ class TestCRMPLS(TransactionCase):
         # rebuild frequencies table and recompute automated_probability for all leads.
         Lead._cron_update_automated_probabilities()
 
+        # As the cron is computing and writing in SQL queries, we need to invalidate the cache
+        self.env.invalidate_all()
+
         self.assertEqual(tools.float_compare(leads[3].automated_probability, 33.49, 2), 0)
         self.assertEqual(tools.float_compare(leads[8].automated_probability, 7.74, 2), 0)
         lead_13_team_3_proba = leads[13].automated_probability
@@ -403,6 +406,7 @@ class TestCRMPLS(TransactionCase):
 
         # Force recompute - A priori, no need to do this as, for each won / lost, we increment tag frequency.
         Lead._cron_update_automated_probabilities()
+        self.env.invalidate_all()
 
         lead_tag_1 = leads_with_tags[30]
         lead_tag_2 = leads_with_tags[90]
@@ -440,6 +444,7 @@ class TestCRMPLS(TransactionCase):
         leads.filtered(lambda lead: lead.id % 2 == 0).email_state = 'correct'
         leads.filtered(lambda lead: lead.id % 2 == 1).email_state = 'incorrect'
         Lead._cron_update_automated_probabilities()
+        self.env.invalidate_all()
 
         self.assertEqual(tools.float_compare(leads[3].automated_probability, 4.21, 2), 0)
         self.assertEqual(tools.float_compare(leads[8].automated_probability, 0.23, 2), 0)
@@ -447,6 +452,7 @@ class TestCRMPLS(TransactionCase):
         # remove all pls fields
         self.env['ir.config_parameter'].sudo().set_param("crm.pls_fields", False)
         Lead._cron_update_automated_probabilities()
+        self.env.invalidate_all()
 
         self.assertEqual(tools.float_compare(leads[3].automated_probability, 34.38, 2), 0)
         self.assertEqual(tools.float_compare(leads[8].automated_probability, 50.0, 2), 0)
@@ -454,6 +460,7 @@ class TestCRMPLS(TransactionCase):
         # check if the probabilities are the same with the old param
         self.env['ir.config_parameter'].sudo().set_param("crm.pls_fields", "country_id,state_id,email_state,phone_state,source_id")
         Lead._cron_update_automated_probabilities()
+        self.env.invalidate_all()
 
         self.assertEqual(tools.float_compare(leads[3].automated_probability, 4.21, 2), 0)
         self.assertEqual(tools.float_compare(leads[8].automated_probability, 0.23, 2), 0)

--- a/addons/delivery/tests/test_delivery_cost.py
+++ b/addons/delivery/tests/test_delivery_cost.py
@@ -45,10 +45,10 @@ class TestDeliveryCost(common.TransactionCase):
         # as the tests hereunder assume all the prices in USD, we must ensure
         # that the company actually uses USD
         # We do an invalidation so the cache is aware of it too.
+        self.env.company.invalidate_recordset()
         self.env.cr.execute(
             "UPDATE res_company SET currency_id = %s WHERE id = %s",
             [self.env.ref('base.USD').id, self.env.company.id])
-        self.env.company.invalidate_recordset()
         self.pricelist.currency_id = self.env.ref('base.USD').id
 
     def test_00_delivery_cost(self):

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -10,10 +10,9 @@ from werkzeug.urls import url_encode
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, _
-from odoo.osv.query import Query
 from odoo.exceptions import ValidationError, AccessError
 from odoo.osv import expression
-from odoo.tools.misc import format_date
+from odoo.tools import format_date, Query
 
 
 class HrEmployeePrivate(models.Model):

--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -4,9 +4,9 @@
 from random import randint
 
 from odoo import api, fields, models, tools, SUPERUSER_ID
-from odoo.osv.query import Query
-from odoo.tools.translate import _
 from odoo.exceptions import AccessError, UserError
+from odoo.tools import Query
+from odoo.tools.translate import _
 
 from dateutil.relativedelta import relativedelta
 

--- a/addons/hr_work_entry_holidays/tests/test_leave.py
+++ b/addons/hr_work_entry_holidays/tests/test_leave.py
@@ -158,17 +158,16 @@ class TestWorkEntryLeave(TestWorkEntryHolidaysBase):
                 'date_to': datetime(2022, 3, 25, 20),
                 'number_of_days': 4,
             })
-            can_cancel_field = leave._fields['can_cancel']
             leave.with_user(SUPERUSER_ID).action_validate()
             # No work entries exist yet
             self.assertTrue(leave.can_cancel, "The leave should still be cancellable")
             # can not create in the future
             self.richard_emp.contract_ids._generate_work_entries(datetime(2022, 3, 21, 6), datetime(2022, 3, 25, 20))
             work_entries = self.env['hr.work.entry'].search([('employee_id', '=', self.richard_emp.id)])
-            self.env.cache.invalidate([(can_cancel_field, leave.ids)])
+            leave.invalidate_recordset(['can_cancel'])
             # Work entries exist but are not locked yet
             self.assertTrue(leave.can_cancel, "The leave should still be cancellable")
             work_entries.action_validate()
-            self.env.cache.invalidate([(can_cancel_field, leave.ids)])
+            leave.invalidate_recordset(['can_cancel'])
             # Work entries locked
             self.assertFalse(leave.can_cancel, "The leave should not be cancellable")

--- a/addons/l10n_eg_edi_eta/tests/common.py
+++ b/addons/l10n_eg_edi_eta/tests/common.py
@@ -89,13 +89,18 @@ class TestEGEdiCommon(AccountEdiTestCommon):
 
     @classmethod
     def create_invoice(cls, **kwargs):
-        return (cls.env['account.move']
-                .with_context(edi_test_mode=True)
-                .create({
-                    'move_type': 'out_invoice',
-                    'partner_id': cls.partner_a.id,
-                    'invoice_date': '2022-03-15',
-                    'date': '2022-03-15',
-                    **kwargs,
-                    'invoice_line_ids': [Command.create({**line_vals, }) for line_vals in kwargs.get('invoice_line_ids', [])]
-                }))
+        invoice = (
+            cls.env['account.move']
+            .with_context(edi_test_mode=True)
+            .create({
+                'move_type': 'out_invoice',
+                'partner_id': cls.partner_a.id,
+                'invoice_date': '2022-03-15',
+                'date': '2022-03-15',
+                **kwargs,
+                'invoice_line_ids': [Command.create({**line_vals, }) for line_vals in kwargs.get('invoice_line_ids', [])]
+            })
+        )
+        # this fixes rounding issues in cache
+        cls.env.invalidate_all()
+        return invoice

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1093,6 +1093,7 @@ class Message(models.Model):
     def _invalidate_documents(self, model=None, res_id=None):
         """ Invalidate the cache of the documents followed by ``self``. """
         fnames = ['message_ids', 'message_needaction', 'message_needaction_counter']
+        self.flush_recordset(['model', 'res_id'])
         for record in self:
             model = model or record.model
             res_id = res_id or record.res_id

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -357,7 +357,7 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
             'parent_id': main_partner_2.id,
             'company_id': self.env.ref('base.main_company').id,
         })
-        self.env.cache.invalidate()
+        self.env.invalidate_all()
 
         # We create a different BoM for the same product
         comp3 = self.env['product.product'].create({

--- a/addons/project/tests/test_project_report.py
+++ b/addons/project/tests/test_project_report.py
@@ -33,6 +33,9 @@ class TestProjectReport(TestProjectCommon):
         self.assertEqual(task_3.rating_avg, 0)
         self.assertEqual(task_3.rating_last_value, 0)
 
+        # fix cache consistency
+        self.env['project.task'].invalidate_model(['rating_avg', 'rating_last_value'])
+
         tasks = [self.task_1, self.task_2, task_3]
         for task in tasks:
             rating_values = task.read(['rating_avg', 'rating_last_value'])[0]

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -638,6 +638,7 @@ class PurchaseOrder(models.Model):
             # Invoice_ids may be filtered depending on the user. To ensure we get all
             # invoices related to the purchase order, we read them in sudo to fill the
             # cache.
+            self.invalidate_model(['invoice_ids'])
             self.sudo()._read(['invoice_ids'])
             invoices = self.invoice_ids
 

--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -602,7 +602,7 @@ class TestReorderingRule(TransactionCase):
                     "route_ids": [],
                 }
             )
-        self.env.cache.invalidate()
+        self.env.invalidate_all()
 
         self.env["procurement.group"].run([procurement])
 
@@ -707,10 +707,11 @@ class TestReorderingRule(TransactionCase):
             {'qty_forecast': -1, 'qty_to_order': 1},
         ])
 
-        delivery.scheduled_date += td(days=7)
+        # invalidate the fields that will eventually be inconsistent
         orderpoint.invalidate_model(fnames=['qty_forecast', 'qty_to_order'])
         orderpoint.product_id.invalidate_model(fnames=['virtual_available'])
 
+        delivery.scheduled_date += td(days=7)
         self.assertRecordValues(orderpoint, [
             {'qty_forecast': 0, 'qty_to_order': 0},
         ])

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -176,6 +176,7 @@ class TestSaleOrder(TestSaleCommon):
 
         # upsell and invoice
         self.sol_serv_order.write({'product_uom_qty': 10})
+
         # There is a bug with `new` and `_origin`
         # If you create a first new from a record, then change a value on the origin record, than create another new,
         # this other new wont have the updated value of the origin record, but the one from the previous new
@@ -184,10 +185,7 @@ class TestSaleOrder(TestSaleCommon):
         # Here, we update `qty_delivered` on the origin record, but the `new` records which are in cache with this order line
         # as origin are not updated, nor the fields that depends on it.
         self.env.flush_all()
-        for field in self.env['sale.order.line']._fields.values():
-            for res_id in list(self.env.cache._data[field]):
-                if not res_id:
-                    self.env.cache._data[field].pop(res_id)
+        self.env.invalidate_all()
 
         invoice3 = self.sale_order._create_invoices()
         self.assertEqual(len(invoice3.invoice_line_ids), 1, 'Sale: third invoice is missing lines')

--- a/addons/sale_loyalty/tests/test_program_rules.py
+++ b/addons/sale_loyalty/tests/test_program_rules.py
@@ -269,8 +269,6 @@ class TestProgramRules(TestSaleCouponCommon):
             })
         ]})
         # Invalidate total_order_count
-        field_order_count = self.env['loyalty.program']._fields['order_count']
-        field_total_order_count = self.env['loyalty.program']._fields['total_order_count']
-        self.env.cache.invalidate([(field_order_count, self.immediate_promotion_program.ids), (field_total_order_count, self.immediate_promotion_program.ids)])
+        self.immediate_promotion_program.invalidate_recordset(['order_count', 'total_order_count'])
         self._auto_rewards(order, self.immediate_promotion_program)
         self.assertEqual(len(order.order_line.ids), 2, "The promo offer shouldn't have been applied as the number of uses is exceeded")

--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -6,7 +6,7 @@ import json
 from odoo import api, fields, models, _, _lt
 from odoo.exceptions import ValidationError, AccessError
 from odoo.osv import expression
-from odoo.osv.query import Query
+from odoo.tools import Query
 
 
 class Project(models.Model):

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -93,6 +93,7 @@ class TestSaleStock(TestSaleCommon, ValuationReconciliationTestCommon):
         self.assertEqual(del_qties, del_qties_truth, 'Sale Stock: delivered quantities are wrong after complete delivery')
         # Without timesheet, we manually set the delivered qty for the product serv_del
         self.so.order_line.sorted()[1]['qty_delivered'] = 2.0
+
         # There is a bug with `new` and `_origin`
         # If you create a first new from a record, then change a value on the origin record, than create another new,
         # this other new wont have the updated value of the origin record, but the one from the previous new
@@ -101,10 +102,8 @@ class TestSaleStock(TestSaleCommon, ValuationReconciliationTestCommon):
         # Here, we update `qty_delivered` on the origin record, but the `new` records which are in cache with this order line
         # as origin are not updated, nor the fields that depends on it.
         self.env.flush_all()
-        for field in self.env['sale.order.line']._fields.values():
-            for res_id in list(self.env.cache._data[field]):
-                if not res_id:
-                    self.env.cache._data[field].pop(res_id)
+        self.env.invalidate_all()
+
         inv_id = self.so._create_invoices()
         self.assertEqual(self.so.invoice_status, 'invoiced',
                          'Sale Stock: so invoice_status should be "fully invoiced" after complete delivery and invoicing')

--- a/addons/stock/report/report_stock_quantity.py
+++ b/addons/stock/report/report_stock_quantity.py
@@ -9,6 +9,15 @@ class ReportStockQuantity(models.Model):
     _auto = False
     _description = 'Stock Quantity Report'
 
+    _depends = {
+        'product.product': ['product_tmpl_id'],
+        'product.template': ['type'],
+        'stock.location': ['parent_path'],
+        'stock.move': ['company_id', 'date', 'location_dest_id', 'location_id', 'product_id', 'product_qty', 'state'],
+        'stock.quant': ['company_id', 'location_id', 'product_id', 'quantity'],
+        'stock.warehouse': ['view_location_id'],
+    }
+
     date = fields.Date(string='Date', readonly=True)
     product_tmpl_id = fields.Many2one('product.template', readonly=True)
     product_id = fields.Many2one('product.product', string='Product', readonly=True)

--- a/addons/website/tests/test_views.py
+++ b/addons/website/tests/test_views.py
@@ -774,7 +774,7 @@ class TestCowViewSaving(TestViewSavingCommon):
             'arch': '<div position="replace"><p>COMPARE</p></div>',
             'key': '_website_sale_comparison.product_add_to_compare',
         })])
-        Website.with_context(load_all_views=True).viewref('_website_sale_comparison.product_add_to_compare').invalidate_model()
+        View.invalidate_model()
 
         # Simulate end of installation/update
         View._create_all_specific_views(['_website_sale_comparison'])

--- a/odoo/addons/base/models/ir_rule.py
+++ b/odoo/addons/base/models/ir_rule.py
@@ -233,8 +233,7 @@ class IrRule(models.Model):
             failing_rules += "\n\n" + _('Note: this might be a multi-company issue.')
 
         # clean up the cache of records prefetched with display_name above
-        for record in records[:6]:
-            record._cache.clear()
+        records_sudo.invalidate_recordset()
 
         msg = f"{operation_error}\n\n{failing_records}\n{failing_user}\n\n{failing_rules}\n\n{resolution_info}"
         return AccessError(msg)

--- a/odoo/addons/base/models/ir_translation.py
+++ b/odoo/addons/base/models/ir_translation.py
@@ -251,6 +251,7 @@ class IrTranslation(models.Model):
         :param src: the source of the translation
         """
         self._modified_model(name.split(',')[0])
+        self.flush_model()
 
         # update existing translations
         self._cr.execute("""UPDATE ir_translation
@@ -259,6 +260,7 @@ class IrTranslation(models.Model):
                             RETURNING res_id""",
                          (value, src, 'translated', lang, tt, name, tuple(ids)))
         existing_ids = [row[0] for row in self._cr.fetchall()]
+        self.invalidate_model(['value', 'src', 'state'])
 
         # create missing translations
         self.sudo().create([{
@@ -723,6 +725,7 @@ class IrTranslation(models.Model):
                 """,
                 (values[0], values[1], values[2], where[0], where[1], where[2], tuple(values[3]))
             )
+        self.invalidate_model(['value', 'src', 'state'])
 
     @api.model
     def translate_fields(self, model, id, field=None):

--- a/odoo/addons/base/tests/test_db_cursor.py
+++ b/odoo/addons/base/tests/test_db_cursor.py
@@ -51,6 +51,8 @@ class TestTestCursor(common.TransactionCase):
         record.flush_model(['ref'])
 
     def check(self, record, value):
+        # make sure to fetch the field from the database
+        record.invalidate_recordset()
         self.assertEqual(record.read(['ref'])[0]['ref'], value)
 
     def test_single_cursor(self):

--- a/odoo/addons/base/tests/test_ir_actions.py
+++ b/odoo/addons/base/tests/test_ir_actions.py
@@ -514,8 +514,8 @@ class TestCustomFields(common.TransactionCase):
                 'store': True,
             })
 
-        # same with a related field, it only takes 5 extra queries
-        with self.assertQueryCount(query_count + 5):
+        # same with a related field, it only takes 8 extra queries
+        with self.assertQueryCount(query_count + 8):
             self.env.registry.clear_caches()
             self.env['ir.model.fields'].create({
                 'model_id': model_id,

--- a/odoo/addons/base/tests/test_osv.py
+++ b/odoo/addons/base/tests/test_osv.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.osv.query import Query
 from odoo.tests.common import BaseCase
+from odoo.tools import Query
 
 
 class QueryTestCase(BaseCase):

--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -112,7 +112,8 @@ class MergePartnerAutomatic(models.TransientModel):
         Partner = self.env['res.partner']
         relations = self._get_fk_on('res_partner')
 
-        self.env.flush_all()
+        # this guarantees cache consistency
+        self.env.invalidate_all()
 
         for table, column in relations:
             if 'base_partner_merge_' in table:  # ignore two tables
@@ -174,8 +175,6 @@ class MergePartnerAutomatic(models.TransientModel):
                     # keeping record with nonexistent partner_id is useless, better delete it
                     query = 'DELETE FROM "%(table)s" WHERE "%(column)s" IN %%s' % query_dic
                     self._cr.execute(query, (tuple(src_partners.ids),))
-
-        self.env.invalidate_all()
 
     @api.model
     def _update_reference_fields(self, src_partners, dst_partner):

--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -935,9 +935,8 @@ class Attachment(models.Model):
             return
         comodel = self.env[self.res_model]
         if 'res_id' in fnames and 'attachment_ids' in comodel:
-            field = comodel._fields['attachment_ids']
             record = comodel.browse(self.res_id)
-            self.env.cache.invalidate([(field, record._ids)])
+            record.invalidate_recordset(['attachment_ids'])
             record.modified(['attachment_ids'])
         return super(Attachment, self).modified(fnames, *args, **kwargs)
 

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -244,6 +244,7 @@ class TestFields(TransactionCaseWithUserDemo):
                 (0, 0, {'name': 'x_stuff_id', 'ttype': 'many2one', 'relation': 'ir.model'}),
             ],
         })
+        self.env.invalidate_all()
         # set 'x_stuff_id' refer to a model not loaded yet
         self.cr.execute("""
             UPDATE ir_model_fields
@@ -791,7 +792,6 @@ class TestFields(TransactionCaseWithUserDemo):
 
         # switch to environment with user demo
         records = records.with_user(self.user_demo)
-        records.env.cache.invalidate()
 
         # check that records are not accessible
         with self.assertRaises(AccessError):
@@ -1611,7 +1611,7 @@ class TestFields(TransactionCaseWithUserDemo):
         """ test field access on new records vs real records. """
         Model = self.env['test_new_api.category']
         real_record = Model.create({'name': 'Foo'})
-        self.env.cache.invalidate()
+        self.env.invalidate_all()
         new_origin = Model.new({'name': 'Bar'}, origin=real_record)
         new_record = Model.new({'name': 'Baz'})
 
@@ -2080,6 +2080,7 @@ class TestFields(TransactionCaseWithUserDemo):
         self.assertEqual(demo_discussion.messages, discussion.messages)
 
         # See YTI FIXME
+        self.env.flush_all()
         self.env.invalidate_all()
 
         # add a message as user demo
@@ -2744,12 +2745,12 @@ class TestX2many(common.TransactionCase):
         self.assertEqual(parent.with_context(active_test=False).active_children_ids, act_children)
 
         # check read()
-        self.env.cache.invalidate()
+        self.env.invalidate_all()
         self.assertEqual(parent.children_ids, act_children)
         self.assertEqual(parent.all_children_ids, all_children)
         self.assertEqual(parent.active_children_ids, act_children)
 
-        self.env.cache.invalidate()
+        self.env.invalidate_all()
         self.assertEqual(parent.with_context(active_test=False).children_ids, all_children)
         self.assertEqual(parent.with_context(active_test=False).all_children_ids, all_children)
         self.assertEqual(parent.with_context(active_test=False).active_children_ids, act_children)

--- a/odoo/addons/test_new_api/tests/test_onchange.py
+++ b/odoo/addons/test_new_api/tests/test_onchange.py
@@ -49,7 +49,7 @@ class TestOnChange(SavepointCaseWithUserDemo):
             'author': USER.id,
             'size': 0,
         }
-        self.env.cache.invalidate()
+        self.env.invalidate_all()
         result = self.Message.onchange(values, 'discussion', field_onchange)
         self.assertIn('name', result['value'])
         self.assertEqual(result['value']['name'], "[%s] %s" % (discussion.name, USER.name))
@@ -62,7 +62,7 @@ class TestOnChange(SavepointCaseWithUserDemo):
             'author': USER.id,
             'size': 0,
         }
-        self.env.cache.invalidate()
+        self.env.invalidate_all()
         result = self.Message.onchange(values, 'body', field_onchange)
         self.assertIn('size', result['value'])
         self.assertEqual(result['value']['size'], len(BODY))
@@ -76,7 +76,7 @@ class TestOnChange(SavepointCaseWithUserDemo):
             'author': USER.id,
             'size': 0,
         }
-        self.env.cache.invalidate()
+        self.env.invalidate_all()
         result = self.Message.onchange(values, 'body', field_onchange)
         self.assertNotIn('name', result['value'])
 
@@ -94,7 +94,7 @@ class TestOnChange(SavepointCaseWithUserDemo):
             'root_categ': False,
         }
 
-        self.env.cache.invalidate()
+        self.env.invalidate_all()
         result = Category.onchange(values, 'parent', field_onchange).get('value', {})
         self.assertIn('root_categ', result)
         self.assertEqual(result['root_categ'], root.name_get()[0])
@@ -102,7 +102,7 @@ class TestOnChange(SavepointCaseWithUserDemo):
         values.update(result)
         values['parent'] = False
 
-        self.env.cache.invalidate()
+        self.env.invalidate_all()
         result = Category.onchange(values, 'parent', field_onchange).get('value', {})
         self.assertIn('root_categ', result)
         self.assertIs(result['root_categ'], False)
@@ -143,7 +143,7 @@ class TestOnChange(SavepointCaseWithUserDemo):
                 }),
             ],
         }
-        self.env.cache.invalidate()
+        self.env.invalidate_all()
         result = self.Discussion.onchange(values, 'name', field_onchange)
         self.assertIn('messages', result['value'])
         self.assertEqual(result['value']['messages'], [
@@ -214,7 +214,7 @@ class TestOnChange(SavepointCaseWithUserDemo):
                 }),
             ],
         }
-        self.env.cache.invalidate()
+        self.env.invalidate_all()
         result = self.Discussion.onchange(values, 'name', field_onchange)
         self.assertIn('messages', result['value'])
         self.assertItemsEqual(result['value']['messages'], [
@@ -263,7 +263,7 @@ class TestOnChange(SavepointCaseWithUserDemo):
             'lines': [Command.set([line1.id]),
                       Command.create({'name': False, 'partner': False, 'tags': [Command.clear()]})],
         }
-        self.env.cache.invalidate()
+        self.env.invalidate_all()
 
         result = multi.onchange(values, 'partner', field_onchange)
         self.assertEqual(result['value'], {
@@ -292,7 +292,7 @@ class TestOnChange(SavepointCaseWithUserDemo):
                               'partner': False,
                               'tags': [Command.clear(), Command.create({'name': 'Tag'})]})],
         }
-        self.env.cache.invalidate()
+        self.env.invalidate_all()
         result = multi.onchange(values, 'partner', field_onchange)
         expected_value = {
             'name': partner2.name,
@@ -313,13 +313,13 @@ class TestOnChange(SavepointCaseWithUserDemo):
         self.assertEqual(result['value'], expected_value)
 
         # ensure ID is not returned when asked and a many2many record is set to be created
-        self.env.cache.invalidate()
+        self.env.invalidate_all()
 
         result = multi.onchange(values, 'partner', dict(field_onchange, **{'lines.tags.id': None}))
         self.assertEqual(result['value'], expected_value)
 
         # ensure inverse of one2many field is not returned
-        self.env.cache.invalidate()
+        self.env.invalidate_all()
 
         result = multi.onchange(values, 'partner', dict(field_onchange, **{'lines.multi': None}))
         self.assertEqual(result['value'], expected_value)
@@ -348,7 +348,7 @@ class TestOnChange(SavepointCaseWithUserDemo):
             'messages': [Command.link(msg.id) for msg in discussion.messages],
             'participants': [Command.link(usr.id) for usr in discussion.participants],
         }
-        self.env.cache.invalidate()
+        self.env.invalidate_all()
         result = discussion.onchange(values, 'moderator', field_onchange)
 
         self.assertIn('participants', result['value'])
@@ -368,13 +368,13 @@ class TestOnChange(SavepointCaseWithUserDemo):
         self.env['ir.default'].set('test_new_api.foo', 'value2', 666, condition='value1=42')
 
         # setting 'value1' to 42 should trigger the change of 'value2'
-        self.env.cache.invalidate()
+        self.env.invalidate_all()
         values = {'name': 'X', 'value1': 42, 'value2': False}
         result = Foo.onchange(values, 'value1', field_onchange)
         self.assertEqual(result['value'], {'value2': 666})
 
         # setting 'value1' to 24 should not trigger the change of 'value2'
-        self.env.cache.invalidate()
+        self.env.invalidate_all()
         values = {'name': 'X', 'value1': 24, 'value2': False}
         result = Foo.onchange(values, 'value1', field_onchange)
         self.assertEqual(result['value'], {})
@@ -442,7 +442,7 @@ class TestOnChange(SavepointCaseWithUserDemo):
         })
 
         # check if server-side cache is working correctly
-        self.env.cache.invalidate()
+        self.env.invalidate_all()
         self.assertIn(email, discussion.emails)
         self.assertNotIn(email, discussion.important_emails)
         email.important = True
@@ -451,7 +451,7 @@ class TestOnChange(SavepointCaseWithUserDemo):
         # check that when trigger an onchange, we don't reset important emails
         # (force `invalidate` as but appear in onchange only when we get a cache
         # miss)
-        self.env.cache.invalidate()
+        self.env.invalidate_all()
         self.assertEqual(len(discussion.messages), 4)
         values = {
             'name': "Foo Bar",
@@ -462,7 +462,7 @@ class TestOnChange(SavepointCaseWithUserDemo):
             'important_messages': [Command.link(msg.id) for msg in discussion.important_messages],
             'important_emails': [Command.link(eml.id) for eml in discussion.important_emails],
         }
-        self.env.cache.invalidate()
+        self.env.invalidate_all()
         result = discussion.onchange(values, 'name', field_onchange)
 
         self.assertEqual(
@@ -494,13 +494,13 @@ class TestOnChange(SavepointCaseWithUserDemo):
             'message_currency': self.env.user.name_get()[0],
         }
 
-        self.env.cache.invalidate()
+        self.env.invalidate_all()
         Message = self.env['test_new_api.related']
         result = Message.onchange(value, 'message', field_onchange)
 
         self.assertEqual(result['value'], onchange_result)
 
-        self.env.cache.invalidate()
+        self.env.invalidate_all()
         Message = self.env(user=self.user_demo.id)['test_new_api.related']
         result = Message.onchange(value, 'message', field_onchange)
 
@@ -530,7 +530,7 @@ class TestOnChange(SavepointCaseWithUserDemo):
 
         # changing 'discussion' on message should not read 'messages' on discussion
         with patch.object(type(discussion), 'read', mock_read, create=True):
-            self.env.cache.invalidate()
+            self.env.invalidate_all()
             self.Message.onchange(values, 'discussion', field_onchange)
 
         self.assertFalse(called[0], "discussion.messages has been read")

--- a/odoo/addons/test_performance/tests/test_performance.py
+++ b/odoo/addons/test_performance/tests/test_performance.py
@@ -455,17 +455,12 @@ class TestPerformance(SavepointCaseWithUserDemo):
         with self.assertQueries([], flush=False):
             records[1].value = 42
 
-        # fetching 'name' prefetches all fields except 'value_pc' on all records
-        # (because 'value_pc' must be computed); reading those fields causes
-        # field 'value' to be flushed first
+        # fetching 'name' prefetches all fields on all records
         queries = [
-            ''' UPDATE "test_performance_base"
-                SET "value"=%s, "write_date"=%s, "write_uid"=%s
-                WHERE id IN %s
-            ''',
             ''' SELECT "test_performance_base"."id" AS "id",
                        "test_performance_base"."name" AS "name",
                        "test_performance_base"."value" AS "value",
+                       "test_performance_base"."value_pc" AS "value_pc",
                        "test_performance_base"."partner_id" AS "partner_id",
                        "test_performance_base"."total" AS "total",
                        "test_performance_base"."create_uid" AS "create_uid",
@@ -482,24 +477,7 @@ class TestPerformance(SavepointCaseWithUserDemo):
         with self.assertQueries([], flush=False):
             result_value = [record.value for record in records]
 
-        # fetching 'value_pc' (missing from above) prefetches all fields on all
-        # records except the one to compute
-        queries = [
-            ''' SELECT "test_performance_base"."id" AS "id",
-                       "test_performance_base"."name" AS "name",
-                       "test_performance_base"."value" AS "value",
-                       "test_performance_base"."partner_id" AS "partner_id",
-                       "test_performance_base"."total" AS "total",
-                       "test_performance_base"."create_uid" AS "create_uid",
-                       "test_performance_base"."create_date" AS "create_date",
-                       "test_performance_base"."write_uid" AS "write_uid",
-                       "test_performance_base"."write_date" AS "write_date",
-                       "test_performance_base"."value_pc" AS "value_pc"
-                FROM "test_performance_base"
-                WHERE "test_performance_base".id IN %s
-            ''',
-        ]
-        with self.assertQueries(queries, flush=False):
+        with self.assertQueries([], flush=False):
             result_value_pc = [record.value_pc for record in records]
 
         result = list(zip(result_name, result_value, result_value_pc))

--- a/odoo/addons/test_performance/tests/test_performance.py
+++ b/odoo/addons/test_performance/tests/test_performance.py
@@ -444,6 +444,67 @@ class TestPerformance(SavepointCaseWithUserDemo):
             (tuple(initial_records.ids),)
         )
 
+    def test_prefetch_compute(self):
+        records = self.env['test_performance.base'].create([
+            {'name': str(i), 'value': i} for i in [1, 2, 3]
+        ])
+        self.env.flush_all()
+        self.env.invalidate_all()
+
+        # prepare an update, and mark a field to compute
+        with self.assertQueries([], flush=False):
+            records[1].value = 42
+
+        # fetching 'name' prefetches all fields except 'value_pc' on all records
+        # (because 'value_pc' must be computed); reading those fields causes
+        # field 'value' to be flushed first
+        queries = [
+            ''' UPDATE "test_performance_base"
+                SET "value"=%s, "write_date"=%s, "write_uid"=%s
+                WHERE id IN %s
+            ''',
+            ''' SELECT "test_performance_base"."id" AS "id",
+                       "test_performance_base"."name" AS "name",
+                       "test_performance_base"."value" AS "value",
+                       "test_performance_base"."partner_id" AS "partner_id",
+                       "test_performance_base"."total" AS "total",
+                       "test_performance_base"."create_uid" AS "create_uid",
+                       "test_performance_base"."create_date" AS "create_date",
+                       "test_performance_base"."write_uid" AS "write_uid",
+                       "test_performance_base"."write_date" AS "write_date"
+                FROM "test_performance_base"
+                WHERE "test_performance_base".id IN %s
+            ''',
+        ]
+        with self.assertQueries(queries, flush=False):
+            result_name = [record.name for record in records]
+
+        with self.assertQueries([], flush=False):
+            result_value = [record.value for record in records]
+
+        # fetching 'value_pc' (missing from above) prefetches all fields on all
+        # records except the one to compute
+        queries = [
+            ''' SELECT "test_performance_base"."id" AS "id",
+                       "test_performance_base"."name" AS "name",
+                       "test_performance_base"."value" AS "value",
+                       "test_performance_base"."partner_id" AS "partner_id",
+                       "test_performance_base"."total" AS "total",
+                       "test_performance_base"."create_uid" AS "create_uid",
+                       "test_performance_base"."create_date" AS "create_date",
+                       "test_performance_base"."write_uid" AS "write_uid",
+                       "test_performance_base"."write_date" AS "write_date",
+                       "test_performance_base"."value_pc" AS "value_pc"
+                FROM "test_performance_base"
+                WHERE "test_performance_base".id IN %s
+            ''',
+        ]
+        with self.assertQueries(queries, flush=False):
+            result_value_pc = [record.value_pc for record in records]
+
+        result = list(zip(result_name, result_value, result_value_pc))
+        self.assertEqual(result, [('1', 1, 0.01), ('2', 42, 0.42), ('3', 3, 0.03)])
+
     def expected_read_group(self):
         groups = defaultdict(list)
         all_records = self.env['test_performance.base'].search([])

--- a/odoo/addons/test_translation_import/tests/test_term_count.py
+++ b/odoo/addons/test_translation_import/tests/test_term_count.py
@@ -230,7 +230,7 @@ class TestTermCount(common.TransactionCase):
         trans_count = self.env['ir.translation'].search_count([('lang', '=', 'dot')])
         self.assertEqual(trans_count, 1, "The imported translations were not created")
 
-        self.env.context = dict(self.env.context, lang="dot")
+        self.env = self.env(context=dict(self.env.context, lang="dot"))
         self.assertEqual(_("Accounting"), "samva", "The code translation was not applied")
 
     def test_export_pollution(self):

--- a/odoo/addons/test_translation_import/tests/test_term_count.py
+++ b/odoo/addons/test_translation_import/tests/test_term_count.py
@@ -66,7 +66,7 @@ class TestTermCount(common.TransactionCase):
         odoo.tools.trans_load(self.cr, 'test_translation_import/i18n/fr.po', 'fr_FR', verbose=False, overwrite=True)
 
         # trans_load invalidates ormcache but not record cache
-        menu.env.cache.invalidate()
+        self.env.invalidate_all()
         self.assertEqual(menu.name, "New Name")
         self.assertEqual(menu.with_context(lang='fr_FR').name, "Nouveau nom")
 

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -918,6 +918,15 @@ class Cache(object):
         field_cache = self._set_field_cache(records, field)
         field_cache.update(zip(records._ids, values))
 
+    def insert_missing(self, records, field, values):
+        """ Set the values of ``field`` for the records in ``records`` that
+        don't have a value yet.  In other words, this does not overwrite
+        existing values in cache.
+        """
+        field_cache = self._set_field_cache(records, field)
+        for id_, val in zip(records._ids, values):
+            field_cache.setdefault(id_, val)
+
     def remove(self, record, field):
         """ Remove the value of ``field`` for ``record``. """
         try:

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -701,8 +701,15 @@ class Environment(Mapping):
         )
         return self.cr.savepoint()
 
-    def invalidate_all(self):
-        """ Invalidate the cache of all records. """
+    def invalidate_all(self, flush=True):
+        """ Invalidate the cache of all records.
+
+        :param flush: whether pending updates should be flushed before invalidation.
+            It is ``True`` by default, which ensures cache consistency.
+            Do not use this parameter unless you know what you are doing.
+        """
+        if flush:
+            self.flush_all()
         self.cache.invalidate()
 
     def _recompute_all(self):

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1079,13 +1079,15 @@ class Field(MetaField('DummyField', (object,), {})):
         # discard recomputation of self on records
         records.env.remove_to_compute(self, records)
 
-        # update the cache, and discard the records that are not modified
+        # discard the records that are not modified
         cache = records.env.cache
         cache_value = self.convert_to_cache(value, records)
         records = cache.get_records_different_from(records, self, cache_value)
         if not records:
             return records
-        cache.update(records, self, [cache_value] * len(records))
+
+        # update the cache
+        cache.update(records, self, itertools.repeat(cache_value))
 
         # update towrite
         if self.store:
@@ -1666,90 +1668,71 @@ class _String(Field):
         return translate
 
     def write(self, records, value):
+        if not (self.translate and self.store and any(records._ids)):
+            return super().write(records, value)
+
         # discard recomputation of self on records
         records.env.remove_to_compute(self, records)
 
-        # update the cache, and discard the records that are not modified
+        # discard the records that are not modified
         cache = records.env.cache
         cache_value = self.convert_to_cache(value, records)
         records = cache.get_records_different_from(records, self, cache_value)
         if not records:
             return records
-        cache.update(records, self, [cache_value] * len(records))
 
-        if not self.store:
-            return records
+        lang = records.env.lang or None  # used in _update_translations below
+        installed = records.env['res.lang'].get_installed()
+        single_lang = installed[0][0] if len(installed) <= 1 else None
 
-        real_recs = records.filtered('id')
-        if not real_recs._ids:
-            return records
-
-        update_column = True
-        update_trans = False
-        single_lang = len(records.env['res.lang'].get_installed()) <= 1
-        if self.translate:
-            lang = records.env.lang or None  # used in _update_translations below
-            if single_lang:
-                # a single language is installed
-                update_trans = True
-            elif callable(self.translate) or lang == 'en_US':
-                # update the source and synchronize translations
-                update_column = True
-                update_trans = True
-            elif lang != 'en_US' and lang is not None:
-                # update the translations only except if emptying
-                update_column = not cache_value
-                update_trans = True
-            # else: lang = None
-
-        # update towrite if modifying the source
-        if update_column:
+        # modify the column (source)
+        if single_lang or lang in (None, 'en_US') or callable(self.translate) or not cache_value:
             towrite = records.env.all.towrite[self.model_name]
-            for rid in real_recs._ids:
+            for rid in records._ids:
                 # cache_value is already in database format
                 towrite[rid][self.name] = cache_value
             if self.translate is True and cache_value:
-                tname = "%s,%s" % (records._name, self.name)
-                records.env['ir.translation']._set_source(tname, real_recs._ids, value)
-            if self.translate:
-                # invalidate the field in the other languages
-                cache.invalidate([(self, records.ids)])
-                cache.update(records, self, [cache_value] * len(records))
+                tname = f"{self.model_name},{self.name}"
+                records.env['ir.translation']._set_source(tname, records._ids, value)
+            # invalidate the field in all languages because the fallback value
+            # for translations is modified
+            cache.invalidate([(self, records.ids)])
 
-        if update_trans:
-            if callable(self.translate):
-                # the source value of self has been updated, synchronize
-                # translated terms when possible
-                records.env['ir.translation']._sync_terms_translations(self, real_recs)
+        cache.update(records, self, itertools.repeat(cache_value))
 
+        if callable(self.translate):
+            # the source value of self has been updated, synchronize translated
+            # terms when possible
+            records.env['ir.translation']._sync_terms_translations(self, records)
+
+        elif lang:
+            # update translations
+            value = self.convert_to_column(value, records)
+            source_recs = records.with_context(lang=None)
+            source_value = first(source_recs)[self.name]
+            if not source_value:
+                source_recs[self.name] = value
+                source_value = value
+            tname = "%s,%s" % (self.model_name, self.name)
+            if not value:
+                records.env['ir.translation'].search([
+                    ('name', '=', tname),
+                    ('type', '=', 'model'),
+                    ('res_id', 'in', records._ids)
+                ]).unlink()
+            elif single_lang:
+                records.env['ir.translation']._update_translations([dict(
+                    src=source_value,
+                    value=value,
+                    name=tname,
+                    lang=lang,
+                    type='model',
+                    state='translated',
+                    res_id=res_id) for res_id in records._ids])
             else:
-                # update translations
-                value = self.convert_to_column(value, records)
-                source_recs = real_recs.with_context(lang=None)
-                source_value = first(source_recs)[self.name]
-                if not source_value:
-                    source_recs[self.name] = value
-                    source_value = value
-                tname = "%s,%s" % (self.model_name, self.name)
-                if not value:
-                    records.env['ir.translation'].search([
-                        ('name', '=', tname),
-                        ('type', '=', 'model'),
-                        ('res_id', 'in', real_recs._ids)
-                    ]).unlink()
-                elif single_lang:
-                    records.env['ir.translation']._update_translations([dict(
-                        src=source_value,
-                        value=value,
-                        name=tname,
-                        lang=lang,
-                        type='model',
-                        state='translated',
-                        res_id=res_id) for res_id in real_recs._ids])
-                else:
-                    records.env['ir.translation']._set_ids(
-                        tname, 'model', lang, real_recs._ids, value, source_value,
-                    )
+                records.env['ir.translation']._set_ids(
+                    tname, 'model', lang, records._ids, value, source_value,
+                )
 
         return records
 
@@ -2295,7 +2278,7 @@ class Binary(Field):
             # determine records that are known to be not null
             not_null = cache.get_records_different_from(records, self, None)
 
-        cache.update(records, self, [cache_value] * len(records))
+        cache.update(records, self, itertools.repeat(cache_value))
 
         # retrieve the attachments that store the values, and adapt them
         if self.store and any(records._ids):
@@ -2359,7 +2342,7 @@ class Image(Binary):
             new_value = self._image_process(value)
             new_record_values.append((record, new_value))
             cache_value = self.convert_to_cache(value if self.related else new_value, record)
-            record.env.cache.update(record, self, [cache_value] * len(record))
+            record.env.cache.update(record, self, itertools.repeat(cache_value))
         super(Image, self).create(new_record_values)
 
     def write(self, records, value):
@@ -2377,7 +2360,7 @@ class Image(Binary):
 
         super(Image, self).write(records, new_value)
         cache_value = self.convert_to_cache(value if self.related else new_value, records)
-        records.env.cache.update(records, self, [cache_value] * len(records))
+        records.env.cache.update(records, self, itertools.repeat(cache_value))
 
     def _image_process(self, value):
         if self.readonly and not self.max_width and not self.max_height:
@@ -2942,7 +2925,7 @@ class Many2one(_Relational):
         self._remove_inverses(records, cache_value)
 
         # update the cache of self
-        cache.update(records, self, [cache_value] * len(records))
+        cache.update(records, self, itertools.repeat(cache_value))
 
         # update towrite
         if self.store:
@@ -3597,7 +3580,7 @@ class One2many(_RelationalMulti):
                         link(recs[-1], comodel.browse(command[1]))
                     elif command[0] in (Command.CLEAR, Command.SET):
                         # assign the given lines to the last record only
-                        cache.update(recs, self, [()] * len(recs))
+                        cache.update(recs, self, itertools.repeat(()))
                         lines = comodel.browse(command[2] if command[0] == Command.SET else [])
                         cache.set(recs[-1], self, lines._ids)
 
@@ -3675,7 +3658,7 @@ class One2many(_RelationalMulti):
                         link(recs[-1], browse([command[1]]))
                     elif command[0] in (Command.CLEAR, Command.SET):
                         # assign the given lines to the last record only
-                        cache.update(recs, self, [()] * len(recs))
+                        cache.update(recs, self, itertools.repeat(()))
                         lines = comodel.browse(command[2] if command[0] == Command.SET else [])
                         cache.set(recs[-1], self, lines._ids)
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -44,7 +44,8 @@ from operator import attrgetter, itemgetter
 
 import babel.dates
 import dateutil.relativedelta
-import psycopg2, psycopg2.extensions
+import psycopg2
+import psycopg2.extensions
 from lxml import etree
 from lxml.builder import E
 
@@ -53,17 +54,15 @@ from . import SUPERUSER_ID
 from . import api
 from . import tools
 from .exceptions import AccessError, MissingError, ValidationError, UserError
-from .osv.query import Query
-from .tools import frozendict, lazy_classproperty, ormcache, \
-                   LastOrderedSet, OrderedSet, ReversedIterable, \
-                   unique, discardattr, partition
-from .tools.config import config
+from .tools import (
+    clean_context, config, CountingStream, date_utils, discardattr,
+    DEFAULT_SERVER_DATE_FORMAT, DEFAULT_SERVER_DATETIME_FORMAT, frozendict,
+    get_lang, LastOrderedSet, lazy_classproperty, OrderedSet, ormcache,
+    partition, populate, Query, ReversedIterable, split_every, unique,
+)
 from .tools.func import frame_codeinfo
-from .tools.misc import CountingStream, clean_context, DEFAULT_SERVER_DATETIME_FORMAT, DEFAULT_SERVER_DATE_FORMAT, get_lang, split_every
-from .tools.translate import _, _lt
-from .tools import date_utils
-from .tools import populate
 from .tools.lru import LRU
+from .tools.translate import _, _lt
 
 _logger = logging.getLogger(__name__)
 _unlink = logging.getLogger(__name__ + '.unlink')
@@ -2315,7 +2314,7 @@ class BaseModel(metaclass=MetaModel):
             These dictionaries contain the qualified name of each groupby
             (fully qualified SQL name for the corresponding field),
             and the (non raw) field name.
-        :param osv.Query query: the query under construction
+        :param Query query: the query under construction
         :return: (groupby_terms, orderby_terms)
         """
         orderby_terms = []
@@ -4616,7 +4615,7 @@ class BaseModel(metaclass=MetaModel):
         :param bool active_test: whether the default filtering of records with
             ``active`` field set to ``False`` should be applied.
         :return: the query expressing the given domain as provided in domain
-        :rtype: osv.query.Query
+        :rtype: Query
         """
         # if the object has an active field ('active', 'x_active'), filter out all
         # inactive records unless they were explicitly asked for

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -245,6 +245,7 @@ class Registry(Mapping):
             This must be called after loading modules and before using the ORM.
         """
         env = odoo.api.Environment(cr, SUPERUSER_ID, {})
+        env.invalidate_all()
 
         # Uninstall registry hooks. Because of the condition, this only happens
         # on a fully loaded registry, and not on a registry being loaded.
@@ -257,12 +258,6 @@ class Registry(Mapping):
 
         lazy_property.reset_all(self)
         self.registry_invalidated = True
-
-        if env.all.tocompute:
-            _logger.error(
-                "Remaining fields to compute before setting up registry: %s",
-                env.all.tocompute, stack_info=True,
-            )
 
         # we must setup ir.model before adding manual fields because _add_manual_models may
         # depend on behavior that is implemented through overrides, such as is_mail_thread which

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -114,23 +114,17 @@ start the server specifying the ``--unaccent`` flag.
 
 """
 import collections.abc
-import warnings
-
 import logging
 import reprlib
 import traceback
-from functools import partial
-
+import warnings
 from datetime import date, datetime, time
 
 from psycopg2.sql import Composable, SQL
 
 import odoo.modules
-from odoo.osv.query import Query, _generate_table_alias
-from odoo.tools import pycompat
-from odoo.tools.misc import get_lang
-from ..models import MAGIC_COLUMNS, BaseModel
-import odoo.tools as tools
+from ..models import BaseModel
+from odoo.tools import pycompat, Query, _generate_table_alias
 
 
 # Domain operators.

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1734,7 +1734,7 @@ def users(*logins):
                     func(*args, **kwargs)
                 # Invalidate the cache between subtests, in order to not reuse
                 # the former user's cache (`test_read_mail`, `test_write_mail`)
-                self.env.cache.invalidate()
+                self.env.invalidate_all()
         finally:
             self.uid = old_uid
 

--- a/odoo/tools/__init__.py
+++ b/odoo/tools/__init__.py
@@ -2,24 +2,25 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import _monkeypatches
+from . import appdirs
+from . import cloc
+from . import pdf
 from . import pycompat
 from . import win32
-from . import appdirs
-from . import pdf
-from . import cloc
 from .config import config
-from .misc import *
-from .translate import *
-from .image import *
-from .sql import *
-from .float_utils import *
-from .mail import *
-from .func import *
-from .debugger import *
-from .xml_utils import *
 from .date_utils import *
-from .convert import *
+from .debugger import *
+from .float_utils import *
+from .func import *
+from .image import *
+from .mail import *
+from .misc import *
+from .query import Query, _generate_table_alias
+from .sql import *
 from .template_inheritance import *
+from .translate import *
+from .xml_utils import *
+from .convert import *
 from . import osutil
 from .js_transpiler import transpile_javascript, is_odoo_module, URL_RE, ODOO_MODULE_RE
 from .sourcemap_generator import SourceMapGenerator

--- a/odoo/tools/date_utils.py
+++ b/odoo/tools/date_utils.py
@@ -5,8 +5,8 @@ from datetime import date, datetime, time
 import pytz
 from dateutil.relativedelta import relativedelta
 
-from . import ustr
 from .func import lazy
+from odoo.loglevels import ustr
 
 def get_month(date):
     ''' Compute the month dates range on which the 'date' parameter belongs to.

--- a/odoo/tools/query.py
+++ b/odoo/tools/query.py
@@ -5,7 +5,7 @@ import re
 import warnings
 from zlib import crc32
 
-from odoo.tools import lazy_property
+from .func import lazy_property
 
 IDENT_RE = re.compile(r'^[a-z_][a-z0-9_$]*$', re.I)
 
@@ -137,7 +137,7 @@ class Query(object):
         """ Add a LEFT JOIN to the current table (if necessary), and return the
         alias corresponding to ``rhs_table``.
 
-        See the documentation of :meth:`~odoo.osv.query.Query.join` for a better overview of the
+        See the documentation of :meth:`join` for a better overview of the
         arguments and what they do.
         """
         return self._join('LEFT JOIN', lhs_alias, lhs_column, rhs_table, rhs_column, link, extra, extra_params)


### PR DESCRIPTION
The idea is to avoid flushing the fields to fetch in method `_read()`.
This delays UPDATE queries, and makes the prefetching mechanism simpler
and more effective.

We do this by not overwriting the cache values by the values fetched
from database.  This simple idea allows to fetch more fields and more
records without having to care about pending computations and updates.
But it requires the cache consistency to be much more strict, because
nothing will "fix" the cache inconsistencies "by chance".  And it also
requires pending updates to be present in cache.