### PR TITLE
[ADD] l10n_ar: Enable AFIP document types

### DIFF
--- a/addons/l10n_ar/__manifest__.py
+++ b/addons/l10n_ar/__manifest__.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Argentinian Accounting',
-    'version': "3.1",
+    'version': "3.2",
     'description': """
 Functional
 ----------

--- a/addons/l10n_ar/data/l10n_latam.document.type.csv
+++ b/addons/l10n_ar/data/l10n_latam.document.type.csv
@@ -3,18 +3,18 @@ dc_a_f,10,1,FACTURAS A,A,FACTURA,invoice,FA-A,base.ar,not_zero,True
 dc_a_nd,20,2,NOTAS DE DEBITO A,A,NOTA DE DEBITO,debit_note,ND-A,base.ar,not_zero,True
 dc_a_nc,30,3,NOTAS DE CREDITO A,A,NOTA DE CREDITO,credit_note,NC-A,base.ar,not_zero,True
 dc_a_r,40,4,RECIBOS A,A,RECIBO,invoice,RE-A,base.ar,not_zero,True
-dc_a_nvc,50,5,NOTAS DE VENTA AL CONTADO A,A,,,,base.ar,not_zero,False
+dc_a_nvc,50,5,NOTAS DE VENTA AL CONTADO A,A,,invoice,NVC-A,base.ar,not_zero,False
 dc_b_f,60,6,FACTURAS B,B,FACTURA,invoice,FA-B,base.ar,zero,True
 dc_b_nd,70,7,NOTAS DE DEBITO B,B,NOTA DE DEBITO,debit_note,ND-B,base.ar,zero,True
 dc_b_nc,80,8,NOTAS DE CREDITO B,B,NOTA DE CREDITO,credit_note,NC-B,base.ar,zero,True
 dc_b_r,90,9,RECIBOS B,B,RECIBO,invoice,RE-B,base.ar,zero,True
-dc_b_nvc,100,10,NOTAS DE VENTA AL CONTADO B,B,,,,base.ar,zero,False
+dc_b_nvc,100,10,NOTAS DE VENTA AL CONTADO B,B,,invoice,NVC-B,base.ar,zero,False
 dc_c_f,110,11,FACTURAS C,C,FACTURA,invoice,FA-C,base.ar,zero,True
 dc_c_nd,120,12,NOTAS DE DEBITO C,C,NOTA DE DEBITO,debit_note,ND-C,base.ar,zero,True
 dc_c_nc,130,13,NOTAS DE CREDITO C,C,NOTA DE CREDITO,credit_note,NC-C,base.ar,zero,True
 dc_aduana,140,14,DOCUMENTO ADUANERO,,,,,base.ar,,False
 dc_c_r,150,15,RECIBOS C,C,RECIBO,invoice,RE-C,base.ar,zero,True
-dc_c_nvc,160,16,NOTAS DE VENTA AL CONTADO C,C,,,,base.ar,zero,False
+dc_c_nvc,160,16,NOTAS DE VENTA AL CONTADO C,C,,invoice,NVC-C,base.ar,zero,False
 dc_e_f,170,19,FACTURAS DE EXPORTACION,E,FACTURA,invoice,FA-E,base.ar,not_zero,True
 dc_e_nd,180,20,NOTAS DE DEBITO POR OPERACIONES CON EL EXTERIOR,E,NOTA DE DEBITO,debit_note,ND-E,base.ar,not_zero,True
 dc_e_nc,190,21,NOTAS DE CREDITO POR OPERACIONES CON EL EXTERIOR,E,NOTA DE CREDITO,credit_note,NC-E,base.ar,not_zero,True
@@ -35,7 +35,7 @@ dc_m_f,330,51,FACTURAS M,M,FACTURA,invoice,FA-M,base.ar,not_zero,True
 dc_m_nd,340,52,NOTAS DE DEBITO M,M,NOTA DE DEBITO,debit_note,ND-C,base.ar,not_zero,True
 dc_m_nc,350,53,NOTAS DE CREDITO M,M,NOTA DE CREDITO,credit_note,NC-C,base.ar,not_zero,True
 dc_m_r,360,54,RECIBOS M,M,RECIBO,invoice,RE-M,base.ar,not_zero,True
-dc_m_nvc,370,55,NOTAS DE VENTA AL CONTADO M,M,,,,base.ar,not_zero,False
+dc_m_nvc,370,55,NOTAS DE VENTA AL CONTADO M,M,,invoice,NVC-M,base.ar,not_zero,False
 dc_m_rg1415,380,56,"COMPROBANTES M DEL ANEXO I, APARTADO A, INC. F), R.G. Nº 1415",M,,invoice,,base.ar,not_zero,False
 dc_m_o_rg1415,390,57,OTROS COMPROBANTES M QUE CUMPLAN CON LA R.G. Nº 1415,M,,invoice,,base.ar,not_zero,False
 dc_m_cvl,400,58,CUENTAS DE VENTA Y LIQUIDO PRODUCTO M,M,,invoice,,base.ar,not_zero,False
@@ -79,10 +79,10 @@ dc_nca,770,104,NOTA DE CREDITO DE ASIGNACION,,,credit_note,,base.ar,,False
 dc_remito_x,790,94,REMITOS X,X,REMITO,,RM-X,base.ar,,False
 dc_liq_s_a,800,17,LIQUIDACION DE SERVICIOS PUBLICOS CLASE A,A,,invoice,LS-A,base.ar,not_zero,True
 dc_liq_s_b,810,18,LIQUIDACION DE SERVICIOS PUBLICOS CLASE B,B,,invoice,LS-B,base.ar,zero,True
-dc_com_a_m,820,23,COMPROBANTES "A" DE COMPRA PRIMARIA PARA EL SECTOR PESQUERO MARITIMO,,,,,base.ar,,False
-dc_con_a_m,830,24,COMPROBANTES "A" DE CONSIGNACION PRIMARIA PARA EL SECTOR PESQUERO MARITIMO,,,,,base.ar,,False
-dc_com_b_m,840,25,COMPROBANTES "B" DE COMPRA PRIMARIA PARA EL SECTOR PESQUERO MARITIMO,,,,,base.ar,,False
-dc_con_b_m,850,26,COMPROBANTES "B" DE CONSIGNACION PRIMARIA PARA EL SECTOR PESQUERO MARITIMO,,,,,base.ar,,False
+dc_com_a_m,820,23,"COMPROBANTES ""A"" DE COMPRA PRIMARIA PARA EL SECTOR PESQUERO MARITIMO",,,,,base.ar,,False
+dc_con_a_m,830,24,"COMPROBANTES ""A"" DE CONSIGNACION PRIMARIA PARA EL SECTOR PESQUERO MARITIMO",,,,,base.ar,,False
+dc_com_b_m,840,25,"COMPROBANTES ""B"" DE COMPRA PRIMARIA PARA EL SECTOR PESQUERO MARITIMO",,,,,base.ar,,False
+dc_con_b_m,850,26,"COMPROBANTES ""B"" DE CONSIGNACION PRIMARIA PARA EL SECTOR PESQUERO MARITIMO",,,,,base.ar,,False
 dc_liq_uci_a,860,27,LIQUIDACION UNICA COMERCIAL IMPOSITIVA CLASE A,A,,invoice,LU-A,base.ar,not_zero,True
 dc_liq_uci_b,870,28,LIQUIDACION UNICA COMERCIAL IMPOSITIVA CLASE B,B,,invoice,LU-B,base.ar,zero,True
 dc_liq_uci_c,880,29,LIQUIDACION UNICA COMERCIAL IMPOSITIVA CLASE C,C,,invoice,LU-C,base.ar,zero,True


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

Notas de Venta documents (AFIP codes 5, 10, 16 and 55) can not be used.

### Current behavior before PR:

Notas de Venta documents can be activated but they do not appear when selecting the document type in the bill form view.

### Desired behavior after PR is merged:

Notas de Venta documents can be activated and they now appear when selecting the document type in the bill form view. If we validate them we will have a valid document that has proper document code prefix.

IMPORTANT: This documents are used to register vendor bills, this one will not be active for generate customer invoices because the way and the conditions yo generate this type of documents is different are not supported by the moment.

NOTE: Also notice a problem with the csv escape characters when try to display on a editor or github, Fixed by adding the proper escape for documents of type COMPROBANTES COMPRA/CONSIGNACION

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
