### PR TITLE
[FIX] google_calendar : check user_id before calculating ownership

### DIFF
--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -196,7 +196,7 @@ class Meeting(models.Model):
         }
         if self.privacy:
             values['visibility'] = self.privacy
-        if self.user_id != self.env.user:
+        if self.user_id and self.user_id != self.env.user:
             values['extendedProperties']['shared']['%s_owner_id' % self.env.cr.dbname] = self.user_id.id
 
         if not self.active:

--- a/addons/google_calendar/tests/test_sync_odoo2google.py
+++ b/addons/google_calendar/tests/test_sync_odoo2google.py
@@ -84,6 +84,18 @@ class TestSyncOdoo2Google(SavepointCase):
             'extendedProperties': {'shared': {'%s_odoo_id' % self.env.cr.dbname: event.id}}
         })
 
+    def test_event_without_user(self):
+        event = self.env['calendar.event'].create({
+            'name': "Event",
+            'start': datetime(2020, 1, 15, 8, 0),
+            'stop': datetime(2020, 1, 15, 18, 0),
+            'user_id': False,
+            'privacy': 'private',
+            'need_sync': False,
+        })
+        values = event._google_values()
+        self.assertFalse('%s_owner_id' % self.env.cr.dbname in values.get('extendedProperties', {}).get('shared', {}))
+
     @patch_api
     def test_event_allday_creation(self):
         event = self.env['calendar.event'].create({

--- a/addons/google_calendar/utils/google_event.py
+++ b/addons/google_calendar/utils/google_event.py
@@ -125,11 +125,17 @@ class GoogleEvent(abc.Set):
         # UserA creates an event in Odoo (he is the owner) but userB syncs first.
         # There is no way to insert the event into userA's calendar since we don't have
         # any authentication access. The event is therefore inserted into userB's calendar
-        # (he is the orginizer in Google). The "real" owner (in Odoo) is stored as an
+        # (he is the organizer in Google). The "real" owner (in Odoo) is stored as an
         # extended property. There is currently no support to "transfert" ownership when
         # userA syncs his calendar the first time.
         real_owner_id = self.extendedProperties and self.extendedProperties.get('shared', {}).get('%s_owner_id' % env.cr.dbname)
-        real_owner = real_owner_id and env['res.users'].browse(int(real_owner_id))
+        try:
+            # If we create an event without user_id, the event properties will be 'false'
+            # and python will interpret this a a NoneType, that's why we have the 'except TypeError'
+            real_owner_id = int(real_owner_id)
+        except (ValueError, TypeError):
+            real_owner_id = False
+        real_owner = real_owner_id and env['res.users'].browse(real_owner_id) or env['res.users']
         if real_owner_id and real_owner.exists():
             return real_owner
         elif self.organizer and self.organizer.get('self'):


### PR DESCRIPTION
Issue:
If we get a 'false' for the real_owner_id from the extendedProperties, we will get an error
ValueError: invalid literal for int() with base 10: 'false'

Fix:
We make sure to set a user for the real_owner_id var if it return a 'false' before

Explain the issue to LUL, he said it was going to be fix in https://github.com/odoo/odoo/pull/66080/commits/2303a772ec7256c67cbdd1e55981154d21fa4dd4
But as he does not know when and since it's urgent, we decide to make another pull request to fix it quicker.
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
