### PR TITLE
[FIX] core: avoid join when there are no translations

### DIFF
--- a/odoo/addons/base/models/ir_translation.py
+++ b/odoo/addons/base/models/ir_translation.py
@@ -459,6 +459,16 @@ class IrTranslation(models.Model):
             self.env.cr.execute("DELETE FROM ir_translation WHERE id IN %s", [discarded._ids])
 
     @api.model
+    @tools.ormcache_context('model_name', 'field_name', keys=('lang',))
+    def _has_field_translations(self, model_name, field_name):
+        return self.sudo().search_count([
+            ('type', '=', 'model'),
+            ('name', '=', '%s,%s' % (model_name, field_name)),
+            ('lang', '=', self.env.lang),
+            ('value', '!=', ''),
+        ]) > 0
+
+    @api.model
     @tools.ormcache_context('model_name', keys=('lang',))
     def get_field_string(self, model_name):
         """ Return the translation of fields strings in the context's language.

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4289,7 +4289,7 @@ Fields:
 
         :return: the qualified field name (or expression) to use for ``field``
         """
-        if self.env.lang:
+        if self.env.lang and self.env['ir.translation']._has_field_translations(self._name, field):
             alias = query.left_join(
                 table_alias, 'id', 'ir_translation', 'res_id', field,
                 extra='"{rhs}"."type" = \'model\' AND "{rhs}"."name" = %s AND "{rhs}"."lang" = %s AND "{rhs}"."value" != %s',


### PR DESCRIPTION
Joining with ir_translation works very slowly in postgres 10 even when there are
no translations. While it's hard to speed up search on translated field in
stable branch, we should at least make a workaround for large databases.

Performance test:

* 350 K records in product.template
* no records in ir.translation
* search_read([('name', 'ilike', 'xxx')], ['name'])

Postgres 12.4

```
| Measurement        | Before | After |
|--------------------+--------+-------|
| Number of queries  |      4 |     4 |
| Query time, ms     |    450 |   440 |
| Remaining time, ms |      9 |     6 |
```

Postgres 10.15

```
| Measurement        | Before | After |
|--------------------+--------+-------|
| Number of queries  |      4 |     4 |
| Query time, ms     |   5500 |   650 |
| Remaining time, ms |      7 |     5 |
```

---

opw-2439347

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
