### PR TITLE
[IMP] website: added a conditional visibility option on <section> blocks

### DIFF
--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -143,6 +143,7 @@ Help your customers with this chat, and analyse their feedback.
             'web/static/src/session.js',
             'web/static/src/legacy/js/core/session.js',
             'web/static/src/legacy/js/core/concurrency.js',
+            'web/static/src/legacy/js/core/cookie_utils.js',
             'web/static/src/legacy/js/core/utils.js',
             'web/static/src/legacy/js/core/dom.js',
             'web/static/src/legacy/js/core/qweb.js',

--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -58,6 +58,7 @@ This module provides the core of the Odoo Web Client.
             'web/static/src/legacy/js/promise_extension.js',
             'web/static/src/boot.js',
             'web/static/src/session.js',
+            'web/static/src/legacy/js/core/cookie_utils.js',
         ],
         'web.assets_common': [
             ('include', 'web._assets_helpers'),
@@ -75,6 +76,7 @@ This module provides the core of the Odoo Web Client.
             ('remove', 'web/static/src/legacy/js/promise_extension.js'),
             ('remove', 'web/static/src/boot.js'),
             ('remove', 'web/static/src/session.js'),
+            ('remove', 'web/static/src/legacy/js/core/cookie_utils.js'),
         ],
         'web.assets_backend': [
             ('include', 'web._assets_helpers'),

--- a/addons/web/static/src/legacy/js/core/cookie_utils.js
+++ b/addons/web/static/src/legacy/js/core/cookie_utils.js
@@ -1,0 +1,41 @@
+odoo.define('web.utils.cookies', function (require) {
+"use strict";
+
+return {
+    /**
+     * Reads the cookie described by the given name.
+     *
+     * @param {string} cookieName
+     * @returns {string}
+     */
+    get_cookie(cookieName) {
+        var cookies = document.cookie ? document.cookie.split('; ') : [];
+        for (var i = 0, l = cookies.length; i < l; i++) {
+            var parts = cookies[i].split('=');
+            var name = parts.shift();
+            var cookie = parts.join('=');
+
+            if (cookieName && cookieName === name) {
+                return cookie;
+            }
+        }
+        return "";
+    },
+    /**
+     * Creates a cookie.
+     *
+     * @param {string} name the name of the cookie
+     * @param {string} value the value stored in the cookie
+     * @param {integer} ttl time to live of the cookie in millis. -1 to erase the cookie.
+     */
+    set_cookie(name, value, ttl) {
+        ttl = ttl || 24 * 60 * 60 * 365;
+        document.cookie = [
+            `${name}=${value}`,
+            'path=/',
+            `max-age=${ttl}`,
+            `expires=${new Date(new Date().getTime() + ttl * 1000).toGMTString()}`
+        ].join(';');
+    },
+};
+});

--- a/addons/web/static/src/legacy/js/core/utils.js
+++ b/addons/web/static/src/legacy/js/core/utils.js
@@ -8,6 +8,7 @@ odoo.define('web.utils', function (require) {
  */
 
 var translation = require('web.translation');
+var cookieUtils = require('web.utils.cookies');
 
 var _t = translation._t;
 var id = -1;
@@ -311,7 +312,7 @@ function Markup(v, ...exprs) {
     return new _Markup(s);
 }
 
-var utils = {
+var utils = Object.assign({
     AlreadyDefinedPatchError,
     UnknownPatchError,
     Markup,
@@ -389,25 +390,6 @@ var utils = {
      */
     generateID: function () {
         return ++id;
-    },
-    /**
-     * Read the cookie described by c_name
-     *
-     * @param {string} c_name
-     * @returns {string}
-     */
-    get_cookie: function (c_name) {
-        var cookies = document.cookie ? document.cookie.split('; ') : [];
-        for (var i = 0, l = cookies.length; i < l; i++) {
-            var parts = cookies[i].split('=');
-            var name = parts.shift();
-            var cookie = parts.join('=');
-
-            if (c_name && c_name === name) {
-                return cookie;
-            }
-        }
-        return "";
     },
     /**
      * Gets dataURL (base64 data) from the given file or blob.
@@ -850,21 +832,6 @@ var utils = {
         return str + new Array(size - str.length + 1).join('0');
     },
     /**
-     * Create a cookie
-     * @param {String} name the name of the cookie
-     * @param {String} value the value stored in the cookie
-     * @param {Integer} ttl time to live of the cookie in millis. -1 to erase the cookie.
-     */
-    set_cookie: function (name, value, ttl) {
-        ttl = ttl || 24*60*60*365;
-        document.cookie = [
-            name + '=' + value,
-            'path=/',
-            'max-age=' + ttl,
-            'expires=' + new Date(new Date().getTime() + ttl*1000).toGMTString()
-        ].join(';');
-    },
-    /**
      * Return a shallow copy of a given array sorted by a given criterion or a default one.
      * The given criterion can either be:
      * - a string: a property name on the array elements returning the sortable primitive
@@ -1174,7 +1141,7 @@ var utils = {
             ['name', '=like', '%.report_assets\_%.css'],
         ];
     },
-};
+}, cookieUtils);
 
 return utils;
 

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -19,6 +19,7 @@
         'auth_signup',
         'mail',
         'google_recaptcha',
+        'utm',
     ],
     'installable': True,
     'data': [
@@ -120,6 +121,13 @@
             'website/static/src/js/show_password.js',
             'website/static/src/js/post_link.js',
             'website/static/src/js/user_custom_javascript.js',
+        ],
+        'web.assets_frontend_minimal': [
+            'website/static/src/js/content/inject_dom.js',
+        ],
+        'web.assets_frontend_lazy': [
+            # Remove assets_frontend_minimal
+            ('remove', 'website/static/src/js/content/inject_dom.js'),
         ],
         'web._assets_primary_variables': [
             'website/static/src/scss/primary_variables.scss',

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -434,6 +434,7 @@ class Http(models.AbstractModel):
         session_info = super(Http, self).get_frontend_session_info()
         session_info.update({
             'is_website_user': request.env.user.id == request.website.user_id.id,
+            'geoip_country_code': request.session.get('geoip', {}).get('country_code'),
         })
         if request.env.user.has_group('website.group_website_publisher'):
             session_info.update({

--- a/addons/website/static/src/js/content/inject_dom.js
+++ b/addons/website/static/src/js/content/inject_dom.js
@@ -1,0 +1,42 @@
+/** @odoo-module */
+
+import { get_cookie } from 'web.utils.cookies';
+import { session } from '@web/session';
+
+document.addEventListener('DOMContentLoaded', () => {
+    // Transfer cookie/session data as HTML element's attributes so that CSS
+    // selectors can be based on them.
+    const htmlEl = document.documentElement;
+    const cookieNamesToDataNames = {
+        'utm_source': 'utmSource',
+        'utm_medium': 'utmMedium',
+        'utm_campaign': 'utmCampaign',
+    };
+    for (const [name, dsName] of Object.entries(cookieNamesToDataNames)) {
+        const cookie = get_cookie(`odoo_${name}`);
+        if (cookie) {
+            // Remove leading and trailing " and '
+            htmlEl.dataset[dsName] = cookie.replace(/(^["']|["']$)/g, '');
+        }
+    }
+    const country = session.geoip_country_code;
+    if (country) {
+        htmlEl.dataset.country = country;
+    }
+
+    // Create CSS rules in a dedicated style tag according to the snippet
+    // visibility option's computed ones (saved as data attributes).
+    const styleEl = document.createElement('style');
+    styleEl.id = "conditional_visibility";
+    document.head.appendChild(styleEl);
+    const conditionalEls = document.querySelectorAll('[data-visibility="conditional"]');
+    for (const conditionalEl of conditionalEls) {
+        const selectors = conditionalEl.dataset.visibilitySelectors;
+        styleEl.sheet.insertRule(`${selectors} { display: none !important; }`);
+    }
+
+    // Now remove the classes that makes them always invisible
+    for (const conditionalEl of conditionalEls) {
+        conditionalEl.classList.remove('o_conditional_hidden');
+    }
+});

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1398,6 +1398,11 @@ $ribbon-padding: 100px;
     @include o-tag-left();
 }
 
+// Conditional visibility
+.o_conditional_hidden {
+    display: none !important;
+}
+
 // Cookies Bar
 #website_cookies_bar {
     :not(.o_cookies_popup) {

--- a/addons/website/static/tests/tours/conditional_visibility.js
+++ b/addons/website/static/tests/tours/conditional_visibility.js
@@ -1,0 +1,76 @@
+/** @odoo-module */
+
+import tour from 'web_tour.tour';
+import wTourUtils from 'website.tour_utils';
+
+const snippets = [
+    {
+        id: 's_text_image',
+        name: 'Text - Image',
+    },
+];
+tour.register('conditional_visibility_1', {
+    test: true,
+    url: '/',
+},
+[{
+    content: "enter edit mode",
+    trigger: 'a[data-action=edit]',
+},
+wTourUtils.dragNDrop(snippets[0]),
+wTourUtils.clickOnSnippet(snippets[0]),
+wTourUtils.changeOption('ConditionalVisibility', 'we-toggler'),
+{
+    content: 'click on conditional visibility',
+    trigger: '[data-name="visibility_conditional"]',
+    run: 'click',
+},
+{
+    content: 'click on utm medium toggler',
+    trigger: '[data-save-attribute="visibilityValueUtmMedium"] we-toggler',
+    run: 'click',
+},
+{
+    trigger: '[data-save-attribute="visibilityValueUtmMedium"] we-selection-items [data-add-record="Email"]',
+    content: 'click on Email',
+    run: 'click',
+},
+...wTourUtils.clickOnSave(),
+{
+    content: 'Check if the rule was applied',
+    trigger: 'body:not(.editor_enable) #wrap',
+    run: function (actions) {
+        const style = window.getComputedStyle(this.$anchor[0].getElementsByClassName('s_text_image')[0]);
+        if (style.display !== 'none') {
+            console.error('error This item should be invisible and only visible if utm_medium === email');
+        }
+    },
+},
+wTourUtils.clickOnEdit(),
+{
+    content: 'Check if the element is visible as it should always be visible in edit view',
+    trigger: 'body.editor_enable #wrap .s_text_image',
+    run: function (actions) {
+        const style = window.getComputedStyle((this.$anchor[0]));
+        if (style.display === 'none') {
+            console.error('error This item should now be visible because utm_medium === email');
+        }
+    },
+},
+]);
+
+tour.register('conditional_visibility_2', {
+    test: true,
+    url: '/?utm_medium=Email',
+},
+[{
+    content: 'The content previously hidden should now be visible',
+    trigger: 'body #wrap',
+    run: function (actions) {
+        const style = window.getComputedStyle(this.$anchor[0].getElementsByClassName('s_text_image')[0]);
+        if (style.display === 'none') {
+            console.error('error This item should now be visible because utm_medium === email');
+        }
+    },
+},
+]);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -202,3 +202,7 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_09_website_edit_link_popover(self):
         self.start_tour("/", "edit_link_popover", login="admin")
+
+    def test_10_website_conditional_visibility(self):
+        self.start_tour('/', 'conditional_visibility_1', login='admin')
+        self.start_tour('/', 'conditional_visibility_2', login='admin')

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -310,6 +310,20 @@
     </we-multi>
 </template>
 
+<template id="snippet_options_conditional_visibility">
+    <we-select t-att-string="option_name" t-att-data-attribute-name="attribute_rule" data-no-preview="true" data-dependencies="visibility_conditional" data-is-visibility-condition="true">
+        <we-button data-select-data-attribute="">Visible for</we-button>
+        <we-button data-select-data-attribute="hide">Hidden for</we-button>
+    </we-select>
+    <we-many2many string=" "
+        data-dependencies="visibility_conditional"
+        t-att-data-save-attribute="save_attribute"
+        t-att-data-attribute-name="attribute_name"
+        data-no-preview="true"
+        t-att-data-model="model" t-att-data-call-with="call_with" data-select-record="" t-att-data-fields="data_fields"
+        data-allow-delete="true" data-fakem2m="true"/>
+</template>
+
 <template id="snippet_options">
     <t t-call="web_editor.snippet_options"/>
 
@@ -1069,6 +1083,60 @@
                        data-select-class="align-items-stretch"
                        data-img="/website/static/src/img/snippets_options/align_stretch.svg"/>
         </we-button-group>
+    </div>
+
+    <div data-js="ConditionalVisibility" data-selector="section">
+        <we-collapse>
+            <we-select string="Visibility" data-attribute-name="visibility" data-no-preview="true">
+                <we-button data-select-data-attribute="">Always visible</we-button>
+                <we-button data-select-data-attribute="conditional" data-select-class="o_snippet_invisible" data-name="visibility_conditional">Conditionally</we-button>
+            </we-select>
+
+            <t t-if="request.session.get('geoip', {}).get('country_code')">
+                <t t-call="website.snippet_options_conditional_visibility">
+                    <t t-set="option_name">⌙ Country</t>
+                    <t t-set="attribute_rule">visibilityValueCountryRule</t>
+                    <t t-set="save_attribute">visibilityValueCountry</t>
+                    <t t-set="attribute_name">data-country</t>
+                    <t t-set="model">res.country</t>
+                    <t t-set="call_with">code</t>
+                    <t t-set="data_fields">[&quot;code&quot;]</t>
+                </t>
+            </t>
+            <t t-call="website.snippet_options_conditional_visibility">
+                <t t-set="option_name">⌙ Languages</t>
+                <t t-set="attribute_rule">visibilityValueLangRule</t>
+                <t t-set="save_attribute">visibilityValueLang</t>
+                <t t-set="attribute_name">lang</t>
+                <t t-set="model">res.lang</t>
+                <t t-set="call_with">code</t>
+                <t t-set="data_fields">[&quot;code&quot;]</t>
+            </t>
+            <t t-call="website.snippet_options_conditional_visibility">
+                <t t-set="option_name">⌙ UTM Campaign</t>
+                <t t-set="attribute_rule">visibilityValueUtmCampaignRule</t>
+                <t t-set="save_attribute">visibilityValueUtmCampaign</t>
+                <t t-set="attribute_name">data-utm-campaign</t>
+                <t t-set="model">utm.campaign</t>
+                <t t-set="call_with">display_name</t>
+            </t>
+            <t t-call="website.snippet_options_conditional_visibility">
+                <t t-set="option_name">⌙ UTM Medium</t>
+                <t t-set="attribute_rule">visibilityValueUtmMediumRule</t>
+                <t t-set="save_attribute">visibilityValueUtmMedium</t>
+                <t t-set="attribute_name">data-utm-medium</t>
+                <t t-set="model">utm.medium</t>
+                <t t-set="call_with">display_name</t>
+            </t>
+            <t t-call="website.snippet_options_conditional_visibility">
+                <t t-set="option_name">⌙ UTM Source</t>
+                <t t-set="attribute_rule">visibilityValueUtmSourceRule</t>
+                <t t-set="save_attribute">visibilityValueUtmSource</t>
+                <t t-set="attribute_name">data-utm-source</t>
+                <t t-set="model">utm.source</t>
+                <t t-set="call_with">display_name</t>
+            </t>
+        </we-collapse>
     </div>
 
     <!-- Cookies Bar -->

--- a/addons/website_forum/models/forum.py
+++ b/addons/website_forum/models/forum.py
@@ -61,7 +61,9 @@ class Forum(models.Model):
                                 </div>
                             </div>
                         </div>
-                    </section>""")
+                    </section>""",
+        sanitize_attributes=False,
+        sanitize_form=False)
     default_order = fields.Selection([
         ('create_date desc', 'Newest'),
         ('write_date desc', 'Last Updated'),


### PR DESCRIPTION
Provide the user with an option to hide or display a section tag
depending on the visitor's location (if geoip enabled), language,
utm_medium, utm_source and utm_campaign.

User can use a M2M widget to select different records. These will be
used to create a CSS Selector on save that will hide the section tag
depending on the various options they selected.
This CSS selectors will be applied, as well as various data attributes
when the page loads to hide the targeted tag. All of these operations
are handled client side.

The geoip country had to be added to the session for the feature to work
with countries.

task-2381049