### PR TITLE
[FIX] l10n_latam_base: identification type default

### DIFF
--- a/addons/l10n_latam_base/models/res_partner.py
+++ b/addons/l10n_latam_base/models/res_partner.py
@@ -24,5 +24,8 @@ class ResPartner(models.Model):
     @api.onchange('country_id')
     def _onchange_country(self):
         country = self.country_id or self.company_id.country_id or self.env.company.country_id
-        self.l10n_latam_identification_type_id = self.env['l10n_latam.identification.type'].search(
-            [('country_id', '=', country.id), ('is_vat', '=', True)], limit=1) or self.env.ref('l10n_latam_base.it_vat', raise_if_not_found=False)
+        identification_type = self.l10n_latam_identification_type_id
+        if not identification_type or (identification_type.country_id != country):
+            self.l10n_latam_identification_type_id = self.env['l10n_latam.identification.type'].search(
+                [('country_id', '=', country.id), ('is_vat', '=', True)], limit=1) or self.env.ref(
+                    'l10n_latam_base.it_vat', raise_if_not_found=False)


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

Identification type  was always been overwrite by the _onchange_country even when just opening the contact form, this was always setting the is_vat identification type as default without taking into account if the user has defined their own default.:
* If Identification type is set and it is compatible with the country then we leave it as it is (this is the case the identification type has been set by a default).
* If Identification type is set but is not compatible with the country then compute and set the Identification type that is is_vat True for the country

Where country is the one set in the partner record, if not set will use the country of the move's company, if not defined then will use the country of the environment company 

Follow this steps:

1. create default for identification type field using DNI record (need to install l10n_ar just for test purpose)
2. create a new user

### Current behavior before PR:

The contact will have CUIT as identification type

### Desired behavior after PR is merged:

The contact will have DNI as identification type, which is the one defined by the user defaults

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
