### PR TITLE
[FIX] account,point_of_sale: ImbalanceJournalEntryError issue

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -16,14 +16,6 @@ import json
 import re
 import warnings
 
-class ImbalanceJournalEntryError(UserError):
-    """Specialized UserError raised by `_check_balanced` method."""
-
-    def __init__(self, message, move_ids, imbalance_amounts):
-        super().__init__(message)
-        self.move_ids = move_ids
-        self.imbalance_amounts = imbalance_amounts
-
 
 #forbidden fields
 INTEGRITY_HASH_MOVE_FIELDS = ('date', 'journal_id', 'company_id')
@@ -1687,7 +1679,7 @@ class AccountMove(models.Model):
         if query_res:
             ids = [res[0] for res in query_res]
             sums = [res[1] for res in query_res]
-            raise ImbalanceJournalEntryError(_("Cannot create unbalanced journal entry. Ids: %s\nDifferences debit - credit: %s") % (ids, sums), ids, sums)
+            raise UserError(_("Cannot create unbalanced journal entry. Ids: %s\nDifferences debit - credit: %s") % (ids, sums))
 
     def _check_fiscalyear_lock_date(self):
         for move in self:


### PR DESCRIPTION
The crash manager doesn't recognize ImbalanceJournalEntryError as
a user error and when creating a journal entry that is not balanced,
a traceback is shown instead of the normal UserError dialog.

In this commit, we fix this issue by getting rid of the new error
and put back the use of UserError when checking the balance of an
account move. We also make sure that the feature in pos where we
show a wizard to unblock the user from closing session with
imbalance amount is intact.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
