### PR TITLE
[FIX] base_vat: accept XI VAT format

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -47,7 +47,7 @@ _ref_vat = {
     'es': 'ESA12345674',
     'fi': 'FI12345671',
     'fr': 'FR32123456789',
-    'gb': 'GB123456782',
+    'gb': 'GB123456782 or XI123456782',
     'gr': 'GR12345670',
     'hu': 'HU12345676',
     'hr': 'HR01234567896',  # Croatia, contributed by Milan Tribuson
@@ -430,3 +430,10 @@ class ResPartner(models.Model):
                 else:
                     res.append(False)
         return all(res)
+
+    def check_vat_xi(self, vat):
+        """ Temporary Nothern Ireland VAT validation following Brexit
+        As of January 1st 2021, companies in Northern Ireland have a
+        new VAT number starting with XI
+        TODO: remove when stdnum is updated to 1.16 in supported distro"""
+        return stdnum.util.get_cc_module('gb', 'vat').is_valid(vat) if stdnum else True


### PR DESCRIPTION
Following Brexit on January 1st 2021, companies in Northern Ireland have
a new VAT number starting with XI instead of GB. More info:
https://www.gov.uk/government/publications/accounting-for-vat-on-goods-moving-between-great-britain-and-northern-ireland-from-1-january-2021/check-when-you-are-trading-under-the-northern-ireland-protocol-if-you-are-vat-registered-business

stdnum support the new XI VAT from 1.16
https://github.com/arthurdejong/python-stdnum/commit/b93d69581f35aa18e7fdd52b3f7fdf06770215e3
This patch add temporary support in base_vat until the new version
is available on the Debian package repository

Community tracked issue
https://github.com/odoo/odoo/issues/64891

opw-2461322

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
