### PR TITLE
[IMP] iap,mail,sms,snailmail,crm_iap_lead(enrich): notification for i…

### DIFF
--- a/addons/crm_iap_enrich/data/mail_templates.xml
+++ b/addons/crm_iap_enrich/data/mail_templates.xml
@@ -15,10 +15,4 @@
         </div>
     </template>
 
-    <template id="mail_message_lead_enrich_no_credit">
-         <div>
-            <span>Not Enough Credits for Lead Enrichment.</span><br/>
-            <a t-attf-href="{{url}}" target="_blank"><i class="fa fa-arrow-right"/>  Buy More Credits</a>
-        </div>
-    </template>
 </data></odoo>

--- a/addons/iap_mail/__init__.py
+++ b/addons/iap_mail/__init__.py
@@ -1,2 +1,3 @@
 # -*- encoding: utf-8 -*-
 
+from . import models

--- a/addons/iap_mail/__manifest__.py
+++ b/addons/iap_mail/__manifest__.py
@@ -18,5 +18,10 @@
     'data': [
         'data/mail_templates.xml',
     ],
+    'assets': {
+        'web.assets_backend': [
+            'iap_mail/static/src/js/**/*',
+        ],
+    },
     'license': 'LGPL-3',
 }

--- a/addons/iap_mail/models/__init__.py
+++ b/addons/iap_mail/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import iap_account

--- a/addons/iap_mail/models/iap_account.py
+++ b/addons/iap_mail/models/iap_account.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import api, models
+
+
+class IapAccount(models.Model):
+    _inherit = 'iap.account'
+
+    @api.model
+    def _send_iap_bus_notification(self, service_name, title, error_type=False):
+        param = {
+            'title': title,
+            'error_type': 'danger' if error_type else 'success'
+        }
+        if error_type == 'credit':
+            param['url'] = self.env['iap.account'].get_credits_url(service_name)
+        self.env['bus.bus']._sendone(self.env.user.partner_id, 'iap_notification', param)

--- a/addons/iap_mail/static/src/js/services/iap_notification_service.js
+++ b/addons/iap_mail/static/src/js/services/iap_notification_service.js
@@ -1,0 +1,49 @@
+/** @odoo-module **/
+
+import { Markup } from 'web.utils';
+import { registry } from "@web/core/registry";
+
+export const iapNotificationService = {
+    dependencies: ["notification"],
+
+    start(env, { notification }) {
+        env.bus.on("WEB_CLIENT_READY", null, async () => {
+            const legacyEnv = owl.Component.env;
+            legacyEnv.services.bus_service.onNotification(this, (notifications) => {
+                for (const { payload, type } of notifications) {
+                    if (type === 'iap_notification') {
+                        if (payload.error_type == 'success') {
+                            displaySuccessIapNotification(payload);
+                        } else if (payload.error_type == 'danger') {
+                            displayFailureIapNotification(payload);
+                        }
+                    }
+                }
+            });
+            legacyEnv.services.bus_service.startPolling();
+        });
+
+        /**
+         * Displays the IAP success notification on user's screen
+         */
+        function displaySuccessIapNotification(notif) {
+            notification.add(notif.title, {
+                type: notif.error_type,
+            });
+        }
+
+        /**
+         * Displays the IAP failure notification on user's screen
+         */
+        function displayFailureIapNotification(notif) {
+            const message = Markup`<a class='btn btn-link' href='${notif.url}' target='_blank' ><i class='fa fa-arrow-right'></i> ${env._t("Buy more credits")}</a>`;
+            notification.add(message, {
+                type: notif.error_type,
+                messageIsHtml: true,
+                title: notif.title
+            });
+        }
+    }
+};
+
+registry.category("services").add("iapNotification", iapNotificationService);

--- a/addons/snailmail/models/snailmail_letter.py
+++ b/addons/snailmail/models/snailmail_letter.py
@@ -344,6 +344,9 @@ class SnailmailLetter(models.Model):
         response = iap_tools.iap_jsonrpc(endpoint + PRINT_ENDPOINT, params=params, timeout=timeout)
         for doc in response['request']['documents']:
             if doc.get('sent') and response['request_code'] == 200:
+                self.env['iap.account']._send_iap_bus_notification(
+                    service_name='snailmail',
+                    title=_("Snail Mails are successfully sent"))
                 note = _('The document was correctly sent by post.<br>The tracking id is %s', doc['send_id'])
                 letter_data = {'info_msg': note, 'state': 'sent', 'error_code': False}
                 notification_data = {
@@ -354,6 +357,11 @@ class SnailmailLetter(models.Model):
             else:
                 error = doc['error'] if response['request_code'] == 200 else response['reason']
 
+                if error == 'CREDIT_ERROR':
+                    self.env['iap.account']._send_iap_bus_notification(
+                        service_name='snailmail',
+                        title=_("Not enough credits for Snail Mail"),
+                        error_type="credit")
                 note = _('An error occurred when sending the document by post.<br>Error: %s', self._get_error_message(error))
                 letter_data = {
                     'info_msg': note,


### PR DESCRIPTION
…ap system

The purpose of this task is to use the system we currently have for partner
autocomplete and to generalize it to our other IAP services. This would be
perfect for actions in list views (e.g. Send for Digitalization for the OCR or
Enrich in CRM) so that the user gets immediate feedback on what he's just done.

In this commit, we improve the iap notification for the below views
-> we display a toast in green when the request was successfully completed
   (and the  user has enough credits).
 - when an SMS is sent in batch from the list view
 - when a letter is sent in batch from the list view
 -  when leads are enriched in batch from the list view
-> we display a toast in orange when the user doesn't have enough  credits with
   a corresponding 'buy credits' link to the service.
 - when an SMS is sent in batch from the list view
 - when a letter is sent in batch from the list view
 - when leads are enriched in batch from the list view or when
   clicking on 'enrich' from the form view
 - when creating a new lead mining request

LINKS
PR: #66977
Task-Id:2185306

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
