### PR TITLE
[FIX] (google,microsoft)_calendar: Fix call to unexisting methods

### DIFF
--- a/addons/google_calendar/static/src/xml/google_calendar_popover.xml
+++ b/addons/google_calendar/static/src/xml/google_calendar_popover.xml
@@ -2,7 +2,7 @@
 <templates>
     <t t-extend="Calendar.attendee.status.popover">
         <t t-jquery=".o_cw_popover_edit" t-operation="after">
-            <a t-if="widget.isGEventSyncedAndArchivable() and widget.isEventDetailsVisible()" href="#" class="btn btn-secondary o_cw_popover_archive_g">Archive</a>
+            <a t-if="typeof widget.isGEventSyncedAndArchivable === 'function' and widget.isGEventSyncedAndArchivable() and widget.isEventDetailsVisible()" href="#" class="btn btn-secondary o_cw_popover_archive_g">Archive</a>
         </t>
     </t>
 </templates>

--- a/addons/microsoft_calendar/static/src/xml/microsoft_calendar_popover.xml
+++ b/addons/microsoft_calendar/static/src/xml/microsoft_calendar_popover.xml
@@ -2,7 +2,7 @@
 <templates>
     <t t-extend="Calendar.attendee.status.popover">
         <t t-jquery=".o_cw_popover_edit" t-operation="after">
-            <a t-if="widget.isMEventSyncedAndArchivable() and widget.isEventDetailsVisible()" href="#" class="btn btn-secondary o_cw_popover_archive_m">Archive</a>
+            <a t-if="typeof widget.isMEventSyncedAndArchivable === 'function' and widget.isMEventSyncedAndArchivable() and widget.isEventDetailsVisible()" href="#" class="btn btn-secondary o_cw_popover_archive_m">Archive</a>
         </t>
     </t>
 </templates>


### PR DESCRIPTION
Introduced at https://github.com/odoo/odoo/pull/65539

Purpose
=======

The dynamic xml files (introducing the inheriting templates) are automatically
updated.

However, the JS files are introduced by adding them to the assets (which is
not respecting the stable policy), and require a module update to introduce
those files.

As the dynamic templates use JS methods that are not included in the assets,
this leads to a traceback.

Reverting the commit wouldn't prevent tracebacks according to the situation
of the customer (up to date or not and/or updated or no).

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
