### PR TITLE
[Fix] hr: Correctly link work address to admin employee

### DIFF
--- a/addons/hr/data/hr_data.xml
+++ b/addons/hr/data/hr_data.xml
@@ -21,7 +21,7 @@
         <record id="employee_admin" model="hr.employee">
             <field name="name" eval="obj(ref('base.partner_admin')).name" model="res.partner"/>
             <field name="user_id" ref="base.user_admin"/>
-            <field name="address_id" ref="base.partner_admin"/>
+            <field name="address_id" ref="base.main_company"/>
             <field name="address_home_id" ref="res_partner_admin_private_address"/>
             <field name="image_1920" eval="obj(ref('base.partner_admin')).image_1920" model="res.partner"/>
         </record>


### PR DESCRIPTION
Before changes when we install Employee App,
the Administrator work address is linked
to a new res.partner (Administrator).

However after some changes Administrator
work address is linked to the res.partner of
company when Employee App is installed and
user Administrator is automatically created.

TaskID: 2479958

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
