### PR TITLE
[13.0] stock: Add missing field in cxt depends on stock calculation.

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -95,7 +95,7 @@ class Product(models.Model):
     @api.depends('stock_move_ids.product_qty', 'stock_move_ids.state')
     @api.depends_context(
         'lot_id', 'owner_id', 'package_id', 'from_date', 'to_date',
-        'company_owned', 'force_company', 'location', 'warehouse'
+        'company_owned', 'force_company', 'location', 'warehouse',
     )
     def _compute_quantities(self):
         products = self.filtered(lambda p: p.type != 'service')
@@ -622,7 +622,7 @@ class ProductTemplate(models.Model):
         'product_variant_ids.stock_move_ids.product_qty',
         'product_variant_ids.stock_move_ids.state',
     )
-    @api.depends_context('company_owned', 'force_company')
+    @api.depends_context('company_owned', 'force_company', 'location', 'warehouse')
     def _compute_quantities(self):
         res = self._compute_quantities_dict()
         for template in self:


### PR DESCRIPTION
This "depends context" was missing fields and the compute of the stock qty's were not correct in several cases.
We add the same as the fields "force_company".

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
