### PR TITLE
[FIX] l10n_latam_invoice_document: monetary fields

### DIFF
--- a/addons/l10n_latam_invoice_document/models/account_move_line.py
+++ b/addons/l10n_latam_invoice_document/models/account_move_line.py
@@ -16,9 +16,9 @@ class AccountMoveLine(models.Model):
 
     l10n_latam_document_type_id = fields.Many2one(
         related='move_id.l10n_latam_document_type_id', auto_join=True, store=True, index=True)
-    l10n_latam_price_unit = fields.Monetary(compute='compute_l10n_latam_prices_and_taxes')
+    l10n_latam_price_unit = fields.Float(compute='compute_l10n_latam_prices_and_taxes', digits='Product Price')
     l10n_latam_price_subtotal = fields.Monetary(compute='compute_l10n_latam_prices_and_taxes')
-    l10n_latam_price_net = fields.Monetary(compute='compute_l10n_latam_prices_and_taxes')
+    l10n_latam_price_net = fields.Float(compute='compute_l10n_latam_prices_and_taxes', digits='Product Price')
     l10n_latam_tax_ids = fields.One2many(compute="compute_l10n_latam_prices_and_taxes", comodel_name='account.tax')
 
     @api.depends('price_unit', 'price_subtotal', 'move_id.l10n_latam_document_type_id')


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

The fields l10n_latam_price_unit and l10n_latam_price_net should be
float instead of monetary in order to show rightly the decimal
accuracy on invoice's reports

**Current behavior before PR:**
In the invoice report of the latam localizations the unit price do not shows with the decimal accuracy of product prices.

**Desired behavior after PR is merged:**
In the invoice report of the latam localizations the unit price is shown with the decimal accuracy of product prices.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
