### PR TITLE
[FIX] account_fleet: Field vehicle_id unavailable on vendor refund

### DIFF
--- a/addons/account_fleet/models/account_move.py
+++ b/addons/account_fleet/models/account_move.py
@@ -16,7 +16,7 @@ class AccountMove(models.Model):
         log_list = []
         not_posted_before = self.filtered(lambda r: not r.posted_before)
         posted = super()._post(soft)  # We need the move name to be set, but we also need to know which move are posted for the first time.
-        for line in (not_posted_before & posted).line_ids.filtered(lambda ml: ml.vehicle_id):
+        for line in (not_posted_before & posted).line_ids.filtered(lambda ml: ml.vehicle_id and ml.move_id.move_type == 'in_invoice'):
             val = {
                 'service_type_id': vendor_bill_service.id,
                 'vehicle_id': line.vehicle_id.id,

--- a/addons/account_fleet/views/account_move_views.xml
+++ b/addons/account_fleet/views/account_move_views.xml
@@ -7,11 +7,11 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='line_ids']//field[@name='account_id']" position="after">
                 <field name='need_vehicle' invisible='1'/>
-                <field name='vehicle_id' attrs="{'required': [('need_vehicle', '=', True), ('parent.move_type', '=', 'in_invoice')], 'column_invisible': [('parent.move_type', '!=', 'in_invoice')]}" optional='hidden'/>
+                <field name='vehicle_id' attrs="{'required': [('need_vehicle', '=', True), ('parent.move_type', 'in', ('in_invoice', 'in_refund'))], 'column_invisible': [('parent.move_type', 'not in', ('in_invoice', 'in_refund'))]}" optional='hidden'/>
             </xpath>
             <xpath expr="//field[@name='invoice_line_ids']//field[@name='account_id']" position="after">
                 <field name='need_vehicle' invisible='1'/>
-                <field name='vehicle_id' attrs="{'required': [('need_vehicle', '=', True), ('parent.move_type', '=', 'in_invoice')], 'column_invisible': [('parent.move_type', '!=', 'in_invoice')]}" optional='hidden'/>
+                <field name='vehicle_id' attrs="{'required': [('need_vehicle', '=', True), ('parent.move_type', 'in', ('in_invoice', 'in_refund'))], 'column_invisible': [('parent.move_type', 'not in', ('in_invoice', 'in_refund'))]}" optional='hidden'/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
The fleet vehicle_id must be visible on vendor refund

opw:2471784