### PR TITLE
[FIX] stock_account: param for aml.date

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -214,7 +214,9 @@ class ProductProduct(models.Model):
             params = (tuple(real_time_product_ids), self.env.user.company_id.id)
             if to_date:
                 query = query % ('AND aml.date <= %s',)
-                params = params + (to_date,)
+                # to_date should be converted back to user's timezone to capture the correct date.
+                to_date_ctx = fields.Datetime.to_string(fields.Datetime.context_timestamp(self, fields.Datetime.to_datetime(to_date)))
+                params = params + (to_date_ctx,)
             else:
                 query = query % ('',)
             self.env.cr.execute(query, params=params)


### PR DESCRIPTION
aml.date is a date while the param passed for this field is a datetime string.
This datetime string should be converted according to user's timezone, or the queried
result may become incorrect. e.g. If I (with Japan timezone) specify 2021-03-01 08:00:00,
queried result shows the inventory as of 2021-02-28 instead of 2021-03-01.

@qrtl

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
