### PR TITLE
[FIX] stock : wrong quantity with transit location

### DIFF
--- a/addons/stock/report/report_stock_quantity.py
+++ b/addons/stock/report/report_stock_quantity.py
@@ -38,18 +38,18 @@ FROM (SELECT
         m.id,
         m.product_id,
         CASE
-            WHEN (whs.id IS NOT NULL AND whd.id IS NULL) OR ls.usage = 'transit' THEN 'out'
-            WHEN (whs.id IS NULL AND whd.id IS NOT NULL) OR ld.usage = 'transit' THEN 'in'
+            WHEN whs.id IS NOT NULL AND whd.id IS NULL THEN 'out'
+            WHEN whd.id IS NOT NULL AND whs.id IS NULL THEN 'in'
         END AS state,
         m.date::date AS date,
         CASE
-            WHEN (whs.id IS NOT NULL AND whd.id IS NULL) OR ls.usage = 'transit' THEN -m.product_qty
-            WHEN (whs.id IS NULL AND whd.id IS NOT NULL) OR ld.usage = 'transit' THEN m.product_qty
+            WHEN whs.id IS NOT NULL AND whd.id IS NULL THEN -m.product_qty
+            WHEN whd.id IS NOT NULL AND whs.id IS NULL THEN m.product_qty
         END AS product_qty,
         m.company_id,
         CASE
-            WHEN (whs.id IS NOT NULL AND whd.id IS NULL) OR ls.usage = 'transit' THEN whs.id
-            WHEN (whs.id IS NULL AND whd.id IS NOT NULL) OR ld.usage = 'transit' THEN whd.id
+            WHEN whs.id IS NOT NULL AND whd.id IS NULL THEN whs.id
+            WHEN whd.id IS NOT NULL AND whs.id IS NULL THEN whd.id
         END AS warehouse_id
     FROM
         stock_move m
@@ -98,15 +98,15 @@ FROM (SELECT
             ELSE m.date::date - interval '1 day'
         END, '1 day'::interval)::date date,
         CASE
-            WHEN ((whs.id IS NOT NULL AND whd.id IS NULL) OR ls.usage = 'transit') AND m.state = 'done' THEN m.product_qty
-            WHEN ((whs.id IS NULL AND whd.id IS NOT NULL) OR ld.usage = 'transit') AND m.state = 'done' THEN -m.product_qty
-            WHEN (whs.id IS NOT NULL AND whd.id IS NULL) OR ls.usage = 'transit' THEN -m.product_qty
-            WHEN (whs.id IS NULL AND whd.id IS NOT NULL) OR ld.usage = 'transit' THEN m.product_qty
+            WHEN whs.id IS NOT NULL AND whd.id IS NULL AND m.state = 'done' THEN m.product_qty
+            WHEN whd.id IS NOT NULL AND whs.id IS NULL AND m.state = 'done' THEN -m.product_qty
+            WHEN whs.id IS NOT NULL AND whd.id IS NULL THEN -m.product_qty
+            WHEN whd.id IS NOT NULL AND whs.id IS NULL THEN m.product_qty
         END AS product_qty,
         m.company_id,
         CASE
-            WHEN (whs.id IS NOT NULL AND whd.id IS NULL) OR ls.usage = 'transit' THEN whs.id
-            WHEN (whs.id IS NULL AND whd.id IS NOT NULL) OR ld.usage = 'transit' THEN whd.id
+            WHEN whs.id IS NOT NULL AND whd.id IS NULL THEN whs.id
+            WHEN whd.id IS NOT NULL AND whs.id IS NULL THEN whd.id
         END AS warehouse_id
     FROM
         stock_move m


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
- Go to runbot
- create a second warehouse, resupply from the first
- create a product, replenish W2 from W1
- Goto Inventory Forecast

--> Issue value are wrong.

An OUT is when WH source is Set and (WH dest is not set or destination location is 'transit').
An IN is when WH dest is Set and (WH source is not set or source location is 'transit').

**Current behavior before PR:**
![image](https://user-images.githubusercontent.com/16716992/110641887-c8ebf200-81b2-11eb-8b78-944b3dbe5334.png)



**Desired behavior after PR is merged:**

![image](https://user-images.githubusercontent.com/16716992/110641794-afe34100-81b2-11eb-8ac7-8466c1504119.png)


@amoyaux
@sla-subteno-it 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
