### PR TITLE
[FIX] stock_account - field is_anglo_saxon_line missing

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -34,7 +34,7 @@ class AccountMove(models.Model):
             for copy_vals in res:
                 if 'line_ids' in copy_vals:
                     copy_vals['line_ids'] = [line_vals for line_vals in copy_vals['line_ids']
-                                             if line_vals[0] != 0 or not line_vals[2]['is_anglo_saxon_line']]
+                                             if line_vals[0] != 0 or not line_vals[2].get('is_anglo_saxon_line',False)]
 
         return res
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When copying the stock movement the field is missing is_anglo_saxon_line

Current behavior before PR:
The field does not exists

Desired behavior after PR is merged:
Not get error


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
