### PR TITLE
[IMP] core: add a neutralize CLI switch

### DIFF
--- a/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
+++ b/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
@@ -191,3 +191,13 @@ class AccountEdiProxyClientUser(models.Model):
         )
         f = Fernet(key)
         return f.decrypt(base64.b64decode(data))
+
+    def _neutralize(self):
+        super()._neutralize()
+        self.flush()
+        self.invalidate_cache()
+        self.env.cr.execute("""
+            INSERT INTO ir_config_parameter(key, value)
+            VALUES ('account_edi_proxy_client.demo', true)
+            ON CONFLICT (key) DO UPDATE SET value = true
+        """)

--- a/addons/auth_oauth/models/auth_oauth.py
+++ b/addons/auth_oauth/models/auth_oauth.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import fields, models
 
 
@@ -21,3 +20,9 @@ class AuthOAuthProvider(models.Model):
     css_class = fields.Char(string='CSS class', default='fa fa-fw fa-sign-in text-primary')
     body = fields.Char(required=True, help='Link text in Login Dialog', translate=True)
     sequence = fields.Integer(default=10)
+
+    def _neutralize(self):
+        super()._neutralize()
+        self.flush()
+        self.invalidate_cache()
+        self.env.cr.execute("UPDATE auth_oauth_provider SET enabled = false")

--- a/addons/delivery/models/delivery_carrier.py
+++ b/addons/delivery/models/delivery_carrier.py
@@ -358,3 +358,16 @@ class DeliveryCarrier(models.Model):
 
     def _product_price_to_company_currency(self, quantity, product, company):
         return company.currency_id._convert(quantity * product.standard_price, product.currency_id, company, fields.Date.today())
+
+    # -------------------------- #
+    # neutralize                 #
+    # -------------------------- #
+
+    def _neutralize(self):
+        super()._neutralize()
+        self.flush()
+        self.invalidate_cache()
+        self.env.cr.execute("""
+            UPDATE delivery_carrier
+            SET prod_environment = false, active = false
+        """)

--- a/addons/delivery/tests/test_packing_delivery.py
+++ b/addons/delivery/tests/test_packing_delivery.py
@@ -76,3 +76,9 @@ class TestPacking(TestPackingCommon):
         # default weight was set.
         pack_wiz = self.env['choose.delivery.package'].with_context(pack_action_ctx).create({})
         self.assertEqual(pack_wiz.shipping_weight, 13.5)
+
+    def test_delivery_carrier_neutralize(self):
+        """ ensure that devlivery carriers can be nautralized """
+        self.assertTrue(self.test_carrier.active)
+        self.env['delivery.carrier']._neutralize()
+        self.assertFalse(self.test_carrier.active, "Delivery Carrier was not neutralized")

--- a/addons/iap/models/iap_account.py
+++ b/addons/iap/models/iap_account.py
@@ -118,3 +118,26 @@ class IapAccount(models.Model):
                 credit = -1
 
         return credit
+
+    def _neutralize(self):
+        super()._neutralize()
+        self.flush()
+        self.invalidate_cache()
+
+        self.env.cr.execute("""
+            INSERT INTO ir_config_parameter(key, value)
+            VALUES ('iap.endpoint', 'https://iap-sandbox.odoo.com')
+            ON CONFLICT (key) DO UPDATE SET value = 'https://iap-sandbox.odoo.com'
+        """)
+
+        iap_service_endpoints = self._get_iap_config_parameters()
+        if iap_service_endpoints:
+            self.env.cr.execute("""
+                UPDATE ir_config_parameter
+                SET value = 'https://iap-services-test.odoo.com'
+                WHERE key IN %s
+            """, [tuple(iap_service_endpoints)])
+
+    def _get_iap_config_parameters(self):
+        """override this method to extend the list with each parameter"""
+        return []

--- a/addons/l10n_es_edi_sii/models/res_company.py
+++ b/addons/l10n_es_edi_sii/models/res_company.py
@@ -42,3 +42,9 @@ class ResCompany(models.Model):
                 )
             else:
                 company.l10n_es_edi_certificate_id = False
+
+    def _neutralize(self):
+        super()._neutralize()
+        self.flush()
+        self.invalidate_cache()
+        self.env.cr.execute("UPDATE res_company SET l10n_es_edi_test_env = true")

--- a/addons/l10n_es_edi_sii/tests/__init__.py
+++ b/addons/l10n_es_edi_sii/tests/__init__.py
@@ -2,3 +2,4 @@
 
 from . import test_edi_xml
 from . import test_edi_web_services
+from . import test_neutralize

--- a/addons/l10n_es_edi_sii/tests/test_neutralize.py
+++ b/addons/l10n_es_edi_sii/tests/test_neutralize.py
@@ -1,0 +1,15 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.tests.common import tagged, TransactionCase
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestL10nEsEdiNeutralize(TransactionCase):
+
+    def test_l10n_es_edi_neutralize(self):
+        ar_company = self.env['res.company'].create({
+            'name': 'Test ES Company',
+            'l10n_es_edi_test_env': False,
+        })
+
+        self.env['res.company']._neutralize()
+        self.assertEqual(ar_company.l10n_es_edi_test_env, True)

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -326,3 +326,13 @@ class MailTemplate(models.Model):
         if force_send:
             mail.send(raise_exception=raise_exception)
         return mail.id  # TDE CLEANME: return mail + api.returns ?
+
+    # ------------------------------------------------------------
+    # neutralize
+    # ------------------------------------------------------------
+
+    def _neutralize(self):
+        super()._neutralize()
+        self.flush()
+        self.invalidate_cache()
+        self.env.cr.execute("UPDATE mail_template SET mail_server_id=NULL")

--- a/addons/mail/tests/test_mail_render.py
+++ b/addons/mail/tests/test_mail_render.py
@@ -463,3 +463,19 @@ class TestMailRender(common.MailCommon):
         self.assertEqual(result, '''<div style="display:none;font-size:1px;height:0px;width:0px;opacity:0;">
                     foo<t t-out="&#34;false&#34; if 1 &gt; 2 else &#34;true&#34;"/>bar
                 </div>body''')
+
+    def test_mail_template_neutralize(self):
+        """ ensure mail templates can be neutralized """
+        fake_mail_server = self.env['ir.mail_server'].create({
+            'name': "fake test email server",
+            'smtp_host': "mail.example.com",
+            'smtp_port': 15626,
+        })
+        self.test_template.mail_server_id = fake_mail_server
+        self.env['mail.template']._neutralize()
+        self.assertFalse(self.test_template.mail_server_id)
+
+        # bonus test mail server neutralize too
+        self.assertTrue(fake_mail_server.active)
+        self.env['ir.mail_server']._neutralize()
+        self.assertFalse(fake_mail_server.active)

--- a/addons/partner_autocomplete/models/__init__.py
+++ b/addons/partner_autocomplete/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import iap_account
 from . import iap_autocomplete_api
 from . import ir_http
 from . import res_partner

--- a/addons/partner_autocomplete/models/iap_account.py
+++ b/addons/partner_autocomplete/models/iap_account.py
@@ -1,0 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class IapAccount(models.Model):
+    _inherit = 'iap.account'
+
+    def _get_iap_config_parameters(self):
+        return super()._get_iap_config_parameters() + ['iap.partner_autocomplete.endpoint']

--- a/addons/partner_autocomplete/tests/test_neutralize.py
+++ b/addons/partner_autocomplete/tests/test_neutralize.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import TransactionCase
+
+
+class TestPartnerAutocompleteNeutralize(TransactionCase):
+
+    def test_partner_autocomplete_neutralize(self):
+        iap_key = 'iap.partner_autocomplete.endpoint'
+        self.env['ir.config_parameter'].create({
+            'key': iap_key,
+            'value': 'fake test iap partner autocomplete endpoint'
+        })
+
+        self.env['iap.account']._neutralize()
+        self.assertEqual(self.env['ir.config_parameter'].get_param(iap_key), 'https://iap-services-test.odoo.com')

--- a/addons/payment_adyen/models/payment_acquirer.py
+++ b/addons/payment_adyen/models/payment_acquirer.py
@@ -134,3 +134,11 @@ class PaymentAcquirer(models.Model):
         if self.provider != 'adyen':
             return super()._get_default_payment_method_id()
         return self.env.ref('payment_adyen.payment_method_adyen').id
+
+    def _neutralize(self):
+        super()._neutralize()
+        self._neutralize_fields('adyen', [
+            'adyen_merchant_account',
+            'adyen_api_key',
+            'adyen_hmac_key',
+        ])

--- a/addons/payment_adyen/tests/test_adyen.py
+++ b/addons/payment_adyen/tests/test_adyen.py
@@ -129,3 +129,10 @@ class AdyenTest(AdyenCommon, PaymentHttpCommon):
             payload,
             self.acquirer.adyen_hmac_key,
         )
+
+    def test_adyen_neutralize(self):
+        self.env['payment.acquirer']._neutralize()
+
+        self.assertEqual(self.acquirer.adyen_merchant_account, False)
+        self.assertEqual(self.acquirer.adyen_api_key, False)
+        self.assertEqual(self.acquirer.adyen_hmac_key, False)

--- a/addons/payment_alipay/models/payment_acquirer.py
+++ b/addons/payment_alipay/models/payment_acquirer.py
@@ -64,3 +64,11 @@ class PaymentAcquirer(models.Model):
         if self.provider != 'alipay':
             return super()._get_default_payment_method_id()
         return self.env.ref('payment_alipay.payment_method_alipay').id
+
+    def _neutralize(self):
+        super()._neutralize()
+        self._neutralize_fields('alipay', [
+            'alipay_merchant_partner_id',
+            'alipay_md5_signature_key',
+            'alipay_seller_email',
+        ])

--- a/addons/payment_alipay/tests/test_alipay.py
+++ b/addons/payment_alipay/tests/test_alipay.py
@@ -214,3 +214,10 @@ class AlipayTest(AlipayCommon, PaymentHttpCommon):
         tx = self.create_transaction('redirect')
         payload = dict(self.NOTIFICATION_DATA, sign='dummy')
         self.assertRaises(Forbidden, AlipayController._verify_notification_signature, payload, tx)
+
+    def test_alipay_neutralize(self):
+        self.env['payment.acquirer']._neutralize()
+
+        self.assertEqual(self.acquirer.alipay_merchant_partner_id, False)
+        self.assertEqual(self.acquirer.alipay_md5_signature_key, False)
+        self.assertEqual(self.acquirer.alipay_seller_email, False)

--- a/addons/payment_authorize/models/payment_acquirer.py
+++ b/addons/payment_authorize/models/payment_acquirer.py
@@ -132,3 +132,12 @@ class PaymentAcquirer(models.Model):
         if self.provider != 'authorize':
             return super()._get_default_payment_method_id()
         return self.env.ref('payment_authorize.payment_method_authorize').id
+
+    def _neutralize(self):
+        super()._neutralize()
+        self._neutralize_fields('authorize', [
+            'authorize_login',
+            'authorize_transaction_key',
+            'authorize_signature_key',
+            'authorize_client_key',
+        ])

--- a/addons/payment_authorize/tests/test_authorize.py
+++ b/addons/payment_authorize/tests/test_authorize.py
@@ -54,3 +54,11 @@ class AuthorizeTest(AuthorizeCommon):
         token = self.create_token(active=False)
         with self.assertRaises(UserError):
             token._handle_reactivation_request()
+
+    def test_authorize_neutralize(self):
+        self.env['payment.acquirer']._neutralize()
+
+        self.assertEqual(self.acquirer.authorize_login, False)
+        self.assertEqual(self.acquirer.authorize_transaction_key, False)
+        self.assertEqual(self.acquirer.authorize_signature_key, False)
+        self.assertEqual(self.acquirer.authorize_client_key, False)

--- a/addons/payment_buckaroo/models/payment_acquirer.py
+++ b/addons/payment_buckaroo/models/payment_acquirer.py
@@ -69,3 +69,7 @@ class PaymentAcquirer(models.Model):
         if self.provider != 'buckaroo':
             return super()._get_default_payment_method_id()
         return self.env.ref('payment_buckaroo.payment_method_buckaroo').id
+
+    def _neutralize(self):
+        super()._neutralize()
+        self._neutralize_fields('buckaroo', ['buckaroo_website_key', 'buckaroo_secret_key'])

--- a/addons/payment_buckaroo/tests/test_buckaroo.py
+++ b/addons/payment_buckaroo/tests/test_buckaroo.py
@@ -107,3 +107,9 @@ class BuckarooTest(BuckarooCommon):
             '937cca8f486b75e93df1e9811a5ebf43357fc3f2',
             msg="The signing string items should be ordered based on a lower-case copy of the keys",
         )
+
+    def test_buckaroo_neutralize(self):
+        self.env['payment.acquirer']._neutralize()
+
+        self.assertEqual(self.acquirer.buckaroo_website_key, False)
+        self.assertEqual(self.acquirer.buckaroo_secret_key, False)

--- a/addons/payment_ogone/models/payment_acquirer.py
+++ b/addons/payment_ogone/models/payment_acquirer.py
@@ -120,3 +120,13 @@ class PaymentAcquirer(models.Model):
         if self.provider != 'ogone':
             return super()._get_default_payment_method_id()
         return self.env.ref('payment_ogone.payment_method_ogone').id
+
+    def _neutralize(self):
+        super()._neutralize()
+        self._neutralize_fields('ogone', [
+            'ogone_pspid',
+            'ogone_userid',
+            'ogone_password',
+            'ogone_shakey_in',
+            'ogone_shakey_out',
+        ])

--- a/addons/payment_ogone/tests/test_ogone.py
+++ b/addons/payment_ogone/tests/test_ogone.py
@@ -161,3 +161,12 @@ class OgoneTest(OgoneCommon, PaymentHttpCommon):
             'dummy',
             tx,
         )
+
+    def test_ogone_neutralize(self):
+        self.env['payment.acquirer']._neutralize()
+
+        self.assertEqual(self.acquirer.ogone_pspid, False)
+        self.assertEqual(self.acquirer.ogone_userid, False)
+        self.assertEqual(self.acquirer.ogone_password, False)
+        self.assertEqual(self.acquirer.ogone_shakey_in, False)
+        self.assertEqual(self.acquirer.ogone_shakey_out, False)

--- a/addons/payment_paypal/models/payment_acquirer.py
+++ b/addons/payment_paypal/models/payment_acquirer.py
@@ -71,3 +71,11 @@ class PaymentAcquirer(models.Model):
         if self.provider != 'paypal':
             return super()._get_default_payment_method_id()
         return self.env.ref('payment_paypal.payment_method_paypal').id
+
+    def _neutralize(self):
+        super()._neutralize()
+        self._neutralize_fields('paypal', [
+            'paypal_email_account',
+            'paypal_seller_account',
+            'paypal_pdt_token',
+        ])

--- a/addons/payment_paypal/tests/test_paypal.py
+++ b/addons/payment_paypal/tests/test_paypal.py
@@ -142,3 +142,10 @@ class PaypalTest(PaypalCommon, PaymentHttpCommon):
         ):
             self._make_http_post_request(url, data=self.NOTIFICATION_DATA)
             self.assertEqual(origin_check_mock.call_count, 1)
+
+    def test_paypal_neutralize(self):
+        self.env['payment.acquirer']._neutralize()
+
+        self.assertEqual(self.acquirer.paypal_email_account, False)
+        self.assertEqual(self.acquirer.paypal_seller_account, False)
+        self.assertEqual(self.acquirer.paypal_pdt_token, False)

--- a/addons/payment_payulatam/models/payment_acquirer.py
+++ b/addons/payment_payulatam/models/payment_acquirer.py
@@ -74,3 +74,11 @@ class PaymentAcquirer(models.Model):
         if self.provider != 'payulatam':
             return super()._get_default_payment_method_id()
         return self.env.ref('payment_payulatam.payment_method_payulatam').id
+
+    def _neutralize(self):
+        super()._neutralize()
+        self._neutralize_fields('payulatam', [
+            'payulatam_merchant_id',
+            'payulatam_account_id',
+            'payulatam_api_key',
+        ])

--- a/addons/payment_payulatam/tests/test_payulatam.py
+++ b/addons/payment_payulatam/tests/test_payulatam.py
@@ -144,3 +144,10 @@ class PayULatamTest(PayULatamCommon):
         self.env['payment.transaction']._handle_feedback_data('payulatam', payulatam_post_data)
         self.assertEqual(tx.state, 'done', 'Payulatam: wrong state after receiving a valid pending notification')
         self.assertEqual(tx.acquirer_reference, 'b232989a-4aa8-42d1-bace-153236eee791', 'Payulatam: wrong txn_id after receiving a valid pending notification')
+
+    def test_payulatam_neutralize(self):
+        self.env['payment.acquirer']._neutralize()
+
+        self.assertEqual(self.acquirer.payulatam_merchant_id, False)
+        self.assertEqual(self.acquirer.payulatam_account_id, False)
+        self.assertEqual(self.acquirer.payulatam_api_key, False)

--- a/addons/payment_payumoney/models/payment_acquirer.py
+++ b/addons/payment_payumoney/models/payment_acquirer.py
@@ -55,3 +55,7 @@ class PaymentAcquirer(models.Model):
         if self.provider != 'payumoney':
             return super()._get_default_payment_method_id()
         return self.env.ref('payment_payumoney.payment_method_payumoney').id
+
+    def _neutralize(self):
+        super()._neutralize()
+        self._neutralize_fields('payumoney', ['payumoney_merchant_key', 'payumoney_merchant_salt'])

--- a/addons/payment_payumoney/tests/test_payumoney.py
+++ b/addons/payment_payumoney/tests/test_payumoney.py
@@ -85,3 +85,9 @@ class PayUMoneyTest(PayumoneyCommon, PaymentHttpCommon):
         self.assertRaises(
             Forbidden, PayUMoneyController._verify_notification_signature, payload, tx
         )
+
+    def test_payumoney_neutralize(self):
+        self.env['payment.acquirer']._neutralize()
+
+        self.assertEqual(self.acquirer.payumoney_merchant_key, False)
+        self.assertEqual(self.acquirer.payumoney_merchant_salt, False)

--- a/addons/payment_sips/models/payment_acquirer.py
+++ b/addons/payment_sips/models/payment_acquirer.py
@@ -60,3 +60,7 @@ class PaymentAcquirer(models.Model):
         if self.provider != 'sips':
             return super()._get_default_payment_method_id()
         return self.env.ref('payment_sips.payment_method_sips').id
+
+    def _neutralize(self):
+        super()._neutralize()
+        self._neutralize_fields('sips', ['sips_merchant_id', 'sips_secret'])

--- a/addons/payment_sips/tests/test_sips.py
+++ b/addons/payment_sips/tests/test_sips.py
@@ -137,3 +137,9 @@ class SipsTest(SipsCommon, PaymentHttpCommon):
         tx = self.create_transaction('redirect')
         payload = dict(self.NOTIFICATION_DATA, Seal='dummy')
         self.assertRaises(Forbidden, SipsController._verify_notification_signature, payload, tx)
+
+    def test_sips_neutralize(self):
+        self.env['payment.acquirer']._neutralize()
+
+        self.assertEqual(self.acquirer.sips_merchant_id, False)
+        self.assertEqual(self.acquirer.sips_secret, False)

--- a/addons/payment_stripe/models/payment_acquirer.py
+++ b/addons/payment_stripe/models/payment_acquirer.py
@@ -78,3 +78,11 @@ class PaymentAcquirer(models.Model):
         if self.provider != 'stripe':
             return super()._get_default_payment_method_id()
         return self.env.ref('payment_stripe.payment_method_stripe').id
+
+    def _neutralize(self):
+        super()._neutralize()
+        self._neutralize_fields('stripe', [
+            'stripe_secret_key',
+            'stripe_publishable_key',
+            'stripe_webhook_secret',
+        ])

--- a/addons/payment_stripe/tests/test_stripe.py
+++ b/addons/payment_stripe/tests/test_stripe.py
@@ -64,3 +64,10 @@ class StripeTest(StripeCommon, PaymentHttpCommon):
         ):
             self._make_json_request(url, data=self.NOTIFICATION_DATA)
             self.assertEqual(signature_check_mock.call_count, 1)
+
+    def test_stripe_neutralize(self):
+        self.env['payment.acquirer']._neutralize()
+
+        self.assertEqual(self.acquirer.stripe_secret_key, False)
+        self.assertEqual(self.acquirer.stripe_publishable_key, False)
+        self.assertEqual(self.acquirer.stripe_webhook_secret, False)

--- a/addons/sms/models/__init__.py
+++ b/addons/sms/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import iap_account
 from . import ir_actions
 from . import ir_model
 from . import mail_followers

--- a/addons/sms/models/iap_account.py
+++ b/addons/sms/models/iap_account.py
@@ -1,0 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class IapAccount(models.Model):
+    _inherit = 'iap.account'
+
+    def _get_iap_config_parameters(self):
+        return super()._get_iap_config_parameters() + ['sms.endpoint']

--- a/addons/sms/tests/__init__.py
+++ b/addons/sms/tests/__init__.py
@@ -2,4 +2,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import common
+from . import test_neutralize
 from . import test_sms_template

--- a/addons/sms/tests/test_neutralize.py
+++ b/addons/sms/tests/test_neutralize.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import TransactionCase
+
+
+class TestSmsNeutralize(TransactionCase):
+
+    def test_sms_neutralize(self):
+        sms_key = 'sms.endpoint'
+        self.env['ir.config_parameter'].create({
+            'key': sms_key,
+            'value': 'fake test sms endpoint'
+        })
+
+        self.env['iap.account']._neutralize()
+        self.assertEqual(self.env['ir.config_parameter'].get_param(sms_key), 'https://iap-services-test.odoo.com')

--- a/addons/snailmail/models/__init__.py
+++ b/addons/snailmail/models/__init__.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from . import res_company
-from . import res_partner
-from . import res_config_settings
-from . import mail_notification
-from . import snailmail_letter
+from . import iap_account
 from . import ir_actions_report
 from . import ir_qweb_fields
 from . import mail_message
+from . import mail_notification
+from . import res_company
+from . import res_config_settings
+from . import res_partner
+from . import snailmail_letter

--- a/addons/snailmail/models/iap_account.py
+++ b/addons/snailmail/models/iap_account.py
@@ -1,0 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class IapAccount(models.Model):
+    _inherit = 'iap.account'
+
+    def _get_iap_config_parameters(self):
+        return super()._get_iap_config_parameters() + ['snailmail.endpoint']

--- a/addons/snailmail/tests/__init__.py
+++ b/addons/snailmail/tests/__init__.py
@@ -2,4 +2,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_neutralize
-from . import test_res_company

--- a/addons/snailmail/tests/test_neutralize.py
+++ b/addons/snailmail/tests/test_neutralize.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import TransactionCase
+
+
+class TestSnailMailNeutralize(TransactionCase):
+
+    def test_snailmail_neutralize(self):
+        key = 'snailmail.endpoint'
+        self.env['ir.config_parameter'].create({
+            'key': key,
+            'value': 'fake test snailmail endpoint'
+        })
+
+        self.env['iap.account']._neutralize()
+        self.assertEqual(self.env['ir.config_parameter'].get_param(key), 'https://iap-services-test.odoo.com')

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1758,3 +1758,12 @@ class Website(models.Model):
                         for word in re.findall(match_pattern, value):
                             if word[0] == search[0]:
                                 yield word.lower()
+
+    # ----------------------------------------------------------
+    # ORM overrides
+    # ----------------------------------------------------------
+    def _neutralize(self):
+        super()._neutralize()
+        self.flush()
+        self.invalidate_cache()
+        self.env.cr.execute("UPDATE website SET domain=NULL")

--- a/addons/website_crm_iap_reveal/models/__init__.py
+++ b/addons/website_crm_iap_reveal/models/__init__.py
@@ -4,4 +4,5 @@
 from . import crm_lead
 from . import crm_reveal_rule
 from . import crm_reveal_view
+from . import iap_account
 from . import ir_http

--- a/addons/website_crm_iap_reveal/models/iap_account.py
+++ b/addons/website_crm_iap_reveal/models/iap_account.py
@@ -1,0 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class IapAccount(models.Model):
+    _inherit = 'iap.account'
+
+    def _get_iap_config_parameters(self):
+        return super()._get_iap_config_parameters() + ['reveal.endpoint']

--- a/addons/website_crm_iap_reveal/tests/__init__.py
+++ b/addons/website_crm_iap_reveal/tests/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_lead_reveal
+from . import test_neutralize

--- a/addons/website_crm_iap_reveal/tests/test_neutralize.py
+++ b/addons/website_crm_iap_reveal/tests/test_neutralize.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import TransactionCase
+
+
+class TestIapLeadWebsiteNeutralize(TransactionCase):
+
+    def test_iap_lead_website_neutralize(self):
+        ICP = self.env['ir.config_parameter']
+        key = 'reveal.endpoint'
+        ICP.set_param(key, 'Fake test reveal endpoint')
+
+        self.env['iap.account']._neutralize()
+        self.assertEqual(ICP.get_param(key), 'https://iap-services-test.odoo.com')

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -658,6 +658,19 @@ class IrActionsServer(models.Model):
                 )
         return res or False
 
+    def _neutralize(self):
+        # In some cases, cron neutralization is not enough as modifying records
+        # like `fetchmail.server`, `calendar.alarm` and `base.automation` will
+        # re-enable their cron jobs as a side-effect.
+        super()._neutralize()
+        self.flush()
+        self.invalidate_cache()
+        self.env.cr.execute("""
+            UPDATE ir_act_server
+            SET code = '#' || REPLACE(code, E'\n', E'\n#')
+            WHERE usage = 'ir_cron' AND state = 'code'
+        """)
+
 
 class IrServerObjectLines(models.Model):
     _name = 'ir.server.object.lines'

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -465,6 +465,19 @@ class ir_cron(models.Model):
             cr.execute('NOTIFY cron_trigger, %s', [self.env.cr.dbname])
         _logger.debug("cron workers notified")
 
+    def _neutralize(self):
+        super()._neutralize()
+        self.flush()
+        self.invalidate_cache()
+        self.env.cr.execute("""
+            UPDATE ir_cron
+            SET active = false
+            WHERE id NOT IN (
+                SELECT res_id FROM ir_model_data
+                WHERE model='ir.cron' AND name = 'autovacuum_job'
+            )
+        """)
+
 
 class ir_cron_trigger(models.Model):
     _name = 'ir.cron.trigger'

--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -712,3 +712,9 @@ class IrMailServer(models.Model):
         outgoing mail server.
         """
         return getattr(threading.currentThread(), 'testing', False) or self.env.registry.in_test_mode()
+
+    def _neutralize(self):
+        super()._neutralize()
+        self.flush()
+        self.invalidate_cache()
+        self.env.cr.execute("UPDATE ir_mail_server SET active = false")

--- a/odoo/cli/__init__.py
+++ b/odoo/cli/__init__.py
@@ -14,3 +14,4 @@ from . import shell
 from . import start
 from . import populate
 from . import tsconfig
+from . import neutralize

--- a/odoo/cli/neutralize.py
+++ b/odoo/cli/neutralize.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+import optparse
+import sys
+
+import odoo
+
+from pathlib import Path
+
+from . import Command
+
+_logger = logging.getLogger(__name__)
+
+
+class Neutralize(Command):
+    """neutralize a database"""
+
+    def run(self, args):
+        parser = odoo.tools.config.parser
+        group = optparse.OptionGroup(parser, "Neutralize", "Neutralize the database specified by the `-d` argument.")
+        parser.add_option_group(group)
+        odoo.tools.config.parse_config(args)
+
+        dbname = odoo.tools.config['db_name']
+        if not dbname:
+            _logger.error('Neutralize command needs a database name. Use "-d" argument')
+            sys.exit(1)
+
+        registry = odoo.registry(dbname)
+        _logger.info('Starting database neutralization')
+        try:
+            with registry.cursor() as cr:
+                env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
+                for model in env.values():
+                    model._neutralize()
+                with open(Path(__file__).parent / 'neutralize_watermarks.xml', 'rb') as f:
+                    odoo.tools.convert_xml_import(cr, "__neutralize__", f)
+        except Exception:
+            _logger.error('An exception occured during neutralization.')
+            raise
+        _logger.info('Neutralization finished')

--- a/odoo/cli/neutralize_watermarks.xml
+++ b/odoo/cli/neutralize_watermarks.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <template t-name="neutralize_banner" inherit_id="web.layout">
+        <xpath expr="//body" position="inside">
+            <div>
+                <span style="text-align: center;
+                        color: #FFFFFF;
+                        background-color: #D0442C;
+                        position: relative;
+                        display: block;
+                        font-size: 16px;">
+                    This database is neutralized.
+                </span>
+            </div>
+        </xpath>
+    </template>
+    <template t-name="neutralize_ribbon" inherit_id="web.layout">
+        <xpath expr="//body" position="inside">
+            <div>
+                <span style="width: 400px;
+                        top: 55px;
+                        left: -100px;
+                        font-size: 32px;
+                        text-align: center;
+                        padding: 10px;
+                        line-height: 30px;
+                        color: #f0f0f0;
+                        transform: rotate(-45deg);
+                        position: fixed;
+                        box-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
+                        background: #D0442C;
+                        opacity: 0.6;
+                        pointer-events: none;
+                        text-transform: uppercase;
+                        z-index:9999">Neutralized</span>
+            </div>
+        </xpath>
+    </template>
+</odoo>

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6684,6 +6684,12 @@ Fields:
             records_batches.append(self.create(create_values))
         return self.concat(*records_batches)
 
+    def _neutralize(self):
+        """ Neutralize this model's records.
+        This should prevent the database from connecting to external services.
+        """
+        return
+
 
 collections.Set.register(BaseModel)
 # not exactly true as BaseModel doesn't have index or count


### PR DESCRIPTION
When debugging a database, it's sometimes desirable to neutralize it to avoid undesired side effects like sending emails.

This PR adds a generic method on models to neutralize the current database.
This method have to be overridden by modules models.

The neutralize operation cannot be reversed should only be used on a database copy.
