### PR TITLE
[FIX] account: Entries from Expense journal

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -480,7 +480,7 @@ class account_journal(models.Model):
             if self.type == 'sale':
                 action['domain'] = [(domain_type_field, 'in', ('out_invoice', 'out_refund', 'out_receipt'))]
             elif self.type == 'purchase':
-                action['domain'] = [(domain_type_field, 'in', ('in_invoice', 'in_refund', 'in_receipt'))]
+                action['domain'] = [(domain_type_field, 'in', ('in_invoice', 'in_refund', 'in_receipt', 'entry'))]
 
         return action
 


### PR DESCRIPTION
Steps to reproduce the bug:

- Create an Expense E
- Create a report R from E in the journal J (type=purchase)
- Generate the journal entry JE from R
- Go to Accounting Dashboard and click on J in the kanban view

Bug:

JE was not displayed in the entries filtered for J

PS: When creating a journal entry from an expense sheet, the move_type of the entry
is 'entry'.

opw:2474729