### PR TITLE
[FIX] stock_account: don't update unit cost

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -175,8 +175,6 @@ class ProductProduct(models.Model):
                             float_repr(rounding_error, precision_digits=currency.decimal_places),
                             currency.symbol
                         )
-                    if self.quantity_svl:
-                        vals['unit_cost'] = self.value_svl / self.quantity_svl
             if self.cost_method == 'fifo':
                 vals.update(fifo_vals)
         return vals


### PR DESCRIPTION
Commit f6b019fcfdd35a693e8af43ae38d10e31e96284a aims to fix the rounding
errors on AVCO valuated product when those exit stock. The issue was we
fixed the value and the unit_cost as it is rounded in the curruncy
precision. This is first wrong then useless.
The wrong part : in case the stock is empty and we make an outgoing
move, self.value = 0 so the unit_cost will be overridden to 0 while it
should stay at the standard price.
The useless part is that the unit_cost will be rerounded right after the
update to be written in database.

opw :

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
