### PR TITLE
[FIX] packaging: add python3-renderpm in debian package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -38,6 +38,7 @@ Depends:
  python3-pyparsing,
  python3-pypdf2,
  python3-qrcode,
+ python3-renderpm,
  python3-reportlab,
  python3-requests,
  python3-tz,

--- a/setup/package.dfdebian
+++ b/setup/package.dfdebian
@@ -45,6 +45,7 @@ RUN apt-get update -qq &&  \
         python3-pyparsing \
         python3-pypdf2 \
         python3-qrcode \
+        python3-renderpm \
         python3-reportlab \
         python3-requests \
         python3-serial \


### PR DESCRIPTION
In Debian and Ubuntu distros, the python reportlab package provides
multiple binary packages among which python3-reportlab [0] [1] and
python3-renderpm [2] [3]. The latter is only recommended, but is mandatory for
odoo because it's needed for rendering barcode with the `asString` method.

[0] https://packages.debian.org/buster/python3-reportlab
[1] https://packages.ubuntu.com/focal/python3-reportlab
[2] https://packages.debian.org/buster/python3-renderpm
[3] https://packages.ubuntu.com/focal/python3-renderpm

