### PR TITLE
[FIX] web: correctly set current_company_id in BasicModel

### DIFF
--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -3711,7 +3711,7 @@ var BasicModel = AbstractModel.extend({
         // in general, the actual "company_id" field of the form should be used for m2o domains, not this fallback
         let current_company_id;
         if (session.user_context.allowed_company_ids) {
-            current_company_id = Object.keys(session.user_context.allowed_company_ids)[0];
+            current_company_id = session.user_context.allowed_company_ids[0];
         } else {
             current_company_id = session.user_companies ?
                 session.user_companies.current_company :

--- a/addons/web/tests/__init__.py
+++ b/addons/web/tests/__init__.py
@@ -7,3 +7,4 @@ from . import test_menu
 from . import test_serving_base
 from . import test_click_everywhere
 from . import test_base_document_layout
+from . import test_session_info

--- a/addons/web/tests/test_session_info.py
+++ b/addons/web/tests/test_session_info.py
@@ -1,0 +1,58 @@
+# -*- encoding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import json
+from uuid import uuid4
+
+from odoo import Command
+from odoo.tests import common
+
+
+class TestSessionInfo(common.HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company_a = cls.env['res.company'].create({'name': "A"})
+        cls.company_b = cls.env['res.company'].create({'name': "B"})
+        cls.company_c = cls.env['res.company'].create({'name': "C"})
+        cls.companies = [cls.company_a, cls.company_b, cls.company_c]
+
+        cls.user_password = "info"
+        cls.user = common.new_test_user(
+            cls.env,
+            "session",
+            email="session@in.fo",
+            password=cls.user_password,
+            tz="UTC")
+        cls.user.write({
+            'company_id': cls.company_a.id,
+            'company_ids': [Command.set([company.id for company in cls.companies])],
+        })
+
+        cls.payload = json.dumps(dict(jsonrpc="2.0", method="call", id=str(uuid4())))
+        cls.headers = {
+            "Content-Type": "application/json",
+        }
+
+    def test_session_info(self):
+        """ Checks that the session_info['user_companies'] structure correspond to what is expected """
+        self.authenticate(self.user.login, self.user_password)
+        response = self.url_open("/web/session/get_session_info", data=self.payload, headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        result = data["result"]
+
+        expected_allowed_companies = {
+            str(company.id): {
+                'id': company.id,
+                'name': company.name,
+            } for company in self.companies
+        }
+        expected_user_companies = {
+            'current_company': self.company_a.id,
+            'allowed_companies': expected_allowed_companies,
+        }
+        self.assertEqual(
+            result['user_companies'],
+            expected_user_companies,
+            "The session_info['user_companies'] does not have the expected structure")


### PR DESCRIPTION
This commit fix a bug introduced in #66551 where a mismatch has been done between
session.user_context.allowed_company_ids and session.user_companies.allowed_companies.

This commit also adds the following tests:

- a JS test in order to prevent future unwanted issues regarding multi company
  in BasicModel.
- a Python test in order to ensure that session_info['user_companies'] is not
  involuntarily changed.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
