### PR TITLE
reset renderer local state when switching view

### DIFF
--- a/addons/web/static/src/js/views/abstract_renderer.js
+++ b/addons/web/static/src/js/views/abstract_renderer.js
@@ -90,6 +90,15 @@ return mvc.Renderer.extend({
     giveFocus: function () {
     },
     /**
+     * Resets state that renderer keeps, state may contains scroll position,
+     * the currently active tab page, ...
+     *
+     * @see getLocalState
+     * @see setLocalState
+     */
+    resetLocalState() {
+    },
+    /**
      * This is the reverse operation from getLocalState.  With this method, we
      * expect the renderer to restore all DOM state, if it is relevant.
      *

--- a/addons/web/static/src/js/views/basic/basic_controller.js
+++ b/addons/web/static/src/js/views/basic/basic_controller.js
@@ -63,6 +63,13 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
         this.$el.toggleClass('o_cannot_create', !this.activeActions.create);
         await this._super(...arguments);
     },
+    /**
+     * Called each time the controller is dettached into the DOM
+     */
+    on_detach_callback() {
+        this._super.apply(this, arguments);
+        this.renderer.resetLocalState();
+    },
 
     //--------------------------------------------------------------------------
     // Public

--- a/addons/web/static/src/js/views/form/form_renderer.js
+++ b/addons/web/static/src/js/views/form/form_renderer.js
@@ -228,6 +228,21 @@ var FormRenderer = BasicRenderer.extend({
         this.lastActivatedFieldIndex = -1;
     },
     /**
+     * Resets state which stores information like scroll position, curently
+     * active page, ...
+     *
+     * @override
+     */
+    resetLocalState() {
+        for (const notebook of this.el.querySelectorAll(':scope div.o_notebook')) {
+            [...notebook.querySelectorAll(':scope .o_notebook_headers .nav-item .nav-link')]
+                .map(nav => nav.classList.remove('active'));
+            [...notebook.querySelectorAll(':scope .tab-content > .tab-pane')]
+                .map(tab => tab.classList.remove('active'));
+        }
+
+    },
+    /**
      * Restore active tab pages for each notebook. It relies on the implicit fact
      * that each nav header corresponds to a tab page.
      *


### PR DESCRIPTION
PURPOSE
Form view keeps local state even when form view is switched to other view due to which when form view is opened again it shows last active notebook tab.

SPEC
Reset local state of renderer which stores information like a currently active notebook page etc. when form view is switched to other view.

TASK 2466057


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
