### PR TITLE
[FIX] website: fix showcase snippet images stretched

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1411,3 +1411,12 @@ $ribbon-padding: 100px;
         display: none;
     }
 }
+
+// Snippet Showcase
+.s_showcase_icon {
+    // Avoid images stretched depending on title size (when icons
+    // are images an not Font Awesome icons). Because the default
+    // value of "align-self" is "strech". We put this code here to
+    // avoid having to create a new scss file in a stable version.
+    align-self: flex-start;
+}


### PR DESCRIPTION
Before this commit, if we replaced an icon of the showcase snippet
with an image, this image was streched depending on title size (if too
long and on 2 lines). Its because the align-self default value of a
flex item is strech.

task-2447087

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
