### PR TITLE
[IMP] website_event: improves the confirmed registration page design

### DIFF
--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -128,13 +128,13 @@ class EventEvent(models.Model):
         'event.tag', string="Tags", readonly=False,
         store=True, compute="_compute_tag_ids")
     # Kanban fields
-    kanban_state = fields.Selection([('normal', 'In Progress'), ('done', 'Done'), ('blocked', 'Blocked')], default='normal')
+    kanban_state = fields.Selection([('normal', 'In Progress'), ('done', 'Done'), ('blocked', 'Blocked')], default='normal', copy=False)
     kanban_state_label = fields.Char(
         string='Kanban State Label', compute='_compute_kanban_state_label',
         store=True, tracking=True)
     stage_id = fields.Many2one(
         'event.stage', ondelete='restrict', default=_get_default_stage_id,
-        group_expand='_read_group_stage_ids', tracking=True)
+        group_expand='_read_group_stage_ids', tracking=True, copy=False)
     legend_blocked = fields.Char(related='stage_id.legend_blocked', string='Kanban Blocked Explanation', readonly=True)
     legend_done = fields.Char(related='stage_id.legend_done', string='Kanban Valid Explanation', readonly=True)
     legend_normal = fields.Char(related='stage_id.legend_normal', string='Kanban Ongoing Explanation', readonly=True)

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -334,32 +334,47 @@
             <div class="row mb-3 o_wereg_confirmed_attendees">
                 <div class="col-md-4 col-xs-12 mt-3" t-foreach="attendees" t-as="attendee">
                     <div class="d-flex flex-column">
-                        <span class="font-weight-bold">
+                        <span class="font-weight-bold text-truncate">
                             <t t-if="attendee.name" t-esc="attendee.name"/>
                             <t t-else="">N/A</t>
                         </span>
-                        <span>
+                        <span class="text-truncate">
                             <i class="fa fa-envelope mr-2   "></i>
                             <t t-if="attendee.email" t-esc="attendee.email"/>
                             <t t-else="">N/A</t>
                         </span>
-                        <span>
+                        <span t-if="attendee.phone">
                             <i class="fa fa-phone mr-2"></i>
-                            <t t-if="attendee.phone" t-esc="attendee.phone"/>
-                            <t t-else="">N/A</t>
+                            <t t-esc="attendee.phone"/>
                         </span>
                         <span>
                             <i class="fa fa-ticket mr-2"></i>
-                            <t t-if="attendee.event_ticket_id" t-esc="attendee.event_ticket_id.name"/>
-                            <t t-else="">N/A</t>
-                            (ref: <t t-esc="attendee.id"/>)
+                            <t t-if="attendee.event_ticket_id">
+                                <t t-esc="attendee.event_ticket_id.name"/> (Ref: <t t-esc="attendee.id"/>)
+                            </t>
+                            <t t-else="">Ref: <t t-esc="attendee.id"/></t>
                         </span>
                     </div>
                 </div>
             </div>
             <div class="row mb-3">
                 <div class="col">
-                    <p><b>Start</b> <span itemprop="startDate" t-esc="event.date_begin_located"/><br/> <b>End</b> <span itemprop="endDate" t-esc="event.date_end_located"/></p>
+                    <div class="row">
+                        <div class="col-2 col-md-1">
+                            <b>Start</b>
+                        </div>
+                        <div class="col pl-0">
+                            <span itemprop="startDate" t-esc="event.date_begin_located"/>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-2 col-md-1">
+                            <b>End</b>
+                        </div>
+                        <div class="col pl-0">
+                            <span itemprop="endDate" t-esc="event.date_end_located"/>
+                        </div>
+                    </div>
                     <div class="mt-4">
                         <h5 t-field="event.address_id" class="text-secondary font-weight-bold" t-options='{
                             "widget": "contact",


### PR DESCRIPTION
PURPOSE
Improve registration confirmed page with set Contact details with their icons, dates in well aligned form. 
Remove unwanted N/A, if event ticket is not available. Change case type of 'ref' to 'Ref'.
When an any event is duplicated, set its kanban stage and state to its initial level.

CURRENT
Contact details with their icons, date and their labels are not of the same length. N/A is display if there 
is no event ticket.When an event is duplicated, kanban stage and state is not changing.

TO BE
Improves event duplication behaviour, which set initial kanban stage and state
of any event which is duplicating. onward now, N/A will not shows, if there is
no tickets. Contact details with their icons, start-date and end-date is well-aligned.

**TaskID - 2463576**
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
