### PR TITLE
[FIX] website_blog: avoid double indexation of blog post

### DIFF
--- a/addons/website_blog/views/website_blog_templates.xml
+++ b/addons/website_blog/views/website_blog_templates.xml
@@ -104,7 +104,7 @@
     <t t-call="website_blog.index">
         <t t-set="head">
             <link t-att-href="'/blog/%s/feed' % (blog.id)" type="application/atom+xml" rel="alternate" title="Atom Feed"/>
-            <meta t-if="len(active_tag_ids) > 0" name="robots" t-attf-content="#{len(active_tag_ids) > 1 and 'noindex,'} nofollow"/>
+            <meta t-if="active_tag_ids" name="robots" t-attf-content="none"/>
         </t>
         <div class="oe_structure" id="oe_structure_website_blog_post_short_1"/>
         <div class="container">


### PR DESCRIPTION
Until now, if you have 2 tags (t1, t2) on blog post (P) of blog (B),
we ask to index:
    /blog/B/post/P
    /blog/B/post/P/t1
    /blog/B/post/P/t2

Now, we only ask to index:
    /blog/B/post/P

opw-2413811

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
