### PR TITLE
[IMP] point_of_sale: Electronic payment cancel might fail

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -318,10 +318,11 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
         async _sendPaymentCancel({ detail: line }) {
             const payment_terminal = line.payment_method.payment_terminal;
             line.set_payment_status('waitingCancel');
-            try {
-                payment_terminal.send_payment_cancel(this.currentOrder, line.cid);
-            } finally {
+            const isCancelSuccessful = await payment_terminal.send_payment_cancel(this.currentOrder, line.cid);
+            if (isCancelSuccessful) {
                 line.set_payment_status('retry');
+            } else {
+                line.set_payment_status('waitingCard');
             }
         }
         async _sendPaymentReverse({ detail: line }) {


### PR DESCRIPTION
With Worldline, the cancel command fails when the card was already inserted.

TaskID: 2415526

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
