### PR TITLE
[FIX] web: prevent popover race condition between unmount and event

### DIFF
--- a/addons/web/static/src/js/core/popover.js
+++ b/addons/web/static/src/js/core/popover.js
@@ -219,6 +219,9 @@ odoo.define('web.Popover', function (require) {
          * @param {Event} ev
          */
         _onResizeWindow(ev) {
+            if (this.__owl__.status === 5 /* destroyed */) {
+                return;
+            }
             this._compute();
         }
 
@@ -230,6 +233,9 @@ odoo.define('web.Popover', function (require) {
          * @param {Event} ev
          */
         _onScrollDocument(ev) {
+            if (this.__owl__.status === 5 /* destroyed */) {
+                return;
+            }
             this._compute();
         }
 


### PR DESCRIPTION
These are throttled/debounced so the handlers are sometimes called after the
component has been destroyed.

opw-2451752