### PR TITLE
[FIX] accounting: fix the creation of the first sample vendor bill during the tour

### DIFF
--- a/addons/account/wizard/account_tour_upload_bill.py
+++ b/addons/account/wizard/account_tour_upload_bill.py
@@ -63,9 +63,9 @@ class AccountTourUploadBill(models.TransientModel):
                 'res_model': 'mail.compose.message',
                 'datas': self.sample_bill_preview,
             })
-            bill = purchase_journal.with_context(default_journal_id=purchase_journal.id, default_move_type='in_invoice').create_invoice_from_attachment(attachment.ids)
-            if self.selection == 'sample':
-                bill.write({
+            bill_action = purchase_journal.with_context(default_journal_id=purchase_journal.id, default_move_type='in_invoice').create_invoice_from_attachment(attachment.ids)
+            bill = self.env['account.move'].browse(bill_action['res_id'])
+            bill.write({
                     'partner_id': self.env.ref('base.main_partner').id,
                     'ref': 'INV/2020/0011'
                 })


### PR DESCRIPTION
Steps to follow to reproduce the bug:
-In V14
-Go to accounting
-In the tour, click on Create First Bill
-Choose ‘Try a sample vendor bill’ and click on continue
-an error is triggered

Problem:
The returned  value of ”create_invoice_from_attachment” method is treated as an “account.move” recordset, but it is a dict used for ‘ir.actions.act_window'

Solution:
We retrieve the ‘account.move’ from the ‘res_id’ found in the dict.

The issue was introduced by this commit : https://github.com/odoo/odoo/commit/8435d0e8990509ee67425977f970ab27bea8133a

opw-2469567

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
