### PR TITLE
Fix mis-ordered computation of stored fields due to base.automation

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -165,8 +165,8 @@ class BaseAutomation(models.Model):
     def _filter_pre(self, records):
         """ Filter the records that satisfy the precondition of action ``self``. """
         if self.filter_pre_domain and records:
-            domain = [('id', 'in', records.ids)] + safe_eval(self.filter_pre_domain, self._get_eval_context())
-            return records.sudo().search(domain).with_env(records.env)
+            domain = safe_eval(self.filter_pre_domain, self._get_eval_context())
+            return records.sudo().filtered_domain(domain).with_env(records.env)
         else:
             return records
 


### PR DESCRIPTION
## Original report

When updating the company of a contact, the Display Name keeps using the previous company's name, so given Bob in company A, if Bob is moved to company B the form's title remains "A, Bob" instead of becoming "B, Bob". More annoying, if Bob is moved back to A the name becomes "B, Bob".

## Cause analysis

On res.partner, `display_name` is a stored computed field which depends on `commercial_company_name` (via `name_get` -> `_get_name` -> `_get_contact_name`). This is an other stored computed name, which depends on `commercial_partner_id`, which is yet another stored computed name, which depends on the `parent_id`.

The dependencies are meh but usually resolve fine, the issue occurs when a base.automation rule is created with a non-empty domain (including an empty literal list, which was the case here): when the first field of the sequence is computed, base.automation's `_compute_field_value` is called. This calls `_filter_pre`, which (because `filter_pre_domain` is non-empty) calls `search` on the model.

This would normally be innocuous as `search` will only flush the fields used in the search, however for `res.partner` the default `_order` is... `display_name`. Meaning we flush that computation, forcing the computation of `commercial_company_name`, but since
`commercial_partner_id` is being computed we reuse its old value (or something). Since the fields have been flushed, they are not recomputed afterwards once the correct value of `commercial_partner_id` has been resolved.

## Fix

Filter the record in-place using `filtered_domain` since that's the intent.

## Possible issues, alternatives

`filtered_domain` is almost certainly more efficient for small datasets, but may be significantly less so for extremely large ones (though that seems somewhat unlikely). Passing `order='id'` to `search` should also fix this specific problem, possibly with a touch less risk?

Note that the issue will recur if e.g. a domain based on `display_name` is used as a prefilter.

Additionally (or alternatively) the computation of the two fields could be merged into a single method, resolving the ordering issue between the two (although `display_name` may not get recomputed with the new value so it might not actually fix anything?). This would be slightly less efficient in the case where we rename a company (because it would recompute both `commercial_partner_id` and `commercial_company_name` on all children rather than just the latter) but... that's somewhat unlikely to be a concern?

OPW-2427264
