### PR TITLE
[FIX] calendar,calendar_sms: repair mail and sms composer actions

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -567,25 +567,20 @@ class Meeting(models.Model):
                 )
         return True
 
-    def action_mass_mailing(self):
-        partners_ids = self.mapped('partner_ids')
-        if not partners_ids:
+    def action_open_composer(self):
+        if not self.partner_ids:
             raise UserError(_("There are no attendees on these events"))
-        compose_form = self.env.ref('mail.email_compose_message_wizard_form', False)
-        default_partners = partners_ids and partners_ids.ids
         compose_ctx = dict(
-            default_use_template=False,
             default_composition_mode='mass_mail',
-            default_partner_ids=default_partners,
-            default_subject=_("Event update")
+            default_subject=_("Event update"),
+            default_model='calendar.event',
+            default_res_ids=self.ids,
         )
         return {
             'name': _('Contact Attendees'),
             'type': 'ir.actions.act_window',
             'view_mode': 'form',
             'res_model': 'mail.compose.message',
-            'views': [(compose_form.id, 'form')],
-            'view_id': compose_form.id,
             'target': 'new',
             'context': compose_ctx,
         }

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -77,7 +77,7 @@
         <field name="arch" type="xml">
             <tree string="Meetings" sample="1" multi_edit="1">
                 <header>
-                    <button name="action_mass_mailing" type="object"
+                    <button name="action_open_composer" type="object"
                             string="Send Mail"/>
                 </header>
                 <field name="name" string="Subject" decoration-bf="1" attrs="{'readonly':[('recurrency','=',True)]}"/>
@@ -132,7 +132,7 @@
                                 class="oe_inline o_calendar_attendees"
                             />
                             <div name="send_buttons">
-                                <button name="action_mass_mailing" help="Send Email to attendees" type="object" string=" EMAIL" icon="fa-envelope"/>
+                                <button name="action_open_composer" help="Send Email to attendees" type="object" string=" EMAIL" icon="fa-envelope"/>
                             </div>
                         </div>
                     </div>

--- a/addons/calendar_sms/models/calendar_event.py
+++ b/addons/calendar_sms/models/calendar_event.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, _
-
+from odoo.exceptions import UserError
 
 class CalendarEvent(models.Model):
     _inherit = 'calendar.event'
@@ -24,8 +24,11 @@ class CalendarEvent(models.Model):
             )
 
     def action_send_sms(self):
+        if not self.partner_ids:
+            raise UserError(_("There are no attendees on these events"))
         return {
             'type': 'ir.actions.act_window',
+            'name': _("Send SMS Text Message"),
             'res_model': 'sms.composer',
             'view_mode': 'form',
             'target': 'new',
@@ -33,6 +36,7 @@ class CalendarEvent(models.Model):
                 'default_composition_mode': 'mass',
                 'default_res_model': 'res.partner',
                 'default_res_ids': self.partner_ids.ids,
+                'default_sms_mass_keep_log': True,
             },
         }
 

--- a/addons/calendar_sms/views/calendar_views.xml
+++ b/addons/calendar_sms/views/calendar_views.xml
@@ -13,26 +13,13 @@
         </field>
     </record>
 
-    <!-- Add action entry in the Action Menu for Events -->
-    <record id="calendar_event_act_window_sms_composer_single" model="ir.actions.act_window">
-        <field name="name">Send SMS</field>
-        <field name="res_model">sms.composer</field>
-        <field name="view_mode">form</field>
-        <field name="target">new</field>
-        <field name="context">{
-            'default_composition_mode': 'guess',
-            'default_res_id': active_id,
-            'default_res_ids': active_ids,
-        }</field>
-    </record>
-
     <record id="view_calendar_event_tree_inherited" model="ir.ui.view">
         <field name="name">calendar.event.tree.calendar_sms</field>
         <field name="model">calendar.event</field>
         <field name="inherit_id" ref="calendar.view_calendar_event_tree"/>
         <field name="arch" type="xml">
             <xpath expr="//header" position="inside">
-                <button name="%(calendar_event_act_window_sms_composer_single)d" type="action"
+                <button name="action_send_sms" type="object"
                         string="Send SMS"/>
             </xpath>
         </field>
@@ -45,6 +32,9 @@
         <field name="arch" type="xml">
             <xpath expr="//div[@name='send_buttons']" position="inside">
                 <button name="action_send_sms" help="Send SMS to attendees" type="object" string="SMS" icon="fa-mobile"/>
+            </xpath>
+            <xpath expr="//field[@name='phone']" position="replace">
+                <field name="phone" widget="phone" options="{'enable_sms': false}"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
This commit follows https://github.com/odoo/odoo/pull/64948
Before this commit, the mail composer was not properly used. It was not instiancied with a model and business document ids.

This commit also reverts a keyword context value for the sms composer.

taskid: 2342252



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
