### PR TITLE
[FIX] sale_timesheet: get no SOL when SOL in task is False and hide non_allow_billable in timesheets

### DIFF
--- a/addons/sale_timesheet/models/account.py
+++ b/addons/sale_timesheet/models/account.py
@@ -108,7 +108,7 @@ class AccountAnalyticLine(models.Model):
                     return map_entry.sale_line_id
             if project.sale_line_id:
                 return project.sale_line_id
-        if task.allow_billable:
+        if task.allow_billable and task.sale_line_id:
             if task.bill_type == 'customer_task':
                 return task.sale_line_id
             if task.pricing_type == 'fixed_rate':

--- a/addons/sale_timesheet/tests/test_project_billing.py
+++ b/addons/sale_timesheet/tests/test_project_billing.py
@@ -11,7 +11,7 @@ class TestProjectBilling(TestCommonSaleTimesheet):
     @classmethod
     def setUpClass(cls, chart_template_ref=None):
         super().setUpClass(chart_template_ref=chart_template_ref)
-        
+
         # set up
         cls.employee_tde = cls.env['hr.employee'].create({
             'name': 'Employee TDE',
@@ -272,6 +272,12 @@ class TestProjectBilling(TestCommonSaleTimesheet):
             'task_id': task.id,
             'unit_amount': 50,
             'employee_id': self.employee_manager.id,
+        })
+
+        self.assertFalse(timesheet1.so_line, "The timesheet should be not linked to the project of the map entry since no SOL in the linked task.")
+
+        task.write({
+            'sale_line_id': self.project_employee_rate_user.sale_line_id.id
         })
 
         self.assertEqual(self.project_employee_rate_manager.sale_line_id, timesheet1.so_line, "The timesheet should be linked to the SOL associated to the Employee manager in the map")

--- a/addons/sale_timesheet/views/hr_timesheet_views.xml
+++ b/addons/sale_timesheet/views/hr_timesheet_views.xml
@@ -42,7 +42,7 @@
         <field name="inherit_id" ref="hr_timesheet.timesheet_view_tree_user"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='user_id']" position="after">
-                <field name="non_allow_billable" attrs="{'invisible': [('non_allow_billable', '=', False)]}"/>
+                <field name="non_allow_billable" attrs="{'invisible': [('non_allow_billable', '=', False)]}" optional="hide"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Two fixes have been done in this PR.
The first one has as goal is the hide by default the non_allow_billable field in the All Timesheets tree view. In fact, this field is visible to allow the user to uncheck the non_allow_billable if he has some timesheets with non_allow_billable=True. 

The goal of the last one fix is to return no SOL for the timesheets linked to a task if the task has no SOL. Before this fix, when the linked project has the pricing type is equal to employee rate with employee mappings and the user removes the SOL in the task, the SOL in the linked timesheets is not removed for all of them. It is because we find a mapping and we give the SOL of the mapping. In this fix, we check if the task has a SOL before to determine a SOL for the timesheets.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
