### PR TITLE
[FIX] check number not assigned correctly

### DIFF
--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -122,6 +122,7 @@ class AccountPayment(models.Model):
                     FROM account_payment payment
                     JOIN account_move move ON movE.id = payment.move_id
                    WHERE journal_id = %(journal_id)s
+				     AND check_number IS NOT NULL
                 ORDER BY check_number::INTEGER DESC
                    LIMIT 1
             """, {

--- a/doc/cla/corporate/trescloud.md
+++ b/doc/cla/corporate/trescloud.md
@@ -1,0 +1,15 @@
+Ecuador, 15/03/2021
+
+TRESCLOUD CÍA LTDA agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Andrés Calle andres.calle@trescloud.com https://github.com/pepetreshere
+
+List of contributors:
+
+Andrés Calle andres.calle@trescloud.com https://github.com/pepetreshere


### PR DESCRIPTION
When printing a check from a payment the check number wizard shows the number 1 for the next check... it should show the last check added one +1, it doesn't because it doesn't exclude the account.payments without checknumber.

This fix excludes the account.payments without checknumber so that it doesn't shows "1" as the next check number when there are multiple new checks to be printed

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
