### PR TITLE
[FIX] stock: fix search by qty_available

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -340,9 +340,28 @@ class Product(models.Model):
         if package_id:
             domain_quant.append(('package_id', '=', package_id))
         quants_groupby = self.env['stock.quant'].read_group(domain_quant, ['product_id', 'quantity'], ['product_id'], orderby='id')
+
+        # check if we need include zero values in result
+        include_zero = (
+            value < 0.0 and operator in ('>', '>=') or
+            value > 0.0 and operator in ('<', '<=') or
+            value == 0.0 and operator in ('>=', '<=', '=')
+        )
+
+        processed_product_ids = set()
         for quant in quants_groupby:
+            product_id = quant['product_id'][0]
+            if include_zero:
+                processed_product_ids.add(product_id)
             if OPERATORS[operator](quant['quantity'], value):
-                product_ids.add(quant['product_id'][0])
+                product_ids.add(product_id)
+
+        if include_zero:
+            products_without_quants_in_domain = self.env['product.product'].search([
+                ('type', '=', 'product'),
+                ('id', 'not in', list(processed_product_ids))]
+            )
+            product_ids |= set(products_without_quants_in_domain.ids)
         return list(product_ids)
 
     def _compute_nbr_reordering_rules(self):

--- a/addons/stock/tests/test_product.py
+++ b/addons/stock/tests/test_product.py
@@ -104,3 +104,14 @@ class TestVirtualAvailable(TestStockCommon):
         self.assertTrue(orderpoint.active)
         self.product_3.active = False
         self.assertFalse(orderpoint.active)
+
+    def test_search_qty_available(self):
+        product = self.env['product.product'].create({
+            'name': 'Brand new product',
+            'type': 'product',
+        })
+        result = self.env['product.product'].search([
+            ('qty_available', '=', 0),
+            ('id', 'in', product.ids),
+        ])
+        self.assertEqual(product, result)


### PR DESCRIPTION
In simple search by qty_available we use optimized method. Before this commit
that method didn't work when product doesn't have stock moves and domain
includes zero qty, e.g. ``[('qty_available', '>=', 0)]``, ``[('qty_available',
'=', 0)]``, etc

The problem comes from https://github.com/odoo/odoo/pull/66652

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
