### PR TITLE
[FIX] Correct spelling mistake in profilecode.rst

### DIFF
--- a/doc/howtos/profilecode.rst
+++ b/doc/howtos/profilecode.rst
@@ -10,7 +10,7 @@ Profiling Odoo code
 Graph a method
 ==============
 
-Odoo embeds a profiler of code. This embeded profiler output can be used to
+Odoo embeds a profiler of code. This embedded profiler output can be used to
 generate a graph of calls triggered by the method, number of queries, percentage
 of time taken in the method itself as well as the time that the method took and
 its sub-called methods.


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR aims to improve spelling in the documentation. The document contained the word "embeded", which has been changed to "embedded".

Current behavior before PR:
Identical behavior with spelling mistake.

Desired behavior after PR is merged:
Identical behavior without spelling mistake.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
