### PR TITLE
Fix auto reconciliation issue

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -191,12 +191,12 @@ class AccountMove(models.Model):
                 continue
 
             products = product or move.mapped('invoice_line_ids.product_id')
-            for product in products:
-                if product.valuation != 'real_time':
+            for prod in products:
+                if prod.valuation != 'real_time':
                     continue
 
                 # We first get the invoices move lines (taking the invoice and the previous ones into account)...
-                product_accounts = product.product_tmpl_id._get_product_accounts()
+                product_accounts = prod.product_tmpl_id._get_product_accounts()
                 if move.is_sale_document():
                     product_interim_account = product_accounts['stock_output']
                 else:
@@ -205,10 +205,10 @@ class AccountMove(models.Model):
                 if product_interim_account.reconcile:
                     # Search for anglo-saxon lines linked to the product in the journal entry.
                     product_account_moves = move.line_ids.filtered(
-                        lambda line: line.product_id == product and line.account_id == product_interim_account and not line.reconciled)
+                        lambda line: line.product_id == prod and line.account_id == product_interim_account and not line.reconciled)
 
                     # Search for anglo-saxon lines linked to the product in the stock moves.
-                    product_stock_moves = stock_moves.filtered(lambda stock_move: stock_move.product_id == product)
+                    product_stock_moves = stock_moves.filtered(lambda stock_move: stock_move.product_id == prod)
                     product_account_moves += product_stock_moves.mapped('account_move_ids.line_ids')\
                         .filtered(lambda line: line.account_id == product_interim_account and not line.reconciled)
 


### PR DESCRIPTION
Auto reconciliation does not happen when selecting multiple invoices from the list and click action "Post Entries"

Description of the issue/feature this PR addresses:
1. I created invoices from Sale Order with delivery order.
2. Go to invoice list, tick several draft invoices (each invoice with different product), select action "Post Entries"
3. The invoices are posted but the auto reconciliation only happened to first of selected invoice and not to the rest of selected invoices.

Current behavior before PR:
Posting multiple invoices only have first of selected invoice with auto reconciliation

Desired behavior after PR is merged:
Posting multiple invoices have all selected invoices with auto reconciliation



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
