### PR TITLE
[13.0] [FIX] partner_autocomplete: Prevent raise error for some users.

### DIFF
--- a/addons/partner_autocomplete/models/res_partner.py
+++ b/addons/partner_autocomplete/models/res_partner.py
@@ -93,7 +93,7 @@ class ResPartner(models.Model):
             'db_uuid': self.env['ir.config_parameter'].sudo().get_param('database.uuid'),
             'account_token': account.account_token,
             'country_code': self.env.company.country_id.code,
-            'zip': self.env.company.zip,
+            'zip': self.sudo().env.company.zip,
         })
         try:
             return jsonrpc(url=url, params=params, timeout=timeout), False


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
For this case, with user without administration access rights, if you want to use partner_autocomplete, in the moment when you try to write something an error occurs. This error is related to the field "zip" in the company that is computed and non store with a method wich attempt to write several values in the company.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
