### PR TITLE
[FIX] base:Multi-website login

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -604,6 +604,10 @@ class Users(models.Model):
                     user = self.search(self._get_login_domain(login))
                     if not user:
                         raise AccessDenied()
+                    elif(len(user) > 1):
+                        website = self.env['website'].get_current_website()
+                        # Limit the current website user
+                        user = user.filtered(lambda u: u.website_id.id == website.id)
                     user = user.sudo(user.id)
                     user._check_credentials(password)
                     user._update_last_login()


### PR DESCRIPTION
When the login returns two users, we limit the current_website user

Description of the issue/feature this PR addresses:
ISSUE:
https://github.com/odoo/odoo/issues/67799

Steps to reproduce:
1.- Activate Free sign up on the website
2.- Register a user with login = imanie383@me.com
3.- Activate Specific User Account in the same website
4.- Register a user with login = imanie383@me.com

Video on odoo/runbot-enterprise 12.0
https://user-images.githubusercontent.com/35231827/111033380-98849d80-83d6-11eb-9e68-a5feb17f7c9f.mp4

Current behavior before PR:
There may be a user.website_id == False and user.website_id = 1
with the same login,

That occasions that the login returns two records and fails in
user = user.sudo(user.id)

Desired behavior after PR is merged:
if you return two users in the login you must limit the _get_login_domain to the .get_current_website ()

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
