### PR TITLE
[FIX] l10n_in: improve perfs of l10n_in invoice report.

### DIFF
--- a/addons/l10n_in/models/account.py
+++ b/addons/l10n_in/models/account.py
@@ -3,6 +3,7 @@
 
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
+from odoo import tools
 
 
 class AccountJournal(models.Model):
@@ -30,6 +31,9 @@ class AccountJournal(models.Model):
 
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
+
+    def init(self):
+        tools.create_index(self._cr, 'account_move_line_move_product_index', self._table, ['move_id', 'product_id'])
 
     @api.depends('move_id.line_ids', 'move_id.line_ids.tax_line_id', 'move_id.line_ids.debit', 'move_id.line_ids.credit')
     def _compute_tax_base_amount(self):

--- a/addons/l10n_in/report/account_invoice_report.py
+++ b/addons/l10n_in/report/account_invoice_report.py
@@ -220,12 +220,17 @@ class L10nInAccountInvoiceReport(models.Model):
                     THEN aml.balance
                     ELSE 0
                     END AS sgst_amount,
-                (SELECT sum(temp_aml.balance) from account_move_line temp_aml
+                (WITH account_tax_temp_table AS (
+                    SELECT account_account_tag_id
+                    FROM account_tax_report_line_tags_rel
+                    WHERE account_tax_report_line_id IN
+                        (SELECT res_id FROM ir_model_data where module='l10n_in' AND name='tax_report_line_cess')
+                    )
+                    SELECT sum(temp_aml.balance) from account_move_line temp_aml
                     JOIN account_account_tag_account_move_line_rel aat_aml_rel_temp ON aat_aml_rel_temp.account_move_line_id = temp_aml.id
                     JOIN account_account_tag aat_temp ON aat_temp.id = aat_aml_rel_temp.account_account_tag_id
-                    JOIN account_tax_report_line_tags_rel tag_rep_ln_temp ON aat_temp.id = tag_rep_ln_temp.account_account_tag_id
+                    JOIN account_tax_temp_table tag_rep_ln_temp ON aat_temp.id = tag_rep_ln_temp.account_account_tag_id
                     where temp_aml.move_id = aml.move_id and temp_aml.product_id = aml.product_id
-                    and tag_rep_ln_temp.account_tax_report_line_id IN (SELECT res_id FROM ir_model_data WHERE module='l10n_in' AND name='tax_report_line_cess')
                     ) AS cess_amount,
                 CASE WHEN tag_rep_ln.account_tax_report_line_id IN
                     (SELECT res_id FROM ir_model_data WHERE module='l10n_in' AND name='tax_report_line_sgst') OR at.l10n_in_reverse_charge = True


### PR DESCRIPTION
Slightly change the view of account_invoice_report to add
a CTE to prefilter rows before joining with account_move_line.

Add a multicolumn index for (product_id, move_id) on account_move_line
to speed-up cess_amount computation.

The speed-up depends on the the result of the CTE in l10_account_invoice_report sql view.
When there is no output rows from the CTE, the speed-up
for GSTR-1 reporting this month is from ~5m45 to ~35s, so close to 10.

If the filter does not apply, then the execution time goes to ~45s so closer to 8.

Some more speed-up data:
  - (with filter) ~10m to ~1.25m for GSTR-1 Reporting Last Year, speedup ~= 7.
  - (with filter) ~1m25s to ~8.5s for clicking on line in GSTR-1 Reporting this month view. speedup ~= 10.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
