### PR TITLE
[IMP] mail: improve sending message

### DIFF
--- a/addons/mail/static/src/components/composer/composer.js
+++ b/addons/mail/static/src/components/composer/composer.js
@@ -168,10 +168,7 @@ export class Composer extends Component {
             }
             return;
         }
-        await this.composer.postMessage();
-        // TODO: we might need to remove trigger and use the store to wait for the post rpc to be done
-        // task-2252858
-        this.trigger('o-message-posted');
+        this.composer.postMessage({ callback: () => this.trigger('o-message-posted') });
     }
 
     /**

--- a/addons/mail/static/src/components/message/message.js
+++ b/addons/mail/static/src/components/message/message.js
@@ -523,6 +523,49 @@ export class Message extends Component {
         ev.preventDefault();
         this.message.originThread.open();
     }
+
+    /**
+     * @private
+     */
+    _onClickSendAgain(ev) {
+        ev.preventDefault();
+        this.message.originThread.messageSender.sendMessage(this.message, { callback: () => this.trigger('o-message-posted') });
+    }
+
+    /**
+     * @private
+     * @param {MouseEvent} ev
+     */
+    _onClickStar(ev) {
+        ev.stopPropagation();
+        this.message.toggleStar();
+    }
+
+    /**
+     * @private
+     * @param {MouseEvent} ev
+     */
+    _onClickMarkAsRead(ev) {
+        ev.stopPropagation();
+        this.message.markAsRead();
+    }
+
+    /**
+     * @private
+     * @param {MouseEvent} ev
+     */
+    _onClickReply(ev) {
+        // Use this._wasSelected because this.props.isSelected might be changed
+        // by a global capture click handler (for example the one from Composer)
+        // before the current handler is executed. Indeed because it does a
+        // toggle it needs to take into account the value before the click.
+        if (this._wasSelected) {
+            this.messaging.discuss.clearReplyingToMessage();
+        } else {
+            this.message.replyTo();
+        }
+    }
+
 }
 
 Object.assign(Message, {

--- a/addons/mail/static/src/components/message/message.scss
+++ b/addons/mail/static/src/components/message/message.scss
@@ -156,6 +156,10 @@
         }
     }
 
+    &.o-isPendingSendOrHasSendError {
+        opacity: 0.65;
+    }
+
     &.o-selected {
         background-color: gray('400');
 
@@ -232,14 +236,16 @@
 .o_Message_notificationIconClickable {
     color: gray('600');
     cursor: pointer;
-
-    &.o-error {
-        color: o-text-color('danger');
-    }
 }
 
 .o_Message_subject {
     font-style: italic;
+}
+
+// Server will add <p> when processing the message
+// This will add the margin on temporary message to avoid flickers
+.o_Message_prettyBody.o-pending {
+    margin-bottom: $paragraph-margin-bottom;
 }
 
 // Used to hide buttons on rating emails in chatter

--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -12,6 +12,7 @@
                 'o-not-discussion': message and !(message.is_discussion or message.is_notification),
                 'o-notification': message and message.message_type === 'notification',
                 'o-selected': isSelected,
+                'o-isPendingSendOrHasSendError': message and (message.isPendingSend or message.hasSendError),
                 'o-squashed': props.isSquashed,
                 'o-starred': message and message.isStarred,
             }" t-on-click="_onClick" t-on-mouseenter="state.isHovered = true" t-on-mouseleave="state.isHovered = false" t-att-data-message-local-id="message and message.localId"
@@ -36,7 +37,10 @@
                         </div>
                     </t>
                     <t t-else="">
-                        <t t-if="isActive and message.date">
+                        <t t-if="message.hasSendError">
+                            <t t-call="mail.Message_sendAgain"/>
+                        </t>
+                        <t t-if="!message.hasSendError and isActive and message.date">
                             <div class="o_Message_date o_Message_sidebarItem d-flex" t-att-class="{ 'o-message-selected': isSelected }">
                                 <t t-esc="shortTime"/>
                             </div>
@@ -73,6 +77,9 @@
                                 <div class="o_Message_date o_Message_headerDate" t-att-class="{ 'o-message-selected': isSelected }" t-att-title="datetime">
                                     - <t t-esc="message.dateFromNow"/>
                                 </div>
+                            </t>
+                            <t t-if="message.hasSendError">
+                                <t t-call="mail.Message_sendAgain"/>
                             </t>
                             <t t-if="message.isCurrentUserOrGuestAuthor and threadView and threadView.thread and threadView.thread.hasSeenIndicators">
                                 <MessageSeenIndicator class="o_Message_seenIndicator" messageLocalId="message.localId" threadLocalId="threadView.thread.localId"/>
@@ -116,7 +123,7 @@
                             hasMarkAsReadIcon="props.hasMarkAsReadIcon"
                         />
                         <div class="o_Message_content m-2" t-ref="content">
-                            <div class="o_Message_prettyBody" t-ref="prettyBody"/><!-- message.prettyBody is inserted here from _update() -->
+                            <div class="o_Message_prettyBody" t-att-class="{ 'o-isPendingSendOrHasSendError': message and (message.isPendingSend or message.hasSendError) }" t-ref="prettyBody"/><!-- message.prettyBody is inserted here from _update() -->
                             <t t-if="message.subtype_description and !message.isBodyEqualSubtypeDescription">
                                 <p t-esc="message.subtype_description"/>
                             </t>
@@ -164,4 +171,17 @@
         </div>
     </t>
 
+    <t t-name="mail.Message_sendAgain" owl="1">
+        <div class="o_Message_sendAgain text-danger">
+            <Popover position="'top'">
+                <i class="o_Message_sendAgainPopover fa fa-exclamation-circle "/>
+                <t t-set="opened">
+                    <p>This message was not delivered</p>
+                    <button class="btn btn-primary o_Message_sendAgain_button" t-on-click="_onClickSendAgain">
+                        Retry
+                    </button>
+                </t>
+            </Popover>
+        </div>
+    </t>
 </templates>

--- a/addons/mail/static/src/components/message_list/message_list.js
+++ b/addons/mail/static/src/components/message_list/message_list.js
@@ -117,6 +117,7 @@ export class MessageList extends Component {
                     break;
                 case 'message-received':
                 case 'messages-loaded':
+                case 'new-pending-message':
                 case 'new-messages-loaded':
                     // messages have been added at the end, either scroll to the
                     // end or keep the current position

--- a/addons/mail/static/src/components/thread_view/tests/thread_view_tests.js
+++ b/addons/mail/static/src/components/thread_view/tests/thread_view_tests.js
@@ -2078,6 +2078,228 @@ QUnit.test('Retry loading more messages on failed load more messages should load
         },
     });
 });
+QUnit.test('After pressing the send button, message should be pending actual posting', async function (assert) {
+    assert.expect(1);
+
+    this.data['mail.channel'].records = [{
+        channel_type: 'channel',
+        id: 20,
+        is_pinned: true,
+        message_unread_counter: 0,
+        name: "General",
+    }];
+
+    await this.start({
+        async mockRPC(route, args) {
+            if (args.method === 'message_post') {
+                // Simulate pending message post indefinitely
+                await new Promise(() => {});
+            }
+            return this._super(...arguments);
+        },
+    });
+
+    const thread = this.env.models['mail.thread'].findFromIdentifyingData({
+        id: 20,
+        model: 'mail.channel'
+    });
+    const threadViewer = this.env.models['mail.thread_viewer'].create({
+        hasThreadView: true,
+        thread: link(thread),
+    });
+    await this.createThreadViewComponent(threadViewer.threadView, { hasComposer: true });
+
+    document.querySelector('.o_ComposerTextInput_textarea').focus();
+    await afterNextRender(() => document.execCommand('insertText', false, "hey !"));
+    await afterNextRender(() =>
+        document.querySelector('.o_Composer_buttonSend').click()
+    );
+    assert.containsOnce(
+        document.body,
+        '.o-isPendingSend.o_Message_prettyBody',
+        "thread_view should contain 1 pending message"
+    );
+});
+
+QUnit.test('After pressing the send button for 2 messages, 2 messages should be pending actual posting', async function (assert) {
+    assert.expect(1);
+
+    this.data['mail.channel'].records = [{
+        channel_type: 'channel',
+        id: 20,
+        is_pinned: true,
+        message_unread_counter: 0,
+        name: "General",
+    }];
+    this.data['mail.message'].records.push(...[...Array(60).keys()].map(id => {
+        return {
+            body: 'coucou',
+            id,
+            model: "mail.channel",
+            res_id: 20,
+        };
+    }));
+    await this.start({
+        async mockRPC(route, args) {
+            if (args.method === 'message_post') {
+                // Simulate pending message post indefinitely
+                await new Promise(() => {});
+            }
+            return this._super(...arguments);
+        },
+    });
+
+    const thread = this.env.models['mail.thread'].findFromIdentifyingData({
+        id: 20,
+        model: 'mail.channel'
+    });
+    const threadViewer = this.env.models['mail.thread_viewer'].create({
+        hasThreadView: true,
+        thread: link(thread),
+    });
+    await this.createThreadViewComponent(threadViewer.threadView, { hasComposer: true });
+
+    document.querySelector('.o_ComposerTextInput_textarea').focus();
+    await afterNextRender(() => document.execCommand('insertText', false, "hey !"));
+    await afterNextRender(() =>
+        document.querySelector('.o_Composer_buttonSend').click()
+    );
+
+    document.querySelector('.o_ComposerTextInput_textarea').focus();
+    await afterNextRender(() => document.execCommand('insertText', false, "hey !"));
+    await afterNextRender(() =>
+        document.querySelector('.o_Composer_buttonSend').click()
+    );
+    assert.containsN(
+        document.body,
+        '.o-isPendingSend.o_Message_prettyBody',
+        2,
+        "thread_view should contain 2 pending messages"
+    );
+});
+
+QUnit.test('Message in thread view should display a retry button when the message failed to be sent', async function (assert) {
+    assert.expect(1);
+
+    this.data['mail.channel'].records = [{
+        channel_type: 'channel',
+        id: 20,
+        is_pinned: true,
+        message_unread_counter: 0,
+        name: "General",
+    }];
+    this.data['mail.message'].records.push(...[...Array(60).keys()].map(id => {
+        return {
+            body: 'coucou',
+            id,
+            model: "mail.channel",
+            res_id: 20,
+        };
+    }));
+
+    await this.start({
+        async mockRPC(route, args) {
+            if (args.method === 'message_post') {
+                // Simulate posting error
+                throw Error();
+            }
+            return this._super(...arguments);
+        },
+    });
+
+    const thread = this.env.models['mail.thread'].findFromIdentifyingData({
+        id: 20,
+        model: 'mail.channel'
+    });
+    const threadViewer = this.env.models['mail.thread_viewer'].create({
+        hasThreadView: true,
+        thread: link(thread),
+    });
+    await this.createThreadViewComponent(threadViewer.threadView, { hasComposer: true });
+
+    document.querySelector('.o_ComposerTextInput_textarea').focus();
+    await afterNextRender(() => document.execCommand('insertText', false, "hey !"));
+    await afterNextRender(() =>
+        document.querySelector('.o_Composer_buttonSend').click()
+    );
+    assert.containsOnce(
+        document.body,
+        '.o_Message_sendAgain',
+        "Message should have a retry button"
+    );
+});
+
+QUnit.test('Pressing retry button should post the message', async function (assert) {
+    assert.expect(3);
+
+    this.data['mail.channel'].records = [{
+        channel_type: 'channel',
+        id: 20,
+        is_pinned: true,
+        message_unread_counter: 0,
+        name: "General",
+    }];
+    this.data['mail.message'].records = [...Array(90).keys()].map(id => {
+        return {
+            body: 'coucou',
+            id,
+            model: "mail.channel",
+            res_id: 20,
+        };
+    });
+    let triggerError = true;
+    await this.start({
+        async mockRPC(route, args) {
+            if (args.method === 'message_post') {
+                // Simulate posting error
+                if (triggerError) {
+                    throw Error();
+                }
+            }
+            return this._super(...arguments);
+        },
+    });
+
+    const thread = this.env.models['mail.thread'].findFromIdentifyingData({
+        id: 20,
+        model: 'mail.channel'
+    });
+    const threadViewer = this.env.models['mail.thread_viewer'].create({
+        hasThreadView: true,
+        thread: link(thread),
+    });
+    await this.createThreadViewComponent(threadViewer.threadView, { hasComposer: true });
+
+    document.querySelector('.o_ComposerTextInput_textarea').focus();
+    await afterNextRender(() => document.execCommand('insertText', false, "hey !"));
+    await afterNextRender(() =>
+        document.querySelector('.o_Composer_buttonSend').click()
+    );
+    assert.containsOnce(
+        document.body,
+        '.o_Message_sendAgain',
+        "should contain one send again notification"
+    );
+
+    await afterNextRender(() =>
+        document.querySelector('.o_Message_sendAgain_popover').click()
+    );
+    assert.containsOnce(
+        document.body,
+        '.o_Message_sendAgain_button',
+        "should contain a button to send the failed message"
+    );
+
+    triggerError = false;
+    await afterNextRender(() =>
+        document.querySelector('.o_Message_sendAgain_button').click()
+    );
+    assert.containsNone(
+        document.body,
+        '.o_Message_sendAgain',
+        "shouldn't contain any send again notification"
+    );
+});
 
 QUnit.test("highlight the message mentioning the current user inside the channel", async function (assert) {
     assert.expect(1);

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -2261,6 +2261,13 @@ function factory(dependencies) {
             inverse: 'thread',
             isCausal: true,
         }),
+        /**
+         * Sender instance to use to send messages to this thread.
+         */
+        messageSender: one2one('mail.thread_message_sender', {
+            default: create(),
+            inverse: 'thread',
+        }),
         model: attr({
             required: true,
         }),

--- a/addons/mail/static/src/models/thread_message_sender/thread_message_sender.js
+++ b/addons/mail/static/src/models/thread_message_sender/thread_message_sender.js
@@ -1,0 +1,249 @@
+/** @odoo-module **/
+
+import emojis from '@mail/js/emojis';
+import { registerNewModel } from '@mail/model/model_core';
+import { attr, one2many, one2one } from '@mail/model/model_field';
+import { link, unlink } from '@mail/model/model_field_command';
+
+import {
+    addLink,
+    escapeAndCompactTextContent,
+    parseAndTransform,
+ } from '@mail/js/utils';
+
+function factory(dependencies) {
+
+    class ThreadMessageSender extends dependencies['mail.model'] {
+
+        //----------------------------------------------------------------------
+        // Public
+        //----------------------------------------------------------------------
+
+        /**
+         * Convert text message to HTML.
+         *
+         * @private
+         * @param {string} text
+         * @returns {String}
+         */
+        convertMessageToHtml(text) {
+            if (!text) {
+                return;
+            }
+            const escapedAndCompactContent = escapeAndCompactTextContent(text);
+            let body = escapedAndCompactContent.replace(/&nbsp;/g, ' ').trim();
+            // This message will be received from the mail composer as html content
+            // subtype but the urls will not be linkified. If the mail composer
+            // takes the responsibility to linkify the urls we end up with double
+            // linkification a bit everywhere. Ideally we want to keep the content
+            // as text internally and only make html enrichment at display time but
+            // the current design makes this quite hard to do.
+            body = this._generateMentionsLinks(body);
+            body = parseAndTransform(body, addLink);
+            body = this._generateEmojisOnHtml(body);
+            return body;
+        }
+
+        /**
+         * Queue a message and start to process it.
+         *
+         * @param {mail.message} message
+         */
+        sendMessage(message) {
+            this.update({
+                messagesPendingToBeSent: link(message),
+                messagesThatFailedToBeSent: unlink(message),
+            });
+            this._processMessagesToBeSent();
+        }
+
+        //----------------------------------------------------------------------
+        // Private
+        //----------------------------------------------------------------------
+
+        /**
+         * Generates the html link related to the mentioned channels and
+         * partners
+         *
+         * @private
+         * @param {string} body
+         * @returns {string}
+         */
+        _generateMentionsLinks(body) {
+            // List of mention data to insert in the body.
+            // Useful to do the final replace after parsing to avoid using the
+            // same tag twice if two different mentions have the same name.
+            const mentions = [];
+            for (const partner of this.thread.composer.mentionedPartners) {
+                const placeholder = `@-mention-partner-${partner.id}`;
+                const text = `@${owl.utils.escape(partner.name)}`;
+                mentions.push({
+                    class: 'o_mail_redirect',
+                    id: partner.id,
+                    model: 'res.partner',
+                    placeholder,
+                    text,
+                });
+                body = body.replace(text, placeholder);
+            }
+            for (const channel of this.thread.composer.mentionedChannels) {
+                const placeholder = `#-mention-channel-${channel.id}`;
+                const text = `#${owl.utils.escape(channel.name)}`;
+                mentions.push({
+                    class: 'o_channel_redirect',
+                    id: channel.id,
+                    model: 'mail.channel',
+                    placeholder,
+                    text,
+                });
+                body = body.replace(text, placeholder);
+            }
+            const baseHREF = this.env.session.url('/web');
+            for (const mention of mentions) {
+                const href = `href='${baseHREF}#model=${mention.model}&id=${mention.id}'`;
+                const attClass = `class='${mention.class}'`;
+                const dataOeId = `data-oe-id='${mention.id}'`;
+                const dataOeModel = `data-oe-model='${mention.model}'`;
+                const target = `target='_blank'`;
+                const link = `<a ${href} ${attClass} ${dataOeId} ${dataOeModel} ${target}>${mention.text}</a>`;
+                body = body.replace(mention.placeholder, link);
+            }
+            return body;
+        }
+
+        /**
+         * @private
+         * @param {string} htmlString
+         * @returns {string}
+         */
+        _generateEmojisOnHtml(htmlString) {
+            for (const emoji of emojis) {
+                for (const source of emoji.sources) {
+                    const escapedSource = String(source).replace(
+                        /([.*+?=^!:${}()|[\]/\\])/g,
+                        '\\$1');
+                    const regexp = new RegExp(
+                        '(\\s|^)(' + escapedSource + ')(?=\\s|$)',
+                        'g');
+                    htmlString = htmlString.replace(regexp, '$1' + emoji.unicode);
+                }
+            }
+            return htmlString;
+        }
+
+        /**
+         * Send a message to the server based on the thread model and handle RPC
+         * error.
+         * @private
+         * @param {Object} options
+         */
+        async _processMessagesToBeSent() {
+            if (this.isSendingMessages) {
+                return;
+            }
+            this.update({ isSendingMessages: true });
+            const messagePending = this.messagesPendingToBeSent[0];
+            try {
+                const postData = {
+                    attachment_ids: messagePending.attachments.map(attachement => attachement.id),
+                    body: messagePending.body,
+                    message_type: 'comment',
+                    partner_ids: this.thread.composer.recipients.map(partner => partner.id),
+                };
+                const params = {
+                    'post_data': postData,
+                    'thread_id': this.thread.id,
+                    'thread_model': this.thread.model,
+                };
+                if (this.thread.model === 'mail.channel') {
+                    Object.assign(postData, {
+                        subtype_xmlid: 'mail.mt_comment',
+                    });
+                } else {
+                    Object.assign(postData, {
+                        subtype_xmlid: this.thread.composer.isLog ? 'mail.mt_note' : 'mail.mt_comment',
+                    });
+                    if (!this.isLog) {
+                        params.context = { mail_post_autofollow: true };
+                    }
+                }
+                const messageData = await this.env.services.rpc({
+                    route: `/mail/message/post`,
+                    params,
+                }, {
+                    shadow: true,
+                });
+                if (!this.messaging) {
+                    return;
+                }
+                const message = this.messaging.models['mail.message'].insert(
+                    this.messaging.models['mail.message'].convertData(messageData)
+                );
+                for (const threadView of message.originThread.threadViews) {
+                    // Reset auto scroll to be able to see the newly posted message.
+                    threadView.update({ hasAutoScrollOnMessageReceived: true });
+                }
+                if (messagePending.afterSendCallback) {
+                    messagePending.afterSendCallback();
+                }
+                // We cannot simply update the temporary message with the
+                // real data since we don't have a we to link temporary
+                // message and the message comming from the bus. We delete
+                // the temporary message after sending it to the server and
+                // let the bus handle the update
+                messagePending.delete();
+                if (this.messagesPendingToBeSent.length > 0 && this.thread.model !== 'mail.channel') {
+                    this.thread.refreshFollowers();
+                    this.thread.fetchAndUpdateSuggestedRecipients();
+                }
+                this.update({ isSendingMessages: false });
+                if (this.messagesPendingToBeSent.length > 0) {
+                    this._processMessagesToBeSent();
+                }
+            } catch (error) {
+                this.update({
+                    isSendingMessages: false,
+                    messagesPendingToBeSent: unlink(messagePending),
+                    messagesThatFailedToBeSent: link(messagePending),
+                });
+            }
+        }
+
+    }
+
+    ThreadMessageSender.fields = {
+        /**
+         * Determines whether messages are being sent to the server
+         */
+        isSendingMessages: attr({
+            default: false
+        }),
+        /**
+         * Determine the messages pending to be sent to the server by
+         * `processMessageToBeSent`. They will be sent one by one in queue order
+         * (first in, first out).
+         */
+        messagesPendingToBeSent: one2many('mail.message', {
+            default: [],
+        }),
+        /**
+         * Determine the messages that could not be sent to the server due to an
+         * error.
+         */
+        messagesThatFailedToBeSent: one2many('mail.message', {
+            default: [],
+        }),
+        /**
+         * Origin thread of the message.
+         */
+        thread: one2one('mail.thread', {
+            inverse: 'messageSender'
+        }),
+    };
+
+    ThreadMessageSender.modelName = 'mail.thread_message_sender';
+
+    return ThreadMessageSender;
+}
+
+registerNewModel('mail.thread_message_sender', factory);


### PR DESCRIPTION
The current implementation rely on a RPC response to clear the composer and
allow the user to write a new message. This introduce multiple issue when the
server is slow (message lost or send twice).
It also block the composer while a message is being sent.

This PR introduce a message queue that will temporary store the user message and
send them. It free the composer directly and send the message in the background.

It also improve the error handling and allow the user to retry to send message
in error.

task-2390637