### PR TITLE
[FIX] hw_drivers: Fix default for action on iot mapping

### DIFF
--- a/addons/hw_drivers/driver.py
+++ b/addons/hw_drivers/driver.py
@@ -49,7 +49,7 @@ class Driver(Thread, metaclass=DriverMetaClass):
         :param data: the `_actions` key mapped to the action method we want to call
         :type data: string
         """
-        self._actions[data['action']](data)
+        self._actions[data.get('action', '')](data)
 
     def disconnect(self):
         self._stopped.set()


### PR DESCRIPTION
Some requests are sended without specific action.
So we need set these call to fit to a default action
who is a empty string.

Pull requeste related: 63375

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
