### PR TITLE
[FIX] account: avoid useless account move synchronization

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -1248,6 +1248,7 @@ class AccountBankStatementLine(models.Model):
 
         line_vals_list = [reconciliation_vals['line_vals'] for reconciliation_vals in reconciliation_overview]
         new_lines = self.env['account.move.line'].create(line_vals_list)
+        new_lines = new_lines.with_context(skip_account_move_synchronization=True)
         for reconciliation_vals, line in zip(reconciliation_overview, new_lines):
             if reconciliation_vals.get('payment'):
                 accounts = (self.journal_id.payment_debit_account_id, self.journal_id.payment_credit_account_id)


### PR DESCRIPTION
Account move synchronization has already taken place during the creation of the moves. No need for this additional check during the reconciliation itself.

This commit helps when a lot of move lines are being reconciled at once.
For instance, the duration of the reconciliation of a batch of about 700 payments on a large database took 20 minutes before this commit, and takes about 4 minutes after this commit.