### PR TITLE
[IMP] mail: add a simple and secure method for putting messages in th…

### DIFF
--- a/addons/account_edi/models/account_move.py
+++ b/addons/account_edi/models/account_move.py
@@ -244,7 +244,7 @@ class AccountMove(models.Model):
                     to_cancel_documents |= doc
                     is_move_marked = True
             if is_move_marked:
-                move.message_post(body=_("A cancellation of the EDI has been requested."))
+                move._message_log_text(_("A cancellation of the EDI has been requested."))
 
         to_cancel_documents.write({'state': 'to_cancel', 'error': False, 'blocking_level': False})
 
@@ -261,7 +261,7 @@ class AccountMove(models.Model):
                     documents |= doc
                     is_move_marked = True
             if is_move_marked:
-                move.message_post(body=_("A request for cancellation of the EDI has been called off."))
+                move._message_log_text(_("A request for cancellation of the EDI has been called off."))
 
         documents.write({'state': 'sent'})
 

--- a/addons/l10n_it_edi/models/account_edi_format.py
+++ b/addons/l10n_it_edi/models/account_edi_format.py
@@ -57,9 +57,8 @@ class AccountEdiFormat(models.Model):
         invoice._check_before_xml_exporting()
         res = invoice.invoice_generate_xml()
         if len(invoice.commercial_partner_id.l10n_it_pa_index or '') == 6:
-            invoice.message_post(
-                body=(_("Invoices for PA are not managed by Odoo, you can download the document and send it on your own."))
-            )
+            invoice._message_log_text(
+                _("Invoices for PA are not managed by Odoo, you can download the document and send it on your own."))
         else:
             invoice.l10n_it_send_state = 'to_send'
         return {invoice: res}
@@ -84,10 +83,7 @@ class AccountEdiFormat(models.Model):
         self.ensure_one()
         if self._is_fattura_pa(filename, tree):
             if len(tree.xpath('//FatturaElettronicaBody')) > 1:
-                invoice.message_post(body='The attachment contains multiple invoices, this invoice was not updated from it.',
-                                     message_type='comment',
-                                     subtype_xmlid='mail.mt_note',
-                                     author_id=self.env.ref('base.partner_root').id)
+                invoice._message_log_text(_('The attachment contains multiple invoices, this invoice was not updated from it.'))
             else:
                 return self._import_fattura_pa(tree, invoice)
         return super()._update_invoice_from_xml_tree(filename, tree, invoice)

--- a/addons/l10n_it_edi/models/account_invoice.py
+++ b/addons/l10n_it_edi/models/account_invoice.py
@@ -149,9 +149,8 @@ class AccountMove(models.Model):
             'type': 'binary',
             })
 
-        self.message_post(
-            body=(_("E-Invoice is generated on %s by %s") % (fields.Datetime.now(), self.env.user.display_name))
-        )
+        self._message_log_text(_("E-Invoice is generated on %s by %s") % (fields.Datetime.now(),
+                                                                          self.env.user.display_name))
         return {'attachment': attachment}
 
     def _export_as_xml(self):
@@ -270,9 +269,8 @@ class AccountMove(models.Model):
             or not self.company_id.l10n_it_mail_pec_server_id.active
             or not self.company_id.l10n_it_address_send_fatturapa
         ):
-            self.message_post(
-                body=(_("Error when sending mail with E-Invoice: Your company must have a mail PEC server and must indicate the mail PEC that will send electronic invoice."))
-                )
+            self._message_log_text(
+                    _("Error when sending mail with E-Invoice: Your company must have a mail PEC server and must indicate the mail PEC that will send electronic invoice."))
             self.l10n_it_send_state = 'invalid'
             return
 

--- a/addons/l10n_it_edi/models/ir_mail_server.py
+++ b/addons/l10n_it_edi/models/ir_mail_server.py
@@ -221,9 +221,7 @@ class FetchmailServer(models.Model):
                 return
             related_invoice.l10n_it_send_state = 'delivered'
             info = self._return_multi_line_xml(tree, ['//IdentificativoSdI', '//DataOraRicezione', '//DataOraConsegna', '//Note'])
-            related_invoice.message_post(
-                body=(_("E-Invoice is delivery to the destinatory:<br/>%s") % (info))
-            )
+            related_invoice._message_log_html("%s <br/>%s", (_("E-Invoice is delivery to the destinatory:"), info))
 
         elif receipt_type == 'NS':
             # Rejection notice

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -29,7 +29,7 @@ from odoo.exceptions import MissingError
 from odoo.osv import expression
 
 from odoo.tools import ustr
-from odoo.tools.misc import clean_context, split_every
+from odoo.tools.misc import clean_context, split_every, html_escape
 
 _logger = logging.getLogger(__name__)
 
@@ -1984,6 +1984,23 @@ class MailThread(models.AbstractModel):
         new_message = MailThread._message_create(values)
         MailThread._notify_thread(new_message, values, **notif_kwargs)
         return new_message
+
+    def _msg_txt(self, txt):
+        """
+        Puts a message in the chatter without HTML formatting, so escaping the message
+        :param txt: The text without html code in it
+        """
+        return self._message_log(body=html_escape(txt))
+
+    def _msg_html(self, html_code, txts):
+        """
+        e.g.: html_code = "<b>%s</b> <br/> <p>%s</p>
+            and txts = ["Title", "Some <rigorous> explanation"]
+        :param html_code: is HTML code with %s where you need text
+        :param txts: list of pure text messages that need escaping and inserted into the html code
+        """
+        text = html_code % tuple(html_escape(t) for t in txts)
+        return self._message_log(body=text)
 
     def _message_log(self, *, body='', author_id=None, email_from=None, subject=False, message_type='notification', **kwargs):
         """ Shortcut allowing to post note on a document. It does not perform

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1985,14 +1985,14 @@ class MailThread(models.AbstractModel):
         MailThread._notify_thread(new_message, values, **notif_kwargs)
         return new_message
 
-    def _msg_txt(self, txt):
+    def _message_log_text(self, text):
         """
         Puts a message in the chatter without HTML formatting, so escaping the message
         :param txt: The text without html code in it
         """
-        return self._message_log(body=html_escape(txt))
+        return self._message_log(body=html_escape(text))
 
-    def _msg_html(self, html_code, txts):
+    def _message_log_html(self, html_code, txts, attachments=[]):
         """
         e.g.: html_code = "<b>%s</b> <br/> <p>%s</p>
             and txts = ["Title", "Some <rigorous> explanation"]


### PR DESCRIPTION
…e chatter

In a lot of cases e.g. in account and its localizations, we just need
to put a simple message in the chatter to have a history of what happened.

The current methods in mail are complex to understand for no reason as most
people just use the default params.

At the same, there is the danger of forgetting to html_escape strings.

That is why we define 2 easy to use methods _msg_txt and _msg_html.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
