### PR TITLE
[IMP] website: validate 308 redirections parameters

### DIFF
--- a/addons/website/models/website_rewrite.py
+++ b/addons/website/models/website_rewrite.py
@@ -1,3 +1,9 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import re
+import werkzeug
+
 from odoo import models, fields, api, _
 from odoo.exceptions import AccessDenied, ValidationError
 
@@ -73,7 +79,7 @@ class WebsiteRewrite(models.Model):
         self.url_from = self.route_id.path
         self.url_to = self.route_id.path
 
-    @api.constrains('url_to', 'redirect_type')
+    @api.constrains('url_to', 'url_from', 'redirect_type')
     def _check_url_to(self):
         for rewrite in self:
             if rewrite.redirect_type == '308':
@@ -81,6 +87,19 @@ class WebsiteRewrite(models.Model):
                     raise ValidationError(_('"URL to" can not be empty.'))
                 elif not rewrite.url_to.startswith('/'):
                     raise ValidationError(_('"URL to" must start with a leading slash.'))
+                for param in re.findall('/<.*?>', rewrite.url_from):
+                    if param not in rewrite.url_to:
+                        raise ValidationError(_('"URL to" must contain parameter %s used in "URL from".', param))
+                for param in re.findall('/<.*?>', rewrite.url_to):
+                    if param not in rewrite.url_from:
+                        raise ValidationError(_('"URL to" cannot contain parameter %s which is not used in "URL from".', param))
+                try:
+                    ir_http = self.env['ir.http']
+                    routing_map = werkzeug.routing.Map(strict_slashes=False, converters=ir_http._get_converters())
+                    rule = werkzeug.routing.Rule(rewrite.url_to)
+                    routing_map.add(rule)
+                except ValueError as e:
+                    raise ValidationError(_('"URL to" is invalid: %s', e))
 
     def name_get(self):
         result = []

--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -278,7 +278,11 @@ class IrHttp(models.AbstractModel):
                 kw = {k: routing[k] for k in xtra_keys if k in routing}
                 rule = werkzeug.routing.Rule(url, endpoint=endpoint, methods=routing['methods'], **kw)
                 rule.merge_slashes = False
-                routing_map.add(rule)
+                try:
+                    routing_map.add(rule)
+                except ValueError as e:
+                    error = "Failed generating route for URL '%s': %s" % (url, e)
+                    _logger.error(error)
             cls._routing_map[key] = routing_map
         return cls._routing_map[key]
 


### PR DESCRIPTION
Before this commit 308 redirections could be configured with a malformed
route which made the routing fail.

After this commit 308 redirections validation makes sure all parameters
of URL from appear in URL to and no other parameter appears.
If the route still causes a problem an error is logged instead of
breaking the whole routing mechanism.

task-2451780

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
