### PR TITLE
Modify the JsonRequest

### DIFF
--- a/doc/cla/individual/chongthon.md
+++ b/doc/cla/individual/chongthon.md
@@ -1,0 +1,11 @@
+China, 2021-03-05
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+TianChong Xie 1010941352@qq.com https://github.com/chongthon

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -605,6 +605,7 @@ class JsonRequest(WebRequest):
         # Read POST content or POST Form Data named "request"
         try:
             self.jsonrequest = json.loads(request)
+            self.body_jsonstr = request
         except ValueError:
             msg = 'Invalid JSON data: %r' % (request,)
             _logger.info('%s: %s', self.httprequest.path, msg)
@@ -614,14 +615,22 @@ class JsonRequest(WebRequest):
         self.context = self.params.pop('context', dict(self.session.context))
 
     def _json_response(self, result=None, error=None):
-        response = {
-            'jsonrpc': '2.0',
-            'id': self.jsonrequest.get('id')
-            }
-        if error is not None:
-            response['error'] = error
-        if result is not None:
-            response['result'] = result
+        custom = self.endpoint.routing.get('custom')
+        if custom == True:
+            response = {}
+            if error is not None:
+                response['error'] = error
+            if result is not None:
+                response = result
+        else:
+            response = {
+                'jsonrpc': '2.0',
+                'id': self.jsonrequest.get('id')
+                }
+            if error is not None:
+                response['error'] = error
+            if result is not None:
+                response['result'] = result
 
         mime = 'application/json'
         body = json.dumps(response, default=date_utils.json_default)

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -615,22 +615,14 @@ class JsonRequest(WebRequest):
         self.context = self.params.pop('context', dict(self.session.context))
 
     def _json_response(self, result=None, error=None):
-        custom = self.endpoint.routing.get('custom')
-        if custom == True:
-            response = {}
-            if error is not None:
-                response['error'] = error
-            if result is not None:
-                response = result
-        else:
-            response = {
-                'jsonrpc': '2.0',
-                'id': self.jsonrequest.get('id')
-                }
-            if error is not None:
-                response['error'] = error
-            if result is not None:
-                response['result'] = result
+        response = {
+            'jsonrpc': '2.0',
+            'id': self.jsonrequest.get('id')
+            }
+        if error is not None:
+            response['error'] = error
+        if result is not None:
+            response['result'] = result
 
         mime = 'application/json'
         body = json.dumps(response, default=date_utils.json_default)


### PR DESCRIPTION
I add a new property to enable the JsonRequest object to access the original characters in the request body.
Sometimes it is necessary to verify **the summary of the string in the request body**, we need to get the original string in the request body instead of ```self.jsonrequest```.
Now,we can get the original string with ```self.body_jsonstr``` not ```json.dumps(self.jsonrequest)```.

The application/json in the request header and json string in the request body when I initiate an http request , the Odoo server receives the request, but the json returned to the client is not what I want to return.
Here are two additional key,```jsonrpc```,```id```,```result```.The dictionary corresponding to the key result is what I really want to return to the client.
I modify method ```_json_response```.
If we want to change the format of the returned json dictionary, for example by removing the ```id``` and ```jsonrpc```, we can add ```custom=True``` to the route.
```@route('/v1/access_something',type='json',auth='none',csrf=False,methods=['GET'],custom=True)```







--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
