### PR TITLE
[FIX] microsoft_calendar: warn user if attendee without email

### DIFF
--- a/addons/microsoft_calendar/i18n/microsoft_calendar.pot
+++ b/addons/microsoft_calendar/i18n/microsoft_calendar.pot
@@ -140,6 +140,16 @@ msgid "Event Recurrence Rule"
 msgstr ""
 
 #. module: microsoft_calendar
+#: code:addons/microsoft_calendar/models/calendar.py:0
+#, python-format
+msgid ""
+"For a correct synchronization between Odoo and Outlook Calendar, all attendees must have an email address. However, some events do not respect this condition. As long as the events are incorrect, the calendars will not be synchronized.\n"
+"Either update the events/attendees or archive these events %s:\n"
+"%s"
+msgstr ""
+
+#. module: microsoft_calendar
+#: model:ir.model.fields,field_description:microsoft_calendar.field_calendar_attendee__id
 #: model:ir.model.fields,field_description:microsoft_calendar.field_calendar_event__id
 #: model:ir.model.fields,field_description:microsoft_calendar.field_calendar_recurrence__id
 #: model:ir.model.fields,field_description:microsoft_calendar.field_microsoft_calendar_account_reset__id

--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -6,7 +6,7 @@ from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, _
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 
 ATTENDEE_CONVERTER_O2M = {
     'needsAction': 'notresponded',
@@ -346,6 +346,27 @@ class Meeting(models.Model):
             }
 
         return values
+
+    def _ensure_attendees_have_email(self):
+        invalid_event_ids = self.env['calendar.event'].search_read(
+            domain=[('id', 'in', self.ids), ('attendee_ids.partner_id.email', '=', False)],
+            fields=['display_time', 'display_name'],
+            order='start',
+        )
+        if invalid_event_ids:
+            list_length_limit = 50
+            total_invalid_events = len(invalid_event_ids)
+            invalid_event_ids = invalid_event_ids[:list_length_limit]
+            invalid_events = ['\t- %s: %s' % (event['display_time'], event['display_name'])
+                              for event in invalid_event_ids]
+            invalid_events = '\n'.join(invalid_events)
+            details = "(%d/%d)" % (list_length_limit, total_invalid_events) if list_length_limit < total_invalid_events else "(%d)" % total_invalid_events
+            raise ValidationError(_("For a correct synchronization between Odoo and Outlook Calendar, "
+                                    "all attendees must have an email address. However, some events do "
+                                    "not respect this condition. As long as the events are incorrect, "
+                                    "the calendars will not be synchronized."
+                                    "\nEither update the events/attendees or archive these events %s:"
+                                    "\n%s", details, invalid_events))
 
     def _microsoft_values_occurence(self, initial_values={}):
         values = dict(initial_values)

--- a/addons/microsoft_calendar/models/calendar_recurrence_rule.py
+++ b/addons/microsoft_calendar/models/calendar_recurrence_rule.py
@@ -102,3 +102,6 @@ class RecurrenceRule(models.Model):
                 values += [event_value]
 
         return values
+
+    def _ensure_attendees_have_email(self):
+        self.calendar_event_ids.filtered(lambda e: e.active)._ensure_attendees_have_email()

--- a/addons/microsoft_calendar/models/microsoft_sync.py
+++ b/addons/microsoft_calendar/models/microsoft_sync.py
@@ -131,6 +131,7 @@ class MicrosoftSync(models.AbstractModel):
             records_to_sync = self
         cancelled_records = self - records_to_sync
 
+        records_to_sync._ensure_attendees_have_email()
         updated_records = records_to_sync.filtered('microsoft_id')
         new_records = records_to_sync - updated_records
         for record in cancelled_records.filtered('microsoft_id'):
@@ -299,6 +300,7 @@ class MicrosoftSync(models.AbstractModel):
     def _microsoft_patch(self, microsoft_service: MicrosoftCalendarService, microsoft_id, values, timeout=TIMEOUT):
         with microsoft_calendar_token(self.env.user.sudo()) as token:
             if token:
+                self._ensure_attendees_have_email()
                 microsoft_service.patch(microsoft_id, values, token=token, timeout=timeout)
                 self.need_sync_m = False
 
@@ -308,6 +310,7 @@ class MicrosoftSync(models.AbstractModel):
             return
         with microsoft_calendar_token(self.env.user.sudo()) as token:
             if token:
+                self._ensure_attendees_have_email()
                 microsoft_id = microsoft_service.insert(values, token=token, timeout=timeout)
                 self.write({
                     'microsoft_id': microsoft_id,
@@ -343,6 +346,9 @@ class MicrosoftSync(models.AbstractModel):
         according to the Microsoft Calendar API
         :return: dict of Microsoft formatted values
         """
+        raise NotImplementedError()
+
+    def _ensure_attendees_have_email(self):
         raise NotImplementedError()
 
     def _get_microsoft_sync_domain(self):


### PR DESCRIPTION
When syncing both Odoo and Outlook Calendar, if one Odoo event has an
attendee who does not have any email adress, it will lead to a traceback
error.

To reproduce the error:
1. Create a partner P who does not have an email address
2. In Calendar, create an event E with P
3. Sync with Outlook

Error: An Odoo Error is raised. When syncing from Outlook to Odoo, it
also sync the E-event (in case the latter has been updated on Outlook).
The Microsoft2Odoo syncing uses the email address of each attendee.
Since P does not have any, this creates the error.

Although Odoo allows the use of participants without email, this is not
the case for Outlook. On Outlook Calendar, as soon as a user adds an
attendee to an Event, Outlook will want to send an invitation before
saving this event (so, if the participant does not have any email
address, it won't be possible to save the event).

When syncing, the E-event will be added to Outlook Calendar. However,
for the same reasons as in the previous paragraph, it will not be
possible to update this event from Outlook Calendar.

Therefore, the solution is to prevent the user from having attendees
without email when his calendar is synchronized with Outlook.

OPW-2439027