### PR TITLE
[IMP] l10n_be: Remove default account on non deductible part in VAT.

### DIFF
--- a/addons/l10n_be/data/account_tax_template_data.xml
+++ b/addons/l10n_be/data/account_tax_template_data.xml
@@ -1803,7 +1803,6 @@
                 (0,0, {
                     'factor_percent': 50,
                     'repartition_type': 'tax',
-                    'account_id': ref('a64012'),
                     'plus_report_line_ids': [ref('tax_report_line_82')],
                 }),
 
@@ -1825,7 +1824,6 @@
                 (0,0, {
                     'factor_percent': 50,
                     'repartition_type': 'tax',
-                    'account_id': ref('a64012'),
                     'minus_report_line_ids': [ref('tax_report_line_82')],
                     'plus_report_line_ids': [ref('tax_report_line_85')],
                 }),


### PR DESCRIPTION
According to the documentation from IPCF, the proportion of VAT that may not be claimed back must be recorded by default on the same account as the base amount in a different move line that this base amount.

**Task ID:** #2373849

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
