### PR TITLE
[FIX] web: misaligned font-size in group headers list view

### DIFF
--- a/addons/web/static/src/scss/list_view.scss
+++ b/addons/web/static/src/scss/list_view.scss
@@ -131,6 +131,10 @@
                 vertical-align: middle;
                 padding-top: ($table-cell-padding-sm*2);
                 padding-bottom: ($table-cell-padding-sm*2);
+                &.progress {
+                    font-size: inherit;
+                    overflow: visible;
+                }
             }
             .o_group_name {
                 @include o-text-overflow(table-cell);
@@ -302,6 +306,10 @@
                 color: $link-hover-color;
                 outline: none;
             }
+        }
+
+        .progress {
+            background-color: unset;
         }
     }
 


### PR DESCRIPTION
Currently, the font-size and background-color of the progress bar widget
are mismatches with the group headers font-size and background-color.
It happens because of the progress bar widget's font-size and background-color.

This commit fixes the issue by overriding the font-size and background-color
property of the progress bar widget.

TaskID-2462152