### PR TITLE
[FIX] account: Avoid add payment_reference from SO

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -388,10 +388,10 @@ class AccountMove(models.Model):
 
         self._recompute_dynamic_lines(recompute_tax_base_amount=True)
 
-    @api.onchange('invoice_payment_ref', 'ref')
+    @api.onchange('invoice_payment_ref')
     def _onchange_invoice_payment_ref(self):
         for line in self.line_ids.filtered(lambda line: line.account_id.user_type_id.type in ('receivable', 'payable')):
-            line.name = self.invoice_payment_ref or self.ref or ''
+            line.name = self.invoice_payment_ref
 
     @api.onchange('invoice_vendor_bill_id')
     def _onchange_invoice_vendor_bill(self):
@@ -933,7 +933,7 @@ class AccountMove(models.Model):
                     # Create new line.
                     create_method = in_draft_mode and self.env['account.move.line'].new or self.env['account.move.line'].create
                     candidate = create_method({
-                        'name': self.invoice_payment_ref or self.ref or '',
+                        'name': self.invoice_payment_ref or '',
                         'debit': balance < 0.0 and -balance or 0.0,
                         'credit': balance > 0.0 and balance or 0.0,
                         'quantity': 1.0,

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -1789,23 +1789,3 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         })
         move.post()
         self.assertEquals(move.name, 'INV/2019/01/1')
-
-    def test_in_invoice_payment_ref(self):
-        ''' Test the 'name' of the payable line fallbacks on the move's ref if the payment ref is empty. '''
-        ref = 'VENDORBILL123456'
-        with Form(self.invoice) as move_form:
-            move_form.ref = ref
-
-        self.assertInvoiceValues(self.invoice, [
-            self.product_line_vals_1,
-            self.product_line_vals_2,
-            self.tax_line_vals_1,
-            self.tax_line_vals_2,
-            {
-                **self.term_line_vals_1,
-                'name': ref,
-            },
-        ], {
-            **self.move_vals,
-            'ref': ref,
-        })


### PR DESCRIPTION
- Install Accounting and Sales;
- Create a SO;
- Add a Customer Reference;
- Confirm and Create the Invoice.

Before this commit, the payment reference and the reference of the
invoice was copied from the SO's customer reference.  This will modify
the current behaviour in which the payment reference is empty and
defined on invoice validation.

Now, only the invoice reference is copied from the SO's customer
reference.

This commit reverts 1027490318f3baa9bef382b3e54b20d05a40aa03

opw-2465994
