### PR TITLE
[FIX] website_sale : check mandatory fields during checkout

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -743,9 +743,25 @@ class WebsiteSale(http.Controller):
         if order.partner_id.id == request.website.user_id.sudo().partner_id.id:
             return request.redirect('/shop/address')
 
-        for f in self._get_mandatory_billing_fields():
+        required_billing_fields = self._get_mandatory_billing_fields()
+        if 'country_id' in required_billing_fields and order.partner_id.country_id:
+            if order.partner_id.country_id.state_required:
+                required_billing_fields += ['state_id']
+            if order.partner_id.country_id.zip_required:
+                required_billing_fields += ['zip']
+        for f in required_billing_fields:
             if not order.partner_id[f]:
                 return request.redirect('/shop/address?partner_id=%d' % order.partner_id.id)
+
+        required_shipping_fields = self._get_mandatory_shipping_fields()
+        if 'country_id' in required_shipping_fields and order.partner_shipping_id.country_id:
+            if order.partner_shipping_id.country_id.state_required:
+                required_shipping_fields += ['state_id']
+            if order.partner_shipping_id.country_id.zip_required:
+                required_shipping_fields += ['zip']
+        for f in required_shipping_fields:
+            if not order.partner_shipping_id[f]:
+                return request.redirect('/shop/address?partner_id=%d' % order.partner_shipping_id.id)
 
         values = self.checkout_values(**post)
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Go to runbot
- create a portal user (in back office), with two adresse:
- Billing : Test, street X, ZIP 001, City 88, France
- Shipping : France (write nothing in street, zip, ...)
- Log with this user (in front office), buy some thing, you arrive in checkout
![image](https://user-images.githubusercontent.com/16716992/110232462-113eb200-7f1e-11eb-8e4e-09643e7bb071.png)
Click Confirm:
--> Issue you arrive in the payment page.
![image](https://user-images.githubusercontent.com/16716992/110232890-ea35af80-7f20-11eb-9624-7036915e0c42.png)


This PR add a redirection if any required field are missing.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
