### PR TITLE
fixing float_round on big number

### DIFF
--- a/doc/cla/individual/jackysupit.md
+++ b/doc/cla/individual/jackysupit.md
@@ -1,0 +1,11 @@
+Indonesia, 2021-03-11
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Jacky supit jsupit@gmail.com https://github.com/jackysupit

--- a/doc/cla/individual/jackysupit.md
+++ b/doc/cla/individual/jackysupit.md
@@ -8,4 +8,4 @@ declaration.
 
 Signed,
 
-Jacky supit jsupit@gmail.com https://github.com/jackysupit
+Jacky supit jackysupit https://github.com/jackysupit

--- a/doc/cla/individual/jackysupit.md
+++ b/doc/cla/individual/jackysupit.md
@@ -8,4 +8,4 @@ declaration.
 
 Signed,
 
-Jacky supit jackysupit https://github.com/jackysupit
+Jacky jsupit@gmail.com https://github.com/jackysupit

--- a/odoo/tools/float_utils.py
+++ b/odoo/tools/float_utils.py
@@ -53,6 +53,13 @@ def float_round(value, precision_digits=None, precision_rounding=None, rounding_
            latest one always rounding down.
        :return: rounded float
     """
+
+    #this to make the process faster and avoid error on big number
+    #100,000,000 with precision_digits = 8, will result: 100,000,000.00000004 (see 4 number here, this is wrong)
+    decimalValue = value - int(value)
+    if(decimalValue == 0):
+        return value
+
     rounding_factor = _float_check_precision(precision_digits=precision_digits,
                                              precision_rounding=precision_rounding)
     if rounding_factor == 0 or value == 0: return 0.0


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
float_round() function is resulting wrong value on big number.
you can reproduce the error like this:
1 set the decimal accuracy Product Price to 8
2 go to sale / purchase, create
3 on the order line, pick any product
4 set the unit price to 100,000,000 enter to trigger onchange
5 the price will change to 100,000,000.00000004
6 see the point .00000004? this should be .00000000


Current behavior before PR:
the price will change from 100,000,000 to 100,000,000.00000004

Desired behavior after PR is merged:
from 100,000,000 to 100,000,000.00000000




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
