### PR TITLE
[FIX] stock: Order Once button

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -217,6 +217,7 @@ class StockWarehouseOrderpoint(models.Model):
             notification = self._get_replenishment_order_notification()
         # Forced to call compute quantity because we don't have a link.
         self._compute_qty()
+        self._compute_qty_to_order()
         self.filtered(lambda o: o.create_uid.id == SUPERUSER_ID and o.qty_to_order <= 0.0 and o.trigger == 'manual').unlink()
         return notification
 


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a stroable product P with vendor V as supplier
- Create a sale order SO for a customer C with P
- Confirm SO and a delivery order DO is created
- Go to Inventory > Operations > Replenishment
- Click on button Order Once of DO in the list view
- A purchase order PO has been created for V
- Confirm PO

Bug:

The button Order Once was still visible on DO when going to Inventory > Operations > Replenishment

opw:2466953