### PR TITLE
[FIX] mrp_subcontracting: wrong subcontracted productions

### DIFF
--- a/addons/mrp_subcontracting/models/stock_picking.py
+++ b/addons/mrp_subcontracting/models/stock_picking.py
@@ -105,7 +105,7 @@ class StockPicking(models.Model):
         return self.picking_type_id.code == 'incoming' and any(m.is_subcontract for m in self.move_lines)
 
     def _get_subcontracted_productions(self):
-        return self.move_lines.move_orig_ids.production_id
+        return self.move_lines.filtered(lambda move: move.is_subcontract).move_orig_ids.production_id
 
     def _get_warehouse(self, subcontract_move):
         return subcontract_move.warehouse_id or self.picking_type_id.warehouse_id


### PR DESCRIPTION
Previously, when we find out subcontracted productions of moves, we get
all production_id from the origin moves of the moves. When user use
multple steps manufacturing, moves may also have their move_orig_ids.
In this case, we will consider its production_id as subcontracted
production.
To fix, we filered the moves, consider only move that is_subcontract is
true.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
