### PR TITLE
[IMP] l10n_ch: skip adding reports to invoice email

### DIFF
--- a/addons/l10n_ch/models/mail_template.py
+++ b/addons/l10n_ch/models/mail_template.py
@@ -33,14 +33,15 @@ class MailTemplate(models.Model):
                 inv_print_name = self._render_template(template.report_name, template.model, res_id)
                 new_attachments = []
 
-                if related_model.l10n_ch_isr_valid:
+                skip_reports = self.env.context.get('l10n_ch_mail_skip_report', [])
+                if 'l10n_ch.l10n_ch_isr_report' not in skip_reports and related_model.l10n_ch_isr_valid:
                     # We add an attachment containing the ISR
                     isr_report_name = 'ISR-' + inv_print_name + '.pdf'
                     isr_pdf = self.env.ref('l10n_ch.l10n_ch_isr_report').render_qweb_pdf([res_id])[0]
                     isr_pdf = base64.b64encode(isr_pdf)
                     new_attachments.append((isr_report_name, isr_pdf))
 
-                if related_model.can_generate_qr_bill():
+                if 'l10n_ch.l10n_ch_qr_report' not in skip_reports and related_model.can_generate_qr_bill():
                     # We add an attachment containing the QR-bill
                     qr_report_name = 'QR-bill-' + inv_print_name + '.pdf'
                     qr_pdf = self.env.ref('l10n_ch.l10n_ch_qr_report').render_qweb_pdf([res_id])[0]


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When sending an invoice by email the reports for ISR and QR are
automatically added if it is possible.

But for some systems, those reports are already joined to the base
report linked to the template and adding them is redudant.

Desired behavior after PR is merged:

This improvement adds the option to skip the addition of those reports
through a context variable.










--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
