### PR TITLE
[FIX] hr_timesheet: Deleting project with timesheets

### DIFF
--- a/addons/hr_timesheet/i18n/hr_timesheet.pot
+++ b/addons/hr_timesheet/i18n/hr_timesheet.pot
@@ -659,6 +659,14 @@ msgid ""
 msgstr ""
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/project.py:0
+#, python-format
+msgid ""
+"You cannot delete a project containing timesheets. You can either archive it"
+" or first delete all of its timesheets."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.report_timesheet
 msgid "for the"
 msgstr ""

--- a/addons/hr_timesheet/models/project.py
+++ b/addons/hr_timesheet/models/project.py
@@ -57,6 +57,13 @@ class Project(models.Model):
         result = super(Project, self).write(values)
         return result
 
+    def unlink(self):
+        for project in self.with_context(active_test=False):
+            timesheets = self.env['account.analytic.line'].search([('project_id', '=', project.id)])
+            if timesheets:
+                raise UserError(_('You cannot delete a project containing timesheets. You can either archive it or first delete all of its timesheets.'))
+        return super(Project, self).unlink()
+
     # ---------------------------------------------------
     #  Business Methods
     # ---------------------------------------------------


### PR DESCRIPTION
In 13.0, when unlinking project P with timesheets, it was impossible to retrieve timesheets
afterwards.

This fix prevent deleting project linked to timesheets

opw:2479249