### PR TITLE
[FIX] web: properly apply onchange in some cases

### DIFF
--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -1750,7 +1750,8 @@ var BasicModel = AbstractModel.extend({
                 } else {
                     var fieldInfo = record.fieldsInfo[viewType][name];
                     if (!fieldInfo) {
-                        return; // ignore changes of x2many not in view
+                        // ignore changes of x2many not in view
+                        continue;
                     }
                     var view = fieldInfo.views && fieldInfo.views[fieldInfo.mode];
                     list = self._makeDataPoint({

--- a/addons/web/static/tests/views/basic_model_tests.js
+++ b/addons/web/static/tests/views/basic_model_tests.js
@@ -127,6 +127,42 @@ odoo.define('web.basic_model_tests', function (require) {
             form.destroy();
         });
 
+        QUnit.test('can process x2many commands (with multiple fields)', async function (assert) {
+            assert.expect(1);
+
+            this.data.partner.fields.product_ids.default = [[0, 0, { category: [] }]];
+
+            const form = await createView({
+                View: FormView,
+                model: 'partner',
+                data: this.data,
+                arch: `
+                    <form>
+                        <field name="product_ids"/>
+                    </form>
+                `,
+                archs: {
+                    'product,false,list': `
+                        <tree>
+                            <field name="display_name"/>
+                            <field name="active"/>
+                        </tree>
+                    `,
+                },
+                mockRPC(route, args) {
+                    if (args.method === "create") {
+                        const product_ids = args.args[0].product_ids;
+                        const values = product_ids[0][2];
+                        assert.strictEqual(values.active, true, "active field should be set");
+                    }
+                    return this._super.apply(this, arguments);
+                },
+            });
+
+            await testUtils.form.clickSave(form);
+            form.destroy();
+        });
+
         QUnit.test('can load a record', async function (assert) {
             assert.expect(7);
 


### PR DESCRIPTION
A previous commit (8dbd1efef899fb637acca3c318ae99cb23838b8f) fixed a
part of the basicmodel that used _.each to iterate on an object with
field names as keys, which does not work when a field is named "length".
To fix it, I simply used a native for ... in statement.  However, I
missed the fact that there was a second 'return' statement in the body
of the closure given to _.each, so the onchange method returned
prematurely.

The fix is to simply use the continue statement in that case.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
