### PR TITLE
[FIX] sale_stock_margin: compute product uom qty

### DIFF
--- a/addons/sale_stock_margin/models/sale_order_line.py
+++ b/addons/sale_stock_margin/models/sale_order_line.py
@@ -15,4 +15,6 @@ class SaleOrderLine(models.Model):
                 lines_without_moves |= line
             else:
                 line.purchase_price = line.product_id.with_company(line.company_id)._compute_average_price(0, line.product_uom_qty, line.move_ids)
+                if line.product_uom and line.product_uom != line.product_id.uom_id:
+                    line.purchase_price = line.product_id.uom_id._compute_price(line.purchase_price, line.product_uom)
         return super(SaleOrderLine, lines_without_moves)._compute_purchase_price()


### PR DESCRIPTION
When confirming a SO, if a line uses a different UoM than the default
UoM of the line product, the computed cost will be updated to the
product unit cost.

To reproduce the error:
1. In Settings, enable:
    - Units of Measure
    - Margins
2. Create a product P
    - Sales Price: $100
    - No customer taxes
    - Cost: $50
    - UoM: Units
3. Create a SO
    - Add P
    - Set the line UoM to 'Dozens'
4. Display the order line field "Cost"
    - [Note] As you can see, since UoM is 'Dozens':
        - Unit Price: $1200
        - Cost: $600
5. Confirm the SO

Error: Line cost becomes $50 (the cost of one P-product). Since the UoM
of the line is 'Dozens', Cost should be $600 (as before confirming the
SO). As a result, this error creates incorrect data in the margins
(95.83% instead of 50%).

OPW-2444335