### PR TITLE
[FIX] stock: pass on change from move to move line

### DIFF
--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -164,6 +164,10 @@ class StockRule(models.Model):
                 'date': new_date,
                 'date_expected': new_date,
                 'location_dest_id': self.location_id.id})
+            # make sure the location_dest_id is consistent with the move line location dest
+            if move.move_line_ids:
+                move.move_line_ids.location_dest_id = move.location_dest_id._get_putaway_strategy(move.product_id) or move.location_dest_id
+
             # avoid looping if a push rule is not well configured; otherwise call again push_apply to see if a next step is defined
             if self.location_id != old_dest_location:
                 # TDE FIXME: should probably be done in the move model IMO


### PR DESCRIPTION
The run_push() method may change the location_dest_id of the stock move
but not the associated stock move line. That can produce a
desynchronisation between stock move and stock quants as those are
updated by the stock move lines.
This commit ensures the location_dest_id of the stock move is also set
on the move lines in run_push()

opw : 2427301

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
