### PR TITLE
[FIX] web: do not forget to unpatch in tests

### DIFF
--- a/addons/web/static/tests/views/calendar_tests.js
+++ b/addons/web/static/tests/views/calendar_tests.js
@@ -543,6 +543,7 @@ QUnit.module('Views', {
         assert.containsOnce($('body'), '.modal', "there should be only one open modal");
 
         calendar.destroy();
+        testUtils.mock.unpatch(ViewDialogs.FormViewDialog);
     });
 
     QUnit.test('create event with timezone in week mode European locale', async function (assert) {


### PR DESCRIPTION
Without this commit, all tests executed after that one would use
the patched version of the FormViewDialog.

Issue spotted in the assets revamp branch, by moving form_tests.js
after calendar_tests.js

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
