### PR TITLE
[FIX] account : Fix error on `search_read` for `account.move.line`

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3605,7 +3605,7 @@ class AccountMoveLine(models.Model):
             )
             FROM %(from)s
             WHERE %(where)s
-        """ % {'from': from_clause, 'where': where_clause, 'order_by': order_string}
+        """ % {'from': from_clause, 'where': where_clause or 'TRUE', 'order_by': order_string}
         self.env.cr.execute(sql, where_clause_params)
         result = {r[0]: r[1] for r in self.env.cr.fetchall()}
         for record in self:

--- a/doc/cla/individual/emilkholod.md
+++ b/doc/cla/individual/emilkholod.md
@@ -1,0 +1,11 @@
+Russia, 2021-03-01
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Emil emil.kholod@gmail.com https://github.com/emilkholod


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The changes related with `account.move.line` model. 

Current behavior before PR:
For example, if we run method `search_read` with empty arguments on this model, then there will be an error in the SQL-query, because `where_clause`-variable is empty, but in the SQL-query it should not be empty.

Desired behavior after PR is merged:
We should set `where_clause` value to `TRUE`, if `where_clause`-variable is empty. So SQL-query will be correct.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
