### PR TITLE
[FIX] web: Allow filtering with decimals on price filter

### DIFF
--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -390,20 +390,20 @@
                         t-att-type="DECIMAL_POINT === '.' ? 'number' : 'text'"
                         t-attf-title="Number using {{ DECIMAL_POINT }} as decimal separator."
                         t-attf-pattern="[0-9]+([\\{{ DECIMAL_POINT }}][0-9]+)?"
-                        t-att-value="condition.value or (0 + DECIMAL_POINT + 0)"
+                        t-att-value="condition.displayedValue"
                         t-on-input="_onValueInput(condition)"
                     />
                     <input t-elif="['integer', 'id'].includes(fieldType)"
                         class="o_input"
                         step="1"
                         type="number"
-                        t-att-value="condition.value or 0"
+                        t-att-value="condition.displayedValue"
                         t-on-input="_onValueInput(condition)"
                     />
                     <input t-else=""
                         type="text"
                         class="o_input"
-                        t-att-value="condition.value or ''"
+                        t-att-value="condition.displayedValue"
                         t-on-input="_onValueInput(condition)"
                     />
                 </span>


### PR DESCRIPTION
Issue

	- Install "Sales"
	- Switch to "German" language
	- Go to Sales -> Products -> Products
	- Try to filter on "Public Price" is equal to "2,3"

	Not possible to add decimal point at the end (only in middle of number).

Cause

	In case the 'decimal point' in DB params is not a dot '.',
	the filter input will be considered as 'text' instead of
	'number'.

	In case of the 'number' type; HTML do already a pre and post
	processing, including managing decimal point (who, for example,
	is not included in ev.target.value if last char is a '.').
	Unfortunalty, the library is not well working with other
	language and not supported on every browser, therefore,
	must use own logic.

	In case of a 'text' type, the value will be send to 'parseFloat'
	,then `parseNumber` will replace decimal_point by dot (also one the
	issues since needed to display decimal_point according user language),
	and `Number` will remove the decimal_point in case of '123,' -> '123',
	and therefore we will not be able to write decimals ( apart of adding
	the decimal point after writing the whole number...)

Solution

	If user input is well parsed, store parsed value in condition.value and
	set condition.displayedValue to the input value (and so without updating
	input value). Else, replace input value with previous value (who should
	be the condition.DisplayedValue).


opw-2463441