### PR TITLE
[FIX] website: state not saved for accordion snippet

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -966,6 +966,7 @@ options.registry.collapse = options.Class.extend({
         var self = this;
         this.$target.on('shown.bs.collapse hidden.bs.collapse', '[role="tabpanel"]', function () {
             self.trigger_up('cover_update');
+            self.$target.trigger('content_changed');
         });
         return this._super.apply(this, arguments);
     },


### PR DESCRIPTION
Before this commit, the states (collapsed/not collapsed) of the tabs
of the accordion snippet were not saved if it was the only changement
in edit mode.

After this commit, we trigger a content change when the states of the
tabs is changed.

task-2442237

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
