### PR TITLE
[FIX] payment: Fix the partner id when paying from the portal

### DIFF
--- a/addons/payment/wizards/payment_link_wizard.py
+++ b/addons/payment/wizards/payment_link_wizard.py
@@ -27,7 +27,7 @@ class PaymentLinkWizard(models.TransientModel):
                 'description': record.payment_reference,
                 'amount': record[amount_field],
                 'currency_id': record.currency_id.id,
-                'partner_id': record.partner_id.id,
+                'partner_id': record.commercial_partner_id.id,
                 'amount_max': record[amount_field],
             })
         return res


### PR DESCRIPTION
Currently, the generated payment link is using the partner_id and not
the commercial_partner_id. This causes issues when trying to reconcile
a payment after it is done.

This will fix that and make sure that payments can be properly
reconciled.

Fixes #66024
opw 2460011

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
