### PR TITLE
[FIX] mass_mailing: fix the merge mailing list

### DIFF
--- a/addons/mass_mailing/i18n/mass_mailing.pot
+++ b/addons/mass_mailing/i18n/mass_mailing.pot
@@ -1659,7 +1659,7 @@ msgstr ""
 
 #. module: mass_mailing
 #: model:ir.actions.act_window,name:mass_mailing.mailing_list_merge_action
-msgid "Merge Selected Mailing Lists"
+msgid "Merge"
 msgstr ""
 
 #. module: mass_mailing
@@ -2781,6 +2781,12 @@ msgstr ""
 #. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.unsubscribe
 msgid "You are not subscribed to any of our mailing list."
+msgstr ""
+
+#. module: mass_mailing
+#: code:addons/mass_mailing/wizard/mailing_list_merge.py:0
+#, python-format
+msgid "You can only apply this action from Mailing Lists."
 msgstr ""
 
 #. module: mass_mailing

--- a/addons/mass_mailing/models/mailing_list.py
+++ b/addons/mass_mailing/models/mailing_list.py
@@ -42,7 +42,7 @@ class MassMailingList(models.Model):
             ''', (tuple(self.ids), ))
             data = dict(self.env.cr.fetchall())
             for mailing_list in self:
-                mailing_list.contact_nbr = data.get(mailing_list.id, 0)
+                mailing_list.contact_nbr = data.get(mailing_list._origin.id, 0)
         else:
             self.contact_nbr = 0
 

--- a/addons/mass_mailing/tests/test_mailing_list.py
+++ b/addons/mass_mailing/tests/test_mailing_list.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import exceptions
 from odoo.addons.mass_mailing.tests.common import MassMailCommon
 from odoo.tests.common import Form, users
 
@@ -71,8 +72,10 @@ class TestMailingListMerge(MassMailCommon):
         # The mailing list C contains the same email address than 'Norbert' in list B
         # This test ensure that the mailing lists are correctly merged and no
         # duplicates are appearing in C
-
-        merge_form = Form(self.env['mailing.list.merge'].with_context(active_ids=[self.mailing_list_1.id, self.mailing_list_2.id]))
+        merge_form = Form(self.env['mailing.list.merge'].with_context(
+            active_ids=[self.mailing_list_1.id, self.mailing_list_2.id],
+            active_model='mailing.list'
+        ))
         merge_form.new_list_name = False
         merge_form.dest_list_id = self.mailing_list_3
         merge_form.merge_options = 'existing'
@@ -88,3 +91,22 @@ class TestMailingListMerge(MassMailCommon):
         self.assertEqual(
             len(list(set(result_list.contact_ids.mapped('email')))), 5,
             'Duplicates have been merged into the destination mailing list. Check %s' % (result_list.contact_ids.mapped('email')))
+
+    @users('user_marketing')
+    def test_mailing_list_merge_cornercase(self):
+        """ Check wrong use of merge wizard """
+        with self.assertRaises(exceptions.UserError):
+            merge_form = Form(self.env['mailing.list.merge'].with_context(
+                active_ids=[self.mailing_list_1.id, self.mailing_list_2.id],
+            ))
+
+        merge_form = Form(self.env['mailing.list.merge'].with_context(
+            active_ids=[self.mailing_list_1.id],
+            active_model='mailing.list',
+            default_src_list_ids=[self.mailing_list_1.id, self.mailing_list_2.id],
+            default_dest_list_id=self.mailing_list_3.id,
+            default_merge_options='existing',
+        ))
+        merge = merge_form.save()
+        self.assertEqual(merge.src_list_ids, self.mailing_list_1 + self.mailing_list_2)
+        self.assertEqual(merge.dest_list_id, self.mailing_list_3)

--- a/addons/mass_mailing/wizard/mailing_list_merge.py
+++ b/addons/mass_mailing/wizard/mailing_list_merge.py
@@ -1,12 +1,31 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
 
 
 class MassMailingListMerge(models.TransientModel):
     _name = 'mailing.list.merge'
     _description = 'Merge Mass Mailing List'
+
+    @api.model
+    def default_get(self, fields):
+        res = super(MassMailingListMerge, self).default_get(fields)
+
+        if not res.get('src_list_ids') and 'src_list_ids' in fields:
+            if self.env.context.get('active_model') != 'mailing.list':
+                raise UserError(_('You can only apply this action from Mailing Lists.'))
+            src_list_ids = self.env.context.get('active_ids')
+            res.update({
+                'src_list_ids': [(6, 0, src_list_ids)],
+            })
+        if not res.get('dest_list_id') and 'dest_list_id' in fields:
+            src_list_ids = res.get('src_list_ids') or self.env.context.get('active_ids')
+            res.update({
+                'dest_list_id': src_list_ids and src_list_ids[0] or False,
+            })
+        return res
 
     src_list_ids = fields.Many2many('mailing.list', string='Mailing Lists')
     dest_list_id = fields.Many2one('mailing.list', string='Destination Mailing List')
@@ -16,16 +35,6 @@ class MassMailingListMerge(models.TransientModel):
     ], 'Merge Option', required=True, default='new')
     new_list_name = fields.Char('New Mailing List Name')
     archive_src_lists = fields.Boolean('Archive source mailing lists', default=True)
-
-    @api.model
-    def default_get(self, fields):
-        res = super(MassMailingListMerge, self).default_get(fields)
-        src_list_ids = self.env.context.get('active_ids')
-        res.update({
-            'src_list_ids': [(6, 0, src_list_ids)],
-            'dest_list_id': src_list_ids and src_list_ids[0] or False,
-        })
-        return res
 
     def action_mailing_lists_merge(self):
         if self.merge_options == 'new':

--- a/addons/mass_mailing/wizard/mailing_list_merge_views.xml
+++ b/addons/mass_mailing/wizard/mailing_list_merge_views.xml
@@ -27,7 +27,7 @@
     </record>
 
     <record id="mailing_list_merge_action" model="ir.actions.act_window">
-        <field name="name">Merge Selected Mailing Lists</field>
+        <field name="name">Merge</field>
         <field name="res_model">mailing.list.merge</field>
         <field name="view_mode">form</field>
         <field name="target">new</field>


### PR DESCRIPTION
PURPOSE:

To resolve the error occurring while merging the mail list and change 
name of button to "MERGE" from "Merge Selected Mailing Lists".

SPECIFICATION:

Current:
Error: 'int' object is not subscriptable
Button name: "MERGE" from "Merge Selected Mailing Lists".

To be:
To resolve this error and change button name to "MERGE"

LINKS:

Task Id: 2471692
PR: #67213

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
