### PR TITLE
[FIX] l10n_ch: Fix missing street on QR-Bill report

### DIFF
--- a/addons/l10n_ch/report/swissqr_report.xml
+++ b/addons/l10n_ch/report/swissqr_report.xml
@@ -41,6 +41,7 @@
                             <span class="swissqr_text title">Payable to</span><br/>
                             <span class="swissqr_text content" t-field="o.partner_bank_id.acc_number"/><br/>
                             <span class="swissqr_text content" t-field="o.company_id.name"/><br/>
+                            <span class="swissqr_text content" t-field="o.company_id.street"/><br/>
                             <span class="swissqr_text content" t-field="o.company_id.country_id.code"/>
                             <span class="swissqr_text content" t-field="o.company_id.zip"/>
                             <span class="swissqr_text content" t-field="o.company_id.city"/><br/>
@@ -52,6 +53,8 @@
 
                             <span class="swissqr_text title">Payable by</span><br/>
                             <span class="swissqr_text content" t-field="o.partner_id.commercial_partner_id.name"/><br/>
+                            <span class="swissqr_text content" t-field="o.partner_id.street" />
+                            <span class="swissqr_text content" t-field="o.partner_id.street2"/><br/>
                             <span class="swissqr_text content" t-field="o.partner_id.country_id.code"/>
                             <span class="swissqr_text content" t-field="o.partner_id.zip"/>
                             <span class="swissqr_text content" t-field="o.partner_id.city"/><br/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The street address is missing on the QR-Bill printout

Current behavior before PR:
Street address is missing

Desired behavior after PR is merged:
Street address is printed on the QR-Bill



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
