### PR TITLE
[Fix]  Location/Putway Rule to include location_out_id in the domain.

### DIFF
--- a/addons/stock/views/product_strategy_views.xml
+++ b/addons/stock/views/product_strategy_views.xml
@@ -85,7 +85,7 @@
         <field name="name">Putaway Rules</field>
         <field name="res_model">stock.putaway.rule</field>
         <field name="context">{'fixed_location': True}</field>
-        <field name="domain">[('location_in_id', '=', active_id)]</field>
+        <field name="domain">['|', ('location_out_id', '=', active_id), ('location_in_id', '=', active_id)]</field>
     </record>
 
     <menuitem id="menu_putaway" name="Putaway Rules" parent="stock.menu_warehouse_config"

--- a/doc/cla/individual/guimarc.md
+++ b/doc/cla/individual/guimarc.md
@@ -1,0 +1,10 @@
+Brazil, 2021-03-03
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+Guilherme Marcondes guimarc@br.ibm.com https://github.com/guimarc-br/


### PR DESCRIPTION
[FIX] stock: add location_out_id field domain into the Putaway Rules menu
[REF] models: use `stock` to implement location_out_id into the Putway Rules Menu

Description of the issue/feature this PR addresses:

On the Location/Location-ID/PutwayRule    we have the  fields:

location_in_id = **_When Product Arrives_**

locatio_out_id =  **_Store To_**

As the products arrives in the WH/STOCK location  and due the putaway rules goes to  other location then we have the fields populated like:

location_in_id = WH/Stock

location_out_id = location opened in the view.

 Due this domain setup the list is returning empty, and then the solution that I applied is  to check if we have the location selected in the location_in_id or location_out_id and show  the entries.

Current behavior before PR:

Only looking for the from  into the location_in_id


After PR merged :

Looking  for the values from the location_in_id or location_out_id.


--

TaskID: N/A
Fixes :  PR 67198
Closes : PR 67198


I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
