### PR TITLE
[FIX] auth_signup, website, base: identical logins

### DIFF
--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -37,7 +37,10 @@ class AuthSignupHome(Home):
                 self.do_signup(qcontext)
                 # Send an account creation confirmation email
                 if qcontext.get('token'):
-                    user_sudo = request.env['res.users'].sudo().search([('login', '=', qcontext.get('login'))])
+                    User = request.env['res.users']
+                    user_sudo = User.sudo().search(
+                        User._get_login_domain(qcontext.get('login')), order=User._get_login_order(), limit=1
+                    )
                     template = request.env.ref('auth_signup.mail_template_user_signup_account_created', raise_if_not_found=False)
                     if user_sudo and template:
                         template.sudo().with_context(

--- a/addons/website/models/res_users.py
+++ b/addons/website/models/res_users.py
@@ -33,6 +33,10 @@ class ResUsers(models.Model):
         return super(ResUsers, self)._get_login_domain(login) + website.website_domain()
 
     @api.model
+    def _get_login_order(self):
+        return 'website_id, ' + super(ResUsers, self)._get_login_order()
+
+    @api.model
     def _signup_create_user(self, values):
         current_website = self.env['website'].get_current_website()
         if request and current_website.specific_user_account:

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -592,6 +592,10 @@ class Users(models.Model):
     def _get_login_domain(self, login):
         return [('login', '=', login)]
 
+    @api.model
+    def _get_login_order(self):
+        return self._order
+
     @classmethod
     def _login(cls, db, login, password):
         if not password:
@@ -601,7 +605,7 @@ class Users(models.Model):
             with cls.pool.cursor() as cr:
                 self = api.Environment(cr, SUPERUSER_ID, {})[cls._name]
                 with self._assert_can_auth():
-                    user = self.search(self._get_login_domain(login))
+                    user = self.search(self._get_login_domain(login), order=self._get_login_order(), limit=1)
                     if not user:
                         raise AccessDenied()
                     user = user.sudo(user.id)


### PR DESCRIPTION
Backport of 1766d3281eec1c23c012049f615097236e43598d

- Create a website:
  Free sign up
  Specific User Account activated
- In the backend, create a partner "test@test.com"
- Grant him portal access
  => user is not website-specific
- Go to the website, Sign Up with "test@test.com"
  => user is website-specific

At login, an expected singleton error arises at:
https://github.com/odoo/odoo/blob/c53f1c6a58b4c8c9e9b3c87f27281c9bfd65a0e1/odoo/addons/base/models/res_users.py#L613

Because this matches both users:
https://github.com/odoo/odoo/blob/c53f1c6a58b4c8c9e9b3c87f27281c9bfd65a0e1/addons/website/models/website.py#L44

When such a case arises, we make sure to always select the most specific
user first.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
