### PR TITLE
[FIX] sale: Wrong untaxed_amount_to_invoice

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1386,7 +1386,7 @@ class SaleOrderLine(models.Model):
                     # has to be called to retrieve the subtotal without them.
                     # `price_reduce_taxexcl` cannot be used as it is computed from `price_subtotal` field. (see upper Note)
                     price_subtotal = line.tax_id.compute_all(
-                        price_subtotal,
+                        line.price_reduce,
                         currency=line.order_id.currency_id,
                         quantity=line.product_uom_qty,
                         product=line.product_id,


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider an included tax T (10%) and a product P (11€) with invoicing policy based on delivery
- Create a sale order SO with one line L with 2 P and T
- Confirm SO and deliver it

Bug:

The untaxed_amount_to_invoice was 40€ on L instead 20€

opw:2457660