### PR TITLE
[13.0] [IMP] account: pass default_type in context when redirecting to new refunds

### DIFF
--- a/addons/account/wizard/account_move_reversal.py
+++ b/addons/account/wizard/account_move_reversal.py
@@ -98,6 +98,7 @@ class AccountMoveReversal(models.TransientModel):
             'name': _('Reverse Moves'),
             'type': 'ir.actions.act_window',
             'res_model': 'account.move',
+            'context': {"default_type": moves_to_redirect[0].type},
         }
         if len(moves_to_redirect) == 1:
             action.update({


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Redirection of the refund wizard.

Current behavior before PR:
No context passed.

Desired behavior after PR is merged:
default_type passed in context. It allows context based invisibility attributes to work the same when opening from the refund menu.




------------------
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
