### PR TITLE
[FIX] payment: link transaction to invoice with payment link

### DIFF
--- a/addons/payment/controllers/portal.py
+++ b/addons/payment/controllers/portal.py
@@ -158,6 +158,8 @@ class WebsitePayment(http.Controller):
             if not token_ok:
                 raise werkzeug.exceptions.NotFound
 
+        invoice_id = kw.get('invoice_id')
+
         # Default values
         values = {
             'amount': 0.0,
@@ -182,6 +184,12 @@ class WebsitePayment(http.Controller):
                 })
             except:
                 order_id = None
+
+        if invoice_id:
+            try:
+                values['invoice_id'] = int(invoice_id)
+            except ValueError:
+                invoice_id = None
 
         # Check currency
         if currency_id:
@@ -266,6 +274,7 @@ class WebsitePayment(http.Controller):
     def transaction(self, acquirer_id, reference, amount, currency_id, partner_id=False, **kwargs):
         acquirer = request.env['payment.acquirer'].browse(acquirer_id)
         order_id = kwargs.get('order_id')
+        invoice_id = kwargs.get('invoice_id')
 
         reference_values = order_id and {'sale_order_ids': [(4, order_id)]} or {}
         reference = request.env['payment.transaction']._compute_reference(values=reference_values, prefix=reference)
@@ -281,6 +290,8 @@ class WebsitePayment(http.Controller):
 
         if order_id:
             values['sale_order_ids'] = [(6, 0, [order_id])]
+        elif invoice_id:
+            values['invoice_ids'] = [(6, 0, [invoice_id])]
 
         reference_values = order_id and {'sale_order_ids': [(4, order_id)]} or {}
         reference_values.update(acquirer_id=int(acquirer_id))

--- a/addons/payment/static/src/js/payment_form.js
+++ b/addons/payment/static/src/js/payment_form.js
@@ -284,6 +284,7 @@ publicWidget.registry.PaymentForm = publicWidget.Widget.extend({
                             'error_url': self.options.errorUrl,
                             'callback_method': self.options.callbackMethod,
                             'order_id': self.options.orderId,
+                            'invoice_id': self.options.invoiceId,
                         },
                     }).then(function (result) {
                         if (result) {

--- a/addons/payment/views/payment_templates.xml
+++ b/addons/payment/views/payment_templates.xml
@@ -30,10 +30,12 @@
                 t-att-data-partner-id="partner_id"
                 t-att-data-callback-method="callback_method or ''"
                 t-att-data-order-id="order_id or ''"
+                t-att-data-invoice-id="invoice_id or ''"
                 t-att-data-mode="mode">
             <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
             <input type="hidden" t-if="prepare_tx_url" name="prepare_tx_url" t-att-value="prepare_tx_url"/>
             <input type="hidden" t-if="order_id" name="order_id" t-att-value="order_id"/>
+            <input type="hidden" t-if="invoice_id" name="invoice_id" t-att-value="invoice_id"/>
             <!-- s2s form submission -->
             <input type="hidden" t-if="access_token" name="access_token" t-att-value="access_token"/>
             <input type="hidden" t-if="success_url" name="success_url" t-att-value="success_url"/>

--- a/addons/payment/wizards/payment_link_wizard.py
+++ b/addons/payment/wizards/payment_link_wizard.py
@@ -80,6 +80,8 @@ class PaymentLinkWizard(models.TransientModel):
                     )
             if payment_link.company_id:
                 link += '&company_id=%s' % payment_link.company_id.id
+            if payment_link.res_model == 'account.move':
+                link += '&invoice_id=%s' % payment_link.res_id
             payment_link.link = link
 
     @api.model


### PR DESCRIPTION
Steps:
- Install account,payment
- Go to Invoicing
- Create an invoice
- Click Actions > Generate a Payment Link
- Follow the generated link
- Pay

Bug:
The transaction is not linked to the sale order in the link table
`account_invoice_transaction_rel`

Explanation:
This fix is broadly mimicking the behavior of the sales module regarding
the link of an order to a transaction, adding `invoice_id`s where they
are needed throughout the payment process in order to link the
transaction to the invoice.

opw:2451534