### PR TITLE
[FIX] account: generate payment when bank statement is reconciled

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -1199,7 +1199,7 @@ class AccountBankStatementLine(models.Model):
         self.ensure_one()
         liquidity_lines, suspense_lines, other_lines = self._seek_for_lines()
 
-        reconciliation_overview, open_balance_vals = self._prepare_reconciliation(lines_vals_list)
+        reconciliation_overview, open_balance_vals = self._prepare_reconciliation(lines_vals_list, True)
 
         # ==== Manage res.partner.bank ====
 


### PR DESCRIPTION
- Go to Accounting > Customers > Invoices
- Create an invoice and confirm it
- Create a bank statement with the same partner and amount than the invoice
- Post it and reconcile it with the invoice
No "account.payment" record is created and therefore customer's payment does not appear
in Accounting > Customers > Payments.

"_prepare_reconciliation" method has a "create_payment_for_invoice" param that is False by default.

opw-2463760

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
