### PR TITLE
[FIX] sale: define team_id with same company than user

### DIFF
--- a/addons/sale/models/account_invoice.py
+++ b/addons/sale/models/account_invoice.py
@@ -60,7 +60,7 @@ class AccountMove(models.Model):
     @api.onchange('invoice_user_id')
     def onchange_user_id(self):
         if self.invoice_user_id and self.invoice_user_id.sale_team_id:
-            self.team_id = self.invoice_user_id.sale_team_id
+            self.team_id = self.env['crm.team']._get_default_team_id(user_id=self.invoice_user_id.id, domain=[('company_id', '=', self.company_id.id)])
 
     def _reverse_moves(self, default_values_list=None, cancel=False):
         # OVERRIDE


### PR DESCRIPTION
When creating a journal entry in company C01, if user's sales team
belongs to another company CXX, the default sales team of the journal
entry is still the user's sales team.

To reproduce the error:
(Use demo data. Let C01 be the current company)
1. Add the `team_id` field to `account_move` form view:
    - With web_studio
    - Directly in the code:
```diff
diff --git a/addons/sale/views/sale_views.xml
b/addons/sale/views/sale_views.xml
index 92cb2a72c4d..acc0e91e890 100644
--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -1154,6 +1154,17 @@
             </field>
         </record>

+        <record id="account_invoice_view_form" model="ir.ui.view">
+            <field name="name">account.move.form.inherit.sale</field>
+            <field name="model">account.move</field>
+            <field name="inherit_id" ref="account.view_move_form"/>
+            <field name="arch" type="xml">
+                <field name="ref" position="after">
+                    <field name="team_id" />
+                </field>
+            </field>
+        </record>
+
         <!-- Update account invoice !-->
         <record model="ir.ui.view" id="account_invoice_form">
             <field name="name">Account Invoice</field>
```
2. Create a second Company C02
3. Edit the Sales Team 'Europe':
    - Company: C02
4. Go to Accounting > Accounting > Journal Entries
5. Click on "Create"

Error: the default Sales Team is 'Europe'. However, this team belongs to
C02 and the user is creating a new JE in C01.

When creating a new journal entry, an `onchange` method uses the user's
sales team to define the JE's sales team.
However, the current user belongs to 'Europe', and the company of
'Europe' is now C02. Therefore, 'Europe' should not be used.

OPW-2375444