### PR TITLE
web_editor: fix selector exclusion rule

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -3,6 +3,7 @@ odoo.define('web_editor.convertInline', function (require) {
 
 var FieldHtml = require('web_editor.field.html');
 
+const SELECTORS_IGNORE = /(^\*$|:hover|:before|:after|:active|:link|::|'|\([^(),]+[,(])/g;
 /**
  * Returns the css rules which applies on an element, tweaked so that they are
  * browser/mail client ok.
@@ -29,16 +30,7 @@ function getMatchedCSSRules(a) {
             if (rules) {
                 for (r = rules.length-1; r >= 0; r--) {
                     var selectorText = rules[r].selectorText;
-                    if (selectorText &&
-                            rules[r].cssText &&
-                            selectorText !== '*' &&
-                            selectorText.indexOf(':hover') === -1 &&
-                            selectorText.indexOf(':before') === -1 &&
-                            selectorText.indexOf(':after') === -1 &&
-                            selectorText.indexOf(':active') === -1 &&
-                            selectorText.indexOf(':link') === -1 &&
-                            selectorText.indexOf('::') === -1 &&
-                            selectorText.indexOf("'") === -1) {
+                    if (selectorText && !SELECTORS_IGNORE.test(selectorText)) {
                         var st = selectorText.split(/\s*,\s*/);
                         for (k = 0 ; k < st.length ; k++) {
                             rulesCache.push({ 'selector': st[k], 'style': rules[r].style });


### PR DESCRIPTION
The current rules would allow through a selector of the form

    :not(sel1, sel2)

then because the matcher thing just splits on `,` it would store the
incorrect sections

    :not sel1(

and

    sel2)

as separate selectors in the rules cache, raising an exception when
matching against elements.

Move all the rules to a single regex, and add a rule to exclude any
situation where a comma or an open parenthesis is inside of an open
parenthesis pair.

Although maybe this should straight up just exclude any rule containing a pseudo-class and pseudo-element? There's no real explanation and it's all part of a big commit, but it tries to exclude all pseudo-elements (::) except it only excludes *some* of the legacy ones (:before and :after, but not :first-letter) and the pseudo-class exclusion also seems somewhat arbitrary e.g. why :active but not :focus?

Is the intent there to exclude rules which can never match because they're "live" rules? (in that case the exclusion I add is not really correct, but that means this thing needs a much more advanced rules parsing in order to handle the case of a multi-parameter `:not`).