### PR TITLE
[IMP] sale(_expense): simplify the re-invoicing.

### DIFF
--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -26,11 +26,12 @@ class ProductTemplate(models.Model):
     sale_line_warn = fields.Selection(WARNING_MESSAGE, 'Sales Order Line', help=WARNING_HELP, required=True, default="no-message")
     sale_line_warn_msg = fields.Text('Message for Sales Order Line')
     expense_policy = fields.Selection(
-        [('no', 'No'), ('cost', 'At cost'), ('sales_price', 'Sales price')],
-        string='Re-Invoice Expenses',
+        [('no', 'No'), ('cost', 'Billed/Expensed price'), ('sales_price', 'Sales price')],
+        string='Re-Invoice From Bills/Expenses',
         default='no',
-        help="Expenses and vendor bills can be re-invoiced to a customer."
-             "With this option, a validated expense can be re-invoice to a customer at its cost or sales price.")
+        help="If enabled, You can re-invoice products by selecting a customer sales order on the expense line "
+             "or by matching the analytic account of the vendor bills line and analytic account of the customer sales order.")
+    reinvoice_margin = fields.Float(string="Re-invoice Margin", help="You can add a specific margin on billed/expense price. For sales order, you should use pricelist.")
     visible_expense_policy = fields.Boolean("Re-Invoice Policy visible", compute='_compute_visible_expense_policy', default=lambda self: self._default_visible_expense_policy())
     sales_count = fields.Float(compute='_compute_sales_count', string='Sold')
     visible_qty_configurator = fields.Boolean("Quantity visible in configurator", compute='_compute_visible_qty_configurator')
@@ -47,10 +48,9 @@ class ProductTemplate(models.Model):
 
     @api.depends('name')
     def _compute_visible_expense_policy(self):
-        visibility = self.user_has_groups('analytic.group_analytic_accounting')
+        visibility = self.user_has_groups('sale.group_re_invoice_sale')
         for product_template in self:
             product_template.visible_expense_policy = visibility
-
 
     @api.onchange('sale_ok')
     def _change_sale_ok(self):

--- a/addons/sale/models/res_config_settings.py
+++ b/addons/sale/models/res_config_settings.py
@@ -62,6 +62,7 @@ class ResConfigSettings(models.TransientModel):
                                                domain="[('model', '=', 'sale.order')]",
                                                config_parameter='sale.default_confirmation_template',
                                                help="Email sent to the customer once the order is paid.")
+    group_re_invoice_sale = fields.Boolean("Re-invoice Products", implied_group="sale.group_re_invoice_sale")
 
     def set_values(self):
         super(ResConfigSettings, self).set_values()

--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1289,8 +1289,9 @@ class SaleOrderLine(models.Model):
         lines = super().create(vals_list)
         for line in lines:
             if line.product_id and line.order_id.state == 'sale':
-                msg = _("Extra line with %s ") % (line.product_id.display_name,)
-                line.order_id.message_post(body=msg)
+                if not self.env.context.get('is_reinvoice'):
+                    msg = _("Extra line with %s ") % (line.product_id.display_name,)
+                    line.order_id.message_post(body=msg)
                 # create an analytic account if at least an expense product
                 if line.product_id.expense_policy not in [False, 'no'] and not line.order_id.analytic_account_id:
                     line.order_id._create_analytic_account()

--- a/addons/sale/security/sale_security.xml
+++ b/addons/sale/security/sale_security.xml
@@ -37,6 +37,15 @@
         <field eval="[(4,ref('base.group_partner_manager'))]" name="groups_id"/>
     </record>
 
+    <record id="group_re_invoice_sale" model="res.groups">
+        <field name="name">Enable product re-invoicing on product configurator</field>
+        <field name="category_id" ref="base.module_category_hidden"/>
+    </record>
+
+    <record id="analytic.group_analytic_accounting" model="res.groups">
+        <field name="implied_ids" eval="[(4, ref('sale.group_re_invoice_sale'))]"/>
+    </record>
+
 <data noupdate="1">
     <!-- Multi - Company Rules -->
 

--- a/addons/sale/tests/test_reinvoice.py
+++ b/addons/sale/tests/test_reinvoice.py
@@ -78,8 +78,8 @@ class TestReInvoice(TestSaleCommon):
         self.assertEqual(len(self.sale_order.order_line), 4, "There should be 4 lines on the SO (2 vendor bill lines created)")
         self.assertEqual(len(self.sale_order.order_line.filtered(lambda sol: sol.is_expense)), 2, "There should be 4 lines on the SO (2 vendor bill lines created)")
 
-        self.assertEqual((sale_order_line3.price_unit, sale_order_line3.qty_delivered, sale_order_line3.product_uom_qty, sale_order_line3.qty_invoiced), (self.company_data['product_order_cost'].standard_price, 3, 0, 0), 'Sale line is wrong after confirming vendor invoice')
-        self.assertEqual((sale_order_line4.price_unit, sale_order_line4.qty_delivered, sale_order_line4.product_uom_qty, sale_order_line4.qty_invoiced), (self.company_data['product_delivery_cost'].standard_price, 3, 0, 0), 'Sale line is wrong after confirming vendor invoice')
+        self.assertEqual((sale_order_line3.price_unit, sale_order_line3.qty_delivered, sale_order_line3.product_uom_qty, sale_order_line3.qty_invoiced), (self.company_data['product_order_cost'].standard_price, 3, 3, 0), 'Sale line is wrong after confirming vendor invoice')
+        self.assertEqual((sale_order_line4.price_unit, sale_order_line4.qty_delivered, sale_order_line4.product_uom_qty, sale_order_line4.qty_invoiced), (self.company_data['product_delivery_cost'].standard_price, 3, 3, 0), 'Sale line is wrong after confirming vendor invoice')
 
         self.assertEqual(sale_order_line3.qty_delivered_method, 'analytic', "Delivered quantity of 'expense' SO line should be computed by analytic amount")
         self.assertEqual(sale_order_line4.qty_delivered_method, 'analytic', "Delivered quantity of 'expense' SO line should be computed by analytic amount")
@@ -107,8 +107,8 @@ class TestReInvoice(TestSaleCommon):
         self.assertEqual(len(self.sale_order.order_line), 6, "There should be still 4 lines on the SO, no new created")
         self.assertEqual(len(self.sale_order.order_line.filtered(lambda sol: sol.is_expense)), 4, "There should be still 2 expenses lines on the SO")
 
-        self.assertEqual((sale_order_line5.price_unit, sale_order_line5.qty_delivered, sale_order_line5.product_uom_qty, sale_order_line5.qty_invoiced), (self.company_data['product_order_cost'].standard_price, 2, 0, 0), 'Sale line 5 is wrong after confirming 2e vendor invoice')
-        self.assertEqual((sale_order_line6.price_unit, sale_order_line6.qty_delivered, sale_order_line6.product_uom_qty, sale_order_line6.qty_invoiced), (self.company_data['product_delivery_cost'].standard_price, 2, 0, 0), 'Sale line 6 is wrong after confirming 2e vendor invoice')
+        self.assertEqual((sale_order_line5.price_unit, sale_order_line5.qty_delivered, sale_order_line5.product_uom_qty, sale_order_line5.qty_invoiced), (self.company_data['product_order_cost'].standard_price, 2, 2, 0), 'Sale line 5 is wrong after confirming 2e vendor invoice')
+        self.assertEqual((sale_order_line6.price_unit, sale_order_line6.qty_delivered, sale_order_line6.product_uom_qty, sale_order_line6.qty_invoiced), (self.company_data['product_delivery_cost'].standard_price, 2, 2, 0), 'Sale line 6 is wrong after confirming 2e vendor invoice')
 
     def test_sales_price(self):
         """ Test invoicing vendor bill at sales price for products based on delivered and ordered quantities. Check no existing SO line is incremented, but when invoicing a
@@ -160,8 +160,8 @@ class TestReInvoice(TestSaleCommon):
         self.assertEqual(len(self.sale_order.order_line), 4, "There should be 4 lines on the SO (2 vendor bill lines created)")
         self.assertEqual(len(self.sale_order.order_line.filtered(lambda sol: sol.is_expense)), 2, "There should be 4 lines on the SO (2 vendor bill lines created)")
 
-        self.assertEqual((sale_order_line3.price_unit, sale_order_line3.qty_delivered, sale_order_line3.product_uom_qty, sale_order_line3.qty_invoiced), (self.company_data['product_delivery_sales_price'].list_price, 3, 0, 0), 'Sale line is wrong after confirming vendor invoice')
-        self.assertEqual((sale_order_line4.price_unit, sale_order_line4.qty_delivered, sale_order_line4.product_uom_qty, sale_order_line4.qty_invoiced), (self.company_data['product_order_sales_price'].list_price, 3, 0, 0), 'Sale line is wrong after confirming vendor invoice')
+        self.assertEqual((sale_order_line3.price_unit, sale_order_line3.qty_delivered, sale_order_line3.product_uom_qty, sale_order_line3.qty_invoiced), (self.company_data['product_delivery_sales_price'].list_price, 3, 3, 0), 'Sale line is wrong after confirming vendor invoice')
+        self.assertEqual((sale_order_line4.price_unit, sale_order_line4.qty_delivered, sale_order_line4.product_uom_qty, sale_order_line4.qty_invoiced), (self.company_data['product_order_sales_price'].list_price, 3, 3, 0), 'Sale line is wrong after confirming vendor invoice')
 
         self.assertEqual(sale_order_line3.qty_delivered_method, 'analytic', "Delivered quantity of 'expense' SO line 3 should be computed by analytic amount")
         self.assertEqual(sale_order_line4.qty_delivered_method, 'analytic', "Delivered quantity of 'expense' SO line 4 should be computed by analytic amount")
@@ -189,7 +189,7 @@ class TestReInvoice(TestSaleCommon):
         self.assertEqual(len(self.sale_order.order_line), 5, "There should be 5 lines on the SO, 1 new created and 1 incremented")
         self.assertEqual(len(self.sale_order.order_line.filtered(lambda sol: sol.is_expense)), 3, "There should be 3 expenses lines on the SO")
 
-        self.assertEqual((sale_order_line6.price_unit, sale_order_line6.qty_delivered, sale_order_line4.product_uom_qty, sale_order_line6.qty_invoiced), (self.company_data['product_order_sales_price'].list_price, 2, 0, 0), 'Sale line is wrong after confirming 2e vendor invoice')
+        self.assertEqual((sale_order_line6.price_unit, sale_order_line6.qty_delivered, sale_order_line4.product_uom_qty, sale_order_line6.qty_invoiced), (self.company_data['product_order_sales_price'].list_price, 2, 3, 0), 'Sale line is wrong after confirming 2e vendor invoice')
 
     def test_no_expense(self):
         """ Test invoicing vendor bill with no policy. Check nothing happen. """

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -254,7 +254,7 @@ class TestSaleOrder(TestSaleCommon):
         inv.action_post()
         sol = so.order_line.filtered(lambda l: l.product_id == serv_cost)
         self.assertTrue(sol, 'Sale: cost invoicing does not add lines when confirming vendor invoice')
-        self.assertEqual((sol.price_unit, sol.qty_delivered, sol.product_uom_qty, sol.qty_invoiced), (160, 2, 0, 0), 'Sale: line is wrong after confirming vendor invoice')
+        self.assertEqual((sol.price_unit, sol.qty_delivered, sol.product_uom_qty, sol.qty_invoiced), (160, 2, 2, 0), 'Sale: line is wrong after confirming vendor invoice')
 
     def test_sale_with_taxes(self):
         """ Test SO with taxes applied on its lines and check subtotal applied on its lines and total applied on the SO """

--- a/addons/sale/views/res_config_settings_views.xml
+++ b/addons/sale/views/res_config_settings_views.xml
@@ -448,6 +448,27 @@
         </field>
     </record>
 
+    <record id="res_config_settings_view_form_invoice" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.invoice</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='invoicing_settings']" position="inside">
+                <div class="col-12 col-lg-6 o_setting_box">
+                    <div class="o_setting_left_pane">
+                        <field name="group_re_invoice_sale"/>
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="group_re_invoice_sale"/>
+                        <div class="text-muted">
+                            Enable product re-invoicing on product configuration
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
     <record id="action_sale_config_settings" model="ir.actions.act_window">
         <field name="name">Settings</field>
         <field name="type">ir.actions.act_window</field>

--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -662,7 +662,7 @@
                                 </group>
                                 <group name="sale_info" string="Invoicing">
                                     <field name="fiscal_position_id" options="{'no_create': True}"/>
-                                    <field name="analytic_account_id" context="{'default_partner_id':partner_invoice_id, 'default_name':name}" attrs="{'readonly': [('invoice_count','!=',0),('state','=','sale')]}" groups="analytic.group_analytic_accounting" force_save="1"/>
+                                    <field name="analytic_account_id" context="{'default_partner_id':partner_invoice_id, 'default_name':name}" attrs="{'readonly': [('invoice_count','!=',0),('state','=','sale')]}" groups="sale.group_re_invoice_sale" force_save="1"/>
                                     <field name="invoice_status" states="sale,done" groups="base.group_no_one"/>
                                 </group>
                             </group>
@@ -1177,6 +1177,7 @@
                         <field name="service_type" widget="radio" invisible="True"/>
                         <field name="visible_expense_policy" invisible="1"/>
                         <field name="expense_policy" widget="radio" attrs="{'invisible': [('visible_expense_policy', '=', False)]}"/>
+                        <field name="reinvoice_margin" widget="percentage" attrs="{'invisible': ['|', ('expense_policy', '!=', 'cost'), ('visible_expense_policy', '=', False)]}"/>
                     </group>
                 </xpath>
             </field>
@@ -1222,6 +1223,9 @@
                    </xpath>
                     <xpath expr="//field[@name='invoice_line_ids']//field[@name='discount']" position="attributes">
                         <attribute name="groups">product.group_discount_per_so_line</attribute>
+                    </xpath>
+                    <xpath expr="//field[@name='invoice_line_ids']//field[@name='analytic_account_id']" position="attributes">
+                        <attribute name="groups">sale.group_re_invoice_sale</attribute>
                     </xpath>
                     <xpath expr="//group[@name='sale_info_group']/field[@name='invoice_user_id']" position="after">
                         <field name="team_id" kanban_view_ref="%(sales_team.crm_team_view_kanban)s"/>

--- a/addons/sale_expense/models/product_template.py
+++ b/addons/sale_expense/models/product_template.py
@@ -14,10 +14,7 @@ class ProductTemplate(models.Model):
     @api.depends('can_be_expensed')
     def _compute_visible_expense_policy(self):
         expense_products = self.filtered(lambda p: p.can_be_expensed)
-        for product_template in self - expense_products:
-            product_template.visible_expense_policy = False
-
-        super(ProductTemplate, expense_products)._compute_visible_expense_policy()
+        super(ProductTemplate, self - expense_products)._compute_visible_expense_policy()
         visibility = self.user_has_groups('hr_expense.group_hr_expense_user')
         for product_template in expense_products:
             if not product_template.visible_expense_policy:

--- a/addons/sale_purchase/views/purchase_order_views.xml
+++ b/addons/sale_purchase/views/purchase_order_views.xml
@@ -13,6 +13,9 @@
                     </div>
                 </button>
             </xpath>
+            <xpath expr="//field[@name='order_line']//field[@name='account_analytic_id']" position="attributes">
+                <attribute name="groups">sale.group_re_invoice_sale</attribute>
+            </xpath>
         </field>
     </record>
 </data></odoo>

--- a/addons/sale_timesheet/tests/test_reinvoice.py
+++ b/addons/sale_timesheet/tests/test_reinvoice.py
@@ -110,8 +110,8 @@ class TestReInvoice(TestCommonSaleTimesheet):
         self.assertFalse(sale_order_line4.task_id, "Adding a new expense SO line should not create a task (sol4)")
         self.assertEqual(len(self.sale_order.project_ids), 1, "SO create only one project with its service line. Adding new expense SO line should not impact that")
 
-        self.assertEqual((sale_order_line3.price_unit, sale_order_line3.qty_delivered, sale_order_line3.product_uom_qty, sale_order_line3.qty_invoiced), (self.company_data['product_order_cost'].standard_price, 3.0, 0, 0), 'Sale line is wrong after confirming vendor invoice')
-        self.assertEqual((sale_order_line4.price_unit, sale_order_line4.qty_delivered, sale_order_line4.product_uom_qty, sale_order_line4.qty_invoiced), (self.company_data['product_delivery_cost'].standard_price, 3.0, 0, 0), 'Sale line is wrong after confirming vendor invoice')
+        self.assertEqual((sale_order_line3.price_unit, sale_order_line3.qty_delivered, sale_order_line3.product_uom_qty, sale_order_line3.qty_invoiced), (self.company_data['product_order_cost'].standard_price, 3.0, 3.0, 0), 'Sale line is wrong after confirming vendor invoice')
+        self.assertEqual((sale_order_line4.price_unit, sale_order_line4.qty_delivered, sale_order_line4.product_uom_qty, sale_order_line4.qty_invoiced), (self.company_data['product_delivery_cost'].standard_price, 3.0, 3.0, 0), 'Sale line is wrong after confirming vendor invoice')
 
         self.assertEqual(sale_order_line3.qty_delivered_method, 'analytic', "Delivered quantity of 'expense' SO line should be computed by analytic amount")
         self.assertEqual(sale_order_line4.qty_delivered_method, 'analytic', "Delivered quantity of 'expense' SO line should be computed by analytic amount")
@@ -139,8 +139,8 @@ class TestReInvoice(TestCommonSaleTimesheet):
         self.assertEqual(len(self.sale_order.order_line), 6, "There should be still 4 lines on the SO, no new created")
         self.assertEqual(len(self.sale_order.order_line.filtered(lambda sol: sol.is_expense)), 4, "There should be still 2 expenses lines on the SO")
 
-        self.assertEqual((sale_order_line5.price_unit, sale_order_line5.qty_delivered, sale_order_line5.product_uom_qty, sale_order_line5.qty_invoiced), (self.company_data['product_order_cost'].standard_price, 2.0, 0, 0), 'Sale line 5 is wrong after confirming 2e vendor invoice')
-        self.assertEqual((sale_order_line6.price_unit, sale_order_line6.qty_delivered, sale_order_line6.product_uom_qty, sale_order_line6.qty_invoiced), (self.company_data['product_delivery_cost'].standard_price, 2.0, 0, 0), 'Sale line 6 is wrong after confirming 2e vendor invoice')
+        self.assertEqual((sale_order_line5.price_unit, sale_order_line5.qty_delivered, sale_order_line5.product_uom_qty, sale_order_line5.qty_invoiced), (self.company_data['product_order_cost'].standard_price, 2.0, 2.0, 0), 'Sale line 5 is wrong after confirming 2e vendor invoice')
+        self.assertEqual((sale_order_line6.price_unit, sale_order_line6.qty_delivered, sale_order_line6.product_uom_qty, sale_order_line6.qty_invoiced), (self.company_data['product_delivery_cost'].standard_price, 2.0, 2.0, 0), 'Sale line 6 is wrong after confirming 2e vendor invoice')
 
     def test_sales_price(self):
         """ Test invoicing vendor bill at sales price for products based on delivered and ordered quantities. Check no existing SO line is incremented, but when invoicing a
@@ -209,8 +209,8 @@ class TestReInvoice(TestCommonSaleTimesheet):
         self.assertFalse(sale_order_line4.task_id, "Adding a new expense SO line should not create a task (sol4)")
         self.assertEqual(len(self.sale_order.project_ids), 1, "SO create only one project with its service line. Adding new expense SO line should not impact that")
 
-        self.assertEqual((sale_order_line3.price_unit, sale_order_line3.qty_delivered, sale_order_line3.product_uom_qty, sale_order_line3.qty_invoiced), (self.company_data['product_delivery_sales_price'].list_price, 3.0, 0, 0), 'Sale line is wrong after confirming vendor invoice')
-        self.assertEqual((sale_order_line4.price_unit, sale_order_line4.qty_delivered, sale_order_line4.product_uom_qty, sale_order_line4.qty_invoiced), (self.company_data['product_order_sales_price'].list_price, 3.0, 0, 0), 'Sale line is wrong after confirming vendor invoice')
+        self.assertEqual((sale_order_line3.price_unit, sale_order_line3.qty_delivered, sale_order_line3.product_uom_qty, sale_order_line3.qty_invoiced), (self.company_data['product_delivery_sales_price'].list_price, 3.0, 3.0, 0), 'Sale line is wrong after confirming vendor invoice')
+        self.assertEqual((sale_order_line4.price_unit, sale_order_line4.qty_delivered, sale_order_line4.product_uom_qty, sale_order_line4.qty_invoiced), (self.company_data['product_order_sales_price'].list_price, 3.0, 3.0, 0), 'Sale line is wrong after confirming vendor invoice')
 
         self.assertEqual(sale_order_line3.qty_delivered_method, 'analytic', "Delivered quantity of 'expense' SO line 3 should be computed by analytic amount")
         self.assertEqual(sale_order_line4.qty_delivered_method, 'analytic', "Delivered quantity of 'expense' SO line 4 should be computed by analytic amount")
@@ -238,7 +238,7 @@ class TestReInvoice(TestCommonSaleTimesheet):
         self.assertEqual(len(self.sale_order.order_line), 5, "There should be 5 lines on the SO, 1 new created and 1 incremented")
         self.assertEqual(len(self.sale_order.order_line.filtered(lambda sol: sol.is_expense)), 3, "There should be 3 expenses lines on the SO")
 
-        self.assertEqual((sale_order_line6.price_unit, sale_order_line6.qty_delivered, sale_order_line4.product_uom_qty, sale_order_line6.qty_invoiced), (self.company_data['product_order_sales_price'].list_price, 2.0, 0, 0), 'Sale line is wrong after confirming 2e vendor invoice')
+        self.assertEqual((sale_order_line6.price_unit, sale_order_line6.qty_delivered, sale_order_line4.product_uom_qty, sale_order_line6.qty_invoiced), (self.company_data['product_order_sales_price'].list_price, 2.0, 3.0, 0), 'Sale line is wrong after confirming 2e vendor invoice')
 
     def test_no_expense(self):
         """ Test invoicing vendor bill with no policy. Check nothing happen. """


### PR DESCRIPTION
Purpose of the commit is to make re-invoicing possible for users without expense and accounting module (e.g. for construction company) also simplify the re-invoice configuration with margin

So in this commit done the below changes:

 - To make the configuration visible for users who don't have expense module
   - Added new setting option for re-invoicing from sale
   - If new setting is enabled, re-invoicing option will be visible on
product form and user can set the re-invoicing policy. Also make the
analytic account field visible on sales order and vendor bill so they
can link bills to SO without having to enable 'analytic account'.
'Analytic account' being only available in the setting if you have
Accounting module installed.

 - Improved the log in the chatter of the SO so that the user can
click through and open the relevant vendor bill or Expense.

 - In the product config, user should be able to specify if they want
to always re-invoice with a specific maring (in %)
   - User can specify a margin if he selected "billed/expensed price".
If null or blank, SO is amended with price from the Vendor Bill/Expense.

TaskID: 2416864
