### PR TITLE
[FIX] Fixed a usb timeout bug for the ESCPOS printer in hw_escpos.

### DIFF
--- a/addons/hw_escpos/escpos/printer.py
+++ b/addons/hw_escpos/escpos/printer.py
@@ -102,7 +102,7 @@ class Usb(Escpos):
             maxiterate += 1
             if maxiterate > 10000:
                 raise NoStatusError()
-            r = self.device.read(self.in_ep, 20, self.interface).tolist()
+            r = self.device.read(self.in_ep, 20).tolist()
             while len(r):
                 rep = r.pop()
         return rep


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The `hw_escpos` module, after trying to read status of faulty escpos hardware, would just hang indefinetally instead of giving an appropriate error. This seized all further communication with the printer.

Current behavior before PR:

The hardware module `hw_escpos` attempts to read the usb device, but passes `self.interface` where a timeout value is expected in miliseconds. Given that the value of `self.interface` is often `0`, it could cause the read operation to wait forever, as that is what a timeout value of `0` is intended to do.

Desired behavior after PR is merged:

Reading the printer status of faulty hardware now throws an `USBTimeoutError`, so that the error is actually apparent.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
