### PR TITLE
[FIX] point_of_sale: fix session closing with purchase rights

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from datetime import timedelta
 
 from odoo import api, fields, models, _
-from odoo.exceptions import UserError, ValidationError
+from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.tools import float_is_zero
 
 
@@ -290,14 +290,14 @@ class PosSession(models.Model):
         # Users without any accounting rights won't be able to create the journal entry. If this
         # case, switch to sudo for creation and posting.
         sudo = False
-        if (
-            not self.env['account.move'].check_access_rights('create', raise_exception=False)
-            and self.user_has_groups('point_of_sale.group_pos_user')
-        ):
-            sudo = True
-            self.sudo()._create_account_move()
-        else:
+        try:
             self._create_account_move()
+        except AccessError as e:
+            if self.user_has_groups('point_of_sale.group_pos_user'):
+                sudo = True
+                self.sudo()._create_account_move()
+            else:
+                raise e
         if self.move_id.line_ids:
             self.move_id.post() if not sudo else self.move_id.sudo().post()
             # Set the uninvoiced orders' state to 'done'


### PR DESCRIPTION
- Create an internal user with ONLY the following rights:
  * Point Of Sale: User|Administrator
  * Purchase: User|Administrator
- Connect with created user
- Open a POS session and validate an order
- Close session
- Validate closing & post entries
The access is denied when trying to create account move due to following rule:
"Purchase User Account Move".

When validating session and creating account move, sudo is applied if user has no
"create" right on "account.move".
In the particular case where user is a purchase user or admin, he also has "create"
right on "account.move" and sudo is not applied when validating session (as it would
have been if he has no purchase rights).
However, as defined by "Purchase User Account Move" rule, he is limited to account
moves where type is in ('in_invoice', 'in_refund', 'in_receipt').
But the account move created when closing and validating session is of type "entry",
and therefore user cannot validate session.
A POS user should be able to close and validate a session, either he is a purchase
user or not.

opw-2456783

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
