### PR TITLE
[13.0] [FIX] product: Get pricelist from origin in _compute_product_pricelist

### DIFF
--- a/addons/product/models/res_partner.py
+++ b/addons/product/models/res_partner.py
@@ -20,8 +20,8 @@ class Partner(models.Model):
     def _compute_product_pricelist(self):
         company = self.env.context.get('force_company', False)
         res = self.env['product.pricelist']._get_partner_pricelist_multi(self.ids, company_id=company)
-        for p in self:
-            p.property_product_pricelist = res.get(p.id)
+        for partner in self:
+            partner.property_product_pricelist = res[partner.ids[0]] if partner.ids else False
 
     def _inverse_product_pricelist(self):
         for partner in self:


### PR DESCRIPTION
cc @Tecnativa TT28556
Description of the issue/feature this PR addresses:
The property pricelist disappears when we change the country. That's happening because when we try to access to the id of the pricelist we get a NewId object.

Desired behavior after PR is merged:
When this PR is merged the NewId problems will not appear.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
