### PR TITLE
[FIX] l10n_it_edi: incorrect field ref in account.invoice model

### DIFF
--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -145,9 +145,6 @@
                                 <ImportoBollo t-esc="format_numbers(record.l10n_it_stamp_duty)"/>
                             </DatiBollo>
                         </DatiGeneraliDocumento>
-                        <DatiOrdineAcquisto t-if="record.ref">
-                            <IdDocumento t-esc="record.ref" />
-                        </DatiOrdineAcquisto>
                         <DatiDDT t-if="record.l10n_it_ddt_id">
                             <!--2.1.8-->
                             <NumeroDDT t-esc="record.l10n_it_ddt_id.name"/>


### PR DESCRIPTION
We should use field reference of account.invoice instead of field ref
which belongs to account.move model. This was introduced by commit https://github.com/odoo/odoo/commit/bb898e663019942a6fd99ce96ce5742a8ff7ea56.

Description of the issue/feature this PR addresses:
opw-2477246
opw-2477158

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
