### PR TITLE
[FIX] purchase,purchase_product_matrix: ignore date planned

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -229,14 +229,19 @@ class PurchaseOrder(models.Model):
                 line.date_planned = line._get_date_planned(seller)
         return new_po
 
+    def _must_delete_date_planned(self, field_name):
+        # To be overridden
+        return field_name == 'order_line'
+
     def onchange(self, values, field_name, field_onchange):
         """Override onchange to NOT to update all date_planned on PO lines when
         date_planned on PO is updated by the change of date_planned on PO lines.
         """
         result = super(PurchaseOrder, self).onchange(values, field_name, field_onchange)
-        if field_name == 'order_line' and 'value' in result:
+        if self._must_delete_date_planned(field_name) and 'value' in result:
+            already_exist = [ol[1] for ol in values.get('order_line', []) if ol[1]]
             for line in result['value'].get('order_line', []):
-                if line[0] < 2 and 'date_planned' in line[2]:
+                if line[0] < 2 and 'date_planned' in line[2] and line[1] in already_exist:
                     del line[2]['date_planned']
         return result
 

--- a/addons/purchase_product_matrix/models/purchase.py
+++ b/addons/purchase_product_matrix/models/purchase.py
@@ -30,6 +30,9 @@ class PurchaseOrder(models.Model):
             self.grid_update = False
             self.grid = json.dumps(self._get_matrix(self.grid_product_tmpl_id))
 
+    def _must_delete_date_planned(self, field_name):
+        return super()._must_delete_date_planned(field_name) or field_name == "grid"
+
     @api.onchange('grid')
     def _apply_grid(self):
         if self.grid and self.grid_update:


### PR DESCRIPTION
When adding a variant product, if the option "Variant Grid Entry" is
enabled, it will reset the delivery date of each purchase order line.

To reproduce the error:
(Use demo data)
1. In Settings, enable "Variant Grid Entry"
2. Create an RfQ
3. Add the field "Delivery Date" to purchase order line view
4. Add a basic product (e.g. "[FURN_6666] Acoustic Bloc Screens")
    - Keep its delivery date in mind
5. Add a variant product (e.g. "[E-COM12] Conference Chair (CONFIG)")

Error: The delivery date of the first purchase order line has changed
for no reason. Moreover, suppose that in step 4, the user defines a
specific date: the latter will still be changed after the variant
product is added.

When adding a product, the delivery date of the purchase order and its
lines are recomputed. However, an override of `onchange` ensures that
the new delivery date of the lines will be ignored if the `onchange`
concerns the field `order_line`. Here is the problem: when using the
Variant Grid Entry, the `onchange` concerns the field `grid`. As a
result, the new delivery dates are kept. This explains the creation of
`_must_delete_date_planned` in this fix.

However, when returing the result of an `onchange` linked to `grid`, the
result contains the existing lines (on client side) and the new ones
(from the Variant Grid Entry). If the field `date_planned` of the new
lines is deleted, the client will raise an error when it tries to render
these dates (it has no information about their value). Since existing
lines are of the form `(0, <client_id>, <values>)`, this fix only
deletes `date_planned` field for lines with <client_id> defined.

OPW-2454164