### PR TITLE
[FIX] Fixed outdated Google logo

### DIFF
--- a/addons/auth_oauth/data/auth_oauth_data.xml
+++ b/addons/auth_oauth/data/auth_oauth_data.xml
@@ -26,7 +26,7 @@
             <field name="scope">https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile</field>
             <field name="validation_endpoint">https://www.googleapis.com/oauth2/v1/tokeninfo</field>
             <field name="data_endpoint">https://www.googleapis.com/oauth2/v1/userinfo</field>
-            <field name="css_class">fa fa-fw fa-google-plus-square</field>
+            <field name="css_class">fa fa-fw fa-google</field>
             <field name="body">Log in with Google</field>
         </record>
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR addresses the issue in #67810 namely that the incorrect Google icon is shown on the auth page. Furthermore, other i18n related files still reference the incorrect logo icon. This PR doesn't address those files.

Current behavior before PR:
Showing incorrect Google logo

Desired behavior after PR is merged:
Correct Google logo is shown

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
