### PR TITLE
[FIX] account: precalculate regexp for reconciliation

### DIFF
--- a/addons/account_perf_reconciliation/__init__.py
+++ b/addons/account_perf_reconciliation/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import models

--- a/addons/account_perf_reconciliation/__manifest__.py
+++ b/addons/account_perf_reconciliation/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'Reconciliation Performance Fix',
+    'version': '1.0',
+    'summary': 'Precalculate some expressions of the reconciliation query in order to speed it up.',
+    'description': """
+Reconciliation Performance Fix
+==============================
+Always prefer to upgrade to version 14.0 or above instead of installing this module, if possible.
+Installing this module will take a few minutes, install it outside working hours.
+
+Depending on your accounting data volume and content, the reconciliation might be slow or even time out.
+This module adds fields to precalculate and store expressions used by the reconciliation.
+This means the reconciliation itself has less work to do and becomes faster.
+Depending on your data, gains could be as much as a factor of 10.
+    """,
+    'category': 'Accounting/Accounting',
+    'depends': ['account']
+}

--- a/addons/account_perf_reconciliation/models/__init__.py
+++ b/addons/account_perf_reconciliation/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import account_reconcile_model

--- a/addons/account_perf_reconciliation/models/account_reconcile_model.py
+++ b/addons/account_perf_reconciliation/models/account_reconcile_model.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+"""
+This module improves reconciliation performance by precalculating and storing slow regexp used by the reconciliation.
+It stores regexp values using computed and stored fields and
+ overrides the query to replace regexps by reference to computed fields (columns).
+"""
+import logging
+import re
+
+from odoo import models, api, fields
+from odoo.tools.sql import column_exists, create_column
+
+_logger = logging.getLogger(__name__)
+
+st_line_num_regexp = r"substring(REGEXP_REPLACE(st_line.name, '[^0-9|^\s]', '', 'g'), '\S(?:.*\S)*')"
+move_num_regexp = r"substring(REGEXP_REPLACE(move.name, '[^0-9|^\s]', '', 'g'), '\S(?:.*\S)*')"
+move_ref_regexp = r"substring(REGEXP_REPLACE(move.ref, '[^0-9|^\s]', '', 'g'), '\S(?:.*\S)*')"
+aml_num_regexp = r"substring(REGEXP_REPLACE(aml.name, '[^0-9|^\s]', '', 'g'), '\S(?:.*\S)*')"
+
+
+class AccountBankStatementLine(models.Model):
+    _inherit = 'account.bank.statement.line'
+
+    precalculated_num = fields.Char(readonly=True, compute='_precalculated_num', store=True)
+
+    def _auto_init(self):
+        """
+        Create column to stop ORM from computing it himself (too slow)
+        """
+        if not column_exists(self.env.cr, 'account_bank_statement_line', 'precalculated_num'):
+            create_column(self.env.cr, 'account_bank_statement_line', 'precalculated_num', 'VARCHAR')
+            _logger.info('computing account_bank_statement_line.precalculated_num')
+            self.env.cr.execute(f"UPDATE account_bank_statement_line st_line "
+                                f"SET precalculated_num = {st_line_num_regexp};")
+
+        return super()._auto_init()
+
+    @api.depends('name')
+    def _precalculated_num(self):
+        for st_line in self:
+            if st_line.name:
+                st_line.precalculated_num = re.sub(r'[^0-9|^\s]', '', st_line.name).strip()
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    precalculated_num = fields.Char(readonly=True, compute='_precalculated_num', store=True)
+    precalculated_ref = fields.Char(readonly=True, compute='_precalculated_ref', store=True)
+
+    def _auto_init(self):
+        """
+        Create columns to stop ORM from computing it himself (too slow)
+        """
+        if not column_exists(self.env.cr, 'account_move', 'precalculated_num'):
+            create_column(self.env.cr, 'account_move', 'precalculated_num', 'VARCHAR')
+            _logger.info('computing account_move.precalculated_num')
+            self.env.cr.execute(f"UPDATE account_move move "
+                                f"SET precalculated_num = {move_num_regexp};")
+
+        if not column_exists(self.env.cr, 'account_move', 'precalculated_ref'):
+            create_column(self.env.cr, 'account_move', 'precalculated_ref', 'VARCHAR')
+            _logger.info('computing account_move.precalculated_ref')
+            self.env.cr.execute(f"UPDATE account_move move "
+                                f"SET precalculated_ref = {move_ref_regexp};")
+
+        return super()._auto_init()
+
+    @api.depends('name')
+    def _precalculated_num(self):
+        for move in self:
+            if move.name:
+                move.precalculated_num = re.sub(r'[^0-9|^\s]', '', move.name).strip()
+
+    @api.depends('ref')
+    def _precalculated_ref(self):
+        for move in self:
+            if move.ref:
+                move.precalculated_ref = re.sub(r'[^0-9|^\s]', '', move.ref).strip()
+
+
+class AccountMoveLine(models.Model):
+    _inherit = 'account.move.line'
+
+    precalculated_num = fields.Char(readonly=True, compute='_precalculated_num', store=True)
+
+    def _auto_init(self):
+        """
+        Create column to stop ORM from computing it himself (too slow)
+        """
+        if not column_exists(self.env.cr, 'account_move_line', 'precalculated_num'):
+            create_column(self.env.cr, 'account_move_line', 'precalculated_num', 'VARCHAR')
+            _logger.info('computing account_move_line.precalculated_num')
+            self.env.cr.execute(f"UPDATE account_move_line aml "
+                                f"SET precalculated_num = {aml_num_regexp};")
+
+        return super()._auto_init()
+
+    @api.depends('name')
+    def _precalculated_num(self):
+        for aml in self:
+            if aml.name:
+                aml.precalculated_num = re.sub(r'[^0-9|^\s]', '', aml.name).strip()
+
+
+class AccountReconcileModel(models.Model):
+    _inherit = 'account.reconcile.model'
+
+    def _get_invoice_matching_query(self, st_lines, excluded_ids=None, partner_map=None):
+        """
+        Equivalent to account.reconcile.model._get_invoice_matching_query except it
+         replaces expressions that are precalculated by the fields containing precalculated values
+        """
+        expr_to_precalc_field = {
+            aml_num_regexp: 'aml.precalculated_num',
+            st_line_num_regexp: 'st_line.precalculated_num',
+            move_num_regexp: 'move.precalculated_num',
+            move_ref_regexp: 'move.precalculated_ref',
+        }
+
+        raw_query, params = super()._get_invoice_matching_query(st_lines, excluded_ids=None, partner_map=None)
+
+        query_with_precalc = raw_query
+        for expr, precalc_field in expr_to_precalc_field.items():
+            query_with_precalc = query_with_precalc.replace(expr, precalc_field)
+
+        return query_with_precalc, params


### PR DESCRIPTION
This is a draft because it will never be merged :
- It modifies the model, which we cannot do in stable.
- It will be distributed by the support to unblock certain users.
- This draft is meant for review only, it won't be merged.

The reconciliation query spends lots of time evaluating regexp.
In order to improve performance :
1. add fields to store precalculated values
2. populate precalculated fields
3. override reconciliation query and replace regexp by fields

Because this modifies the model, it cannot be merged in stable.
Further, it's not required since version 14.0 which already solved this problem.
This module aims to help blocked clients until they upgrade.
It is provided as a zip on a per-ticket basis.

opw-2453849

Description of the issue/feature this PR addresses:
Slow reconciliation

Current behavior before PR:
Reconciliation is slow.

Desired behavior after ~~PR~~ module is ~~merged~~ deployed:
Reconciliation is fast.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
