### PR TITLE
[FIX] website_blog: display post_date on latest blogs 

### DIFF
--- a/addons/website_blog/views/snippets/s_latest_posts.xml
+++ b/addons/website_blog/views/snippets/s_latest_posts.xml
@@ -61,7 +61,7 @@
     <figure t-foreach="posts" t-as="p" class="post s_latest_posts_post col-md-6 col-lg-4">
         <figcaption>
             <h4 class="mb0"><a t-att-href="'/blog/%s/%s' % (p.blog_id.id, p.id)"><t t-esc="p.name"/></a></h4>
-            <h5 class="mt0 mb4" t-field="p.write_date" t-options='{"format": "dd/MM"}' />
+            <h5 class="mt0 mb4" t-field="p.post_date" t-options='{"format": "dd/MM"}' />
         </figcaption>
         <a t-att-href="'/blog/%s/%s' % (p.blog_id.id, p.id)">
             <t t-call="website.record_cover">
@@ -85,7 +85,7 @@
                 <a t-att-href="'/blog/%s/%s' % (p.blog_id.id, p.id)"><h4 class="mb-0"><t t-esc="p.name"/></h4></a>
             </div>
             <div class="card-footer d-flex justify-content-between">
-                <span class="text-muted mb-0" t-field="p.write_date" t-options='{"format": "MMM d, yyyy"}' />
+                <span class="text-muted mb-0" t-field="p.post_date" t-options='{"format": "MMM d, yyyy"}' />
                 <span class="text-muted mb-0">In <a class="font-weight-bold" t-esc="p.blog_id.name" t-att-href="'/blog/%s' % (p.blog_id.id)" /></span>
             </div>
         </div>


### PR DESCRIPTION
Issue

	- Install 'Blogs' module
	- Create a blog post
	- Set published_date to 01/01/1997
	- Go to website
	- Edit any page and add a 'Blog Posts' Block
	- Set 'Layout' to 'Cards' (or 'Horizontal')
	- Save

	In snippet cards, the blog post date is not the published date.

Cause

	Displaying update date ('write_date' field) instead of
	the published date ('post_date' field).

Solution

	Replace 'write_date' by 'post_date'.

opw-2443104