### PR TITLE
[FIX] core: avoid astroid imp module deprecation warning

### DIFF
--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -136,6 +136,7 @@ def init_logger():
         'zeep.loader',# zeep using defusedxml.lxml
         'reportlab.lib.rl_safe_eval',# reportlab importing ABC from collections
         'ofxparse',# ofxparse importing ABC from collections
+        'astroid',  # deprecated imp module (fixed in 2.5.1)
     ]:
         warnings.filterwarnings('ignore', category=DeprecationWarning, module=module)
 


### PR DESCRIPTION
The astroid package where version is lower than  2.5.1 imports the `imp`
module that was deprecated in python 3.4 [0].

In Debian buster, astroid version is 2.1.0 and 2.3.3 in Ubuntu Focal.

With this commit, the deprecation warning is filtered out.

[0] https://docs.python.org/3/library/imp.html