### PR TITLE
Check first employee's calendar hours_per_day

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -414,7 +414,7 @@ class HolidaysRequest(models.Model):
             calendar = holiday.employee_id.sudo().resource_calendar_id or self.env.user.company_id.resource_calendar_id
             if holiday.date_from and holiday.date_to:
                 number_of_hours = calendar.get_work_hours_count(holiday.date_from, holiday.date_to)
-                holiday.number_of_hours_display = number_of_hours or (holiday.number_of_days * HOURS_PER_DAY)
+                holiday.number_of_hours_display = number_of_hours or (holiday.number_of_days * (calendar.hours_per_day or HOURS_PER_DAY))
             else:
                 holiday.number_of_hours_display = 0
 


### PR DESCRIPTION
Fix Issue https://github.com/odoo/odoo/issues/67915

Description of the issue/feature this PR addresses:
If employee calendar hours_per_day is different than Company hours_per_day, displayed hours can be wrong.

Current behavior before PR:
Hours not showing properly because if calendar can't compute number of hours, always set hours per day by multiplying by constant HOURS_PER_DAY.

Desired behavior after PR is merged:
Show hours based on employee calendar.

On Version 13.0+ the approach is the same.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
