### PR TITLE
[FIX] point_of_sale: do not display pricelist reduction as discount

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -2836,7 +2836,7 @@ exports.Order = Backbone.Model.extend({
     get_total_discount: function() {
         return round_pr(this.orderlines.reduce((function(sum, orderLine) {
             sum += (orderLine.get_unit_price() * (orderLine.get_discount()/100) * orderLine.get_quantity());
-            if (orderLine.display_discount_policy() === 'without_discount'){
+            if (orderLine.get_discount() !== 0 && orderLine.display_discount_policy() === 'without_discount'){
                 sum += ((orderLine.get_lst_price() - orderLine.get_unit_price()) * orderLine.get_quantity());
             }
             return sum;


### PR DESCRIPTION
Have a pricelist which apply a price reduction for [DEMO]
Configure discount to show in invoice
Open POS, add [DEMO] to order and process payment
Receipt ticket will show the price reduction as discount while it should
not

opw-2467341

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
