### PR TITLE
[FIX] point_of_sale: tour waits for everything to be loaded

### DIFF
--- a/addons/point_of_sale/static/tests/tours/point_of_sale.js
+++ b/addons/point_of_sale/static/tests/tours/point_of_sale.js
@@ -44,9 +44,12 @@ odoo.define('point_of_sale.tour.pricelist', function (require) {
         };
     }
 
+    // The global posmodel is only present when the posmodel is instanciated
+    // So, wait for everythiong to be loaded
     var steps = [{ // Leave category displayed by default
         content: 'waiting for loading to finish',
-        trigger: 'body:not(:has(.loader))',
+        extra_trigger: 'body .pos:not(:has(.loader))', // Pos has finished loading
+        trigger: 'body:not(.oe_wait)', // WebClient has finished Loading
         run: function () {
             var product_wall_shelf = posmodel.db.search_product_in_category(0, 'Wall Shelf Unit')[0];
             var product_small_shelf = posmodel.db.search_product_in_category(0, 'Small Shelf')[0];


### PR DESCRIPTION
Before this commit, the first step of the tour pos_basic_order
waited for something not precise enough, and that was true
before anything was loaded

After this commit, we wait both the the webClient and the Chrome to be loaded
with a more specific selector

Runbot issue fingerprint: bd10372b7db10c743f38312470ff528a74bfe9dcc0348a3e1f0bd47f55764378
Runbot issue id: 1357

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
