### PR TITLE
[FIX] mass_mailing: wrong clicks_ratio compute

### DIFF
--- a/addons/mass_mailing/models/mass_mailing.py
+++ b/addons/mass_mailing/models/mass_mailing.py
@@ -580,7 +580,6 @@ class MassMailing(models.Model):
             total = row['expected'] = (row['expected'] - row['ignored']) or 1
             row['received_ratio'] = 100.0 * row['delivered'] / total
             row['opened_ratio'] = 100.0 * row['opened'] / total
-            row['clicks_ratio'] = 100.0 * row['clicked'] / total
             row['replied_ratio'] = 100.0 * row['replied'] / total
             row['bounced_ratio'] = 100.0 * row['bounced'] / total
             self.browse(row.pop('mailing_id')).update(row)


### PR DESCRIPTION
The `clicks_ratio` field was computed outside of its compute method,
this is illegale as the ORM cannot protect the field from being included
in the "towrite" structure.

Backport of 7acc035

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
