### PR TITLE
[FIX] account: fix standalone test with demo data creation

### DIFF
--- a/addons/account/demo/account_demo.py
+++ b/addons/account/demo/account_demo.py
@@ -106,7 +106,10 @@ class AccountChartTemplate(models.Model):
         ref = self.env.ref
         return ('account.bank.statement', {
             f'{cid}_demo_bank_statement_1': {
-                'journal_id': self.env['account.journal'].search([('type', '=', 'bank')], limit=1).id,
+                'journal_id': self.env['account.journal'].search([
+                    ('type', '=', 'bank'),
+                    ('company_id', '=', cid),
+                ], limit=1).id,
                 'date': time.strftime('%Y')+'-01-01',
                 'balance_end_real': 9944.87,
                 'balance_start': 5103.0,

--- a/addons/account/tests/test_account_all_l10n.py
+++ b/addons/account/tests/test_account_all_l10n.py
@@ -13,6 +13,8 @@ def test_all_l10n(env):
     As the module install is not yet fully transactional, the modules will
     remain installed after the test.
     """
+    # Do not install the demo data while installing the modules
+    env.ref('base.module_account').demo = False
     l10n_mods = env['ir.module.module'].search([
         ('name', 'like', 'l10n%'),
         ('state', '=', 'uninstalled'),
@@ -21,6 +23,8 @@ def test_all_l10n(env):
     env.reset()     # clear the set of environments
     env = env()     # get an environment that refers to the new registry
 
+    # Install the demo data when testing
+    env.ref('base.module_account').demo = True
     coas = env['account.chart.template'].search([])
     for coa in coas:
         cname = 'company_%s' % str(coa.id)


### PR DESCRIPTION
The test is running in sudo mode, so we need to specify the company in
the search.

Creating a company is not usefull anymore since the demo data already
are creating and installing a chart template on it.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
