### PR TITLE
[FIX] base: invalid attribute "delete" for gantt

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1219,8 +1219,15 @@ actual arch.
                         not self._context.get("create", True) and is_base_model):
                     node.set("create", 'false')
 
-        if node.tag in ('kanban', 'tree', 'form', 'gantt'):
+        if node.tag in ('kanban', 'tree', 'form'):
             for action, operation in (('create', 'create'), ('delete', 'unlink'), ('edit', 'write')):
+                if (not node.get(action) and
+                        not Model.check_access_rights(operation, raise_exception=False) or
+                        not self._context.get(action, True) and is_base_model):
+                    node.set(action, 'false')
+
+        if node.tag in ('gantt',):
+            for action, operation in (('create', 'create'), ('edit', 'write')):
                 if (not node.get(action) and
                         not Model.check_access_rights(operation, raise_exception=False) or
                         not self._context.get(action, True) and is_base_model):


### PR DESCRIPTION
Issue
    - remove the delete rights to the user for the project
    - using studio on the project activate the Gantt view

    Validation Error (Invalid view)

Cause
    The method to postprocess access rights add  attributes
    on the main node of the view to allow/disallow creation/edition of
    records through the view globally

    In the case of the Gantt view, An attribute `delete`  is added
    that is not in the correct schema of the Gantt view

Solution
    on the method  postprocess, access rights don't check the delete
    access right for Gantt view

Already fixed on v13 https://github.com/odoo/enterprise/commit/c13a399

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
