### PR TITLE
[FIX] mrp: done production stay in done

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -347,6 +347,7 @@ class MrpProduction(models.Model):
                 if (
                     production.bom_id.consumption == 'flexible'
                     and float_compare(production.qty_produced, production.product_qty, precision_rounding=production.product_uom_id.rounding) == -1
+                    and production.state != 'done'
                 ):
                     production.state = 'progress'
                 else:


### PR DESCRIPTION
As the production state depends on component moves state AND on
product quantities, updating the finished_move quantity will bring back
the state to 'In progress'.
There were already a fix/workaround (see c99fe9dc) to force the done
state by cancelling the production. As this was not user-friendly
enough, this commit ensures a validated production will stay in done
state.

opw : 2457576

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
