### PR TITLE
[FIX] tools: properly format error message

### DIFF
--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -992,7 +992,7 @@ class TranslationModuleReader:
             return
         self._to_translate.append((module, source, name, res_id, ttype, tuple(comments or ()), record_id))
 
-    def _get_translatable_records(self, records):
+    def _get_translatable_records(self, imd_records):
         """ Filter the records that are translatable
 
         A record is considered as untranslatable if:
@@ -1003,7 +1003,7 @@ class TranslationModuleReader:
 
         :param records: a list of namedtuple ImdInfo belonging to the same model
         """
-        model = next(iter(records)).model
+        model = next(iter(imd_records)).model
         if model not in self.env:
             _logger.error("Unable to find object %r", model)
             return self.env["_unknown"].browse()
@@ -1011,11 +1011,12 @@ class TranslationModuleReader:
         if not self.env[model]._translate:
             return self.env[model].browse()
 
-        res_ids = [r.res_id for r in records]
+        res_ids = [r.res_id for r in imd_records]
         records = self.env[model].browse(res_ids).exists()
         if len(records) < len(res_ids):
-            missing_ids = set(records.ids) - set(res_ids)
-            _logger.warning("Unable to find objects %r with id %d", model, ', '.join(missing_ids))
+            missing_ids = set(res_ids) - set(records.ids)
+            missing_records = [f"{r.module}.{r.name}" for r in imd_records if r.res_id in missing_ids]
+            _logger.warning("Unable to find records of type %r with external ids %s", model, ', '.join(missing_records))
             if not records:
                 return records
 


### PR DESCRIPTION
To reproduce:
1. take a translatable record with an external id
2. delete the record but keep the ir.model.data (sql)
3. export the translations of the module linked to the orphan
   ir.model.data

-> Error while formating the message

This commit fixes three issues:
- %d instead of %s to construct the string
- wrong order to identify the missing records
- display the external ids instead of the ids (which may not be very
  helpful to debug)

Courtesy of Yannick Brant
