### PR TITLE
[FIX] sale_timesheet: all the employees in the project overview

### DIFF
--- a/addons/sale_timesheet/models/project_overview.py
+++ b/addons/sale_timesheet/models/project_overview.py
@@ -3,6 +3,7 @@ import babel.dates
 from dateutil.relativedelta import relativedelta
 import itertools
 import json
+from odoo.osv import expression
 
 from odoo import fields, _, models
 from odoo.osv import expression
@@ -20,7 +21,9 @@ class Project(models.Model):
 
     def _qweb_prepare_qcontext(self, view_id, domain):
         values = super()._qweb_prepare_qcontext(view_id, domain)
-
+        project_ids = self.env.context.get('active_ids')
+        if project_ids:
+            domain = expression.AND([[('id', 'in', project_ids)], domain])
         projects = self.search(domain)
         values.update(projects._plan_prepare_values())
         values['actions'] = projects._plan_prepare_actions(values)


### PR DESCRIPTION
Steps to reproduce the bug:

1/ Install these apps: Sales, Planning, Employees, Project, Timesheets
2/ Add some employees (stay below 20 employees)
3/ Create a project with Planning, Timesheets and Billable
4/ Click on the overview

Bug:

List of all employees

opw:2460616