### PR TITLE
[FIX] purchase: add read access on tax tag

### DIFF
--- a/addons/purchase/security/ir.model.access.csv
+++ b/addons/purchase/security/ir.model.access.csv
@@ -10,6 +10,7 @@ access_purchase_order_line_invoicing_payments_readonly,purchase.order.line,model
 access_purchase_order_line_invoicing_payments,purchase.order.line,model_purchase_order_line,account.group_account_invoice,1,1,0,0
 access_purchase_order_line_portal,purchase.order.line.portal,purchase.model_purchase_order_line,base.group_portal,1,0,0,0
 access_account_tax_purchase_user,account.tax,account.model_account_tax,group_purchase_user,1,0,0,0
+access_account_tag_purchase_user,account.account.tag,account.model_account_account_tag,group_purchase_user,1,0,0,0
 access_account_tax_purchase_user_manager,account.tax,account.model_account_tax,group_purchase_manager,1,0,0,0
 access_product_product_purchase_user,product.product.purchase.user,product.model_product_product,group_purchase_user,1,0,0,0
 access_product_product_purchase_manager,product.product purchase_manager,product.model_product_product,purchase.group_purchase_manager,1,1,1,1


### PR DESCRIPTION
As a user accessing only the purchase module, create a request for
quotation, add a line with a tax and a cost > 0.
Confirm the RfQ to create the purchase order.

Before this commit, the user get a access error on account.account.tag
This patch add read access on this model for purchase users

opw : 2466688

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
