### PR TITLE
[FIX] l10n_in_*: Set GST treatment and journal when sale from website

### DIFF
--- a/addons/l10n_in_sale/models/sale_order.py
+++ b/addons/l10n_in_sale/models/sale_order.py
@@ -8,8 +8,8 @@ class SaleOrder(models.Model):
     _inherit = "sale.order"
 
     l10n_in_reseller_partner_id = fields.Many2one('res.partner',
-        string='Reseller', domain="[('vat', '!=', False), '|', ('company_id', '=', False), ('company_id', '=', company_id)]", readonly=True, states={'draft': [('readonly', False)]})
-    l10n_in_journal_id = fields.Many2one('account.journal', string="Journal", compute="_compute_l10n_in_journal_id", store=True, readonly=True, states={'draft': [('readonly', False)]})
+        string='Reseller', domain="[('vat', '!=', False), '|', ('company_id', '=', False), ('company_id', '=', company_id)]", readonly=True, states={'draft': [('readonly', False)], 'sent': [('readonly', False)]})
+    l10n_in_journal_id = fields.Many2one('account.journal', string="Journal", compute="_compute_l10n_in_journal_id", store=True, readonly=True, states={'draft': [('readonly', False)], 'sent': [('readonly', False)]})
     l10n_in_gst_treatment = fields.Selection([
             ('regular', 'Registered Business - Regular'),
             ('composition', 'Registered Business - Composition'),
@@ -18,7 +18,7 @@ class SaleOrder(models.Model):
             ('overseas', 'Overseas'),
             ('special_economic_zone', 'Special Economic Zone'),
             ('deemed_export', 'Deemed Export'),
-        ], string="GST Treatment", readonly=True, states={'draft': [('readonly', False)]}, compute="_compute_l10n_in_gst_treatment", store=True)
+        ], string="GST Treatment", readonly=True, states={'draft': [('readonly', False)], 'sent': [('readonly', False)]}, compute="_compute_l10n_in_gst_treatment", store=True)
     l10n_in_company_country_code = fields.Char(related='company_id.country_id.code', string="Country code")
 
     @api.depends('partner_id')

--- a/addons/l10n_in_sale/models/sale_order.py
+++ b/addons/l10n_in_sale/models/sale_order.py
@@ -9,7 +9,7 @@ class SaleOrder(models.Model):
 
     l10n_in_reseller_partner_id = fields.Many2one('res.partner',
         string='Reseller', domain="[('vat', '!=', False), '|', ('company_id', '=', False), ('company_id', '=', company_id)]", readonly=True, states={'draft': [('readonly', False)]})
-    l10n_in_journal_id = fields.Many2one('account.journal', string="Journal", readonly=True, states={'draft': [('readonly', False)]})
+    l10n_in_journal_id = fields.Many2one('account.journal', string="Journal", compute="_compute_l10n_in_journal_id", store=True, readonly=True, states={'draft': [('readonly', False)]})
     l10n_in_gst_treatment = fields.Selection([
             ('regular', 'Registered Business - Regular'),
             ('composition', 'Registered Business - Composition'),
@@ -18,8 +18,33 @@ class SaleOrder(models.Model):
             ('overseas', 'Overseas'),
             ('special_economic_zone', 'Special Economic Zone'),
             ('deemed_export', 'Deemed Export'),
-        ], string="GST Treatment", readonly=True, states={'draft': [('readonly', False)]})
+        ], string="GST Treatment", readonly=True, states={'draft': [('readonly', False)]}, compute="_compute_l10n_in_gst_treatment", store=True)
     l10n_in_company_country_code = fields.Char(related='company_id.country_id.code', string="Country code")
+
+    @api.depends('partner_id')
+    def _compute_l10n_in_gst_treatment(self):
+        for order in self:
+            # set default value as False so CacheMiss error never occurs for this field.
+            order.l10n_in_gst_treatment = False
+            if order.l10n_in_company_country_code == 'IN':
+                l10n_in_gst_treatment = order.partner_id.l10n_in_gst_treatment
+                if not l10n_in_gst_treatment and order.partner_id.country_id and order.partner_id.country_id.code != 'IN':
+                    l10n_in_gst_treatment = 'overseas'
+                if not l10n_in_gst_treatment:
+                    l10n_in_gst_treatment = order.partner_id.vat and 'regular' or 'consumer'
+                order.l10n_in_gst_treatment = l10n_in_gst_treatment
+
+    @api.depends('company_id')
+    def _compute_l10n_in_journal_id(self):
+        for order in self:
+            # set default value as False so CacheMiss error never occurs for this field.
+            order.l10n_in_journal_id = False
+            if order.l10n_in_company_country_code == 'IN':
+                domain = [('company_id', '=', order.company_id.id), ('type', '=', 'sale')]
+                journal = self.env['account.journal'].search(domain, limit=1)
+                if journal:
+                    order.l10n_in_journal_id = journal.id
+
 
     def _prepare_invoice(self):
         invoice_vals = super(SaleOrder, self)._prepare_invoice()
@@ -29,17 +54,3 @@ class SaleOrder(models.Model):
                 invoice_vals['journal_id'] = self.l10n_in_journal_id.id
             invoice_vals['l10n_in_gst_treatment'] = self.l10n_in_gst_treatment
         return invoice_vals
-
-    @api.onchange('company_id')
-    def l10n_in_onchange_company_id(self):
-        if self.l10n_in_company_country_code == 'IN':
-            domain = [('company_id', '=', self.company_id.id), ('type', '=', 'sale')]
-            journal = self.env['account.journal'].search(domain, limit=1)
-            if journal:
-                self.l10n_in_journal_id = journal.id
-
-    @api.onchange('partner_id')
-    def onchange_partner_id(self):
-        if self.l10n_in_company_country_code == 'IN':
-            self.l10n_in_gst_treatment = self.partner_id.l10n_in_gst_treatment
-        return super().onchange_partner_id()

--- a/addons/l10n_in_sale_stock/models/sale_order.py
+++ b/addons/l10n_in_sale_stock/models/sale_order.py
@@ -7,9 +7,10 @@ from odoo import models, fields, api
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
-    @api.onchange('company_id', 'warehouse_id')
-    def l10n_in_onchange_company_id(self):
-        if self.warehouse_id.l10n_in_sale_journal_id:
-            self.l10n_in_journal_id = self.warehouse_id.l10n_in_sale_journal_id.id
-        else:
-            super().l10n_in_onchange_company_id()
+    @api.depends('company_id','warehouse_id')
+    def _compute_l10n_in_journal_id(self):
+        super()._compute_l10n_in_journal_id()
+        for order in self:
+            if order.l10n_in_company_country_code == 'IN':
+                if order.warehouse_id.l10n_in_sale_journal_id:
+                    order.l10n_in_journal_id = order.warehouse_id.l10n_in_sale_journal_id.id


### PR DESCRIPTION
when sale from a website then GST treatment is not set and order is confirmed so not able to change it

after this commit, GST treatment is set when creating a sale order or invoice from RPC

remove readonly in the sent state for Reseller and Journal

When an order is created from a website then onchange is not called so we set a journal when order is created and set a value on the journal from the warehouse



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
