### PR TITLE
[IMP] crm: improve crm.lead kanban ribbon display

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1042,7 +1042,7 @@ class Lead(models.Model):
             :return dict: dictionary value for created kanban view
         """
         self.ensure_one()
-        action = self.env["ir.actions.actions"]._for_xml_id("crm.crm_lead_action_duplicates")
+        action = self.env["ir.actions.actions"]._for_xml_id("crm.crm_lead_opportunities")
         action['domain'] = [('id', 'in', self.duplicate_lead_ids.ids)]
         action['context'] = {
             'active_test': False,

--- a/addons/crm/models/res_partner.py
+++ b/addons/crm/models/res_partner.py
@@ -41,7 +41,7 @@ class Partner(models.Model):
         all_partners = self.with_context(active_test=False).search([('id', 'child_of', self.ids)])
         all_partners.read(['parent_id'])
 
-        opportunity_data = self.env['crm.lead'].read_group(
+        opportunity_data = self.env['crm.lead'].with_context(active_test=False).read_group(
             domain=[('partner_id', 'in', all_partners.ids)],
             fields=['partner_id'], groupby=['partner_id']
         )
@@ -108,6 +108,7 @@ class Partner(models.Model):
         This function returns an action that displays the opportunities from partner.
         '''
         action = self.env['ir.actions.act_window']._for_xml_id('crm.crm_lead_opportunities')
+        action['context'] = {'active_test': False}
         if self.is_company:
             action['domain'] = [('partner_id.commercial_partner_id.id', '=', self.id)]
         else:

--- a/addons/crm/static/src/scss/crm.scss
+++ b/addons/crm/static/src/scss/crm.scss
@@ -21,7 +21,7 @@
         }
     }
 
-    .oe_kanban_card[data-ribbon="true"] {
+    .oe_kanban_card_lost_ribbon {
         min-height: 105px;
         .o_kanban_record_title {
             max-width: calc(100% - 65px);

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -504,6 +504,7 @@
                 <kanban default_group_by="stage_id" class="o_kanban_small_column o_opportunity_kanban" on_create="quick_create" quick_create_view="crm.quick_create_opportunity_form"
                     archivable="false" sample="1">
                     <field name="stage_id" options='{"group_by_tooltip": {"requirements": "Description"}}'/>
+                    <field name="probability"/>
                     <field name="color"/>
                     <field name="priority"/>
                     <field name="expected_revenue"/>
@@ -520,9 +521,14 @@
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}' sum_field="expected_revenue" help="This bar allows to filter the opportunities based on scheduled activities."/>
                     <templates>
                         <t t-name="kanban-box">
-                            <div t-attf-class="#{!selection_mode ? kanban_color(record.color.raw_value) : ''} oe_kanban_global_click oe_kanban_card d-flex flex-column">
-                                <div class="o_dropdown_kanban dropdown">
+                            <t t-set="lost_ribbon" t-value="!record.active.raw_value and record.probability and record.probability.raw_value == 0"/>
+                            <div t-attf-class="#{!selection_mode ? kanban_color(record.color.raw_value) : ''} #{lost_ribbon ? 'oe_kanban_card_lost_ribbon' : ''} oe_kanban_global_click oe_kanban_card d-flex flex-column">
+                                <div class="ribbon ribbon-top-right"
+                                    attrs="{'invisible': ['|', ('probability', '&gt;', 0), ('active', '=', True)]}">
+                                    <span class="bg-danger">Lost</span>
+                                </div>
 
+                                <div class="o_dropdown_kanban dropdown">
                                     <a class="dropdown-toggle o-no-caret btn" role="button" data-toggle="dropdown" data-display="static" href="#" aria-label="Dropdown menu" title="Dropdown menu">
                                         <span class="fa fa-ellipsis-v"/>
                                     </a>
@@ -1074,52 +1080,6 @@ if record:
             <field name="view_mode">graph</field>
             <field name="view_id" ref="crm_lead_view_graph"/>
             <field name="act_window_id" ref="crm_lead_action_pipeline"/>
-        </record>
-
-        <record id="crm_lead_action_duplicates" model="ir.actions.act_window">
-            <field name="name">Similar Leads</field>
-            <field name="res_model">crm.lead</field>
-            <field name="view_mode">tree,form,kanban</field>
-            <field name="search_view_id" ref="crm.view_crm_case_leads_filter"/>
-        </record>
-
-        <record id="crm_lead_view_kanban_duplicates" model="ir.ui.view">
-            <field name="name">crm.lead.view.kanban.duplicates</field>
-            <field name="model">crm.lead</field>
-            <field name="mode">primary</field>
-            <field name="inherit_id" ref="crm.crm_case_kanban_view_leads"/>
-            <field name="arch" type="xml">
-                <xpath expr="//kanban" position="inside">
-                    <field name="probability" invisible="1"/>
-                </xpath>
-                <xpath expr="//div" position="attributes">
-                    <attribute name="t-att-data-ribbon">((
-                        !record.active.raw_value and
-                        record.probability and
-                        record.probability.raw_value == 0
-                    ) or (
-                        record.active.raw_value and
-                        record.probability and
-                        record.probability.raw_value == 100
-                    ))</attribute>
-                </xpath>
-                <xpath expr="//div[hasclass('o_dropdown_kanban')]" position="before">
-                    <div class="ribbon ribbon-top-right"
-                        attrs="{'invisible': ['|', ('probability', '&gt;', 0), ('active', '=', True)]}">
-                        <span class="bg-danger">Lost</span>
-                    </div>
-                    <div class="ribbon ribbon-top-right"
-                        attrs="{'invisible': [('probability', '&lt;', 100)]}">
-                        <span class="bg-success">Won</span>
-                    </div>
-                </xpath>
-            </field>
-        </record>
-
-        <record id="crm_lead_action_duplicates_view_kanban" model="ir.actions.act_window.view">
-            <field name="view_mode">kanban</field>
-            <field name="view_id" ref="crm_lead_view_kanban_duplicates"/>
-            <field name="act_window_id" ref="crm_lead_action_duplicates"/>
         </record>
 
         <record id="menu_crm_opportunities" model="ir.ui.menu">


### PR DESCRIPTION
Since e86f892a7b277cc35fe32d365cfe50b7509a93a5

We have the possibility to display a "lost" and a "won" ribbon on the crm.lead
kanban view.

In this commit, we change things around a bit:
- The "WON" ribbon was removed.
  Since it was redundant with the stage anyway and not very useful.
- The "LOST" ribbon is now always displayed in the kanban view.
  And not only when coming from "duplicate leads".

In addition, leads displayed when coming from the stat button on the
res.partner form view now also shows lost leads (active_test=False).
This can be helpful for the end user because he wants to know "all the deals
that are in progress/lost/won with this specific contact".

Task-2349526

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
