### PR TITLE
[FIX] point_of_sale: Multicompany tax

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -2257,6 +2257,7 @@ exports.Orderline = Backbone.Model.extend({
 
         var product =  this.get_product();
         var taxes_ids = this.tax_ids || product.taxes_id;
+        taxes_ids = _.filter(taxes_ids, t => t in this.pos.taxes_by_id);
         var taxes =  this.pos.taxes;
         var taxdetail = {};
         var product_taxes = [];


### PR DESCRIPTION
Steps to reproduce the bug:

- Create a multi-company environment with two companies A & B
- Create two sales taxes TA & TB, one for company A & one for company B
- Created a shared product P and assign both TA & TB
- Login with user having access of both companies
- Open POS session and select P

Bug:

A traceback was raised

opw:2422866