### PR TITLE
[FIX] account: if there is no invoice_tax_id and no refund_tax_id the…

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -672,10 +672,14 @@ class AccountTaxRepartitionLine(models.Model):
         for record in self:
             record.factor = record.factor_percent / 100.0
 
-    @api.depends('invoice_tax_id.company_id', 'refund_tax_id.company_id')
+    @api.depends('invoice_tax_id.company_id', 'refund_tax_id.company_id', 'account_id.company_id')
     def _compute_company(self):
         for record in self:
-            record.company_id = record.invoice_tax_id and record.invoice_tax_id.company_id.id or record.refund_tax_id.company_id.id
+            record.company_id = (
+                record.invoice_tax_id or
+                record.refund_tax_id or
+                record.account_id
+            ).company_id
 
     @api.depends('invoice_tax_id', 'refund_tax_id')
     def _compute_tax_id(self):


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
If there is no `invoice_tax_id` and no `refund_tax_id` there must be a `company_id` at least

As on inverse set of repartition lines while unlinking the company check is executed, it is impossible to unset the link to `account.tax`
Based on this we assume that the best possible company would be the company of the current user...


**Current behavior before PR:**
Company Check is blocking and there is IMO no situation where the company should be false in account.tax in multi company

**Desired behavior after PR is merged:**
Company Check is passing

Info: @wt-io-it


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
