### PR TITLE
[FIX] stock: allow destination address change in transfer

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -442,12 +442,12 @@ class Picking(models.Model):
 
     @api.onchange('partner_id')
     def onchange_partner_id(self):
-        for picking in self:
-            picking_id = isinstance(picking.id, int) and picking.id or getattr(picking, '_origin', False) and picking._origin.id
+        if self.partner_id:
+            picking_id = isinstance(self.id, int) and self.id or getattr(self, '_origin', False) and self._origin.id
             if picking_id:
                 moves = self.env['stock.move'].search([('picking_id', '=', picking_id)])
                 for move in moves:
-                    move.write({'partner_id': picking.partner_id.id})
+                    move.write({'partner_id': self.partner_id.id})
 
     @api.onchange('picking_type_id', 'partner_id')
     def onchange_picking_type(self):


### PR DESCRIPTION
Fine tuning of
b730d42e37275fd891fa0a3fd4a8ec1a4f95f3cf
In v12 _origin is not available while iterating on
the original recordset

opw-2429018

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
