### PR TITLE
[FIX] hr_expense: Don't write 'payment_id' on aml

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -541,7 +541,6 @@ Or send your receipts at <a href="mailto:%(email)s?subject=Lunch%%20with%%20cust
                     'amount': abs(total_amount_currency) if different_currency else abs(total_amount),
                     'ref': expense.name,
                 })
-                move_line_dst['payment_id'] = payment.id
 
             # link move lines to move, and move to expense sheet
             move.write({'line_ids': [(0, 0, line) for line in move_line_values]})


### PR DESCRIPTION
This line was an hack to manage the custom register payment wizard of hr_expense.
Since this wizard is gone and 'payment_id' is a related stored field in account.move.line, we should not write such data explicitely.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
