### PR TITLE
[FIX] website_sale: impossible to pay

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1546,6 +1546,8 @@
                         </div>
                     </div>
                 </div>
+                <br/>
+                <br/>
                 <div class="oe_structure" id="oe_structure_website_sale_payment_2"/>
             </div>
         </t>


### PR DESCRIPTION
**Impacted versions: 14.0**

Steps to reproduce:
Go to runbot : https://6421336-14-0-all.runbot49.odoo.com/shop/payment
Activate chatter.
Use small screen
--> issue impossible to click pay

Current behavior:
![image](https://user-images.githubusercontent.com/16716992/109361563-709b2300-7889-11eb-8b54-f3cab51e5d32.png)


OPW #2469986