### PR TITLE
[IMP] web_editor, *: add a replace media button as an opt in the panel

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -270,6 +270,12 @@ var SnippetEditor = Widget.extend({
         if (this.$target.is('img')) {
             return _t("Image");
         }
+        if (this.$target.is('.fa')) {
+            return _t("Icon");
+        }
+        if (this.$target.is('.media_iframe_video')) {
+            return _t("Video");
+        }
         if (this.$target.parent('.row').length) {
             return _t("Column");
         }

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -3780,6 +3780,63 @@ registry['sizing_y'] = registry.sizing.extend({
     },
 });
 
+/**
+ * Allows for media to be replaced.
+ */
+registry.ReplaceMedia = SnippetOptionWidget.extend({
+    /**
+     * @override
+     */
+    start() {
+        const $button = this.$el.find('we-button.fa');
+        this.$overlayRemove = this.$overlay.find('.oe_snippet_remove');
+        $button.insertBefore(this.$overlayRemove);
+
+        return this._super(...arguments);
+    },
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    async updateUIVisibility() {
+        this.$overlayRemove.toggleClass('d-none', this.$target.is('.fa'));
+        return this._super(...arguments);
+    },
+
+    //--------------------------------------------------------------------------
+    // Options
+    //--------------------------------------------------------------------------
+
+    /**
+     * Replaces the media.
+     *
+     * @see this.selectClass for parameters
+     */
+    async replaceMedia() {
+        // TODO for now, this simulates a double click on the media,
+        // to be refactored when the new editor is merged
+        this.$target.dblclick();
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    async _computeWidgetVisibility(widgetName, params) {
+        if (widgetName === 'replace_media_overlay_opt') {
+            return !this.$target.is('.fa');
+        }
+        return this._super(...arguments);
+    }
+});
+
 /*
  * Abstract option to be extended by the ImageOptimize and BackgroundOptimize
  * options that handles all the common parts.

--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -353,6 +353,18 @@
     <div data-js="VersionControl"
          data-selector="[data-snippet]"/>
 
+    <!-- Replace a media -->
+    <!-- TODO probably review this system once the new editor is merged to not duplicate the selector, etc -->
+    <!-- TODO enable on span.fa, i.fa too but in current editor, this is problematic so best not waste more time for now -->
+    <div data-js="ReplaceMedia" data-selector="img, .media_iframe_video">
+        <!-- Overlay button -->
+        <we-button data-name="replace_media_overlay_opt" title="Replace" class="fa fa-refresh" data-replace-media="true" data-no-preview="true"/>
+        <!-- Panel button-->
+        <we-row string="Media">
+            <we-button class="o_we_bg_success" data-replace-media="true" data-no-preview="true">Replace</we-button>
+        </we-row>
+    </div>
+
     <div data-js="ImageOptimize"
          data-selector="img">
         <t t-call="web_editor.snippet_options_image_optimization_widgets"/>

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -2591,37 +2591,6 @@ options.registry.ScrollButton = options.Class.extend({
     },
 });
 
-/**
- * Allows for images to be replaced.
- */
-options.registry.ReplaceImage = options.Class.extend({
-    /**
-     * @override
-     */
-    start: function () {
-        const $button = this.$el.find('we-button');
-        const $overlayArea = this.$overlay.find('.oe_snippet_remove');
-        $button.insertBefore($overlayArea);
-
-        return this._super(...arguments);
-    },
-    
-    //--------------------------------------------------------------------------
-    // Options
-    //--------------------------------------------------------------------------
-
-    /**
-     * Replaces the image.
-     *
-     * @see this.selectClass for parameters
-     */
-    replaceImage: async function () {
-        // TODO: simulates a double click on an image from summernote,
-        // to be refactored when the new editor is merged
-        this.$target.dblclick();
-    },
-});
-
 return {
     UrlPickerUserValueWidget: UrlPickerUserValueWidget,
     FontFamilyPickerUserValueWidget: FontFamilyPickerUserValueWidget,

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -437,11 +437,6 @@
         <we-button class="fa fa-fw fa-angle-right" data-move-snippet="next" data-no-preview="true" data-name="move_right_opt"/>
     </div>
 
-    <!-- Replace an image -->
-    <div data-js="ReplaceImage" data-selector="img">
-        <we-button class="fa fa-refresh" data-replace-image="true" data-no-preview="true"/>
-    </div>
-
     <!-- Background -->
     <t t-set="only_bg_color_selector" t-value="'section .row > div, .s_text_highlight'"/>
     <t t-set="only_bg_color_exclude" t-value="'.s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .o_mega_menu .row > div, .s_image_gallery .row > div'"/>


### PR DESCRIPTION
*: website

On top of the new overlay button to replace an image, we now have a
snippet option button. This is a duplicate of the editor one which is
meant to be removed in the future... hopefully.

Note 1: this is not enabled on icons for now even if the code has been
        made for them as well. There is a bug which is likely to be
        solved with the new editor so best not waste time on it now.

Note 2: there are some glitches when switching between different media
        types (image/icons/video). Again, this is likely to be solvable
        by the editor team so best not waste time there as well.
