### PR TITLE
[FIX] web: relative column do not get to 0 (THIS IS A WIP)


### DIFF
--- a/addons/web/static/src/js/views/list/list_editable_renderer.js
+++ b/addons/web/static/src/js/views/list/list_editable_renderer.js
@@ -684,6 +684,13 @@ ListRenderer.include({
 
         // Set the table layout to fixed
         table.style.tableLayout = 'fixed';
+
+        thElements.forEach((th, index) => {
+            // Fix relative width that ends up near zero width
+            if (th.style.width.indexOf('%') && th.offsetWidth < 70) {
+                th.style.width = '70px';
+            }
+        });
     },
     /**
      * Returns the first or last editable row of the list


### PR DESCRIPTION

THIS IS A WIP, NOT SOLUTION THAT WOULD BE MERGED

If for example we have a lot of columns that have a given width (eg.
integer) as well as columns with relative width (eg. many2one). We might
get in a situation where all relative widths will be computed over 0 so
all the relative width columns are hidden.

eg. have lots of column in sale.order lines => the product, description
and taxes column might disappear for records where they are not filled
(eg. when the list is empty, or the value is empty when the record is
opened).

opw-2443695
