### PR TITLE
[FIX]base: fix domain of "user_id" field in res.partner

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -160,7 +160,7 @@ class Partner(models.Model):
                                "render date and time values: your computer's timezone.")
     tz_offset = fields.Char(compute='_compute_tz_offset', string='Timezone offset', invisible=True)
     user_id = fields.Many2one('res.users', string='Salesperson',
-      help='The internal user in charge of this contact.')
+      help='The internal user in charge of this contact.', domain=lambda self: [('groups_id', 'in', self.env.ref('base.group_user').id)])
     vat = fields.Char(string='Tax ID', index=True, help="The Tax Identification Number. Complete it if the contact is subjected to government taxes. Used in some legal statements.")
     bank_ids = fields.One2many('res.partner.bank', 'partner_id', string='Banks')
     website = fields.Char()


### PR DESCRIPTION
Steps to follow to reproduce the bug:
-Go to the Contact app
-Choose any contact
-In the contact form> go to the "sales & purchase" tab and try to assign a user in the "salesperson" fields

Problem:
You can choose any user regardless of their type. While normally we can only choose internal users

Solution:
Add a domain to the "user_id" fields to only see users of the kind "internal type"

opw-2468819

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
