### PR TITLE
[FIX] link_tracker: Filter by tracked URL code is not working

### DIFF
--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -215,6 +215,7 @@ class link_tracker(models.Model):
 class link_tracker_code(models.Model):
     _name = "link.tracker.code"
     _description = 'Link Tracker Code'
+    _rec_name = 'code'
 
     code = fields.Char(string='Short URL Code', store=True)
     link_id = fields.Many2one('link.tracker', 'Link', required=True, ondelete='cascade')


### PR DESCRIPTION
When trying to filter links by a tracked URL code, the following warning
is shown:

    WARNING dbname odoo.models: Cannot execute name_search, no _rec_name
	defined on link.tracker.code

and the applied filter gives all records.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
