### PR TITLE
[FIX] website_forum: don't show editor image button

### DIFF
--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -126,7 +126,7 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
                 ['table', ['table']],
             ];
             if (hasFullEdit) {
-                toolbar.push(['insert', ['link', 'picture']]);
+                toolbar.push(['insert', ['link']]);
             }
             toolbar.push(['history', ['undo', 'redo']]);
 


### PR DESCRIPTION

Don't show image button since it is only usable by internal users and
forum users might be public users.

This is a forward-port of saas-12.3 with a5b82e286 and as said in this
commit, currently to add an image only drag and drop is working.

opw-2470720
