### PR TITLE
[FIX] base: fix the customer search by vat number

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -793,7 +793,7 @@ class Partner(models.Model):
                                vat=unaccent('res_partner.vat'),)
 
             where_clause_params += [search_name]*3  # for email / display_name, reference
-            where_clause_params += [re.sub('[^a-zA-Z0-9]+', '', search_name) or None]  # for vat
+            where_clause_params += [re.sub('[^a-zA-Z0-9\-\.]+', '', search_name) or None]  # for vat
             where_clause_params += [search_name]  # for order by
             if limit:
                 query += ' limit %s'


### PR DESCRIPTION
Steps to follow to reproduce the bug:
-Go to sales
-Add a vat number with a '-' like: "123456789-5" to any customer
-Create a new SO
-Search the customer by entering their VAT number

Problem :
When the VAT number contains the character '-' you cannot find the customer with his VAT number.
Because, the "_name_search" method before creating the query to search clients by VAT number, removes all the special characters from user input

Solution :
Do not remove the '-' character from user input for the customer search by vat number

opw-2457692

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
