### PR TITLE
[FIX] web: hide filters not relevant to the current screen

### DIFF
--- a/addons/web/static/src/js/views/calendar/calendar_model.js
+++ b/addons/web/static/src/js/views/calendar/calendar_model.js
@@ -614,6 +614,10 @@ return AbstractModel.extend({
                 return;
             }
 
+            _.each(filter.filters, function (filter) {
+                filter.display = !filter.active;
+            });
+
             var fs = [];
             var undefined_fs = [];
             _.each(events, function (event) {


### PR DESCRIPTION
Open Calendar weekly view
Scroll the weeks
The 'Responsible' filter will accumulate entries from the events and not
deleting them.
This create issue with the view in db with heavy calendar use and a lot
of responsibles

This reverts commit 64d0fe411840fb43c96f0252a7ff5e74bd7cdc90, coming from
task 2146842, addressing the following issue in calendar view (i.e. in planning
app) not reproducible anymore

"
In calendar view, when you unselect all filters of a category, all
events disappear (it's expected), but all filters also disappear.
So you can't selectd anything, you must reload the view to unlock
the situation.
"

opw-2479920

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
