### PR TITLE
[FIX] base: traceback on testing outgoing mail server connection

### DIFF
--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -146,7 +146,7 @@ class IrMailServer(models.Model):
             except smtplib.SMTPResponseException as e:
                 raise UserError(_("Server replied with following exception:\n %s", ustr(e.smtp_error)))
             except smtplib.SMTPException as e:
-                raise UserError(_("An SMTP exception occurred. Check port number and connection security type.\n %s", ustr(e.smtp_error)))
+                raise UserError(_("An SMTP exception occurred. Check port number and connection security type.\n %s", ustr(e)))
             except SSLError as e:
                 raise UserError(_("An SSL exception occurred. Check connection security type.\n %s", ustr(e)))
             except Exception as e:


### PR DESCRIPTION
- Settings > Technical > Email > Outgoing Mail Servers;
- Create a new serve with no security;
- Test connection.

Before this commit,  a traceback error is raised. This occurs because
SMTPException don't have 'smtp_error'.

Now, the UserError is shown correctly.

opw-2464796
