### PR TITLE
[FIX] website: fix showcase snippet images stretched

### DIFF
--- a/addons/website/static/src/snippets/s_showcase/002.scss
+++ b/addons/website/static/src/snippets/s_showcase/002.scss
@@ -1,0 +1,8 @@
+.s_showcase[data-vcss='002'] {
+    .s_showcase_icon {
+        // Avoid images stretched depending on title size (when icons
+        // are images an not Font Awesome icons). Because the default
+        // value of "align-self" is "strech".
+        align-self: flex-start;
+    }
+}

--- a/addons/website/views/snippets/s_showcase.xml
+++ b/addons/website/views/snippets/s_showcase.xml
@@ -72,5 +72,10 @@
         <link rel="stylesheet" type="text/scss" href="/website/static/src/snippets/s_showcase/001.scss"/>
     </xpath>
 </template>
+<template id="assets_snippet_s_showcase_css_002" inherit_id="website.assets_frontend">
+    <xpath expr="//link[last()]" position="after">
+        <link rel="stylesheet" type="text/scss" href="/website/static/src/snippets/s_showcase/002.scss"/>
+    </xpath>
+</template>
 
 </odoo>


### PR DESCRIPTION
Before this commit, if we replaced an icon of the showcase snippet
with an image, this image was streched depending on title size (if too
long and on 2 lines). Its because the align-self default value of a
flex item is strech.

task-2447087

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
