### PR TITLE
[FIX] sale management : fix the “unit_price” in so line

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1577,7 +1577,8 @@ class SaleOrderLine(models.Model):
                 uom=self.product_uom.id,
                 fiscal_position=self.env.context.get('fiscal_position')
             )
-            self.price_unit = self.env['account.tax']._fix_tax_included_price_company(self._get_display_price(product), product.taxes_id, self.tax_id, self.company_id)
+            price_unit = self.price_unit if product.price!=self.price_unit else self._get_display_price(product)
+            self.price_unit = self.env['account.tax']._fix_tax_included_price_company(price_unit, product.taxes_id, self.tax_id, self.company_id)
 
     @api.multi
     def name_get(self):


### PR DESCRIPTION
Steps to follow to reproduce the bug:
  - Go to Sales app
  - Create a product and give it for example a “price_unit” of 200 and a “cost” of 100
  - Create a new SO
  - Add the product you just created
  - Modify in the order line, the value of “price_unit” 200 to 120 for example.
  - Change the quantity to 2
  - The modified unit price is replaced by the base price of the product

Problem :
In the "product_uom_changes" function, The "unit_price" is calculated in relation to the base price of the product and never takes price changes into account.

Solution :
Check if the “unit_price” has not been changed in the order line. If it's the case, calculate the “price_unit” according to this price

opw-2473726

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
