### PR TITLE
[IMP] core: New XMLRPC endpoint

### DIFF
--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -241,20 +241,19 @@ class WithContext(HttpCase):
         self.assertEqual('I am a specific page' in r.text, True, "Admin should see the specific unpublished page")
 
     def test_search(self):
-        dbname = common.get_db_name()
-        admin_uid = self.env.ref('base.user_admin').id
         website = self.env['website'].get_current_website()
 
-        robot = self.xmlrpc_object.execute(
-            dbname, admin_uid, 'admin',
-            'website', 'search_pages', [website.id], 'info'
-        )
+        rpc_models = self.get_xmlrpc_models_proxy('admin', 'admin')
+        robot = rpc_models.website.search_pages({
+            'records': website.ids,
+            'args': ['info']
+        })
         self.assertIn({'loc': '/website/info'}, robot)
 
-        pages = self.xmlrpc_object.execute(
-            dbname, admin_uid, 'admin',
-            'website', 'search_pages', [website.id], 'page'
-        )
+        pages = rpc_models.website.search_pages({
+            'records': website.ids,
+            'args': ['page']
+        })
         self.assertIn(
             '/page_1',
             [p['loc'] for p in pages],

--- a/odoo/addons/base/controllers/rpc.py
+++ b/odoo/addons/base/controllers/rpc.py
@@ -1,21 +1,79 @@
+import encodings
+import logging
 import re
+import socket
 import sys
+import threading
 import traceback
 import xmlrpc.client
 from datetime import date, datetime
+from http import HTTPStatus
+from json.decoder import JSONDecodeError
+from xml.parsers.expat import ExpatError
 
 from markupsafe import Markup
+from werkzeug.exceptions import (
+    HTTPException, Unauthorized, Forbidden, NotFound, UnsupportedMediaType,
+    abort
+)
 from werkzeug.wrappers import Response
 
 import odoo
-from odoo.http import Controller, route, dispatch_rpc, request
+from odoo.exceptions import AccessDenied
 from odoo.fields import Date, Datetime, Command
-from odoo.tools import lazy, ustr
-from odoo.tools.misc import frozendict
+from odoo.http import (
+    dispatch_rpc, serialize_exception, Controller, route, request,
+    borrow_request,
+)
+from odoo.tools import frozendict, lazy, unique, ustr
+
+from .rpc2.exceptions import RpcError, RpcErrorCode
+from .rpc2.marshaller import XMLRPCMarshaller, JSONMarshaller
+from .rpc2.admin import dispatch as admin_dispatch
+from .rpc2.model import dispatch as model_dispatch
+
+_logger = logging.getLogger(__name__)
+
 
 # ==========================================================
-# XML-RPC helpers
+# Deprecated /xmlrpc, /xmlrpc/2, /jsonrpc and helpers
 # ==========================================================
+_XMLRPC_DEPRECATION_WARNING = """Deprecation Warning!
+
+The /xmlrpc and /xmlrpc/2 endpoints are deprecated but are still used
+by a client at %s [%s]. Please report them the problem
+with the following notice:
+
+The two Odoo XMLRPC endpoints at /xmlrpc and /xmlrpc/2 are deprecated
+since version 17 (autumn 2023) and are scheduled for removal. The two
+endpoints have been replaced by a new unique one: /RPC2. This new url
+offers a better integration with XMLRPC libraries:
+
+* support for HTTP Basic-Authentication;
+* support of the None/null/nil value;
+* support of dot-name function notation (see below);
+* enhanced support for the "new" (Odoo 8) ORM API.
+
+Using python's xmlrpc client and previous endpoint, you used to do:
+
+    common = xmlrpc.client.ServerProxy(f'https://{domain}/xmlrpc/2/common')
+    uid = common.authenticate(db, username, password, {})
+    models = xmlrpc.client.ServerProxy(f'https://{domain}/xmlrpc/2/object')
+    models.execute_kw(db, uid, password, 'res.partner', 'read', ...)
+
+With the new /RPC2 endpoint, you do:
+
+    url = f'https://{username}:{password}@{domain}/RPC/{db}'
+    models = xmlrpclib.ServerProxy(url)
+    models.res.partner.read(...)
+
+Several others XML-RPC and JSON-RPC clients libraries from a multitude
+for different languages benefit too from this shorter syntax. A complete
+tutorial that includes currated examples for many languages is available
+in the "External API" section of the Odoo Online Documentation.
+
+https://www.odoo.com/documentation/16.0/developer/api/external_api.html
+"""
 
 # XML-RPC fault codes. Some care must be taken when changing these: the
 # constants are also defined client-side and must remain in sync.
@@ -46,10 +104,17 @@ def xmlrpc_handle_exception_int(e):
         formatted_info = "".join(traceback.format_exception(*info))
         fault = xmlrpc.client.Fault(RPC_FAULT_CODE_APPLICATION_ERROR, formatted_info)
 
-    return xmlrpc.client.dumps(fault, allow_none=None)
+    return fault
 
 
 def xmlrpc_handle_exception_string(e):
+    """ Legacy converter: historically Odoo has mis-generated XML-RPC fault by
+    using a ``<string>`` as the ``<faultCode>`` even though it must be an
+    ``<int>``.
+    This function provides the old (incorrect) behavior where
+    :func:`~.xmlrpc_handle_exception_int` implements the correct behavior of
+    integral ``<faultCode>``
+    """
     if isinstance(e, odoo.exceptions.RedirectWarning):
         fault = xmlrpc.client.Fault('warning -- Warning\n\n' + str(e), '')
     elif isinstance(e, odoo.exceptions.MissingError):
@@ -60,13 +125,12 @@ def xmlrpc_handle_exception_string(e):
         fault = xmlrpc.client.Fault('AccessDenied', str(e))
     elif isinstance(e, odoo.exceptions.UserError):
         fault = xmlrpc.client.Fault('warning -- UserError\n\n' + str(e), '')
-    #InternalError
     else:
         info = sys.exc_info()
         formatted_info = "".join(traceback.format_exception(*info))
         fault = xmlrpc.client.Fault(odoo.tools.exception_to_unicode(e), formatted_info)
 
-    return xmlrpc.client.dumps(fault, allow_none=None, encoding=None)
+    return xmlrpc.client.dumps(fault)
 
 
 class OdooMarshaller(xmlrpc.client.Marshaller):
@@ -116,9 +180,7 @@ class OdooMarshaller(xmlrpc.client.Marshaller):
 # monkey-patch xmlrpc.client's marshaller
 xmlrpc.client.Marshaller = OdooMarshaller
 
-# ==========================================================
-# RPC Controller
-# ==========================================================
+
 class RPC(Controller):
     """Handle RPC connections."""
 
@@ -136,6 +198,15 @@ class RPC(Controller):
         This entrypoint is historical and non-compliant, but kept for
         backwards-compatibility.
         """
+        # Famous event that occured in 2013:
+        # * Edward Snowden leaked the NSA secrets;
+        # * Francis was elected Pope;
+        # * Antony Lesuisse deprecated this route.
+        _logger.warning(
+            _XMLRPC_DEPRECATION_WARNING,
+            socket.getnameinfo((request.httprequest.remote_addr, 0), 0)[0],
+            request.httprequest.remote_addr,
+        )
         try:
             response = self._xmlrpc(service)
         except Exception as error:
@@ -145,13 +216,185 @@ class RPC(Controller):
     @route("/xmlrpc/2/<service>", auth="none", methods=["POST"], csrf=False, save_session=False)
     def xmlrpc_2(self, service):
         """XML-RPC service that returns faultCode as int."""
+        _logger.warning(
+            _XMLRPC_DEPRECATION_WARNING,
+            socket.getnameinfo((request.httprequest.remote_addr, 0), 0)[0],
+            request.httprequest.remote_addr,
+        )
         try:
             response = self._xmlrpc(service)
         except Exception as error:
-            response = xmlrpc_handle_exception_int(error)
+            response = xmlrpc.client.dumps(xmlrpc_handle_exception_int(error))
         return Response(response=response, mimetype='text/xml')
 
     @route('/jsonrpc', type='json', auth="none", save_session=False)
     def jsonrpc(self, service, method, args):
         """ Method used by client APIs to contact OpenERP. """
         return dispatch_rpc(service, method, args)
+
+
+# ==========================================================
+# New RPC endpoint
+# ==========================================================
+ACCEPT_CHARSET = ', '.join(
+    'application/json; charset={0}, text/xml; charset={0}'.format(
+        charset.replace('_', '-')
+    ) for charset in unique(encodings.aliases.aliases.values())
+)
+
+class Rpc2(Controller):
+    # python's <3.9 xmlrpc client doesn't send query-strings, hence the /RPC2/<db> route
+    # https://github.com/python/cpython/commit/5334605035d38139a04189ecb3899f36702517b2
+    @route(['/RPC2', '/RPC2/<db>'], auth='none', methods=['POST'], csrf=False)
+    def rpc2(self, db=None):
+        req = request.httprequest
+
+        # by default werkzeug decode the request using utf-8, use the
+        # real charset of the request instead (falling back on utf-8)
+        req.charset = req.mimetype_params.get('charset', req.charset)
+        req.encoding_errors = 'strict'
+
+        if db and db not in odoo.http.db_list([db]):
+            raise NotFound("Database not found")
+
+        if req.mimetype == 'text/xml':
+            return Response(
+                (b"<?xml version='1.0'?>\n<methodResponse>%s</methodResponse>\n"
+                    % XMLRPCMarshaller('utf-8').dumps(self._xmlrpc(db))),
+                mimetype='text/xml'
+            )
+        elif req.mimetype == 'application/json':
+            return Response(
+                JSONMarshaller(ensure_ascii=False).encode(self._jsonrpc(db)),
+                mimetype='application/json; charset=utf-8'
+            )
+
+        resp = UnsupportedMediaType(
+            f"{req.mimetype} mime type not supported by /RPC2, request may "
+            "be either XML-RPC as text/xml or JSON-RPC 2.0 as application/json."
+        ).get_response()
+        resp.headers['Accept'] = ACCEPT_CHARSET
+        abort(resp)
+
+
+    def _xmlrpc(self, db):
+        try:
+            try:
+                params, method = xmlrpc.client.loads(request.httprequest.get_data(as_text=True))
+            except LookupError as exc:
+                request.future_response.status = HTTPStatus.UNSUPPORTED_MEDIA_TYPE
+                request.future_response.headers['Accept'] = ACCEPT_CHARSET
+                raise RpcError(RpcErrorCode.unsupported_encoding) from exc
+            except UnicodeDecodeError as exc:
+                request.future_response.status = HTTPStatus.BAD_REQUEST
+                raise RpcError(RpcErrorCode.encoding_error) from exc
+            except ExpatError as exc:
+                request.future_response.status = HTTPStatus.BAD_REQUEST
+                raise RpcError(RpcErrorCode.parse_error) from exc
+            except Exception as exc1:
+                request.future_response.status = HTTPStatus.BAD_REQUEST
+                exc2 = ValueError("malformed XML-RPC request")
+                exc2.__cause__ = exc1
+                raise RpcError(RpcErrorCode.invalid_request) from exc2
+            try:
+                return (self._dispatch(db, method, params),)
+            except HTTPException:
+                raise
+            except RpcError:
+                raise
+            except Exception as exc:
+                _logger.exception("Exception during XMLRPC request handling.")
+                raise RpcError(RpcErrorCode.from_exception(exc)) from exc
+        except RpcError as rpc_error:
+            return xmlrpc.client.Fault(
+                faultCode=int(rpc_error.code),
+                faultString=''.join(traceback.format_exception_only(rpc_error.__cause__)).strip()
+            )
+
+    def _jsonrpc(self, db):
+        try:
+            jsonreq = {}
+            try:
+                jsonreq.update(request.get_json_data())
+                id_ = jsonreq['id']
+                method = jsonreq['method']
+                params = jsonreq.get('params', [])
+            except LookupError as exc:
+                request.future_response.status = HTTPStatus.UNSUPPORTED_MEDIA_TYPE
+                request.future_response.headers['Accept'] = ACCEPT_CHARSET
+                raise RpcError(RpcErrorCode.unsupported_encoding) from exc
+            except UnicodeDecodeError as exc:
+                request.future_response.status = HTTPStatus.BAD_REQUEST
+                raise RpcError(RpcErrorCode.encoding_error) from exc
+            except JSONDecodeError as exc:
+                request.future_response.status = HTTPStatus.BAD_REQUEST
+                raise RpcError(RpcErrorCode.parse_error) from exc
+            except Exception as exc1:
+                request.future_response.status = HTTPStatus.BAD_REQUEST
+                exc2 = ValueError("malformed JSON-RPC request")
+                exc2.__cause__ = exc1
+                raise RpcError(RpcErrorCode.invalid_request) from exc2
+            try:
+                return {
+                    'jsonrpc': '2.0',
+                    'id': id_,
+                    'result': self._dispatch(db, method, params)
+                }
+            except HTTPException:
+                raise
+            except RpcError:
+                raise
+            except Exception as exc:
+                _logger.exception("Exception during JSONRPC request handling.")
+                raise RpcError(RpcErrorCode.from_exception(exc)) from exc
+        except RpcError as rpc_error:
+            return {
+                'jsonrpc': '2.0',
+                'id': jsonreq.get('id'),
+                'error': {
+                    'code': int(rpc_error.code),
+                    'message': ''.join(traceback.format_exception_only(rpc_error.__cause__)).strip(),
+                    'data': serialize_exception(rpc_error.__cause__)
+                }
+            }
+
+    def _dispatch(self, db, method, params):
+        model, _, method = method.rpartition('.')
+        auth = request.httprequest.authorization
+        if not db and model:
+            raise RpcError(RpcErrorCode.method_not_found) from (
+                NameError(f"{model+'.'+method!r} is not a valid admin function"))
+        if db and not model:
+            raise RpcError(RpcErrorCode.method_not_found) from (
+                NameError(f"{method!r} is not a valid model name"))
+
+        with borrow_request():
+            if not db:
+                try:
+                    pwd = auth.password if auth else None
+                    return admin_dispatch(method, *params, admin_password=pwd)
+                except AccessDenied as exc:
+                    if not auth or auth.type != 'basic':
+                        response = Response(status=401)
+                        response.www_authenticate.set_basic("Odoo-RPC")
+                        raise Unauthorized(response=response) from exc
+                    raise Forbidden(exc.args[0]) from exc
+
+            if not auth or auth.type != 'basic':
+                response = Response(status=401)
+                response.www_authenticate.set_basic("Odoo-RPC")
+                raise Unauthorized(response=response)
+
+            registry = odoo.registry(db)
+            registry.check_signaling()
+            try:
+                uid = registry['res.users'].authenticate(
+                    db, auth.username, auth.password, {'interactive': False})
+            except AccessDenied as exc:
+                raise Forbidden(exc.args[0]) from exc
+
+            threading.current_thread().uid = uid
+            threading.current_thread().dbname = db
+
+            with registry.manage_changes():
+                return model_dispatch(registry, uid, model, method, *params)

--- a/odoo/addons/base/controllers/rpc2/admin.py
+++ b/odoo/addons/base/controllers/rpc2/admin.py
@@ -1,0 +1,126 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import collections.abc
+import inspect
+from odoo.service import common, db
+from .exceptions import RpcError, RpcErrorCode
+
+_functions = {}
+def register(*, admin_only):
+    def register_(fn):
+        fn.admin_only = admin_only
+        _functions[fn.__name__.rstrip('_')] = fn
+        return fn
+    return register_
+
+def dispatch(function_name, *params, admin_password=None):
+    args, kwargs = extract_call_info(params)
+    function = find_function(function_name, args, kwargs)
+    if function.admin_only:
+        db.check_super(admin_password)
+    return function(*args, **kwargs)
+
+def extract_call_info(params):
+    params = params or ({},)
+
+    if len(params) > 1:
+        suggestion = {'args': list(params)}
+        raise RpcError(RpcErrorCode.invalid_params) from TypeError(
+            "the RPC2 endpoint takes a single parameter: a dict with "
+            "args and kwargs (both optional) keys. Did you mean "
+            f"{suggestion}?")
+
+    if (not isinstance(params[0], collections.abc.Mapping)
+     or not {'args', 'kwargs'}.issuperset(params[0].keys())):
+        raise RpcError(RpcErrorCode.invalid_params) from TypeError(
+            "the RPC2 endpoint takes a single parameter: a dict with "
+            "args and kwargs (both optional) keys")
+
+    return params[0].get('args', []), params[0].get('kwargs', {})
+
+def find_function(function_name, args, kwargs):
+    try:
+        function = _functions[function_name]
+    except KeyError as exc:
+        err = NameError(f"no admin function {function_name!r} found")
+        err.__cause__ = exc
+        raise RpcError(RpcErrorCode.method_not_found) from err
+    try:
+        inspect.signature(function).bind(*args, **kwargs)
+    except TypeError as exc:
+        raise RpcError(RpcErrorCode.invalid_params) from exc
+    return function
+
+
+@register(admin_only=False)
+def login(db, login, password):
+    return common.exp_authenticate(db, login, password, None)
+
+
+@register(admin_only=False)
+def authenticate(db, login, password, user_agent_env):
+    return common.exp_authenticate(db, login, password, user_agent_env)
+
+
+@register(admin_only=False)
+def version():
+    return common.exp_version()
+
+
+@register(admin_only=True)
+def create(dbname, demo, lang, user_password='admin'):
+    return db.exp_create_database(
+        dbname, demo, lang, user_password=user_password)
+
+
+@register(admin_only=True)
+def drop(dbname):
+    return db.exp_drop(dbname)
+
+
+@register(admin_only=True)
+def dump(dbname, frmt):
+    return db.exp_dump(dbname, frmt)
+
+
+@register(admin_only=True)
+def restore(dbname, data, copy=False):
+    return db.exp_restore(dbname, data, copy)
+
+
+@register(admin_only=True)
+def rename(old, new):
+    return db.exp_rename(old, new)
+
+
+@register(admin_only=True)
+def change_admin_password(new):
+    return db.exp_change_admin_password(new)
+
+
+@register(admin_only=True)
+def migrate_databases(databases):
+    return db.exp_migrate_databases(databases)
+
+
+@register(admin_only=True)
+def duplicate(source, destination):
+    return db.exp_duplicate_database(source, destination)
+
+
+@register(admin_only=False)
+def exists(dbname):
+    return db.exp_db_exist(dbname)
+
+
+@register(admin_only=False)
+def list_(document=False):
+    return db.exp_list(document)
+
+
+@register(admin_only=False)
+def list_languages():
+    return db.exp_list_lang()
+
+
+del register

--- a/odoo/addons/base/controllers/rpc2/exceptions.py
+++ b/odoo/addons/base/controllers/rpc2/exceptions.py
@@ -1,0 +1,47 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import enum
+import logging
+from odoo.exceptions import UserError
+from odoo.tools import snake
+
+_logger = logging.getLogger(__name__)
+
+
+# https://xmlrpc-epi.sourceforge.net/specs/rfc.fault_codes.php
+class RpcErrorCode(enum.IntEnum):
+    parse_error = -32700
+    unsupported_encoding = -32701
+    encoding_error = -32702
+    invalid_request = -32600
+    method_not_found = -32601
+    invalid_params = -32602
+    internal_error = -32603
+    application_error = -32500
+    system_error = -32500
+    transport_error = -32300
+
+    odoo_user_error = -32100
+    odoo_access_denied = -32101
+    odoo_access_error = -32102
+    odoo_missing_error = -32103
+    odoo_validation_error = -32104
+
+    @classmethod
+    def from_exception(cls, exc):
+        if isinstance(exc, UserError):
+            snake_name = snake(type(exc).__name__)
+            code = getattr(cls, f'odoo_{snake_name}', None)
+            if code:
+                return code
+
+            _logger.warning("%s lacks a RPC error code, using -32100 (UserError) instead.", type(exc))
+            return cls.odoo_user_error
+
+        return cls.application_error
+
+
+class RpcError(Exception):
+    def __init__(self, code):
+        super().__init__()
+        self.code = code

--- a/odoo/addons/base/controllers/rpc2/marshaller.py
+++ b/odoo/addons/base/controllers/rpc2/marshaller.py
@@ -1,0 +1,118 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import base64
+import collections.abc
+import datetime
+import functools
+import json
+import xmlrpc.client
+
+from lxml import etree
+from lxml.builder import E  # pylint: disable=no-name-in-module
+
+from odoo import models, http
+
+
+class XMLRPCMarshaller:
+    def __init__(self, encoding='utf-8'):
+        self.encoding = encoding
+        self.memo = set()
+
+    def dumps(self, values):
+        if isinstance(values, xmlrpc.client.Fault):
+            tree = E.fault(self.serialize({
+                'faultCode': values.faultCode,
+                'faultString': values.faultString,
+            }))
+        else:
+            tree = E.params()
+            tree.extend(E.param(self.serialize(value)) for value in values)
+        return etree.tostring(tree, encoding=self.encoding, xml_declaration=False)
+
+    @functools.singledispatchmethod
+    def serialize(self, value):
+        # Default serializer if no specilized one matched
+        return self.serialize(vars(value))
+
+    @serialize.register
+    def dump_model(self, value: models.BaseModel):
+        return self.serialize(value.ids)
+
+    @serialize.register
+    def dump_none(self, value: type(None)):
+        return E.value(E.nil())
+
+    @serialize.register
+    def dump_bool(self, value: bool):
+        return E.value(E.boolean("1" if value else "0"))
+
+    @serialize.register
+    def dump_int(self, value: int):
+        if not (xmlrpc.client.MININT <= value <= xmlrpc.client.MAXINT):
+            raise OverflowError("int exceeds XML-RPC limits")
+        return E.value(E.int(str(value)))
+
+    @serialize.register
+    def dump_float(self, value: float):
+        return E.value(E.double(repr(value)))
+
+    @serialize.register
+    def dump_str(self, value: str):
+        return E.value(E.string(value))
+
+    @serialize.register
+    def dump_mapping(self, value: collections.abc.Mapping):
+        m = id(value)
+        if m in self.memo:
+            raise TypeError("cannot marshal recursive dictionaries")
+        self.memo.add(m)
+        struct = E.struct()
+        struct.extend(
+            # coerce all keys to string (same as JSON)
+            E.member(E.name(str(k)), self.serialize(v))
+            for k, v in value.items()
+        )
+        self.memo.remove(m)
+        return E.value(struct)
+
+    @serialize.register
+    def dump_iterable(self, value: collections.abc.Iterable):
+        m = id(value)
+        if m in self.memo:
+            raise TypeError("cannot marshal recursive sequences")
+        self.memo.add(m)
+        data = E.data()
+        data.extend(self.serialize(v) for v in value)
+        self.memo.remove(m)
+        return E.value(E.array(data))
+
+    @serialize.register
+    def dump_datetime(self, value: datetime.datetime):
+        d = etree.Element('dateTime.iso8601')
+        d.text = value.replace(microsecond=0).isoformat()
+        return E.value(d)
+
+    @serialize.register
+    def dump_date(self, value: datetime.date):
+        d = etree.Element('dateTime.iso8601')
+        d.text = value.isoformat()
+        return E.value(d)
+
+    @serialize.register
+    def dump_bytes(self, value: bytes):
+        return E.value(E.base64(base64.b64encode(value).decode()))
+
+
+class JSONMarshaller(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, datetime.datetime):
+            return o.replace(microsecond=0).isoformat()
+        if isinstance(o, models.BaseModel):
+            return o.ids
+        if isinstance(o, collections.abc.Mapping):
+            return dict(o)
+        if isinstance(o, collections.abc.Iterable):
+            return list(o)
+        if isinstance(o, Exception):
+            return http.serialize_exception(o)
+        return super().default(o)

--- a/odoo/addons/base/controllers/rpc2/model.py
+++ b/odoo/addons/base/controllers/rpc2/model.py
@@ -1,0 +1,58 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import collections.abc
+import contextlib
+import functools
+import inspect
+
+import odoo.api
+from odoo.exceptions import AccessError
+from odoo.http import DEFAULT_LANG
+from odoo.service.model import retrying
+from .exceptions import RpcError, RpcErrorCode
+
+def dispatch(registry, uid, model, method_name, *params):
+    record_ids, context, args, kwargs = extract_call_info(params)
+    with contextlib.closing(registry.cursor()) as cr:
+        env = odoo.api.Environment(cr, uid, context)
+        method = bind_method(env, model, record_ids, context, method_name, args, kwargs)
+        return retrying(method, env)
+
+def extract_call_info(params):
+    params = params or [{}]
+
+    if (len(params) > 1
+     or not isinstance(params[0], collections.abc.Mapping)
+     or not {'records', 'context', 'args', 'kwargs'}.issuperset(params[0].keys())):
+        raise RpcError(RpcErrorCode.invalid_params) from TypeError(
+            "the RPC2 endpoint takes a single parameter: a dict with "
+            "records, context, args and kwargs (all optional) keys")
+
+    return (
+        params[0].get('records', []),
+        {'lang': DEFAULT_LANG, **params[0].get('context', {})},
+        params[0].get('args', []),
+        params[0].get('kwargs', {}),
+    )
+
+def bind_method(env, model, record_ids, context, method_name, args, kwargs):
+    if method_name.startswith('_'):
+        raise AccessError(f"{method_name!r} is a private method and can not be called over RPC")
+    try:
+        records = env[model].browse(record_ids).with_context(context)
+    except KeyError as exc1:
+        exc2 = NameError(f"no model {model!r} found")
+        exc2.__cause__ = exc1
+        raise RpcError(RpcErrorCode.method_not_found) from exc2
+    try:
+        method = getattr(records, method_name)
+    except AttributeError as exc1:
+        exc2 = NameError(f"no method {method_name!r} found on model {model!r}")
+        exc2.__cause__ = exc1
+        raise RpcError(RpcErrorCode.method_not_found) from exc2
+    try:
+        inspect.signature(method).bind(*args, **kwargs)
+    except TypeError as exc:
+        raise RpcError(RpcErrorCode.invalid_params) from exc
+
+    return functools.partial(method, *args, **kwargs)

--- a/odoo/addons/base/models/__init__.py
+++ b/odoo/addons/base/models/__init__.py
@@ -46,3 +46,4 @@ from . import res_users
 from . import res_users_deletion
 
 from . import decimal_precision
+from . import system

--- a/odoo/addons/base/models/system.py
+++ b/odoo/addons/base/models/system.py
@@ -1,0 +1,11 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class RpcSystem(models.AbstractModel):
+    _name = 'system'
+    _description = "RPC system"
+
+    def noop(self):
+        pass

--- a/odoo/addons/test_apikeys/tests/test_flow.py
+++ b/odoo/addons/test_apikeys/tests/test_flow.py
@@ -25,11 +25,19 @@ class TestAPIKeys(HttpCase):
 
         [(_, [key], [])] = self.messages
 
-        uid = self.xmlrpc_common.authenticate(db, 'demo', key, {})
-        [r] = self.xmlrpc_object.execute_kw(
-            db, uid, key,
-            'res.users', 'read', [uid, ['login']]
+        rpc_common = self.get_xmlrpc_common_proxy()
+        rpc_models = self.get_xmlrpc_models_proxy('demo', key)
+
+        uid = rpc_common.authenticate({'args': [db, 'demo', key, {}]})
+        self.assertEqual(
+            uid, demo_user.id,
+            "the key should be usable as a way to perform RPC calls"
         )
+
+        [r] = rpc_models.res.users.read({
+            'records': [uid],
+            'kwargs': {'fields': ['login']}
+        })
         self.assertEqual(
             r['login'], 'demo',
             "the key should be usable as a way to perform RPC calls"

--- a/odoo/addons/test_rpc2/__manifest__.py
+++ b/odoo/addons/test_rpc2/__manifest__.py
@@ -1,0 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'Test RPC2',
+    'version': '1.0',
+    'category': 'Hidden/Tests',
+    'description': """A module to test the /RCP2 endpoint and the related documentation""",
+    'depends': ['base', 'web', 'auth_totp', 'test_exceptions'],
+    'installable': True,
+    'license': 'LGPL-3',
+}

--- a/odoo/addons/test_rpc2/tests/.gitignore
+++ b/odoo/addons/test_rpc2/tests/.gitignore
@@ -1,0 +1,7 @@
+# ripcord
+composer.json
+composer.lock
+vendor/
+
+# apache xmlrpc
+apache-xmlrpc-3.1.3

--- a/odoo/addons/test_rpc2/tests/README.md
+++ b/odoo/addons/test_rpc2/tests/README.md
@@ -1,0 +1,89 @@
+Test RPC2 doc snippets
+======================
+
+The snippets from the external documentation are extracted by the few
+`test_rpc2_doc.*` files of the current directory. All those files are
+actual executable that you can run.
+
+In case you are an odoo employee running Linux Mint, you should go fine
+executing the `install_deps.sh` script. It installs all the programming
+languages used here along with the libraries we used in the examples.
+
+Javascript Steps
+----------------
+
+Install the following dependencies:
+
+	# apt install nodejs npm
+	$ cd /tmp
+	$ npm install jayson
+
+Reported version on the author's laptop:
+
+	$ node --version
+	v12.22.9
+
+Then simply run the tests with `--test-tags .test_rpc2_doc_js`.
+
+Ruby Steps
+----------
+
+Install the following dependencies:
+
+	# apt install ruby ruby-xmlrpc
+
+Reported version on the author's laptop:
+
+	$ ruby --version
+	ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-linux]
+
+Then simply run the tests with `--test-tags .test_rpc2_doc_ruby`
+
+PHP Steps
+---------
+
+Install the following dependencies:
+
+	# apt install php-cli php-dom php-xmlrpc composer
+	$ cd /tmp
+	$ composer require laminas/laminas-xmlrpc
+
+Reported version on the author's laptop:
+
+	$ php --version
+	PHP 8.1.2-1ubuntu2.8 (cli) (built: Nov  2 2022 13:35:25) (NTS)
+	Copyright (c) The PHP Group
+	Zend Engine v4.1.2, Copyright (c) Zend Technologies
+		with Zend OPcache v8.1.2-1ubuntu2.8, Copyright (c), by Zend Technologies
+
+Then simply run the tests with `--test-tags .test_rpc2_doc_php`
+
+Java Steps
+----------
+
+Install the following dependencies:
+
+	# apt install openjdk-8-jdk-headless
+	$ cp /tmp
+	$ wget https://archive.apache.org/dist/ws/xmlrpc/apache-xmlrpc-current-bin.tar.gz
+	$ tar --remove-files -xf apache-xmlrpc-current-bin.tar.gz
+
+Reported version on the author's laptop:
+
+	$ javac -version
+	javac 1.8.0_352
+	$ ls | grep apache-xmlrpc
+	apache-xmlrpc-3.1.3
+
+Then simply run the tests with `--test-tags .test_rpc2_doc_java`. The test
+takes care of both the compilation and the execution.
+
+SH/cURL Steps
+-------------
+
+Install the following dependencies:
+
+	# apt install bash curl jq
+
+Then simply run the tests with `--test-tags .test_rpc2_doc_curl`
+

--- a/odoo/addons/test_rpc2/tests/__init__.py
+++ b/odoo/addons/test_rpc2/tests/__init__.py
@@ -1,0 +1,2 @@
+from . import test_rpc2
+from . import test_rpc2_doc

--- a/odoo/addons/test_rpc2/tests/doc_result.json
+++ b/odoo/addons/test_rpc2/tests/doc_result.json
@@ -1,0 +1,92 @@
+<a id=common>
+{
+  "server_version": "16.1alpha1",
+  "server_version_info": [16, 1, 0, "alpha", 1, ""],
+  "server_serie": "16.1",
+  "protocol_version": 1
+}
+</a>
+<a id=models>
+null
+</a>
+<a id=check_access_rights>
+true
+</a>
+<a id=list>
+[26,33,27,35,18,19,20,22,31,23,34,21,25,37,24,36,30,38,29,28,17,32,16,39,40,8,7,3]
+</a>
+<a id=pagination>
+[34,21,25,37,24]
+</a>
+<a id=count>
+28
+</a>
+<a id=search_read>
+[
+  {
+    "id": 26,
+    "name": "Brandon Freeman",
+    "title": false,
+    "parent_name": "Azure Interior"
+  }
+]
+</a>
+<a id=read>
+[
+  {
+    "id": 26,
+    "name": "Brandon Freeman",
+    "title": false,
+    "parent_name": "Azure Interior"
+  }
+]
+</a>
+<a id=fields_get>
+{
+  "name":        {"type": "char",     "string": "Name"},
+  "street":      {"type": "char",     "string": "Street"},
+  "street2":     {"type": "char",     "string": "Street2"},
+  "zip":         {"type": "char",     "string": "Zip"},
+  "city":        {"type": "char",     "string": "City"},
+  "state":       {"type": "many2one", "string": "Fed. State"},
+  "country":     {"type": "many2one", "string": "Country"},
+  "email":       {"type": "char",     "string": "Email"},
+  "phone":       {"type": "char",     "string": "Phone"},
+  "active":      {"type": "boolean",  "string": "Active"},
+  "bic":         {"type": "char",     "string": "Bank Identifier Code"},
+  "id":          {"type": "integer",  "string": "ID"},
+  "display_name":{"type": "char",     "string": "Display Name"},
+  "create_uid":  {"type": "many2one", "string": "Created by"},
+  "create_date": {"type": "datetime", "string": "Created on"},
+  "write_uid":   {"type": "many2one", "string": "Last Updated by"},
+  "write_date":  {"type": "datetime", "string": "Last Updated on"}
+}
+</a>
+<a id=create>
+[41]
+</a>
+<a id=write>
+[[41,"Newer Partner"]]
+</a>
+<a id=unlink>
+[]
+</a>
+<a id=ir.model>
+{
+  "id":           {"type": "integer",  "string": "ID"},
+  "display_name": {"type": "char",     "string": "Display Name"},
+  "create_uid":   {"type": "many2one", "string": "Created by"},
+  "create_date":  {"type": "datetime", "string": "Created on"},
+  "write_uid":    {"type": "many2one", "string": "Last Updated by"},
+  "write_date":   {"type": "datetime", "string": "Last Updated on"},
+  "x_name":       {"type": "char",     "string": "Name"}
+}
+</a>
+<a id=ir.model.fields>
+[
+  {
+    "id": 1,
+    "x_foo": "test record"
+  }
+]
+</a>

--- a/odoo/addons/test_rpc2/tests/install_deps.sh
+++ b/odoo/addons/test_rpc2/tests/install_deps.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+read -p 'apt install node ruby php java curl (yes/[no])? ' prompt
+set -v
+[[ $prompt == 'yes' || $prompt == 'y' ]] && sudo apt install \
+	nodejs npm \
+	ruby ruby-xmlrpc \
+	php-cli php-dom php-xmlrpc composer \
+	openjdk-8-jdk-headless \
+	bash curl jq
+
+cd /tmp
+npm i jayson
+composer require laminas/laminas-xmlrpc
+wget https://archive.apache.org/dist/ws/xmlrpc/apache-xmlrpc-current-bin.tar.gz
+tar -xf apache-xmlrpc-current-bin.tar.gz
+rm apache-xmlrpc-current-bin.tar.gz

--- a/odoo/addons/test_rpc2/tests/test_rpc2.py
+++ b/odoo/addons/test_rpc2/tests/test_rpc2.py
@@ -1,0 +1,366 @@
+import base64
+import secrets
+import textwrap
+import time
+
+from http import HTTPStatus
+from lxml import etree
+from urllib.parse import urlparse
+
+from freezegun import freeze_time
+
+from odoo.tests.common import get_db_name, tagged, HttpCase, new_test_user
+from odoo.tools import config, mute_logger, submap
+
+from odoo.addons.auth_totp.models import totp
+from odoo.addons.base.controllers.rpc2 import admin
+
+CT_JSON = 'application/json; charset=utf-8'
+CT_XML = 'text/xml; charset=utf-8'
+HEADER_JSON = {'Content-Type': CT_JSON}
+HEADER_XML = {'Content-Type': CT_XML}
+
+
+def xmlrpc_req(method, params):
+    return textwrap.dedent(f"""\
+        <?xml version="1.0"?>
+        <methodCall>
+            <methodName>{method}</methodName>
+            <params>
+                {params}
+            </params>
+        </methodCall>
+    """)
+
+def xmlrpc_fault(code, string):
+    return textwrap.dedent(f"""\
+        <?xml version="1.0"?>
+        <methodResponse>
+            <fault>
+                <value>
+                    <struct>
+                        <member>
+                            <name>faultCode</name>
+                            <value><int>{code}</int></value>
+                        </member>
+                        <member>
+                            <name>faultString</name>
+                            <value><string>{string}</string></value>
+                        </member>
+                    </struct>
+                </value>
+            </fault>
+        </methodResponse>
+    """)
+
+def jsonrpc_req(method, params):
+    return {
+        "version": "2.0",
+        "method": method,
+        "params": params,
+        "id": None
+    }
+
+
+@tagged('-at_install', 'post_install')
+class TestRpc2(HttpCase):
+    @mute_logger('odoo.http')
+    def test_rpc2_unsupported_media_type(self):
+        res = self.url_open('/RPC2', data={'method': 'version', 'params': []})
+        self.assertEqual(res.status_code, HTTPStatus.UNSUPPORTED_MEDIA_TYPE)
+        self.assertIn(CT_XML, res.headers.get('Accept', ''))
+        self.assertIn(CT_JSON, res.headers.get('Accept', ''))
+        self.assertIn("mime type not supported", res.text)
+
+    def test_rpc2_db(self):
+        db = get_db_name()
+
+        with self.subTest(dblist=[]), self.nodb():
+            res = self.opener.post(
+                self.base_url() + '/RPC2',
+                json=jsonrpc_req('version', []))
+            self.assertEqual(res.status_code, HTTPStatus.OK,
+                "The rpc2 controllers should always be accessible.")
+
+        dblist = [db, f'definitely_not_{db}']
+        with self.subTest(dblist=dblist), self.multidb(dblist):
+            res = self.opener.post(
+                self.base_url() + f'/RPC2?db={get_db_name()}',
+                json=jsonrpc_req('system.noop', []),
+                auth=('admin', 'admin'))
+            self.assertEqual(res.status_code, HTTPStatus.OK,
+                "Accessing its own db in multi-db mode works")
+
+        dblist = [f'definitely_not_{db}1', f'definitely_not_{db}2']
+        with self.subTest(dblist=dblist), self.multidb(dblist):
+            res = self.opener.post(
+                self.base_url() + f'/RPC2?db={db}',
+                json=jsonrpc_req('system.noop', []),
+                auth=('admin', 'admin'))
+            self.assertEqual(res.status_code, HTTPStatus.NOT_FOUND)
+
+    def test_rpc2_auth_admin(self):
+        version_func = admin._functions['version']
+        assert not version_func.admin_only
+        version_func.admin_only = True
+        self.addCleanup(version_func.__setattr__, 'admin_only', False)
+
+        with self.subTest(missing='auth header'):
+            res = self.opener.post(
+                f'{self.base_url()}/RPC2',
+                json=jsonrpc_req('version', []))
+            self.assertEqual(res.status_code, HTTPStatus.UNAUTHORIZED)
+            self.assertEqual(res.headers.get('WWW-Authenticate'), 'Basic realm="Odoo-RPC"')
+
+        with self.subTest(bad='password'):
+            res = self.opener.post(
+                f'{self.base_url()}/RPC2',
+                json=jsonrpc_req('version', []),
+                auth=('', 'bad password')
+            )
+            self.assertEqual(res.status_code, HTTPStatus.FORBIDDEN)
+
+        with self.subTest(good='password'):
+            res = self.opener.post(
+                f'{self.base_url()}/RPC2',
+                json=jsonrpc_req('version', []),
+                auth=('', config['admin_passwd'])
+            )
+            self.assertEqual(res.status_code, HTTPStatus.OK)
+
+    @mute_logger('odoo.addons.base.controllers.rpc')
+    def test_rpc2_auth_model(self):
+        db = get_db_name()
+
+        with self.subTest(missing='auth header'):
+            res = self.opener.post(
+                f'{self.base_url()}/RPC2?db={db}',
+                json=jsonrpc_req('system.noop', []))
+            self.assertEqual(res.status_code, HTTPStatus.UNAUTHORIZED)
+            self.assertEqual(res.headers.get('WWW-Authenticate'), 'Basic realm="Odoo-RPC"')
+
+        with self.subTest(bad='user'):
+            res = self.opener.post(
+                f'{self.base_url()}/RPC2?db={db}',
+                json=jsonrpc_req('system.noop', []),
+                auth=('baduser', 'admin'))
+            self.assertEqual(res.status_code, HTTPStatus.FORBIDDEN)
+
+        with self.subTest(bad='password'):
+            res = self.opener.post(
+                f'{self.base_url()}/RPC2?db={db}',
+                json=jsonrpc_req('system.noop', []),
+                auth=('admin', 'badpassword'))
+            self.assertEqual(res.status_code, HTTPStatus.FORBIDDEN)
+
+        with self.subTest(good='user/pwd'):
+            res = self.opener.post(
+                f'{self.base_url()}/RPC2?db={db}',
+                json=jsonrpc_req('system.noop', []),
+                auth=('admin', 'admin'))
+            self.assertEqual(res.status_code, HTTPStatus.OK)
+
+    @mute_logger('odoo.addons.base.controllers.rpc')
+    @freeze_time('2022-12-07 16:18:10')
+    def test_rpc2_basic_auth_mfa(self):
+        jack = new_test_user(self.env, 'jackoneill', context={'lang': 'en_US'})
+
+        # Enable TOTP and add an API key
+        totp_secret = secrets.token_bytes()
+        totp_secret_humain = base64.b32encode(totp_secret).decode()
+        totp_code = totp.hotp(totp_secret, int(time.time() / totp.TIMESTEP))
+        jack.with_user(jack)._totp_try_setting(totp_secret_humain, totp_code)
+        ApiKeys = self.env['res.users.apikeys'].with_user(jack)
+        apikey = ApiKeys._generate('rpc', 'test_rpc2')
+        self.assertTrue(jack._rpc_api_keys_only())
+
+        db = get_db_name()
+        with self.subTest(bad='login/pwd'):
+            res = self.opener.post(
+                f'{self.base_url()}/RPC2?db={db}',
+                json=jsonrpc_req('system.noop', []),
+                auth=('jackoneill', 'jackoneill'))
+            self.assertEqual(res.status_code, HTTPStatus.FORBIDDEN)
+
+        with self.subTest(good='login/apikey'):
+            res = self.opener.post(
+                f'{self.base_url()}/RPC2?db={db}',
+                json=jsonrpc_req('system.noop', []),
+                auth=('jackoneill', apikey))
+            self.assertEqual(res.status_code, HTTPStatus.OK)
+
+    @mute_logger('odoo.addons.base.controllers.rpc')
+    def test_xmlrpc2_transport_errors(self):
+        invalid_xml = "invalid xml"
+        unknown_charset = xmlrpc_req('version', '').encode('ascii')
+        bad_encoding = xmlrpc_req('vérsion', '').encode('utf-8')
+        invalid_request = """<?xml version="1.0"?><methodCall></methodCall>"""
+
+        test_matrix = [
+            # pylint: disable=bad-whitespace
+            # payload,        charset, expected http status, expected fault code, expected fault string
+            (invalid_xml,     'utf-8', -32700, "xml.parsers.expat.ExpatError: syntax error: line 1, column 0"),
+            (unknown_charset, 'ansi',  -32701, "LookupError: unknown encoding: ansi"),
+            (bad_encoding,    'ascii', -32702, "UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 52: ordinal not in range(128)"),
+            (invalid_request, 'utf-8', -32600, "ValueError: malformed XML-RPC request"),
+        ]
+
+        for payload, charset, fault_code, fault_string in test_matrix:
+            with self.subTest(fault=fault_string):
+                res = self.url_open(
+                    '/RPC2',
+                    headers={'Content-Type': f'text/xml; charset={charset}'},
+                    data=payload,
+                )
+                if fault_code == -32701:
+                    self.assertEqual(res.status_code, HTTPStatus.UNSUPPORTED_MEDIA_TYPE)
+                    self.assertIn(CT_XML, res.headers.get('Accept'))
+                else:
+                    self.assertEqual(res.status_code, HTTPStatus.BAD_REQUEST)
+                self.assertEqual(res.headers['Content-Type'], CT_XML)
+                self.assertTreesEqual(
+                    etree.fromstring(res.text),
+                    etree.fromstring(xmlrpc_fault(fault_code, fault_string))
+                )
+
+    @mute_logger('odoo.addons.base.controllers.rpc')
+    def test_jsonrpc2_transport_errors(self):
+        invalid_json = "invalid json"
+        unknown_charset = str(jsonrpc_req('version', [])).encode('ascii')
+        bad_encoding = str(jsonrpc_req('vérsion', [])).encode('utf-8')
+        invalid_request = 'null'
+
+        test_matrix = [
+            # pylint: disable=bad-whitespace
+            # payload,        charset, expected error code, expected error message
+            (invalid_json,    'utf-8', -32700, "json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)"),
+            (unknown_charset, 'ansi',  -32701, "LookupError: unknown encoding: ansi"),
+            (bad_encoding,    'ascii', -32702, "UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 31: ordinal not in range(128)"),
+            (invalid_request, 'utf-8', -32600, "ValueError: malformed JSON-RPC request"),
+        ]
+
+        for payload, charset, error_code, error_message in test_matrix:
+            with self.subTest(fault=error_message):
+                res = self.url_open(
+                    '/RPC2',
+                    headers={'Content-Type': f'application/json; charset={charset}'},
+                    data=payload,
+                )
+                if error_code == -32701:
+                    self.assertEqual(res.status_code, HTTPStatus.UNSUPPORTED_MEDIA_TYPE)
+                    self.assertIn(CT_JSON, res.headers.get('Accept'))
+                else:
+                    self.assertEqual(res.status_code, HTTPStatus.BAD_REQUEST)
+                self.assertEqual(res.headers['Content-Type'], CT_JSON)
+                self.assertEqual(
+                    submap(res.json()['error'], {'code', 'message'}),
+                    {'code': error_code, 'message': error_message}
+                )
+
+    @mute_logger('odoo.addons.base.controllers.rpc')
+    def test_rpc2_routing_errors(self):
+        unknown_admin_method = 'idontexist', []
+        invalid_admin_params = 'version', [('string', 'bad')]
+        old_admin_params = 'version', [('string', 'bad'), ('string', 'bad')]
+        wrong_model_on_admin = 'res.partner.search', []
+        unknown_model_name = 'i.dont.exist', []
+        unknown_model_method = 'res.partner.idontexist', []
+        wrong_admin_on_model = 'version', []
+        invalid_model_params = 'res.partner.search', []
+        bad_model_subject = 'res.partner.search', [('int', 1)]
+        private_model_method = 'res.partner._search', []
+
+        base_url = urlparse(self.base_url())
+        admin_url = f'{base_url.scheme}://{base_url.netloc}/RPC2'
+        model_url = f'{base_url.scheme}://admin:admin@{base_url.netloc}/RPC2?db={get_db_name()}'
+
+        test_matrix = [
+            # pylint: disable=bad-whitespace
+            # client,  call,                  expected fault code, expected fault string
+            ('admin', unknown_admin_method, -32601, "NameError: no admin function 'idontexist' found"),
+            ('admin', invalid_admin_params, -32602, "TypeError: the RPC2 endpoint takes a single parameter: a dict with args and kwargs (both optional) keys"),
+            ('admin', old_admin_params,     -32602, "TypeError: the RPC2 endpoint takes a single parameter: a dict with args and kwargs (both optional) keys. Did you mean {'args': ['bad', 'bad']}?"),
+            ('admin', wrong_model_on_admin, -32601, "NameError: 'res.partner.search' is not a valid admin function"),
+            ('model', unknown_admin_method, -32601, "NameError: 'idontexist' is not a valid model name"),
+            ('model', unknown_model_name,   -32601, "NameError: no model 'i.dont' found"),
+            ('model', unknown_model_method, -32601, "NameError: no method 'idontexist' found on model 'res.partner'"),
+            ('model', wrong_admin_on_model, -32601, "NameError: 'version' is not a valid model name"),
+            ('model', invalid_model_params, -32602, "TypeError: missing a required argument: 'domain'"),
+            ('model', bad_model_subject,    -32602, "TypeError: the RPC2 endpoint takes a single parameter: a dict with records, context, args and kwargs (all optional) keys"),
+            ('model', private_model_method, -32102, "odoo.exceptions.AccessError: '_search' is a private method and can not be called over RPC"),
+        ]
+
+        for client, (method, params), fault_code, fault_string in test_matrix:
+            with self.subTest(type='xmlrpc', fault=fault_string):
+                url = admin_url if client == 'admin' else model_url
+                payload = xmlrpc_req(method, '\n        '.join(
+                    f'<param><value><{ptype}>{pvalue}</{ptype}></value></param>'
+                    for ptype, pvalue in params
+                ))
+                res = self.url_open(url, headers=HEADER_XML, data=payload)
+                res.raise_for_status()
+                self.assertEqual(res.headers['Content-Type'], CT_XML)
+                self.assertTreesEqual(
+                    etree.fromstring(res.text),
+                    etree.fromstring(xmlrpc_fault(fault_code, fault_string))
+                )
+
+            with self.subTest(type='jsonrpc', fault=fault_string):
+                url = admin_url if client == 'admin' else model_url
+                payload = jsonrpc_req(method, [pvalue for ptype, pvalue in params])
+                res = self.opener.post(url, json=payload)
+                res.raise_for_status()
+                self.assertEqual(res.headers['Content-Type'], CT_JSON)
+                self.assertEqual(
+                    submap(res.json()['error'], {'code', 'message'}),
+                    {'code': fault_code, 'message': fault_string}
+                )
+
+    @mute_logger('odoo.addons.base.controllers.rpc')
+    def test_rpc2_application_errors(self):
+        func = 'test.exceptions.model.generate'
+        test_matrix = [
+            # pylint: disable=bad-whitespace
+            # method                     expected fault code, expected fault string
+            (f'{func}_user_error',       -32100, "odoo.exceptions.UserError: description"),
+            (f'{func}_access_denied',    -32101, "odoo.exceptions.AccessDenied: Access Denied"),
+            (f'{func}_access_error',     -32102, "odoo.exceptions.AccessError: description"),
+            (f'{func}_missing_error',    -32103, "odoo.exceptions.MissingError: description"),
+            (f'{func}_validation_error', -32104, "odoo.exceptions.ValidationError: description"),
+            (f'{func}_undefined',        -32500, "AttributeError: 'test.exceptions.model' object has no attribute 'surely_undefined_symbol'"),
+        ]
+
+        base_url = urlparse(self.base_url())
+        url = f'{base_url.scheme}://admin:admin@{base_url.netloc}/RPC2?db={get_db_name()}'
+        for method, fault_code, fault_string in test_matrix:
+            with self.subTest(type='xmlrpc', fault=fault_string):
+                res = self.url_open(url, headers=HEADER_XML, data=xmlrpc_req(method, ''))
+                res.raise_for_status()
+                self.assertEqual(res.headers['Content-Type'], CT_XML)
+                self.assertTreesEqual(
+                    etree.fromstring(res.text),
+                    etree.fromstring(xmlrpc_fault(fault_code, fault_string))
+                )
+
+            with self.subTest(type='jsonrpc', fault=fault_string):
+                res = self.opener.post(url, json=jsonrpc_req(method, []))
+                res.raise_for_status()
+                self.assertEqual(res.headers['Content-Type'], CT_JSON)
+                self.assertEqual(
+                    submap(res.json()['error'], {'code', 'message'}),
+                    {'code': fault_code, 'message': fault_string}
+                )
+
+    def test_rpc2_context(self):
+        models = self.get_xmlrpc_models_proxy('admin', 'admin')
+        self.env['res.lang']._activate_lang('fr_FR')
+
+        title = self.env['res.partner.title'].create({'name': 'Major'})
+        title.with_context(lang='fr_FR').name = 'Commandant'
+
+        self.assertEqual(
+            models.res.partner.title.name_get(
+                {'records': title.ids, 'context': {'lang': 'fr_FR'}}),
+            [[title.id, "Commandant"]],
+            "subject can be a dict with a list of ids and a context"
+        )

--- a/odoo/addons/test_rpc2/tests/test_rpc2_doc.java
+++ b/odoo/addons/test_rpc2/tests/test_rpc2_doc.java
@@ -1,0 +1,238 @@
+import java.net.URL;
+import java.util.*;
+import org.xml.sax.SAXException;
+import static java.util.Arrays.asList;
+import static java.util.Collections.*;
+
+import org.apache.ws.commons.util.NamespaceContextImpl;
+import org.apache.xmlrpc.common.*;
+import org.apache.xmlrpc.client.*;
+import org.apache.xmlrpc.parser.*;
+import org.apache.xmlrpc.serializer.*;
+import org.apache.xmlrpc.XmlRpcException;
+
+// adds support for <nil/>: https://zugiart.com/2011/07/apache-xml-rpc-handle-null-nil/
+class CustomXmlRpcTypeNil extends TypeFactoryImpl {
+    CustomXmlRpcTypeNil(XmlRpcClient c) {
+        super(c);
+    }
+    public TypeParser getParser(XmlRpcStreamConfig pConfig, NamespaceContextImpl pContext, String pURI, String pLocalName) {
+        return NullSerializer.NIL_TAG.equals(pLocalName)
+            ? new NullParser()
+            : super.getParser(pConfig, pContext, pURI, pLocalName);
+    }
+    public TypeSerializer getSerializer(XmlRpcStreamConfig pConfig, Object pObject) throws SAXException {
+        return (pObject instanceof CustomXmlRpcTypeNil)
+            ? new NullSerializer()
+            : super.getSerializer(pConfig, pObject);
+    }
+}
+
+class test_rpc2_doc {
+    public static void main(String[] cmdline)
+        throws org.apache.xmlrpc.XmlRpcException,
+               java.net.MalformedURLException {
+
+        String scheme = cmdline[0];
+        String domain = cmdline[1];
+        String database = cmdline[2];
+        String username = cmdline[3];
+        String password = cmdline[4];
+
+        //<a id=setup>
+        // The following code replicates this JSON structure:
+        // [{ "records":[], "context":{}, "args":[], "kwargs":{} }]
+        List<Object> records = new ArrayList<>();
+        Map<String, Object> context = new HashMap<>();
+        List<Object> args = new ArrayList<>();
+        Map<String, Object> kwargs = new HashMap<>();
+        Map<String, Object> callInfo = new HashMap<>();
+        List<Map> params = new ArrayList<>();
+        callInfo.put("records", records);
+        callInfo.put("context", context);
+        callInfo.put("args", args);
+        callInfo.put("kwargs", kwargs);
+        params.add(callInfo);
+
+        // custom map for create and write
+        Map<String, Object> values = new HashMap<>();
+        // </a>
+
+        //<a id=common>
+        URL commonUrl = new URL(String.format("%s://%s/RPC2", scheme, domain));
+        XmlRpcClientConfigImpl commonConfig = new XmlRpcClientConfigImpl();
+        commonConfig.setServerURL(commonUrl);
+        XmlRpcClient common = new XmlRpcClient();
+        common.setConfig(commonConfig);
+
+        Map version = (Map<String, Object>)common.execute("version", emptyList());
+        //</a>
+
+        //<a id=models>
+        URL modelsURL = new URL(String.format("%s://%s/RPC2?db=%s", scheme, domain, database));
+        XmlRpcClientConfigImpl modelsConfig = new XmlRpcClientConfigImpl();
+        modelsConfig.setServerURL(modelsURL);
+        modelsConfig.setBasicUserName(username);
+        modelsConfig.setBasicPassword(password);
+        XmlRpcClient models = new XmlRpcClient();
+        CustomXmlRpcTypeNil modelsCustomXmlRpcTypeNil = new CustomXmlRpcTypeNil(models);
+        models.setTypeFactory(modelsCustomXmlRpcTypeNil);
+        models.setConfig(modelsConfig);
+
+        models.execute("system.noop", emptyList());
+        //</a>
+
+        //<a id=check_access_rights>
+        args.add("read");
+        kwargs.put("raise_exception", false);
+        boolean canAccess = (boolean) models.execute(
+            "res.partner.check_access_rights", params);
+        args.clear();
+        kwargs.clear();
+        //</a>
+
+        //<a id=list>
+        kwargs.put("domain", asList(asList("is_company", "=", false)));
+        Object[] recordIds1 = (Object[]) models.execute(
+            "res.partner.search", params);
+        kwargs.clear();
+        //</a>
+
+        //<a id=pagination>
+        // Map<String, Object> kwargs = new HashMap<>();
+        kwargs.put("domain", asList(asList("is_company", "=", false)));
+        kwargs.put("offset", 10);
+        kwargs.put("limit", 5);
+        Object[] recordIds2 = (Object[]) models.execute(
+            "res.partner.search", params);
+        kwargs.clear();
+        //</a>
+
+        //<a id=count>
+        kwargs.put("domain", asList(asList("is_company", "=", false)));
+        int count = (int) models.execute(
+            "res.partner.search_count", params);
+        kwargs.clear();
+        //</a>
+
+        //<a id=search_read>
+        kwargs.put("domain", asList(asList("is_company", "=", false)));
+        kwargs.put("fields", asList("name", "title", "parent_name"));
+        kwargs.put("limit", 1);
+        Map recordData1 = (Map<String, Object>) ((Object[]) models.execute(
+            "res.partner.search_read", params))[0];
+        kwargs.clear();
+        //</a>
+
+        //<a id=read>
+        records.add(recordIds1[0]);
+        kwargs.put("fields", asList("name", "title", "parent_name"));
+        Map recordData2 = (Map<String, Object>) ((Object[]) models.execute(
+            "res.partner.read", params))[0];
+        records.clear();
+        kwargs.clear();
+        //</a>
+
+        //<a id=fields_get>
+        kwargs.put("attributes", asList("type", "string"));
+        Map fields = (Map<String, Map<String, Object>>) models.execute(
+            "res.bank.fields_get", params);
+        kwargs.clear();
+        //</a>
+
+        //<a id=create>
+        values.put("name", "New Partner");
+        args.add(values);
+        Object[] newRecordIds = (Object[]) models.execute(
+            "res.partner.create", params);
+        values.clear();
+        args.clear();
+        //</a>
+
+        //<a id=write>
+        records.addAll(asList(newRecordIds));
+        values.put("name", "Newer Partner");
+        args.add(values);
+        models.execute("res.partner.write", params);
+        values.clear();
+        args.clear();
+        // get record name after having changed it
+        Object[] recordsName = (Object[]) models.execute(
+            "res.partner.name_get", params);
+        records.clear();
+        //</a>
+
+        //<a id=unlink>
+        records.addAll(asList(newRecordIds));
+        models.execute("res.partner.unlink", params);
+        // check if the deleted record is still in the database
+        Object[] recordIds3 = (Object[]) models.execute(
+            "res.partner.exists", params);
+        records.clear();
+        //</a>
+
+        //<a id=ir.model>
+        values.put("name", "Custom Model");
+        values.put("model", "x_custom_model");
+        values.put("state", "manual");
+        args.add(values);
+        int xCustomModelId = (int) ((Object[]) models.execute(
+            "ir.model.create", params))[0];
+        values.clear();
+        args.clear();
+
+        // grant the admin CRUD operations
+        args.add("base");
+        args.add("group_system");
+        int systemGroupId = (int) ((Object[]) models.execute(
+            "ir.model.data.check_object_reference", params))[1];
+        args.clear();
+
+        values.put("name", "access_x_custom_model_admin");
+        values.put("model_id", xCustomModelId);
+        values.put("group_id", systemGroupId);
+        values.put("perm_read", true);
+        values.put("perm_write", true);
+        values.put("perm_create", true);
+        values.put("perm_unlink", true);
+        args.add(values);
+        models.execute("ir.model.access.create", params);
+        values.clear();
+        args.clear();
+
+        // get the fields of our newly created model
+        kwargs.put("attributes", asList("type", "string"));
+        Map xCustomModelFields = (Map<String, Map<String, Object>>) models.execute(
+            "x_custom_model.fields_get", params);
+        kwargs.clear();
+        //</a>
+
+        //<a id=ir.model.fields>
+        // Add a new field "x_foo" on "x_custom_model"
+        values.clear();
+        values.put("model_id", xCustomModelId);  // above example
+        values.put("name", "x_foo");
+        values.put("ttype", "char");
+        values.put("state", "manual");
+        args.add(values);
+        models.execute("ir.model.fields.create", params);
+        values.clear();
+        args.clear();
+
+        // Create a new record and read it
+        // Map<String, Object> createData = new HashMap<>();
+        values.put("x_foo", "test record");
+        args.add(values);
+        Object[] xRecordIds = (Object[]) models.execute(
+            "x_custom_model.create", params);
+        values.clear();
+        args.clear();
+
+        records.addAll(asList(xRecordIds));
+        kwargs.put("fields", asList("x_foo"));
+        Map xRecordData = (Map<String, Object>) ((Object[]) models.execute(
+            "x_custom_model.read", params))[0];
+        kwargs.clear();
+        //</a>
+    }
+}

--- a/odoo/addons/test_rpc2/tests/test_rpc2_doc.js
+++ b/odoo/addons/test_rpc2/tests/test_rpc2_doc.js
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+"use strict";
+
+const jayson = require("jayson");
+const process = require("process");
+const util = require("util");
+
+
+async function main(scheme, domain, database, username, password) {
+    //<a id=common>
+    // Callback way
+    const common = jayson.Client[scheme](`${scheme}://${domain}/RPC2`);
+    common.request("version", [], (error, response) => {
+        if (error) throw error;
+        if (response.error) throw new Error(response.error.message);
+        const version = response.result;
+    });
+    //</a>
+
+    //<a id=models>
+    // Promise way
+    let response;
+    const modelsClient = jayson.Client[scheme](`${scheme}://${username}:${password}@${domain}/RPC2?db=${database}`);
+    const models = util.promisify(modelsClient.request).bind(modelsClient);
+
+    response = await models("system.noop", []);
+    if (response.error) throw new Error(response.error.message);
+    //</a>
+    console.log(response.result);
+
+    //<a id=check_access_rights>
+    response = await models("res.partner.check_access_rights", [{
+        args: ["read"],
+        kwargs: {
+            raise_exception: false,
+        },
+    }]);
+    if (response.error) throw new Error(response.error.message);
+    const canAccess = response.result;
+    //</a>
+    console.log(canAccess);
+
+    //<a id=list>
+    response = await models("res.partner.search", [{
+        kwargs: {
+            domain: [["is_company", "=", false]],
+        },
+    }]);
+    if (response.error) throw new Error(response.error.message);
+    const recordIds1 = response.result;
+    //</a>
+    console.log(recordIds1);
+
+    //<a id=pagination>
+    response = await models("res.partner.search", [{
+        kwargs: {
+            domain: [["is_company", "=", false]],
+            offset: 10,
+            limit: 5,
+        },
+    }]);
+    if (response.error) throw new Error(response.error.message);
+    const recordIds2 = response.result;
+    //</a>
+    console.log(recordIds2)
+
+    //<a id=count>
+    response = await models("res.partner.search_count", [{
+        kwargs: {
+            domain: [["is_company", "=", false]],
+        },
+    }]);
+    if (response.error) throw new Error(response.error.message);
+    const count = response.result;
+    //</a>
+    console.log(count);
+
+    //<a id=search_read>
+    response = await models("res.partner.search_read", [{
+        kwargs: {
+            domain: [["is_company", "=", false]],
+            fields: ["name", "title", "parent_name"],
+            limit: 1,
+        },
+    }]);
+    if (response.error) throw new Error(response.error.message);
+    const recordData1 = response.result[0];
+    //</a>
+    console.log(recordData1);
+
+    //<a id=read>
+    response = await models("res.partner.read", [{
+        records: recordIds1,
+        kwargs: {
+            fields: ["name", "title", "parent_name"],
+        },
+    }]);
+    if (response.error) throw new Error(response.error.message);
+    const recordData2 = response.result[0];
+    //</a>
+    console.log(recordData2);
+
+    //<a id=fields_get>
+    response = await models("res.bank.fields_get", [{
+        kwargs: {
+            attributes: ["type", "string"],
+        },
+    }]);
+    if (response.error) throw new Error(response.error.message);
+    const fields = response.result;
+    //</a>
+    console.log(fields);
+
+    //<a id=create>
+    response = await models("res.partner.create", [{
+        args: [{name: "New Partner"}],
+    }]);
+    if (response.error) throw new Error(response.error.message);
+    const newRecordIds = response.result;
+    //</a>
+    console.log(newRecordIds);
+
+    //<a id=write>
+    response = await models("res.partner.write", [{
+        records: newRecordIds,
+        args: [{name: "Newer partner"}],
+    }]);
+    if (response.error) throw new Error(response.error.message);
+
+    // get record name after having changed it
+    response = await models("res.partner.name_get", [{
+        records: newRecordIds,
+    }]);
+    if (response.error) throw new Error(response.error.message);
+    const recordsName = response.result;
+    //</a>
+    console.log(recordsName);
+
+    //<a id=unlink>
+    response = await models("res.partner.unlink", [{
+        records: newRecordIds,
+    }]);
+    if (response.error) throw new Error(response.error.message);
+
+    response = await models("res.partner.exists", [{
+        records: newRecordIds,
+    }]);
+    if (response.error) throw new Error(response.error.message);
+    const records = response.result;
+    //</a>
+    console.log(records);
+
+    //<a id=ir.model>
+    response = await models("ir.model.create", [{
+        args: [{
+            name: "Custom Model",
+            model: "x_custom_model",
+            state: "manual"
+        }],
+    }]);
+    if (response.error) throw new Error(response.error.message);
+    const xCustomModelId = response.result[0];
+
+    // grant the admin CRUD operations
+    response = await models("ir.model.data.check_object_reference", [{
+        args: ["base", "group_system"],
+    }]);
+    if (response.error) throw new Error(response.error.message);
+    const systemGroupId = response.result[1];
+
+    response = models("ir.model.access.create", [{
+        args: [{
+            name: "access_x_custom_model_admin",
+            model_id: xCustomModelId,
+            group_id: systemGroupId,
+            perm_read: true,
+            perm_write: true,
+            perm_create: true,
+            perm_unlink: true,
+        }],
+    }]);
+    if (response.error) throw new Error(response.error.message);
+
+    // get the fields of our newly created model
+    response = await models("x_custom_model.fields_get", [{
+        kwargs: {
+            attributes: ["type", "string"],
+        },
+    }]);
+    if (response.error) throw new Error(response.error.message);
+    const xCustomModelFields = response.result;
+    //</a>
+    console.log(xCustomModelFields);
+
+    //<a id=ir.model.fields>
+    // Add a new field "x_foo" on "x_custom_model"
+    response = await models("ir.model.fields.create", [{
+        args: [{
+            model_id: xCustomModelId,  // from the above example
+            name: "x_foo",
+            ttype: "char",
+            state: "manual",
+        }],
+    }]);
+    if (response.error) throw new Error(response.error.message);
+
+    // Create a new record and read it
+    response = await models("x_custom_model.create", [{
+        args: [{x_foo: "test record"}],
+    }]);
+    if (response.error) throw new Error(response.error.message);
+    const xRecordIds = response.result;
+
+    response = await models("x_custom_model.read", [{
+        records: xRecordIds,
+        kwargs: {
+            fields: ["x_foo"],
+        },
+    }]);
+    if (response.error) throw new Error(response.error.message);
+    const xRecordData = response.result[0];
+    //</a>
+    console.log(xRecordData);
+}
+
+main(...process.argv.slice(2));

--- a/odoo/addons/test_rpc2/tests/test_rpc2_doc.php
+++ b/odoo/addons/test_rpc2/tests/test_rpc2_doc.php
@@ -1,0 +1,178 @@
+#!/usr/bin/env php
+
+<?php
+
+require "/tmp/vendor/autoload.php";
+
+$scheme = $argv[1];
+$domain = $argv[2];
+$database = $argv[3];
+$username = $argv[4];
+$password = $argv[5];
+
+//<a id=common>
+
+$common = new Laminas\XmlRpc\Client("$scheme://$domain/RPC2");
+$common->setSkipSystemLookup(true);
+$version = $common->call("version");
+//</a>
+
+//<a id=models>
+$modelsClient = new Laminas\XmlRpc\Client(
+    "$scheme://$username:$password@$domain/RPC2?db=$database");
+$modelsClient->setSkipSystemLookup(true);
+$models = $modelsClient->getProxy();
+$version = $models->system->noop();
+//</a>
+
+//<a id=check_access_rights>
+$partners = $models->res->partner;
+$can_access = $partners->check_access_rights([
+    "args" => ["read"],
+    "kwargs" => ["raise_exception" => false],
+]);
+//</a>
+
+//<a id=list>
+$partners = $models->res->partner;
+$record_ids = $partners->search([
+    "kwargs" => [
+        "domain" => [["is_company", "=", false]],
+    ],
+]);
+//</a>
+
+//<a id=pagination>
+$partners = $models->res->partner;
+$partners->search([
+    "kwargs" => [
+        "domain" => [["is_company", "=", false]],
+        "offset" => 10,
+        "limit" => 5,
+    ]
+]);
+//</a>
+
+//<a id=count>
+$partners = $models->res->partner;
+$count = $partners->search_count([
+    "kwargs" => [
+        "domain" => [["is_company", "=", false]],
+    ],
+]);
+//</a>
+
+//<a id=search_read>
+$partners = $models->res->partner;
+$record_data = $partners->search_read([
+    "kwargs" => [
+        "domain" => [["is_company", "=", false]],
+        "fields" => ["name", "title", "parent_name"],
+        "limit" => 1,
+    ],
+])[0];
+//</a>
+
+//<a id=read>
+$partners = $models->res->partner;
+$record_data = $partners->read([
+    "records" => $record_ids,
+    "kwargs" => [
+        "fields" => ["name", "title", "parent_name"],
+    ],
+])[0];
+//</a>
+
+//<a id=fields_get>
+$banks = $models->res->bank;
+$fields = $banks->fields_get([
+    "kwargs" => [
+        "attributes" => ["type", "string"],
+    ],
+]);
+//</a>
+
+//<a id=create>
+$partners = $models->res->partner;
+$new_record_ids = $partners->create([
+    "args" => [["name" => "New Partner"]],
+]);
+//</a>
+
+//<a id=write>
+$partners = $models->res->partner;
+$partners->write([
+    "records" => $new_record_ids,
+    "args" => [["name" => "Newer partner"]],
+]);
+// get record name after having changed it
+$records_name = $partners->name_get([
+    "records" => $new_record_ids,
+]);
+//</a>
+
+//<a id=unlink>
+$partners = $models->res->partner;
+$partners->unlink([
+    "records" => $new_record_ids,
+]);
+// check if the deleted record is still in the database
+$records = $partners->exists([
+    "records" => $new_record_ids,
+]);
+//</a>
+
+//<a id=ir.model>
+$x_custom_model_id = $models->ir->model->create([
+    "args" => [[
+        "name" => "Custom Model",
+        "model" => "x_custom_model",
+        "state" => "manual",
+    ]],
+])[0];
+
+# grant the admin CRUD operations
+$system_group_id = $models->ir->model->data->check_object_reference([
+    "args" => ["base", "group_system"],
+])[1];
+$models->ir->model->access->create([
+    "args" => [[
+        "name" => "access_x_custom_model_admin",
+        "model_id" => $x_custom_model_id,
+        "group_id" => $system_group_id,
+        "perm_read" => true,
+        "perm_write" => true,
+        "perm_create" => true,
+        "perm_unlink" => true,
+    ]],
+]);
+
+// get the fields of our newly created model
+$x_custom_model_fields = $models->x_custom_model->fields_get([
+    "kwargs" => [
+        "attributes" => ["type", "string"],
+    ],
+]);
+
+//<a id=ir.model.fields>
+// Add a new field "x_foo" on "x_custom_model"
+$models->ir->model->fields->create([
+    "args" => [[
+        "model_id" => $x_custom_model_id,  // above example
+        "name" => "x_foo",
+        "ttype" => "char",
+        "state" => "manual",
+    ]],
+]);
+
+// Create a new record and read it
+$x_record_ids = $models->x_custom_model->create([
+    "args" => [["x_foo" => "test record"]],
+]);
+$x_record_data = $models->x_custom_model->read([
+    "records" => $x_record_ids,
+    "kwargs" => [
+        "fields" => ["x_foo"],
+    ],
+])[0];
+//</a>

--- a/odoo/addons/test_rpc2/tests/test_rpc2_doc.py
+++ b/odoo/addons/test_rpc2/tests/test_rpc2_doc.py
@@ -1,0 +1,527 @@
+import os
+import os.path
+import platform
+import resource
+import subprocess as sp
+import tempfile
+import xmlrpc.client
+
+from unittest import skipUnless
+from unittest.mock import patch
+from urllib.parse import urlparse
+
+import odoo
+from odoo.tests.common import (
+    get_db_name, tagged, Transport, HttpCase, RecordCapturer
+)
+from odoo.tools import jsonrpc_client
+from odoo.tools.which import which_files
+
+from odoo.addons.base.controllers.rpc import Rpc2
+
+
+failure_message__please_sync_doc = """\
+This test file covers all the JSON-RPC and XML-RPC examples from the \
+External API documentation. Either (1) your code contains mistakes that \
+must be solved, or (2) the documentation is not up to date. In the later \
+case, please update the test files for the other languages too. They are \
+located in the same folder as this python test file.
+"""
+
+is_linux_like = (os.name == 'posix' and platform.system() != 'Darwin')
+
+# We only run test_rpc2.{ext} in subprocesses
+# in case we find a tool for the job
+node_path = next(which_files('node'), None)
+ruby_path = next(which_files('ruby'), None)
+php_path = next(which_files('php'), None)
+javac_path = next(which_files('javac'), None)
+java_path = next(which_files('java'), None)
+bash_path = next(which_files('bash'), None)
+curl_path = next(which_files('curl'), None)
+jq_path = next(which_files('jq'), None)
+
+
+@tagged('-at_install', 'post_install')
+class _RpcDocCase(HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        base_url = urlparse(cls.base_url())
+        cls.scheme, cls.domain, cls.database, cls.username, cls.password = \
+        cls.argv = [
+            base_url.scheme, base_url.netloc, get_db_name(), 'admin', 'admin'
+        ]
+
+class _RpcDocMixin:
+    # pylint: disable=bad-whitespace
+
+    def test_rpc2_doc_00_common(self):
+        self.assertEqual(self.common.version(), {
+            "server_version": odoo.release.version,
+            "server_version_info": list(odoo.release.version_info),
+            "server_serie": odoo.release.serie,
+            "protocol_version": 1
+        }, failure_message__please_sync_doc)
+
+    def test_rpc2_doc_01_models(self):
+        self.assertIsNone(
+            self.models.system.noop(),
+            failure_message__please_sync_doc
+        )
+
+    def test_rpc2_doc_02_check_access_rights(self):
+        models = self.models
+
+        #<a id=check_access_rights>
+        partners = models.res.partner
+        can_access = partners.check_access_rights({
+            'args': ['read'],
+            'kwargs': {
+                'raise_exception': False,
+            },
+        })
+        #</a>
+
+        self.assertTrue(can_access, failure_message__please_sync_doc)
+
+    def test_rpc2_doc_03_list(self):
+        models = self.models
+
+        #<a id=list>
+        partners = models.res.partner
+        record_ids = partners.search({
+            'kwargs': {
+                'domain': [('is_company', '=', False)],
+            },
+        })
+        #</a>
+
+        self.assertEqual(
+            record_ids,
+            self.env['res.partner'].search(
+                [('is_company', '=', False)]
+            ).ids,
+            failure_message__please_sync_doc,
+        )
+
+    def test_rpc2_doc_04_pagination(self):
+        models = self.models
+
+        #<a id=pagination>
+        partners = models.res.partner
+        record_ids = partners.search({
+            'kwargs': {
+                'domain': [('is_company', '=', False)],
+                'offset': 10,
+                'limit': 5,
+            },
+        })
+        #</a>
+
+        self.assertEqual(
+            record_ids,
+            self.env['res.partner'].search(
+                [('is_company', '=', False)],
+                offset=10, limit=5,
+            ).ids,
+            failure_message__please_sync_doc,
+        )
+
+    def test_rpc2_doc_05_count(self):
+        models = self.models
+
+        #<a id=count>
+        partners = models.res.partner
+        count = partners.search_count({
+            'kwargs': {
+                'domain': [('is_company', '=', False)],
+            },
+        })
+        #</a>
+
+        self.assertEqual(
+            count,
+            self.env['res.partner'].search_count(
+                [('is_company', '=', False)]
+            ),
+            failure_message__please_sync_doc,
+        )
+
+    def test_rpc2_doc_06_search_read(self):
+        models = self.models
+
+        #<a id=search_read>
+        partners = models.res.partner
+        [record_data] = partners.search_read({
+            'kwargs': {
+                'domain': [('is_company', '=', False)],
+                'fields': ['name', 'title', 'parent_name'],
+                'limit': 1,
+            }
+        })
+        #</a>
+
+        self.assertEqual(
+            record_data,
+            self.env['res.partner'].search_read(
+                [('is_company', '=', False)],
+                ['name', 'title', 'parent_name'],
+                limit=1,
+            )[0],
+            failure_message__please_sync_doc,
+        )
+
+    def test_rpc2_doc_07_read(self):
+        models = self.models
+
+        # The documentation states "using the first record we fetched in
+        # the search example", hence this weird code.
+        records = self.env['res.partner'].search(
+            [('is_company', '=', False)], limit=1)
+        record_ids = records.ids
+
+        #<a id=read>
+        partners = models.res.partner
+        [record_data] = partners.read({
+            'records': record_ids,
+            'kwargs': {
+                'fields': ['name', 'title', 'parent_name'],
+            }
+        })
+        #</a>
+
+        self.assertEqual(
+            record_data,
+            records.read(['name', 'title', 'parent_name'])[0],
+            failure_message__please_sync_doc,
+        )
+
+    def test_rpc2_doc_08_fields_get(self):
+        models = self.models
+
+        #<a id=fields_get>
+        banks = models.res.bank
+        fields = banks.fields_get({
+            'kwargs': {'attributes': ['type', 'string']}
+        })
+        #</a>
+
+        self.assertEqual(
+            fields,
+            self.env['res.bank'].fields_get(attributes=['type', 'string']),
+            failure_message__please_sync_doc,
+        )
+
+    def test_rpc2_doc_09_create(self):
+        models = self.models
+
+        with RecordCapturer(self.env['res.partner'], []) as capture:
+            #<a id=create>
+            partners = models.res.partner
+            new_record_ids = partners.create({
+                'args': [ [{'name': "New Partner"}] ],
+            })
+            #</a>
+
+        self.assertEqual(len(capture.records), 1)
+        self.assertEqual(
+            capture.records.ids, new_record_ids,
+            failure_message__please_sync_doc,
+        )
+        self.assertEqual(
+            capture.records.name, "New Partner",
+            failure_message__please_sync_doc,
+        )
+
+    def test_rpc2_doc_10_write(self):
+        models = self.models
+
+        new_record = self.env['res.partner'].create({
+            'name': "New Partner"
+        })
+        new_record_ids = new_record.ids
+
+        #<a id=write>
+        partners = models.res.partner
+        partners.write({
+            'records': new_record_ids,
+            'args': [{'name': "Newer Partner"}],
+        })
+        # get record name after having changed it
+        records_name = partners.name_get({'records': new_record_ids})
+        #</a>
+
+        self.assertEqual(
+            records_name, [[new_record_ids[0], "Newer Partner"]],
+            failure_message__please_sync_doc,
+        )
+
+    def test_rpc2_doc_11_unlink(self):
+        models = self.models
+
+        new_record = self.env['res.partner'].create({
+            'name': "New Partner"
+        })
+        new_record_ids = new_record.ids
+
+        #<a id=unlink>
+        partners = models.res.partner
+        partners.unlink({'records': new_record_ids})
+        # check if the deleted record is still in the database
+        records = partners.exists({'records': new_record_ids})
+        #</a>
+
+        self.assertEqual(records, [], failure_message__please_sync_doc)
+
+    def test_rpc2_doc_12_ir_model(self):
+        models = self.models
+
+        #<a id=ir.model>
+        # create the model
+        [x_custom_model_id] = models.ir.model.create({
+            'args': [ [{
+                'name': "Custom Model",
+                'model': 'x_custom_model',
+                'state': 'manual',
+            }] ],
+        })
+
+        # grant the admin CRUD operations
+        system_group_id = models.ir.model.data.check_object_reference({
+            'args': ['base', 'group_system']
+        })[1]
+        models.ir.model.access.create({
+            'args': [ [{
+                'name': 'access_x_custom_model_admin',
+                'model_id': x_custom_model_id,
+                'group_id': system_group_id,
+                'perm_read': True,
+                'perm_write': True,
+                'perm_create': True,
+                'perm_unlink': True,
+            }] ],
+        })
+
+        # get the fields
+        x_custom_model_fields = models.x_custom_model.fields_get({
+            'kwargs': {'attributes': ['type', 'string']},
+        })
+        #</a>
+
+        self.assertEqual(
+            x_custom_model_fields,
+            {
+                "create_date":   {"type": "datetime", "string": "Created on"},
+                "create_uid":    {"type": "many2one", "string": "Created by"},
+                "display_name":  {"type": "char",     "string": "Display Name"},
+                "id":            {"type": "integer",  "string": "ID"},
+                "write_date":    {"type": "datetime", "string": "Last Updated on"},
+                "write_uid":     {"type": "many2one", "string": "Last Updated by"},
+                "x_name":        {"type": "char",     "string": "Name"},
+            },
+            failure_message__please_sync_doc,
+        )
+
+    def test_rpc2_doc_13_ir_model_fields(self):
+        models = self.models
+
+        x_custom_model_id = self.env['ir.model'].create([{
+            'name': "Custom Model",
+            'model': 'x_custom_model',
+            'state': 'manual'
+        }]).id
+        self.env['ir.model.access'].create([{
+            'name': 'access_x_custom_model_admin',
+            'model_id': x_custom_model_id,
+            'group_id': self.env.ref('base.group_system').id,
+            'perm_read': True,
+            'perm_write': True,
+            'perm_create': True,
+            'perm_unlink': True,
+        }])
+
+        #<a id=ir.model.fields>
+        # add a new field "x_foo" on "x_custom_model"
+        models.ir.model.fields.create({
+            'args': [ [{
+                'model_id': x_custom_model_id,  # above example
+                'name': 'x_foo',
+                'ttype': 'char',
+                'state': 'manual',
+            }] ]
+        })
+
+        # create a new record and read it
+        x_record_ids = models.x_custom_model.create({
+            'args': [ [{'x_foo': "test record"}] ],
+        })
+        [x_record_data] = models.x_custom_model.read({
+            'records': x_record_ids,
+            'kwargs': {
+                'fields': ['x_foo']
+            }
+        })
+        #</a>
+
+        self.assertEqual(
+            x_record_data, {'id': x_record_ids[0], 'x_foo': "test record"},
+            failure_message__please_sync_doc
+        )
+
+class TestXmlRpcDocumentation(_RpcDocCase, _RpcDocMixin):
+
+    # pylint: disable=pointless-string-statement
+    def setUp(self):
+        super().setUp()
+
+        """<a id=xmlcommon>
+        common = xmlrpc.client.ServerProxy(
+            f'{scheme}://{domain}/RPC2',
+            allow_none=True,
+        )
+        version = common.version()
+        </a>"""
+        self.common = xmlrpc.client.ServerProxy(
+            f'{self.scheme}://{self.domain}/RPC2',
+            transport=Transport(self.cr),
+            allow_none=True,
+        )
+
+        """<a id=xmlmodels>
+        models = xmlrpc.client.ServerProxy(
+            f'{scheme}://{username}:{password}@{domain}/RPC2/{database}',
+            allow_none=True,
+        )
+        models.system.noop()
+        </a>"""
+        self.models = xmlrpc.client.ServerProxy(
+            (f'{self.scheme}://{self.username}:{self.password}@'
+             f'{self.domain}/RPC2?db={self.database}'),
+            transport=Transport(self.cr),
+            allow_none=True,
+        )
+
+class TestJsonRpcDocumentation(_RpcDocCase, _RpcDocMixin):
+
+    # pylint: disable=pointless-string-statement
+    def setUp(self):
+        super().setUp()
+
+        """<a id=jsoncommon>
+        common = jsonrpc_client.proxy(scheme, domain)
+        common.version()
+        </a>"""
+        self.common = jsonrpc_client.proxy(
+            self.scheme, self.domain, requests=self.opener)
+
+        """<a id=jsonmodels>
+        models = jsonrpc_client.proxy(
+            scheme, domain, database, username, password
+        )
+        models.system.noop()
+        </a>"""
+        self.models = jsonrpc_client.proxy(
+            self.scheme, self.domain,
+            self.database, self.username, self.password,
+            requests=self.opener
+        )
+
+class TestManyLangsRpcDocumentation(_RpcDocCase):
+    def setUp(self):
+        super().setUp()
+        real_rpc2_endpoint = Rpc2.rpc2.original_endpoint
+        patcher = patch.object(Rpc2.rpc2, 'original_endpoint')
+        self.rpc2_endpoint = patcher.start()
+        self.rpc2_endpoint.side_effect = real_rpc2_endpoint
+        self.addCleanup(patcher.stop)
+
+    def tearDown(self):
+        self.assertEqual(self.rpc2_endpoint.call_count, 21,
+            "Not all examples have been run.")
+        super().tearDown()
+
+    @skipUnless(node_path, "Missing NodeJS")
+    def test_rpc2_doc_node(self):
+        script = __file__.removesuffix('.py') + '.js'
+        with open('result2.json', 'w') as f:
+            proc = sp.run(
+                [node_path, '--unhandled-rejections=strict', script, *self.argv],
+                stdout=f, stderr=sp.PIPE, check=False, text=True,
+                env={'NODE_PATH': '/tmp/node_modules'}
+            )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+    @skipUnless(ruby_path, "Missing Ruby")
+    def test_rpc2_doc_ruby(self):
+        script = __file__.removesuffix('.py') + '.rb'
+        proc = sp.run(
+            [ruby_path, script, *self.argv],
+            stderr=sp.PIPE, check=False, text=True
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+    @skipUnless(php_path, "Missing PHP")
+    def test_rpc2_doc_php(self):
+        script = __file__.removesuffix('.py') + '.php'
+        proc = sp.run(
+            [php_path, script, *self.argv],
+            stderr=sp.PIPE, check=False, text=True
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+    @skipUnless(javac_path and java_path, "Missing java or javac")
+    def test_rpc2_doc_java(self):
+
+        def unlimit_virtual_memory():
+            resource.setrlimit(resource.RLIMIT_AS, (resource.RLIM_INFINITY, resource.RLIM_INFINITY))
+
+        sourcepath = os.path.dirname(__file__)
+        classname = os.path.basename(__file__).removesuffix('.py')
+        classpath = [
+            '.',
+            '/tmp/apache-xmlrpc-3.1.3/lib/ws-commons-util-1.0.2.jar',
+            '/tmp/apache-xmlrpc-3.1.3/lib/xmlrpc-client-3.1.3.jar',
+            '/tmp/apache-xmlrpc-3.1.3/lib/xmlrpc-common-3.1.3.jar',
+        ]
+        with tempfile.TemporaryDirectory(prefix='odoo-rpc2') as buildpath:
+
+            proc_build = sp.run(
+                [
+                    javac_path,
+                    '-d', buildpath,
+                    '-classpath', ':'.join(classpath),
+                    f'{classname}.java'
+                ],
+                check=False, cwd=sourcepath,
+                stdout=sp.PIPE, stderr=sp.STDOUT, text=True,
+                preexec_fn=unlimit_virtual_memory if is_linux_like else None,
+            )
+            self.assertEqual(
+                proc_build.returncode, 0,
+                "Compilation failed!\n" + proc_build.stdout
+            )
+
+            proc_run = sp.run(
+                [
+                    java_path,
+                    '-classpath', ':'.join(classpath),
+                    classname, *self.argv
+                ],
+                check=False, cwd=buildpath,
+                stdout=sp.PIPE, stderr=sp.STDOUT, text=True,
+                preexec_fn=unlimit_virtual_memory if is_linux_like else None,
+            )
+            self.assertEqual(
+                proc_run.returncode, 0,
+                "Execution failed!\n" + proc_run.stdout
+            )
+
+    @skipUnless(bash_path and curl_path and jq_path, "Missing bash, curl or jq")
+    def test_rpc2_doc_curl(self):
+        script = __file__.removesuffix('.py') + '.sh'
+        proc = sp.run(
+            [bash_path, script, *self.argv],
+            stdout=sp.DEVNULL, stderr=sp.PIPE, check=False, text=True
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)

--- a/odoo/addons/test_rpc2/tests/test_rpc2_doc.rb
+++ b/odoo/addons/test_rpc2/tests/test_rpc2_doc.rb
@@ -1,0 +1,178 @@
+#!/usr/bin/env ruby
+
+require "uri"
+require "xmlrpc/client"
+XMLRPC::Config.const_set(:ENABLE_NIL_PARSER, true)
+
+scheme = ARGV[0]
+domain = ARGV[1]
+database = ARGV[2]
+username = ARGV[3]
+password = ARGV[4]
+
+#<a id=common>
+common = XMLRPC::Client.new2("#{scheme}://#{domain}/RPC2")
+version = common.call("version")
+#</a>
+
+#<a id=models>
+models = XMLRPC::Client.new2(
+    "#{scheme}://#{username}:#{password}@#{domain}/RPC2?db=#{database}")
+models.call("system.noop")
+#</a>
+
+#<a id=check_access_rights>
+partners = models.proxy("res.partner")
+can_access = partners.check_access_rights({
+    args: ["read"],
+    kwargs: {
+        raise_exception: false,
+    },
+})
+#</a>
+
+#<a id=list>
+partners = models.proxy("res.partner")
+record_ids = partners.search({
+    kwargs: {
+        domain: [["is_company", "=", false]],
+    },
+})
+#</a>
+
+#<a id=pagination>
+partners = models.proxy("res.partner")
+record_ids = partners.search({
+    kwargs: {                        
+        domain: [["is_company", "=", false]],
+        offset: 10,
+        limit: 5,
+    }
+})
+#</a>
+
+#<a id=count>
+partners = models.proxy("res.partner")
+count = partners.search_count({
+    kwargs: {
+        domain: [["is_company", "=", false]],
+    }
+})
+#</a>
+
+#<a id=search_read>
+partners = models.proxy("res.partner")
+record_data = partners.search_read({
+    kwargs: {
+        domain: [["is_company", "=", false]],
+        fields: ["name", "title", "parent_name"],
+        limit: 1,
+    },
+}).first
+#</a>
+
+#<a id=read>
+partners = models.proxy("res.partner")
+record_data = partners.read({
+    records: record_ids,
+    kwargs: {
+        fields: ["name", "title", "parent_name"],
+    },
+}).first
+#</a>
+
+#<a id=fields_get>
+banks = models.proxy("res.bank")
+fields = banks.fields_get({
+    kwargs: {
+        attributes: %w(type, string),
+    },
+})
+#</a>
+
+#<a id=create>
+partners = models.proxy("res.partner")
+new_record_ids = partners.create({
+    args: [{name: "New Partner"}]
+})
+#</a>
+
+#<a id=write>
+partners = models.proxy("res.partner")
+partners.write({
+    records: new_record_ids,
+    args: [{name: "Newer partner"}]
+})
+# get record name after having changed it
+records_name = partners.name_get({
+    records: new_record_ids,
+})
+#</a>
+
+#<a id=unlink>
+partners = models.proxy("res.partner")
+partners.unlink({
+    records: new_record_ids,
+})
+# check if the deleted record is still in the database
+records = partners.exists({
+    records: new_record_ids,
+})
+#</a>
+
+#<a id=ir.model>
+x_custom_model_id = models.proxy("ir.model").create({
+    args: [{
+        name: "Custom Model",
+        model: "x_custom_model",
+        state: "manual",
+    }],
+}).first
+
+# grant the admin CRUD operations
+system_group_id = models.proxy("ir.model.data").check_object_reference({
+    args: ["base", "group_system"]
+})[1]
+models.proxy("ir.model.access").create({
+    args: [{
+        name: "access_x_custom_model_admin",
+        model_id: x_custom_model_id,
+        group_id: system_group_id,
+        perm_read: true,
+        perm_write: true,
+        perm_create: true,
+        perm_unlink: true,
+    }],
+})
+
+# get the fields of our newly created model
+x_custom_model_fields = models.proxy("x_custom_model").fields_get({
+    kwargs: {
+        attributes: %w(type, string),
+    }
+})
+#</a>
+
+#<a id=ir.model.fields>
+# Add a new field "x_foo" on "x_custom_model"
+models.proxy("ir.model.fields").create({
+    args: [{
+        model_id: x_custom_model_id,  # from the above example
+        name: "x_foo",
+        ttype: "char",
+        state: "manual",
+    }],
+})
+
+# Create a new record and read it
+x_record_ids = models.proxy("x_custom_model").create({
+    args: [{x_foo: "test record"}]
+}
+)
+x_record_data = models.proxy("x_custom_model").read({
+    records: x_record_ids,
+    kwargs: {
+        fields: ["x_foo"],
+    },
+}).first
+#</a>

--- a/odoo/addons/test_rpc2/tests/test_rpc2_doc.sh
+++ b/odoo/addons/test_rpc2/tests/test_rpc2_doc.sh
@@ -1,0 +1,453 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+scheme=$1
+domain=$2
+database=$3
+username=$4
+password=$5
+
+echo '<a id=common>'
+curl "$scheme://$domain/RPC2" \
+     --silent \
+     -X POST \
+     -H 'Content-Type: application/json' \
+     -d @- <<EOF |
+          {
+               "jsonrpc": "2.0",
+               "method": "version",
+               "id": 0
+          }
+EOF
+     jq -c 'if has("error") then halt_error else .result end'
+echo '</a>'
+
+echo '<a id=models>'
+curl "$scheme://$domain/RPC2?db=$database" \
+     --silent \
+     -X POST \
+     -H 'Content-Type: application/json' \
+     --basic -u "$username:$password" \
+     -d @- <<EOF |
+          {
+               "jsonrpc": "2.0",
+               "method": "system.noop",
+               "id": 0
+          }
+EOF
+     jq -c 'if has("error") then halt_error else .result end'
+echo '</a>'
+
+echo '<a id=check_access_rights>'
+curl "$scheme://$domain/RPC2?db=$database" \
+     --silent \
+     -X POST \
+     -H 'Content-Type: application/json' \
+     --basic -u "$username:$password" \
+     -d @- <<EOF |
+          {
+               "jsonrpc": "2.0",
+               "method": "res.partner.check_access_rights",
+               "params": [{
+                    "args": ["read"],
+                    "kwargs": {
+                         "raise_exception": false
+                    }
+               }],
+               "id": 0
+          }
+EOF
+     jq 'if has("error") then halt_error else .result end'
+echo '</a>'
+
+echo '<a id=list>'
+record_ids=$(
+     (
+          curl "$scheme://$domain/RPC2?db=$database" \
+               --silent \
+               -X POST \
+               -H 'Content-Type: application/json' \
+               --basic -u "$username:$password" \
+               -d @- | \
+          jq -c 'if has("error") then halt_error else .result end'
+     ) <<EOF
+               {
+                    "jsonrpc": "2.0",
+                    "method": "res.partner.search",
+                    "params": [{
+                         "kwargs": {
+                              "domain": [["is_company", "=", false]]
+                         }
+                    }],
+                    "id": 0
+               }
+EOF
+)
+echo $record_ids
+echo '</a>'
+
+echo '<a id=pagination>'
+curl "$scheme://$domain/RPC2?db=$database" \
+     --silent \
+     -X POST \
+     -H 'Content-Type: application/json' \
+     --basic -u "$username:$password" \
+     -d @- <<EOF |
+          {
+               "jsonrpc": "2.0",
+               "method": "res.partner.search",
+               "params": [{
+                    "kwargs": {
+                         "domain": [["is_company", "=", false]],
+                         "offset": 10,
+                         "limit": 5
+                    }
+               }],
+               "id": 0
+          }
+EOF
+     jq -c 'if has("error") then halt_error else .result end'
+echo '</a>'
+
+echo '<a id=count>'
+curl "$scheme://$domain/RPC2?db=$database" \
+     --silent \
+     -X POST \
+     -H 'Content-Type: application/json' \
+     --basic -u "$username:$password" \
+     -d @- <<EOF |
+          {
+               "jsonrpc": "2.0",
+               "method": "res.partner.search_count",
+               "params": [{
+                    "kwargs": {
+                         "domain": [["is_company", "=", false]]
+                    }
+               }],
+               "id": 0
+          }
+EOF
+     jq 'if has("error") then halt_error else .result end'
+echo '</a>'
+
+echo '<a id=search_read>'
+curl "$scheme://$domain/RPC2?db=$database" \
+     --silent \
+     -X POST \
+     -H 'Content-Type: application/json' \
+     --basic -u "$username:$password" \
+     -d @- <<EOF |
+          {
+               "jsonrpc": "2.0",
+               "method": "res.partner.search_read",
+               "params": [{
+                    "kwargs": {
+                         "domain": [["is_company", "=", false]],
+                         "fields": ["name", "title", "parent_name"],
+                         "limit": 1
+                    }
+               }],
+               "id": 0
+          }
+EOF
+     jq 'if has("error") then halt_error else .result end'
+echo '</a>'
+
+echo '<a id=read>'
+curl "$scheme://$domain/RPC2?db=$database" \
+     --silent \
+     -X POST \
+     -H 'Content-Type: application/json' \
+     --basic -u "$username:$password" \
+     -d @- <<EOF |
+          {
+               "jsonrpc": "2.0",
+               "method": "res.partner.read",
+               "params": [{
+                    "records": $record_ids,
+                    "kwargs": {
+                         "fields": ["name", "title", "parent_name"]
+                    }
+               }],
+               "id": 0
+          }
+EOF
+     jq 'if has("error") then halt_error else .result end'
+echo '</a>'
+
+echo '<a id=fields_get>'
+curl "$scheme://$domain/RPC2?db=$database" \
+     --silent \
+     -X POST \
+     -H 'Content-Type: application/json' \
+     --basic -u "$username:$password" \
+     -d @- <<EOF |
+          {
+               "jsonrpc": "2.0",
+               "method": "res.bank.fields_get",
+               "params": [{
+                    "kwargs": {
+                         "attributes": ["type", "string"]
+                    }
+               }],
+               "id": 0
+          }
+EOF
+     jq 'if has("error") then halt_error else .result end'
+echo '</a>'
+
+echo '<a id=create>'
+new_record_ids=$(
+     (
+          curl "$scheme://$domain/RPC2?db=$database" \
+               --silent \
+               -X POST \
+               -H 'Content-Type: application/json' \
+               --basic -u "$username:$password" \
+               -d @- | \
+          jq -c 'if has("error") then halt_error else .result end'
+     ) <<EOF
+          {
+               "jsonrpc": "2.0",
+               "method": "res.partner.create",
+               "params": [{
+                    "args": [{"name": "New Partner"}]
+               }],
+               "id": 0
+          }
+EOF
+)
+echo $new_record_ids
+echo '</a>'
+
+echo '<a id=write>'
+curl "$scheme://$domain/RPC2?db=$database" \
+     --silent \
+     -X POST \
+     -H 'Content-Type: application/json' \
+     --basic -u "$username:$password" \
+     -d @- <<EOF |
+          {
+               "jsonrpc": "2.0",
+               "method": "res.partner.write",
+               "params": [{
+                    "records": $new_record_ids,
+                    "args": [{"name": "Newer Partner"}]
+               }],
+               "id": 0
+          }
+EOF
+     jq 'if has("error") then halt_error else . end' > /dev/null
+
+# get record name after having changed it
+curl "$scheme://$domain/RPC2?db=$database" \
+     --silent \
+     -X POST \
+     -H 'Content-Type: application/json' \
+     --basic -u "$username:$password" \
+     -d @- <<EOF | jq -c 'if has("error") then halt_error else .result end'
+          {
+               "jsonrpc": "2.0",
+               "method": "res.partner.name_get",
+               "params": [{
+                    "records": $new_record_ids
+               }],
+               "id": 0
+          }
+EOF
+echo '</a>'
+
+echo '<a id=unlink>'
+curl "$scheme://$domain/RPC2?db=$database" \
+     --silent \
+     -X POST \
+     -H 'Content-Type: application/json' \
+     --basic -u "$username:$password" \
+     -d @- <<EOF |
+          {
+               "jsonrpc": "2.0",
+               "method": "res.partner.unlink",
+               "params": [{
+                    "records": $new_record_ids
+               }],
+               "id": 0
+          }
+EOF
+     jq 'if has("error") then halt_error else . end' > /dev/null
+
+# check if the deleted record is still in the database
+curl "$scheme://$domain/RPC2?db=$database" \
+     --silent \
+     -X POST \
+     -H 'Content-Type: application/json' \
+     --basic -u "$username:$password" \
+     -d @- <<EOF |
+          {
+               "jsonrpc": "2.0",
+               "method": "res.partner.exists",
+               "params": [{
+                    "records": $new_record_ids
+               }],
+               "id": 0
+          }
+EOF
+     jq 'if has("error") then halt_error else .result end'
+echo '</a>'
+
+echo '<a id=ir.model>'
+x_custom_model_id=$(
+     (
+          curl "$scheme://$domain/RPC2?db=$database" \
+               --silent \
+               -X POST \
+               -H 'Content-Type: application/json' \
+               --basic -u "$username:$password" \
+               -d @- | \
+          jq .result[0]
+     ) <<EOF
+               {
+                    "jsonrpc": "2.0",
+                    "method": "ir.model.create",
+                    "params": [{
+                         "args": [{
+                                "name": "Custom Model",
+                                "model": "x_custom_model",
+                                "state": "manual"
+                         }]
+                    }],
+                    "id": 0
+               }
+EOF
+)
+
+# grant the admin CRUD operations
+system_group_id=$(
+     (
+          curl "$scheme://$domain/RPC2?db=$database" \
+               --silent \
+               -X POST \
+               -H 'Content-Type: application/json' \
+               --basic -u "$username:$password" \
+               -d @- | \
+          jq 'if has("error") then halt_error else .result[1] end'
+     ) <<EOF
+               {
+                    "jsonrpc": "2.0",
+                    "method": "ir.model.data.check_object_reference",
+                    "params": [{
+                         "args": ["base", "group_system"]
+                    }],
+                    "id": 0
+               }
+EOF
+)
+curl "$scheme://$domain/RPC2?db=$database" \
+     --silent \
+     -X POST \
+     -H 'Content-Type: application/json' \
+     --basic -u "$username:$password" \
+     -d @- <<EOF |
+          {
+               "jsonrpc": "2.0",
+               "method": "ir.model.access.create",
+               "params": [{
+                    "args": [{
+                          "name": "access_x_custom_model_admin",
+                          "model_id": $x_custom_model_id,
+                          "group_id": $system_group_id,
+                          "perm_read": true,
+                          "perm_write": true,
+                          "perm_create": true,
+                          "perm_unlink": true
+                    }]
+               }],
+               "id": 0
+          }
+EOF
+     jq 'if has("error") then halt_error else . end' > /dev/null
+
+# get the fields of our newly created model
+curl "$scheme://$domain/RPC2?db=$database" \
+     --silent \
+     -X POST \
+     -H 'Content-Type: application/json' \
+     --basic -u "$username:$password" \
+     -d @- <<EOF |
+          {
+               "jsonrpc": "2.0",
+               "method": "x_custom_model.fields_get",
+               "params": [{
+                    "kwargs": {
+                         "attributes": ["type", "string"]
+                    }
+               }],
+               "id": 0
+          }
+EOF
+     jq 'if has("error") then halt_error else .result end'
+echo '</a>'
+
+echo '<a id=ir.model.fields>'
+curl "$scheme://$domain/RPC2?db=$database" \
+     --silent \
+     -X POST \
+     -H 'Content-Type: application/json' \
+     --basic -u "$username:$password" \
+     -d @- <<EOF |
+          {
+               "jsonrpc": "2.0",
+               "method": "ir.model.fields.create",
+               "params": [{
+                    "args": [{
+                           "model_id": $x_custom_model_id,
+                           "name": "x_foo",
+                           "ttype": "char",
+                           "state": "manual"
+                    }]
+               }],
+               "id": 0
+          }
+EOF
+     jq 'if has("error") then halt_error else . end' > /dev/null
+
+# Create a new record and read it
+x_record_ids=$(
+     (
+          curl "$scheme://$domain/RPC2?db=$database" \
+               --silent \
+               -X POST \
+               -H 'Content-Type: application/json' \
+               --basic -u "$username:$password" \
+               -d @- | \
+          jq -c 'if has("error") then halt_error else .result end'
+     ) <<EOF
+          {
+               "jsonrpc": "2.0",
+               "method": "x_custom_model.create",
+               "params": [{
+                    "args": [{"x_foo": "test record"}]
+               }],
+               "id": 0
+          }
+EOF
+)
+curl "$scheme://$domain/RPC2?db=$database" \
+     --silent \
+     -X POST \
+     -H 'Content-Type: application/json' \
+     --basic -u "$username:$password" \
+     -d @- <<EOF |
+          {
+               "jsonrpc": "2.0",
+               "method": "x_custom_model.read",
+               "params": [{
+                    "records": $x_record_ids,
+                    "kwargs": {
+                         "fields": ["x_foo"]
+                    }
+               }],
+               "id": 0
+          }
+EOF
+     jq 'if has("error") then halt_error else .result end'
+echo '</a>'

--- a/odoo/cli/scaffold.py
+++ b/odoo/cli/scaffold.py
@@ -9,6 +9,7 @@ import sys
 import jinja2
 
 from . import Command
+from ..tools import snake, pascal
 
 class Scaffold(Command):
     """ Generates an Odoo module skeleton. """
@@ -48,23 +49,6 @@ builtins = lambda *args: os.path.join(
     os.path.abspath(os.path.dirname(__file__)),
     'templates',
     *args)
-
-def snake(s):
-    """ snake cases ``s``
-
-    :param str s:
-    :return: str
-    """
-    # insert a space before each uppercase character preceded by a
-    # non-uppercase letter
-    s = re.sub(r'(?<=[^A-Z])\B([A-Z])', r' \1', s)
-    # lowercase everything, split on whitespace and join
-    return '_'.join(s.lower().split())
-def pascal(s):
-    return ''.join(
-        ss.capitalize()
-        for ss in re.sub('[_\s]+', ' ', s).split()
-    )
 
 def directory(p, create=False):
     expanded = os.path.abspath(

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -690,12 +690,12 @@ def route(route=None, **routing):
 
         @functools.wraps(endpoint)
         def route_wrapper(self, *args, **params):
-            params_ok = filter_kwargs(endpoint, params)
+            params_ok = filter_kwargs(route_wrapper.original_endpoint, params)
             params_ko = set(params) - set(params_ok)
             if params_ko:
                 _logger.warning("%s called ignoring args %s", fname, params_ko)
 
-            result = endpoint(self, *args, **params_ok)
+            result = route_wrapper.original_endpoint(self, *args, **params_ok)
             if routing['type'] == 'http':  # _generate_routing_rules() ensures type is set
                 return Response.load(result)
             return result

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1115,6 +1115,7 @@ class FutureResponse:
     max_cookie_size = 4093
 
     def __init__(self):
+        self.status = None
         self.headers = werkzeug.datastructures.Headers()
 
     @functools.wraps(werkzeug.Response.set_cookie)
@@ -1394,6 +1395,8 @@ class Request:
         return contextlib.nullcontext()
 
     def _inject_future_response(self, response):
+        if self.future_response.status is not None:
+            response.status = self.future_response.status
         response.headers.extend(self.future_response.headers)
         return response
 

--- a/odoo/service/common.py
+++ b/odoo/service/common.py
@@ -16,6 +16,15 @@ RPC_VERSION_1 = {
         'protocol_version': 1,
 }
 
+
+ODOO18_DEPRECATION_WARNING = """
+The %r service was deprecated in Odoo 7 (more than 10 years ago)
+and does nothing since then. This service is scheduled for removal in
+Odoo 18 but one of your clients is still using it, please report them
+this current warning. If they desire to keep on using a no-op function,
+they can use the 'version' service."""
+
+
 def exp_login(db, login, password):
     return exp_authenticate(db, login, password, None)
 
@@ -37,6 +46,7 @@ def exp_about(extended=False):
     @param extended: if True then return version info
     @return string if extended is False else tuple
     """
+    _logger.warning(ODOO18_DEPRECATION_WARNING, "about")
 
     info = _('See http://openerp.com')
 
@@ -45,8 +55,7 @@ def exp_about(extended=False):
     return info
 
 def exp_set_loglevel(loglevel, logger=None):
-    # TODO Previously, the level was set on the now deprecated
-    # `odoo.netsvc.Logger` class.
+    _logger.warning(ODOO18_DEPRECATION_WARNING, "set_loglevel")
     return True
 
 def dispatch(method, params):

--- a/odoo/service/common.py
+++ b/odoo/service/common.py
@@ -17,7 +17,7 @@ RPC_VERSION_1 = {
 }
 
 
-ODOO18_DEPRECATION_WARNING = """
+ODOO17_DEPRECATION_WARNING = """
 The %r service was deprecated in Odoo 7 (more than 10 years ago)
 and does nothing since then. This service is scheduled for removal in
 Odoo 18 but one of your clients is still using it, please report them
@@ -46,7 +46,7 @@ def exp_about(extended=False):
     @param extended: if True then return version info
     @return string if extended is False else tuple
     """
-    _logger.warning(ODOO18_DEPRECATION_WARNING, "about")
+    _logger.warning(ODOO17_DEPRECATION_WARNING, "about")
 
     info = _('See http://openerp.com')
 
@@ -55,7 +55,7 @@ def exp_about(extended=False):
     return info
 
 def exp_set_loglevel(loglevel, logger=None):
-    _logger.warning(ODOO18_DEPRECATION_WARNING, "set_loglevel")
+    _logger.warning(ODOO17_DEPRECATION_WARNING, "set_loglevel")
     return True
 
 def dispatch(method, params):

--- a/odoo/tools/jsonrpc_client.py
+++ b/odoo/tools/jsonrpc_client.py
@@ -1,0 +1,113 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import functools
+import uuid
+import requests as requests_
+from urllib.parse import quote
+
+
+def call(
+    method, *params, scheme, domain, database=None, username=None,
+    password=None, requests=requests_
+):
+    """
+    Execute a single procedure on the remote server via JSON-RPC.
+
+    See also ``odoo.utils.jsonrpc.proxy`` to execute multiple procedures
+    on a same remote server.
+
+    .. warning
+
+       JSON-RPC doesn't support binary data but XML-RPC does, see
+       ``xmlrpc.client.Server``.
+
+    >>> call('res.partner.search_read', {
+             'records': [1, 2],
+             'context': {'lang': 'en_US'},
+             'args': [['id', 'name']],
+             'kwargs': {'load': None}
+        },
+        scheme='https',
+        domain='mycompany.odoo.com',
+        database='mycompany',
+        username='admin',
+        password='admin'
+    )
+    [{'id': 1, 'name': 'Bob'}, {'id': 2, 'name': 'Eve'}]
+
+    :param str method: the remote procedure that will be executed
+    :param Sequence params: the args to call the remote procedure with
+    :param str scheme: the network scheme of the underlying connection
+    :param str domain: the domain name and port where to connect to
+    :param str|None database: the odoo database to connect to
+    :param str|None username: the username for the authentication
+    :param str|None password: the password for the authentication
+    :param requests: An opener from the ``requests`` library, by default
+        it is ``requests`` itself.
+    """
+    should_auth = username is not None or password is not None
+    url = f'{scheme}://{domain}/RPC2'
+    if database:
+        url += f'?db={quote(database)}'
+
+    res = requests.post(
+        url,
+        json={
+            'jsonrpc': '2.0',
+            'method': method,
+            'params': params,
+            'id': str(uuid.uuid4()),
+        },
+        **{'auth': (username, password) for _ in (1,) if should_auth},
+    )
+    res.raise_for_status()
+    res_data = res.json()
+    if 'error' in res_data:
+        raise Exception(res_data['error']['message'])
+    return res_data['result']
+
+
+class _Method:
+    def __init__(self, callback, attrs):
+        self.callback = callback
+        self._attrs = attrs
+
+    def __getattr__(self, attr):
+        return type(self)(self.callback, (*self._attrs, attr))
+
+    def __call__(self, *args):
+        return self.callback('.'.join(self._attrs), *args)
+
+def proxy(scheme, domain, database=None, username=None, password=None, requests=requests_):
+    """
+    Create a JSON-RPC proxy to a remote server.
+
+    See also ``xmlrpc.client.ServerProxy`` which has support for binary
+    data that JSON-RPC lacks.
+
+    >>> common = proxy('https', 'mycompany.odoo.com')
+    >>> common.version()
+    >>> {'server_version': '16.0', ...}
+
+    >>> models = proxy('https', 'mycompany.odoo.com', 'mycompany', 'admin', 'admin')
+    >>> models.res.partner.read({
+            'records': [1, 2],
+            'context': {'lang': 'en_US'},
+            'args': [['id', 'name']],
+            'kwargs': {'load': None},
+        })
+    [{'id': 1, 'name': 'Bob'}, {'id': 2, 'name': 'Eve'}]
+
+    :param str scheme: the network scheme of the underlying connection
+    :param str domain: the domain name where the Odoo server is at
+    :param str|None database: the optional database to log on
+    :param str|None username: the username for the authentication
+    :param str|None password: the password for the authentication
+    :param requests: An opener from the ``requests`` library, by default
+        it is ``requests`` itself.
+    """
+    callback = functools.partial(call,
+        scheme=scheme, domain=domain, database=database, username=username,
+        password=password, requests=requests
+    )
+    return _Method(callback, tuple())

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -745,6 +745,33 @@ class unquote(str):
     def __repr__(self):
         return self
 
+def snake(input_str):
+    """
+    snake cases ``input_str``
+
+    >>> snake("HelloWorld")
+    'hello_world'
+    """
+    # insert a space before each uppercase character preceded by a
+    # non-uppercase letter
+    input_str = re.sub(r'(?<=[^A-Z])\B([A-Z])', r' \1', input_str)
+    # lowercase everything, split on whitespace and join
+    return '_'.join(input_str.lower().split())
+
+def pascal(input_str):
+    """
+    pascal cases ``input_str``
+
+    >>> pascal('hello_world')
+    'HelloWorld'
+    >>> pascal('hello world')
+    'HelloWorld'
+    """
+    return ''.join(
+        word.capitalize()
+        for word in re.sub(r'[_\s]+', ' ', input_str).split()
+    )
+
 
 class mute_logger(logging.Handler):
     """Temporary suppress the logging.


### PR DESCRIPTION
The current XMLRPC endpoints (`/xmlrpc/` and `/xmlrpc/2/`) use the old
calling conventions (CC) of odoo-7. They can't be converted to the new
CC of the "new" odoo-8 ORM API as there  is not enough information at
their level to do so (knowledge of whether/where ids and contexts are).

This means new-CC methods must currently be decorated with `@model` to
be exposed over RPC, or calling them raises a TypeError (number of
parameters does not match). The old CC can't be deprecated/removed
until an RPC endpoint using the new CC is available.

At the same time, while working on the webservice documentation, it
turns out that Odoo's xmlrpc layer is pretty idiosyncratic and doesn't
really take advantage of xmlrpc and the facilities provided by xmlrpc
libraries. We use the opportunity of defining a new endpoint switch to
explore/improvate that part as well.

Problems of the existing endpoint / system
==========================================

1. does RPC over RPC (implements its own Odoo RPC over XML-RPC) so
   can't take advantage of library conveniences when they exist
2. only works with dicts and lists, not recordset or other types of
   mappings and sequences
3. doesn't allow None/nil/null, will break clients if support is
   enabled, this is an issue because json-rpc serialises None by default
   so devs lose the habit of returning a dummy placeholder as it works
   fine from the web client
4. user a non-standard authentication scheme

Calling Conventions (improves on 1 and 2)
=========================================

    call('admin_function', {
        'args': [...],
        'kwargs': {...},
    })

    call('model.method', {
        'records': [...],
        'context': {...},
        'args': [...],
        'kwargs': {...},
    })

Each call now uses a single parameter, a dictionary with records,
context, args (python positional arguments) and kwargs (python named
arguments), all four values are optional.

The records and context are extracted by the server to build the
environment and recordset, the args and kwargs are used when calling the
function.

This scheme makes it clear what each argument is for and brings the
missing abstraction RPC abstraction needed for the "new" odoo-8 API.

Even if it is not strictly necessary, it has been decided to use the
same scheme also for admin functions (e.g. database management).

Custom XMLRPC serializer (improves on 2)
========================================

New CC methods can return recordsets, which the new RPC endpoint has to
automatically convert somehow, the easiest was to serialise recordsets
as lists of ids (that's coherent with the old/new API decorators, and
means e.g. `search` returns the same thing).

Customizing `xmlrpclib.Marshaller` didn't work because it dispatches by
strict type equality, so it wasn't possible to hook into it to serialise
arbitrary recordsets (they get types created on-the-fly). A new
marshaller was reimplemented on top of lxml instead. It provides the
following features not provided by `xmlrpclib.Marshaller`:

* serialises recordsets to lists of ids, uses `BaseModel.ids` (ignores
  NewId)
* converts all mapping keys to strings (same as `json.dumps`) instead
  of raising an error (see #12667 and probably others I didn't find)
* can serialise arbitrary mappings (e.g. `Counter`, `defaultdict`) not
  just `dict`
* can serialise arbitrary iterables, not just `list` and `tuple`

Allow None/nil/null (fixes 3)
=============================

Of the 5 libraries we have examples for, 4 either enable the feature by
default or via a simple flag. The last one (Apache XML-RPC) can be
coerced into supporting it using ~15 lines of code which is downright
terse as far as the combination of Java and dynamically typed RPC goes.

This allows more natural returns from methods (aka don't return anything
instead of the artificial unconditional `return True` and `return False`
peppered through the codebase) and is in line with JSON-RPC.

Endpoint (avoids conflict with existing)
========================================

Uses `/RPC2`:

* does not conflict with existing endpoints
* used for the examples in the [XML-RPC specification][1]
* a number of documents call it the conventional XML-RPC path
* at least [one stdlib defaults to /RPC2][Ruby XMLRPC] when no `path`
  is provided

Authentication (fixes 4, also improves on 1)
============================================

All xmlrpc libraries surveyed provide built-in support for [Basic
Authentication](http://en.wikipedia.org/wiki/Basic_access_authentication).
The new endpoint thus replaces the custom authentication by BA

* no less (or more) secure than the existing scheme: relies on
  underlying transport being HTTPS for security
* avoids an extraneous auth step to resolve a uid (although that means
  if the "current user"'s uid is needed it has to be resolved separately)
* no need to keep uid/password around, they're embedded in the xmlrpc
  proxy object
* easy to integrate (Basic sends "cleartext" username and password,
  they're just base64-encoded)

Leverage XML-RPC conventions (improves on 1)
============================================

XML-RPC `methodName` is conventionally a dotted path (e.g.
`system.listMethods`), which most libraries can map onto the language's
own dereferencing/attribute access. This maps nicely to Odoo's models:
the last segment of the `methodName` is the method itself, the rest is
the model name. This means `read` for `account.account` can be called as:

    a_db.account.account.read(...)

Ruby's stdlib XMLRPC::Client has no separation between dereferencing and
method call, but it's still possible to proxy to a model then call a
number of methods on it e.g.

    partner = a_db.proxy('res.partner')
    partner.read(...)
    partner.write(...)

Because authentication depends on the db (or lack thereof), the database
name is part of the endpoint URL (query parameter)

* Admin methods (e.g. create/drop database) are done on a DB-less
endpoint

* Method calls on models are calls on DB'd endpoint with at least one
dot in methodName

Code comparison
===============

setup

    common = xmlrpc.client.ServerProxy('https://{}/xmlrpc/2/common'.format(domain))
    uid = common.authenticate(db, username, password, {})
    models = xmlrpc.client.ServerProxy('https://{}/xmlrpc/2/object'.format(domain))
    partners = lambda *args: models.execute_kw(db, uid, password, 'res.partner', *args)
    partners('read', ...)

becomes

    db = xmlrpclib.ServerProxy(f'https://{username}:{password}@{domain}/RPC2/{db}')
    partners = db.res.partner
    partners.read(...)

or in Ruby

    common = XMLRPC::Client.new(host, "/xmlrpc/2/common", 8069)
    uid = common.authenticate(db, username, password, {})
    models = XMLRPC::Client.new(host, "/xmlrpc/2/object", 8069)
    partners = lambda {|*args| models.execute_kw(db, uid, password, 'res.partner', *args) }
    partners.call('read', …)

becomes

    db = XMLRPC::Client.new(host, '/RPC2/' + db, 8069, nil, nil, username, password)
    partners = db.proxy('res.partner')
    partners.read(…)

simple method call

    models.execute_kw(
        db, uid, password,
        'res.partner', 'check_access_rights',
        ['read'], {'raise_exception': False})

becomes

    partners.check_access_rights({
        'args': ['read'],
        'kwargs': {'raise_exception': False}
    })

search

    models.execute_kw(
        db, uid, password,
        'res.partner', 'search',
        [[['is_company', '=', True], ['customer', '=', True]]])

becomes

    partners.search({'kwargs': {
        'domain': [['is_company', '=', True], ['customer', '=', True]]
    }})

read

    models.execute_kw(
        db, uid, password,
        'res.partner', 'read',
        [ids])

becomes

    partners.read({'records': ids})

Co-authored-by: Julien Castiaux <juc@odoo.com>

Closes #3989

[XML-RPC specification]: http://xmlrpc.com/
[Ruby XMLRPC]: http://www.ruby-doc.org/stdlib-2.1.5/libdoc/xmlrpc/rdoc/XMLRPC/Client.html#method-c-new