### PR TITLE
[FIX] web: fix x2many quick edit behaviours

### DIFF
--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -2218,6 +2218,19 @@ var FieldMany2Many = FieldX2Many.extend({
         renderingContext.noCreate = !this.canLink;
         return renderingContext;
     },
+    /**
+     * @private
+     * @override
+     * @param {Object} extraInfo
+     * @param {string} [extraInfo.type]
+     */
+    _quickEdit: function (extraInfo) {
+        if (extraInfo.type === 'add') {
+            this.onAddRecordOpenDialog();
+        } else {
+            this._super(...arguments);
+        }
+    },
 
     //--------------------------------------------------------------------------
     // Handlers
@@ -2234,7 +2247,16 @@ var FieldMany2Many = FieldX2Many.extend({
      */
     _onAddRecord: function (ev) {
         ev.stopPropagation();
-        this.onAddRecordOpenDialog();
+
+        if (this._canQuickEdit && this.isReadonly) {
+            this.trigger_up('quick_edit', {
+                fieldName: this.name,
+                target: this.el,
+                extraInfo: { type: 'add' },
+            });
+        } else {
+            this.onAddRecordOpenDialog();
+        }
     },
 
     /**

--- a/addons/web/static/tests/fields/relational_fields/field_many2many_tests.js
+++ b/addons/web/static/tests/fields/relational_fields/field_many2many_tests.js
@@ -564,8 +564,8 @@ QUnit.module('fields', {}, function () {
                 res_id: 1,
             });
 
-            assert.ok(!form.$('.o_list_record_remove').length,
-                'delete icon should not be visible in readonly');
+            assert.ok(form.$('.o_list_record_remove').length,
+                'delete icon should be visible in readonly');
             assert.ok(form.$('.o_field_x2many_list_row_add').length,
                 '"Add an item" should be visible in readonly');
 

--- a/addons/web/static/tests/fields/relational_fields/field_many2one_tests.js
+++ b/addons/web/static/tests/fields/relational_fields/field_many2one_tests.js
@@ -3432,7 +3432,7 @@ QUnit.module('fields', {}, function () {
                     '</form>',
                 res_id: 1,
             });
-            assert.containsN(form, 'th', 2,
+            assert.containsN(form, 'th:not(.o_list_record_remove_header)', 2,
                 "should be 2 columns in the one2many");
             await testUtils.form.clickEdit(form);
             await testUtils.dom.click(form.$('.o_field_many2one[name="product_id"] input'));
@@ -3482,7 +3482,7 @@ QUnit.module('fields', {}, function () {
             });
 
             // bar is false so there should be 1 column
-            assert.containsOnce(form, 'th',
+            assert.containsOnce(form, 'th:not(.o_list_record_remove_header)',
                 "should be only 1 column ('foo') in the one2many");
             assert.containsOnce(form, '.o_list_view .o_data_row', "should contain one row");
 
@@ -3528,7 +3528,7 @@ QUnit.module('fields', {}, function () {
                     '</tree>',
                 },
             });
-            assert.containsN(form, 'th', 2,
+            assert.containsN(form, 'th:not(.o_list_record_remove_header)', 2,
                 "should be 2 columns in the one2many");
             await testUtils.form.clickEdit(form);
             await testUtils.dom.click(form.$('.o_field_many2one[name="product_id"] input'));

--- a/addons/web/static/tests/fields/relational_fields/field_one2many_tests.js
+++ b/addons/web/static/tests/fields/relational_fields/field_one2many_tests.js
@@ -408,8 +408,8 @@ QUnit.module('fields', {}, function () {
                 "embedded one2many should not have a selector");
             assert.ok(form.$('.o_field_x2many_list_row_add').length,
                 "embedded one2many should be editable");
-            assert.ok(!form.$('td.o_list_record_remove').length,
-                "embedded one2many records should not have a remove icon");
+            assert.ok(form.$('td.o_list_record_remove').length,
+                "embedded one2many records should have a remove icon");
 
             await testUtils.form.clickEdit(form);
 
@@ -2701,8 +2701,8 @@ QUnit.module('fields', {}, function () {
                 },
             });
 
-            assert.ok(!form.$('.o_list_record_remove').length,
-                'remove icon should not be visible in readonly');
+            assert.ok(form.$('.o_list_record_remove').length,
+                'remove icon should be visible in readonly');
             assert.ok(form.$('.o_field_x2many_list_row_add').length,
                 '"Add an item" should be visible in readonly');
 
@@ -8664,7 +8664,7 @@ QUnit.module('fields', {}, function () {
                     '</form>',
                 res_id: 1,
             });
-            assert.containsN(form, 'th', 2,
+            assert.containsN(form, 'th:not(.o_list_record_remove_header)', 2,
                 "should be 2 columns in the one2many");
             await testUtils.form.clickEdit(form);
             await testUtils.dom.click(form.$('.o_field_many2one[name="product_id"] input'));
@@ -8802,7 +8802,7 @@ QUnit.module('fields', {}, function () {
             });
 
             // bar is false so there should be 1 column
-            assert.containsOnce(form, 'th',
+            assert.containsOnce(form, 'th:not(.o_list_record_remove_header)',
                 "should be only 1 column ('foo') in the one2many");
             assert.containsOnce(form, '.o_list_view .o_data_row', "should contain one row");
 
@@ -8848,7 +8848,7 @@ QUnit.module('fields', {}, function () {
                         '</tree>',
                 },
             });
-            assert.containsN(form, 'th', 2,
+            assert.containsN(form, 'th:not(.o_list_record_remove_header)', 2,
                 "should be 2 columns in the one2many");
             await testUtils.form.clickEdit(form);
             await testUtils.dom.click(form.$('.o_field_many2one[name="product_id"] input'));
@@ -9293,10 +9293,11 @@ QUnit.module('fields', {}, function () {
                 res_id: 1,
             });
 
-            assert.containsN(form, '.o_list_view thead th:visible', 2);
-            assert.containsN(form, '.o_list_view tbody .o_data_row td:visible', 2);
-            assert.containsN(form, '.o_list_view tfoot td:visible', 2);
-            assert.containsNone(form, '.o_list_record_remove_header');
+            // should have three visible columns in readonly: foo + readonly button + trash
+            assert.containsN(form, '.o_list_view thead th:visible', 3);
+            assert.containsN(form, '.o_list_view tbody .o_data_row td:visible', 3);
+            assert.containsN(form, '.o_list_view tfoot td:visible', 3);
+            assert.containsOnce(form, '.o_list_record_remove_header');
 
             await testUtils.form.clickEdit(form);
 

--- a/addons/web/static/tests/fields/relational_fields_tests.js
+++ b/addons/web/static/tests/fields/relational_fields_tests.js
@@ -3362,7 +3362,7 @@ QUnit.module('relational_fields', {
                 '</form>',
             res_id: 1,
         });
-        assert.containsN(form, 'th', 2,
+        assert.containsN(form, 'th:not(.o_list_record_remove_header)', 2,
             "should be 2 columns in the one2many");
         await testUtils.form.clickEdit(form);
         await testUtils.fields.many2one.clickOpenDropdown("product_id");
@@ -3412,7 +3412,7 @@ QUnit.module('relational_fields', {
         });
 
         // bar is false so there should be 1 column
-        assert.containsOnce(form, 'th',
+        assert.containsOnce(form, 'th:not(.o_list_record_remove_header)',
             "should be only 1 column ('foo') in the one2many");
         assert.containsOnce(form, '.o_list_view .o_data_row', "should contain one row");
 
@@ -3459,7 +3459,7 @@ QUnit.module('relational_fields', {
                 '</tree>',
             },
         });
-        assert.containsN(form, 'th', 2,
+        assert.containsN(form, 'th:not(.o_list_record_remove_header)', 2,
             "should be 2 columns in the one2many");
         await testUtils.form.clickEdit(form);
         await testUtils.dom.click(form.$('.o_field_many2one[name="product_id"] input'));
@@ -3507,7 +3507,7 @@ QUnit.module('relational_fields', {
         });
 
         // should have 2 columns 1 for foo and 1 for advanced dropdown
-        assert.containsN(form.$('.o_field_one2many'), 'th', 1,
+        assert.containsN(form.$('.o_field_one2many'), 'th:not(.o_list_record_remove_header)', 1,
             "should be 1 th in the one2many in readonly mode");
         assert.containsOnce(form.$('.o_field_one2many table'), '.o_optional_columns_dropdown_toggle',
             "should have the optional columns dropdown toggle inside the table");

--- a/addons/web/static/tests/views/form_tests.js
+++ b/addons/web/static/tests/views/form_tests.js
@@ -10777,6 +10777,50 @@ QUnit.module('Views', {
         form.destroy();
     });
 
+    QUnit.test('Quick Edition: Many2Many', async function (assert) {
+        assert.expect(6);
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: `
+                <form>
+                    <field name="timmy">
+                        <tree>
+                            <field name="display_name"/>
+                        </tree>
+                        <form>
+                            <field name="display_name"/>
+                        </form>
+                    </field>
+                </form>`,
+            archs: {
+                'partner_type,false,list': '<tree><field name="display_name"/></tree>',
+                'partner_type,false,search': '<search><field name="display_name"/></search>',
+            },
+            res_id: 1,
+        });
+
+        assert.containsOnce(form, '.o_form_view.o_form_readonly');
+        assert.containsOnce(form, '.o_field_x2many_list_row_add',
+            'create line should be displayed');
+
+        await testUtils.dom.click(form.$('.o_field_x2many_list_row_add a'));
+        await testUtils.nextTick(); // wait for quick edit
+
+        assert.containsOnce(form, '.o_form_view.o_form_editable',
+            'should switch into edit mode');
+        assert.containsOnce(document.body, '.modal',
+            'should display a dialog');
+
+        assert.containsNone(form, '.o_field_many2many[name="timmy"] .o_data_row');
+        await testUtils.dom.click($('.modal .o_list_view .o_data_row')[0]);
+        assert.containsOnce(form, '.o_field_many2many[name="timmy"] .o_data_row');
+
+        form.destroy();
+    });
+
     QUnit.test('Quick Edition: Many2Many checkbox', async function (assert) {
         assert.expect(7);
 


### PR DESCRIPTION
[FIX] web: display remove buttons in embedded list
---
Since the quick edit behaviour has added, embedded lists
can be edited and display the "add a line" buttons  in a
readonly form but not display the remove buttons
This commit fixes that inconsistency.

[FIX] web: quick edit when add a line on m2m
---
Before this commit, clicking on the "add a line" button on a
many2many list field directly opened the dialog without
switching the form into edit mode.
This is incorrect, the form needs to switch into edit mode otherwise
the selected records are saved and cannot be discarded.