### PR TITLE
[IMP] im_livechat, rating: few improvements regarding ratings

### DIFF
--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -94,11 +94,11 @@ class ImLivechatChannel(models.Model):
     def action_view_rating(self):
         """ Action to display the rating relative to the channel, so all rating of the
             sessions of the current channel
-            :returns : the ir.action 'action_view_rating' with the correct domain
+            :returns : the ir.action 'action_view_rating' with the correct context
         """
         self.ensure_one()
         action = self.env['ir.actions.act_window']._for_xml_id('im_livechat.rating_rating_action_livechat')
-        action['domain'] = [('parent_res_id', '=', self.id), ('parent_res_model', '=', 'im_livechat.channel')]
+        action['context'] = {'search_default_parent_res_name': self.name}
         return action
 
     # --------------------------

--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -29,6 +29,7 @@
                     <field name="user_ids"/>
                     <field name="nbr_channel"/>
                     <field name="rating_percentage_satisfaction"/>
+                    <field name="rating_count"/>
                     <templates>
                         <t t-name="kanban-box">
                             <div class="oe_kanban_global_click">
@@ -48,15 +49,11 @@
                                             <br/>
                                             <i class="fa fa-comments" role="img" aria-label="Comments" title="Comments"></i>
                                             <t t-esc="record.nbr_channel.raw_value"/> Sessions
-                                             <div class="float-right">
-                                                <t t-if="record.rating_percentage_satisfaction.raw_value &gt; 0">
-                                                    <a type="action" name="%(rating_rating_action_livechat)d" tabindex="10">
-                                                        <i class="fa fa-smile-o text-success" t-if="record.rating_percentage_satisfaction.raw_value &gt;= 70" title="Rating: Great" role="img" aria-label="Happy face"/>
-                                                        <i class="fa fa-meh-o text-warning" t-if="record.rating_percentage_satisfaction.raw_value &gt; 30 and record.rating_percentage_satisfaction.raw_value &lt; 70" title="Rating: Okay" role="img" aria-label="Neutral face"/>
-                                                        <i class="fa fa-frown-o text-danger" t-if="record.rating_percentage_satisfaction.raw_value &lt;= 30" title="Rating: Bad" role="img" aria-label="Sad face"/>
-                                                       <t t-esc="record.rating_percentage_satisfaction.raw_value"/>%
-                                                   </a>
-                                                </t>
+                                            <div t-if="record.rating_count.raw_value &gt; 0" class="float-right">
+                                                <a name="action_view_rating" type="object" tabindex="10">
+                                                    <i class="fa fa-smile-o text-success" title="Percentage of happy ratings" role="img" aria-label="Happy face"/>
+                                                    <t t-esc="record.rating_percentage_satisfaction.raw_value"/>%
+                                               </a>
                                             </div>
                                         </div>
                                     </div>
@@ -79,11 +76,12 @@
                         <field name="are_you_inside" invisible="1"/>
                     </header>
                     <sheet>
+                        <field name="rating_count" invisible="1"/>
                         <div class="oe_button_box" name="button_box">
                             <button class="oe_stat_button" type="action" attrs="{'invisible':[('nbr_channel','=', 0)]}" name="%(mail_channel_action_from_livechat_channel)d" icon="fa-comments">
                                 <field string="Sessions" name="nbr_channel" widget="statinfo"/>
                             </button>
-                            <button name="action_view_rating" attrs="{'invisible':[('rating_percentage_satisfaction','=', -1)]}" class="oe_stat_button" type="object" icon="fa-smile-o">
+                            <button name="action_view_rating" attrs="{'invisible':[('rating_count', '=', 0)]}" class="oe_stat_button" type="object" icon="fa-smile-o">
                                 <field string="% Happy" name="rating_percentage_satisfaction" widget="statinfo"/>
                             </button>
                         </div>

--- a/addons/im_livechat/views/rating_views.xml
+++ b/addons/im_livechat/views/rating_views.xml
@@ -24,7 +24,6 @@
                 <filter string="Code" name="resource" context="{'group_by':'res_name'}"/>
             </xpath>
             <xpath expr="//filter[@name='resource']" position="after">
-                <field name="parent_res_name"/>
                 <filter string="Livechat Channel" name="groupby_livechat_channel" context="{'group_by': 'parent_res_name'}"/>
             </xpath>
             <xpath expr="/search" position="inside">

--- a/addons/rating/models/rating_mixin.py
+++ b/addons/rating/models/rating_mixin.py
@@ -20,6 +20,7 @@ class RatingParentMixin(models.AbstractModel):
         "Rating Satisfaction",
         compute="_compute_rating_percentage_satisfaction", compute_sudo=True,
         store=False, help="Percentage of happy ratings")
+    rating_count = fields.Integer(string='# Ratings', compute="_compute_rating_percentage_satisfaction", compute_sudo=True)
 
     @api.depends('rating_ids.rating', 'rating_ids.consumed')
     def _compute_rating_percentage_satisfaction(self):
@@ -45,6 +46,7 @@ class RatingParentMixin(models.AbstractModel):
         # compute percentage per parent
         for record in self:
             repartition = grades_per_parent.get(record.id, default_grades)
+            record.rating_count = sum(repartition.values())
             record.rating_percentage_satisfaction = repartition['great'] * 100 / sum(repartition.values()) if sum(repartition.values()) else -1
 
 


### PR DESCRIPTION
**PURPOSE**

In livechat, rating emojis(happy, neutral and sad) display with percentage of
how happy visitors are with the particular channel, click on that will show all
ratings of livechat channels and stat button is visible while creation, if it
has no rating.

**SPECIFICATION**

Add one computed field "rating_count" for the model 'rating.parent.mixin' which
shows the total rating amount of a particular channel and based on that field
invisible the stat button when the count is 0.
Also, display only happy face emoji with the percentage of happiness on
the kanban view of livechat channel, click on that will only display ratings of
the particular channel.

Task- 2471714