### PR TITLE
[FIX] purchase_product_matrix: fix product onchange on PO form

### DIFF
--- a/addons/purchase_product_matrix/static/src/js/product_matrix_configurator.js
+++ b/addons/purchase_product_matrix/static/src/js/product_matrix_configurator.js
@@ -96,15 +96,11 @@ var MatrixConfiguratorWidget = relationalFields.FieldMany2One.extend({
      * before calling super.
      *
      * @override
-     * @private
      */
-    _onFieldChanged: function (ev) {
-        var self = this;
-
-        this._super.apply(this, arguments);
-
-        if (ev.data.changes && ev.data.changes.product_template_id && ev.data.changes.product_template_id.id) {
-            self._onTemplateChange(ev.data.changes.product_template_id.id, ev.data.dataPointID);
+    reset: async function (record, ev) {
+        await this._super(...arguments);
+        if (ev.data.changes && ev.data.changes.product_template_id && record.data.product_template_id.data.id) {
+            this._onTemplateChange(record.data.product_template_id.data.id, ev.data.dataPointID);
         }
     },
 

--- a/addons/purchase_product_matrix/static/tests/section_and_note_widget_tests.js
+++ b/addons/purchase_product_matrix/static/tests/section_and_note_widget_tests.js
@@ -172,5 +172,40 @@ QUnit.module('section_and_note: purchase_product_matrix', {
 
         form.destroy();
     });
+
+    QUnit.test('_onTemplateChange is executed after product template quick create', async function (assert) {
+        assert.expect(1);
+
+        let created_product_template;
+
+        const form = await createView({
+            View: FormView,
+            model: 'purchase_order',
+            data: this.data,
+            arch: `<form>
+                    <field name="order_line_ids" widget="section_and_note_one2many">
+                        <tree editable="bottom">
+                            <field name="product_template_id" widget="matrix_configurator"/>
+                        </tree>
+                    </field>
+                </form>`,
+            async mockRPC(route, args) {
+                if (route === '/web/dataset/call_kw/product.template/get_single_product_variant') {
+                    assert.strictEqual(args.args[0], created_product_template[0]);
+                }
+
+                const result = await this._super(...arguments);
+                if (args.method === 'name_create') {
+                    created_product_template = result;
+                }
+                return result;
+            },
+        });
+
+        await testUtils.dom.click('.o_field_x2many_list_row_add a');
+        await testUtils.fields.many2one.searchAndClickItem("product_template_id", {search: 'new product'});
+
+        form.destroy();
+    });
 });
 });


### PR DESCRIPTION
- Install purchase_product_matrix
- Go to Purchase and create a PO
- In PO Line, type a text (i.e. test) in product field and use quick create option
Description and UoM fields should be updated following product creation, but they are not.
"onchange_product_id" is not triggered.

"purchase_product_matrix" module overrides "purchase.order" form view by replacing product_id
field by product_template_id field.
"_onFieldChanged" function should execute "_onTemplateChange" when product_template_id is changed
and if id is set, which would trigger "field_changed" on product_id, but it cannot be done after
a quick create as id is false.

opw-2462538

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
