### PR TITLE
[IMP] (website_slides)_survey,web : change survey's kanban view, improve float_time and ribbon widgets, allow kanaban to pass xml attributes

### DIFF
--- a/addons/survey/models/survey_user.py
+++ b/addons/survey/models/survey_user.py
@@ -24,6 +24,7 @@ class SurveyUserInput(models.Model):
     survey_id = fields.Many2one('survey.survey', string='Survey', required=True, readonly=True, ondelete='cascade')
     scoring_type = fields.Selection(string="Scoring", related="survey_id.scoring_type")
     start_datetime = fields.Datetime('Start date and time', readonly=True)
+    end_datetime = fields.Datetime('End date and time', readonly=True)
     deadline = fields.Datetime('Deadline', help="Datetime until customer can open the survey and submit answers")
     state = fields.Selection([
         ('new', 'Not started yet'),
@@ -203,7 +204,11 @@ class SurveyUserInput(models.Model):
         - It has a certification_mail_template_id set
         - The user succeeded the test
         Will also run challenge Cron to give the certification badge if any."""
-        self.write({'state': 'done'})
+        self.write({
+            'end_datetime': fields.Datetime.now(),
+            'state': 'done'
+        })
+
         Challenge = self.env['gamification.challenge'].sudo()
         badge_ids = []
         for user_input in self:

--- a/addons/survey/static/src/scss/survey_views.scss
+++ b/addons/survey/static/src/scss/survey_views.scss
@@ -1,26 +1,135 @@
-.o_kanban_card_survey {
-    & > .row {
-    min-height: 60px;
+.o_survey_kanban {
+    .o_kanban_card_survey_successed {
+        background-image:
+            linear-gradient(rgba(255,255,255,.9),
+                            rgba(255,255,255,.9)),
+            url(/survey/static/src/img/trophy-solid.svg);
+        background-repeat: no-repeat;
     }
-}
+    .o_kanban_activity {
+        position: absolute;
+        right: 0px;
+        bottom: 6px;
+        max-width: max-content;
+        padding-right: 2px;
+    }
 
-.o_kanban_card_survey_successed{
-    background-image:
-        linear-gradient(rgba(255,255,255,.9), 
-                        rgba(255,255,255,.9)),
-        url(/survey/static/src/img/trophy-solid.svg);
-    background-repeat: no-repeat;
-    background-position: bottom 6px left -45px;
-    background-size: 100%, 100px;
-}
+    &.o_kanban_ungrouped {
+        padding: 0;
+        .o_kanban_card_survey {
+            width: 100%;
+            margin: 0px;
+            margin-top: -1px;
+            .o_kanban_card_content_survey {
+                display: flex;
+                .o_kanban_record_top {
+                    flex-flow: column;
+                    min-width: min-content;
+                    width: 400px;
+                    align-self: center;
+                    padding-left: 4px;
+                    padding-right: 16px;
+                }
+                & > .row {
+                    width: 100%;
+                    margin-left: 0;
+                    margin-right: 0;
+                    align-self: center;
+                    flex-flow: row;
+                    .o_kanban_content {
+                        max-width: max-content;
+                        .o_kanban_card_bottom {
+                            & > .row {
+                                margin: 0 !important;
+                            }
+                            .o_kanban_content_details {
+                                padding: 4px;
+                                min-width: min-content;
+                                width: 110px;
+                                text-align: left;
+                                & > a {
+                                    color: #666666;
+                                    pointer-events: none;
+                                    > span {
+                                        align-self: start;
+                                    }
+                                }
+                                & > span {
+                                    display: block;
+                                }
+                            }
+                        }
+                    }
+                    .o_ungrouped_actions {
+                        align-self: center;
+                        margin-left: auto;
+                        margin-right: 35px;
+                        text-align: end;
+                        & .o_reopen {
+                            margin-right: -35px;
+                            margin-top: 25px;
+                        }
+                    }
+                }
+            }
+        }
 
-table.o_section_list_view tr.o_data_row.o_is_section {
-    font-weight: bold;
-    background-color: #DDD;
-    border-top: 1px solid #BBB;
-    border-bottom: 1px solid #BBB;
-}
+        .o_kanban_card_survey_successed {
+            background-position: center right -25px;
+            background-size: 100%, 55px;
+        }
 
-.icon_rotates {
-    transform: rotate(180deg);
+        .o_grouped_visibility {
+            display: none;
+        }
+    }
+
+    &.o_kanban_grouped {
+        .o_kanban_card_survey {
+            .o_kanban_content_details {
+                padding: 6px;
+                flex: 0 0 33.33333333%;
+                max-width: 33.33333333%;
+                &:not(.o_details_answers) {
+                    border-left: 1px solid #dee2e6;
+                }
+                & > a {
+                    min-width: 45px;
+                }
+            }
+        }
+
+        .o_kanban_card_survey_successed {
+            background-position: bottom 6px left -45px;
+            background-size: 100%, 100px;
+        }
+
+        .o_kanban_card_content_survey {
+            display: block;
+            & > .row {
+                min-height: 60px;
+            }
+            & o_kanban_activity {
+                position: absolute;
+                right: 0;
+                padding-right: 6px;
+                padding-left: 0;
+            }
+        }
+
+        table.o_section_list_view tr.o_data_row.o_is_section {
+            font-weight: bold;
+            background-color: #DDD;
+            border-top: 1px solid #BBB;
+            border-bottom: 1px solid #BBB;
+        }
+
+        .icon_rotates {
+            transform: rotate(180deg);
+        }
+
+        .o_ungrouped_visibily {
+            display: none;
+        }
+    }
 }

--- a/addons/survey/tests/test_survey_ui_session.py
+++ b/addons/survey/tests/test_survey_ui_session.py
@@ -5,6 +5,7 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import fields
 from odoo.tests.common import tagged, HttpCase
+from unittest.mock import patch
 
 
 @tagged('post_install', '-at_install')
@@ -140,8 +141,18 @@ class TestUiSession(HttpCase):
         # =======================
         # PART 1 : CREATE SESSION
         # =======================
+        def action_open_session_manager_mock(self):
+            self.ensure_one()
 
-        self.start_tour('/web', 'test_survey_session_create_tour', login='admin')
+            return {
+                'type': 'ir.actions.act_url',
+                'name': "Open Session Manager",
+                'target': 'self',
+                'url': '/survey/session/manage/%s' % self.access_token
+            }
+
+        with patch('odoo.addons.survey.models.survey_survey.Survey.action_open_session_manager', action_open_session_manager_mock):
+            self.start_tour('/web', 'test_survey_session_create_tour', login='admin')
 
         # tricky part: we only take into account answers created after the session_start_time
         # the create_date of the answers we just saved is set to the beginning of the test.
@@ -164,7 +175,8 @@ class TestUiSession(HttpCase):
         # PART 2 : OPEN SESSION AND CHECK ATTENDEES
         # =========================================
 
-        self.start_tour('/web', 'test_survey_session_start_tour', login='admin')
+        with patch('odoo.addons.survey.models.survey_survey.Survey.action_open_session_manager', action_open_session_manager_mock):
+            self.start_tour('/web', 'test_survey_session_start_tour', login='admin')
 
         self.assertEqual('in_progress', survey_session.session_state)
         self.assertTrue(bool(survey_session.session_start_time))
@@ -203,7 +215,8 @@ class TestUiSession(HttpCase):
         attendee_3.save_lines(timed_scored_choice_question,
             [timed_scored_choice_answer_2.id])
 
-        self.start_tour('/web', 'test_survey_session_manage_tour', login='admin')
+        with patch('odoo.addons.survey.models.survey_survey.Survey.action_open_session_manager', action_open_session_manager_mock):
+            self.start_tour('/web', 'test_survey_session_manage_tour', login='admin')
 
         self.assertFalse(bool(survey_session.session_state))
         self.assertTrue(all(answer.state == 'done' for answer in all_attendees))

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -182,9 +182,10 @@
         <field name="name">Kanban view for survey</field>
         <field name="model">survey.survey</field>
         <field name="arch" type="xml">
-            <kanban sample="1">
+            <kanban class="o_survey_kanban" sample="1">
                 <field name="title" />
                 <field name="answer_done_count" />
+                <field name="question_ids" />
                 <field name="certification" />
                 <field name="scoring_type" />
                 <field name="color" />
@@ -194,58 +195,93 @@
                 <field name="success_count"/>
                 <field name="success_ratio"/>
                 <field name='active'/>
+                <field name="session_state" invisible="1"/>
                 <templates>
-                    <div t-name="kanban-box" 
-                        t-attf-class="oe_kanban_color_#{kanban_getcolor(record.color.raw_value)} oe_kanban_card oe_kanban_global_click o_kanban_card_survey 
+                    <div t-name="kanban-box"
+                        t-attf-class="oe_kanban_color_#{kanban_getcolor(record.color.raw_value)} oe_kanban_card oe_kanban_global_click o_kanban_card_survey
                             #{record.certification.raw_value ? 'o_kanban_card_survey_successed' : ''}">
-                        <div class="o_dropdown_kanban dropdown" t-if="widget.editable">
+                        <div class="o_dropdown_kanban dropdown" t-if="widget.editable" attrs="{'invisible': [('active', '=', False)]}">
 
                             <a role="button" class="dropdown-toggle o-no-caret btn" data-toggle="dropdown" data-display="static" href="#" aria-label="Dropdown menu" title="Dropdown menu">
                                 <span class="fa fa-ellipsis-v"/>
                             </a>
                             <div class="dropdown-menu" role="menu">
                                 <a role="menuitem" type="edit" class="dropdown-item">Edit Survey</a>
-                                <a t-if="record.active.raw_value" role="menuitem" type="object" class="dropdown-item" name="action_send_survey">Share</a>
+                                <a t-if="record.active.raw_value" role="menuitem" type="object" class="dropdown-item o_grouped_visibility" name="action_send_survey">Share</a>
                                 <a t-if="widget.deletable" role="menuitem" type="delete" class="dropdown-item">Delete</a>
                                 <div role="separator" class="dropdown-divider"/>
                                 <div role="separator" class="dropdown-item-text">Color</div>
                                 <ul class="oe_kanban_colorpicker" data-field="color"/>
                             </div>
                         </div>
-                        <div class="o_kanban_record_top">
+                        <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
+                        <div class="o_kanban_card_content_survey">
+                            <div class="o_kanban_record_top">
                                 <h4 class="o_kanban_record_title p-0 mb4"><field name="title" /></h4>
-                        </div>
-                        <div class="row">
-                            <div class="col-10 p-0 pb-1">
-                                <div class="container o_kanban_card_content" t-if="record.answer_done_count.raw_value != 0">
-                                    <div class="row mt-4 ml-5">
-                                        <div class="col-4 p-0">
-                                            <a name="action_result_survey" type="object" class="d-flex flex-column align-items-center">
-                                                <span class="font-weight-bold"><field name="answer_done_count"/></span>
-                                                <span class="text-muted">Answers</span>
-                                            </a>
-                                        </div>
-                                        <div class="col-4 p-0 border-left" t-if="record.scoring_type.raw_value != 'no_scoring'" >
-                                            <a name="action_survey_user_input_certified" type="object" class="d-flex flex-column align-items-center">
-                                                <span class="font-weight-bold"><field name="success_count"/></span>
-                                                <span class="text-muted" t-if="!record.certification.raw_value">Passed</span>
-                                                <span class="text-muted" t-else="">Certified</span>
-                                            </a>
-                                        </div>
-                                        <div class="col-4 p-0 border-left" t-if="record.scoring_type.raw_value != 'no_scoring'" >
-                                            <a name="action_survey_user_input_completed" type="object" class="d-flex flex-column align-items-center">
-                                                <span class="font-weight-bold"> <t t-esc="Math.round(record.success_ratio.raw_value)"></t> %</span>
-                                                <span class="text-muted" >Success</span>
-                                            </a> 
+                                <span class="o_ungrouped_visibily"><field name="user_id" domain="[('share', '=', False)]"/> - <t t-esc="moment(record.create_date).format('MMM YYYY')"/></span>
+                            </div>
+                            <div class="row">
+                                <div class="o_kanban_content p-0 pb-1">
+                                    <div t-attf-class="container o_kanban_card_bottom #{record.answer_done_count.raw_value!=0 ? '' : 'o_ungrouped_visibily'}">
+                                        <div class="row mt-4 ml-5">
+                                            <div class="o_kanban_content_details o_ungrouped_visibily">
+                                                <span class="font-weight-bold" ><t t-esc="record.question_ids.raw_value.length"/></span>
+                                                <span class="text-muted">Questions</span>
+                                            </div>
+                                            <div class="o_kanban_content_details o_details_answers">
+                                                <a name="action_result_survey" type="object" class="d-flex flex-column align-items-center">
+                                                    <span class="font-weight-bold"><field name="answer_done_count"/></span>
+                                                    <span class="text-muted">Answers</span>
+                                                </a>
+                                            </div>
+                                            <div class="o_kanban_content_details o_ungrouped_visibily">
+                                                <span class="font-weight-bold"><field name="answer_count"/></span>
+                                                <span class="text-muted">Registered</span>
+                                            </div>
+                                            <div class="o_kanban_content_details" t-if="record.scoring_type.raw_value != 'no_scoring'" >
+                                                <a name="action_survey_user_input_certified" type="object" class="d-flex flex-column align-items-center">
+                                                    <span class="font-weight-bold"><field name="success_count"/></span>
+                                                    <span class="text-muted" t-if="!record.certification.raw_value">Passed</span>
+                                                    <span class="text-muted" t-else="">Certified</span>
+                                                </a>
+                                            </div>
+                                            <div class="o_kanban_content_details o_details_success" t-if="record.scoring_type.raw_value != 'no_scoring'" >
+                                                <a name="action_survey_user_input_completed" type="object" class="d-flex flex-column align-items-center">
+                                                    <span class="font-weight-bold"> <t t-esc="Math.round(record.success_ratio.raw_value)"></t> %</span>
+                                                    <span class="text-muted" >Success</span>
+                                                </a>
+                                            </div>
+                                            <div class="o_kanban_content_details o_ungrouped_visibily" t-if="record.average_duration.raw_value != 0">
+                                                <span class="font-weight-bold"><field name="average_duration"
+                                                    widget="float_time" options="{'unit':'seconds', 'pattern':'hh:mm:ss'}"/></span>
+                                                <span class="text-muted">Average Duration</span>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-2 align-self-end">
-                                <div class="o_kanban_record_bottom">
-                                    <div class="oe_kanban_bottom_left"/>
-                                    <div class="oe_kanban_bottom_right">
-                                        <field name="activity_ids" widget="kanban_activity"/>
+                                <div class="o_ungrouped_actions o_ungrouped_visibily">
+                                    <button name="action_send_survey" string="Share" type="object"
+                                        class="btn btn-secondary border" attrs="{'invisible': [('active', '=', False)]}">
+                                        Share</button>
+                                    <button name="action_test_survey" string="Test" type="object"
+                                        class="btn btn-secondary border" attrs="{'invisible': [('active', '=', False)]}">
+                                        Test</button>
+                                    <button name="action_start_session" string="Create Live Session" type="object"
+                                        class="btn btn-secondary border" attrs="{'invisible': ['|', ('session_state', '!=', False), '|', ('active', '=', False), ('certification', '=', True)]}">
+                                        Live Survey</button>
+                                    <button name="action_end_session" string="Close Live Session" type="object"
+                                        class="btn btn-secondary border" attrs="{'invisible': [('session_state', 'not in', ['ready', 'in_progress'])]}">
+                                        End Survey</button>
+                                    <button name="action_unarchive" string="Reopen" type="object"
+                                        class="btn btn-secondary border o_reopen" attrs="{'invisible': [('active', '=', True)]}">
+                                        Reopen</button>
+                                </div>
+                                <div class="o_kanban_activity col-2 align-self-end">
+                                    <div class="o_kanban_record_bottom">
+                                        <div class="oe_kanban_bottom_left"/>
+                                        <div class="oe_kanban_bottom_right">
+                                            <field name="activity_ids" widget="kanban_activity" attrs="{'invisible': [('active', '=', False)]}"/>
+                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/addons/web/static/src/js/views/kanban/kanban_record.js
+++ b/addons/web/static/src/js/views/kanban/kanban_record.js
@@ -345,14 +345,20 @@ var KanbanRecord = Widget.extend(WidgetAdapterMixin, {
         this.$("widget").each(function () {
             var $field = $(this);
 
+            const attrs = {};
+            for (const attr of $field[0].attributes) {
+                attrs[attr.name] = attr.value;
+            }
+            const options = Object.assign({}, self.options, { attrs });
+
             const name = $field.attr('name');
             const Widget = widgetRegistryOwl.get(name) || widgetRegistry.get(name);
             const legacy = !(Widget.prototype instanceof owl.Component);
             let widget;
             if (legacy) {
-                widget = new Widget(self, self.state);
+                widget = new Widget(self, self.state, options);
             } else {
-                widget = new WidgetWrapper(this, Widget, { record: self.state });
+                widget = new WidgetWrapper(this, Widget, { record: self.state, options });
             }
             // Prepare widget rendering and save the related promise
             let def;

--- a/addons/web/static/src/scss/ribbon.scss
+++ b/addons/web/static/src/scss/ribbon.scss
@@ -1,6 +1,4 @@
 .ribbon {
-    width: 150px;
-    height: 150px;
     overflow: hidden;
     position: absolute;
 
@@ -14,30 +12,17 @@
 
     & span {
         z-index: 1;
-        position: absolute;
         display: grid;
         align-items: center;
-        width: 225px;
-        height: 48px;
-        padding: 0 44px;
-        box-shadow: 0 5px 10px rgba(0, 0, 0, .1);
         color: #fff;
-        font: 700 18px/1 'Lato', sans-serif;
         text-shadow: 0 1px 1px rgba(0, 0, 0, .2);
         text-transform: uppercase;
         text-align: center;
         overflow: hidden;
         user-select: none;
-        &.o_small {
-            font-size: 12px;
-        }
-        &.o_medium {
-            font-size: 15px;
-        }
     }
 
     &-top-right {
-        margin-top: -$o-sheet-vpadding;
         right: 0;
 
         &::before, &::after {
@@ -54,11 +39,57 @@
             bottom: 0;
             right: 0;
         }
+    }
+}
+
+.o_form_view {
+    .ribbon {
+        width: 150px;
+        height: 150px;
 
         & span {
-            left: -15px;
-            top: 30px;
-            transform: rotate(45deg);
+            position: absolute;
+            width: 225px;
+            height: 48px;
+            padding: 0 44px;
+            box-shadow: 0 5px 10px rgba(0, 0, 0, .1);
+            font: 700 18px/1 'Lato', sans-serif;
+            &.o_small {
+                font-size: 12px;
+            }
+            &.o_medium {
+                font-size: 15px;
+            }
+        }
+
+        &-top-right {
+            margin-top: -$o-sheet-vpadding;
+
+            & span {
+                left: -15px;
+                top: 30px;
+                transform: rotate(45deg);
+            }
+        }
+    }
+}
+
+.o_kanban_view {
+    .ribbon {
+        height: 25px;
+
+        & span {
+            width: fit-content;
+            height: 19px;
+            padding: 0 18px;
+            box-shadow: 0 3px 5px rgba(0, 0, 0, .1);
+            font: 700 9px/1 'Lato', sans-serif;
+            &.o_small {
+                font-size: 5px;
+            }
+            &.o_medium {
+                font-size: 7px;
+            }
         }
     }
 }

--- a/addons/web/static/tests/fields/field_utils_tests.js
+++ b/addons/web/static/tests/fields/field_utils_tests.js
@@ -176,7 +176,7 @@ QUnit.test('format float time', function (assert) {
     assert.strictEqual(fieldUtils.format.float_time(-0.5), '-00:30');
 
     const options = {
-        noLeadingZeroHour: true,
+        pattern: 'h:mm'
     };
     assert.strictEqual(fieldUtils.format.float_time(2, null, options), '2:00');
     assert.strictEqual(fieldUtils.format.float_time(3.5, null, options), '3:30');

--- a/addons/web/static/tests/views/kanban_tests.js
+++ b/addons/web/static/tests/views/kanban_tests.js
@@ -7528,6 +7528,38 @@ QUnit.module('Views', {
 
         kanban.destroy();
     });
-});
 
+    QUnit.test("Instantiate widget with option parameters", async function (assert) {
+        assert.expect(2);
+
+        widgetRegistry.add('optionwidget', Widget.extend({
+            init(parent, state, options) {
+                this._super(...arguments);
+                this.title = options.attrs.title;
+            },
+            start() {
+                this.$el.html($("<div>", {text: this.title, class: 'option-widget'}));
+            },
+        }));
+
+        const kanban = await testUtils.createView({
+            data: this.data,
+            model: "partner",
+            View: KanbanView,
+            arch: `
+                <kanban><templates><t t-name="kanban-box">
+                    <div>
+                        <widget name="optionwidget" title="Widget with Option" />
+                    </div>
+                </t></templates></kanban>
+            `,
+        });
+
+        assert.containsN(kanban, '.option-widget', 4);
+        assert.strictEqual(kanban.$('.option-widget')[0].textContent, 'Widget with Option');
+
+        kanban.destroy();
+        delete widgetRegistry.map.optionwidget;
+    });
+});
 });

--- a/addons/website_slides_survey/views/survey_survey_views.xml
+++ b/addons/website_slides_survey/views/survey_survey_views.xml
@@ -43,4 +43,20 @@
             </xpath>
         </field>
     </record>
+
+    <record id="survey_survey_view_kanban" model="ir.ui.view">
+        <field name="name">survey.survey.view.kanban.inherit.website_slides</field>
+        <field name="model">survey.survey</field>
+        <field name="inherit_id" ref="survey.survey_kanban"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[hasclass('o_details_success')]" position="after">
+                <div class="o_kanban_content_details o_ungrouped_visibily"
+                    attrs="{'invisible': [('slide_channel_count', '=', 0)]}"
+                    groups="website_slides.group_website_slides_officer">
+                    <span class="font-weight-bold"><field name="slide_channel_count"/></span>
+                    <span class="text-muted">Courses</span>
+                </div>
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
The number of survey being possibly important, the current "cards" display
is not convenient.
The average duration of each survey is added. To avoid perf issues, the value
is not stored, and calculated with raw SQL.
Live surveys now open in a new tab instead of in-place.

The Float_time widget can now be uses to convert float values given
in hours, minutes or secondes with the 'unit' parameter.
The widget can convert in d days hh:mm:ss format automatically
The widget can  take custome formatting thanks to the 'pattern' parameter.

Adapt ribbon's css to allow the display of the widget on kanban views.

Kanban views can now pass their xml attributes.

Task-2388785
