### PR TITLE
[IMP]sms: resend sms

### DIFF
--- a/addons/sms/models/sms_sms.py
+++ b/addons/sms/models/sms_sms.py
@@ -4,7 +4,7 @@
 import logging
 import threading
 
-from odoo import api, fields, models, tools
+from odoo import api, fields, models, tools, _
 
 _logger = logging.getLogger(__name__)
 
@@ -55,6 +55,26 @@ class SmsSms(models.Model):
             # auto-commit if asked except in testing mode
             if auto_commit is True and not getattr(threading.currentThread(), 'testing', False):
                 self._cr.commit()
+
+    def retry(self):
+        self.state = 'outgoing'
+
+    def resend(self):
+        failed_sms = self.search([('state','=','error')])
+        if failed_sms:
+            failed_sms.send()
+        title = _("Success")
+        message = _("The selected SMS Text Messages are successfully being resent")
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'title': title,
+                'message': message,
+                'sticky': True,
+                'type': 'success'
+            }
+        }
 
     def cancel(self):
         self.state = 'canceled'

--- a/addons/sms/views/sms_sms_views.xml
+++ b/addons/sms/views/sms_sms_views.xml
@@ -7,7 +7,8 @@
             <form string="SMS">
                 <header>
                     <button name="send" string="Send Now" type="object" states='outgoing' class="oe_highlight"/>
-                    <button name="cancel" string="Cancel" type="object" states='outgoing'/>
+                    <button name="retry" string="RETRY" type="object" states='error,canceled'/>
+                    <button name="cancel" string="Cancel" type="object" states='error,outgoing'/>
                     <field name="state" widget="statusbar"/>
                 </header>
                 <sheet>
@@ -64,5 +65,13 @@
         action="sms_sms_action"
         sequence="1"/>
 
+    <record id="model_sms_sms_action_resend" model="ir.actions.server">
+        <field name="name">Resend</field>
+        <field name="model_id" ref="sms.model_sms_sms"/>
+        <field name="binding_model_id" ref="sms.model_sms_sms"/>
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="code">action = records.resend()</field>
+    </record>
 </data>
 </odoo>


### PR DESCRIPTION
PURPOSE

If the user send SMS automatically and doesn't pay
attention that the sending of his SMS is failing,
he has to go through each record one by one to
resend the SMS. An action to resend all of the
failed SMS in batch would ease the process.

SPECIFICATION

by sending SMS one by one is a heavy process if
message in a bulk, and in the form view if the SMS
failed there are no option to resend that message or
put that message again in outgoing state.

so for this problem we are adding a resend button in
form view and it's visible only in error or canceled
state, by clicking this the message will be in outgoing
state so user can resend the message.

and if there are lots of failed messages in the tree view
than user can select the failed messages and from the tree view
it can resend all the messages directly.

Task Id:2465233

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
