### PR TITLE
[FIX] mail: correct display of channel name in invite dialog

### DIFF
--- a/addons/mail/static/src/widgets/discuss_invite_partner_dialog/discuss_invite_partner_dialog.js
+++ b/addons/mail/static/src/widgets/discuss_invite_partner_dialog/discuss_invite_partner_dialog.js
@@ -31,7 +31,7 @@ const PartnerInviteDialog = Dialog.extend({
         this.channelId = channel.id;
         this.env = env;
         this._super(parent, {
-            title: _.str.sprintf(this.env._t("Invite people to #%s"), channel.displayName),
+            title: _.str.sprintf(this.env._t("Invite people to #%s"), owl.utils.escape(channel.displayName)),
             size: 'medium',
             buttons: [{
                 text: this.env._t("Invite"),


### PR DESCRIPTION
Some characters were not rendered properly, this commit restores the display
as it was in v13.0.
