### PR TITLE
[FIX] mrp: avoid done and cancelled MO from todo filter

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -465,7 +465,7 @@
                     <field name="move_raw_ids" string="Component" filter_domain="[('move_raw_ids.product_id', 'ilike', self)]"/>
                     <field name="name" string="Work Center" filter_domain="[('bom_id.operation_ids.workcenter_id', 'ilike', self)]"/>
                     <field name="origin"/>
-                    <filter string="To Do" name="todo" domain="['|', ('state', 'in', ('draft', 'confirmed', 'progress', 'to_close')), ('is_planned', '=', True)]"
+                    <filter string="To Do" name="todo" domain="[('state', 'in', ('draft', 'confirmed', 'progress', 'to_close'))]"
                         help="Manufacturing Orders which are in confirmed state."/>
                     <filter string="Starred" name="starred" domain="[('priority', '=', '1')]"/>
                     <separator/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Fix tends to hide done/cancel MOs from mrp.production form
- A planned MO is already a confirmed MO

Current behavior before PR:
- To-do filter displays all MOs

Desired behavior after PR is merged:
- To-do filter hides MOs with done/cancel state

Task ID: 2442058


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
