### PR TITLE
[FIX] stock_move: Real Quantity (product_qty) digits

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -54,7 +54,7 @@ class StockMove(models.Model):
     description_picking = fields.Text('Description of Picking')
     product_qty = fields.Float(
         'Real Quantity', compute='_compute_product_qty', inverse='_set_product_qty',
-        digits=0, store=True, compute_sudo=True,
+        digits='Product Unit of Measure', store=True, compute_sudo=True,
         help='Quantity in the default UoM of the product')
     product_uom_qty = fields.Float(
         'Demand',


### PR DESCRIPTION
Stock Move product_qty is currently set to zero.

The forecast widgit uses this to round the quanity on one side
of the comparison, and uses "Product Unit of Measure" on the other
side, resulting in a bad comparison.

1) Stock adjust a product to have 10 on hand.
2) Create an MRP order with a raw material line needing 2.8
3) The line says "Not Available" because the forecast availabity
   for the line is 2.8 (correct), but the css in the widget compares
   2.8 to 3 (incorrectly using 0 digits to round).

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
