### PR TITLE
[FIX] stock: don't display assign SN for returns

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -194,6 +194,7 @@ class StockMove(models.Model):
                 move.state in ('partially_available', 'assigned', 'confirmed') and
                 move.picking_type_id.use_create_lots and
                 not move.picking_type_id.use_existing_lots
+                and not move.origin_returned_move_id.id
             )
 
     @api.depends('picking_id.priority')


### PR DESCRIPTION
Before this commit, when delivered qty. for a product tracked by serial numbers and then create a returns for this product, as the move is linked to its original returned move, when the detailed operations will be displayed, it will hide `lot_name` field and display the `lot_id`.
The issue is it will still show the "Assign Serial Numbers" feature.
As this feature is for the creation of new SN only (not for assign existing ones), it should be hidden in this case because it will lead to attempt to create already existing.

How to reproduce:
  - Create a product tracked by serial numbers;
  - Add at least two qty. on hand for this product and create as many serial numbers, following by numbers (ex.: sn01, sn02, sn03, ...);
  - Make a delivery for at least two of this product and proceed it;
  - When it's done, make a return for this delivery;
  - Open the delivery's return and display the detailed operations, then use the "Assign Serial Numbers" to try to reassign the delivery SN.
  --> First, we will not see the SN on the move line (as `lot_id` is visible but `lot_name` is invisible).
  --> Second, you can't mark as done the return as it will try to create the SN but they already exist.

To fix the issue, we can simply hide this feature when we hide the `lot_name` field.

task-2474919
opw-2455971