### PR TITLE
[FIX] uom: delete weight category raise traceback on product form

### DIFF
--- a/addons/uom/models/uom_uom.py
+++ b/addons/uom/models/uom_uom.py
@@ -14,7 +14,8 @@ class UoMCategory(models.Model):
     def unlink(self):
         uom_categ_unit = self.env.ref('uom.product_uom_categ_unit')
         uom_categ_wtime = self.env.ref('uom.uom_categ_wtime')
-        if any(categ.id in (uom_categ_unit + uom_categ_wtime).ids for categ in self):
+        uom_categ_kg = self.env.ref('uom.product_uom_categ_kgm')
+        if any(categ.id in (uom_categ_unit + uom_categ_wtime + uom_categ_kg).ids for categ in self):
             raise UserError(_("You cannot delete this UoM Category as it is used by the system."))
         return super(UoMCategory, self).unlink()
 
@@ -109,7 +110,8 @@ class UoM(models.Model):
     def unlink(self):
         uom_categ_unit = self.env.ref('uom.product_uom_categ_unit')
         uom_categ_wtime = self.env.ref('uom.uom_categ_wtime')
-        if any(uom.category_id.id in (uom_categ_unit + uom_categ_wtime).ids and uom.uom_type == 'reference' for uom in self):
+        uom_categ_kg = self.env.ref('uom.product_uom_categ_kgm')
+        if any(uom.category_id.id in (uom_categ_unit + uom_categ_wtime + uom_categ_kg).ids and uom.uom_type == 'reference' for uom in self):
             raise UserError(_("You cannot delete this UoM as it is used by the system. You should rather archive it."))
         # UoM with external IDs shouldn't be deleted since they will most probably break the app somewhere else.
         # For example, in addons/product/models/product_template.py, cubic meters are used in `_get_volume_uom_id_from_ir_config_parameter()`,


### PR DESCRIPTION
Usecase to reproduce:
- Go to Uom category list view.
- Unlink weight category
- Go to product form view
--> Traceback due to missing xml_id

The weight uom is needed for the weight and for the carrier.
The user should not be able to unlink it
