### PR TITLE
[FIX] hr_skills, web: fix css rules leak

### DIFF
--- a/addons/hr_skills/static/src/css/hr_skills.scss
+++ b/addons/hr_skills/static/src/css/hr_skills.scss
@@ -33,120 +33,116 @@
                 pointer-events: initial;
             }
         }
-    }
 
-    // Resumé design
-    // =========================================
-    .o_group_resume {
-        .o_data_row td {
-            padding: $o-hrs-timeline-entry-padding;
+        // Resumé design
+        // =========================================
+        &.o_group_resume {
+            .o_data_row td {
+                padding: $o-hrs-timeline-entry-padding;
 
-            &.o_resume_timeline_cell {
-                div {
-                    @include size($o-hrs-timeline-dot-size);
-                }
+                &.o_resume_timeline_cell {
+                    div {
+                        @include size($o-hrs-timeline-dot-size);
+                    }
 
-                &:before {
-                    @include o-position-absolute(0, $left: ($o-hrs-timeline-dot-size * .5 + $o-hrs-timeline-entry-padding));
-                    @include size(1px, 100%);
-                    margin-left: -.01rem;
-                    background-color: $border-color;
-                    content: "";
+                    &:before {
+                        @include o-position-absolute(0, $left: ($o-hrs-timeline-dot-size * .5 + $o-hrs-timeline-entry-padding));
+                        @include size(1px, 100%);
+                        margin-left: -.01rem;
+                        background-color: $border-color;
+                        content: "";
+                    }
                 }
             }
-        }
 
-        .o_resume_line_desc {
-            white-space: normal;
-        }
-
-        .o_resume_line_title, .o_resume_line_dates {
-            line-height: 1;
-        }
-
-        .o_resume_group_header + .o_data_row .o_resume_timeline_cell:before {
-            top: $o-hrs-timeline-entry-padding;
-        }
-
-        .o_data_row.o_data_row_last {
             .o_resume_line_desc {
-                margin-bottom: $headings-margin-bottom;
+                white-space: normal;
             }
 
-            .o_resume_timeline_cell:before {
-                height: $o-hrs-timeline-entry-padding;
+            .o_resume_line_title, .o_resume_line_dates {
+                line-height: 1;
+            }
+
+            .o_resume_group_header + .o_data_row .o_resume_timeline_cell:before {
+                top: $o-hrs-timeline-entry-padding;
+            }
+
+            .o_data_row.o_data_row_last {
+                .o_resume_line_desc {
+                    margin-bottom: $headings-margin-bottom;
+                }
+
+                .o_resume_timeline_cell:before {
+                    height: $o-hrs-timeline-entry-padding;
+                }
+            }
+        }
+
+        // Skills design
+        // =========================================
+        &.o_group_skills {
+            .o_resume_empty_helper {
+                display: none;
+            }
+
+            .o_group_header {
+                > .o_group_name {
+                    padding: .8rem .5rem 0 0;
+                }
+
+                &:first-child > .o_group_name {
+                    padding-top: 0;
+                }
+            }
+
+            .o_skill_cell {
+                padding-left: 0;
+                white-space: normal !important;
+
+                .o_progressbar {
+                    display: inline-flex;
+                    align-items: center;
+                }
+
+                .o_progress {
+                    border: 0;
+                    background: $gray-300;
+                    height: 5px;
+                }
+
+                .o_progressbar_value {
+                    width: auto;
+                    font-size: $font-size-sm;
+                    font-weight: bold;
+                }
             }
         }
     }
+}
 
-    // Skills design
-    // =========================================
-    .o_group_skills {
-        .o_resume_empty_helper {
-            display: none;
-        }
-
-        .o_group_header {
-            > .o_group_name {
-                padding: .8rem .5rem 0 0;
-            }
-
-            &:first-child > .o_group_name {
-                padding-top: 0;
-            }
-        }
-
-        .o_skill_cell {
-            padding-left: 0;
-            white-space: normal !important;
-
-            .o_progressbar {
-                display: inline-flex;
-                align-items: center;
-            }
-
-            .o_progress {
-                border: 0;
-                background: $gray-300;
-                height: 5px;
-            }
-
-            .o_progressbar_value {
-                width: auto;
-                font-size: $font-size-sm;
-                font-weight: bold;
-            }
-        }
+// Editing mode
+// =========================================
+.o_form_view.o_form_editable .o_form_sheet .o_hr_skills_group {
+    .o_group_name {
+        background-color: gray('200');
     }
 
-    // Editing mode
-    // =========================================
-    .o_form_view.o_form_editable & {
-        .o_group_name {
-            background-color: gray('200');
-        }
+    .o_resume_group_header .btn {
+        margin-top: .25rem;
+        margin-right: .4rem;
+    }
 
-        .o_resume_group_header .btn {
-            margin-top: .25rem;
-            margin-right: .4rem;
-        }
+    &.o_group_skills .o_group_name {
+        padding-top: .4em;
+        padding-bottom: .4rem;
+    }
 
-        .o_group_skills .o_group_name {
-            padding-top: .4em;
-            padding-bottom: .4rem;
-        }
+    .o_group_name, .o_skill_cell {
+        padding-left: .5rem;
+    }
 
-        .o_group_name, .o_skill_cell {
-            padding-left: .5rem;
-        }
-
-        .o_group_skills .o_group_name > b, .o_hr_skills_group .o_horizontal_separator {
-            color: color-yiq(gray('200'));
-            font-style: italic;
-        }
-
-        .o_list_record_remove > button {
-            @include o-hover-text-color($text-muted, theme-color('danger'));
-        }
+    &.o_group_skills .o_group_name > b, .o_horizontal_separator {
+        color: color-yiq(gray('200'));
+        font-style: italic;
     }
 }

--- a/addons/web/static/src/scss/list_view.scss
+++ b/addons/web/static/src/scss/list_view.scss
@@ -132,6 +132,7 @@
             border-style: none;
             display: table-cell;
             cursor: pointer;
+            @include o-hover-text-color($text-muted, theme-color('danger'));
         }
 
         // Contextual classes


### PR DESCRIPTION
Before this commit, hr_skills module defined a few css rules
but weren't enclosed in a custom class to make them only
for hr skills so these rules leaked everywhere in odoo.

This commit encloses these css rules to not leak them and move
a rule which changes the color of list's remove button into web
module to keep the color.