### PR TITLE
[FIX] web: display better tracebacks in debug=assets

### DIFF
--- a/addons/web/static/lib/qunit/qunit-2.9.1.js
+++ b/addons/web/static/lib/qunit/qunit-2.9.1.js
@@ -3376,6 +3376,7 @@
   					then.call(promise, function () {
   						resume();
   					}, function (error) {
+  						lastError = error;
   						message = "Promise rejected " + (!phase ? "during" : phase.replace(/Each$/, "")) + " \"" + test.testName + "\": " + (error && error.message || error);
   						test.pushFailure(message, extractStacktrace(error, 0));
 


### PR DESCRIPTION
A previous commit (934e0896160272542dd00) modified QUnit to make sure we
can display better tracebacks in debug=assets mode.  However, this
commit did not apply to errors coming from failing promises.

To fix this, we can simply keep a reference to the error in that
specific case.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
