### PR TITLE
[FIX] web: clipboard; remove fake_element on 'Applications' menu

### DIFF
--- a/addons/web/static/lib/clipboard/clipboard.js
+++ b/addons/web/static/lib/clipboard/clipboard.js
@@ -227,8 +227,8 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
                     this.fakeHandlerCallback = null;
                 }
 
-                if (this.fakeElem) {
-                    this.container.removeChild(this.fakeElem);
+                if (this.fakeElem && this.fakeElem.parentNode) {
+                    this.fakeElem.parentNode.removeChild(this.fakeElem);
                     this.fakeElem = null;
                 }
             }


### PR DESCRIPTION
Issue

	- Install 'Appointments' module
	- Go to Calendar -> Onlie Appointments
	- Edit any one
	- Add an employee (if not already) in 'Available Employees'
	- Click on 'copy' icon to copy the link
	- Click on top left button ('Applications' button) in main navbar

	Traceback raised.

Cause

	Trying to remove fake_elem from container that has been removed.

Solution

	Remove fake_elem from fake_elem.parentNode.

opw-2450922