### PR TITLE
[FIX] Wrong Constrains logic in function _constraint_kode_ppn

### DIFF
--- a/addons/website_event_meet/models/ir_autovacuum.py
+++ b/addons/website_event_meet/models/ir_autovacuum.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import datetime
+
+from odoo import api, models, fields
+
+
+class AutoVacuum(models.AbstractModel):
+    _inherit = 'ir.autovacuum'
+
+    _DELAY_CLEAN = datetime.timedelta(hours=4)
+
+    @api.model
+    def power_on(self, *args, **kwargs):
+        """Archive all non-pinned room with 0 participant if nobody has joined it for a moment."""
+        self.env["event.meeting.room"].sudo().search([
+            ("is_pinned", "=", False),
+            ("active", "=", True),
+            ("room_participant_count", "=", 0),
+            ("room_last_activity", "<", fields.Datetime.now() - self._DELAY_CLEAN),
+        ]).active = False
+
+        return super(AutoVacuum, self).power_on(*args, **kwargs)

--- a/doc/cla/corporate/FalinwaIndonesia.md
+++ b/doc/cla/corporate/FalinwaIndonesia.md
@@ -1,0 +1,15 @@
+Indonesia, 2021-02-27
+
+Falinwa Indonesia, PT. agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Randy randyraharjo93@gmail.com https://github.com/randyraharjo93
+
+List of contributors:
+
+Randy randyraharjo93@gmail.com https://github.com/randyraharjo93

--- a/odoo/tools/test-config-values
+++ b/odoo/tools/test-config-values
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import logging
+import os
+import signal
+import sys
+import threading
+import traceback
+import time
+
+import odoo
+
+odoo.tools.config.parse_config(sys.argv[1:])
+config = odoo.tools.config
+
+for name in [
+    'db_name',
+    'addons_path',
+    'demo',
+    'osv_memory_count_limit',
+    'osv_memory_age_limit',
+    ]:
+    print "%s: %s - %s" % (name, config[name], type(config[name]))
+

--- a/odoo/tools/test-config-values-00.conf
+++ b/odoo/tools/test-config-values-00.conf
@@ -1,0 +1,3 @@
+[options]
+osv_memory_count_limit = 5
+transient_age_limit = 3.4

--- a/odoo/tools/test_config.py
+++ b/odoo/tools/test_config.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+""" Tests for the configuration file/command-line arguments. """
+
+# This test should be run from its directory.
+
+# TODO A configmanager object cannot parse multiple times a config file
+# and/or the command line, preventing to 'reload' a configuration.
+
+import os
+
+from . import config
+
+config_file_00 = os.path.join(os.path.dirname(__file__),'test-config-values-00.conf')
+
+# 1. No config file, no command-line arguments (a.k.a. default values)
+
+conf = config.configmanager()
+conf.parse_config()
+
+assert conf['transient_age_limit'] == 1.0
+assert os.path.join(conf['root_path'], 'addons') == conf['addons_path']
+
+# 2. No config file, some command-line arguments
+
+conf = config.configmanager()
+# mess with the optparse.Option definition to allow an invalid path
+conf.casts['addons_path'].action = 'store'
+conf.parse_config(['--addons-path=/xyz/dont-exist', '--transient-age-limit=2.3'])
+
+assert conf['transient_age_limit'] == 2.3
+assert conf['addons_path'] == '/xyz/dont-exist'
+
+# 3. Config file, no command-line arguments
+
+conf = config.configmanager()
+conf.parse_config(['-c', config_file_00])
+
+assert conf['transient_age_limit'] == 3.4
+
+# 4. Config file, and command-line arguments
+
+conf = config.configmanager()
+conf.parse_config(['-c', config_file_00, '--transient-age-limit=2.3'])
+
+assert conf['transient_age_limit'] == 2.3


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

1. Make an Indonesian Company
2. Install l10n_id & e-faktur module
3. Make an invoice with 1 product (with tax 10%) & 1section & 1 note

On Method _constraint_kode_ppn, it have logic to make sure that all invoice lines are in the same tax tag, but it also count invoice lines that are type section / note. 
This commit add extra rules not to include invoice lines with display_type

Current behavior before PR:

Error occured (Cannot mix VAT subject and Non-VAT subject items in the same invoice with this kode transaksi)

Desired behavior after PR is merged:

No error, because section / notes in invoice lines should not be treated as real invoice lines

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
