### PR TITLE
[FIX] web_editor: show mimemtype warning for illustrations

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -228,7 +228,7 @@ class Web_Editor(http.Controller):
             # Find attachment by url. There can be multiple matches because of default
             # snippet images referencing the same image in /static/, so we limit to 1
             attachment = request.env['ir.attachment'].search([
-                ('url', '=like', src),
+                '|', ('url', '=like', src), ('url', '=like', '%s?%%' % src),
                 ('mimetype', 'in', SUPPORTED_IMAGE_MIMETYPES),
             ], limit=1)
         if not attachment:


### PR DESCRIPTION
Previously, when clicking on an illustration in the editor, the image
options would be unavailable with a message saying that it was due to
technical limitations, and that the user should reselect the image in
the media-dialog for quality options to become available. This was
caused by the fact that in order to support more than one customizable
color in illustrations, they are now saved inside the database with an
url containing which colors are customizable inside the url's query
parameters. Since the endpoint that finds which attachment corresponds
to which image src was looking for an exact URL match, but query params
are trimmed on the client side before talking to the endpoint, they were
no longer matching.

This commit fixes that by searching for attachments whose URL matches
the provided one with or without any extra query parameters.