### PR TITLE
[FIX] sale_coupon: fiscal position for promotion product line

### DIFF
--- a/addons/sale_coupon/models/sale_order.py
+++ b/addons/sale_coupon/models/sale_order.py
@@ -140,6 +140,9 @@ class SaleOrder(models.Model):
 
     def _get_reward_values_discount(self, program):
         if program.discount_type == 'fixed_amount':
+            taxes = program.discount_line_product_id.taxes_id
+            if self.fiscal_position_id:
+                taxes = self.fiscal_position_id.map_tax(taxes)
             return [{
                 'name': _("Discount: ") + program.name,
                 'product_id': program.discount_line_product_id.id,
@@ -147,7 +150,7 @@ class SaleOrder(models.Model):
                 'product_uom_qty': 1.0,
                 'product_uom': program.discount_line_product_id.uom_id.id,
                 'is_reward_line': True,
-                'tax_id': [(4, tax.id, False) for tax in program.discount_line_product_id.taxes_id],
+                'tax_id': [(4, tax.id, False) for tax in taxes],
             }]
         reward_dict = {}
         lines = self._get_paid_order_lines()


### PR DESCRIPTION
create a SO;
Add a fiscal position;
Add a promotion of fixed amount kind.
Before this commit, the taxes of the promotion are the one of the
promotion product and not the one of the fiscal position.

Now, the taxes will be computed taken into account the fiscal position.

opw-2467966