### PR TITLE
[IMP] mrp: make the WO done, if nothing to do

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1401,6 +1401,10 @@ class MrpProduction(models.Model):
                     wo.qty_producing = 1
                 else:
                     wo.qty_producing = wo.qty_remaining
+                    if wo.qty_remaining == 0:
+                        wo.button_finish()
+                        move = wo.production_id.move_raw_ids.filtered(lambda m: m.operation_id.id == wo.operation_id.id)
+                        move.quantity_done = wo.qty_produced
 
             production.name = self._get_name_backorder(production.name, production.backorder_sequence)
 


### PR DESCRIPTION
Here, if partial production happens in any MO, backorder
is generated. and if qty is already produced in any WO
that should be finished instead of ready.

TaskId - 2457420

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
