### PR TITLE
[IMP] website: make images wall editable

### DIFF
--- a/addons/website/static/src/snippets/s_image_gallery/options.js
+++ b/addons/website/static/src/snippets/s_image_gallery/options.js
@@ -17,9 +17,6 @@ options.registry.gallery = options.Class.extend({
     start: function () {
         var self = this;
 
-        // The snippet should not be editable
-        this.$target.addClass('o_fake_not_editable').attr('contentEditable', false);
-
         // Make sure image previews are updated if images are changed
         this.$target.on('image_changed', 'img', function (ev) {
             var $img = $(ev.currentTarget);


### PR DESCRIPTION
The goal of this commit is to make the Images Wall/Gallery snippet
editable to be able to open the media dialog on "double-click"
on images.

Backport from https://github.com/odoo/odoo/pull/66544
