### PR TITLE
[FIX] website: restore mobile visibility snippet option

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -2588,21 +2588,6 @@ options.registry.ScrollButton = options.Class.extend({
     },
 });
 
-options.registry.MobileVisibility = options.Class.extend({
-
-    //--------------------------------------------------------------------------
-    // Private
-    //--------------------------------------------------------------------------
-
-    /**
-     * @override
-     */
-    async _computeVisibility() {
-        // Same as default but overridden by other apps
-        return true;
-    },
-});
-
 return {
     UrlPickerUserValueWidget: UrlPickerUserValueWidget,
     FontFamilyPickerUserValueWidget: FontFamilyPickerUserValueWidget,


### PR DESCRIPTION
Conflict between a fix in 14.0 (see [1]) and an improvement in master
(see [2]) broke the feature (because both introducing a JS option for
the feature).

[1]: https://github.com/odoo/odoo/commit/9463f0f889f9dd8da6077895c125da4998a933c0
[2]: https://github.com/odoo/odoo/commit/25173a4c29b57a01cbe415de439f2da0f4760507
