### PR TITLE
[FIX]: mid-day calculation should not go back in time.

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1189,7 +1189,11 @@ class PurchaseOrderLine(models.Model):
         """Return a datetime which is the noon of the input date(time) according
         to order user's time zone, convert to UTC time.
         """
-        return timezone(self.order_id.user_id.tz or self.company_id.partner_id.tz or 'UTC').localize(datetime.combine(date, time(12))).astimezone(UTC).replace(tzinfo=None)
+        midday = timezone(self.order_id.user_id.tz or self.company_id.partner_id.tz or 'UTC').localize(
+            datetime.combine(date, time(12))).astimezone(UTC).replace(tzinfo=None)
+        if midday < date:
+            return midday + relativedelta(days=1)
+        return midday
 
     def _update_date_planned(self, updated_date):
         self.date_planned = updated_date

--- a/doc/cla/corporate/solnet.md
+++ b/doc/cla/corporate/solnet.md
@@ -12,7 +12,7 @@ Kevin McMenamin kevin.mcmenamin@solnet.co.nz https://github.com/KevinCMcMenamin
 
 List of contributors:
 
-Jonathan Chen jonathan.chen@solnet.co.nz  https://github.com/daemonblade
+Jonathan Chen jonc@chen.org.nz  https://github.com/daemonblade
 Divya Jain divya.jain@solnet.co.nz https://github.com/Divya2506
 Kevin McMenamin kevin.mcmenamin@solnet.co.nz https://github.com/KevinCMcMenamin
 Adrian Merrall adrian.merrall@solnet.co.nz https://github.com/adrianmerrall

--- a/doc/cla/corporate/solnet.md
+++ b/doc/cla/corporate/solnet.md
@@ -1,0 +1,19 @@
+New Zealand, 2021-03-05
+
+Solnet Solutions agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Kevin McMenamin kevin.mcmenamin@solnet.co.nz https://github.com/KevinCMcMenamin
+
+List of contributors:
+
+Jonathan Chen jonathan.chen@solnet.co.nz  https://github.com/daemonblade
+Divya Jain divya.jain@solnet.co.nz https://github.com/Divya2506
+Kevin McMenamin kevin.mcmenamin@solnet.co.nz https://github.com/KevinCMcMenamin
+Adrian Merrall adrian.merrall@solnet.co.nz https://github.com/adrianmerrall
+Kristina Seregina kristina.seregina@solnet.co.nz https://github.com/kristroma


### PR DESCRIPTION
**Purchase Order Receipt Date goes back in time**

Impacted versions:
 
 - 14.0
 
Steps to reproduce:
 
1. Wait until UTC time is after 12pm
2. Create new Purchase Order
3. Enter a Purchase Order line
 
Current behavior:
 
 - The date_planned is calculated to midday of the day before. (Easy to see if seller.delay is zero)
 
Expected behavior:
 
 - date_planned should be the next day, if current time is after UTC 12pm

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
