### PR TITLE
web studio keep notebook page hap

### DIFF
--- a/addons/web/static/src/js/chrome/action_manager_act_window.js
+++ b/addons/web/static/src/js/chrome/action_manager_act_window.js
@@ -303,6 +303,7 @@ ActionManager.include({
                 .then(function () {
                     var viewOptions = {
                         controllerState: options.controllerState,
+                        rendererState: options.rendererState,
                         currentId: options.resID,
                     };
                     var curViewDef = self._createViewController(action, curView.type, viewOptions, {

--- a/addons/web/static/src/js/views/abstract_controller.js
+++ b/addons/web/static/src/js/views/abstract_controller.js
@@ -161,6 +161,9 @@ var AbstractController = mvc.Controller.extend(ActionMixin, {
     discardChanges: function (recordID, options) {
         return Promise.resolve();
     },
+    exportRenererState() {
+        return this.renderer.getLocalState();
+    },
     /**
      * Export the state of the controller containing information that is shared
      * between different controllers of a same action (like the current search

--- a/addons/web/static/src/js/views/abstract_view.js
+++ b/addons/web/static/src/js/views/abstract_view.js
@@ -134,6 +134,7 @@ var AbstractView = Factory.extend({
             arch: this.arch,
             isEmbedded: isEmbedded,
             noContentHelp: htmlHelp.innerText.trim() ? help : "",
+            rendererState: params.rendererState || {},
         };
 
         this.controllerParams = {

--- a/addons/web/static/src/js/views/form/form_renderer.js
+++ b/addons/web/static/src/js/views/form/form_renderer.js
@@ -51,6 +51,7 @@ var FormRenderer = BasicRenderer.extend({
         // display them (e.g. in Studio, in "show invisible" mode). This flag
         // allows to disable this optimization.
         this.renderInvisible = false;
+        this.rendererState = params.rendererState;
     },
     /**
      * @override
@@ -58,6 +59,13 @@ var FormRenderer = BasicRenderer.extend({
     start: function () {
         this._applyFormSizeClass();
         return this._super.apply(this, arguments);
+    },
+    on_attach_callback: function () {
+        this._super(...arguments);
+        if (this.rendererState) {
+            this.setLocalState(this.rendererState);
+            this.rendererState = {};
+        }
     },
 
     //--------------------------------------------------------------------------

--- a/addons/web/static/src/js/views/graph/graph_renderer.js
+++ b/addons/web/static/src/js/views/graph/graph_renderer.js
@@ -1039,6 +1039,7 @@ odoo.define("web/static/src/js/views/graph/graph_renderer", function (require) {
         mode: { validate: m => ["bar", "line", "pie"].includes(m) },
         origins: { type: Array, element: String },
         processedGroupBy: { type: Array, element: String },
+        rendererState: Object,
         stacked: Boolean,
         timeRanges: Object,
         noContentHelp: { type: String, optional: 1 },

--- a/addons/web/static/tests/views/form_tests.js
+++ b/addons/web/static/tests/views/form_tests.js
@@ -974,6 +974,40 @@ QUnit.module('Views', {
         form.destroy();
     });
 
+    QUnit.test('set focus on notebook page from rendererState', async function (assert) {
+        assert.expect(4);
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: `<form string="Partners">' +
+                    <sheet>
+                        <field name="product_id"/>
+                        <notebook name="first_notebook">
+                            <page string="Choucroute">
+                                <field name="foo"/>
+                            </page>
+                            <page string="Cassoulet">
+                                <field name="bar"/>
+                            </page>
+                        </notebook>
+                    </sheet>
+                </form>`,
+            res_id: 1,
+            viewOptions: {
+                rendererState: { 'first_notebook': 1, },
+            },
+        });
+
+        assert.doesNotHaveClass(form.$('.o_notebook .nav .nav-link:first()'), 'active');
+        assert.hasClass(form.$('.o_notebook .nav .nav-link:nth(1)'), 'active');
+        assert.doesNotHaveClass(form.$('.o_notebook .tab-content .tab-pane:first()'), 'active');
+        assert.hasClass(form.$('.o_notebook .tab-content .tab-pane:nth(1)'), 'active');
+
+        form.destroy();
+    });
+
     QUnit.test('invisible attrs on group are re-evaluated on field change', async function (assert) {
         assert.expect(2);
 


### PR DESCRIPTION
PURPOSE
When enabling studio on a form view, it reset the notebook page and activate the first page instead of the currently activated page.

SPEC
When enabling studio keep same notebook page opened which was opened previously before opening studio mode.

TASK 2416755



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
