### PR TITLE
[IMP] purchase: agreements and dropshipping

### DIFF
--- a/addons/purchase_requisition_stock/models/purchase_requisition.py
+++ b/addons/purchase_requisition_stock/models/purchase_requisition.py
@@ -19,6 +19,7 @@ class PurchaseRequisition(models.Model):
 
     warehouse_id = fields.Many2one('stock.warehouse', string='Warehouse', domain="[('company_id', '=', company_id)]")
     picking_type_id = fields.Many2one('stock.picking.type', 'Operation Type', required=True, default=_get_picking_in, domain="['|',('warehouse_id', '=', False), ('warehouse_id.company_id', '=', company_id)]")
+    procurement_group_id = fields.Many2one('procurement.group', 'Procurement Group')
 
     def _prepare_tender_values(self, product_id, product_qty, product_uom, location_id, name, origin, company_id, values):
         return {
@@ -26,6 +27,7 @@ class PurchaseRequisition(models.Model):
             'date_end': values['date_planned'],
             'user_id': False,
             'warehouse_id': values.get('warehouse_id') and values['warehouse_id'].id or False,
+            'procurement_group_id': values.get('group_id') and values['group_id'].id or False,
             'company_id': company_id.id,
             'line_ids': [(0, 0, {
                 'product_id': product_id.id,

--- a/addons/purchase_requisition_stock_dropshipping/__init__.py
+++ b/addons/purchase_requisition_stock_dropshipping/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/purchase_requisition_stock_dropshipping/__manifest__.py
+++ b/addons/purchase_requisition_stock_dropshipping/__manifest__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'Purchase Requisition Stock Dropshipping',
+    'version': '1.0',
+    'category': 'Hidden',
+    'summary': 'Purchase Requisition, Stock, Dropshipping',
+    'description': """
+This module makes the link between the purchase requisition and dropshipping applications.
+
+Set shipping address on purchase orders created from purchase agreements
+and link with originating sale order.
+""",
+    'depends': ['purchase_requisition_stock', 'stock_dropshipping'],
+    'data': [
+        'views/purchase_views.xml',
+    ],
+    'installable': True,
+    'auto_install': True,
+}

--- a/addons/purchase_requisition_stock_dropshipping/models/__init__.py
+++ b/addons/purchase_requisition_stock_dropshipping/models/__init__.py
@@ -1,0 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import purchase
+from . import purchase_requisition

--- a/addons/purchase_requisition_stock_dropshipping/models/purchase.py
+++ b/addons/purchase_requisition_stock_dropshipping/models/purchase.py
@@ -1,0 +1,16 @@
+# -*- encoding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class PurchaseOrder(models.Model):
+    _inherit = 'purchase.order'
+
+    @api.onchange('requisition_id')
+    def _onchange_requisition_id(self):
+        super()._onchange_requisition_id()
+        if self.requisition_id and self.requisition_id.procurement_group_id:
+            self.group_id = self.requisition_id.procurement_group_id.id
+            if self.group_id.sale_id.partner_id:
+                self.dest_address_id = self.group_id.sale_id.partner_id.id

--- a/addons/purchase_requisition_stock_dropshipping/models/purchase_requisition.py
+++ b/addons/purchase_requisition_stock_dropshipping/models/purchase_requisition.py
@@ -1,0 +1,26 @@
+# -*- encoding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class PurchaseRequisition(models.Model):
+    _inherit = 'purchase.requisition'
+
+    def _prepare_tender_values(self, product_id, product_qty, product_uom, location_id, name, origin, company_id, values):
+        res = super()._prepare_tender_values(product_id, product_qty, product_uom, location_id, name, origin, company_id, values)
+        if 'sale_line_id' in values:
+            res['line_ids'][0][2]['sale_line_id'] = values['sale_line_id']
+        return res
+
+
+class PurchaseRequisitionLine(models.Model):
+    _inherit = "purchase.requisition.line"
+
+    sale_line_id = fields.Many2one('sale.order.line', string="Origin Sale Order Line")
+
+    def _prepare_purchase_order_line(self, name, product_qty=0.0, price_unit=0.0, taxes_ids=False):
+        res = super()._prepare_purchase_order_line(name, product_qty, price_unit, taxes_ids)
+        if self.sale_line_id:
+            res['sale_line_id'] = self.sale_line_id.id
+        return res

--- a/addons/purchase_requisition_stock_dropshipping/tests/__init__.py
+++ b/addons/purchase_requisition_stock_dropshipping/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_purchase_requisition_stock_dropshipping

--- a/addons/purchase_requisition_stock_dropshipping/tests/test_purchase_requisition_stock_dropshipping.py
+++ b/addons/purchase_requisition_stock_dropshipping/tests/test_purchase_requisition_stock_dropshipping.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.fields import Command
+from odoo.tests import common
+from odoo.tests.common import Form
+
+
+class TestPurchaseRequisitionStockDropshipping(common.TransactionCase):
+
+    def test_purchase_requisition_stock_dropshipping(self):
+
+        # create 'dropship - call for tender' product
+        product = self.env['product.product'].create({'name': 'prsds-product'})
+        dropshipping_route = self.env.ref('stock_dropshipping.route_drop_shipping')
+        product.write({'route_ids': [Command.set([dropshipping_route.id])]})
+        product.write({'purchase_requisition': 'tenders'})
+
+        # sell this product
+        customer = self.env['res.partner'].create({'name': 'prsds-customer'})
+        sale_order = self.env['sale.order'].create({
+            'partner_id': customer.id,
+            'partner_invoice_id': customer.id,
+            'partner_shipping_id': customer.id,
+            'order_line': [Command.create({
+                'name': product.name,
+                'product_id': product.id,
+                'product_uom_qty': 10.00,
+                'product_uom': product.uom_id.id,
+                'price_unit': 10,
+            })],
+        })
+
+        # confirm order
+        sale_order.action_confirm()
+
+        # call for tender must exists
+        call_for_tender = self.env['purchase.requisition'].search([('origin', '=', sale_order.name)])
+        self.assertTrue(call_for_tender)
+
+        # confirm call for tender
+        call_for_tender.action_in_progress()
+
+        # create purchase order from call for tender
+        vendor = self.env['res.partner'].create({'name': 'prsds-vendor'})
+        f = Form(self.env['purchase.order'].with_context(default_requisition_id=call_for_tender))
+        f.partner_id = vendor
+        purchase_order = f.save()
+
+        # check purchase order
+        self.assertEqual(purchase_order.requisition_id.id, call_for_tender.id, 'Purchase order should be linked with call for tender')
+        self.assertEqual(purchase_order.dest_address_id.id, customer.id, 'Purchase order should be delivered at customer')
+        self.assertEqual(len(purchase_order.order_line), 1, 'Purchase order should have one line')
+        purchase_order_line = purchase_order.order_line
+        self.assertEqual(purchase_order_line.sale_order_id.id, sale_order.id, 'Purchase order should be linked with sale order')
+        self.assertEqual(purchase_order_line.sale_line_id.id, sale_order.order_line.id, 'Purchase order line should be linked with sale order line')

--- a/addons/purchase_requisition_stock_dropshipping/views/purchase_views.xml
+++ b/addons/purchase_requisition_stock_dropshipping/views/purchase_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="purchase_order_view_form_inherit" model="ir.ui.view">
+            <field name="name">purchase.order.form.inherit</field>
+            <field name="model">purchase.order</field>
+            <field name="inherit_id" ref="purchase.purchase_order_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='origin']" position="after">
+                    <field name="picking_type_id"/>
+                    <field name="group_id" invisible="1"/>
+                </xpath>
+                <xpath expr="//field[@name='order_line']/tree//field[@name='price_subtotal']" position="after">
+                    <field name="sale_line_id" invisible="1"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Consider products with both 'dropship' route and 'propose a call for tenders' procurement attributes.

Purchase orders created from purchase agreements are not correctly linked with shipping address and originating sale order.

description

task: 2453275

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
