### PR TITLE
[FIX] account: redirect after statement close

### DIFF
--- a/addons/account/models/reconciliation_widget.py
+++ b/addons/account/models/reconciliation_widget.py
@@ -252,6 +252,7 @@ class AccountReconciliation(models.AbstractModel):
 
         results.update({
             'statement_name': len(bank_statements_left) == 1 and bank_statements_left.name or False,
+            'statement_id': len(bank_statements_left) == 1 and bank_statements_left.id or False,
             'journal_id': bank_statements and bank_statements[0].journal_id.id or False,
             'notifications': []
         })

--- a/addons/account/static/src/js/reconciliation/reconciliation_action.js
+++ b/addons/account/static/src/js/reconciliation/reconciliation_action.js
@@ -137,7 +137,7 @@ var StatementAction = AbstractAction.extend({
                         var title = result && result[0] ? result[0]['display_name'] : self.params.display_name || ''
                         self._setTitle(title);
                         self.renderer = new self.config.ActionRenderer(self, self.model, {
-                            'bank_statement_line_id': self.model.bank_statement_line_id,
+                            'bank_statement_id': self.model.bank_statement_id,
                             'valuenow': self.model.valuenow,
                             'valuemax': self.model.valuemax,
                             'defaultDisplayQty': self.model.defaultDisplayQty,
@@ -379,11 +379,11 @@ var StatementAction = AbstractAction.extend({
      */
     _onCloseStatement: function (event) {
         var self = this;
-        return this.model.closeStatement().then(function (result) {
+        return this.model.closeStatement().then(function () {
             self.do_action({
                 name: 'Bank Statements',
-                res_model: 'account.bank.statement.line',
-                res_id: result,
+                res_model: 'account.bank.statement',
+                res_id: self.model.bank_statement_id.id,
                 views: [[false, 'form']],
                 type: 'ir.actions.act_window',
                 view_mode: 'form',
@@ -414,6 +414,7 @@ var StatementAction = AbstractAction.extend({
             self.renderer.update({
                 'valuenow': self.model.valuenow,
                 'valuemax': self.model.valuemax,
+                'bank_statement_id': self.model.bank_statement_id,
                 'title': self.title,
                 'time': Date.now()-self.time,
                 'notifications': result.notifications,

--- a/addons/account/static/src/js/reconciliation/reconciliation_model.js
+++ b/addons/account/static/src/js/reconciliation/reconciliation_model.js
@@ -19,7 +19,7 @@ var _t = core._t;
  *  {
  *      valuenow: integer
  *      valuenow: valuemax
- *      [bank_statement_line_id]: {
+ *      [bank_statement_id]: {
  *          id: integer
  *          display_name: string
  *      }
@@ -261,12 +261,9 @@ var StatementModel = BasicModel.extend({
     closeStatement: function () {
         var self = this;
         return this._rpc({
-                model: 'account.bank.statement.line',
+                model: 'account.bank.statement',
                 method: 'button_confirm_bank',
-                args: [self.bank_statement_line_id.id],
-            })
-            .then(function () {
-                return self.bank_statement_line_id.id;
+                args: [self.bank_statement_id.id],
             });
     },
     /**
@@ -413,7 +410,7 @@ var StatementModel = BasicModel.extend({
             })
             .then(function (statement) {
                 self.statement = statement;
-                self.bank_statement_line_id = self.statement_line_ids.length === 1 ? {id: self.statement_line_ids[0], display_name: statement.statement_name} : false;
+                self.bank_statement_id = statement.statement_id ? {id: statement.statement_id, display_name: statement.statement_name} : false;
                 self.valuenow = self.valuenow || statement.value_min;
                 self.valuemax = self.valuemax || statement.value_max;
                 self.context.journal_id = statement.journal_id;

--- a/addons/account/static/src/js/reconciliation/reconciliation_renderer.js
+++ b/addons/account/static/src/js/reconciliation/reconciliation_renderer.js
@@ -68,6 +68,7 @@ var StatementRenderer = Widget.extend(FieldManagerMixin, {
             'number': state.valuenow,
             'timePerTransaction': Math.round(dt/1000/state.valuemax),
             'context': state.context,
+            'bank_statement_id': state.bank_statement_id,
         }));
         $done.find('*').addClass('o_reward_subcontent');
         $done.find('.button_close_statement').click(this._onCloseBankStatement.bind(this));

--- a/addons/account/static/src/xml/account_reconciliation.xml
+++ b/addons/account/static/src/xml/account_reconciliation.xml
@@ -79,7 +79,7 @@
             <t t-if="context.journal_id">
                 <button class="button_back_to_statement btn btn-secondary" t-att-data_journal_id='context.journal_id'>Go to bank statement(s)</button>
             </t>
-            <t t-if="context['active_model'] === 'account.bank.statement'">
+            <t t-if="bank_statement_id">
                 <button class="button_close_statement btn btn-primary" style="display: inline-block;">Close statement</button>
             </t>
         </p>


### PR DESCRIPTION
We need to redirect the user to the statement he closed, not to a
statement line.

opw-[2426924](https://www.odoo.com/web#active_id=2426924&cids=1&id=2426924&model=project.task&menu_id=)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
