### PR TITLE
14.0 opw 2450259 avd

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -717,11 +717,12 @@ class Meeting(models.Model):
         events = super().create(other_vals)
 
         for vals in recurring_vals:
-
-            recurrence_values = {field: vals.pop(field) for field in recurrence_fields if field in vals}
             vals['follow_recurrence'] = True
-            event = super().create(vals)
-            events |= event
+        recurring_events = super().create(recurring_vals)
+        events += recurring_events
+
+        for event, vals in zip(recurring_events, recurring_vals):
+            recurrence_values = {field: vals.pop(field) for field in recurrence_fields if field in vals}
             if vals.get('recurrency'):
                 detached_events = event._apply_recurrence_values(recurrence_values)
                 detached_events.active = False

--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -226,3 +226,10 @@ class Meeting(models.Model):
         super(Meeting, my_cancelled_records)._cancel()
         attendees = (self - my_cancelled_records).attendee_ids.filtered(lambda a: a.partner_id == user.partner_id)
         attendees.state = 'declined'
+
+    def _notify_attendees(self):
+        # filter events before notifying attendees through calendar_alarm_manager
+        need_notifs = self.filtered(lambda event: event.alarm_ids and event.stop >= fields.Datetime.now())
+        partners = need_notifs.partner_ids
+        if partners:
+            self.env['calendar.alarm_manager']._notify_next_alarm(partners.ids)

--- a/addons/google_calendar/models/calendar_recurrence_rule.py
+++ b/addons/google_calendar/models/calendar_recurrence_rule.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import re
+from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models
 
@@ -131,8 +132,10 @@ class RecurrenceRule(models.Model):
             vals['calendar_event_ids'] = [(4, base_event.id)]
             # event_tz is written on event in Google but on recurrence in Odoo
             vals['event_tz'] = gevent.start.get('timeZone')
-        recurrence = super()._create_from_google(gevents, vals_list)
-        recurrence._apply_recurrence()
+        recurrence = super(RecurrenceRule, self.with_context(dont_notify=True))._create_from_google(gevents, vals_list)
+        recurrence.with_context(dont_notify=True)._apply_recurrence()
+        if not recurrence._context.get("dont_notify"):
+            recurrence._notify_attendees()
         return recurrence
 
     def _get_sync_domain(self):
@@ -172,3 +175,13 @@ class RecurrenceRule(models.Model):
             },
         }
         return values
+
+    def _notify_attendees(self):
+        recurrences = self.filtered(
+            lambda recurrence: recurrence.base_event_id.alarm_ids and (
+                not recurrence.until or recurrence.until >= fields.Date.today() - relativedelta(days=1)
+            ) and (max(recurrence.calendar_event_ids.mapped('stop')) >= fields.Datetime.now())
+        )
+        partners = recurrences.base_event_id.partner_ids
+        if partners:
+            self.env['calendar.alarm_manager']._notify_next_alarm(partners.ids)

--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -402,3 +402,10 @@ class Meeting(models.Model):
         super(Meeting, my_cancelled_records)._cancel_microsoft()
         attendees = (self - my_cancelled_records).attendee_ids.filtered(lambda a: a.partner_id == user.partner_id)
         attendees.state = 'declined'
+
+    def _notify_attendees(self):
+        # filter events before notifying attendees through calendar_alarm_manager
+        need_notifs = self.filtered(lambda event: event.alarm_ids and event.stop >= fields.Datetime.now())
+        partners = need_notifs.partner_ids
+        if partners:
+            self.env['calendar.alarm_manager']._notify_next_alarm(partners.ids)

--- a/addons/microsoft_calendar/models/calendar_recurrence_rule.py
+++ b/addons/microsoft_calendar/models/calendar_recurrence_rule.py
@@ -4,6 +4,7 @@
 import re
 
 from odoo import api, fields, models
+from dateutil.relativedelta import relativedelta
 
 from odoo.addons.microsoft_calendar.utils.microsoft_calendar import MicrosoftCalendarService
 
@@ -105,3 +106,13 @@ class RecurrenceRule(models.Model):
 
     def _ensure_attendees_have_email(self):
         self.calendar_event_ids.filtered(lambda e: e.active)._ensure_attendees_have_email()
+
+    def _notify_attendees(self):
+        recurrences = self.filtered(
+            lambda recurrence: recurrence.base_event_id.alarm_ids and (
+                not recurrence.until or recurrence.until >= fields.Date.today() - relativedelta(days=1)
+            ) and max(recurrence.calendar_event_ids.mapped('stop')) >= fields.Datetime.now()
+        )
+        partners = recurrences.base_event_id.partner_ids
+        if partners:
+            self.env['calendar.alarm_manager']._notify_next_alarm(partners.ids)

--- a/addons/microsoft_calendar/models/microsoft_sync.py
+++ b/addons/microsoft_calendar/models/microsoft_sync.py
@@ -256,9 +256,12 @@ class MicrosoftSync(models.AbstractModel):
             dict(self._microsoft_to_odoo_values(e, default_reminders, default_values), need_sync_m=False)
             for e in (new - new_recurrent)
         ]
-        new_odoo = self.create(odoo_values)
+        new_odoo = self.with_context(dont_notify=True).create(odoo_values)
 
-        synced_recurrent_records = self._sync_recurrence_microsoft2odoo(new_recurrent)
+        synced_recurrent_records = self.with_context(dont_notify=True)._sync_recurrence_microsoft2odoo(new_recurrent)
+        if not self._context.get("dont_notify"):
+            new_odoo._notify_attendees()
+            synced_recurrent_records._notify_attendees()
 
         cancelled = existing.cancelled()
         cancelled_odoo = self.browse(cancelled.odoo_ids(self.env))
@@ -360,5 +363,15 @@ class MicrosoftSync(models.AbstractModel):
     def _get_microsoft_synced_fields(self):
         """Return a set of field names. Changing one of these fields
         marks the record to be re-synchronized.
+        """
+        raise NotImplementedError()
+
+    def _notify_attendees(self):
+        """ Notify calendar event partners.
+        This is called when creating new calendar events in _sync_microsoft2odoo.
+        At the initialization of a synced calendar, Odoo requests all events for a specific
+        MicrosoftCalendar. Among those there will probably be lots of events that will never triggers a notification
+        (e.g. single events that occured in the past). Processing all these events through the notification procedure
+        of calendar.event.create is a possible performance bottleneck. This method aimed at alleviating that.
         """
         raise NotImplementedError()

--- a/addons/microsoft_calendar/static/src/js/microsoft_calendar.js
+++ b/addons/microsoft_calendar/static/src/js/microsoft_calendar.js
@@ -21,6 +21,7 @@ const MicrosoftCalendarModel = CalendarModel.include({
     init: function () {
         this._super.apply(this, arguments);
         this.microsoft_is_sync = true;
+        this.microsoft_pending_sync = false;
     },
 
     /**
@@ -38,6 +39,10 @@ const MicrosoftCalendarModel = CalendarModel.include({
      */
     async _loadCalendar() {
         const _super = this._super.bind(this);
+        // When the calendar synchronization takes some time, prevents retriggering the sync while navigating the calendar.
+        if (this.microsoft_pending_sync) {
+            return _super(...arguments);
+        }
         try {
             await Promise.race([
                 new Promise(resolve => setTimeout(resolve, 1000)),
@@ -48,12 +53,14 @@ const MicrosoftCalendarModel = CalendarModel.include({
                 error.event.preventDefault();
             }
             console.error("Could not synchronize Outlook events now.", error);
+            this.microsoft_pending_sync = false;
         }
         return _super(...arguments);
     },
 
     _syncMicrosoftCalendar(shadow = false) {
         var self = this;
+        this.microsoft_pending_sync = true;
         return this._rpc({
             route: '/microsoft_calendar/sync_data',
             params: {
@@ -66,6 +73,7 @@ const MicrosoftCalendarModel = CalendarModel.include({
             } else if (result.status === "no_new_event_from_microsoft" || result.status === "need_refresh") {
                 self.microsoft_is_sync = true;
             }
+            self.microsoft_pending_sync = false;
             return result
         });
     },


### PR DESCRIPTION
Improve calendar recurrency creation performances by moving the call to super().create out of the for loop.
For a client database with 120 recurrences creating around 50k calendar events in total, the 5 times 
averaged execution time went from 1410s to 630s, so a speed up slightly bigger than 2.

The other optimization comes from turning off the calendar.attendee notifications during the event creation. The 
attendees are only notified after the calendar.event creation. This is done because lots of newly created synced will never
trigger a notification (in the client database there are events ending in 2010).

In total, for this particular database with 120 recurrences and 10K calendar events, so with a total of 60K events, the execution
time went from ~1h30 to 24 minutes, a speed-up of ~3.

Apart from the speed-up, this PR also introduces a flag in google/microsoft_calendar.js. This is done to avoid retriggering
a calendar synchronization while a previous one is still pending. This caused the client database to crash while navigating the 
calendar view.

(NB for review: LUL should probably also review this PR).

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
