### PR TITLE
[IMP] web: patch/unpatch: allow to re-apply a patch

### DIFF
--- a/addons/web/static/src/js/core/utils.js
+++ b/addons/web/static/src/js/core/utils.js
@@ -227,7 +227,22 @@ function _getExtractorFrom(criterion) {
     }
 }
 
+class AlreadyDefinedPatchError extends Error {
+    constructor() {
+        super(...arguments);
+        this.name = 'AlreadyDefinedPatchError';
+    }
+}
+class UnknownPatchError extends Error {
+    constructor() {
+        super(...arguments);
+        this.name = 'UnknownPatchError';
+    }
+}
+
 var utils = {
+    AlreadyDefinedPatchError,
+    UnknownPatchError,
 
     /**
      * Throws an error if the given condition is not true
@@ -627,7 +642,7 @@ var utils = {
         }
         const objDesc = patchMap.get(obj);
         if (objDesc.patches.some(p => p.name === patchName)) {
-            throw new Error(`Class ${obj.name} already has a patch ${patchName}`);
+            throw new AlreadyDefinedPatchError(`Patch ${patchName} is already defined`);
         }
         objDesc.patches.push({
             name: patchName,
@@ -901,8 +916,8 @@ var utils = {
      */
     unpatch: function (obj, patchName) {
         const objDesc = patchMap.get(obj);
-        if (!objDesc.patches.some(p => p.name === patchName)) {
-            throw new Error(`Class ${obj.name} does not have any patch ${patchName}`);
+        if (!objDesc || !objDesc.patches.some(p => p.name === patchName)) {
+            throw new UnknownPatchError(`Could not find patch ${patchName}`);
         }
         patchMap.delete(obj);
 

--- a/addons/web/static/src/js/core/utils.js
+++ b/addons/web/static/src/js/core/utils.js
@@ -897,6 +897,7 @@ var utils = {
      *
      * @param {Object} obj
      * @param {string} patchName
+     * @returns {Object} the removed patch
      */
     unpatch: function (obj, patchName) {
         const objDesc = patchMap.get(obj);
@@ -915,11 +916,16 @@ var utils = {
         }
 
         // Re-apply the patches except the one to remove.
+        let removedPatch;
         for (const patchDesc of objDesc.patches) {
             if (patchDesc.name !== patchName) {
                 utils.patch(obj, patchDesc.name, patchDesc.patch);
+            } else {
+                removedPatch = patchDesc.patch;
             }
         }
+
+        return removedPatch;
     },
     /**
      * @param {any} node

--- a/addons/web/static/tests/core/patch_tests.js
+++ b/addons/web/static/tests/core/patch_tests.js
@@ -1,7 +1,7 @@
 odoo.define("web.patch_tests", function (require) {
 "use strict";
 
-const { patch, unpatch } = require('web.utils');
+const { AlreadyDefinedPatchError, patch, unpatch, UnknownPatchError } = require('web.utils');
 
 function makeBaseClass(assert, assertInSetup) {
     class BaseClass {
@@ -122,7 +122,7 @@ QUnit.module('core', {}, function () {
             // keys should be unique
             assert.throws(() => {
                 patch(A.prototype, 'patch');
-            });
+            }, AlreadyDefinedPatchError);
         });
 
         QUnit.test('unpatch', async function (assert) {
@@ -278,6 +278,15 @@ QUnit.module('core', {}, function () {
             ]);
         });
 
+        QUnit.test('unpatch a class that has not been patched', async function (assert) {
+            assert.expect(1);
+
+            const A = class {};
+            assert.throws(() => {
+                unpatch(A.prototype, 'patch');
+            }, UnknownPatchError);
+        });
+
         QUnit.test('unpatch twice the same patch name', async function (assert) {
             assert.expect(1);
 
@@ -287,7 +296,7 @@ QUnit.module('core', {}, function () {
             unpatch(A.prototype, 'patch');
             assert.throws(() => {
                 unpatch(A.prototype, 'patch');
-            });
+            }, UnknownPatchError);
         });
 
         QUnit.test('unpatch and re-patch', async function (assert) {

--- a/addons/web/static/tests/core/patch_tests.js
+++ b/addons/web/static/tests/core/patch_tests.js
@@ -290,6 +290,52 @@ QUnit.module('core', {}, function () {
             });
         });
 
+        QUnit.test('unpatch and re-patch', async function (assert) {
+            assert.expect(13);
+
+            const BaseClass = makeBaseClass(assert);
+
+            patch(BaseClass.prototype, 'patch', {
+                setup() {
+                    this._super();
+                    assert.step('patch.setup');
+                },
+                fn() {
+                    this._super();
+                    assert.step('patch.fn');
+                },
+            });
+
+            (new BaseClass()).fn();
+
+            assert.verifySteps([
+                'base.setup',
+                'patch.setup',
+                'base.fn',
+                'patch.fn',
+            ]);
+
+            const p = unpatch(BaseClass.prototype, 'patch');
+
+            (new BaseClass()).fn();
+
+            assert.verifySteps([
+                'base.setup',
+                'base.fn',
+            ]);
+
+            patch(BaseClass.prototype, 'patch', p);
+
+            (new BaseClass()).fn();
+
+            assert.verifySteps([
+                'base.setup',
+                'patch.setup',
+                'base.fn',
+                'patch.fn',
+            ]);
+        });
+
         QUnit.test('patch for specialization', async function (assert) {
             assert.expect(1);
 

--- a/doc/reference/javascript_reference.rst
+++ b/doc/reference/javascript_reference.rst
@@ -2811,10 +2811,14 @@ Therefore, patching a component constructor is always possible:
 Removing a patch
 -----------------
 
-We can also remove the patch by calling the ``unpatch`` function. This is really
-only useful for tests.
+In tests, it is sometimes useful to remove a patch for a specific test, for instance,
+to remove a patch applied when another addon is installed, which overrides the behavior
+implemented in the addon where the test is defined. The function ``unpatch`` exists for
+that purpose. It returns the removed patch, such that it can be re-applied at the end
+of the test.
 
 .. code-block:: javascript
 
-  unpatch(object, "patch name");
-
+  const p = unpatch(object, "patch name");
+  // test stuff here
+  patch(object, "patch name", p);


### PR DESCRIPTION
In tests, we might want to disable a specific patch for a specific
test (e.g. to remove a monkey patch done when another addon is
installed, to test the behavior of the current addon).

Before this commit, it was possible to unpatch at the beginning of
the test, but we couldn't re-patch when the test was over.

Feature required by task~2392303

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
