### PR TITLE
[FIX] account: Fix tests depending the date after 18 months

### DIFF
--- a/addons/account/tests/test_reconciliation_matching_rules.py
+++ b/addons/account/tests/test_reconciliation_matching_rules.py
@@ -96,12 +96,14 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
                 'journal_id': cls.bank_journal.id,
                 'line_ids': [
                     (0, 0, {
+                        'date': '2020-01-01',
                         'payment_ref': 'invoice %s-%s-%s' % tuple(invoice_number.split('/')[1:]),
                         'partner_id': cls.partner_1.id,
                         'amount': 100,
                         'sequence': 1,
                     }),
                     (0, 0, {
+                        'date': '2020-01-01',
                         'payment_ref': 'xxxxx',
                         'partner_id': cls.partner_1.id,
                         'amount': 600,
@@ -113,6 +115,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
                 'journal_id': cls.bank_journal.id,
                 'line_ids': [
                     (0, 0, {
+                        'date': '2020-01-01',
                         'payment_ref': 'nawak',
                         'narration': 'Communication: RF12 3456',
                         'partner_id': cls.partner_3.id,
@@ -120,12 +123,14 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
                         'sequence': 1,
                     }),
                     (0, 0, {
+                        'date': '2020-01-01',
                         'payment_ref': 'RF12 3456',
                         'partner_id': cls.partner_3.id,
                         'amount': 600,
                         'sequence': 2,
                     }),
                     (0, 0, {
+                        'date': '2020-01-01',
                         'payment_ref': 'baaaaah',
                         'ref': 'RF12 3456',
                         'partner_id': cls.partner_3.id,
@@ -138,6 +143,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
                 'journal_id': cls.cash_journal.id,
                 'line_ids': [
                     (0, 0, {
+                        'date': '2020-01-01',
                         'payment_ref': 'yyyyy',
                         'partner_id': cls.partner_2.id,
                         'amount': -1000,
@@ -181,6 +187,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
         self.cash_st.balance_end_real = self.cash_st.balance_end
         (self.bank_st + self.bank_st_2 + self.cash_st).button_post()
 
+    @freeze_time('2020-01-01')
     def _check_statement_matching(self, rules, expected_values, statements=None):
         if statements is None:
             statements = self.bank_st + self.cash_st
@@ -719,6 +726,7 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
             'match_total_amount_param': 95.0,
             'match_same_currency': False,
             'company_id': self.company_data['company'].id,
+            'past_months_limit': False,
         })
 
         statement = self.env['account.bank.statement'].create({
@@ -777,11 +785,11 @@ class TestReconciliationMatchingRules(AccountTestInvoicingCommon):
         move_line_1 = move.line_ids.filtered(lambda line: line.debit == 100.0)
         move_line_2 = move.line_ids.filtered(lambda line: line.debit == 14.0)
 
-        with freeze_time('2017-01-01'):
-            self._check_statement_matching(matching_rule, {
-                statement_line.id: {'aml_ids': (move_line_1 + move_line_2).ids, 'model': matching_rule, 'partner': statement_line.partner_id}
-            }, statements=statement)
+        self._check_statement_matching(matching_rule, {
+            statement_line.id: {'aml_ids': (move_line_1 + move_line_2).ids, 'model': matching_rule, 'partner': statement_line.partner_id}
+        }, statements=statement)
 
+    @freeze_time('2020-01-01')
     def test_inv_matching_with_write_off(self):
         self.rule_1.match_total_amount_param = 90
         self.bank_st.line_ids[1].unlink() # We don't need this one here


### PR DESCRIPTION
Tests are crashing when the number of months between the data date and today is higher than 18 months due to the 'past_months_limit' field on account.reconcile.model.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
