### PR TITLE
[FIX] website: fix fullscreen indication pointer events

### DIFF
--- a/addons/website/static/src/scss/website.ui.scss
+++ b/addons/website/static/src/scss/website.ui.scss
@@ -51,6 +51,8 @@ body.o_connected_user {
     top: 0;
     margin-top: $o-navbar-height!important;
     opacity: 0;
+    pointer-events: none;
+
     p {
         padding: 15px 30px;
         background-color: rgba(0, 0, 0, 0.7);


### PR DESCRIPTION
As the container div of the fullscreen indication stays on the page to
be displayed, it was obstructing the click events of the elements it was
displayed on. The user could not access what was on top of the screen.

The solution was to remove pointer events for that div so that it
doesn't interfere with other elements on the page.

Related to https://github.com/odoo/odoo/pull/65255


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
