### PR TITLE
[FIX] sale: Wrong untaxed_amount_to_invoice

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1452,10 +1452,8 @@ class SaleOrderLine(models.Model):
                 # amount and not zero. Since we compute untaxed amount, we can use directly the price
                 # reduce (to include discount) without using `compute_all()` method on taxes.
                 price_subtotal = 0.0
-                if line.product_id.invoice_policy == 'delivery':
-                    price_subtotal = line.price_reduce * line.qty_delivered
-                else:
-                    price_subtotal = line.price_reduce * line.product_uom_qty
+                umo_qty_to_consider = line.qty_delivered if line.product_id.invoice_policy == 'delivery' else line.product_uom_qty
+                price_subtotal = line.price_reduce * umo_qty_to_consider
                 if len(line.tax_id.filtered(lambda tax: tax.price_include)) > 0:
                     # As included taxes are not excluded from the computed subtotal, `compute_all()` method
                     # has to be called to retrieve the subtotal without them.
@@ -1463,7 +1461,7 @@ class SaleOrderLine(models.Model):
                     price_subtotal = line.tax_id.compute_all(
                         line.price_reduce,
                         currency=line.order_id.currency_id,
-                        quantity=line.product_uom_qty,
+                        quantity=umo_qty_to_consider,
                         product=line.product_id,
                         partner=line.order_id.partner_shipping_id)['total_excluded']
 


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider an included tax T (10%) and a product P (11€) with invoicing policy based on delivery
- Create a sale order SO with one line L with 2 P and T
- Confirm SO

Bug:

The untaxed_amount_to_invoice was 20€ on L instead 0€
The untaxed_amount_to_invoice must be 20€ when the delivery is processed

opw:2457660