### PR TITLE
[FIX] base: prevent splitting a corrupt pdf

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -564,9 +564,9 @@ class IrAttachment(models.Model):
         with io.BytesIO(base64.b64decode(self.datas)) as stream:
             try:
                 input_pdf = PdfFileReader(stream)
+                max_page = input_pdf.getNumPages()
             except Exception:
                 raise exceptions.ValidationError(_("ERROR: Invalid PDF file!"))
-            max_page = input_pdf.getNumPages()
             remainder_set = set(range(0, max_page))
             new_pdf_ids = []
             if not pdf_groups:


### PR DESCRIPTION
Issue

	- Install 'Documents' module
	- Upload an invalid pdf
	- Open preview of the pdf
	- Click on split

	Traceback raised.

Cause

	Since no check is done when uploading document,
	a corrupt pdf can be uploaded.
	When wanting to get number of page in corrupt pdf,
	PY2PDF raise an error.

Solution

    - If pdf corrupt when spliting, raise user error.

opw-2467022