### PR TITLE
[FIX] stock: Resupply Subcontractor on Order

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -709,6 +709,10 @@ class StockMove(models.Model):
         """Cleanup hook used when merging moves"""
         self.write({'propagate_cancel': False})
 
+    def _keep_subcontract_moves(self):
+        pass
+
+
     def _merge_moves(self, merge_into=False):
         """ This method will, for each move in `self`, go up in their linked picking and try to
         find in their existing moves a candidate into which we can merge the move.
@@ -746,6 +750,7 @@ class StockMove(models.Model):
             moves_to_unlink |= moves[1:]
 
         if moves_to_unlink:
+            moves_to_unlink._keep_subcontract_moves()
             # We are using propagate to False in order to not cancel destination moves merged in moves[0]
             moves_to_unlink._clean_merged()
             moves_to_unlink._action_cancel()


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider a consumable product P with a subcontracted BOM B
- Let's consider that B is subcontracted by a partner S and B has a storable component C
- C has the route Resupply Subcontractor on Order and has a partner SUP as supplier
- Create a purchase order PO with 1 P to S and confirm PO
- A delivery order DO1 is created with C to S
- Change the ordered quantity on PO and set 2 instead of 1

Bug:

DO1 was canceled and a new delivery order DO2 was created with only 1 C instead of 2

With this fix, DO2 is created with 1 C and DO1 is kept.

opw:2419222

Co-authored-by: Kristoffer