### PR TITLE
[FIX] point_of_sale: allow pos user to open pos with cash control

### DIFF
--- a/addons/point_of_sale/security/ir.model.access.csv
+++ b/addons/point_of_sale/security/ir.model.access.csv
@@ -50,3 +50,4 @@ access_closing_balance_confirm_wizard,access.closing.balance.confirm.wizard,mode
 access_pos_details_wizard,access.pos.details.wizard,model_pos_details_wizard,point_of_sale.group_pos_manager,1,1,1,0
 access_pos_make_payment,access.pos.make.payment,model_pos_make_payment,point_of_sale.group_pos_manager,1,1,1,0
 access_money_in_out_wizard,access.money.in.out.wizard,model_cash_box_out,point_of_sale.group_pos_user,1,1,1,0
+access_account_cash_rounding_pos_user,account.cash.rounding pos_user,account.model_account_cash_rounding,group_pos_user,1,0,0,0


### PR DESCRIPTION
Have a user [DEMO] with just user permission on POS
Have a POS configured with advanced cash control
With user [DEMO] open POS session

Traceback will occur because [DEMO] cannot access the relevant model

opw-2464150

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:

Fixes https://github.com/odoo/odoo/issues/65943
Closes https://github.com/odoo/odoo/issues/65943



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
