### PR TITLE
[FIX] website: fix image gallery slider index

### DIFF
--- a/addons/website/static/src/snippets/s_image_gallery/000.js
+++ b/addons/website/static/src/snippets/s_image_gallery/000.js
@@ -124,7 +124,8 @@ const GallerySliderWidget = publicWidget.Widget.extend({
         }
 
         function update() {
-            index = $lis.index($lis.filter('.active')) || 0;
+            const active = $lis.filter('.active');
+            index = active.length ? $lis.index(active) : 0;
             page = Math.floor(index / realNbPerPage);
             hide();
         }


### PR DESCRIPTION
The gallery slider index was wrongly calculated when the gallery had no
active element, as the jquery method .index() will still return -1 when
no element is found.

task-2472041


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
