### PR TITLE
[12.0][FIX] add sale group to sale's fields added to views to show on…

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -123,7 +123,7 @@ class ProductionLot(models.Model):
             ]).mapped('move_id')
             stock_moves = stock_moves.search([('id', 'in', stock_moves.ids)]).filtered(
                 lambda move: move.picking_id.location_dest_id.usage == 'customer' and move.state == 'done')
-            lot.sale_order_ids = stock_moves.mapped('sale_line_id.order_id')
+            lot.sale_order_ids = stock_moves.sudo().mapped('sale_line_id.order_id')
             lot.sale_order_count = len(lot.sale_order_ids)
 
     def action_view_so(self):

--- a/addons/sale_stock/views/stock_production_lot_views.xml
+++ b/addons/sale_stock/views/stock_production_lot_views.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('oe_button_box')]/button" position="before">
                 <button class="oe_stat_button" name="action_view_so"
+                        groups="sales_team.group_sale_salesman"
                         type="object" icon="fa-pencil-square-o" attrs="{'invisible': [('sale_order_count', '=', 0)]}" help="Sale Orders">
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_value">
@@ -25,7 +26,7 @@
         <field name="arch" type="xml">
             <xpath expr="//group[@name='main_group']" position="after">
                 <group>
-                    <field name="sale_order_ids" widget="many2many" readonly="True" attrs="{'invisible': [('sale_order_ids', '=', [])]}">
+                    <field name="sale_order_ids" widget="many2many" readonly="True" groups="sales_team.group_sale_salesman" attrs="{'invisible': [('sale_order_ids', '=', [])]}">
                         <tree>
                             <field name="name"/>
                             <field name="partner_id"/>


### PR DESCRIPTION
…ly to enabled users and get SO with sudo()

Description of the issue/feature this PR addresses: fix #68052 

Current behavior before PR: an access error is raised if a user without sale permission open stock production lot which have a SO

Desired behavior after PR is merged: access error is not raised




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
