### PR TITLE
[13.0][FIX] website_forum: cannot add a nofollow attribute to links

### DIFF
--- a/addons/website_forum/models/forum.py
+++ b/addons/website_forum/models/forum.py
@@ -399,7 +399,7 @@ class Post(models.Model):
         if content and self.env.user.karma < forum.karma_dofollow:
             for match in re.findall(r'<a\s.*href=".*?">', content):
                 match = re.escape(match)  # replace parenthesis or special char in regex
-                content = re.sub(match, match[:3] + 'rel="nofollow" ' + match[3:], content)
+                content = re.sub(match, match[:4] + 'rel="nofollow" ' + match[4:], content)
 
         if self.env.user.karma <= forum.karma_editor:
             filter_regexp = r'(<img.*?>)|(<a[^>]*?href[^>]*?>)|(<[a-z|A-Z]+[^>]*style\s*=\s*[\'"][^\'"]*\s*background[^:]*:[^url;]*url)'


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

With ```<a href="https://viindoo.com/">``` string, after replace parenthesis or special char in regex: ```<a\ href="https://viindoo\.com/">```.
If using match[:3], result as ```<a\rel="nofollow href="https://viindoo\.com/">``` instead of ```<a\ rel="nofollow href="https://viindoo\.com/">```

Current behavior before PR:

A nofollow attribute is not added to links

Desired behavior after PR is merged:

A nofollow attribute is added to links



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
