### PR TITLE
[FIX] product: drop filter _filter_single_value_lines

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -104,6 +104,7 @@ class ProductProduct(models.Model):
         'Barcode', copy=False,
         help="International Article Number used for product identification.")
     product_template_attribute_value_ids = fields.Many2many('product.template.attribute.value', relation='product_variant_combination', string="Attribute Values", ondelete='restrict')
+    product_template_variant_value_ids = fields.Many2many('product.template.attribute.value', relation='product_variant_combination', domain=[('attribute_id.create_variant', '!=', 'no_variant')], string="Variant Values", ondelete='restrict')
     combination_indices = fields.Char(compute='_compute_combination_indices', store=True, index=True)
     is_product_variant = fields.Boolean(compute='_compute_is_product_variant')
 
@@ -470,9 +471,12 @@ class ProductProduct(models.Model):
             for r in supplier_info:
                 supplier_info_by_template.setdefault(r.product_tmpl_id, []).append(r)
         for product in self.sudo():
-            variant = product.product_template_attribute_value_ids._get_combination_name()
+            name = product.name
+            variant = ""
+            if product.product_template_variant_value_ids:
+                variant = ", ".join(product.product_template_variant_value_ids.mapped('name'))
+                name = "%s (%s)" % (product.name, variant)
 
-            name = variant and "%s (%s)" % (product.name, variant) or product.name
             sellers = []
             if partner_ids:
                 product_supplier_info = supplier_info_by_template.get(product.product_tmpl_id, [])

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -3424,7 +3424,8 @@ class Many2many(_RelationalMulti):
             )
         if self.store:
             if not (self.relation and self.column1 and self.column2):
-                self._explicit = False
+                if not self.relation:
+                    self._explicit = False
                 # table name is based on the stable alphabetical order of tables
                 comodel = model.env[self.comodel_name]
                 if not self.relation:


### PR DESCRIPTION
Method _filter_single_value_lines() in _get_combination_name() is aimed to
filter out attributes that have a single value, e.g. no need specify product
color in name if we sale one color only. It makes sense, but it works too
slow. Because it doesn't seem that important we can drop it for sake of speed.

Perfomance test
===============

* 10 K product templates with 2 attributes and 2 values in each
* 2 languages
* postgres 12.5
* Odoo v14

```
get_all_products_by_barcode

|        | Number of queries | Query time, sec | Remaining time, sec |
|--------+-------------------+-----------------+---------------------|
| Before |             10288 |           8.054 |              18.621 |
| After  |               216 |           1.725 |               7.570 |

name_search limit=8

|        | Number of queries | Query time, sec | Remaining time, sec |
|--------+-------------------+-----------------+---------------------|
| Before |                17 |           0.067 |               0.014 |
| After  |                12 |           0.072 |               0.013 |

```

---

Co-authored with FP

opw-2459937
opw-2452738
opw-2355449
opw-2377443

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
