### PR TITLE
[IMP] web: Focus should be on Searchbar

### DIFF
--- a/addons/web/static/src/js/views/abstract_controller.js
+++ b/addons/web/static/src/js/views/abstract_controller.js
@@ -119,6 +119,7 @@ var AbstractController = mvc.Controller.extend(ActionMixin, {
     on_attach_callback: function () {
         ActionMixin.on_attach_callback.call(this);
         this.searchModel.on('search', this, this._onSearch);
+        this.searchModel.trigger('focus-control-panel');
         if (this.withControlPanel) {
             this.searchModel.on('get-controller-query-params', this, this._onGetOwnedQueryParams);
         }

--- a/addons/web/static/tests/control_panel/search_bar_tests.js
+++ b/addons/web/static/tests/control_panel/search_bar_tests.js
@@ -666,5 +666,37 @@ odoo.define('web.search_bar_tests', function (require) {
 
             actionManager.destroy();
         });
+
+        QUnit.test('focus should be on search bar when switching between views', async function (assert) {
+            assert.expect(4);
+
+            this.actions[0].views = [[false, 'list'], [false, 'form']];
+            this.archs['partner,false,form'] = `
+            <form>
+                <group>
+                    <field name="display_name"/>
+                </group>
+            </form>`;
+
+            const actionManager = await createActionManager({
+                actions: this.actions,
+                archs: this.archs,
+                data: this.data,
+            });
+
+            await actionManager.doAction(1);
+
+            assert.containsOnce(actionManager, '.o_list_view');
+            assert.strictEqual(document.activeElement, actionManager.el.querySelector('.o_searchview input.o_searchview_input'),
+                "searchview should have focus");
+
+            await testUtils.dom.click(actionManager.$('.o_list_view .o_data_cell:first'));
+            assert.containsOnce(actionManager, '.o_form_view');
+            await testUtils.dom.click(actionManager.$('.o_back_button'));
+            assert.strictEqual(document.activeElement, actionManager.el.querySelector('.o_searchview input.o_searchview_input'),
+                "searchview should have focus");
+
+            actionManager.destroy();
+        });
     });
 });


### PR DESCRIPTION
PURPOSE
if user moves to form view and come back to list-view then,
focus is not coming back to search-view.

SPEC
focus should be default on seachbar input element.

TaskId-2393795

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr