### PR TITLE
[FIX] mass_mailing typo that broke ensure_one down the line

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -737,7 +737,7 @@ class MassMailing(models.Model):
 
             mail_values = {
                 'subject': _('24H Stats of %(mailing_type)s "%(mailing_name)s"',
-                             mailing_type=self._get_pretty_mailing_type(),
+                             mailing_type=mailing._get_pretty_mailing_type(),
                              mailing_name=mailing.subject
                             ),
                 'email_from': user.email_formatted,


### PR DESCRIPTION
Sometimes it crashed when the domain used for the mailing cron
returned more than one record

source commit: 1738f9c8f7188ac4f6e50f771c78905bd3d9396b

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
