### PR TITLE
[I18N] sale_timesheet: translate "Late" on web too

### DIFF
--- a/addons/sale_timesheet/i18n/sale_timesheet.pot
+++ b/addons/sale_timesheet/i18n/sale_timesheet.pot
@@ -775,6 +775,7 @@ msgid "Last Updated on"
 msgstr ""
 
 #. module: sale_timesheet
+#. openerp-web
 #: code:addons/sale_timesheet/models/project_overview.py:0
 #, python-format
 msgid "Late"


### PR DESCRIPTION
This is used in mail and sale_timesheet but wasn't an openerp-web
translation there.
Similar to 5caa0f0cc2c9025bef
Courtesy of Erwin van der Ploeg