### PR TITLE
[FIX] stock, sale_stock: qty_at_date widget with Stock location, not …

### DIFF
--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -323,10 +323,10 @@ class SaleOrderLine(models.Model):
         for line in self.filtered(lambda l: l.state in ('draft', 'sent')):
             if not (line.product_id and line.display_qty_widget):
                 continue
-            grouped_lines[(line.warehouse_id.id, line.order_id.commitment_date or line._expected_date())] |= line
+            grouped_lines[(line.warehouse_id.lot_stock_id.id, line.order_id.commitment_date or line._expected_date())] |= line
 
-        for (warehouse, scheduled_date), lines in grouped_lines.items():
-            product_qties = lines.mapped('product_id').with_context(to_date=scheduled_date, warehouse=warehouse).read([
+        for (location, scheduled_date), lines in grouped_lines.items():
+            product_qties = lines.mapped('product_id').with_context(to_date=scheduled_date, location=location).read([
                 'qty_available',
                 'free_qty',
                 'virtual_available',

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -240,7 +240,7 @@ class Product(models.Model):
             warehouse = [warehouse]
         # filter by location and/or warehouse
         if warehouse:
-            w_ids = set(Warehouse.browse(_search_ids('stock.warehouse', warehouse)).mapped('view_location_id').ids)
+            w_ids = set(Warehouse.browse(_search_ids('stock.warehouse', warehouse)).mapped('lot_stock_id').ids)
             if location:
                 l_ids = _search_ids('stock.location', location)
                 location_ids = w_ids & l_ids
@@ -250,7 +250,7 @@ class Product(models.Model):
             if location:
                 location_ids = _search_ids('stock.location', location)
             else:
-                location_ids = set(Warehouse.search([]).mapped('view_location_id').ids)
+                location_ids = set(Warehouse.search([]).mapped('lot_stock_id').ids)
 
         return self._get_domain_locations_new(location_ids, compute_child=self.env.context.get('compute_child', True))
 

--- a/addons/stock/report/report_stock_forecasted.py
+++ b/addons/stock/report/report_stock_forecasted.py
@@ -82,7 +82,7 @@ class ReplenishmentReport(models.AbstractModel):
             ], limit=1)
             self.env.context = dict(self.env.context, warehouse=warehouse.id)
         wh_location_ids = [loc['id'] for loc in self.env['stock.location'].search_read(
-            [('id', 'child_of', warehouse.view_location_id.id)],
+            [('id', 'child_of', warehouse.lot_stock_id.id)],
             ['id'],
         )]
         res['active_warehouse'] = warehouse.display_name


### PR DESCRIPTION
…the whole warehouse (Issue #2484634)

What are the steps to reproduce your issue?

* Activate multi locations
* Create a location "Not for Sales" under "WH"
* Add 50 office chairs in that location
* Create a sales order for that chair
* Open the Forecast icon on the sale order line

What is the current behavior that you observe?

* Forecasted quantity: 85
* Available quantity: 50

What would be your expected behavior in this case?

* Forecasted quantity: 35
* Available quantity: 0

The location "Not for Sales" is not under WH/Stock so the stock there should not be available for sales.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
