### PR TITLE
[FIX] web: control panel shouldn't flicker

### DIFF
--- a/addons/web/static/src/scss/control_panel.scss
+++ b/addons/web/static/src/scss/control_panel.scss
@@ -73,6 +73,7 @@
         display: flex;
         width: 50%;
         margin-top: 5px;
+        min-height: 30px;
 
         > .o_cp_pager {
             margin: auto 0 auto auto;


### PR DESCRIPTION
PURPOSE
if there is only kanban view and we apply group-by
pager is removed and height of control panel is reduce.
when remove group-by height of control panel increase.

SPEC
it shouldn't flicker, the size should remain the same

TASK 2463582