### PR TITLE
[FIX] sale_management : fix purchase price on order line after confir…

### DIFF
--- a/addons/sale_stock_margin/models/sale_order_line.py
+++ b/addons/sale_stock_margin/models/sale_order_line.py
@@ -13,6 +13,6 @@ class SaleOrderLine(models.Model):
         for line in self:
             if not line.move_ids:
                 lines_without_moves |= line
-            else:
+            elif line.product_id.categ_id.property_cost_method != 'standard':
                 line.purchase_price = line.product_id.with_company(line.company_id)._compute_average_price(0, line.product_uom_qty, line.move_ids)
         return super(SaleOrderLine, lines_without_moves)._compute_purchase_price()


### PR DESCRIPTION
…ming the order

Steps to follow to reproduce the bug:
- Go to Sales app
- Create a product and give it for example a “sales price” of 200 and a “cost” of 100. Select a category of product with "Costing Method == Standard Price"
- Create a new Quotation/Order
- Add the product you just created
- Modify in the order line, the value of cost from 100 to 120 for example.
- Save the sale order and confirm it

Problem :
The final price is calculated in relation to the base price of the product and never takes price changes into account.

Solution :
Check if the "Costing method" of the product category is "Standard price". If it's the case, do not change the "purchase_price" is defined in the order line.

opw-2451721

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
