### PR TITLE
[FIX] base: Uninstalling stock with ondelete == 'set default'

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1386,7 +1386,7 @@ class IrModelSelection(models.Model):
                 selection._get_records().write({field.name: False})
             elif ondelete == 'set default':
                 value = field.convert_to_write(field.default(Model), Model)
-                selection._get_records().write({field.name: value})
+                selection._get_records()._write({field.name: value})
             elif ondelete == 'cascade':
                 selection._get_records().unlink()
             else:


### PR DESCRIPTION
Uninstalling stock module set all the product.template records with type = 'product' to 'consumable'
But some python constraints were unrespected.
Such as the domain defined on the required field product_id in model stock.warehouse.orderpoint.
This domain expects a product.template record with type = 'product'
Setting field type on model product.template in a write method triggered all the python constraints and
the transaction was rolback.
Setting it with _write method avoids to check the python constraints

opw:2451126