### PR TITLE
[FIX] portal: translate email to partner's language

### DIFF
--- a/addons/portal/wizard/portal_share.py
+++ b/addons/portal/wizard/portal_share.py
@@ -42,7 +42,6 @@ class PortalShare(models.TransientModel):
     @api.multi
     def action_send_mail(self):
         active_record = self.env[self.res_model].browse(self.res_id)
-        template = self.env.ref('portal.portal_share_template', False)
         note = self.env.ref('mail.mt_note')
         signup_enabled = self.env['ir.config_parameter'].sudo().get_param('auth_signup.invitation_scope') == 'b2c'
 
@@ -53,23 +52,31 @@ class PortalShare(models.TransientModel):
         # if partner already user or record has access token send common link in batch to all user
         for partner in self.partner_ids:
             share_link = active_record.get_base_url() + active_record._get_share_url(redirect=True, pid=partner.id)
+            saved_lang = self.env.lang
+            self = self.with_context(lang=partner.lang)
+            template = self.env.ref('portal.portal_share_template', False)
             active_record.with_context(mail_post_autofollow=True).message_post_with_view(template,
                 values={'partner': partner, 'note': self.note, 'record': active_record,
                         'share_link': share_link},
-                subject=_("You are invited to access %s" % active_record.display_name),
+                subject=_("You are invited to access %s") % active_record.display_name,
                 subtype_id=note.id,
                 notif_layout='mail.mail_notification_light',
                 partner_ids=[(6, 0, partner.ids)])
+            self = self.with_context(lang=saved_lang)
         # when partner not user send individual mail with signup token
         for partner in self.partner_ids - partner_ids:
             #  prepare partner for signup and send singup url with redirect url
             partner.signup_get_auth_param()
             share_link = partner._get_signup_url_for_action(action='/mail/view', res_id=self.res_id, model=self.model)[partner.id]
+            saved_lang = self.env.lang
+            self = self.with_context(lang=partner.lang)
+            template = self.env.ref('portal.portal_share_template', False)
             active_record.with_context(mail_post_autofollow=True).message_post_with_view(template,
                 values={'partner': partner, 'note': self.note, 'record': active_record,
                         'share_link': share_link},
-                subject=_("You are invited to access %s" % active_record.display_name),
+                subject=_("You are invited to access %s") % active_record.display_name,
                 subtype_id=note.id,
                 notif_layout='mail.mail_notification_light',
                 partner_ids=[(6, 0, partner.ids)])
+            self = self.with_context(lang=saved_lang)
         return {'type': 'ir.actions.act_window_close'}


### PR DESCRIPTION
Steps:
- Install Projects
- Go to Settings / Translations / Languages
- Install Dutch
- Go to Settings / Users & Companies / Users
- Edit demo:
  - Language: Dutch
- Go to Projects
- Click the three dots on the first project in the dashboard
- Click Share
- Select demo as recipient
- Send
- Go to Settings / Technical / Email / Emails
- Click the email you just sent

Bug:
The email is not translated in the partner's language

Explanation:
The context of the template didn't take the current partner's language
into account since it was out of the partners loop.
The subject of the email wasn't aware of the partner's language as the
context hadn't been changed.

Wrapping the translations with the right `lang` context value fixes the
issue.

Also, the subject used the formatted string as the translation source.
This makes it impossible to find a matching translation since the source
is different every time.

opw:2475398