### PR TITLE
[FIX] web: Optional field does not work consistently

### DIFF
--- a/addons/web/static/src/js/views/basic/basic_controller.js
+++ b/addons/web/static/src/js/views/basic/basic_controller.js
@@ -766,6 +766,7 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
      * @private
      */
     _onLoadOptionalFields: function (ev) {
+        ev.stopPropagation();
         var res = this.call(
             'local_storage',
             'getItem',


### PR DESCRIPTION
Currently, when we enable the optional field from the many2one dialog
then it is displayed in the parent listview but it does not work in
reverse scenario.

Scenario: Open CRM menu, go to any kanban record, open customer many2one,
make optional field enable from many2one select dialog, go to customer listview
from CRM menu, see listview, field will be there but it does not work reverse.
It happens because the event is bubbling up to its parents

This commit fixes the issue by stopping the event from bubbling up.

Task-Id: 2376304
