### PR TITLE
improve many2one_avatar widget for form edit mode

### DIFF
--- a/addons/hr/static/tests/many2one_avatar_employee_tests.js
+++ b/addons/hr/static/tests/many2one_avatar_employee_tests.js
@@ -78,7 +78,7 @@ QUnit.module('hr', {}, function () {
 
         // click on first employee
         await afterNextRender(() =>
-            dom.click(list.$('.o_data_cell:nth(0) .o_m2o_avatar'))
+            dom.click(list.$('.o_data_cell:nth(0) .o_m2o_avatar > img'))
         );
         assert.verifySteps(
             ['read hr.employee.public 11'],
@@ -97,7 +97,7 @@ QUnit.module('hr', {}, function () {
 
         // click on second employee
         await afterNextRender(() =>
-            dom.click(list.$('.o_data_cell:nth(1) .o_m2o_avatar')
+            dom.click(list.$('.o_data_cell:nth(1) .o_m2o_avatar > img')
         ));
         assert.verifySteps(
             ['read hr.employee.public 7'],
@@ -117,7 +117,7 @@ QUnit.module('hr', {}, function () {
 
         // click on third employee (same as first)
         await afterNextRender(() =>
-            dom.click(list.$('.o_data_cell:nth(2) .o_m2o_avatar'))
+            dom.click(list.$('.o_data_cell:nth(2) .o_m2o_avatar > img'))
         );
         assert.verifySteps(
             [],
@@ -155,10 +155,10 @@ QUnit.module('hr', {}, function () {
 
         assert.strictEqual(kanban.$('.o_kanban_record').text().trim(), '');
         assert.containsN(kanban, '.o_m2o_avatar', 4);
-        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(0)').data('src'), '/web/image/hr.employee.public/11/image_128');
-        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(1)').data('src'), '/web/image/hr.employee.public/7/image_128');
-        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(2)').data('src'), '/web/image/hr.employee.public/11/image_128');
-        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(3)').data('src'), '/web/image/hr.employee.public/23/image_128');
+        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(0) > img').data('src'), '/web/image/hr.employee.public/11/image_128');
+        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(1) > img').data('src'), '/web/image/hr.employee.public/7/image_128');
+        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(2) > img').data('src'), '/web/image/hr.employee.public/11/image_128');
+        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(3) > img').data('src'), '/web/image/hr.employee.public/23/image_128');
 
         kanban.destroy();
     });
@@ -191,7 +191,7 @@ QUnit.module('hr', {}, function () {
 
         assert.strictEqual(form.$('.o_field_widget[name=employee_id]').text().trim(), 'Mario');
 
-        await dom.click(form.$('.o_m2o_avatar'));
+        await dom.click(form.$('.o_m2o_avatar > img'));
 
         assert.verifySteps([
             'read foo 1',

--- a/addons/mail/static/src/js/many2one_avatar_user.js
+++ b/addons/mail/static/src/js/many2one_avatar_user.js
@@ -20,7 +20,7 @@ const { Component } = owl;
 
 const Many2OneAvatarUser = Many2OneAvatar.extend({
     events: Object.assign({}, Many2OneAvatar.prototype.events, {
-        'click .o_m2o_avatar': '_onAvatarClicked',
+        'click .o_m2o_avatar > img': '_onAvatarClicked',
     }),
     // This widget is only supported on many2ones pointing to 'res.users'
     supportedModels: ['res.users'],
@@ -29,9 +29,6 @@ const Many2OneAvatarUser = Many2OneAvatar.extend({
         this._super(...arguments);
         if (!this.supportedModels.includes(this.field.relation)) {
             throw new Error(`This widget is only supported on many2one fields pointing to ${JSON.stringify(this.supportedModels)}`);
-        }
-        if (this.mode === 'readonly') {
-            this.className += ' o_clickable_m2o_avatar';
         }
     },
 

--- a/addons/mail/static/src/scss/many2one_avatar_user.scss
+++ b/addons/mail/static/src/scss/many2one_avatar_user.scss
@@ -1,5 +1,5 @@
-.o_field_many2one_avatar.o_clickable_m2o_avatar {
-    .o_m2o_avatar:hover {
+.o_field_many2one_avatar {
+    .o_m2o_avatar > img:hover {
         cursor: pointer;
         filter: brightness(0.8);
     }

--- a/addons/mail/static/tests/many2one_avatar_user_tests.js
+++ b/addons/mail/static/tests/many2one_avatar_user_tests.js
@@ -72,9 +72,9 @@ QUnit.module('mail', {}, function () {
         // sanity check: later on, we'll check that clicking on the avatar doesn't open the record
         await dom.click(list.$('.o_data_row:first span'));
 
-        await dom.click(list.$('.o_data_cell:nth(0) .o_m2o_avatar'));
-        await dom.click(list.$('.o_data_cell:nth(1) .o_m2o_avatar'));
-        await dom.click(list.$('.o_data_cell:nth(2) .o_m2o_avatar'));
+        await dom.click(list.$('.o_data_cell:nth(0) .o_m2o_avatar > img'));
+        await dom.click(list.$('.o_data_cell:nth(1) .o_m2o_avatar > img'));
+        await dom.click(list.$('.o_data_cell:nth(2) .o_m2o_avatar > img'));
 
 
         assert.verifySteps([
@@ -111,10 +111,10 @@ QUnit.module('mail', {}, function () {
 
         assert.strictEqual(kanban.$('.o_kanban_record').text().trim(), '');
         assert.containsN(kanban, '.o_m2o_avatar', 4);
-        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(0)').data('src'), '/web/image/res.users/11/image_128');
-        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(1)').data('src'), '/web/image/res.users/7/image_128');
-        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(2)').data('src'), '/web/image/res.users/11/image_128');
-        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(3)').data('src'), '/web/image/res.users/23/image_128');
+        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(0) > img').data('src'), '/web/image/res.users/11/image_128');
+        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(1) > img').data('src'), '/web/image/res.users/7/image_128');
+        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(2) > img').data('src'), '/web/image/res.users/11/image_128');
+        assert.strictEqual(kanban.$('.o_m2o_avatar:nth(3) > img').data('src'), '/web/image/res.users/23/image_128');
 
         kanban.destroy();
     });

--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -1017,10 +1017,13 @@ const Many2OneAvatar = FieldMany2One.extend({
         if (this.mode === 'readonly') {
             this.template = null;
             this.tagName = 'div';
-            this.className = 'o_field_many2one_avatar';
             // disable the redirection to the related record on click, in readonly
             this.noOpen = true;
         }
+    },
+    start() {
+        this.el.classList.add('o_field_many2one_avatar');
+        return this._super(...arguments);
     },
 
     //--------------------------------------------------------------------------
@@ -1028,15 +1031,26 @@ const Many2OneAvatar = FieldMany2One.extend({
     //--------------------------------------------------------------------------
 
     /**
+     * Adds avatar image to before many2one value.
+     *
      * @override
      */
-    _renderReadonly() {
-        this.$el.empty();
-        if (this.value) {
-            this.$el.html(qweb.render(this._template, {
-                url: `/web/image/${this.field.relation}/${this.value.res_id}/image_128`,
-                value: this.m2o_value,
-            }));
+    _render() {
+        const m2oAvatar = qweb.render(this._template, {
+            url: `/web/image/${this.field.relation}/${this.value.res_id}/image_128`,
+            value: this.m2o_value,
+            widget: this,
+        });
+        if (this.mode === 'edit') {
+            this._super(...arguments);
+            if (this.el.querySelector('.o_m2o_avatar')) {
+                this.el.querySelector('.o_m2o_avatar').remove();
+            }
+            dom.prepend(this.$('.o_field_many2one_selection'), m2oAvatar);
+        }
+        if (this.mode === 'readonly') {
+            this.$el.empty();
+            dom.append(this.$el, m2oAvatar);
         }
     },
 });

--- a/addons/web/static/src/scss/fields.scss
+++ b/addons/web/static/src/scss/fields.scss
@@ -104,12 +104,16 @@
 
     // Many2OneAvatar
     &.o_field_many2one_avatar {
-        > img.o_m2o_avatar {
+        .o_m2o_avatar > img, .o_m2o_avatar > .o_m2o_avatar_empty {
             border-radius: 50%;
             width: 19px;
             height: 19px;
             object-fit: cover;
             margin-right: 4px;
+        }
+        .o_m2o_avatar_empty {
+            display: block;
+            background-color: #e9ecef;
         }
     }
 

--- a/addons/web/static/src/scss/form_view.scss
+++ b/addons/web/static/src/scss/form_view.scss
@@ -566,6 +566,14 @@ $o-form-label-margin-right: 0px;
                     }
                 }
             }
+
+            .o_field_widget {
+                &.o_field_many2one_avatar {
+                    .o_field_many2one_selection {
+                        width: calc(100% - 24px);
+                    }
+                }
+            }
         }
 
         .o_form_label {

--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -1273,8 +1273,11 @@
 </t>
 
 <t t-name="web.Many2OneAvatar">
-    <img t-att-src="url" t-att-alt="value" class="o_m2o_avatar"/>
-    <span t-esc="value"/>
+    <div class="o_m2o_avatar">
+        <img t-if="widget.value" t-att-src="url" t-att-alt="value"/>
+        <span t-elif="widget.mode === 'edit'" class="o_m2o_avatar_empty"></span>
+        <span t-if="widget.mode === 'readonly'" t-esc="value"/>
+    </div>
 </t>
 
 <t t-name="FieldReference" t-extend="FieldMany2One">


### PR DESCRIPTION
PURPOSE
The goal of this task is to unify the editable and readonly design of the many2one_avatar widget
This is especially motivated by the fact that we plan on getting rid of the readonly formview to always be in edit mode.

SPEC
add the <img> in the o_input_dropdown div, left of the input

TASK 2451340


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
