### PR TITLE
[FIX] account_checking_printing: use correct fields on partial payment

### DIFF
--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -252,7 +252,8 @@ class AccountPayment(models.Model):
             invoice_payment_reconcile = invoice.line_ids.mapped('matched_credit_ids').filtered(lambda r: r.credit_move_id in self.line_ids)
 
         if self.currency_id != self.journal_id.company_id.currency_id:
-            amount_paid = abs(sum(invoice_payment_reconcile.mapped('amount_currency')))
+            amount_paid = abs(sum(invoice_payment_reconcile.mapped('debit_amount_currency'))) + \
+                          abs(sum(invoice_payment_reconcile.mapped('credit_amount_currency')))
         else:
             amount_paid = abs(sum(invoice_payment_reconcile.mapped('amount')))
 


### PR DESCRIPTION
The currency amount fields on the account.partial.reconcile changed

opw-2444189

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
