### PR TITLE
[IMP] payment_payumoney: do safe landing to Odoo store from PayUMoney

### DIFF
--- a/addons/payment_payumoney/controllers/main.py
+++ b/addons/payment_payumoney/controllers/main.py
@@ -21,8 +21,15 @@ class PayuMoneyController(http.Controller):
         a new session cookie. Therefore, the previous session and all related information will be lost, so it will lead
         to undesirable behaviors. This is the reason why `save_session=False` is needed.
         """
+        return werkzeug.utils.redirect('/payment/process')
+
+    @http.route(['/payment/payumoney/webhook'], type='json', auth='public')
+    def payu_webhook(self):
+        """ Create this webhook record under https://www.payu.in/business/settings/webhooks """
+        post = http.request.jsonrequest
         _logger.info(
             'PayUmoney: entering form_feedback with post data %s', pprint.pformat(post))
         if post:
+            if post.get('status'):
+                post['status'] = post['status'].lower()
             request.env['payment.transaction'].sudo().form_feedback(post, 'payumoney')
-        return werkzeug.utils.redirect('/payment/process')

--- a/addons/payment_payumoney/models/payment.py
+++ b/addons/payment_payumoney/models/payment.py
@@ -45,7 +45,7 @@ class PaymentAcquirerPayumoney(models.Model):
             sign = ''.join('%s|' % (values.get(k) or '') for k in keys)
             sign += self.payumoney_merchant_salt or ''
         else:
-            keys = "|status||||||||||udf1|email|firstname|productinfo|amount|txnid".split('|')
+            keys = "|status||||||||||udf1|customerEmail|customerName|productInfo|amount|merchantTransactionId".split('|')
             sign = ''.join('%s|' % (values.get(k) or '') for k in keys)
             sign = self.payumoney_merchant_salt + sign + self.payumoney_merchant_key
 
@@ -86,8 +86,8 @@ class PaymentTransactionPayumoney(models.Model):
     def _payumoney_form_get_tx_from_data(self, data):
         """ Given a data dict coming from payumoney, verify it and find the related
         transaction record. """
-        reference = data.get('txnid')
-        pay_id = data.get('mihpayid')
+        reference = data.get('merchantTransactionId')
+        pay_id = data.get('paymentId')
         shasign = data.get('hash')
         if not reference or not pay_id or not shasign:
             raise ValidationError(_('PayUmoney: received data with missing reference (%s) or pay_id (%s) or shashign (%s)') % (reference, pay_id, shasign))
@@ -123,7 +123,7 @@ class PaymentTransactionPayumoney(models.Model):
     def _payumoney_form_validate(self, data):
         status = data.get('status')
         result = self.write({
-            'acquirer_reference': data.get('payuMoneyId'),
+            'acquirer_reference': data.get('paymentId'),
             'date': fields.Datetime.now(),
         })
         if status == 'success':


### PR DESCRIPTION
Currently no data is posted to Odoo from PayUMoney's http request.

PayUMoney has a settings where it allows us to receive the payment statuses
to our server through configuring webhook. This webhook is a json request
to our server.

Certain keys in received data are named differently. So The sign used when
comparing the hashes should also be updated.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr