### PR TITLE
[FIX] link_tracker: prevent downloading big or non-html files

### DIFF
--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -14,6 +14,7 @@ from werkzeug import urls, utils
 from odoo import models, fields, api, _
 from odoo.tools import ustr
 
+URL_MAX_SIZE = 10 * 1024 * 1024
 URL_REGEX = r'(\bhref=[\'"](?!mailto:|tel:|sms:)([^\'"]+)[\'"])'
 
 def VALIDATE_URL(url):
@@ -111,7 +112,15 @@ class link_tracker(models.Model):
     @api.depends('url')
     def _get_title_from_url(self, url):
         try:
-            page = requests.get(url, timeout=5)
+            head = requests.head(url, timeout=5)
+            if (
+                    int(head.headers.get('Content-Length', 0)) > URL_MAX_SIZE
+                    or
+                    'text/html' not in head.headers.get('Content-Type', 'text/html')
+            ):
+                return url
+            # HTML parser can work with a part of page, so ask server to limit downloading to 50 KB
+            page = requests.get(url, timeout=5, headers={"range": "bytes=0-50000"})
             p = html.fromstring(page.text.encode('utf-8'), parser=html.HTMLParser(encoding='utf-8'))
             title = p.find('.//title').text
         except:


### PR DESCRIPTION
link tracker tries to get title from HTML, but the url may be not an html page
or too big html to process. It's a waste of bandwidth, but may alos lead to a
Server Memory Limit error.

As a solution, make HEAD request and don't proceed to GET request if it's not an
html page or it's too big

STEPS:

- Have a standard database with link_tracker and mass_mailing.
- Create a new mass mail MM
- Add a link to a large file in MM Mail Body
- Click "SEND"
- Go to Settings / Technical / Automation / Scheduled Actions
- Open the "Process Mass Mailing Queue" or "Email Marketing: Process queue"
- Click "RUN MANUALLY"

---

opw-2457640

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
