### PR TITLE
[FIX][l10n_it_edi] remove auto_install

### DIFF
--- a/addons/l10n_it_edi/__manifest__.py
+++ b/addons/l10n_it_edi/__manifest__.py
@@ -24,5 +24,4 @@ E-invoice implementation
     'demo': [
         'data/account_invoice_demo.xml',
     ],
-    'auto_install': True,
 }

--- a/doc/cla/individual/dcorio.md
+++ b/doc/cla/individual/dcorio.md
@@ -1,0 +1,9 @@
+Italy, 2021-03-03
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Davide Corio enlightx@gmail.com https://github.com/dcorio


### PR DESCRIPTION
This module isn't ready yet and therefore should not be set as auto_install.

We would love to have an official Italian localization but at the moment we have to rely on the OCA modules to create, send and receive electronic invoices.
When a customer creates a new database and installs the Italian chart of accounts, l10n_it_edi gets automatically installed and introduces the following problems:

1. Customers use the fields created by this modules without knowing that they'll soon have to uninstall it
2. We always have to manually export/import the data in order to migrate the customer from l10n_it_edi to OCA modules
3. Customers get to us quite frustrated because Odoo's direct team told them that Odoo could manage Italian e-invoicing
4. We can't use any CI/CD system (Travis, Runbot, etc) because we'd need to manually uninstall l10n_it_edi as it's not compatible with the OCA's italian localization

PS: I'm well aware that you won't accept this PR as I've already opened a ticket using an Odoo Enterprise license code and you already refused to modify this module.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
