### PR TITLE
[FIX] website_event_track: allow removing favicon

### DIFF
--- a/addons/website_event_track/models/website.py
+++ b/addons/website_event_track/models/website.py
@@ -34,6 +34,9 @@ class Website(models.Model):
             App Icon should be in PNG format and size of at least 512x512.
         """
         for website in self:
+            if not website.favicon:
+                website.app_icon = False
+                continue
             image = ImageProcess(website.favicon)
             w, h = image.image.size
             square_size = w if w > h else h


### PR DESCRIPTION
Issue

	- Install 'website_event_track' module
	- Go to settings and remove website favicon
	- Save

	Traceback is raised.

Cause

	Trying to create image from favicon for app_icon,
	but favicon not set anymore.

Solution

	If no website.favicon, set website.app_icon to False.

opw-2451934