### PR TITLE
[FIX] website: fix image gallery slider index

### DIFF
--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -968,7 +968,8 @@ registry.gallerySlider = publicWidget.Widget.extend({
         }
 
         function update() {
-            index = $lis.index($lis.filter('.active')) || 0;
+            const active = $lis.filter('.active');
+            index = active.length ? $lis.index(active) : 0;
             page = Math.floor(index / realNbPerPage);
             hide();
         }


### PR DESCRIPTION
The gallery slider index was wrongly calculated when the gallery had no
active element, as the jquery method .index() will still return -1 when
no element is found.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
