### PR TITLE
[FIX] snailmail: avoid timeout issue

### DIFF
--- a/addons/snailmail/models/snailmail_letter.py
+++ b/addons/snailmail/models/snailmail_letter.py
@@ -279,8 +279,9 @@ class SnailmailLetter(models.Model):
         invalid_address_letters = self - valid_address_letters
         invalid_address_letters._snailmail_print_invalid_address()
         if valid_address_letters and immediate:
-            valid_address_letters._snailmail_print_valid_address()
-        self.env.cr.commit()
+            for letter in valid_address_letters:
+                letter._snailmail_print_valid_address()
+                self.env.cr.commit()
 
     @api.multi
     def _snailmail_print_invalid_address(self):


### PR DESCRIPTION
_snailmail_print can be called on multiple letters, and this can lead to a timeout from IAP Service. However, letters are sent, credits are consumed, but letters aren't marked as sent. To avoid that, we force the sending to IAP service to be done letter by letter.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
