### PR TITLE
website.tools.MockRequest: allow to pass environ and path

### DIFF
--- a/addons/website/tools.py
+++ b/addons/website/tools.py
@@ -65,7 +65,8 @@ def werkzeugRaiseNotFound(*args, **kwargs):
 def MockRequest(
         env, *, routing=True, multilang=True,
         context=None,
-        cookies=None, country_code=None, website=None, sale_order_id=None
+        cookies=None, country_code=None, website=None, sale_order_id=None,
+        environ=None, path=None
 ):
     router = MagicMock()
     match = router.return_value.bind.return_value.match
@@ -82,7 +83,8 @@ def MockRequest(
         context = {}
     lang_code = context.get('lang', env.context.get('lang', 'en_US'))
     context.setdefault('lang', lang_code)
-
+    environ = environ or {}
+    environ.setdefault('REMOTE_ADDR', '127.0.0.1')
     request = Mock(
         context=context,
         db=None,
@@ -90,9 +92,9 @@ def MockRequest(
         env=env,
         httprequest=Mock(
             host='localhost',
-            path='/hello/',
+            path=path or '/hello/',
             app=odoo.http.root,
-            environ={'REMOTE_ADDR': '127.0.0.1'},
+            environ=environ,
             cookies=cookies or {},
             referrer='',
         ),


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Make `environ` and `path` configurable for mocked request

**Current behavior before PR:** 

You cannot pass these important args at ctx manager init.

**Desired behavior after PR is merged:**

Ease init of mocked request w/ custom headers and path.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
