### PR TITLE
[FIX] base: child contact language should get company language

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -348,6 +348,13 @@ class Partner(models.Model):
                 result['value'] = {key: convert(self.parent_id[key]) for key in address_fields}
         return result
 
+    @api.onchange('parent_id')
+    def _onchange_parent_id_for_lang(self):
+        # While creating / updating child contact, take the parent lang by default if any
+        # otherwise, fallback to default context / DB lang
+        if self.parent_id:
+            self.lang = self.parent_id.lang or self.env.context.get('default_lang') or self.env.lang
+
     @api.onchange('country_id')
     def _onchange_country_id(self):
         if self.country_id and self.country_id != self.state_id.country_id:
@@ -566,6 +573,9 @@ class Partner(models.Model):
 
         for partner, vals in zip(partners, vals_list):
             partner._fields_sync(vals)
+            # Lang: propagate from parent if no value was given
+            if 'lang' not in vals and partner.parent_id:
+                partner._onchange_parent_id_for_lang()
             partner._handle_first_contact_creation()
         return partners
 

--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.tests import Form
 from odoo.tests.common import TransactionCase
 from odoo.exceptions import UserError
 
@@ -56,3 +57,84 @@ class TestPartner(TransactionCase):
 
         with self.assertRaises(UserError, msg="You should not be able to update the company_id of the partner company if the linked user of a child partner is not an allowed to be assigned to that company"), self.cr.savepoint():
             test_partner_company.write({'company_id': company_2.id})
+
+    def test_lang_computation_code(self):
+        """ Check computation of lang: coming from installed languages, forced
+        default value and propagation from parent."""
+        default_lang_info = self.env['res.lang'].get_installed()[0]
+        default_lang_code = default_lang_info[0]
+        self.assertNotEqual(default_lang_code, 'de_DE')  # should not be the case, just to ease test
+        self.assertNotEqual(default_lang_code, 'fr_FR')  # should not be the case, just to ease test
+
+        # default is installed lang
+        partner = self.env['res.partner'].create({'name': "Test Company"})
+        self.assertEqual(partner.lang, default_lang_code)
+
+        # check propagation of parent to child
+        child = self.env['res.partner'].create({'name': 'First Child', 'parent_id': partner.id})
+        self.assertEqual(child.lang, default_lang_code)
+
+        # activate another languages to test language propagation when being in multi-lang
+        self.env['res.lang']._activate_lang('de_DE')
+        self.env['res.lang']._activate_lang('fr_FR')
+
+        # default from context > default from installed
+        partner = self.env['res.partner'].with_context(default_lang='de_DE').create({'name': "Test Company"})
+        self.assertEqual(partner.lang, 'de_DE')
+        first_child = self.env['res.partner'].create({'name': 'First Child', 'parent_id': partner.id})
+        partner.write({'lang': 'fr_FR'})
+        second_child = self.env['res.partner'].create({'name': 'Second Child', 'parent_id': partner.id})
+
+        # check user input is kept
+        self.assertEqual(partner.lang, 'fr_FR')
+        self.assertEqual(first_child.lang, 'de_DE')
+        self.assertEqual(second_child.lang, 'fr_FR')
+
+    def test_lang_computation_form_view(self):
+        """ Check computation of lang: coming from installed languages, forced
+        default value and propagation from parent."""
+        default_lang_info = self.env['res.lang'].get_installed()[0]
+        default_lang_code = default_lang_info[0]
+        self.assertNotEqual(default_lang_code, 'de_DE')  # should not be the case, just to ease test
+        self.assertNotEqual(default_lang_code, 'fr_FR')  # should not be the case, just to ease test
+
+        # default is installed lang
+        partner_form = Form(self.env['res.partner'], 'base.view_partner_form')
+        partner_form.name = "Test Company"
+        self.assertEqual(partner_form.lang, default_lang_code, "New partner's lang should be default one")
+        partner = partner_form.save()
+        self.assertEqual(partner.lang, default_lang_code)
+
+        # check propagation of parent to child
+        with partner_form.child_ids.new() as child:
+            child.name = "First Child"
+            self.assertEqual(child.lang, default_lang_code, "Child contact's lang should have the same as its parent")
+        partner = partner_form.save()
+        self.assertEqual(partner.child_ids.lang, default_lang_code)
+
+        # activate another languages to test language propagation when being in multi-lang
+        self.env['res.lang']._activate_lang('de_DE')
+        self.env['res.lang']._activate_lang('fr_FR')
+
+        # default from context > default from installed
+        partner_form = Form(
+            self.env['res.partner'].with_context(default_lang='de_DE'),
+            'base.view_partner_form'
+        )
+        partner_form.is_company = True
+        partner_form.name = "Test Company"
+        self.assertEqual(partner_form.lang, 'de_DE', "New partner's lang should take default from context")
+        with partner_form.child_ids.new() as child:
+            child.name = "First Child"
+            self.assertEqual(child.lang, 'de_DE', "Child contact's lang should be the same as its parent.")
+        partner_form.lang = 'fr_FR'
+        self.assertEqual(partner_form.lang, 'fr_FR', "New partner's lang should take user input")
+        with partner_form.child_ids.new() as child:
+            child.name = "Second Child"
+            self.assertEqual(child.lang, 'fr_FR', "Child contact's lang should be the same as its parent.")
+        partner = partner_form.save()
+
+        # check final values (kept from form input)
+        self.assertEqual(partner.lang, 'fr_FR')
+        self.assertEqual(partner.child_ids.filtered(lambda p: p.name == "First Child").lang, 'de_DE')
+        self.assertEqual(partner.child_ids.filtered(lambda p: p.name == "Second Child").lang, 'fr_FR')

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -230,7 +230,7 @@
 
                     <notebook colspan="4">
                         <page string="Contacts &amp; Addresses" name="contact_addresses" autofocus="autofocus">
-                            <field name="child_ids" mode="kanban" context="{'default_parent_id': active_id, 'default_street': street, 'default_street2': street2, 'default_city': city, 'default_state_id': state_id, 'default_zip': zip, 'default_country_id': country_id, 'default_lang': None, 'default_user_id': user_id, 'default_type': 'other'}">
+                            <field name="child_ids" mode="kanban" context="{'default_parent_id': active_id, 'default_street': street, 'default_street2': street2, 'default_city': city, 'default_state_id': state_id, 'default_zip': zip, 'default_country_id': country_id, 'default_lang': lang, 'default_user_id': user_id, 'default_type': 'other'}">
                                 <kanban>
                                     <field name="id"/>
                                     <field name="color"/>


### PR DESCRIPTION
PURPOSE 

Currently, if we create a child contact for a parent company with some
language (if any) our child contact's language is falling back to DB language.
What we expect is when a contact (child)  is created from a company (parent)
should have the same language, if provided.

SPECIFICATIONS 

If we create a child contact for parent contact, an onchange is triggered 
before default_get. So what we are trying to do is that we will check if 
parent  has a language while creating a child, if it has one we will check if 
its lang is same as parent lang or otherwise, we will set it as same and note
that any change in parent_id should affect the child's contact thus if any change 
in parent contact lang would affect the child contact lang. 

LINKS

PR #68009
Task 2416922




