### PR TITLE
[FIX] mrp: fix reserved_qty precision issue with forecast availibility

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -28,9 +28,8 @@ class StockMoveLine(models.Model):
     product_id = fields.Many2one('product.product', 'Product', ondelete="cascade", check_company=True, domain="[('type', '!=', 'service'), '|', ('company_id', '=', False), ('company_id', '=', company_id)]")
     product_uom_id = fields.Many2one('uom.uom', 'Unit of Measure', required=True, domain="[('category_id', '=', product_uom_category_id)]")
     product_uom_category_id = fields.Many2one(related='product_id.uom_id.category_id')
-    product_qty = fields.Float(
-        'Real Reserved Quantity', digits=0,
-        compute='_compute_product_qty', inverse='_set_product_qty', store=True)
+    product_qty = fields.Float('Real Reserved Quantity', compute='_compute_product_qty',
+        inverse='_set_product_qty', store=True)
     product_uom_qty = fields.Float('Reserved', default=0.0, digits='Product Unit of Measure', required=True)
     qty_done = fields.Float('Done', default=0.0, digits='Product Unit of Measure', copy=False)
     package_id = fields.Many2one(

--- a/addons/stock/static/src/js/forecast_widget.js
+++ b/addons/stock/static/src/js/forecast_widget.js
@@ -31,7 +31,7 @@ const ForecastWidgetField = AbstractField.extend({
         if (data.forecast_expected_date && data.date_deadline) {
             data.forecast_is_late = data.forecast_expected_date > data.date_deadline;
         }
-        data.will_be_fulfilled = utils.round_decimals(data.forecast_availability, this.record.fields.forecast_availability.digits[1]) >= utils.round_decimals(data.product_qty, this.record.fields.product_qty.digits[1]);
+        data.will_be_fulfilled = utils.round_decimals(data.forecast_availability, this.record.fields.forecast_availability.digits[1]) >= utils.round_decimals(data.product_qty, this.record.fields.forecast_availability.digits[1]);
 
         this.$el.html(QWeb.render('stock.forecastWidget', data));
         this.$('.o_forecast_report_button').on('click', this._onOpenReport.bind(this));


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Fix tends to fix reserved_qty if the precision of product_uom_qty is higher than 0.5

Current behavior before PR:
- If the precision of product_uom_qty is higher than 0.5 reserved_qty (components availability) appears to be not available although there is enough qty in the stock.

Desired behavior after PR is merged:
- Unless there's no enough qty in the stock, reserved_qty is available.

opw-2425473
opw-2459650
opw-2448443
opw-2446985
opw-2440853
opw-2464507


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
