### PR TITLE
[FIX] web: optional column dropdown out off screen on mobile

### DIFF
--- a/addons/web/static/src/js/views/list/list_renderer.js
+++ b/addons/web/static/src/js/views/list/list_renderer.js
@@ -1137,12 +1137,12 @@ var ListRenderer = BasicRenderer.extend({
         ev.stopPropagation();
         this.$('.o_optional_columns .dropdown-toggle').dropdown('toggle');
         // Explicitly set left of the optional column dropdown as it is pushed inside
-        // this.$el, so we need to position it at the end of top right/left corner based
-        // on language direction.
-        var left = _t.database.parameters.direction === 'rtl' ?
-            this.$('.o_optional_columns .o_optional_columns_dropdown').width() :
-            this.$("table").width();
-        this.$('.o_optional_columns').css("left", left);
+        // this.$el, so we need to position it at the end of top left corner in case of
+        // rtl language direction.
+        if (_t.database.parameters.direction === 'rtl') {
+            var left = this.$('.o_optional_columns .o_optional_columns_dropdown').width();
+            this.$('.o_optional_columns').css("left", left);
+        }
     },
     /**
      * Manages the keyboard events on the list. If the list is not editable, when the user navigates to


### PR DESCRIPTION
The left css property computation wasn't usefull for ltr mode and
even worse, it introduced a bug when a horizontal bar was present
(as often on mobile).

The entire width of the table was used to compute the offset even
though we only saw part of it (scroll bar). It's why this left css
property was too high.

We can simply remove this logic as "right: 0" on .o_optional_columns
already do the job for the ltr mode.

Note that we still need to compute the left property for the rtl mode
to put the dropdown menu above the table. Otherwise it will be on his left!

Steps to reproduce:
- Go to Subscription
- Open an existing record
- Try to open subscription lines column dropdown
=> You need to scroll on the right to see it.

Related PR: https://github.com/odoo/odoo/pull/62472
Related Task ID: 1929043

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
