### PR TITLE
[FIX] website_slides: fix compute field when editing the form view with studio

### DIFF
--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -232,7 +232,13 @@ class Slide(models.Model):
     @api.depends('slide_partner_ids.vote')
     @api.depends_context('uid')
     def _compute_user_info(self):
-        slide_data = dict.fromkeys(self.ids, dict({'likes': 0, 'dislikes': 0, 'user_vote': False}))
+        default_stats = {'likes': 0, 'dislikes': 0, 'user_vote': False}
+
+        if not self.ids:
+            self.update(default_stats)
+            return
+
+        slide_data = dict.fromkeys(self.ids, default_stats)
         slide_partners = self.env['slide.slide.partner'].sudo().search([
             ('slide_id', 'in', self.ids)
         ])


### PR DESCRIPTION
Steps to follow to reproduce the bug:
> In the elearning app
> Select a course
> Open studio
> Click on the “content” list
> Click on “edit form view”
> without modifying anything, close studio
> Add a new section on the "content" list
> An error is triggered

Problem:
in this case, studio creates a copy of the base view. In this view we have certain fields that call certain compute methods when creating the record. But The ID list of newly added records is empty.

partial-backport of https://github.com/odoo/odoo/commit/a677859a03c86bf6ac791c31f52ce8609bcba594
opw-2448329

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
