### PR TITLE
[FIX] account_check_printing: Fix 'amount_currency' field don't exist…

### DIFF
--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -203,26 +203,66 @@ class AccountPayment(models.Model):
         """ The stub is the summary of paid invoices. It may spill on several pages, in which case only the check on
             first page is valid. This function returns a list of stub lines per page.
         """
-        if len(self.move_id._get_reconciled_invoices()) == 0:
-            return None
+        self.ensure_one()
 
-        multi_stub = self.company_id.account_check_printing_multi_stub
+        def prepare_vals(invoice, partials):
+            number = ' - '.join([invoice.name, invoice.ref] if invoice.ref else [invoice.name])
 
-        invoices = self.move_id._get_reconciled_invoices().sorted(key=lambda r: r.invoice_date_due or fields.Date.context_today(self))
-        debits = invoices.filtered(lambda r: r.move_type == 'in_invoice')
-        credits = invoices.filtered(lambda r: r.move_type == 'in_refund')
+            if invoice.is_outbound():
+                invoice_sign = 1
+                partial_field = 'debit_amount_currency'
+            else:
+                invoice_sign = -1
+                partial_field = 'credit_amount_currency'
 
-        # Prepare the stub lines
-        if not credits:
-            stub_lines = [self._check_make_stub_line(inv) for inv in invoices]
-        else:
+            if invoice.currency_id.is_zero(invoice.amount_residual):
+                amount_residual_str = '-'
+            else:
+                amount_residual_str = formatLang(self.env, invoice_sign * invoice.amount_residual, currency_obj=invoice.currency_id)
+
+            return {
+                'due_date': format_date(self.env, invoice.invoice_date_due),
+                'number': number,
+                'amount_total': formatLang(self.env, invoice_sign * invoice.amount_total, currency_obj=invoice.currency_id),
+                'amount_residual': amount_residual_str,
+                'amount_paid': formatLang(self.env, invoice_sign * sum(partials.mapped(partial_field)), currency_obj=self.currency_id),
+                'currency': invoice.currency_id,
+            }
+
+        # Decode the reconciliation to keep only invoices.
+        term_lines = self.line_ids.filtered(lambda line: line.account_id.internal_type in ('receivable', 'payable'))
+        invoices = (term_lines.matched_debit_ids.debit_move_id.move_id + term_lines.matched_credit_ids.credit_move_id.move_id)\
+            .filtered(lambda x: x.is_outbound())
+        invoices = invoices.sorted(lambda x: x.invoice_date_due or x.date)
+
+        # Group partials by invoices.
+        invoice_map = {invoice: self.env['account.partial.reconcile'] for invoice in invoices}
+        for partial in term_lines.matched_debit_ids:
+            invoice = partial.debit_move_id.move_id
+            if invoice in invoice_map:
+                invoice_map[invoice] |= partial
+        for partial in term_lines.matched_credit_ids:
+            invoice = partial.credit_move_id.move_id
+            if invoice in invoice_map:
+                invoice_map[invoice] |= partial
+
+        # Prepare stub_lines.
+        if 'out_refund' in invoices.mapped('move_type'):
             stub_lines = [{'header': True, 'name': "Bills"}]
-            stub_lines += [self._check_make_stub_line(inv) for inv in debits]
+            stub_lines += [prepare_vals(invoice, partials)
+                           for invoice, partials in invoice_map.items()
+                           if invoice.move_type == 'in_invoice']
             stub_lines += [{'header': True, 'name': "Refunds"}]
-            stub_lines += [self._check_make_stub_line(inv) for inv in credits]
+            stub_lines += [prepare_vals(invoice, partials)
+                           for invoice, partials in invoice_map.items()
+                           if invoice.move_type == 'out_refund']
+        else:
+            stub_lines = [prepare_vals(invoice, partials)
+                          for invoice, partials in invoice_map.items()
+                          if invoice.move_type == 'in_invoice']
 
         # Crop the stub lines or split them on multiple pages
-        if not multi_stub:
+        if not self.company_id.account_check_printing_multi_stub:
             # If we need to crop the stub, leave place for an ellipsis line
             num_stub_lines = len(stub_lines) > INV_LINES_PER_STUB and INV_LINES_PER_STUB - 1 or INV_LINES_PER_STUB
             stub_pages = [stub_lines[:num_stub_lines]]
@@ -243,6 +283,7 @@ class AccountPayment(models.Model):
     def _check_make_stub_line(self, invoice):
         """ Return the dict used to display an invoice/refund in the stub
         """
+        # DEPRECATED: TO BE REMOVED IN MASTER
         # Find the account.partial.reconcile which are common to the invoice and the payment
         if invoice.move_type in ['in_invoice', 'out_refund']:
             invoice_sign = 1

--- a/addons/account_check_printing/tests/test_print_check.py
+++ b/addons/account_check_printing/tests/test_print_check.py
@@ -22,8 +22,8 @@ class TestPrintCheck(AccountTestInvoicingCommon):
             ))],
         })
 
-    def test_inbound_check_manual_sequencing(self):
-        ''' Test the check generation for customer invoices. '''
+    def test_in_invoice_check_manual_sequencing(self):
+        ''' Test the check generation for vendor bills. '''
         nb_invoices_to_test = INV_LINES_PER_STUB + 1
 
         self.company_data['default_journal_bank'].write({
@@ -32,17 +32,17 @@ class TestPrintCheck(AccountTestInvoicingCommon):
         })
 
         # Create 10 customer invoices.
-        out_invoices = self.env['account.move'].create([{
-            'move_type': 'out_invoice',
+        in_invoices = self.env['account.move'].create([{
+            'move_type': 'in_invoice',
             'partner_id': self.partner_a.id,
             'date': '2017-01-01',
             'invoice_date': '2017-01-01',
             'invoice_line_ids': [(0, 0, {'product_id': self.product_a.id, 'price_unit': 100.0})]
         } for i in range(nb_invoices_to_test)])
-        out_invoices.action_post()
+        in_invoices.action_post()
 
         # Create a single payment.
-        payment = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=out_invoices.ids).create({
+        payment = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=in_invoices.ids).create({
             'group_payment': True,
             'payment_method_id': self.payment_method_check.id,
         })._create_payments()
@@ -57,13 +57,13 @@ class TestPrintCheck(AccountTestInvoicingCommon):
         # Check pages.
         self.company_data['company'].account_check_printing_multi_stub = True
         report_pages = payment._check_get_pages()
-        self.assertEqual(len(report_pages), int(math.ceil(len(out_invoices) / INV_LINES_PER_STUB)))
+        self.assertEqual(len(report_pages), int(math.ceil(len(in_invoices) / INV_LINES_PER_STUB)))
 
         self.company_data['company'].account_check_printing_multi_stub = False
         report_pages = payment._check_get_pages()
         self.assertEqual(len(report_pages), 1)
 
-    def test_outbound_check_manual_sequencing(self):
+    def test_out_refund_check_manual_sequencing(self):
         ''' Test the check generation for refunds. '''
         nb_invoices_to_test = INV_LINES_PER_STUB + 1
 
@@ -103,3 +103,33 @@ class TestPrintCheck(AccountTestInvoicingCommon):
         self.company_data['company'].account_check_printing_multi_stub = False
         report_pages = payment._check_get_pages()
         self.assertEqual(len(report_pages), 1)
+
+    def test_multi_currency_stub_lines(self):
+        # Invoice in company's currency: 100$
+        invoice = self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'partner_id': self.partner_a.id,
+            'date': '2016-01-01',
+            'invoice_date': '2016-01-01',
+            'invoice_line_ids': [(0, 0, {'product_id': self.product_a.id, 'price_unit': 100.0})]
+        })
+        invoice.action_post()
+
+        # Partial payment in foreign currency: 100Gol = 33.33$.
+        payment = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({
+            'payment_method_id': self.payment_method_check.id,
+            'currency_id': self.currency_data['currency'].id,
+            'amount': 100.0,
+            'payment_date': '2017-01-01',
+        })._create_payments()
+
+        stub_pages = payment._check_make_stub_pages()
+
+        self.assertEqual(stub_pages, [[{
+            'due_date': '01/01/2016',
+            'number': invoice.name,
+            'amount_total': '$ 100.00',
+            'amount_residual': '$ 50.00',
+            'amount_paid': '150.000 ☺',
+            'currency': invoice.currency_id,
+        }]])


### PR DESCRIPTION
… on account.partial.reconcile

Since https://github.com/odoo/odoo/commit/beccf82e09d536255d9d9cb9bfe58ebae2559843, 'amount_currency' is now 'debit_amount_currency' / 'credit_amount_currency'.

opw: 2444189
