### PR TITLE
[FIX] digest: visibility of digest config section

### DIFF
--- a/addons/digest/views/res_config_settings_views.xml
+++ b/addons/digest/views/res_config_settings_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@id='contacts_settings']" position="before">
-                <div id="statistics" invisible="1">
+                <div id="statistics" >
                     <h2>Statistics</h2>
                     <div class='row mt16 o_settings_container' id='statistics_div'>
                         <div class="col-12 col-lg-6 o_setting_box"


### PR DESCRIPTION
odoo/odoo#48362 updated the systems to not show the "Statistics" section when it's empty, but left an @invisible in leading to not never showing the section at all (which technically does avoid showing an empty section).

Remove the `invisible` attribute, since the section is now added by `digest` it should never be hidden. This doesn't fix existing views tho.
