### PR TITLE
[FIX] web, account: dashboard's links are not well placed on mobile

### DIFF
--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -301,7 +301,7 @@
                                 <button class="btn btn-primary o_button_upload_bill oe_kanban_action_button" journal_type="purchase" groups="account.group_account_invoice">
                                     <span>Upload</span>
                                 </button>
-                                <a type="object" name="action_create_new" class="o_invoice_new" groups="account.group_account_invoice"><span>Create</span></a><span> Manually</span>
+                                <a type="object" name="action_create_new" class="o_invoice_new" groups="account.group_account_invoice">Create Manually</a>
                             </t>
                         </div>
                         <div class="col-12 col-sm-7 o_kanban_primary_right">

--- a/addons/web/static/src/scss/kanban_dashboard.scss
+++ b/addons/web/static/src/scss/kanban_dashboard.scss
@@ -174,6 +174,13 @@
                 @include o-text-overflow(inline-block);
             }
 
+            @include media-breakpoint-down(md) {
+                button + a {
+                    display: block;
+                    margin-top: map-get($spacers, 3);
+                }
+            }
+
             .o_kanban_primary_bottom {
                 margin-top: $o-kanban-dashboard-vpadding;
                 margin-bottom: -$o-kanban-dashboard-vpadding;


### PR DESCRIPTION
Before this commit, on mobile in the Accounting app, the link in a
kanban card was not well placed.

After this commit, in mobile we consider a link as a block so he is
moved below.

Steps to reproduce:
* Open Odoo on Mobile
* Go to Accounting => Bug ("Create Manually" is in a strange position)

Task ID : 2200168 (4.a)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
