### PR TITLE
[IMP]sms: resend sms

### DIFF
--- a/addons/sms/views/sms_sms_views.xml
+++ b/addons/sms/views/sms_sms_views.xml
@@ -7,7 +7,8 @@
             <form string="SMS">
                 <header>
                     <button name="send" string="Send Now" type="object" states='outgoing' class="oe_highlight"/>
-                    <button name="cancel" string="Cancel" type="object" states='outgoing'/>
+                    <button name="set_outgoing" string="Retry" type="object" states='error,canceled'/>
+                    <button name="cancel" string="Cancel" type="object" states='error,outgoing'/>
                     <field name="state" widget="statusbar"/>
                 </header>
                 <sheet>
@@ -33,7 +34,7 @@
         <field name="name">sms.sms.view.tree</field>
         <field name="model">sms.sms</field>
         <field name="arch" type="xml">
-            <tree string="SMS Templates">
+            <tree string="SMS Templates" decoration-muted="state == 'canceled'" decoration-info="state == 'outgoing'" decoration-danger="state == 'error'">
                 <field name="number"/>
                 <field name="partner_id"/>
                 <field name="state"/>
@@ -64,5 +65,13 @@
         action="sms_sms_action"
         sequence="1"/>
 
+    <record id="ir_actions_server_sms_sms_resend" model="ir.actions.server">
+        <field name="name">Resend</field>
+        <field name="model_id" ref="sms.model_sms_sms"/>
+        <field name="binding_model_id" ref="sms.model_sms_sms"/>
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="code">action = records.resend_failed()</field>
+    </record>
 </data>
 </odoo>

--- a/addons/sms/wizard/sms_resend_views.xml
+++ b/addons/sms/wizard/sms_resend_views.xml
@@ -29,7 +29,7 @@
                             attrs="{'invisible': [('has_unregistered_account', '=', False)]}"/>
                     <button string="Resend" name="action_resend" type="object" class="btn-primary o_mail_send"/>
                     <button string="Ignore all" name="action_cancel" type="object" class="btn-secondary" />
-                    <button string="Cancel" class="btn-secondary" special="cancel" />
+                    <button string="Discard" class="btn-secondary" special="cancel"/>
                 </footer>
             </form>
         </field>


### PR DESCRIPTION
    PURPOSE

    If the user send SMS automatically and doesn't pay
    attention that the sending of his SMS is failing,
    he has to go through each record one by one to
    resend the SMS. An action to resend all of the
    failed SMS in batch would ease the process.

    SPECIFICATION

    by sending SMS one by one is a heavy process if
    message in a bulk, and in the form view if the SMS
    failed there are no option to resend that message or
    put that message again in outgoing state.

    so for this problem we are adding a resend button in
    form view and it's visible only in error or canceled
    state, by clicking this the message will be in outgoing
    state so user can resend the message.

    and if there are lots of failed messages in the tree view
    than user can select the failed messages and from the tree view
    it can resend all the messages directly.

    Task Id:2465233

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
