### PR TITLE
[FIX] test: non deterministic test

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -862,6 +862,11 @@ class TransactionCase(BaseCase):
         # flush everything in setUpClass before introducing a savepoint
         self.env.flush_all()
 
+        # do the cleanups before starting the first transaction so that everything is clean
+        # for the first test too.
+        self.registry.clear_caches()
+        self.env.clear()
+
         self._savepoint_id = next(savepoint_seq)
         self.cr.execute('SAVEPOINT test_%d' % self._savepoint_id)
         self.addCleanup(self.cr.execute, 'ROLLBACK TO SAVEPOINT test_%d' % self._savepoint_id)


### PR DESCRIPTION
When creating a test, for instance (the bug was in `master` but it makes sense to fix it in 14.0 IMO)

```python
@freeze_time("2020-11-30 19:45:00")
class TestNacha(AccountTestInvoicingCommon):
    @classmethod
    def setUpClass(cls, chart_template_ref='l10n_generic_coa.configurable_chart_template'):
        super().setUpClass(chart_template_ref=chart_template_ref)

        cls.company_data["default_journal_bank"].write({
            "nacha_immediate_destination": "IMM_DESTINATION",
            "nacha_immediate_origin": "IMM_ORIGIN",
            "nacha_destination": "DESTINATION",
            "nacha_company_identification": "COMPANY_ID",
            "nacha_origination_dfi_identification": "ORIGINATION_DFI",
        })

        cls.bank = cls.env["res.partner.bank"].create({
            "partner_id": cls.partner_a.id,
            "acc_number": "987654321",
            "aba_routing": "123456789",
        })

        def create_payment(partner, amount, ref):
            return cls.env['account.payment'].create({
                "partner_id": partner.id,
                "partner_bank_id": cls.bank.id,
                "ref": ref,
                "amount": amount,
                "payment_type": "outbound",
                "date": datetime.datetime.today(),
            })
        cls.batch = cls.env["account.batch.payment"].create({
            "journal_id": cls.company_data["default_journal_bank"].id,
            "batch_type": "outbound",
            "payment_ids": [
                Command.link(create_payment(cls.partner_a, 123, 'test1').id),
                Command.link(create_payment(cls.partner_b, 456, 'test2').id),
            ]
        })

    def testGenerateNachaFile(self):
        expected = [
            # header
            "101IMM_DESTINIMM_ORIGIN2011301945A094101DESTINATION            company_1_data         {:8d}".format(self.batch.id),
            # batch header for payment "test1"
            "5225company_1_data                      COMPANY_IDPPDtest1     201130201130   1ORIGINAT0000000",
            # entry detail for payment "test1"
            "627123456789987654321        0000012300               partner_a               0ORIGINAT0000000",
            # batch control record for payment "test1"
            "82250000010000000036000000012300000000000000COMPANY_ID                         ORIGINAT0000000",
            # batch header for payment "test2"
            "5225company_1_data                      COMPANY_IDPPDtest2     201130201130   1ORIGINAT0000001",
            # entry detail for payment "test2"
            "627123456789987654321        0000045600               partner_b               0ORIGINAT0000000",
            # batch control record for payment "test2"
            "82250000010000000036000000045600000000000000COMPANY_ID                         ORIGINAT0000001",
            # file control record
            "9000002000004000000020000000072000000000579000000000000                                       ",
        ]

        for generated, expected in zip(self.batch._generate_nacha_file().splitlines(), expected):
            self.assertEqual(generated, expected, "Generated line in NACHA file does not match expected.")
```

We have a non deterministic error because the `Command.link` is using a python `set`, which is not ordered[1]
We are then setting a random order on the field stored in the x2m field when setting it. We won't have that issue in other transactions because we will then have to populate the cache again, which will take care of the `_order`.

I have identified 4 ways to correct that.
* The first commit
* The second commit
* Calling `self.env.cache.invalidate()` in the test case
* Calling `.sorted()` in the business code (which will be useless in all cases outside of the test)

[1] https://stackoverflow.com/questions/45581901/are-sets-ordered-like-dicts-in-python3-6
https://docs.python.org/3/tutorial/datastructures.html#sets
> A set is an unordered collection with no duplicate elements

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
