### PR TITLE
[IMP] l10n_co: reuse identification types from l10n_latam_invoice_doc…

### DIFF
--- a/addons/l10n_co/data/l10n_latam.identification.type.csv
+++ b/addons/l10n_co/data/l10n_latam.identification.type.csv
@@ -1,11 +1,12 @@
 id,name,l10n_co_document_code,country_id:id,is_vat,sequence
 rut,NIT,rut,base.co,TRUE,1
 national_citizen_id,Cédula de ciudadanía,national_citizen_id,base.co,FALSE,2
-external_id,ID del Exterior,external_id,base.co,FALSE,3
-foreign_id_card,Cédula Extranjera,foreign_id_card,base.co,FALSE,4
-passport,Pasaporte,passport,base.co,FALSE,5
+external_id,ID del Exterior,external_id,,FALSE,3
 id_card,Tarjeta de Identidad,id_card,base.co,FALSE,6
 civil_registration,Registro Civil,civil_registration,base.co,FALSE,7
 diplomatic_card,Carné Diplomatico,diplomatic_card,base.co,FALSE,8
 residence_document,Salvoconducto de Permanencia,residence_document,base.co,FALSE,9
 id_document,Cédula,id_document,base.co,FALSE,10
+l10n_latam_base.it_vat,VAT,rut,,TRUE,80
+l10n_latam_base.it_pass,Passport,passport,,FALSE,90,
+l10n_latam_base.it_fid,Foreign ID,foreign_id_card,,FALSE,100


### PR DESCRIPTION
…ument

We also set a country_id for e.g. foreign which we should not.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
