### PR TITLE
[MERGE] calendar: prepare appointment type-based communication

### DIFF
--- a/addons/calendar/controllers/main.py
+++ b/addons/calendar/controllers/main.py
@@ -83,6 +83,16 @@ class CalendarController(http.Controller):
             })
         return request.make_response(response_content, headers=[('Content-Type', 'text/html')])
 
+    @http.route('/calendar/meeting/join', type='http', auth="user", website=True)
+    def calendar_join_meeting(self, token, **kwargs):
+        event = request.env['calendar.event'].sudo().search([
+            ('access_token', '=', token)])
+        if not event:
+            return request.not_found()
+        event.action_join_meeting(request.env.user.partner_id.id)
+        attendee = request.env['calendar.attendee'].sudo().search([('partner_id', '=', request.env.user.partner_id), ('event_id', '=', event.id)])
+        return request.redirect('/calendar/meeting/view?token=%s&id=%s' % (attendee.access_token, event.id))
+
     # Function used, in RPC to check every 5 minutes, if notification to do for an event or not
     @http.route('/calendar/notify', type='json', auth="user")
     def notify(self):

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -122,6 +122,7 @@ class Meeting(models.Model):
     # filtering
     active = fields.Boolean(
         'Active', default=True,
+        tracking=True,
         help="If the active field is set to false, it will allow you to hide the event alarm information without removing it.")
     categ_ids = fields.Many2many(
         'calendar.event.type', 'meeting_category_rel', 'event_id', 'type_id', 'Tags')

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -590,6 +590,14 @@ class Meeting(models.Model):
             'context': compose_ctx,
         }
 
+    def action_join_meeting(self, partner_id):
+        """ Method used when an existing user wants to join
+        """
+        self.ensure_one()
+        partner = self.env['res.partner'].browse(partner_id)
+        if partner not in self.partner_ids:
+            self.write({'partner_ids': [(4, partner.id)]})
+
     # ------------------------------------------------------------
     # MAILING
     # ------------------------------------------------------------


### PR DESCRIPTION
This PR introduces a new route for users to join existing events.
It's also some preparatory changes for the enterprise PR linked below

Enterprise PR: https://github.com/odoo/enterprise/pull/17141
