### PR TITLE
[FIX] website_blog: avoid overlap around blog's paragraph

### DIFF
--- a/addons/website_blog/views/snippets.xml
+++ b/addons/website_blog/views/snippets.xml
@@ -41,5 +41,8 @@
     <xpath expr="//div[@data-js='layout_column']" position="attributes">
         <attribute name="data-exclude" add=".s_latest_posts, .s_latest_posts_big_picture" separator=","/>
     </xpath>
+    <xpath expr="//*[@data-js='anchorName']" position="attributes">
+        <attribute name="data-exclude" add=".o_wblog_post_content_field > :not(div, section)" separator=","/>
+    </xpath>
 </template>
 </odoo>


### PR DESCRIPTION
[FIX] website: avoid overlap around blog's paragraph

Fixing anchor selector to pick only section and div elements.

task-2449620
