### PR TITLE
[FIX] web: Aria attributes on buttons Export All & optional columns

### DIFF
--- a/addons/web/i18n/web.pot
+++ b/addons/web/i18n/web.pot
@@ -2641,6 +2641,13 @@ msgstr ""
 #. openerp-web
 #: code:addons/web/static/src/xml/debug.xml:0
 #, python-format
+msgid "Open Developer Tools"
+msgstr ""
+
+#. module: web
+#. openerp-web
+#: code:addons/web/static/src/xml/debug.xml:0
+#, python-format
 msgid "Open Developer Tools#{widget.debug_mode_help}"
 msgstr ""
 
@@ -2688,6 +2695,13 @@ msgstr ""
 #: code:addons/web/static/src/js/views/view_dialogs.js:0
 #, python-format
 msgid "Open: "
+msgstr ""
+
+#. module: web
+#. openerp-web
+#: code:addons/web/static/src/js/views/list/list_renderer.js:0
+#, python-format
+msgid "Optional columns"
 msgstr ""
 
 #. module: web

--- a/addons/web/static/src/js/core/dom.js
+++ b/addons/web/static/src/js/core/dom.js
@@ -434,6 +434,9 @@ var dom = {
         if (options && options.prop) {
             $input.prop(options.prop);
         }
+        if (options && options.role) {
+            $input.attr('role', options.role);
+        }
         return $container.append($input, $label);
     },
     /**

--- a/addons/web/static/src/js/views/list/list_renderer.js
+++ b/addons/web/static/src/js/views/list/list_renderer.js
@@ -875,6 +875,7 @@ var ListRenderer = BasicRenderer.extend({
             'data-toggle': "dropdown",
             'data-display': "static",
             'aria-expanded': false,
+            'aria-label': _t('Optional columns'),
         });
         $a.appendTo($optionalColumnsDropdown);
 
@@ -893,6 +894,7 @@ var ListRenderer = BasicRenderer.extend({
                 (config.isDebug() ? (' (' + col.attrs.name + ')') : '');
             var $checkbox = dom.renderCheckbox({
                 text: txt,
+                role: "menuitemcheckbox",
                 prop: {
                     name: col.attrs.name,
                     checked: _.contains(self.optionalColumnsEnabled, col.attrs.name),

--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -276,7 +276,7 @@
             </button>
         </t>
         <t t-if="widget.is_action_enabled('export_xlsx')">
-            <button type="button" class="btn btn-secondary fa fa-download o_list_export_xlsx" title="Export All"/>
+            <button type="button" class="btn btn-secondary fa fa-download o_list_export_xlsx" title="Export All" aria-label="Export All"/>
         </t>
     </div>
 </t>

--- a/addons/web/static/src/xml/debug.xml
+++ b/addons/web/static/src/xml/debug.xml
@@ -3,8 +3,11 @@
 
 <t t-name="WebClient.DebugManager">
     <li class="o_debug_manager" role="menuitem">
-        <a role="button" href="#" class="o_debug_mode" t-attf-title="Open Developer Tools#{widget.debug_mode_help}"
-                         t-att-data-debug-mode="widget.debug_mode" aria-label="Open Developer Tools#{widget.debug_mode_help}"
+        <t t-set="_devtool_button_title">Open Developer Tools</t>
+        <a role="button" href="#" class="o_debug_mode"
+                         t-att-title="_devtool_button_title + widget.debug_mode_help"
+                         t-att-aria-label="_devtool_button_title + widget.debug_mode_help"
+                         t-att-data-debug-mode="widget.debug_mode"
                          data-toggle="dropdown" aria-expanded="false" tabindex="-1" data-display="static">
             <span class="fa fa-bug"/>
         </a>


### PR DESCRIPTION
Some aria attributes were missing or incorrectly set on these new
buttons:
- The button "Export All" was missing an `aria-label` attribute
- The button to show/hide optional columns was also missing an
  `aria-label` attribute, and its menu items (checkboxes to show/hide
  columns) were missing a proper role
- Ever since the debug manager was added in frontend on 73327db0656b,
  the `aria-label` attribute was not being rendered correctly on the
  button to open developer tools



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
