### PR TITLE
[IMP] payment: better exception feedback for logs

### DIFF
--- a/addons/payment/models/payment_acquirer.py
+++ b/addons/payment/models/payment_acquirer.py
@@ -901,7 +901,7 @@ class PaymentTransaction(models.Model):
                 tx._post_process_after_done()
                 self.env.cr.commit()
             except Exception as e:
-                _logger.exception("Transaction post processing failed")
+                _logger.exception("Transaction post processing failed. Reason: %s", str(e))
                 self.env.cr.rollback()
 
     @api.model


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Better feedback in the logs

Current behavior before PR: The log basically prints "Transaction post processing failed" but has zero added value.

Desired behavior after PR is merged: By adding in the exception its details it gives a good idea of why this crashed.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
