### PR TITLE
[IMP] stock: set partner for inter-warehouse transfers

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -577,6 +577,17 @@ class StockMove(models.Model):
             move_to_recompute_state._recompute_state()
         if receipt_moves_to_reassign:
             receipt_moves_to_reassign._action_assign()
+        # when assign picking for inter-warehouse transfers, set the warehouses as partners on pickings
+        if 'picking_id' in vals:
+            picking = self.picking_id
+            partner = self.env['res.partner']
+            if picking.location_dest_id == picking.company_id.internal_transit_location_id:
+                partner = self.move_dest_ids.location_dest_id.warehouse_id.partner_id
+            if picking.location_id == picking.company_id.internal_transit_location_id:
+                partner = self.move_orig_ids.location_id.warehouse_id.partner_id
+            if len(partner) == 1:
+                picking.partner_id = partner
+
         return res
 
     def _delay_alert_get_documents(self):

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -577,17 +577,6 @@ class StockMove(models.Model):
             move_to_recompute_state._recompute_state()
         if receipt_moves_to_reassign:
             receipt_moves_to_reassign._action_assign()
-        # when assign picking for inter-warehouse transfers, set the warehouses as partners on pickings
-        if 'picking_id' in vals:
-            picking = self.picking_id
-            partner = self.env['res.partner']
-            if picking.location_dest_id == picking.company_id.internal_transit_location_id:
-                partner = self.move_dest_ids.location_dest_id.warehouse_id.partner_id
-            if picking.location_id == picking.company_id.internal_transit_location_id:
-                partner = self.move_orig_ids.location_id.warehouse_id.partner_id
-            if len(partner) == 1:
-                picking.partner_id = partner
-
         return res
 
     def _delay_alert_get_documents(self):

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -290,6 +290,15 @@ class StockRule(models.Model):
         if not self.location_id.should_bypass_reservation():
             move_dest_ids = values.get('move_dest_ids', False) and [(4, x.id) for x in values['move_dest_ids']] or []
 
+        # when create chained moves for inter-warehouse transfers, set the warehouses as partners
+        if not partner and move_dest_ids:
+            move_dest = values['move_dest_ids']
+            if location_id == company_id.internal_transit_location_id:
+                partners = move_dest.location_dest_id.warehouse_id.partner_id
+                if len(partners) == 1:
+                    partner = partners
+                    move_dest.partner_id = partner
+
         move_values = {
             'name': name[:2000],
             'company_id': self.company_id.id or self.location_src_id.company_id.id or self.location_id.company_id.id or company_id.id,

--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -5,14 +5,38 @@
             <t t-call="web.external_layout">
                 <t t-set="o" t-value="o.with_context(lang=o.partner_id.lang)" />
                 <t t-set="partner" t-value="o.partner_id or (o.move_lines and o.move_lines[0].partner_id) or False"/>
-                <t t-if="partner" name="partner_header">
-                    <t t-set="address">
-                        <div t-esc="partner"
-                        t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True}'/>
-                   </t>
-                </t>
 
                 <div class="page">
+                    <div class="row">
+                        <div class="col-6" name="div_outgoing_address">
+                            <div t-if="o.move_ids_without_package and o.move_ids_without_package[0].partner_id and o.move_ids_without_package[0].partner_id.id != o.partner_id.id">
+                                <span><strong>Delivery Address:</strong></span>
+                                <div t-field="o.move_ids_without_package[0].partner_id"
+                                    t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
+                            </div>
+                            <div t-if="o.picking_type_id.code != 'internal' and (not o.move_ids_without_package or not o.move_ids_without_package[0].partner_id) and o.picking_type_id.warehouse_id.partner_id">
+                                <span><strong>Warehouse Address:</strong></span>
+                                <div t-field="o.picking_type_id.warehouse_id.partner_id"
+                                    t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
+                            </div>
+                        </div>
+                        <div class="col-5 offset-1" name="div_incoming_address">
+                            <div t-if="o.picking_type_id.code=='incoming' and partner">
+                                <span><strong>Vendor Address:</strong></span>
+                            </div>
+                            <div t-if="o.picking_type_id.code=='internal' and partner">
+                                <span><strong>Warehouse Address:</strong></span>
+                            </div>
+                            <div t-if="o.picking_type_id.code=='outgoing' and partner">
+                                <span><strong>Customer Address:</strong></span>
+                            </div>
+                            <div t-if="partner" name="partner_header">
+                                <div t-field="partner.self"
+                                    t-options='{"widget": "contact", "fields": ["name", "phone"], "no_marker": True, "phone_icons": True}'/>
+                                <p t-if="partner.sudo().vat"><t t-esc="o.company_id.country_id.vat_label or 'Tax ID'"/>: <span t-field="partner.sudo().vat"/></p>
+                            </div>
+                        </div>
+                    </div>
                     <h2>
                         <span t-field="o.name"/>
                     </h2>

--- a/addons/stock/wizard/product_replenish.py
+++ b/addons/stock/wizard/product_replenish.py
@@ -76,9 +76,7 @@ class ProductReplenish(models.TransientModel):
             raise UserError(error)
 
     def _prepare_run_values(self):
-        replenishment = self.env['procurement.group'].create({
-            'partner_id': self.product_id.with_company(self.company_id).responsible_id.partner_id.id,
-        })
+        replenishment = self.env['procurement.group'].create({})
 
         values = {
             'warehouse_id': self.warehouse_id,


### PR DESCRIPTION
when we have wh1 resupply form wh2, two transfers will be created. One
delivery from wh2 to transit location, one receipt from transit location
to wh1. Both transders don't have receive from/deviver to. In this
commit, we set the corresponding warehouse address as receive
from/deliver to.

Task 2334764



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
