### PR TITLE
[FIX] website_sale : get accessory with website domain

### DIFF
--- a/addons/website_sale/models/product.py
+++ b/addons/website_sale/models/product.py
@@ -264,6 +264,25 @@ class ProductTemplate(models.Model):
 
         return self._get_possible_variants(parent_combination).sorted(_sort_key_variant)
 
+    def _get_website_accessory_product(self, website=None):
+        domains = []
+        domains.append([('website_published', '=', True)])
+        if website:
+            domains.append(website.sale_product_domain())
+            domains.append([('company_id', 'in', [False, website.company_id.id])])
+        domain = expression.AND(domains)
+        tmpl_allowed = self.accessory_product_ids.product_tmpl_id.filtered_domain(domain)
+        return self.accessory_product_ids.filtered(lambda x: x.product_tmpl_id in tmpl_allowed)
+
+    def _get_website_alternative_product(self, website=None):
+        domains = []
+        domains.append([('website_published', '=', True)])
+        if website:
+            domains.append(website.sale_product_domain())
+            domains.append([('company_id', 'in', [False, website.company_id.id])])
+        domain = expression.AND(domains)
+        return self.alternative_product_ids.filtered_domain(domain)
+
     def _get_combination_info(self, combination=False, product_id=False, add_qty=1, pricelist=False, parent_combination=False, only_template=False):
         """Override for website, where we want to:
             - take the website pricelist if no pricelist is set

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -294,13 +294,11 @@ class SaleOrder(models.Model):
             accessory_products = self.env['product.product']
             for line in order.website_order_line.filtered(lambda l: l.product_id):
                 combination = line.product_id.product_template_attribute_value_ids + line.product_no_variant_attribute_value_ids
-                accessory_products |= line.product_id.accessory_product_ids.filtered(lambda product:
-                    product.website_published and
+                accessory_products |= line.product_id.product_tmpl_id._get_website_accessory_product(
+                    order.website_id).filtered(lambda product:
                     product not in products and
-                    product._is_variant_possible(parent_combination=combination) and
-                    (product.company_id == line.company_id or not product.company_id)
+                    product._is_variant_possible(parent_combination=combination)
                 )
-
             return random.sample(accessory_products, len(accessory_products))
 
     def action_recovery_email_send(self):

--- a/addons/website_sale/models/website_snippet_filter.py
+++ b/addons/website_sale/models/website_snippet_filter.py
@@ -146,7 +146,7 @@ class WebsiteSnippetFilter(models.Model):
             if current_template.exists():
                 excluded_products = website.sale_get_order().order_line.product_id.ids
                 excluded_products.extend(current_template.product_variant_ids.ids)
-                included_products = current_template.product_variant_ids.accessory_product_ids.filtered('website_published').ids
+                included_products = current_template._get_website_accessory_product(website).ids
                 products_ids = list(set(included_products) - set(excluded_products))
                 if products_ids:
                     domain = expression.AND([

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -682,10 +682,11 @@
 
     <template id="recommended_products" inherit_id="website_sale.product" customize_show="True" name="Alternative Products">
         <xpath expr="//div[@id='product_full_description']" position="after">
-            <div class="container mt32" t-if="product.alternative_product_ids">
+            <t t-set="alternative_products" t-value="product._get_website_alternative_product(website)"/>
+            <div class="container mt32" t-if="alternative_products">
                 <h3>Alternative Products:</h3>
                 <div class="row mt16" style="">
-                    <t t-foreach="product.alternative_product_ids" t-as="alt_product">
+                    <t t-foreach="alternative_products" t-as="alt_product">
                         <div class="col-lg-2" style="width: 170px; height:130px; float:left; display:inline; margin-right: 10px; overflow:hidden;">
                             <div class="mt16 text-center" style="height: 100%;">
                                 <t t-set="combination_info" t-value="alt_product._get_combination_info()"/>

--- a/addons/website_sale_comparison/views/website_sale_comparison_template.xml
+++ b/addons/website_sale_comparison/views/website_sale_comparison_template.xml
@@ -85,7 +85,7 @@
             -->
             <t t-set="product_variant" t-value="product_variant or product._create_first_product_variant()"/>
             <t t-set="id_list" t-value="[product_variant.id] if product_variant else []"/>
-            <t t-foreach="product.alternative_product_ids" t-as="alt_product">
+            <t t-foreach="product._get_website_alternative_product(website)" t-as="alt_product">
                 <t t-set="alt_product_variant_id" t-value="alt_product._create_first_product_variant().id"/>
                 <t t-if="alt_product_variant_id" t-set="id_list" t-value="id_list + [alt_product_variant_id]"/>
             </t>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
@JKE-be before this commit, some accessory from an other website can be access. And it use the generic `sale_product_domain()`.

In database with 2 websites 1 and 2, create a product A, with 2 accessories product B and C.
A and B are available in website 1
A and C are available in website 2

Go to website 1, add product A in the cart
--> issue you see B and C in the accessories page. You should see only the product B.

Note : It is a really rare case, but in custom project if you inherit `sale_product_domain()`, it is logical that it is apply everywhere.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
