### PR TITLE
[FIX] website_sale: add padding when no footer

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -61,6 +61,10 @@ $o-wsale-products-layout-grid-gutter-width: min($grid-gutter-width / 2, $o-wsale
     }
 }
 
+.o_ws_nofooter {
+    padding-bottom: 32px !important;
+}
+
 .o_alternative_product {
     margin: auto;
 }

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -873,7 +873,7 @@
     <template id="extra_info" name="Checkout Extra Info">
         <t t-call="website.layout">
             <t t-set="no_footer" t-value="1"/>
-            <div id="wrap">
+            <div id="wrap" class="o_ws_nofooter">
                 <div class="container oe_website_sale py-2">
                     <div class="row">
                         <div class="col-12">
@@ -1194,7 +1194,7 @@
         <t t-call="website.layout">
             <t t-set="additional_title">Shop - Checkout</t>
             <t t-set="no_footer" t-value="1"/>
-            <div id="wrap">
+            <div id="wrap" class="o_ws_nofooter">
                 <div class="container oe_website_sale py-2">
                     <t t-set="same_shipping" t-value="bool(order.partner_shipping_id==order.partner_id or only_services)" />
                     <div class="row">
@@ -1303,7 +1303,7 @@
     <template id="address" name="Address Management">
         <t t-set="no_footer" t-value="1"/>
         <t t-call="website.layout">
-            <div id="wrap">
+            <div id="wrap" class="o_ws_nofooter">
                 <div class="container oe_website_sale py-2">
                     <div class="row">
                         <div class="col-12">
@@ -1474,7 +1474,7 @@
             <t t-set="additional_title">Shop - Select Payment Acquirer</t>
             <t t-set="no_footer" t-value="1"/>
 
-            <div id="wrap">
+            <div id="wrap" class="o_ws_nofooter">
                 <div class="container oe_website_sale py-2">
                     <div class="row">
                         <div class='col-12'>


### PR DESCRIPTION
Before this commit, you can have some extra tool like comparison, livechat, ...
that appears sticky on the bottom of the screen and overlay the cta button to
go to the next step.

Now we add default padding of 32px to avoid the overflow.

This commit closes #66967
Related to fix odoo/odoo@59105 and discussion odoo/design-themes@403

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
