### PR TITLE
[FIX] web: fix error-handling infinitely-looping on non-chrome browsers

### DIFF
--- a/addons/web/static/src/js/core/error_utils.js
+++ b/addons/web/static/src/js/core/error_utils.js
@@ -2,6 +2,7 @@
 
 import { loadJS } from "web.ajax";
 import BrowserDetection from "web.BrowserDetection";
+import { _t } from "web.core";
 /**
  * Format the traceback of an error.  Basically, we just add the error message
  * in the traceback if necessary (Chrome already does it by default, but not


### PR DESCRIPTION
The formatTraceback function relies on _t to add the error message to
tracebacks, it was recently moved around while refactoring but it seems
that its dependency was forgotten and not imported. This causes the
attempt to call _t to crash, which will try to format the error, which
will again try to call _t and crash, until the browser itself crashes.

This commit fixes that issue by adding the required import.
