### PR TITLE
[FIX] stock: reset product.template records to default type

### DIFF
--- a/addons/stock/__init__.py
+++ b/addons/stock/__init__.py
@@ -28,3 +28,12 @@ def _assign_default_mail_template_picking_id(cr, registry):
         company_ids_without_default_mail_template_id.write({
             'stock_mail_confirmation_template_id': default_mail_template_id.id,
         })
+
+
+def uninstall_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    default = env['product.template']._fields['type'].default(env['product.template'])
+    # stock introduces an option on the `type` Selection field of `product.template`
+    # if this module is uninstalled and any `product.template` record still points to this option
+    # the registry will find itself in an unstable state and will most likely crash (eventually)
+    cr.execute("UPDATE product_template SET type = %s WHERE type = %s", (default, 'product'))

--- a/addons/stock/__manifest__.py
+++ b/addons/stock/__manifest__.py
@@ -94,4 +94,5 @@
     'auto_install': False,
     'pre_init_hook': 'pre_init_hook',
     'post_init_hook': '_assign_default_mail_template_picking_id',
+    'uninstall_hook': 'uninstall_hook',
 }


### PR DESCRIPTION
Stock introduces the option 'product' for the field `type` of the
`product.template` model.

If there exists records for this model with the aforementioned option
selected when the stock module is uninstalled, the records will remain
in the database for an indefinite amount of time, all while pointing to
an option that does no longer exist (except if the record was created by
the stock module itself), making the registry inconsistent and
eventually leading to a crash.

This is a known limitation of the ORM regarding Selection fields and
more specifically the `selection_add` mechanism, no "generic" solution
has been chosen thus far because it is not always clear which approach
should be taken:

    1) Delete the record?
    2) Set the option to a fallback, base option?
    3) Something else handled by the module itself?
    ...

In this case the second approach has been chosen and whenever the module
stock is uninstalled, all remaining product.template records of `type`
'product' will be reset to the default option defined by the field,
which as of this commit is 'consu'.

See opw#2193814, 2451126
