### PR TITLE
[I18N] account: fix translation missing placeholder

### DIFF
--- a/addons/account/i18n/hu.po
+++ b/addons/account/i18n/hu.po
@@ -79,7 +79,7 @@ msgstr "%s (másolat)"
 #: code:addons/account/models/account.py:698
 #, python-format
 msgid "%s Sequence"
-msgstr "Sorrend"
+msgstr "%s Sorrend"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document


### PR DESCRIPTION
Missing string placeholder in translation.
Causes upgrade issues while creating new sequences for HU locale.

Targeting directly sass-12.3 as this branch is no longer in Transifex.
Not to be forward-ported.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
