### PR TITLE
[FIX] website_event_track: Unpublish canceled event

### DIFF
--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -353,6 +353,8 @@ class Track(models.Model):
     def _synchronize_with_stage(self, stage):
         if stage.is_done:
             self.is_published = True
+        elif stage.is_cancel:
+            self.is_published = False
 
     # ------------------------------------------------------------
     # MESSAGING


### PR DESCRIPTION
A canceled event track must be unpublished.

opw:2485928