### PR TITLE
[FIX] website_event*: align checkboxes in Event Template Settings

### DIFF
--- a/addons/website_event/views/event_type_views.xml
+++ b/addons/website_event/views/event_type_views.xml
@@ -21,12 +21,12 @@
                         </div>
                         <div class="row mt16" name="menu_register_cta"
                             groups="base.group_no_one">
-                            <label class="col-lg-4" for="menu_register_cta"/> <field name="menu_register_cta"/>
+                            <label class="col" for="menu_register_cta"/> <field name="menu_register_cta"/>
                         </div>
                         <div class="row mt16" name="community_menu"
                             id="community-menu"
                             attrs="{'invisible': [('website_menu', 'in', (True, False))]}">
-                            <label class="col-lg-4" for="community_menu"/> <field name="community_menu"/>
+                            <label class="col" for="community_menu"/> <field name="community_menu"/>
                         </div>
                     </div>
                 </div>

--- a/addons/website_event_exhibitor/views/event_type_views.xml
+++ b/addons/website_event_exhibitor/views/event_type_views.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//div[@name='website_menu']" position='after'>
                 <div class="row mt16" attrs="{'invisible': [('website_menu', '=', False)]}">
-                    <label class="col-lg-4" for="exhibitor_menu"/> <field name="exhibitor_menu"/>
+                    <label class="col" for="exhibitor_menu"/> <field name="exhibitor_menu"/>
                 </div>
             </xpath>
         </field>

--- a/addons/website_event_meet/views/event_type_views.xml
+++ b/addons/website_event_meet/views/event_type_views.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//div[@id='community-menu']" position='after'>
                 <div class="row mt16" attrs="{'invisible': [('website_menu', '=', False)]}">
-                    <label class="col-lg-4" for="meeting_room_allow_creation"/> <field name="meeting_room_allow_creation"/>
+                    <label class="col" for="meeting_room_allow_creation"/> <field name="meeting_room_allow_creation"/>
                 </div>
             </xpath>
             <xpath expr="//div[@id='community-menu']" position="attributes">

--- a/addons/website_event_track/views/event_type_views.xml
+++ b/addons/website_event_track/views/event_type_views.xml
@@ -8,10 +8,10 @@
         <field name="arch" type="xml">
             <xpath expr="//div[@name='website_menu']" position='after'>
                 <div class="row mt16" attrs="{'invisible': [('website_menu', '=', False)]}">
-                    <label class="col-lg-4" for="website_track"/> <field name="website_track"/>
+                    <label class="col" for="website_track"/> <field name="website_track"/>
                 </div>
                 <div class="row mt16" attrs="{'invisible': [('website_menu', '=', False)]}">
-                    <label class="col-lg-4" for="website_track_proposal"/> <field name="website_track_proposal"/>
+                    <label class="col" for="website_track_proposal"/> <field name="website_track_proposal"/>
                 </div>
             </xpath>
         </field>


### PR DESCRIPTION
Before this fix, the checkboxes were under the label on mobile.

The easiest fix is to not specify the col number as the field is
displayed with a width of 50%.

We now have two columns with 50% each that let more space for
long labels.

Steps to reproduce:
- Go to Events
- Configuration / Event Templates
- Go to the form view
- See "Display a dedicated menu on Website" options

Task-ID: 1929043

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
