### PR TITLE
[FIX] mass_mailing: fix display condition of mass.mailing alert ribbon

### DIFF
--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -65,7 +65,7 @@
 
                         <field name="state" readonly="1" widget="statusbar"/>
                     </header>
-                    <div class="alert alert-info text-center" role="alert" attrs="{'invisible': ['|','&amp;','&amp;','&amp;',('state', '!=', 'in_queue'),('sent', '=', 0),('ignored', '=', 0),('scheduled', '=', 0),('failed', '=', 0)]}">
+                    <div class="alert alert-info text-center" role="alert" attrs="{'invisible': ['&amp;','&amp;','&amp;','&amp;',('state', '!=', 'in_queue'),('sent', '=', 0),('ignored', '=', 0),('scheduled', '=', 0),('failed', '=', 0)]}">
                         <div attrs="{'invisible': [('ignored', '=', 0)]}">
                             <button class="btn-link py-0"
                                     name="action_view_traces_ignored"


### PR DESCRIPTION
Oversight of 20b34ae867e927eba2951bd81d73661d21084d17

This commit fixes the display condition of the small alert block on top of the
mass.mailing form view.

The condition was not working because it would hide the alert if:
('failed', '=', 0)
OR (
  ('state', '!=', 'in_queue')
  AND
  ('sent', '=', 0)
  AND
  ('scheduled', '=', 0))

Instead, we want to hide it if:
('failed', '=', 0)
AND
('state', '!=', 'in_queue')
AND
('sent', '=', 0)
AND
('scheduled', '=', 0)

This would for example prevent showing that the mailing is "scheduled" or that
it has successfully been sent with various mailing statistics.

Task-2457227

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
