### PR TITLE
[FIX] website_sale: Wrong price in the shop

### DIFF
--- a/addons/website_sale/models/product.py
+++ b/addons/website_sale/models/product.py
@@ -319,8 +319,10 @@ class ProductTemplate(models.Model):
 
             # The list_price is always the price of one.
             quantity_1 = 1
+            combination_info['price'] = self.env['account.tax']._fix_tax_included_price_company(combination_info['price'], product.sudo().taxes_id, taxes, company_id)
             price = taxes.compute_all(combination_info['price'], pricelist.currency_id, quantity_1, product, partner)[tax_display]
             if pricelist.discount_policy == 'without_discount':
+                combination_info['list_price'] = self.env['account.tax']._fix_tax_included_price_company(combination_info['list_price'], product.sudo().taxes_id, taxes, company_id)
                 list_price = taxes.compute_all(combination_info['list_price'], pricelist.currency_id, quantity_1, product, partner)[tax_display]
             else:
                 list_price = price

--- a/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
+++ b/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
@@ -114,3 +114,18 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueSe
         combination_info = test_product._get_combination_info()
         self.assertEqual(combination_info['price'], 500, "500% + 0% tax (mapped from fp 15% -> 0% for BE)")
         self.assertEqual(combination_info['list_price'], 500, "500% + 0% tax (mapped from fp 15% -> 0% for BE) (2)")
+
+        # Try same flow with tax included
+        tax15.write({'price_include': True})
+
+        # Reset / Safety check
+        self.env.user.partner_id.country_id = None
+        combination_info = test_product._get_combination_info()
+        self.assertEqual(combination_info['price'], 500, "434.78$ + 15% tax")
+        self.assertEqual(combination_info['list_price'], 500, "434.78$ + 15% tax (2)")
+
+        # Now with fiscal position, taxes should be mapped
+        self.env.user.partner_id.country_id = self.env.ref('base.be').id
+        combination_info = test_product._get_combination_info()
+        self.assertEqual(round(combination_info['price'], 2), 434.78, "434.78$ + 0% tax (mapped from fp 15% -> 0% for BE)")
+        self.assertEqual(round(combination_info['list_price'], 2), 434.78, "434.78$ + 0% tax (mapped from fp 15% -> 0% for BE)")


### PR DESCRIPTION
Steps to reproduce the issue:

- Let's consider a product P (11€) with a 10% included tax T1
- Let's consider a fiscal position FP that mappes T1 to a tax T2 (0%)
- Let's consider a website that displays prices with tax included
- Let's consider a portal user PU with FP as fiscal postion
- Log with PU
- Go to the shop and filter products to see P

Bug:

The price of P was 11€ instead of 10€

PS: When adding P in the cart, the correct price is displayed.

opw:2472528

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
