### PR TITLE
[FIX] product: drop filter _filter_single_value_lines

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -3556,7 +3556,8 @@ class Many2many(_RelationalMulti):
             )
         if self.store:
             if not (self.relation and self.column1 and self.column2):
-                self._explicit = False
+                if not self.relation:
+                    self._explicit = False
                 # table name is based on the stable alphabetical order of tables
                 comodel = model.env[self.comodel_name]
                 if not self.relation:


### PR DESCRIPTION
Method _filter_single_value_lines() in _get_combination_name() is aimed to
filter out attributes that have a single value, e.g. no need specify product
color in name if we sale one color only. It makes sense, but it works too
slow. Because it doesn't seem that important we can drop it for sake of speed.

Perfomance test
===============

* 33 K product templates with 2 attributes and 2 values in each
* 2 languages
* postgres 12.5

```
get_all_products_by_barcode

|        | Number of queries | Query time, sec | Remaining time, sec |
|--------+-------------------+-----------------+---------------------|
| Before |             33909 |          29.298 |              64.672 |
| After  |               671 |           7.108 |              26.787 |

name_search limit=8

|        | Number of queries | Query time, sec | Remaining time, sec |
|--------+-------------------+-----------------+---------------------|
| Before |                15 |           0.217 |               0.015 |
| After  |                10 |           0.211 |               0.011 |
```

---

Co-authored with FP

opw-2459937
opw-2452738
opw-2355449
opw-2377443

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
