### PR TITLE
[FIX] web: no quick edit on mouse text selection


### DIFF
--- a/addons/web/static/src/js/views/form/form_controller.js
+++ b/addons/web/static/src/js/views/form/form_controller.js
@@ -21,6 +21,10 @@ var FormController = BasicController.extend({
         quick_edit: '_onQuickEdit',
     }),
     /**
+     * Time between multiple clicks (used to detect double click text selection)
+     */
+    multiClickTime: 350,
+    /**
      * @override
      *
      * @param {boolean} params.hasActionMenus
@@ -35,6 +39,9 @@ var FormController = BasicController.extend({
         this.defaultButtons = params.defaultButtons;
         this.hasActionMenus = params.hasActionMenus;
         this.toolbarActions = params.toolbarActions || {};
+        // Quick edit is delayed by `multiClickTime` time. If a subsequent click
+        // happens within this time, the quick edit is aborted.
+        this.quickEditTimeout = undefined;
     },
     /**
      * Called each time the form view is attached into the DOM
@@ -691,9 +698,14 @@ var FormController = BasicController.extend({
      */
     _onQuickEdit: async function (ev) {
         ev.stopPropagation();
-        if (this.activeActions.edit) {
-            await this._setEditMode();
-            this.renderer.quickEdit(ev.data);
+        clearTimeout(this.quickEditTimeout);
+        if (this.activeActions.edit && !window.getSelection().toString()) {
+            this.quickEditTimeout = setTimeout(async () => {
+                if (!this.isDestroyed()) {
+                    await this._setEditMode();
+                    this.renderer.quickEdit(ev.data);
+                }
+            }, this.multiClickTime);
         }
     },
     /**

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -6,6 +6,7 @@ var basicFields = require('web.basic_fields');
 var concurrency = require('web.concurrency');
 var config = require('web.config');
 var core = require('web.core');
+var FormController = require('web.FormController');
 var FormView = require('web.FormView');
 var KanbanView = require('web.KanbanView');
 var ListView = require('web.ListView');
@@ -150,7 +151,14 @@ QUnit.module('basic_fields', {
                 }]
             },
         };
-    }
+
+        testUtils.mock.patch(FormController, {
+            'multiClickTime': 0,
+        });
+    },
+    afterEach() {
+        testUtils.mock.unpatch(FormController);
+    },
 }, function () {
 
     QUnit.module('DebouncedField');

--- a/addons/web/static/tests/fields/relational_fields/field_many2one_tests.js
+++ b/addons/web/static/tests/fields/relational_fields/field_many2one_tests.js
@@ -2,6 +2,7 @@ odoo.define('web.field_many_to_one_tests', function (require) {
 "use strict";
 
 var BasicModel = require('web.BasicModel');
+var FormController = require('web.FormController');
 var FormView = require('web.FormView');
 var ListView = require('web.ListView');
 var relationalFields = require('web.relational_fields');
@@ -151,6 +152,13 @@ QUnit.module('fields', {}, function () {
                     }]
                 },
             };
+
+            testUtils.mock.patch(FormController, {
+                'multiClickTime': 0,
+            });
+        },
+        afterEach: function () {
+            testUtils.mock.unpatch(FormController);
         },
     }, function () {
         QUnit.module('FieldMany2One');

--- a/addons/web/static/tests/fields/relational_fields/field_one2many_tests.js
+++ b/addons/web/static/tests/fields/relational_fields/field_one2many_tests.js
@@ -5,6 +5,7 @@ var AbstractField = require('web.AbstractField');
 var AbstractStorageService = require('web.AbstractStorageService');
 const ControlPanel = require('web.ControlPanel');
 const fieldRegistry = require('web.field_registry');
+var FormController = require('web.FormController');
 var FormView = require('web.FormView');
 var KanbanRecord = require('web.KanbanRecord');
 var ListRenderer = require('web.ListRenderer');
@@ -162,7 +163,14 @@ QUnit.module('fields', {}, function () {
                     }]
                 },
             };
-        }
+
+            testUtils.mock.patch(FormController, {
+                'multiClickTime': 0,
+            });
+        },
+        afterEach: function () {
+            testUtils.mock.unpatch(FormController);
+        },
     }, function () {
         QUnit.module('FieldOne2Many');
 

--- a/addons/web/static/tests/fields/relational_fields_tests.js
+++ b/addons/web/static/tests/fields/relational_fields_tests.js
@@ -2,6 +2,7 @@ odoo.define('web.relational_fields_tests', function (require) {
 "use strict";
 
 var AbstractStorageService = require('web.AbstractStorageService');
+var FormController = require('web.FormController');
 var FormView = require('web.FormView');
 var ListView = require('web.ListView');
 var RamStorage = require('web.RamStorage');
@@ -169,6 +170,13 @@ QUnit.module('relational_fields', {
                 onchanges: {},
             },
         };
+
+        testUtils.mock.patch(FormController, {
+            'multiClickTime': 0,
+        });
+    },
+    afterEach: function () {
+        testUtils.mock.unpatch(FormController);
     },
 }, function () {
 

--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -35,6 +35,9 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
     className: 'oe_form_field oe_form_field_html',
     supportedFieldTypes: ['html'],
     isQuickEditable: true,
+    quickEditExclusion: [
+        '[href]',
+    ],
 
     custom_events: {
         wysiwyg_focus: '_onWysiwygFocus',

--- a/addons/web_editor/static/tests/field_html_tests.js
+++ b/addons/web_editor/static/tests/field_html_tests.js
@@ -2,6 +2,7 @@ odoo.define('web_editor.field_html_tests', function (require) {
 "use strict";
 
 var ajax = require('web.ajax');
+var FormController = require('web.FormController');
 var FormView = require('web.FormView');
 var testUtils = require('web.test_utils');
 var weTestUtils = require('web_editor.test_utils');
@@ -95,9 +96,13 @@ QUnit.module('web_editor', {}, function () {
                     throw 'Wrong template';
                 },
             });
+            testUtils.mock.patch(FormController, {
+                'multiClickTime': 0,
+            });
         },
         afterEach: function () {
             testUtils.mock.unpatch(ajax);
+            testUtils.mock.unpatch(FormController);
         },
     }, function () {
 
@@ -401,6 +406,34 @@ QUnit.module('web_editor', {}, function () {
             await testUtils.dom.click($field.find('.note-toolbar .note-back-color-preview .o_we_color_btn.bg-o-color-3'));
 
             await testUtils.form.clickSave(form);
+
+            form.destroy();
+        });
+
+        QUnit.test('Quick Edition: click on link inside html field', async function (assert) {
+            assert.expect(3);
+
+            this.data['note.note'].records[0]['body'] = '<p><a href="#">hello</a> world</p>';
+
+            const form = await testUtils.createView({
+                View: FormView,
+                model: 'note.note',
+                data: this.data,
+                arch: '<form>' +
+                    '<field name="body" widget="html" style="height: 100px"/>' +
+                    '</form>',
+                res_id: 1,
+            });
+
+            assert.containsOnce(form, '.o_form_view.o_form_readonly');
+
+            await testUtils.dom.click(form.$('.oe_form_field[name="body"] a'));
+            await testUtils.nextTick();
+            assert.containsOnce(form, '.o_form_view.o_form_readonly');
+
+            await testUtils.dom.click(form.$('.oe_form_field[name="body"] p'));
+            await testUtils.nextTick();
+            assert.containsOnce(form, '.o_form_view.o_form_editable');
 
             form.destroy();
         });


### PR DESCRIPTION
Do not trigger quick edit when we are selection text with mouse:

- click and holding to select text
- multiple clicks selecting text

Since click on an editable field now change the edit mode, we could no
longer select the text.

With this change, quick edit is delayed by a given delay and if the edit
mode is not enabled if:

- there is a subsequent click within the delay
- there is a text selection when the click event is handled