### PR TITLE
[FIX] web, mail: speed up read_progress_bar

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -795,3 +795,70 @@ class MailActivityMixin(models.AbstractModel):
             domain = ['&'] + domain + [('user_id', '=', user_id)]
         self.env['mail.activity'].search(domain).unlink()
         return True
+
+    def _read_progress_bar(self, domain, group_by, progress_bar):
+        group_by_fname = group_by.partition(':')[0]
+        if not (progress_bar['field'] == 'activity_state' and self._fields[group_by_fname].store):
+            return super()._read_progress_bar(domain, group_by, progress_bar)
+
+        # optimization for 'activity_state'
+
+        # explicitly check access rights, since we bypass the ORM
+        self.check_access_rights('read')
+        query = self._where_calc(domain)
+        self._apply_ir_rules(query, 'read')
+        gb = group_by.partition(':')[0]
+        annotated_groupbys = [
+            self._read_group_process_groupby(gb, query)
+            for gb in [group_by, 'activity_state']
+        ]
+        groupby_dict = {gb['groupby']: gb for gb in annotated_groupbys}
+        for gb in annotated_groupbys:
+            if gb['field'] == 'activity_state':
+                gb['qualified_field'] = '"_last_activity_state"."activity_state"'
+        groupby_terms, orderby_terms = self._read_group_prepare('activity_state', [], annotated_groupbys, query)
+        select_terms = [
+            '%s as "%s"' % (gb['qualified_field'], gb['groupby'])
+            for gb in annotated_groupbys
+        ]
+        from_clause, where_clause, where_params = query.get_sql()
+        tz = self._context.get('tz') or self.env.user.tz or 'UTC'
+        select_query = """
+            SELECT 1 AS id, count(*) AS "__count", {fields}
+            FROM {from_clause}
+            JOIN (
+                SELECT res_id,
+                CASE
+                    WHEN min(date_deadline - (now() AT TIME ZONE COALESCE(res_partner.tz, %s))::date) > 0 THEN 'planned'
+                    WHEN min(date_deadline - (now() AT TIME ZONE COALESCE(res_partner.tz, %s))::date) < 0 THEN 'overdue'
+                    WHEN min(date_deadline - (now() AT TIME ZONE COALESCE(res_partner.tz, %s))::date) = 0 THEN 'today'
+                    ELSE null
+                END AS activity_state
+                FROM mail_activity
+                JOIN res_users ON (res_users.id = mail_activity.user_id)
+                JOIN res_partner ON (res_partner.id = res_users.partner_id)
+                WHERE res_model = '{model}'
+                GROUP BY res_id
+            ) AS "_last_activity_state" ON ("{table}".id = "_last_activity_state".res_id)
+            WHERE {where_clause}
+            GROUP BY {group_by}
+        """.format(
+            fields=', '.join(select_terms),
+            from_clause=from_clause,
+            model=self._name,
+            table=self._table,
+            where_clause=where_clause or '1=1',
+            group_by=', '.join(groupby_terms),
+        )
+        self.env.cr.execute(select_query, [tz] * 3 + where_params)
+        fetched_data = self.env.cr.dictfetchall()
+        self._read_group_resolve_many2one_fields(fetched_data, annotated_groupbys)
+        data = [
+            {key: self._read_group_prepare_data(key, val, groupby_dict)
+             for key, val in row.items()}
+            for row in fetched_data
+        ]
+        return [
+            self._read_group_format_result(vals, annotated_groupbys, [group_by], domain)
+            for vals in data
+        ]

--- a/addons/test_mail/models/test_mail_models.py
+++ b/addons/test_mail/models/test_mail_models.py
@@ -37,6 +37,7 @@ class MailTestActivity(models.Model):
     _inherit = ['mail.thread', 'mail.activity.mixin']
 
     name = fields.Char()
+    date = fields.Date()
     email_from = fields.Char()
     active = fields.Boolean(default=True)
 

--- a/addons/test_mail/tests/__init__.py
+++ b/addons/test_mail/tests/__init__.py
@@ -19,3 +19,4 @@ from . import test_discuss
 from . import test_performance
 from . import test_res_users
 from . import test_odoobot
+from . import test_read_progress_bar

--- a/addons/test_mail/tests/test_read_progress_bar.py
+++ b/addons/test_mail/tests/test_read_progress_bar.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from odoo.tests import common
+from odoo import fields
+from datetime import timedelta
+
+
+class TestReadProgressBar(common.TransactionCase):
+    """Test for read_progress_bar"""
+
+    def setUp(self):
+        super(TestReadProgressBar, self).setUp()
+        self.Model = self.env['mail.test.activity']
+
+    def test_week_grouping(self):
+        """The labels associated to each record in read_progress_bar should match
+        the ones from read_group, even in edge cases like en_US locale on sundays
+        """
+        context = {"lang": "en_US"}
+        model = self.Model.with_context(context)
+        groupby = "date:week"
+        sunday1 = '2021-05-02'
+        sunday2 = '2021-05-09'
+        sunday3 = '2021-05-16'
+        # Don't mistake fields date and date_deadline:
+        # * date is just a random value
+        # * date_deadline defines activity_state
+        self.Model.create({'date': sunday1, 'name': "Yesterday, all my troubles seemed so far away"}).activity_schedule(
+            'test_mail.mail_act_test_todo',
+            summary="Make another test super asap (yesterday)",
+            date_deadline=fields.Date.context_today(model) - timedelta(days=7)
+        )
+        self.Model.create({'date': sunday2, 'name': "Things we said today"}).activity_schedule(
+            'test_mail.mail_act_test_todo',
+            summary="Make another test asap",
+            date_deadline=fields.Date.context_today(model)
+        )
+        self.Model.create({'date': sunday3, 'name': "Tomorrow Never Knows"}).activity_schedule(
+            'test_mail.mail_act_test_todo',
+            summary="Make a test tomorrow",
+            date_deadline=fields.Date.context_today(model) + timedelta(days=7)
+        )
+
+        progress_bar = {
+            'field': 'activity_state',
+            'colors': {
+                "overdue": 'danger',
+                "today": 'warning',
+                "planned": 'success',
+            }
+        }
+
+        domain = [('date', "!=", False)]
+        # call read_group to compute group names
+        groups = model.read_group(domain, fields=['date'], groupby=[groupby])
+        progressbars = model.read_progress_bar(domain, group_by=groupby, progress_bar=progress_bar)
+        self.assertEqual(len(groups), 3)
+        self.assertEqual(len(progressbars), 3)
+
+        # format the read_progress_bar result to get a dictionary under this format : {activity_state: group_name}
+        # original format (after read_progress_bar) is : {group_name: {activity_state: count}}
+        pg_groups = {
+            next(activity_state for activity_state, count in data.items() if count): group_name \
+                for group_name, data in progressbars.items()
+        }
+
+        self.assertEqual(groups[0][groupby], pg_groups["overdue"])
+        self.assertEqual(groups[1][groupby], pg_groups["today"])
+        self.assertEqual(groups[2][groupby], pg_groups["planned"])

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -1,11 +1,19 @@
 # -*- coding: utf-8 -*-
-from datetime import datetime
 import babel.dates
 import pytz
 
-from odoo.tools import pycompat, date_utils
-from odoo.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT, DEFAULT_SERVER_DATE_FORMAT
-from odoo import _, api, fields, models
+from odoo import api, fields, models
+from odoo.exceptions import UserError
+from odoo.tools import date_utils
+
+
+DISPLAY_DATE_FORMATS = {
+    'day': 'dd MMM yyyy',
+    'week': "'W'w YYYY",
+    'month': 'MMMM yyyy',
+    'quarter': 'QQQ yyyy',
+    'year': 'yyyy',
+}
 
 
 class Base(models.AbstractModel):
@@ -25,24 +33,47 @@ class Base(models.AbstractModel):
         :return a dictionnary mapping group_by values to dictionnaries mapping
                 progress bar field values to the related number of records
         """
+        group_by_fname = group_by.partition(':')[0]
+        field_type = self._fields[group_by_fname].type
+        if field_type == 'selection':
+            selection_labels = dict(self.fields_get()[group_by]['selection'])
+
+        def adapt(value):
+            if field_type == 'selection':
+                value = selection_labels.get(value, False)
+            if type(value) == tuple:
+                value = value[1]  # FIXME should use technical value (0)
+            return value
+
+        result = {}
+        for group in self._read_progress_bar(domain, group_by, progress_bar):
+            group_by_value = str(adapt(group[group_by]))
+            field_value = group[progress_bar['field']]
+            if group_by_value not in result:
+                result[group_by_value] = dict.fromkeys(progress_bar['colors'], 0)
+            if field_value in result[group_by_value]:
+                result[group_by_value][field_value] += group['__count']
+        return result
+
+    def _read_progress_bar(self, domain, group_by, progress_bar):
+        """ Implementation of read_progress_bar() that returns results in the
+            format of read_group().
+        """
+        try:
+            fname = progress_bar['field']
+            return self.read_group(domain, [fname], [group_by, fname], lazy=False)
+        except UserError:
+            # possibly failed because of grouping on or aggregating non-stored
+            # field; fallback on alternative implementation
+            pass
 
         # Workaround to match read_group's infrastructure
         # TO DO in master: harmonize this function and readgroup to allow factorization
         group_by_modifier = group_by.partition(':')[2] or 'month'
         group_by = group_by.partition(':')[0]
-        display_date_formats = {
-            'day': 'dd MMM yyyy',
-            'week': "'W'w YYYY",
-            'month': 'MMMM yyyy',
-            'quarter': 'QQQ yyyy',
-            'year': 'yyyy'}
 
         records_values = self.search_read(domain or [], [progress_bar['field'], group_by])
-
-        data = {}
         field_type = self._fields[group_by].type
-        if field_type == 'selection':
-            selection_labels = dict(self.fields_get()[group_by]['selection'])
 
         for record_values in records_values:
             group_by_value = record_values[group_by]
@@ -56,27 +87,14 @@ class Base(models.AbstractModel):
                 if field_type == 'datetime' and self._context.get('tz') in pytz.all_timezones:
                     tz_info = self._context.get('tz')
                     group_by_value = babel.dates.format_datetime(
-                        group_by_value, format=display_date_formats[group_by_modifier],
+                        group_by_value, format=DISPLAY_DATE_FORMATS[group_by_modifier],
                         tzinfo=tz_info, locale=locale)
                 else:
                     group_by_value = babel.dates.format_date(
-                        group_by_value, format=display_date_formats[group_by_modifier],
+                        group_by_value, format=DISPLAY_DATE_FORMATS[group_by_modifier],
                         locale=locale)
+                record_values[group_by] = group_by_value
 
-            if field_type == 'selection':
-                group_by_value = selection_labels[group_by_value] \
-                    if group_by_value in selection_labels else False
+            record_values['__count'] = 1
 
-            if type(group_by_value) == tuple:
-                group_by_value = group_by_value[1] # FIXME should use technical value (0)
-
-            if group_by_value not in data:
-                data[group_by_value] = {}
-                for key in progress_bar['colors']:
-                    data[group_by_value][key] = 0
-
-            field_value = record_values[progress_bar['field']]
-            if field_value in data[group_by_value]:
-                data[group_by_value][field_value] += 1
-
-        return data
+        return records_values

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2139,9 +2139,11 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
 
         self._apply_ir_rules(query, 'read')
         for gb in groupby_fields:
-            assert gb in self._fields, "Unknown field %r in 'groupby'" % gb
+            if gb not in self._fields:
+                raise UserError(_("Unknown field %r in 'groupby'") % gb)
             gb_field = self._fields[gb].base_field
-            assert gb_field.store and gb_field.column_type, "Fields in 'groupby' must be regular database-persisted fields (no function or related fields), or function fields with store=True"
+            if not (gb_field.store and gb_field.column_type):
+                raise UserError(_("Fields in 'groupby' must be database-persisted fields (no computed fields)"))
 
         aggregated_fields = []
         select_terms = []


### PR DESCRIPTION
The method is used to get progress per column in kanban
view (green-yellow-red-red lines in Project, CRM etc). There are two main
usage:

1. get statistics for ``kanban_state`` (red/green circles)
2. get statistics for ``activity_state`` (colored clock icon for overdue/today/planned)

Before this commit all cases were handled by calling search_read and then
counting records per group in a python script. This is very inefficient,
especially for ``activity_state``.

With the new implementation, we just call ``read_group`` if both grouping
fields (kanban column and progressbar field) are stored (case n.1), or use
patched read_group to make grouping on a computed field ``activity_state``.

1. Performance test on 60 K project.task records (kanban_state):

With a filter for 6 records:

```
| measurement        | before | after |
|--------------------+--------+-------|
| number of queries  |      6 |     4 |
| query time, ms     |      6 |     5 |
| remaining time, ms |      9 |     6 |
```

All records:
```
| measurement        | before | after |
|--------------------+--------+-------|
| number of queries  |     66 |     4 |
| query time, ms     |    580 |    53 |
| remaining time, ms |   1900 |     8 |
```

2. Performance test on 29 K crm.lead records (activity_state):

With a filter for 10 records:

```
| measurement        | before | after |
|--------------------+--------+-------|
| number of queries  |     22 |     4 |
| query time, ms     |     11 |     4 |
| remaining time, ms |     35 |     8 |
```

All records:

```
| measurement        | before | after |
|--------------------+--------+-------|
| number of queries  |   1301 |     4 |
| query time, ms     |   1790 |   382 |
| remaining time, ms |  40000 |     8 |
```

---

opw-2346901
task-1915411