### PR TITLE
[FIX] account: Set 'move_id.ref' as payment memo with vendor bill

### DIFF
--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -119,6 +119,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
+            'ref': 'INV/2017/01/0001 INV/2017/01/0002',
             'payment_method_id': self.custom_payment_method_in.id,
         }])
         self.assertRecordValues(payments.line_ids.sorted('balance'), [
@@ -152,6 +153,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
+            'ref': 'INV/2017/01/0001 INV/2017/01/0002',
             'payment_method_id': self.custom_payment_method_in.id,
         }])
         self.assertRecordValues(payments.line_ids.sorted('balance'), [
@@ -186,6 +188,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
+            'ref': 'INV/2017/01/0001 INV/2017/01/0002',
             'payment_method_id': self.custom_payment_method_in.id,
         }])
         self.assertRecordValues(payments.line_ids.sorted('balance'), [
@@ -228,6 +231,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
+            'ref': 'INV/2017/01/0001 INV/2017/01/0002',
             'payment_method_id': self.custom_payment_method_in.id,
         }])
         self.assertRecordValues(payments.line_ids.sorted('balance'), [
@@ -270,6 +274,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
+            'ref': 'BILL/2017/01/0001 BILL/2017/01/0002',
             'payment_method_id': self.custom_payment_method_in.id,
         }])
         self.assertRecordValues(payments.line_ids.sorted('balance'), [
@@ -312,6 +317,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
+            'ref': 'BILL/2017/01/0001 BILL/2017/01/0002',
             'payment_method_id': self.custom_payment_method_in.id,
         }])
         self.assertRecordValues(payments.line_ids.sorted('balance'), [
@@ -349,8 +355,14 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [
-            {'payment_method_id': self.manual_payment_method_in.id},
-            {'payment_method_id': self.manual_payment_method_in.id},
+            {
+                'ref': 'INV/2017/01/0001',
+                'payment_method_id': self.manual_payment_method_in.id,
+            },
+            {
+                'ref': 'INV/2017/01/0002',
+                'payment_method_id': self.manual_payment_method_in.id,
+            },
         ])
         self.assertRecordValues(payments[0].line_ids.sorted('balance') + payments[1].line_ids.sorted('balance'), [
             # == Payment 1: to pay out_invoice_1 ==
@@ -399,8 +411,14 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [
-            {'payment_method_id': self.manual_payment_method_out.id},
-            {'payment_method_id': self.manual_payment_method_out.id},
+            {
+                'ref': 'BILL/2017/01/0001 BILL/2017/01/0002',
+                'payment_method_id': self.manual_payment_method_out.id,
+            },
+            {
+                'ref': 'BILL/2017/01/0003',
+                'payment_method_id': self.manual_payment_method_out.id,
+            },
         ])
         self.assertRecordValues(payments[0].line_ids.sorted('balance') + payments[1].line_ids.sorted('balance'), [
             # == Payment 1: to pay in_invoice_1 & in_invoice_2 ==
@@ -449,9 +467,18 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [
-            {'payment_method_id': self.manual_payment_method_out.id},
-            {'payment_method_id': self.manual_payment_method_out.id},
-            {'payment_method_id': self.manual_payment_method_out.id},
+            {
+                'ref': 'BILL/2017/01/0001',
+                'payment_method_id': self.manual_payment_method_out.id,
+            },
+            {
+                'ref': 'BILL/2017/01/0002',
+                'payment_method_id': self.manual_payment_method_out.id,
+            },
+            {
+                'ref': 'BILL/2017/01/0003',
+                'payment_method_id': self.manual_payment_method_out.id,
+            },
         ])
         self.assertRecordValues(payments[0].line_ids.sorted('balance') + payments[1].line_ids.sorted('balance') + payments[2].line_ids.sorted('balance'), [
             # == Payment 1: to pay in_invoice_1 ==

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -115,7 +115,8 @@ class AccountPaymentRegister(models.TransientModel):
         :param batch_result:    A batch returned by '_get_batches'.
         :return:                A string representing a communication to be set on payment.
         '''
-        return ' '.join(label for label in batch_result['lines'].mapped('name') if label)
+        labels = set(line.name or line.move_id.ref or line.move_id.name for line in batch_result['lines'])
+        return ' '.join(sorted(labels))
 
     @api.model
     def _get_line_batch_key(self, line):


### PR DESCRIPTION
The current behavior was to set the label as memo in the payment register wizard.
However, this is to restrictive when a vendor bill hasn't any payment reference but a bill reference.
In that case, the user is expecting to have the bill 'ref' in the payment 'memo'.

Since the matching rules in the reconciliation widget are matching line.name, then line.move_id.ref and then line.move_id.name, the same logic is applied here to construct the payment 'memo'.

opw: 2440389

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
