### PR TITLE
[FIX] product_packaging: fix package dimension datatype

### DIFF
--- a/addons/delivery/models/product_packaging.py
+++ b/addons/delivery/models/product_packaging.py
@@ -14,9 +14,9 @@ class ProductPackaging(models.Model):
     def _get_default_weight_uom(self):
         return self.env['product.template']._get_weight_uom_name_from_ir_config_parameter()
 
-    height = fields.Integer('Height')
-    width = fields.Integer('Width')
-    packaging_length = fields.Integer('Length')
+    height = fields.Float('Height')
+    width = fields.Float('Width')
+    packaging_length = fields.Float('Length')
     max_weight = fields.Float('Max Weight', help='Maximum weight shippable in this packaging')
     shipper_package_code = fields.Char('Package Code')
     package_carrier_type = fields.Selection([('none', 'No carrier integration')], string='Carrier', default='none')


### PR DESCRIPTION
The package dimensions are collected in meters. To have the chance to define packages smaller than 1mx1mx1m, the datatype should be float.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
