### PR TITLE
[FIX] hr_holidays: Initialize hr.employee.public view after hr.employ…

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -184,3 +184,13 @@ class HrEmployeeBase(models.AbstractModel):
             allocations = self.env['hr.leave.allocation'].sudo().search([('state', 'in', ['draft', 'confirm']), ('employee_id', 'in', self.ids)])
             allocations.write(hr_vals)
         return res
+
+class HrEmployeePrivate(models.Model):
+    _inherit = 'hr.employee'
+
+class HrEmployeePublic(models.Model):
+    _inherit = 'hr.employee.public'
+
+    def _compute_leave_status(self):
+        super()._compute_leave_status()
+        self.current_leave_id = False


### PR DESCRIPTION
…ee.public

Purpose
======

Currently, in some rare cases, if the hr.employee.public is initialized before the hr.employee.public
table, this could lead to a traceback or even some inconsistencies when computing the field
current_leave_id, probably because of the MRO graph construction (to be investigated).

Specification
=========

1/ Ensure the table existence
2/ Set a dummy value for current_leave_id to force the recomputation to a valid one.

opw-2476677

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
