### PR TITLE
[FIX] report: Pre load img in b64 with attribute loading='eager'

### DIFF
--- a/addons/l10n_ch/report/swissqr_report.xml
+++ b/addons/l10n_ch/report/swissqr_report.xml
@@ -94,8 +94,8 @@
                             <span>Payment Part</span>
                         </div>
 
-                        <img class="swissqr" t-att-src="o.invoice_partner_bank_id.build_swiss_code_url(o.amount_residual, o.currency_id.name, None, o.partner_id, None, o.invoice_payment_ref, o.ref or o.name)"/>
-                        <img class="ch_cross" src="/l10n_ch/static/src/img/CH-Cross_7mm.png"/>
+                        <img class="swissqr" loading="eager" t-att-src="o.invoice_partner_bank_id.build_swiss_code_url(o.amount_residual, o.currency_id.name, None, o.partner_id, None, o.invoice_payment_ref, o.ref or o.name)"/>
+                        <img class="ch_cross" loading="eager" src="/l10n_ch/static/src/img/CH-Cross_7mm.png"/>
 
                         <div id="indications_zone" class="swissqr_column_right indication_zone">
                             <div class="swissqr_text">


### PR DESCRIPTION
Related to https://github.com/odoo/odoo/pull/64457


wkhtmltopdf 0.12.4 doesn't hand well multiple images.
See: https://github.com/wkhtmltopdf/wkhtmltopdf/issues/3715

This is an issue when printing a list of objects in multi-print from
the list view. As some images won't be loaded nor displayed.

A work around is to insert the base64 into the generated html before we feed it to the renderer.

This could have an impact on performances, thus, to make it
an opt in I recycle the HTML img loading attribute to prepare the html
before the rendering.
https://www.w3schools.com/tags/att_img_loading.asp

The loading attribute has no effect using wkhtmltopdf 0.12.4.

This also fixes the QR-bill report when printed from the list view.

**Description of the issue/feature this PR addresses:**

This fixes image not displayed when printing QWeb reports with images using `src=<url>`

**Current behavior before PR:**

[QR-bill-7.pdf](https://github.com/odoo/odoo/files/6085755/QR-bill-7.pdf)

This is an example, with more invoice even the little image with Swiss cross can be missing on the first page and on all other documents. My assumption is that wkhtmltopdf 0.12.4 has some kind of timeout and doesn't wait for all the resources.

**Desired behavior after PR is merged:**

All images are displaed.

[QR-bill-8.pdf](https://github.com/odoo/odoo/files/6085757/QR-bill-8.pdf)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
