### PR TITLE
[IMP] mail: unfollow button in discuss

### DIFF
--- a/addons/mail/controllers/main.py
+++ b/addons/mail/controllers/main.py
@@ -133,24 +133,13 @@ class MailController(http.Controller):
         request.env[res_model].browse(res_id).check_access_rule("read")
         follower_recs = request.env['mail.followers'].search([('res_model', '=', res_model), ('res_id', '=', res_id)])
 
-        followers = []
         follower_id = None
         for follower in follower_recs:
             if follower.partner_id == request.env.user.partner_id:
                 follower_id = follower.id
-            followers.append({
-                'id': follower.id,
-                'partner_id': follower.partner_id.id,
-                'name': follower.name,
-                'display_name': follower.display_name,
-                'email': follower.email,
-                'is_active': follower.is_active,
-                # When editing the followers, the "pencil" icon that leads to the edition of subtypes
-                # should be always be displayed and not only when "debug" mode is activated.
-                'is_editable': True
-            })
+
         return {
-            'followers': followers,
+            'followers': follower_recs._follower_format(),
             'subtypes': self.read_subscription_data(follower_id) if follower_id else None
         }
 

--- a/addons/mail/models/mail_followers.py
+++ b/addons/mail/models/mail_followers.py
@@ -334,3 +334,16 @@ GROUP BY fol.id%s%s""" % (
                         update[fol_id] = {'subtype_ids': update_cmd}
 
         return new, update
+
+    def _follower_format(self):
+        """Returns the followers in the format expected by the web client."""
+        return [{
+            'email': follower.email,
+            'id': follower.id,
+            'is_active': follower.is_active,
+            # When editing the followers, the "pencil" icon that leads to the edition of subtypes
+            # should be always be displayed and not only when "debug" mode is activated.
+            'is_editable': True,
+            'name': follower.name,
+            'partner_id': follower.partner_id.id
+        } for follower in self]

--- a/addons/mail/static/src/components/discuss/tests/discuss_inbox_tests.js
+++ b/addons/mail/static/src/components/discuss/tests/discuss_inbox_tests.js
@@ -424,6 +424,49 @@ QUnit.test('error notifications should not be shown in Inbox', async function (a
     );
 });
 
+QUnit.test('should display unfollow button when current user is follower of the thread', async function (assert) {
+    assert.expect(1);
+
+    this.data['res.partner'].records.push({
+        id: 20,
+        message_follower_ids: [1],
+    });
+    this.data['mail.followers'].records.push({
+        email: "bla@bla.bla",
+        id: 1,
+        is_active: true,
+        is_editable: true,
+        name: "François Perusse",
+        partner_id: this.data.currentPartnerId,
+        res_id: 20,
+        res_model: 'res.partner',
+    });
+    this.data['mail.message'].records.push({
+        body: "<p>Test</p>",
+        id: 100,
+        model: 'res.partner',
+        needaction: true,
+        record_name: 'Refactoring',
+        res_id: 20,
+    });
+    this.data['mail.notification'].records.push({
+        mail_message_id: 100,
+        res_partner_id: this.data.currentPartnerId,
+    });
+    await this.start({
+        discuss: {
+            params: {
+                default_active_id: 'mail.box_inbox',
+            },
+        },
+    });
+    assert.containsOnce(
+        document.body,
+        '.o_Message_commandUnfollow',
+        "should have button unfollow"
+    );
+});
+
 QUnit.test('show subject of message in Inbox', async function (assert) {
     assert.expect(3);
 
@@ -547,6 +590,34 @@ QUnit.test('click on (non-channel/non-partner) origin thread link should redirec
 
     document.querySelector('.o_Message_originThreadLink').click();
     assert.verifySteps(['do-action'], "should have made an action on click on origin thread (to open form view)");
+});
+
+QUnit.test('should not display unfollow button when current user is not follower of the thread', async function (assert) {
+    assert.expect(1);
+
+    this.data['mail.message'].records.push({
+        body: "<p>Test</p>",
+        id: 100,
+        model: 'res.partner',
+        record_name: 'Refactoring',
+        res_id: 20,
+    });
+    this.data['mail.notification'].records.push({
+        mail_message_id: 100,
+        res_partner_id: this.data.currentPartnerId,
+    });
+    await this.start({
+        discuss: {
+            params: {
+                default_active_id: 'mail.box_inbox',
+            },
+        },
+    });
+    assert.containsNone(
+        document.body,
+        '.o_Message_commandUnfollow',
+        "should not have button unfollow"
+    );
 });
 
 QUnit.test('subject should not be shown when subject is the same as the thread name', async function (assert) {

--- a/addons/mail/static/src/components/message/message.js
+++ b/addons/mail/static/src/components/message/message.js
@@ -79,6 +79,7 @@ class Message extends Component {
                 message: message ? message.__state : undefined,
                 notifications: message ? message.notifications.map(notif => notif.__state) : [],
                 originThread,
+                originThreadCurrentPartnerFollowing: originThread && originThread.isCurrentPartnerFollowing,
                 originThreadModel: originThread && originThread.model,
                 originThreadName: originThread && originThread.name,
                 originThreadUrl: originThread && originThread.url,
@@ -647,6 +648,18 @@ class Message extends Component {
         } else {
             this.message.replyTo();
         }
+    }
+
+    /**
+     * @private
+     * @param {MouseEvent} ev
+     */
+    _onClickUnfollow(ev) {
+        if (!this.message.originThread) {
+            return;
+        }
+        this.message.markAsRead();
+        this.message.originThread.unfollow();
     }
 
     /**

--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -119,6 +119,9 @@
                                 </t>
                             </t>
                             <div class="o_Message_commands o_Message_headerCommands" t-att-class="{ 'o-mobile': env.messaging.device.isMobile }">
+                                <t t-if="threadView and threadView.thread === env.messaging.inbox and message.originThread and message.originThread.isCurrentPartnerFollowing">
+                                    <span class="o_Message_command o_Message_commandUnfollow o_Message_headerCommand fa fa-bell-slash-o" t-att-class="{ 'o-message-selected': isSelected, 'o-mobile': env.messaging.device.isMobile }" t-on-click="_onClickUnfollow" title="Unfollow"/>
+                                </t>
                                 <t t-if="!message.isTemporary and ((message.message_type !== 'notification' and message.originThread and message.originThread.model === 'mail.channel') or !message.isTransient) and message.moderation_status !== 'pending_moderation'">
                                     <span class="o_Message_command o_Message_commandStar o_Message_headerCommand fa"
                                         t-att-class="{

--- a/addons/mail/static/src/components/message_list/message_list.js
+++ b/addons/mail/static/src/components/message_list/message_list.js
@@ -603,6 +603,10 @@ Object.assign(MessageList, {
         hasSquashCloseMessages: Boolean,
         haveMessagesMarkAsReadIcon: Boolean,
         haveMessagesReplyIcon: Boolean,
+        haveMessagesUnfollowIcon: {
+            type: Boolean,
+            optional: true,
+        },
         hasScrollAdjust: Boolean,
         order: {
             type: String,

--- a/addons/mail/static/src/components/thread_view/thread_view.js
+++ b/addons/mail/static/src/components/thread_view/thread_view.js
@@ -215,6 +215,10 @@ Object.assign(ThreadView, {
         hasSquashCloseMessages: Boolean,
         haveMessagesMarkAsReadIcon: Boolean,
         haveMessagesReplyIcon: Boolean,
+        haveMessagesUnfollowIcon: {
+            type: Boolean,
+            optional: true,
+        },
         /**
          * Determines whether this should become focused.
          */

--- a/addons/mail/static/src/models/message/message.js
+++ b/addons/mail/static/src/models/message/message.js
@@ -87,6 +87,11 @@ function factory(dependencies) {
                     id: data.res_id,
                     model: data.model,
                 };
+                if ('followers' in data && data.followers) {
+                    originThreadData.followers = insertAndReplace(data.followers.map(followerData =>
+                        this.env.models['mail.follower'].convertData(followerData)
+                    ));
+                }
                 if ('record_name' in data && data.record_name) {
                     originThreadData.name = data.record_name;
                 }
@@ -190,19 +195,22 @@ function factory(dependencies) {
          * Performs the `message_fetch` RPC on `mail.message`.
          *
          * @static
-         * @param {Array[]} domain
-         * @param {integer} [limit]
-         * @param {integer[]} [moderated_channel_ids]
-         * @param {Object} [context]
+         * @param {Object} param0
+         * @param {Object} param0.context
+         * @param {Array[]} param0.domain
+         * @param {boolean} param0.fetchFollowers
+         * @param {integer} param0.limit
+         * @param {integer[]} param0.moderated_channel_ids
          * @returns {mail.message[]}
          */
-        static async performRpcMessageFetch(domain, limit, moderated_channel_ids, context) {
+        static async performRpcMessageFetch({ domain, limit, moderated_channel_ids, context, fetchFollowers }) {
             const messagesData = await this.env.services.rpc({
                 model: 'mail.message',
                 method: 'message_fetch',
                 kwargs: {
                     context,
                     domain,
+                    fetch_followers: fetchFollowers,
                     limit,
                     moderated_channel_ids,
                 },

--- a/addons/mail/static/src/models/thread_cache/thread_cache.js
+++ b/addons/mail/static/src/models/thread_cache/thread_cache.js
@@ -296,15 +296,17 @@ function factory(dependencies) {
             const moderated_channel_ids = this.thread.moderation
                 ? [this.thread.id]
                 : undefined;
+            const fetchFollowers = (this.thread === this.env.messaging.inbox);
             let messages;
             try {
                 messages = await this.async(() =>
-                    this.env.models['mail.message'].performRpcMessageFetch(
+                    this.env.models['mail.message'].performRpcMessageFetch({
                         domain,
                         limit,
                         moderated_channel_ids,
                         context,
-                    )
+                        fetchFollowers,
+                    })
                 );
             } catch(e) {
                 this.update({

--- a/addons/portal_rating/models/mail_message.py
+++ b/addons/portal_rating/models/mail_message.py
@@ -13,11 +13,11 @@ class MailMessage(models.Model):
             field_list += ['rating_value']
         return super(MailMessage, self)._portal_message_format(field_list)
 
-    def _message_format(self, fnames):
+    def _message_format(self, fnames, fetch_followers=False):
         """ Override the method to add information about a publisher comment
         on each rating messages if requested, and compute a plaintext value of it.
         """
-        vals_list = super(MailMessage, self)._message_format(fnames)
+        vals_list = super(MailMessage, self)._message_format(fnames, fetch_followers=fetch_followers)
 
         if self._context.get('rating_include'):
             infos = ["id", "publisher_comment", "publisher_id", "publisher_datetime", "message_id"]

--- a/addons/sms/models/mail_message.py
+++ b/addons/sms/models/mail_message.py
@@ -34,13 +34,13 @@ class MailMessage(models.Model):
             return ['&', ('notification_ids.notification_status', '=', 'exception'), ('notification_ids.notification_type', '=', 'sms')]
         raise NotImplementedError()
 
-    def message_format(self):
+    def message_format(self, fetch_followers=False):
         """ Override in order to retrieves data about SMS (recipient name and
             SMS status)
 
         TDE FIXME: clean the overall message_format thingy
         """
-        message_values = super(MailMessage, self).message_format()
+        message_values = super(MailMessage, self).message_format(fetch_followers=fetch_followers)
         all_sms_notifications = self.env['mail.notification'].sudo().search([
             ('mail_message_id', 'in', [r['id'] for r in message_values]),
             ('notification_type', '=', 'sms')

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -302,7 +302,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         self._create_test_records()
         test_record = self.env['mail.test.ticket'].browse(self.test_record_full.id)
         test_template = self.env['mail.template'].browse(self.test_template_full.id)
-        with self.assertQueryCount(__system__=11, emp=12):
+        with self.assertQueryCount(__system__=14, emp=15):
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -332,7 +332,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_assignation_inbox(self):
         record = self.env['mail.test.track'].create({'name': 'Test'})
-        with self.assertQueryCount(__system__=17, emp=19):
+        with self.assertQueryCount(__system__=18, emp=20):
             record.write({
                 'user_id': self.user_test.id,
             })
@@ -388,7 +388,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_message_post_one_inbox_notification(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(__system__=11, emp=15):
+        with self.assertQueryCount(__system__=12, emp=16):
             record.message_post(
                 body='<p>Test Post Performances with an inbox ping</p>',
                 partner_ids=self.user_test.partner_id.ids,
@@ -611,7 +611,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         customer_id = self.customer.id
         user_id = self.user_portal.id
 
-        with self.assertQueryCount(__system__=105, emp=106):
+        with self.assertQueryCount(__system__=106, emp=107):
             rec = self.env['mail.test.ticket'].create({
                 'name': 'Test',
                 'container_id': container_id,
@@ -640,7 +640,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.user_portal.partner_id | self.env.user.partner_id)
         self.assertEqual(len(rec1.message_ids), 1)
-        with self.assertQueryCount(__system__=75, emp=75):
+        with self.assertQueryCount(__system__=76, emp=76):
             rec.write({
                 'name': 'Test2',
                 'container_id': self.container.id,
@@ -826,7 +826,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
             ]
         }])
 
-        with self.assertQueryCount(emp=5):
+        with self.assertQueryCount(emp=6):
             res = messages.message_format()
             self.assertEqual(len(res), 2)
             for message in res:
@@ -835,7 +835,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         messages.flush()
         messages.invalidate_cache()
 
-        with self.assertQueryCount(emp=16):
+        with self.assertQueryCount(emp=17):
             res = messages.message_format()
             self.assertEqual(len(res), 2)
             for message in res:
@@ -856,14 +856,14 @@ class TestMailComplexPerformance(BaseMailPerformance):
             'res_id': record.id
         } for record in records])
 
-        with self.assertQueryCount(emp=4):
+        with self.assertQueryCount(emp=5):
             res = messages.message_format()
             self.assertEqual(len(res), 6)
 
         messages.flush()
         messages.invalidate_cache()
 
-        with self.assertQueryCount(emp=12):
+        with self.assertQueryCount(emp=13):
             res = messages.message_format()
             self.assertEqual(len(res), 6)
 
@@ -952,7 +952,7 @@ class TestMailHeavyPerformancePost(BaseMailPerformance):
         ]
         self.attachements = self.env['ir.attachment'].with_user(self.env.user).create(self.vals)
         attachement_ids = self.attachements.ids
-        with self.assertQueryCount(emp=66):
+        with self.assertQueryCount(emp=70):
             self.cr.sql_log = self.warm and self.cr.sql_log_count
             record.with_context({}).message_post(
                 body='<p>Test body <img src="cid:cid1"> <img src="cid:cid2"></p>',


### PR DESCRIPTION
**PURPOSE**

It would be nice to have an unfollow button when in the inbox, starred and
history. This way, if we receive a notification for a record we no longer are
interested in, we could easily stop this from happening again.

**SPECIFICATION**

Adding an unfollow button with icon 'fa-bell-slash-o' next to the name of the
record, should only be visible if the user is part of the followers from the
thread. Clicking on the icon, the notification will be marked as read and the
user will be removed from the followers of the thread.

**LINKS**

PR https://github.com/odoo/odoo/pull/67759
Task- 2242170
