### PR TITLE
[13.0][FIX] Stock_move: Avoid to run procurement on an empty procurement_request.

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1032,7 +1032,8 @@ class StockMove(models.Model):
                 move.product_id, move.product_uom_qty, move.product_uom,
                 move.location_id, move.rule_id and move.rule_id.name or "/",
                 origin, move.company_id, values))
-        self.env['procurement.group'].run(procurement_requests)
+        if procurement_requests:
+            self.env['procurement.group'].run(procurement_requests)
 
         move_to_confirm.write({'state': 'confirmed'})
         (move_waiting | move_create_proc).write({'state': 'waiting'})


### PR DESCRIPTION

Description of the issue/feature this PR addresses:
Stock_move: Avoid to run procurement on an empty procurement_request as it fails if it is empty
- Validate a MO with only `make_to_stock` -> it fails with an empty `procurement_requests`

Current behavior before PR:
Have a manufacturing order in draft and try to validate it.
The moves generated have all the `procure_method == make_to_stock`.
The `procurement_requests` will be populated only if we have MO with `make_to_order`
https://github.com/odoo/odoo/blob/13.0/addons/stock/models/stock_move.py#L1017
In this case it will let `procurement_requests` empty and the line `self.env['procurement.group'].run(procurement_requests)` will fail.

Desired behavior after PR is merged:
To be able to have a manufacturing order that generates moves that have for only method `make_to_stock`



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
