### PR TITLE
[FIX] l10n_it_edi: generate xml for invoices with 0% tax only

### DIFF
--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -172,7 +172,17 @@
                                 <RiferimentoNormativo t-if="tax_line.tax_line_id.l10n_it_has_exoneration" t-esc="tax_line.tax_line_id.l10n_it_law_reference"/>
                             </DatiRiepilogo>
                         </t>
-
+                        <!-- 0% tax lines -->
+                        <t t-foreach="tax_map" t-as="tax">
+                            <DatiRiepilogo>
+                                <AliquotaIVA t-esc="format_numbers(tax.amount)"/>
+                                <Natura t-if="tax.l10n_it_has_exoneration" t-esc="tax.l10n_it_kind_exoneration"/>
+                                <ImponibileImporto t-esc="format_monetary(tax_map[tax], currency)"/>
+                                <Imposta t-esc="format_monetary(0.00, currency)"/>
+                                <EsigibilitaIVA t-if="not tax.l10n_it_has_exoneration or tax.l10n_it_kind_exoneration=='N6'" t-esc="tax.l10n_it_vat_due_date"/>
+                                <RiferimentoNormativo t-if="tax.l10n_it_has_exoneration" t-esc="tax.l10n_it_law_reference"/>
+                            </DatiRiepilogo>
+                        </t>
                     </DatiBeniServizi>
                     <DatiPagamento>
                         <t t-set="payments" t-value="record.line_ids.filtered(lambda line: line.account_id.user_type_id.type in ('receivable', 'payable'))"/>

--- a/addons/l10n_it_edi/models/account_invoice.py
+++ b/addons/l10n_it_edi/models/account_invoice.py
@@ -241,6 +241,13 @@ class AccountMove(models.Model):
         pdf = base64.b64encode(pdf)
         pdf_name = re.sub(r'\W+', '', self.name) + '.pdf'
 
+        # tax map for 0% taxes which have no tax_line_id
+        tax_map = dict()
+        for line in self.line_ids:
+            for tax in line.tax_ids:
+                if tax.amount == 0.0:
+                    tax_map[tax] = tax_map.get(tax, 0.0) + line.price_subtotal
+
         # Create file content.
         template_values = {
             'record': self,
@@ -258,6 +265,7 @@ class AccountMove(models.Model):
             'document_type': document_type,
             'pdf': pdf,
             'pdf_name': pdf_name,
+            'tax_map': tax_map,
         }
         return template_values
 


### PR DESCRIPTION
Have an invoice with single line and 0% tax on it
As the tax has 0 amount, no related moves are created,
the e-invoice export will fail the formal compliance check as it is
missing a section

opw-2461496

closes odoo/odoo#66960

X-original-commit: 71cc7212b1c1abad5d37e29f3a1f33f6e6cd2a81
Signed-off-by: agr-odoo <agr-odoo@users.noreply.github.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
