### PR TITLE
[IMP] web_editor: update color picker layout

### DIFF
--- a/addons/web/static/src/legacy/js/widgets/colorpicker.js
+++ b/addons/web/static/src/legacy/js/widgets/colorpicker.js
@@ -187,6 +187,12 @@ var ColorpickerWidget = Widget.extend({
      * @param {integer} [a]
      */
     _updateRgba: function (r, g, b, a) {
+        // Remove full transparency in case some lightness is added
+        const opacity = a || this.colorComponents.opacity;
+        if (opacity < 0.1 && (r > 0.1 || g > 0.1 || b > 0.1)) {
+            a = 100;
+        }
+
         // We update the hexadecimal code by transforming into a css color and
         // ignoring the opacity (we don't display opacity component in hexa as
         // not supported on all browsers)
@@ -211,6 +217,12 @@ var ColorpickerWidget = Widget.extend({
      * @param {integer} l
      */
     _updateHsl: function (h, s, l) {
+        // Remove full transparency in case some lightness is added
+        let a = this.colorComponents.opacity;
+        if (a < 0.1 && l > 0.1) {
+            a = 100;
+        }
+
         var rgb = ColorpickerWidget.convertHslToRgb(h, s, l);
         if (!rgb) {
             return;
@@ -220,7 +232,8 @@ var ColorpickerWidget = Widget.extend({
         _.extend(this.colorComponents,
             {hue: h, saturation: s, lightness: l},
             rgb,
-            {hex: hex}
+            {hex: hex},
+            {opacity: a},
         );
         this._updateCssColor();
     },

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -1438,6 +1438,9 @@ const ColorpickerUserValueWidget = SelectUserValueWidget.extend({
         if (this.options.dataAttributes.withCombinations) {
             options.withCombinations = !!this.options.dataAttributes.withCombinations;
         }
+        if (this.options.dataAttributes.selectedTab) {
+            options.selectedTab = this.options.dataAttributes.selectedTab;
+        }
         const oldColorPalette = this.colorPalette;
         this.colorPalette = new ColorPaletteWidget(this, options);
         if (oldColorPalette) {

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
@@ -38,7 +38,6 @@ const ColorPaletteWidget = Widget.extend({
      */
     init: function (parent, options) {
         this._super.apply(this, arguments);
-        this.customColorsArray = [].concat(...customColors);
         this.style = window.getComputedStyle(document.documentElement);
         this.options = _.extend({
             selectedColor: false,
@@ -254,9 +253,7 @@ const ColorPaletteWidget = Widget.extend({
             return;
         }
         this.el.querySelectorAll('.o_custom_color').forEach(el => el.remove());
-        const existingColors = new Set(this.customColorsArray.concat(
-            Object.keys(this.colorToColorNames)
-        ));
+        const existingColors = new Set(Object.keys(this.colorToColorNames));
         this.trigger_up('get_custom_colors', {
             onSuccess: (colors) => {
                 colors.forEach(color => {

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
@@ -47,6 +47,7 @@ const ColorPaletteWidget = Widget.extend({
             excludeSectionOf: null,
             $editable: $(),
             withCombinations: false,
+            selectedTab: 'theme-colors',
         }, options || {});
 
         this.selectedColor = '';
@@ -129,13 +130,21 @@ const ColorPaletteWidget = Widget.extend({
                 this.pickers[pickerId] = pickerEl;
             });
 
-            // Hide section and associated button if empty
+            // If the section is empty, hide it and
+            // select the next tab if none is given in the options
             if (sectionIsEmpty) {
                 sectionEl.classList.add('d-none');
                 switchPaneButtons[index].classList.add('d-none');
+                if (this.options.selectedTab === tab.id) {
+                    this.options.selectedTab = this.tabs[(index + 1) % this.tabs.length].id;
+                }
             }
             this.sections[tab.id] = sectionEl;
         });
+
+        // Switch to the correct tab
+        const selectedButtonIndex = this.tabs.map(tab => tab.id).indexOf(this.options.selectedTab);
+        this._selectTabFromButton(this.el.querySelectorAll('button')[selectedButtonIndex]);
 
         // Remove the buttons display if there is only one
         const visibleButtons = Array.from(switchPaneButtons).filter(button => !button.classList.contains('d-none'));
@@ -358,6 +367,18 @@ const ColorPaletteWidget = Widget.extend({
             selectedButton.classList.add('selected');
         }
     },
+    /**
+     * Display button element as selected
+     *
+     * @private
+     * @param {HTMLElement} buttonEl
+     */
+     _selectTabFromButton(buttonEl) {
+        buttonEl.classList.add('active');
+        this.el.querySelectorAll('.o_colorpicker_sections').forEach(el => {
+            el.classList.toggle('d-none', el.dataset.colorTab !== buttonEl.dataset.target);
+        });
+    },
 
     //--------------------------------------------------------------------------
     // Handlers
@@ -430,10 +451,7 @@ const ColorPaletteWidget = Widget.extend({
         this.el.querySelectorAll('.o_we_colorpicker_switch_pane_btn').forEach(el => {
             el.classList.remove('active');
         });
-        ev.currentTarget.classList.add('active');
-        this.el.querySelectorAll('.o_colorpicker_sections').forEach(el => {
-            el.classList.toggle('d-none', el.dataset.colorTab !== ev.currentTarget.dataset.target);
-        });
+        this._selectTabFromButton(ev.currentTarget);
     },
 });
 

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
@@ -54,6 +54,25 @@ const ColorPaletteWidget = Widget.extend({
         this.withCombinations = this.options.withCombinations;
 
         this.trigger_up('request_editable', {callback: val => this.options.$editable = val});
+
+        this.tabs = [{
+            id: 'theme-colors',
+            pickers: [
+                'theme',
+                'common',
+            ],
+        },
+        {
+            id: 'custom-colors',
+            pickers: [
+                'custom',
+                'transparent_grayscale',
+                'common_grays',
+            ],
+        }];
+
+        this.sections = {};
+        this.pickers = {};
     },
     /**
      * @override
@@ -68,10 +87,61 @@ const ColorPaletteWidget = Widget.extend({
     start: async function () {
         const res = this._super.apply(this, arguments);
 
-        const $colorSection = this.$('.o_colorpicker_sections[data-color-tab="theme-colors"]');
-        const $clpicker = $(colorpickerArch || `<colorpicker><div class="o_colorpicker_section" data-name="common"></div></colorpicker>`);
-        $clpicker.find('button').addClass('o_we_color_btn');
-        $clpicker.appendTo($colorSection);
+        const switchPaneButtons = this.el.querySelectorAll('.o_we_colorpicker_switch_pane_btn');
+
+        let colorpickerEl;
+        if (colorpickerArch) {
+            colorpickerEl = $(colorpickerArch)[0];
+        } else {
+            colorpickerEl = document.createElement("colorpicker");
+            const sectionEl = document.createElement('DIV');
+            sectionEl.classList.add('o_colorpicker_section');
+            sectionEl.dataset.name = 'common';
+            colorpickerEl.appendChild(sectionEl);
+        }
+        colorpickerEl.querySelectorAll('button').forEach(el => el.classList.add('o_we_color_btn'));
+
+        // Populate tabs based on the tabs configuration indicated in this.tabs
+        _.each(this.tabs, (tab, index) => {
+            // Append pickers to section
+            const sectionEl = this.el.querySelector(`.o_colorpicker_sections[data-color-tab="${tab.id}"]`);
+            let sectionIsEmpty = true;
+            _.each(tab.pickers, pickerId => {
+                let pickerEl;
+                switch (pickerId) {
+                    case 'common_grays':
+                        pickerEl = colorpickerEl.querySelector('[data-name="common"]').cloneNode(true);
+                        break;
+                    case 'custom':
+                        pickerEl = document.createElement('DIV');
+                        pickerEl.classList.add("o_colorpicker_section");
+                        pickerEl.dataset.name = 'custom';
+                        break;
+                    default:
+                        pickerEl = colorpickerEl.querySelector(`[data-name="${pickerId}"]`).cloneNode(true);
+                }
+                sectionEl.appendChild(pickerEl);
+
+                if (!this.options.excluded.includes(pickerId)) {
+                    sectionIsEmpty = false;
+                }
+
+                this.pickers[pickerId] = pickerEl;
+            });
+
+            // Hide section and associated button if empty
+            if (sectionIsEmpty) {
+                sectionEl.classList.add('d-none');
+                switchPaneButtons[index].classList.add('d-none');
+            }
+            this.sections[tab.id] = sectionEl;
+        });
+
+        // Remove the buttons display if there is only one
+        const visibleButtons = Array.from(switchPaneButtons).filter(button => !button.classList.contains('d-none'));
+        if (visibleButtons.length === 1) {
+            visibleButtons[0].classList.add('d-none');
+        }
 
         // Remove excluded palettes (note: only hide them to still be able
         // to remove their related colors on the DOM target)
@@ -88,12 +158,11 @@ const ColorPaletteWidget = Widget.extend({
 
         // Render common colors
         if (!this.options.excluded.includes('common')) {
-            const $commonColorSection = this.$('[data-name="common"]');
             customColors.forEach((colorRow, i) => {
                 if (i === 0) {
                     return; // Ignore the wysiwyg gray palette and use ours
                 }
-                const $div = $('<div/>', {class: 'clearfix'}).appendTo($commonColorSection);
+                const $div = $('<div/>', {class: 'clearfix'}).appendTo(this.pickers['common']);
                 colorRow.forEach(color => {
                     $div.append(this._createColorButton(color, ['o_common_color']));
                 });
@@ -144,7 +213,7 @@ const ColorPaletteWidget = Widget.extend({
             this.colorPicker = new ColorpickerWidget(this, {
                 defaultColor: defaultColor,
             });
-            await this.colorPicker.prependTo($colorSection);
+            await this.colorPicker.appendTo(this.sections['custom-colors']);
         }
 
         return res;
@@ -230,9 +299,8 @@ const ColorPaletteWidget = Widget.extend({
      */
     _addCustomColorButton: function (color, classes = []) {
         classes.push('o_custom_color');
-        const $themeSection = this.$('.o_colorpicker_section[data-name="theme"]');
         const $button = this._createColorButton(color, classes);
-        return $button.appendTo($themeSection);
+        return $button.appendTo(this.pickers['custom']);
     },
     /**
      * Return a color button.

--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -78,6 +78,8 @@ $o-we-zindex: $o-we-overlay-zindex + 1 !default;
             bottom: 100%;
             margin-top: 0;
             margin-bottom: 0.125rem;
+            min-width: 222px !important;
+            height: auto !important;
         }
     }
     .dropdown-toggle::after {

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -1655,6 +1655,7 @@ body.editor_enable.editor_has_snippets {
     color: $o-we-sidebar-content-field-colorpicker-dropdown-color;
 
     .o_we_colorpicker_switch_panel {
+        font-size: $o-we-font-size;
         border-bottom: 1px solid $o-we-bg-dark;
         box-shadow: inset 0 1px 0 rgba(white, .2);
     }
@@ -1667,6 +1668,13 @@ body.editor_enable.editor_has_snippets {
         @extend %we-generic-button;
     }
     .o_colorpicker_sections {
+        > * {
+            padding-top: $o-we-sidebar-content-field-spacing;
+            &:first-child {
+                padding-top: 0;
+            }
+        }
+
         .o_colorpicker_widget {
             .o_hex_div, .o_rgba_div  {
                 &:focus-within {
@@ -1744,8 +1752,6 @@ body.editor_enable.editor_has_snippets {
             }
         }
         .o_colorpicker_section {
-            padding-top: $o-we-sidebar-content-field-spacing;
-
             &::after {
                 content: "";
                 display: table;
@@ -1766,7 +1772,7 @@ body.editor_enable.editor_has_snippets {
                 }
             }
 
-            &[data-name="transparent_grayscale"], &[data-name="theme"], &[data-name="reset"] {
+            &[data-name="transparent_grayscale"], &[data-name="theme"], &[data-name="reset"], &[data-name="custom"] {
                 .o_we_color_btn {
                     @extend %o-preview-alpha-background;
 

--- a/addons/web_editor/static/src/xml/editor.xml
+++ b/addons/web_editor/static/src/xml/editor.xml
@@ -60,7 +60,7 @@
                         data-original-title="Font Color">
                         <i class="fa fa-font color-indicator fore-color"></i>
                     </div>
-                    <ul class="dropdown-menu colorpicker-menu" style="min-width: 172px;">
+                    <ul class="dropdown-menu colorpicker-menu">
                         <li><div data-event-name="foreColor" class="colorPalette"></div></li>
                     </ul>
                 </div>
@@ -70,7 +70,7 @@
                         data-original-title="Background Color">
                         <i class="fa fa-paint-brush color-indicator hilite-color"></i>
                     </button>
-                    <ul class="dropdown-menu colorpicker-menu" style="min-width: 172px;">
+                    <ul class="dropdown-menu colorpicker-menu">
                         <li><div data-event-name="backColor" class="colorPalette"></div></li>
                     </ul>
                 </div>

--- a/addons/web_editor/static/src/xml/snippets.xml
+++ b/addons/web_editor/static/src/xml/snippets.xml
@@ -47,14 +47,12 @@
     <!-- options -->
     <div t-name="web_editor.snippet.option.colorpicker" class="colorpicker">
         <div class="o_we_colorpicker_switch_panel d-flex justify-content-end px-2">
-            <t t-if="widget.withCombinations">
-                <button type="button" tabindex="1" class="o_we_colorpicker_switch_pane_btn active" data-target="color-combinations">
-                    <span>Combinations</span>
-                </button>
-                <button type="button" tabindex="2" t-attf-class="o_we_colorpicker_switch_pane_btn #{widget.withCombinations ? '' : 'active'}" data-target="theme-colors">
-                    <span>Custom</span>
-                </button>
-            </t>
+            <button type="button" tabindex="1" class="o_we_colorpicker_switch_pane_btn active" t-attf-data-target="#{widget.withCombinations? 'color-combinations' : 'theme-colors'}">
+                <span>Theme</span>
+            </button>
+            <button type="button" tabindex="2" class="o_we_colorpicker_switch_pane_btn" data-target="custom-colors">
+                <span>Custom</span>
+            </button>
             <button t-if="widget.resetButton" type="button" class="my-1 ml-auto o_we_color_btn o_colorpicker_reset">
                 <t t-if="widget.withCombinations">None</t>
                 <t t-else="">Reset</t>
@@ -69,6 +67,7 @@
             </t>
         </div>
         <div t-attf-class="o_colorpicker_sections #{widget.withCombinations ? 'd-none' : ''} py-3 px-2 bg-black-25" data-color-tab="theme-colors"/>
+        <div class="o_colorpicker_sections d-none py-3 px-2 bg-black-25" data-color-tab="custom-colors"/>
     </div>
     <t t-name="web_editor.colorpalette.combination.btn">
         <button type="button" class="o_we_color_btn o_we_color_combination_btn"

--- a/addons/web_editor/static/src/xml/snippets.xml
+++ b/addons/web_editor/static/src/xml/snippets.xml
@@ -47,7 +47,7 @@
     <!-- options -->
     <div t-name="web_editor.snippet.option.colorpicker" class="colorpicker">
         <div class="o_we_colorpicker_switch_panel d-flex justify-content-end px-2">
-            <button type="button" tabindex="1" class="o_we_colorpicker_switch_pane_btn active" t-attf-data-target="#{widget.withCombinations? 'color-combinations' : 'theme-colors'}">
+            <button type="button" tabindex="1" class="o_we_colorpicker_switch_pane_btn" t-attf-data-target="#{widget.withCombinations? 'color-combinations' : 'theme-colors'}">
                 <span>Theme</span>
             </button>
             <button type="button" tabindex="2" class="o_we_colorpicker_switch_pane_btn" data-target="custom-colors">
@@ -58,7 +58,7 @@
                 <t t-else="">Reset</t>
             </button>
         </div>
-        <div t-attf-class="o_colorpicker_sections #{widget.withCombinations ? '' : 'd-none'} pt-2 px-2 pb-3 bg-black-25" data-color-tab="color-combinations">
+        <div class="o_colorpicker_sections pt-2 px-2 pb-3 bg-black-25" data-color-tab="color-combinations">
             <!-- List all Presets -->
             <t t-foreach="5" t-as="i">
                 <t t-call="web_editor.colorpalette.combination.btn">
@@ -66,8 +66,8 @@
                 </t>
             </t>
         </div>
-        <div t-attf-class="o_colorpicker_sections #{widget.withCombinations ? 'd-none' : ''} py-3 px-2 bg-black-25" data-color-tab="theme-colors"/>
-        <div class="o_colorpicker_sections d-none py-3 px-2 bg-black-25" data-color-tab="custom-colors"/>
+        <div class="o_colorpicker_sections py-3 px-2 bg-black-25" data-color-tab="theme-colors"/>
+        <div class="o_colorpicker_sections py-3 px-2 bg-black-25" data-color-tab="custom-colors"/>
     </div>
     <t t-name="web_editor.colorpalette.combination.btn">
         <button type="button" class="o_we_color_btn o_we_color_combination_btn"

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -1092,16 +1092,16 @@
         <we-row class="o_we_theme_colors_selector">
             <we-colorpicker data-name="color_1_opt" title="Primary"
                             data-customize-website-color="" data-color="o-color-1"
-                            data-use-css-color="true"/>
+                            data-use-css-color="true" data-selected-tab="custom-colors"/>
             <we-colorpicker data-name="color_2_opt" title="Secondary"
                             data-customize-website-color="" data-color="o-color-2"
-                            data-use-css-color="true"/>
+                            data-use-css-color="true" data-selected-tab="custom-colors"/>
             <we-colorpicker data-customize-website-color="" data-color="o-color-3"
-                            data-use-css-color="true"/>
+                            data-use-css-color="true" data-selected-tab="custom-colors"/>
             <we-colorpicker data-customize-website-color="" data-color="o-color-4"
-                            data-use-css-color="true"/>
+                            data-use-css-color="true" data-selected-tab="custom-colors"/>
             <we-colorpicker data-customize-website-color="" data-color="o-color-5"
-                            data-use-css-color="true"/>
+                            data-use-css-color="true" data-selected-tab="custom-colors"/>
             <we-select data-icon="fa-lightbulb-o" class="o_we_theme_colors_select" data-variable="color-palettes-name"/>
         </we-row>
     </div>
@@ -1216,10 +1216,10 @@
         </we-collapse>
 
         <we-row string="Status Colors">
-            <we-colorpicker title="Success" data-customize-website-color="" data-color-type="theme" data-color="success"/>
-            <we-colorpicker title="Info" data-customize-website-color="" data-color-type="theme" data-color="info"/>
-            <we-colorpicker title="Warning" data-customize-website-color="" data-color-type="theme" data-color="warning"/>
-            <we-colorpicker title="Error" data-customize-website-color="" data-color-type="theme" data-color="danger"/>
+            <we-colorpicker title="Success" data-customize-website-color="" data-color-type="theme" data-color="success" data-selected-tab="custom-colors"/>
+            <we-colorpicker title="Info" data-customize-website-color="" data-color-type="theme" data-color="info" data-selected-tab="custom-colors"/>
+            <we-colorpicker title="Warning" data-customize-website-color="" data-color-type="theme" data-color="warning" data-selected-tab="custom-colors"/>
+            <we-colorpicker title="Error" data-customize-website-color="" data-color-type="theme" data-color="danger" data-selected-tab="custom-colors"/>
         </we-row>
         <we-collapse>
             <we-row string="Grays" class="o_we_gray_preview o_we_collapse_toggler">


### PR DESCRIPTION
In order to save space & gain clarity, the color picker is now
displaying two separate tabs : "theme" and "custom".
It is still possible to display the combinations tab instead of the
theme to update buttons and backgrounds.

task-2476601


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
