### PR TITLE
[FIX] website_sale: only show products of the current companies

### DIFF
--- a/addons/website_sale/models/website_visitor.py
+++ b/addons/website_sale/models/website_visitor.py
@@ -21,7 +21,10 @@ class WebsiteVisitor(models.Model):
     @api.depends('website_track_ids')
     def _compute_product_statistics(self):
         results = self.env['website.track'].read_group(
-            [('visitor_id', 'in', self.ids), ('product_id', '!=', False)], ['visitor_id', 'product_id'], ['visitor_id', 'product_id'], lazy=False)
+            [('visitor_id', 'in', self.ids), ('product_id', '!=', False),
+             '|', ('product_id.company_id', 'in', self.env.companies.ids), ('product_id.company_id', '=', False)],
+            ['visitor_id', 'product_id'], ['visitor_id', 'product_id'],
+            lazy=False)
         mapped_data = {}
         for result in results:
             visitor_info = mapped_data.get(result['visitor_id'][0], {'product_count': 0, 'product_ids': set()})


### PR DESCRIPTION
Steps:
- Create a second company
- Go to Website > Products > Products
- Create a product for all companies
- Click the "Go to Website" smart button
- Click "Edit in Backend" in the top-right corner
- Change the product's company to the one you're not on
- Go to Visitors > Visitors

Bug:
Access Error:
The requested operation ("read" on "Product" (product.product)) was
rejected because of the following rules:

(Records: Two prod (id=42), User: Mitchell Admin (id=2))

Explanation:
It happens because of the rule `product_comp_rule` which prevents
reading a product from a different company.
This commit filters the visited products on the current companies.

opw:2467138