### PR TITLE
[IMP] calendar: set default stop different than default start

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -203,7 +203,7 @@ class Meeting(models.Model):
         'Start', required=True, tracking=True, default=fields.Date.today,
         help="Start date of an event, without time for full days events")
     stop = fields.Datetime(
-        'Stop', required=True, tracking=True, default=fields.Date.today,
+        'Stop', required=True, tracking=True, default=lambda self: fields.Datetime.today() + timedelta(hours=1),
         compute='_compute_stop', readonly=False, store=True,
         help="Stop date of an event, without time for full days events")
 


### PR DESCRIPTION
Before this commit, the default stop was equal to default start, creating events with duration = 0.

taskid: 2475473




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
