### PR TITLE
[FIX] web: image has no value should be blank

### DIFF
--- a/addons/web/static/src/scss/fields.scss
+++ b/addons/web/static/src/scss/fields.scss
@@ -406,6 +406,10 @@
     &.o_field_image {
         position: relative;
 
+        &.o_field_empty {
+            display: none;
+        }
+
         .o_form_image_controls {
             @include o-position-absolute(0, 0);
             width: 100%;


### PR DESCRIPTION
**Before this commit:**

In readonly mode, widget "image" on fields displaying placeholder(camera) image
if it has no value.
For example: In livechat, if visitor left the conversation without giving rating
it shows placeholder image on livechat session's tree view.

**After this commit:**

In readonly mode, image fields will be blank instead of displaying placeholder
image.

Task-2481519