### PR TITLE
[FIX] website_forum: show normal image modal in forum


### DIFF
--- a/addons/web_editor/static/src/js/editor/rte.summernote.js
+++ b/addons/web_editor/static/src/js/editor/rte.summernote.js
@@ -512,7 +512,12 @@ eventHandler.modules.linkDialog.showLinkDialog = function ($editable, $dialog, l
     });
     return def;
 };
+var originalShowImageDialog = eventHandler.modules.imageDialog.showImageDialog;
 eventHandler.modules.imageDialog.showImageDialog = function ($editable) {
+    var options = $editable.closest('.o_editable, .note-editor').data('options');
+    if (options.disableFullMediaDialog) {
+        return originalShowImageDialog.apply(this, arguments);
+    }
     var r = $editable.data('range');
     if (r.sc.tagName && r.sc.childNodes.length) {
         r.sc = r.sc.childNodes[r.so];
@@ -520,7 +525,6 @@ eventHandler.modules.imageDialog.showImageDialog = function ($editable) {
     var media = $(r.sc).parents().addBack().filter(function (i, el) {
         return dom.isImg(el);
     })[0];
-    var options = $editable.closest('.o_editable, .note-editor').data('options');
     core.bus.trigger('media_dialog_demand', {
         $editable: $editable,
         media: media,
@@ -933,6 +937,9 @@ eventHandler.attach = function (oLayoutInfo, options) {
     oLayoutInfo.editor().on('dragstart', 'img', function (e) { e.preventDefault(); });
     $(document).on('mousedown', summernote_mousedown).on('mouseup', summernote_mouseup);
     oLayoutInfo.editor().off('click').on('click', function (e) {e.preventDefault();}); // if the content editable is a link
+    oLayoutInfo.editor().find('.note-image-dialog').on('click', '.note-image-input', function (e) {
+        e.stopPropagation(); // let browser default happen for image file input
+    });
 
     /**
      * Open Media Dialog on double click on an image/video/icon.

--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -126,7 +126,7 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
                 ['table', ['table']],
             ];
             if (hasFullEdit) {
-                toolbar.push(['insert', ['link']]);
+                toolbar.push(['insert', ['link', 'picture']]);
             }
             toolbar.push(['history', ['undo', 'redo']]);
 
@@ -141,6 +141,7 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
                     res_model: 'forum.post',
                     res_id: +window.location.pathname.split('-').pop(),
                 },
+                disableFullMediaDialog: true,
                 disableResizeImage: true,
             };
             if (!hasFullEdit) {


### PR DESCRIPTION

In #67893 the image icon was removed, but it contradicts the interface
and worked for accounts that were employee.

Since saas-12.3 editor change and reverts in 13.0, we always use the
full media dialog when showing the editor on the forum.

Before saas-12.3, the original summernote image modal was shown, but the
full media modal was shown for website editor (beecause we are using the
same editor to do both things).

With this change, we always have the original editor in the forum
message editor thanks to a new option "disableFullMediaEditor".

opw-2470720
