### PR TITLE
[IMP] calendar:change in action_mass_mailing button's string EMAIl to…

### DIFF
--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -122,7 +122,7 @@
                                 class="oe_inline o_calendar_attendees"
                             />
                             <div name="send_buttons">
-                                <button name="action_mass_mailing" help="Send Email to attendees" type="object" string=" EMAIl" icon="fa-envelope"/>
+                                <button name="action_mass_mailing" help="Send Email to attendees" type="object" string=" EMAIL" icon="fa-envelope"/>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
In calendar module there is one mistake in action_mass_mailing button's string.
So, old string is 'EMAIl' and I have changed string to 'EMAIL'.

**Task-id** :- 2478549
=
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
