### PR TITLE
[FIX] stock: to_date with greater than

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -127,8 +127,8 @@ class Product(models.Model):
         quants_res = dict((item['product_id'][0], item['quantity']) for item in Quant.read_group(domain_quant, ['product_id', 'quantity'], ['product_id'], orderby='id'))
         if dates_in_the_past:
             # Calculate the moves that were done before now to calculate back in time (as most questions will be recent ones)
-            domain_move_in_done = [('state', '=', 'done'), ('date', '>', to_date)] + domain_move_in_done
-            domain_move_out_done = [('state', '=', 'done'), ('date', '>', to_date)] + domain_move_out_done
+            domain_move_in_done = [('state', '=', 'done'), ('date', '<=', to_date)] + domain_move_in_done
+            domain_move_out_done = [('state', '=', 'done'), ('date', '<=', to_date)] + domain_move_out_done
             moves_in_res_past = dict((item['product_id'][0], item['product_qty']) for item in Move.read_group(domain_move_in_done, ['product_id', 'product_qty'], ['product_id'], orderby='id'))
             moves_out_res_past = dict((item['product_id'][0], item['product_qty']) for item in Move.read_group(domain_move_out_done, ['product_id', 'product_qty'], ['product_id'], orderby='id'))
 


### PR DESCRIPTION
This is fixed in newer versions, 13.0 and 14.0.

Description of the issue/feature this PR addresses:
Not sure about this but it is fairly obvious that `to_date` should be compared with `<=` and not `>`.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
