### PR TITLE
[FIX] crm: allow any users to see event with privacy="Everyone"

### DIFF
--- a/addons/crm/security/crm_security.xml
+++ b/addons/crm/security/crm_security.xml
@@ -45,13 +45,6 @@
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
     </record>
 
-    <record id="calendar_event_global" model="ir.rule">
-        <field name="name">Hide Private Meetings</field>
-        <field ref="model_calendar_event" name="model_id"/>
-        <field eval="1" name="global"/>
-        <field name="domain_force">['|',('user_id','=',user.id),('show_as','=','busy')]</field>
-    </record>
-
     <record id="crm_activity_report_rule_all_activities" model="ir.rule">
         <field name="name">All Activities</field>
         <field ref="model_crm_activity_report" name="model_id"/>


### PR DESCRIPTION
Issue

	- Create a database with 2 users
	- Open the calendar application and create a meeting for you and the other user
	- In the option:
	  set Privacy to 'Everyone'
	  set Show times as 'Free'
	- Send the invitation to the other user

	Access Error (rule: Hide Private Meetings)

Cause

	The 'calendar_event_global' ir.rule is deprecated and related ir.rules
	are now in calendar module (crm.meeting -> calendar.event).

Solution

	Remove rule since deprecated.

opw-2469433