### PR TITLE
[FIX] stock_account: fix access error when validating delivery

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -164,7 +164,7 @@ class ProductProduct(models.Model):
             # In case of AVCO, fix rounding issue of standard price when needed.
             if self.cost_method == 'average':
                 currency = self.env.company.currency_id
-                rounding_error = currency.round(self.standard_price * self.quantity_svl - self.value_svl)
+                rounding_error = currency.round(self.standard_price * self.sudo().quantity_svl - self.value_svl)
                 if rounding_error:
                     # If it is bigger than the (smallest number of the currency * quantity) / 2,
                     # then it isn't a rounding error but a stock valuation error, we shouldn't fix it under the hood ...


### PR DESCRIPTION
- Create a Product (i.e. Product X) with some quantity on hand
- Configure its Product Category:
  * Costing Method: Average Cost (AVCO)
  * Inventory Valuation: Automated
- Connect with an User with rights "Inventory: User" (i.e. Marc Demo)
- Create a SO with Product X and validate the delivery
During the validation of the delivery, an error is raised while trying to access
documents of type 'Stock Valuation Layer' (stock.valuation.layer).

This happens when "quantity_svl" and "value_svl" fields are computed in "_compute_value_svl".

opw-2465585

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
