### PR TITLE
[FIX] Tools: Remove unneded dot from CLI group header

### DIFF
--- a/doc/cla/individual/tmotyl.md
+++ b/doc/cla/individual/tmotyl.md
@@ -1,0 +1,11 @@
+Poland, 2021-03-11
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Tymoteusz Motylewski t.motylewski@gmail.com https://github.com/tmotyl

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -241,7 +241,7 @@ class configmanager(object):
                          help="specify a custom database template to create a new database")
         parser.add_option_group(group)
 
-        group = optparse.OptionGroup(parser, "Internationalisation options. ",
+        group = optparse.OptionGroup(parser, "Internationalisation options",
             "Use these options to translate Odoo to another language. "
             "See i18n section of the user manual. Option '-d' is mandatory. "
             "Option '-l' is mandatory in case of importation"


### PR DESCRIPTION
This fixes small typo in the CLI odoo-bin
before:
```
Internationalisation options. : 
```
is now
```
Internationalisation options:
```



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
