### PR TITLE
[FIX] mrp: generate all stock picking

### DIFF
--- a/addons/mrp/views/stock_move_views.xml
+++ b/addons/mrp/views/stock_move_views.xml
@@ -98,6 +98,7 @@
                     <field name="product_uom_qty" string="To Consume"/>
                     <field name="reserved_availability" attrs="{'invisible': [('is_done', '=', True)], 'column_invisible': [('parent.state', 'in', ('draft', 'done'))]}" string="Reserved"/>
                     <field name="quantity_done" string="Consumed" attrs="{'column_invisible': [('parent.state', '=', 'draft')]}" readonly="1"/>
+                    <field name="group_id" invisible="1"/>
                 </tree>
             </field>
         </record>


### PR DESCRIPTION
If the company uses multi-step routes, when duplicating a MO, if the
user changes the BoM, one stock picking will be missing.

To reproduce the error:
1. In Settings, enable "Multi-Step Routes"
2. Go to Inventory > Configuration > Warehouse Management > Warehouses
3. Edit the warehouse "YourCompany"
4. Set Manufacture to "Pick components, [...] products (3 steps)"
5. Create a storable product SP
6. Create two non-empty BoM (BoM01 and BoM02) for SP
    - (Hint: set a different reference for each BoM)
7. Create a MO
    - Product: SP
    - BoM: BoM01
8. Save, Mark as Todo
    - (As you can see, 2 transfers have been created: one from WH/Stock
to WH/Pre-Production, and a second one from from WH/Post-Production to
WH/Stock)
9. Duplicate the MO
10. Set BoM to BoM02
11. Save, Mark as Todo

Error: Only one transfer has been generated. The transfer from WH/Stock
to WH/Pre-Production is missing. (The duplication step is used to
compare the result. If the user saves a new MO, and then edits this MO
to change the BoM, the same problem will occur).

When confirming the MO, the module runs both pull and push rules. When
running the pull rule, the modules assigns a stock picking to a stock
move. To do so, it checks if one stock picking already exists:
https://github.com/odoo/odoo/blob/7d9264c56ac725c8d19aebad55d5668df2a8c814/addons/stock/models/stock_move.py#L863-L873
Since such a stock picking does not exist, the module creates a new one:
https://github.com/odoo/odoo/blob/7d9264c56ac725c8d19aebad55d5668df2a8c814/addons/stock/models/stock_move.py#L887-L900

When changing the BoM, an `onchange` method is raised, deletes the stock
moves linked to the first BoM and creates some new ones. However, since
`group_id` is not a field required by the view
`view_stock_move_raw_tree`, this field will not be included in the
`onchange` response.

As a result, when saving the new MO, the `write` request does not
contain the `group_id` field, so the new stock moves do not have this
information. Therefore, when running `_search_picking_for_assignation`,
the module finds a picking and does not create a new one.

OPW-2444235