### PR TITLE
[FIX] web_editor: fix selection style for icons

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.variables.scss
+++ b/addons/web_editor/static/src/scss/web_editor.variables.scss
@@ -419,19 +419,24 @@ $o-we-sidebar-content-field-toggle-control-shadow: 0 2px 3px 0 $o-we-bg-darkest 
 // ------------------------------------------------------------------
 
 @mixin o-we-active-wrapper($icon: '\f00c', $top: auto, $right: auto, $bottom: auto, $left: auto) {
-    border: 3px solid $o-brand-primary;
-    &:before {
-        content: $icon;
-        @include o-position-absolute($top, $right, $bottom, $left);
-        width: 19px;
-        height: 19px;
-        background-color: $o-brand-primary;
-        font-family: 'FontAwesome';
-        color: white;
-        border-radius: 50%;
-        text-align: center;
-        z-index: 1;
-        box-shadow: $box-shadow;
+    box-shadow: 0 0 0 3px $o-brand-primary;
+
+    &:not(.fa) {
+        border: 3px solid $o-brand-primary;
+        box-shadow: none;
+        &:before {
+            content: $icon;
+            @include o-position-absolute($top, $right, $bottom, $left);
+            width: 19px;
+            height: 19px;
+            background-color: $o-brand-primary;
+            font-family: 'FontAwesome';
+            color: white;
+            border-radius: 50%;
+            text-align: center;
+            z-index: 1;
+            box-shadow: $box-shadow;
+        }
     }
 }
 

--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -313,7 +313,7 @@ body .modal {
                     margin: 5px;
                     width: 50px;
                     height: 50px;
-                    padding: 15px;
+                    padding: 15px 0; // 0 allows to center properly
                     cursor: pointer;
                 }
             }


### PR DESCRIPTION
The code added in bb65b742e7eec000248b7df0f048dda61ac3ff5a to update style for multi image selection
is not compatible with .fa icons and causes a strange behaviour when
trying to select one.
The goal of this PR is to fix style for selected icons on Media Dialog.

task-2326573