### PR TITLE
[FIX] Added a workaround in which Sam4s escpos printers don't read th…

### DIFF
--- a/addons/hw_escpos/escpos/escpos.py
+++ b/addons/hw_escpos/escpos/escpos.py
@@ -907,7 +907,10 @@ class Escpos:
         else:
             raise CashDrawerError()
 
-        self.get_printer_status()
+        # For some reason, some Sam4s model(s) (e.g. the Ellix30IIIS) break when reading its status.
+        # So as a workaround, lets work around this workaround.
+        if self.idVendor != 0x1c8a:
+            self.get_printer_status()
 
     def hw(self, hw):
         """ Hardware operations """


### PR DESCRIPTION
…e printer status, which was a workaround in itself anyway. Some Sam4s printers don't handle reading the printer status very well.

Related to issue: https://github.com/odoo/odoo/issues/66941

Description of the issue/feature this PR addresses:
There is a workaround made for some printers, which is explained in the issue above. Sam4s printers don't handle this workaround very well, so the workaround is skipped for those printers.

Current behavior before PR:
The existing workaround fails for Sam4s ellix30iiis printers. Moreover, the printer itself stops responding after that, until you restart it. But that is a hardware related issue, not that of odoo.

Desired behavior after PR is merged:
The workaround is not executed for Sam4s printers, preventing any failure on the hardware side.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
