### PR TITLE
[FIX] web: misaligned font-size in group headers list view

### DIFF
--- a/addons/web/static/src/js/views/list/list_renderer.js
+++ b/addons/web/static/src/js/views/list/list_renderer.js
@@ -222,9 +222,6 @@ var ListRenderer = BasicRenderer.extend({
                 return;
             }
             var $cell = $('<td>');
-            if (config.debug) {
-                $cell.addClass(column.attrs.name);
-            }
             if (column.attrs.name in aggregateValues) {
                 var field = self.state.fields[column.attrs.name];
                 var value = aggregateValues[column.attrs.name].value;


### PR DESCRIPTION
Currently, the font-size and background-color of the progress bar widget
are mismatches with the group headers font-size and background-color.
It happens because of the progress bar widget's font-size and background-color.

This commit fixes the issue by overriding the font-size and background-color
property of the progress bar widget.

TaskID-2462152