### PR TITLE
[FIX] base: make the tests of sorted ir.filters work

### DIFF
--- a/odoo/addons/base/tests/test_ir_filters.py
+++ b/odoo/addons/base/tests/test_ir_filters.py
@@ -325,6 +325,6 @@ class TestAllFilters(TransactionCase):
                     domain=filter_._get_eval_domain(),
                     fields=[field.split(':')[0] for field in (groupby or [])],
                     groupby=groupby,
-                    order=ast.literal_eval(filter_.sort),
+                    order=','.join(ast.literal_eval(filter_.sort)),
                     context=context,
                 )


### PR DESCRIPTION
Before this commit ir_filter tests were calling model.search() with an
array as order. It was not a problem because none of the tested filters
was actually using the sort and the falsy empty array was therefore
ignored by model.search().

After this commit ir_filter test calls model.search() with a string as
order.

Required for task-2453416 and task-2477207

Replaces #67912 which was on master

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
