### PR TITLE
[FIX] website: fix image gallery miniatures disappearing

### DIFF
--- a/addons/website/views/snippets/s_image_gallery.xml
+++ b/addons/website/views/snippets/s_image_gallery.xml
@@ -22,7 +22,7 @@
                     <li class="o_indicators_left text-center d-none" aria-label="Previous" title="Previous">
                         <i class="fa fa-chevron-left"/>
                     </li>
-                    <li data-target="#slideshow_sample" data-slide-to="0" style="background-image: url(/web/image/website.library_image_08)"/>
+                    <li data-target="#slideshow_sample" data-slide-to="0" style="background-image: url(/web/image/website.library_image_08)" class="active"/>
                     <li data-target="#slideshow_sample" data-slide-to="1" style="background-image: url(/web/image/website.library_image_03)"/>
                     <li data-target="#slideshow_sample" data-slide-to="2" style="background-image: url(/web/image/website.library_image_02)"/>
                     <li class="o_indicators_right text-center d-none" aria-label="Next" title="Next">


### PR DESCRIPTION
When the snippet was dropped, the miniatures were disappearing and
replaced by an arrow.

It was due to the wrongly calculated index when the snippet was
initialized, as the jquery method .index() will still return -1 when no
element is found.

task-2472041

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
