### PR TITLE
[REM] l10n_fr: duplicate method (_prepare_all_journals)

### DIFF
--- a/addons/l10n_fr/models/account_chart_template.py
+++ b/addons/l10n_fr/models/account_chart_template.py
@@ -11,7 +11,10 @@ class AccountChartTemplate(models.Model):
     def _prepare_all_journals(self, acc_template_ref, company, journals_dict=None):
         journal_data = super(AccountChartTemplate, self)._prepare_all_journals(
             acc_template_ref, company, journals_dict)
+        if company.country_id.code != 'FR':
+            return journal_data
+
         for journal in journal_data:
-            if journal['type'] in ('sale', 'purchase') and company.country_id.code == "FR":
+            if journal['type'] in ('sale', 'purchase'):
                 journal.update({'refund_sequence': True})
         return journal_data

--- a/addons/l10n_fr/models/l10n_fr.py
+++ b/addons/l10n_fr/models/l10n_fr.py
@@ -8,14 +8,3 @@ class ResPartner(models.Model):
 
     siret = fields.Char(string='SIRET', size=14)
 
-class ChartTemplate(models.Model):
-    _inherit = 'account.chart.template'
-
-    def _prepare_all_journals(self, acc_template_ref, company, journals_dict=None):
-        journals = super(ChartTemplate, self)._prepare_all_journals(acc_template_ref, company, journals_dict)
-        if company.country_id.code == "FR":
-            #For France, sale/purchase journals must have a dedicated sequence for refunds
-            for journal in journals:
-                if journal['type'] in ['sale', 'purchase']:
-                    journal['refund_sequence'] = True
-        return journals


### PR DESCRIPTION
defined first 4y ago in https://github.com/odoo/odoo/commit/d56baebc8e7f654304eca59b3c58ceb80846c659
then 2y ago in https://github.com/odoo/odoo/commit/182b4d86f443eefcc647fb44f0b1f5fe406637d4

Merge the two methods, keeping the one in the dedicated account_chart_template file,
but improving it with the early check on the company country code.

Fixes #67728


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
