### PR TITLE
[FIX] pos_restaurant: order done at bill screen

### DIFF
--- a/addons/pos_restaurant/static/src/js/Screens/BillScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/BillScreen.js
@@ -10,6 +10,9 @@ odoo.define('pos_restaurant.BillScreen', function (require) {
                 this.props.resolve({ confirmed: true, payload: null });
                 this.trigger('close-temp-screen');
             }
+            orderDone() {
+                this.confirm();
+            }
         }
         BillScreen.template = 'BillScreen';
         return BillScreen;


### PR DESCRIPTION
Bug description:

When "Skip Preview Screen" is activated in pos.config (which is
automatically activated when printer is setup), printing the bill
will finalize the order -- which basically delete's the current order.
Also, a traceback is shown because the deleted order is being accessed
by the bill screen for rerendering because the bill screen is not
properly closed after printing.

Solution:

With this commit, we override the `orderDone` to properly close
the bill screen after successful printing of the bill. This also
prevents the unexpected deletion of the current order.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
