### PR TITLE
[FIX] account_edi : fix visibility of 'Retry' button

### DIFF
--- a/addons/account_edi/views/account_move_views.xml
+++ b/addons/account_edi/views/account_move_views.xml
@@ -51,7 +51,6 @@
                         <div class="o_row">
                             <field name="edi_error_message" />
                             <button name="%(account_edi.action_open_edi_documents)d" string="⇒ See errors" type="action" class="oe_link" attrs="{'invisible': [('edi_error_count', '=', 1)]}" /> 
-                            <button name="action_retry_edi_documents_error" type="object" class="oe_link oe_inline" string="Retry" />
                         </div>
                     </div>
                     <div class="alert alert-info" role="alert" style="margin-bottom:0px;"
@@ -59,7 +58,6 @@
                         <div class="o_row">
                             <field name="edi_error_message" />
                             <button name="%(account_edi.action_open_edi_documents)d" string="⇒ See errors" type="action" class="oe_link" attrs="{'invisible': [('edi_error_count', '=', 1)]}" /> 
-                            <button name="action_retry_edi_documents_error" type="object" class="oe_link oe_inline" string="Retry" />
                         </div>
                     </div>
                 </xpath>


### PR DESCRIPTION
Before this commit, the button 'Retry' would appear if the blocking_level of an account.move (aggregated value of all the related edi.document) was lower than 'error' even though the button 'Send now' also appears. The button 'retry' should only show if the blocking_level is 'error'.

Was fixed in https://github.com/odoo/odoo/pull/65714
Reintroduced in https://github.com/odoo/odoo/pull/65745

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
