### PR TITLE
[FIX] account: wrong batching to compute the name

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1111,7 +1111,7 @@ class AccountMove(models.Model):
                 if (
                     not final_batches
                     or final_batches[-1]['format'] != date_group['format']
-                    or final_batches[-1]['format_values'] != date_group['format_values']
+                    or dict(final_batches[-1]['format_values'], seq=0) != dict(date_group['format_values'], seq=0)
                 ):
                     final_batches += [date_group]
                 elif date_group['reset'] == 'never':

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -486,19 +486,20 @@ class TestAccountMove(AccountTestInvoicingCommon):
         moves = self.env['account.move'].create([{
             'journal_id': journals[i].id,
             'line_ids': [(0, 0, {'account_id': account.id, 'name': 'line'})],
+            'date': '2010-01-01',
         } for i in range(2)])._post()
-        year = moves[0].date.year
         for i in range(2):
-            moves[i].name = f'J{i}/{year}/00001'
+            moves[i].name = f'J{i}/2010/00001'
 
         # Check that the moves are correctly batched
         moves = self.env['account.move'].create([{
-            'journal_id': journals[i].id,
+            'journal_id': journals[journal_index].id,
             'line_ids': [(0, 0, {'account_id': account.id, 'name': 'line'})],
-        } for i in [1, 0, 1]])._post()
+            'date': f'2010-{month}-01',
+        } for journal_index, month in [(1, 1), (0, 1), (1, 2), (1, 1)]])._post()
         self.assertEqual(
             moves.mapped('name'),
-            [f'J1/{year}/00002', f'J0/{year}/00002', f'J1/{year}/00003'],
+            ['J1/2010/00002', 'J0/2010/00002', 'J1/2010/00004', 'J1/2010/00003'],
         )
 
     def test_journal_override_sequence_regex(self):


### PR DESCRIPTION
Fine tuning of f816c326f348ff78a982f91a736cc005d3e0cd31
We should not look at the `seq` when grouping again.

opw-[2472061](https://www.odoo.com/web#active_id=2472061&cids=1&id=2472061&model=project.task&menu_id=)





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
