### PR TITLE
[FIX] mass_mailing: hide action buttons in sending  state

### DIFF
--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -56,9 +56,9 @@
             <field name="arch" type="xml">
                 <form string="Mailing">
                     <header style="min-height:31px;">
-                        <button name="action_put_in_queue" type="object" attrs="{'invisible': [('state', 'in', ('in_queue', 'done'))]}" class="oe_highlight" string="Send"
+                        <button name="action_put_in_queue" type="object" attrs="{'invisible': [('state', 'in', ('in_queue', 'sending', 'done'))]}" class="oe_highlight" string="Send"
                             confirm="This will send the email to all recipients. Do you still want to proceed ?"/>
-                        <button name="action_schedule" type="object" attrs="{'invisible': [('state', 'in', ('in_queue', 'done'))]}" class="btn-secondary" string="Schedule"/>
+                        <button name="action_schedule" type="object" attrs="{'invisible': [('state', 'in', ('in_queue', 'sending', 'done'))]}" class="btn-secondary" string="Schedule"/>
                         <button name="action_test" type="object" class="btn-secondary" string="Test"/>
                         <button name="action_cancel" type="object" attrs="{'invisible': [('state', '!=', 'in_queue')]}" class="btn-secondary" string="Cancel"/>
                         <button name="action_retry_failed" type="object" attrs="{'invisible': ['|', ('state', '!=', 'done'), ('failed', '=', 0)]}" class="oe_highlight" string="Retry"/>


### PR DESCRIPTION
PURPOSE

On sending a mailing in mass_mailing currently in sending state both action
buttons wise 'Send' and 'Schedule' are visible. The purpose of this task is to 
make them invisible as that of when they are in 'In Queue' and 'Done' state

SPECIFICATIONS

In this commit we made both the 'action_put_in_queue' (Send) and 
'action_schedule' (Schedule) button invisible whenever its state is in 
'sending' (Sending) by setting the invisible attribute for the same

LINKS

PR #66994
Task 2469352