### PR TITLE
[FIX]mail: apply groups & invisible on followers

### DIFF
--- a/addons/mail/static/src/js/followers.js
+++ b/addons/mail/static/src/js/followers.js
@@ -52,6 +52,12 @@ var Followers = AbstractField.extend({
         this.isEditable = options.isEditable;
     },
     _render: function () {
+        //if we should invisible this field 
+        //applied it when groups & attrs invisible
+        if (this.attrs.invisible) {
+            this.$el.toggleClass("o_invisible_modifier");
+            return;
+        }
         // note: the rendering of this widget is asynchronous as it needs to
         // fetch the details of the followers, but it performs a first rendering
         // synchronously (_displayGeneric), and updates its rendering once it


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
[67426](https://github.com/odoo/odoo/issues/67426)

Current behavior before PR:
chatter didn't apply the groups in field message_follower_ids

Desired behavior after PR is merged:
chatter apply the groups in field message_follower_ids



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
