### PR TITLE
[FIX] sale_stock: Enable adding custom fields to the lots table

### DIFF
--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -95,6 +95,8 @@ class AccountMove(models.Model):
                 'quantity': qty,
                 'uom_name': lot_id.product_uom_id.name,
                 'lot_name': lot_id.name,
+                # The lot id is needed by localizations to inherit the method and add custom fields on the invoice's report.
+                'lot_id': lot_id.id
             })
         return lot_values
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

If we add the id on the values returned by the method
_get_invoiced_lot_values() then we can inherit it to add
custom fields on the table of invoiced lot on the invoice's report.

**l10n_ar task:** 486

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
