### PR TITLE
[FIX] web: properly find the scrolling element of zoomed pages

### DIFF
--- a/addons/web/static/src/js/libs/jquery.js
+++ b/addons/web/static/src/js/libs/jquery.js
@@ -171,7 +171,7 @@ $.fn.extend({
             // Search for a body child which is at least as tall as the body
             // and which has the ability to scroll if enough content in it. If
             // found, suppose this is the top scrolling element.
-            if (el.scrollHeight < bodyHeight) {
+            if (bodyHeight - el.scrollHeight > 1) {
                 continue;
             }
             const $el = $(el);


### PR DESCRIPTION
To find the main element which scrolls in the page, we rely on its
height being as tall as the body one. The code which checks that was
making a comparison between a rounded value and floating value without
care of the rounding errors that might induce, especially on zoomed
pages.

Fixes https://github.com/odoo/odoo/issues/63306
