### PR TITLE
[FIX] crm: reposition tooltip to avoid resize flicker

### DIFF
--- a/addons/crm/static/src/js/tours/crm.js
+++ b/addons/crm/static/src/js/tours/crm.js
@@ -60,7 +60,7 @@ tour.register('crm_tour', {
 }, {
     trigger: '.modal-footer button[name="action_close_dialog"]',
     content: _t("All set. Let’s <b>Schedule</b> it."),
-    position: "bottom",
+    position: "top",  // dot NOT move to bottom, it would cause a resize flicker, see task-2476595
     run: function (actions) {
         actions.auto('.modal-footer button[special=cancel]');
     },


### PR DESCRIPTION
The tour bubble "animation" that makes it to bounce up and down can cause
issues when its position is at the edge of the bottom of the screen.

In the CRM tour, this would make the window constantly resize to show a
scrollbar and then resize to hide the scrollbar, creating quite a sickening
effect visually.

While waiting for a more "robust" solution on the framework side, we solve this
occurrence of the issue by simply moving the tooltip position on top of the
button instead of below it.

Task-2476595