### PR TITLE
[FIX] product: drop filter _filter_single_value_lines

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -465,9 +465,13 @@ class ProductProduct(models.Model):
             for r in supplier_info:
                 supplier_info_by_template.setdefault(r.product_tmpl_id, []).append(r)
         for product in self.sudo():
-            variant = product.product_template_attribute_value_ids._get_combination_name()
+            name = product.name
+            variant = ""
+            product_template_variant_values = product.product_template_attribute_value_ids._without_no_variant_attributes()
+            if product_template_variant_values:
+                variant = ", ".join(product_template_variant_values.mapped('name'))
+                name = "%s (%s)" % (product.name, variant)
 
-            name = variant and "%s (%s)" % (product.name, variant) or product.name
             sellers = []
             if partner_ids:
                 product_supplier_info = supplier_info_by_template.get(product.product_tmpl_id, [])


### PR DESCRIPTION
Method _filter_single_value_lines() in _get_combination_name() is aimed to
filter out attributes that have a single value, e.g. no need specify product
color in name if we sale one color only. It makes sense, but it works too
slow. Because it doesn't seem that important we can drop it for sake of speed.

Perfomance test
===============

* 106 K product templates with 2 attributes and 2 values in each
* 2 languages
* postgres 12.5
* Odoo v13

```
get_all_products_by_barcode

|        | Number of queries | Query time, sec | Remaining time, sec |
|--------+-------------------+-----------------+---------------------|
| Before |            108038 |          85.131 |             247.619 |
| After  |              2141 |          22.744 |             148.291 |

name_search limit=8

|        | Number of queries | Query time, sec | Remaining time, sec |
|--------+-------------------+-----------------+---------------------|
| Before |                21 |           1.564 |               0.028 |
| After  |                19 |           1.620 |               0.021 |

```

---

Co-authored with FP

opw-2459937
opw-2452738
opw-2355449
opw-2377443

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
