### PR TITLE
[IMP] deprecate server-side t-raw & remove occurrences

### DIFF
--- a/addons/account_payment/views/account_portal_templates.xml
+++ b/addons/account_payment/views/account_portal_templates.xml
@@ -125,7 +125,7 @@
         <xpath expr="//a[hasclass('close')]" position="after">
             <t t-if="success == 'pay_invoice'">
                 <t t-set="payment_tx_id" t-value="invoice.get_portal_last_transaction()"/>
-                <span t-if='payment_tx_id.acquirer_id.sudo().done_msg' t-raw="payment_tx_id.acquirer_id.sudo().done_msg"/>
+                <span t-if='payment_tx_id.acquirer_id.sudo().done_msg' t-out="payment_tx_id.acquirer_id.sudo().done_msg"/>
                 <div t-if="payment_tx_id.acquirer_id.sudo().pending_msg and payment_tx_id.provider == 'transfer' and invoice.ref">
                     <b>Communication: </b><span t-esc='invoice.ref'/>
                 </div>

--- a/addons/digest/data/digest_data.xml
+++ b/addons/digest/data/digest_data.xml
@@ -333,7 +333,7 @@
          </style>
     </head>
     <body>
-        <t t-raw="body"/>
+        <t t-out="body"/>
     </body>
 </html>
     </template>

--- a/addons/digest/data/digest_data.xml
+++ b/addons/digest/data/digest_data.xml
@@ -355,11 +355,12 @@
 </div>
 
 <div style="background-color: #eeeeee;">
-<div t-foreach="tips" t-as="tip" t-raw="tip" class="global_layout" />
+<div t-foreach="tips" t-as="tip" t-out="tip" class="global_layout" />
 
 <div t-if="kpi_data" class="global_layout" style="padding-bottom: 0;">
+    <t t-set="kpi_color" t-value="'kpi_border_col'"/>
     <div t-foreach="kpi_data" t-as="kpi_info" class="kpi_row_footer">
-        <div t-if="kpi_info.get('kpi_col1') or kpi_info.get('kpi_col2') or kpi_info.get('kpi_col3')">
+        <div t-if="kpi_info.get('kpi_col1') or kpi_info.get('kpi_col2') or kpi_info.get('kpi_col3')" t-att-data-field="kpi_info['kpi_name']">
             <div class="kpi_header">
                 <span t-esc="kpi_info['kpi_fullname']" style="vertical-align: middle;" />
                 <a t-if="kpi_info['kpi_action']" t-att-href="'/web#action=%s' % kpi_info['kpi_action']"><span class="button" id="button_open_report">Open Report</span></a>
@@ -369,23 +370,20 @@
                     <t t-set="kpi_value" t-value="kpi_info['kpi_col1']['value']"/>
                     <t t-set="kpi_margin" t-value="kpi_info['kpi_col1'].get('margin')"/>
                     <t t-set="kpi_subtitle" t-value="kpi_info['kpi_col1']['col_subtitle']"/>
-                    <t t-set="kpi_color" t-value="'kpi_border_col'"/>
                 </div>
             </div>
             <div t-if="kpi_info.get('kpi_col2')" class="kpi_cell kpi_cell_center">
                 <div t-call="digest.digest_tool_kpi">
-                    <div t-set="kpi_value" t-value="kpi_info['kpi_col2']['value']"/>
-                    <div t-set="kpi_margin" t-value="kpi_info['kpi_col2'].get('margin')"/>
-                    <div t-set="kpi_subtitle" t-value="kpi_info['kpi_col2']['col_subtitle']"/>
-                    <t t-set="kpi_color" t-value="'kpi_center_col'"/>
+                    <t t-set="kpi_value" t-value="kpi_info['kpi_col2']['value']"/>
+                    <t t-set="kpi_margin" t-value="kpi_info['kpi_col2'].get('margin')"/>
+                    <t t-set="kpi_subtitle" t-value="kpi_info['kpi_col2']['col_subtitle']"/>
                 </div>
             </div>
             <div t-if="kpi_info.get('kpi_col3')" class="kpi_cell kpi_cell_border">
                 <div t-call="digest.digest_tool_kpi">
-                    <div t-set="kpi_value" t-value="kpi_info['kpi_col3']['value']"/>
-                    <div t-set="kpi_margin" t-value="kpi_info['kpi_col3'].get('margin')"/>
-                    <div t-set="kpi_subtitle" t-value="kpi_info['kpi_col3']['col_subtitle']"/>
-                    <t t-set="kpi_color" t-value="'kpi_border_col'"/>
+                    <t t-set="kpi_value" t-value="kpi_info['kpi_col3']['value']"/>
+                    <t t-set="kpi_margin" t-value="kpi_info['kpi_col3'].get('margin')"/>
+                    <t t-set="kpi_subtitle" t-value="kpi_info['kpi_col3']['col_subtitle']"/>
                 </div>
             </div>
             <div class="kpi_trick" />
@@ -397,7 +395,7 @@
     <div class="global_layout">
         <div class="preference_div">
             <div t-foreach="preferences" t-as="preference" class="preference">
-                <t t-raw="preference"/>
+                <t t-out="preference"/>
             </div>
             <div class="by_odoo">
                 Sent by <a href="https://www.odoo.com" target="_blank" class="odoo_link"><span class="odoo_link_text">Odoo</span></a> –
@@ -407,7 +405,7 @@
     </div>
 </div>
 
-<t t-if="body" t-raw="body"/>
+<t t-if="body" t-out="body"/>
 <div t-if="display_mobile_banner" t-call="digest.digest_section_mobile" />
 
 <div class="global_layout" id="footer">

--- a/addons/digest/tests/__init__.py
+++ b/addons/digest/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_digest

--- a/addons/digest/tests/test_digest.py
+++ b/addons/digest/tests/test_digest.py
@@ -1,0 +1,74 @@
+import itertools
+import random
+
+from dateutil.relativedelta import relativedelta
+from lxml import html
+
+from odoo import fields
+from odoo.addons.mail.tests import common as mail_test
+
+
+class TestDigest(mail_test.MailCommon):
+    def test_digest_numbers(self):
+        self._setup_messages()
+
+        digest = self.env['digest.digest'].create({
+            'name': "My Digest",
+            'kpi_mail_message_total': True
+        })
+
+        digest_user = digest.with_user(self.user_employee)
+        # subscribe a user so at least one mail gets sent
+        digest_user.action_subscribe()
+        self.assertTrue(
+            digest_user.is_subscribed,
+            "check the user was subscribed as action_subscribe will silently "
+            "ignore subs of non-employees"
+        )
+
+        # digest creates its mails in auto_delete mode so we need to capture
+        # the formatted body during the sending process
+        with self.mock_mail_gateway():
+            digest.action_send()
+
+        self.assertEqual(len(self._mails), 1, "a mail has been created for the digest")
+        body = self._mails[0]['body']
+
+        kpi_message_values = html.fromstring(body).xpath('//div[@data-field="kpi_mail_message_total"]//*[hasclass("kpi_value")]/text()')
+        self.assertEqual(
+            [t.strip() for t in kpi_message_values],
+            ['3', '8', '15']
+        )
+
+    def _setup_messages(self):
+        """ Remove all existing messages, then create a bunch of them on random
+        partners with the correct types in correct time-bucket:
+
+        - 3 in the previous 24h
+        - 5 more in the 6 days before that for a total of 8 in the previous week
+        - 7 more in the 20 days before *that* (because digest doc lies and is
+          based around weeks and months not days), for a total of 15 in the
+          previous month
+        """
+        self.env['mail.message'].search([]).unlink()
+        now = fields.Datetime.now()
+        # regular employee can't necessarily access "private" addresses
+        partners = self.env['res.partner'].search([('type', '!=', 'private')])
+        counter = itertools.count()
+
+        # pylint: disable=bad-whitespace
+        for count, (low, high) in [
+            (3, (0 * 24,  1 * 24)),
+            (5, (1 * 24,  7 * 24)),
+            (7, (7 * 24, 27 * 24)),
+        ]:
+            for _ in range(count):
+                create_date = now - relativedelta(hours=random.randint(low + 1, high - 1))
+                random.choice(partners).message_post(
+                    body=f"Awesome Partner! ({next(counter)})",
+                    message_type='comment',
+                    subtype_xmlid='mail.mt_comment',
+                    # adjust top and bottom by 1h to avoid overlapping with the
+                    # range limit and dropping out of the digest's selection thing
+                    create_date=create_date
+                )

--- a/addons/http_routing/views/http_routing_template.xml
+++ b/addons/http_routing/views/http_routing_template.xml
@@ -103,7 +103,7 @@
     <template id="404" name="Page Not Found">
         <t t-call="web.frontend_layout">
             <div id="wrap">
-                <t t-raw="0"/>
+                <t t-out="0"/>
                 <div class="oe_structure oe_empty">
                     <section class="s_text_image pt104 pb104" data-snippet="s_image_text" data-name="Image - Text">
                         <div class="container">

--- a/addons/hw_drivers/iot_handlers/drivers/DisplayDriver.py
+++ b/addons/hw_drivers/iot_handlers/drivers/DisplayDriver.py
@@ -9,6 +9,7 @@ import os
 import subprocess
 import threading
 import time
+
 import urllib3
 
 from odoo import http

--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -43,7 +43,7 @@ class ImLivechatChannel(models.Model):
         help="URL to a static page where you client can discuss with the operator of the channel.")
     are_you_inside = fields.Boolean(string='Are you inside the matrix?',
         compute='_are_you_inside', store=False, readonly=True)
-    script_external = fields.Text('Script (external)', compute='_compute_script_external', store=False, readonly=True)
+    script_external = fields.Html('Script (external)', compute='_compute_script_external', store=False, readonly=True, sanitize=False)
     nbr_channel = fields.Integer('Number of conversation', compute='_compute_nbr_channel', store=False, readonly=True)
 
     image_128 = fields.Image("Image", max_width=128, max_height=128, default=_default_image)
@@ -58,7 +58,7 @@ class ImLivechatChannel(models.Model):
             channel.are_you_inside = bool(self.env.uid in [u.id for u in channel.user_ids])
 
     def _compute_script_external(self):
-        view = self.env['ir.model.data'].get_object('im_livechat', 'external_loader')
+        view = self.env.ref('im_livechat.external_loader')
         values = {
             "url": self.env['ir.config_parameter'].sudo().get_param('web.base.url'),
             "dbname": self._cr.dbname,

--- a/addons/im_livechat/views/im_livechat_channel_templates.xml
+++ b/addons/im_livechat/views/im_livechat_channel_templates.xml
@@ -106,7 +106,7 @@
                         var button = new im_livechat.LivechatButton(
                             rootWidget,
                             "<t t-esc="info['server_url']"/>",
-                            <t t-raw="json.dumps(info.get('options', {}))"/>
+                            <t t-out="json.dumps(info.get('options', {}))"/>
                         );
                         button.appendTo(document.body);
                         window.livechat_button = button;

--- a/addons/im_livechat/views/im_livechat_channel_templates.xml
+++ b/addons/im_livechat/views/im_livechat_channel_templates.xml
@@ -17,7 +17,7 @@
                     <title><t t-esc="channel_name"/> Livechat Support Page</title>
 
                     <!-- Call the external Bundle to render the css, js, and js loader tags -->
-                    <t t-raw="channel.script_external"/>
+                    <t t-out="channel.script_external"/>
 
                     <style type="text/css">
                         body {
@@ -80,11 +80,11 @@
         -->
         <template id="external_loader" name="Livechat : external_script field of livechat channel">
             <!-- css style -->
-            <link t-att-href="'%s/im_livechat/external_lib.css' % (url)" rel="stylesheet"/>
+            <link t-attf-href="{{url}}/im_livechat/external_lib.css" rel="stylesheet"/>
             <!-- js of all the required lib (internal and external) -->
-            <script t-att-src="'%s/im_livechat/external_lib.js' % (url)" type="text/javascript" />
+            <script t-attf-src="{{url}}/im_livechat/external_lib.js" type="text/javascript" />
             <!-- the loader -->
-            <script t-att-src="'%s/im_livechat/loader/%i' % (url, channel_id)" type="text/javascript"/>
+            <script t-attf-src="{{url}}/im_livechat/loader/{{channel_id}}" type="text/javascript"/>
         </template>
 
         <!-- the js code to initialize the LiveSupport object -->

--- a/addons/l10n_de/report/din5008_report.xml
+++ b/addons/l10n_de/report/din5008_report.xml
@@ -81,7 +81,7 @@
                             </t>
                         </div>
                     </div>
-                        <t t-raw="0" />
+                        <t t-out="0" />
                 </div>
 
                 <div class="footer o_background_footer din">

--- a/addons/link_tracker/models/mail_render_mixin.py
+++ b/addons/link_tracker/models/mail_render_mixin.py
@@ -3,6 +3,7 @@
 
 import re
 
+import markupsafe
 from werkzeug import urls, utils
 
 from odoo import api, models, tools
@@ -35,7 +36,7 @@ class MailRenderMixin(models.AbstractModel):
         base_url = base_url or self.env['ir.config_parameter'].sudo().get_param('web.base.url')
         short_schema = base_url + '/r/'
         for match in re.findall(tools.HTML_TAG_URL_REGEX, html):
-            href = match[0]
+            href = markupsafe.Markup(match[0])
             long_url = match[1]
             label = (match[3] or '').strip()
 

--- a/addons/mail/data/mail_templates.xml
+++ b/addons/mail/data/mail_templates.xml
@@ -43,13 +43,13 @@
     </tr></tbody>
     </table>
 </div>
-<div t-raw="message.body"/>
+<div t-out="message.body"/>
 <ul t-if="tracking_values">
     <t t-foreach="tracking_values" t-as="tracking">
         <li><t t-esc="tracking[0]"/>: <t t-esc="tracking[1]"/> -&gt; <t t-esc="tracking[2]"/></li>
     </t>
 </ul>
-<div t-if="signature" t-raw="signature" style="font-size: 13px;"/>
+<div t-if="signature" t-out="signature" style="font-size: 13px;"/>
 <p style="color: #555555; margin-top:32px;">
     Sent
     <span t-if="company.name">
@@ -88,7 +88,7 @@
         <td align="center" style="min-width: 590px;">
             <table width="590" border="0" cellpadding="0" bgcolor="#ffffff" style="min-width: 590px; background-color: rgb(255, 255, 255); padding: 20px; border-collapse:separate;">
                 <tbody><td valign="top" style="font-family:Arial,Helvetica,sans-serif; color: #555; font-size: 14px;">
-                    <t t-raw="message.body"/>
+                    <t t-out="message.body"/>
                 </td></tbody>
             </table>
         </td>
@@ -148,7 +148,7 @@
     <!-- CONTENT -->
     <tr>
         <td style="min-width: 590px;">
-            <t t-raw="message.body"/>
+            <t t-out="message.body"/>
         </td>
     </tr>
     <!-- FOOTER -->
@@ -218,7 +218,7 @@
     <!-- CONTENT -->
     <tr>
         <td style="padding: 0">
-            <t t-raw="message.body"/>
+            <t t-out="message.body"/>
             <div t-if="is_online and not record._context.get('proforma')" style="margin: 32px 0px 32px 0px; text-align: center;">
                 <a t-att-href="access_url"
                     style="background-color: #875A7B; padding: 8px 16px 8px 16px; text-decoration: none; color: #fff; border-radius: 5px; font-size:13px;">
@@ -231,7 +231,7 @@
                 </div>
                 <div>&amp;nbsp;</div>
                 <div t-if="record.user_id.sudo().signature" style="font-size: 13px;">
-                    <div t-raw="record.user_id.sudo().signature"/>
+                    <div t-out="record.user_id.sudo().signature"/>
                 </div>
             </t>
         </td>
@@ -338,8 +338,8 @@
 
         <!-- Mail bounce alias mail template -->
         <template id="mail_bounce_alias_security">
-<div><t t-raw="body"/></div>
-<blockquote><t t-raw="message['body']"/></blockquote>
+<div><t t-out="body"/></div>
+<blockquote><t t-out="message['body']"/></blockquote>
         </template>
 
         <!-- Channel and moderation related data -->

--- a/addons/mass_mailing/data/mail_data.xml
+++ b/addons/mass_mailing/data/mail_data.xml
@@ -16,7 +16,7 @@
                 <t t-call="mass_mailing.mass_mailing_mail_style"/>
             </head>
             <body>
-                <t t-raw="body"/>
+                <t t-out="body"/>
             </body>
         </html>
     </template>

--- a/addons/mass_mailing/tests/test_mailing_internals.py
+++ b/addons/mass_mailing/tests/test_mailing_internals.py
@@ -49,7 +49,7 @@ class TestMassMailValues(MassMailCommon):
         })
 
         mail_values = composer.get_mail_values([recipient.id])
-        body_html = str(mail_values[recipient.id]['body_html'])
+        body_html = mail_values[recipient.id]['body_html']
 
         self.assertIn('<!DOCTYPE html>', body_html)
         self.assertIn('<head>', body_html)

--- a/addons/mass_mailing/views/mass_mailing_templates_portal.xml
+++ b/addons/mass_mailing/views/mass_mailing_templates_portal.xml
@@ -130,7 +130,7 @@
                 </header>
                 <div id="wrap" class="oe_structure oe_empty"/>
                 <main>
-                    <t t-raw="0"/>
+                    <t t-out="0"/>
                 </main>
             </body>
             <xpath expr="//footer" position="replace">

--- a/addons/mass_mailing/views/mass_mailing_templates_portal.xml
+++ b/addons/mass_mailing/views/mass_mailing_templates_portal.xml
@@ -99,7 +99,7 @@
 
     <template id="view" name="Browser View">
         <!-- Raw body inserted here because it is a rendered mailing, therefore internal content -->
-        <t t-raw="body"/>
+        <t t-out="body"/>
     </template>
 
     <template id="page_unsubscribe" name="Unsubscribe">

--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -829,7 +829,7 @@
 <!-- Snippet themes Options -->
 <template id="snippet_options">
     <t t-call="web_editor.snippet_options"/>
-    <t t-raw="0"/>
+    <t t-out="0"/>
 
     <div data-js="mass_mailing_sizing_x"
         data-selector="img, .mv, .col_mv, td, th"

--- a/addons/mass_mailing/wizard/mail_compose_message.py
+++ b/addons/mass_mailing/wizard/mail_compose_message.py
@@ -77,7 +77,7 @@ class MailComposeMessage(models.TransientModel):
                     'email': mail_to or mail_values.get('email_to'),
                 }
                 if mail_values.get('body_html') and mass_mail_layout:
-                    mail_values['body_html'] = mass_mail_layout._render({'body': mail_values['body_html']}, engine='ir.qweb', minimal_qcontext=True)
+                    mail_values['body_html'] = mass_mail_layout._render({'body': mail_values['body_html']}, engine='ir.qweb', minimal_qcontext=True).decode()
                 # propagate ignored state to trace when still-born
                 if mail_values.get('state') == 'cancel':
                     trace_vals['ignored'] = fields.Datetime.now()

--- a/addons/pad/models/pad.py
+++ b/addons/pad/models/pad.py
@@ -7,6 +7,7 @@ import re
 import string
 
 import requests
+from markupsafe import Markup
 
 from odoo import api, models, _
 from odoo.exceptions import UserError
@@ -99,7 +100,7 @@ class PadCommon(models.AbstractModel):
                     if mo:
                         content = mo.group(1)
 
-        return content
+        return Markup(content)
 
     # TODO
     # reverse engineer protocol to be setHtml without using the api key

--- a/addons/pad_project/views/project_portal_templates.xml
+++ b/addons/pad_project/views/project_portal_templates.xml
@@ -23,7 +23,7 @@
                     </div>
                 </t>
                 <t t-else="">
-                    <div class="py-1 px-2 bg-100 small" t-raw="task._get_pad_content()"/>
+                    <div class="py-1 px-2 bg-100 small" t-esc="task._get_pad_content()"/>
                 </t>
             </t>
             <t t-else="">

--- a/addons/payment/views/payment_portal_templates.xml
+++ b/addons/payment/views/payment_portal_templates.xml
@@ -132,7 +132,7 @@
                                 HTML field associated with the transaction state, defined on the
                                 acquirer.  -->
                                 <div t-attf-class="alert alert-#{status}"
-                                     t-raw="message"
+                                     t-out="message"
                                      role="status"/>
                                 <div class="form-group row">
                                     <label for="form_partner_name" class="col-md-3 col-form-label">

--- a/addons/payment/views/payment_templates.xml
+++ b/addons/payment/views/payment_templates.xml
@@ -77,7 +77,7 @@
                         <t t-call="payment.icon_list"/>
                         <!-- === Help message === -->
                         <div t-if="acquirer.pre_msg"
-                             t-raw="acquirer.pre_msg"
+                             t-out="acquirer.pre_msg"
                              class="text-muted ml-3"/>
                     </div>
                     <!-- === Acquirer inline form === -->
@@ -208,7 +208,7 @@
                         <t t-call="payment.icon_list"/>
                         <!-- === Help message === -->
                         <div t-if="acquirer.pre_msg"
-                             t-raw="acquirer.pre_msg"
+                             t-out="acquirer.pre_msg"
                              class="text-muted ml-3"/>
                     </div>
                     <!-- === Acquirer inline form === -->
@@ -335,19 +335,19 @@
         -->
         <div t-if="tx.state == 'pending'" class="alert alert-warning alert-dismissible">
             <span t-if='tx.acquirer_id.sudo().pending_msg'
-                  t-raw="tx.acquirer_id.sudo().pending_msg"/>
+                  t-out="tx.acquirer_id.sudo().pending_msg"/>
             <button class="close" data-dismiss="alert" title="Dismiss">×</button>
         </div>
         <div t-elif="tx.state == 'authorized'" class="alert alert-success alert-dismissible">
-            <span t-if='tx.acquirer_id.sudo().auth_msg' t-raw="tx.acquirer_id.sudo().auth_msg"/>
+            <span t-if='tx.acquirer_id.sudo().auth_msg' t-out="tx.acquirer_id.sudo().auth_msg"/>
             <button class="close" data-dismiss="alert" title="Dismiss">×</button>
         </div>
         <div t-elif="tx.state == 'done'" class="alert alert-success alert-dismissible">
-            <span t-if='tx.acquirer_id.sudo().done_msg' t-raw="tx.acquirer_id.sudo().done_msg"/>
+            <span t-if='tx.acquirer_id.sudo().done_msg' t-out="tx.acquirer_id.sudo().done_msg"/>
             <button class="close" data-dismiss="alert" title="Dismiss">×</button>
         </div>
         <div t-elif="tx.state == 'cancel'" class="alert alert-danger alert-dismissible">
-            <span t-if='tx.acquirer_id.sudo().cancel_msg' t-raw="tx.acquirer_id.sudo().cancel_msg"/>
+            <span t-if='tx.acquirer_id.sudo().cancel_msg' t-out="tx.acquirer_id.sudo().cancel_msg"/>
             <button class="close" data-dismiss="alert" title="Dismiss">×</button>
         </div>
         <span t-if="tx.state_message" t-esc="tx.state_message"/>

--- a/addons/payment_transfer/views/payment_transfer_templates.xml
+++ b/addons/payment_transfer/views/payment_transfer_templates.xml
@@ -8,7 +8,7 @@
     </template>
 
     <template id="transfer_transaction_status" inherit_id="payment.transaction_status">
-        <xpath expr="//span[@t-raw='tx.acquirer_id.sudo().pending_msg']" position="after">
+        <xpath expr="//span[@t-out='tx.acquirer_id.sudo().pending_msg']" position="after">
             <t t-if="tx.acquirer_id.sudo().provider == 'transfer'">
                 <div t-if="tx.reference">
                     <strong>Communication: </strong><span t-esc="tx.reference"/>

--- a/addons/point_of_sale/views/pos_assets_index.xml
+++ b/addons/point_of_sale/views/pos_assets_index.xml
@@ -26,7 +26,7 @@
         <link rel="shortcut icon" href="/web/static/src/img/favicon.ico" type="image/x-icon"/>
 
         <script type="text/javascript">
-            var odoo = <t t-raw="json.dumps({
+            var odoo = <t t-out="json.dumps({
                 'csrf_token': request.csrf_token(None),
                 'session_info': session_info,
                 'login_number': login_number,

--- a/addons/point_of_sale/views/pos_assets_qunit.xml
+++ b/addons/point_of_sale/views/pos_assets_qunit.xml
@@ -64,7 +64,7 @@
         <t t-set="head">
             <!-- we need session_info in order to properly instantiate PosModel -->
             <script type="text/javascript">
-                var odoo = <t t-raw="json.dumps({
+                var odoo = <t t-out="json.dumps({
                     'csrf_token': request.csrf_token(None),
                     'session_info': session_info,
                     'debug': debug,

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -515,7 +515,7 @@
                 <a t-att-href=" pager['page_previous']['url'] if pager['page']['num'] != 1 else None" t-attf-class="page-link #{extraLinkClass}">Prev</a>
             </li>
             <t t-foreach="pager['pages']" t-as="page">
-                <li t-attf-class="page-item #{'active' if page['num'] == pager['page']['num'] else ''}"> <a t-att-href="page['url']" t-attf-class="page-link #{extraLinkClass}" t-raw="page['num']"></a></li>
+                <li t-attf-class="page-item #{'active' if page['num'] == pager['page']['num'] else ''}"> <a t-att-href="page['url']" t-attf-class="page-link #{extraLinkClass}" t-out="page['num']"/></li>
             </t>
             <li t-attf-class="page-item #{'disabled' if pager['page']['num'] == pager['page_count'] else ''}">
                 <a t-att-href="pager['page_next']['url'] if pager['page']['num'] != pager['page_count'] else None" t-attf-class="page-link #{extraLinkClass}">Next</a>

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -29,7 +29,7 @@
         <xpath expr="//div[@id='wrapwrap']/main/t[@t-out='0']" position="before">
             <div t-if="o_portal_fullwidth_alert" class="alert alert-info alert-dismissible rounded-0 fade show d-print-none css_editable_mode_hidden">
                 <div class="container">
-                    <t t-raw="o_portal_fullwidth_alert"/>
+                    <t t-out="o_portal_fullwidth_alert"/>
                 </div>
             </div>
         </xpath>

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -94,7 +94,7 @@
 
     <template id="portal_back_in_edit_mode" name="Back to edit mode">
         <div t-ignore="true" class="text-center">
-            <t t-if="custom_html" t-raw="custom_html"/>
+            <t t-if="custom_html" t-out="custom_html"/>
             <t t-else="">This is a preview of the customer portal.</t>
             <a t-att-href="backend_url"><i class="fa fa-arrow-right mr-1"/>Back to edit mode</a>
         </div>
@@ -199,9 +199,9 @@
         <div t-attf-class="#{classes}">
             <div class="card bg-white mb-4 sticky-top" id="sidebar_content">
                 <div t-if="title" class="card-body text-center pb-2 pt-3">
-                    <t t-raw="title"/>
+                    <t t-out="title"/>
                 </div>
-                <t t-if="entries" t-raw="entries"/>
+                <t t-if="entries" t-out="entries"/>
                 <div class="card-footer small text-center text-muted border-top-0 pt-1 pb-1 d-none d-lg-block">
                     Powered by <a target="_blank" href="http://www.odoo.com?utm_source=db&amp;utm_medium=portal" title="odoo"><img src="/web/static/src/img/logo.png" alt="Odoo Logo" height="15"/></a>
                 </div>
@@ -302,9 +302,9 @@
                             <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown"/>
                             <div class="dropdown-menu" role="menu">
                                 <t t-foreach='searchbar_inputs' t-as='input'>
-                                    <a t-att-href="'#' + searchbar_inputs[input]['input']"
-                                        t-attf-class="dropdown-item#{search_in == searchbar_inputs[input]['input'] and ' active' or ''}">
-                                        <span t-raw="searchbar_inputs[input]['label']"/>
+                                    <a t-att-href="'#' + input_value['input']"
+                                        t-attf-class="dropdown-item#{search_in == input_value['input'] and ' active' or ''}">
+                                        <span t-out="input_value['label']"/>
                                     </a>
                                 </t>
                             </div>
@@ -324,10 +324,10 @@
     <template id="portal_record_layout" name="Portal single record layout">
         <div t-attf-class="card mt-0 border-top-0 rounded-0 rounded-bottom #{classes if classes else ''}">
             <div t-if="card_header" t-attf-class="card-header #{header_classes if header_classes else ''}">
-                <t t-raw="card_header"/>
+                <t t-out="card_header"/>
             </div>
             <div t-if="card_body" t-attf-class="card-body #{body_classes if body_classes else ''}">
-                <t t-raw="card_body"/>
+                <t t-out="card_body"/>
             </div>
         </div>
     </template>

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -26,7 +26,7 @@
                 </div>
             </nav>
         </xpath>
-        <xpath expr="//div[@id='wrapwrap']/main/t[@t-raw='0']" position="before">
+        <xpath expr="//div[@id='wrapwrap']/main/t[@t-out='0']" position="before">
             <div t-if="o_portal_fullwidth_alert" class="alert alert-info alert-dismissible rounded-0 fade show d-print-none css_editable_mode_hidden">
                 <div class="container">
                     <t t-raw="o_portal_fullwidth_alert"/>
@@ -120,7 +120,7 @@
                     <t t-if="my_details">
                         <div class="row justify-content-between mt-4">
                             <div t-attf-class="col-12 col-md col-lg-6">
-                                <t t-raw="0"/>
+                                <t t-out="0"/>
                             </div>
                             <div id="o_my_sidebar" class="pt-3 pt-lg-0 col-12 col-md col-lg-4 col-xl-3 o_my_sidebar">
                                 <div class="o_my_contact" t-if="sales_user">
@@ -140,7 +140,7 @@
                         </div>
                     </t>
                     <t t-else="">
-                        <t t-raw="0"/>
+                        <t t-out="0"/>
                     </t>
                 </div>
             </div>
@@ -187,7 +187,7 @@
     <template id="portal_table" name="My Portal Table">
         <div t-attf-class="table-responsive border rounded border-top-0 #{classes if classes else ''}">
             <table class="table rounded mb-0 bg-white o_portal_my_doc_table">
-                <t t-raw="0"/>
+                <t t-out="0"/>
             </table>
         </div>
         <div t-if="pager" class="o_portal_pager text-center">
@@ -294,7 +294,7 @@
                             </div>
                         </div>
                     </div>
-                    <t t-raw="0"/>
+                    <t t-out="0"/>
                 </div>
                 <form t-if="searchbar_inputs" class="form-inline o_portal_search_panel ml-lg-4 col-xl-4 col-md-5">
                     <div class="input-group input-group-sm w-100">

--- a/addons/product_matrix/views/matrix_templates.xml
+++ b/addons/product_matrix/views/matrix_templates.xml
@@ -44,7 +44,7 @@
                   accurate to display it.
                   -->
               <span class="variant_price_extra" style="white-space: nowrap;">
-                  <t t-raw="price"/>
+                  <t t-out="price"/>
               </span>
           </span>
     </template>

--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -4,6 +4,8 @@
 from collections import OrderedDict
 from operator import itemgetter
 
+from markupsafe import Markup
+
 from odoo import http, _
 from odoo.exceptions import AccessError, MissingError
 from odoo.http import request
@@ -113,7 +115,7 @@ class CustomerPortal(portal.CustomerPortal):
             'all': {'label': _('All'), 'domain': []},
         }
         searchbar_inputs = {
-            'content': {'input': 'content', 'label': _('Search <span class="nolabel"> (in Content)</span>')},
+            'content': {'input': 'content', 'label': Markup(_('Search <span class="nolabel"> (in Content)</span>'))},
             'message': {'input': 'message', 'label': _('Search in Messages')},
             'customer': {'input': 'customer', 'label': _('Search in Customer')},
             'stage': {'input': 'stage', 'label': _('Search in Stages')},

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -159,7 +159,8 @@ class TestPurchase(AccountTestInvoicingCommon):
         ])
         self.assertTrue(activity)
         self.assertIn(
-            '<p> partner_a modified receipt dates for the following products:</p><p> \xa0 - product_a from 2020-06-06 to %s </p>' % fields.Date.today(),
+            '<p>partner_a modified receipt dates for the following products:</p>\n'
+            '<p> - product_a from 2020-06-06 to %s</p>' % fields.Date.today(),
             activity.note,
         )
 
@@ -167,6 +168,8 @@ class TestPurchase(AccountTestInvoicingCommon):
         po._update_date_planned_for_lines([(po.order_line[1], fields.Datetime.today())])
         self.assertEqual(po.order_line[1].date_planned, fields.Datetime.today())
         self.assertIn(
-            '<p> partner_a modified receipt dates for the following products:</p><p> \xa0 - product_a from 2020-06-06 to %s </p><p> \xa0 - product_b from 2020-06-06 to %s </p>' % (fields.Date.today(), fields.Date.today()),
+            '<p>partner_a modified receipt dates for the following products:</p>\n'
+            '<p> - product_a from 2020-06-06 to %(today)s</p>\n'
+            '<p> - product_b from 2020-06-06 to %(today)s</p>' % {'today': fields.Date.today()},
             activity.note,
         )

--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from markupsafe import Markup
+from dateutil.relativedelta import relativedelta
+
 from odoo import api, fields, models, SUPERUSER_ID, _
 from odoo.tools.float_utils import float_compare
-from datetime import datetime
-from dateutil.relativedelta import relativedelta
 from odoo.exceptions import UserError
 
 from odoo.addons.purchase.models.purchase import PurchaseOrder as Purchase
@@ -241,11 +242,12 @@ class PurchaseOrder(models.Model):
         """
         validated_picking = self.picking_ids.filtered(lambda p: p.state == 'done')
         if validated_picking:
-            activity.note += _("<p>Those dates couldn’t be modified accordingly on the receipt %s which had already been validated.</p>") % validated_picking[0].name
+            message = _("Those dates couldn’t be modified accordingly on the receipt %s which had already been validated.", validated_picking[0].name)
         elif not self.picking_ids:
-            activity.note += _("<p>Corresponding receipt not found.</p>")
+            message = _("Corresponding receipt not found.")
         else:
-            activity.note += _("<p>Those dates have been updated accordingly on the receipt %s.</p>") % self.picking_ids[0].name
+            message = _("Those dates have been updated accordingly on the receipt %s.", self.picking_ids[0].name)
+        activity.note += Markup('<p>{}</p>').format(message)
 
     def _create_update_date_activity(self, updated_dates):
         activity = super()._create_update_date_activity(updated_dates)
@@ -255,7 +257,7 @@ class PurchaseOrder(models.Model):
         # remove old picking info to update it
         note_lines = activity.note.split('<p>')
         note_lines.pop()
-        activity.note = '<p>'.join(note_lines)
+        activity.note = Markup('<p>').join(note_lines)
         super()._update_update_date_activity(updated_dates, activity)
         self._add_picking_info(activity)
 

--- a/addons/purchase_stock/tests/test_purchase_order.py
+++ b/addons/purchase_stock/tests/test_purchase_order.py
@@ -229,8 +229,10 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
             ('res_id', '=', po.id),
         ])
         self.assertTrue(activity)
-        self.assertIn(
-            '<p> partner_a modified receipt dates for the following products:</p><p> \xa0 - Large Desk from %s to %s </p><p>Those dates have been updated accordingly on the receipt %s.</p>' % (today.date(), tomorrow.date(), po.picking_ids.name),
+        self.assertEqual(
+            '<p>partner_a modified receipt dates for the following products:</p>\n'
+            '<p> - Large Desk from %s to %s</p>\n'
+            '<p>Those dates have been updated accordingly on the receipt %s.</p>' % (today.date(), tomorrow.date(), po.picking_ids.name),
             activity.note,
         )
 
@@ -243,8 +245,12 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
         old_date = po.order_line[1].date_planned
         po._update_date_planned_for_lines([(po.order_line[1], tomorrow)])
         self.assertEqual(po.order_line[1].date_planned, old_date)
-        self.assertIn(
-            '<p> partner_a modified receipt dates for the following products:</p><p> \xa0 - Large Desk from %s to %s </p><p> \xa0 - Conference Chair from %s to %s </p><p>Those dates couldn’t be modified accordingly on the receipt %s which had already been validated.</p>' % (today.date(), tomorrow.date(), today.date(), tomorrow.date(), po.picking_ids.name),
+        self.assertEqual(
+            '<p>partner_a modified receipt dates for the following products:</p>\n'
+            '<p> - Large Desk from %s to %s</p>\n'
+            '<p> - Conference Chair from %s to %s</p>\n'
+            '<p>Those dates couldn’t be modified accordingly on the receipt %s which had already been validated.</p>' % (
+                today.date(), tomorrow.date(), today.date(), tomorrow.date(), po.picking_ids.name),
             activity.note,
         )
 

--- a/addons/stock/views/report_stock_traceability.xml
+++ b/addons/stock/views/report_stock_traceability.xml
@@ -76,9 +76,13 @@
     </template>
 
     <template id="report_stock_inventory_print">
-        <t t-raw="'&lt;base href=%s&gt;' % base_url"/>
         <t t-call="web.html_container">
-            <t t-call-assets="stock.assets_stock_print_report" t-js="False"/>
+            <t t-set="head_start">
+                <base t-att-href="base_url"/>
+            </t>
+            <t t-set="head_end">
+                <t t-call-assets="stock.assets_stock_print_report" t-js="False"/>
+            </t>
             <t t-call='stock.report_stock_body_print'/>
         </t>
     </template>

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1,16 +1,13 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import babel.messages.pofile
 import base64
 import copy
 import datetime
 import functools
-import glob
 import hashlib
 import io
 import itertools
-import jinja2
 import json
 import logging
 import operator
@@ -18,17 +15,19 @@ import os
 import re
 import sys
 import tempfile
+import unicodedata
+from collections import OrderedDict, defaultdict
 
+import babel.messages.pofile
+import jinja2
 import werkzeug
 import werkzeug.exceptions
 import werkzeug.utils
 import werkzeug.wrappers
 import werkzeug.wsgi
-from collections import OrderedDict, defaultdict, Counter
-from werkzeug.urls import url_encode, url_decode, iri_to_uri
 from lxml import etree
-import unicodedata
-
+from markupsafe import Markup
+from werkzeug.urls import url_encode, url_decode, iri_to_uri
 
 import odoo
 import odoo.modules.registry
@@ -1063,7 +1062,7 @@ class Database(http.Controller):
             monodb = db_monodb()
             if monodb:
                 d['databases'] = [monodb]
-        return env.get_template("database_manager.html").render(d)
+        return Markup(env.get_template("database_manager.html").render(d))
 
     @http.route('/web/database/selector', type='http', auth="none")
     def selector(self, **kw):

--- a/addons/web/models/base_document_layout.py
+++ b/addons/web/models/base_document_layout.py
@@ -48,14 +48,7 @@ class BaseDocumentLayout(models.TransientModel):
     report_layout_id = fields.Many2one('report.layout')
 
     # All the sanitization get disabled as we want true raw html to be passed to an iframe.
-    preview = fields.Html(compute='_compute_preview',
-                          sanitize=False,
-                          sanitize_tags=False,
-                          sanitize_attributes=False,
-                          sanitize_style=False,
-                          sanitize_form=False,
-                          strip_style=False,
-                          strip_classes=False)
+    preview = fields.Html(compute='_compute_preview', sanitize=False)
 
     # Those following fields are required as a company to create invoice report
     partner_id = fields.Many2one(related='company_id.partner_id', readonly=True)

--- a/addons/web/tests/test_js.py
+++ b/addons/web/tests/test_js.py
@@ -22,7 +22,7 @@ class WebSuite(odoo.tests.HttpCase):
     def _check_only_call(self, suite):
         # As we currently aren't in a request context, we can't render `web.layout`.
         # redefinied it as a minimal proxy template.
-        self.env.ref('web.layout').write({'arch_db': '<t t-name="web.layout"><head><meta charset="utf-8"/><t t-raw="head"/></head></t>'})
+        self.env.ref('web.layout').write({'arch_db': '<t t-name="web.layout"><head><meta charset="utf-8"/><t t-esc="head"/></head></t>'})
 
         for asset in self.env['ir.qweb']._get_asset_content(suite, options={})[0]:
             filename = asset['filename']

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -246,42 +246,39 @@
                 <t t-call-assets="web.report_assets_common" t-js="false"/>
                 <t t-call-assets="web.report_assets_pdf" t-css="false"/>
                 <meta charset="utf-8"/>
-                <t t-set="subst_needed" t-value="subst is True"/>
-                <t t-if="subst_needed">
-                    <script>
-                        function subst() {
-                            var vars = {};
-                            var x = document.location.search.substring(1).split('&amp;');
-                            for (var i in x) {
-                                var z = x[i].split('=', 2);
-                                vars[z[0]] = unescape(z[1]);
-                            }
-                            var x = ['sitepage', 'sitepages', 'section', 'subsection', 'subsubsection'];
-                            var z = {'sitepage': 'page', 'sitepages': 'topage'};
-                            for (var i in x) {
-                                var y = document.getElementsByClassName(z[x[i]] || x[i])
-                                for (var j=0; j&lt;y.length; ++j)
-                                    y[j].textContent = vars[x[i]];
-                            }
-
-                            var index = vars['webpage'].split('.', 4)[3];
-                            var header = document.getElementById('minimal_layout_report_headers');
-                            if(header !== null){
-                                var companyHeader = header.children[index];
-                                header.textContent = '';
-                                header.appendChild(companyHeader);
-                            }
-                            var footer = document.getElementById('minimal_layout_report_footers');
-                            if(footer !== null){
-                                var companyFooter = footer.children[index];
-                                footer.textContent = '';
-                                footer.appendChild(companyFooter);
-                            }
+                <script t-if="subst">
+                    function subst() {
+                        var vars = {};
+                        var x = document.location.search.substring(1).split('&amp;');
+                        for (var i in x) {
+                            var z = x[i].split('=', 2);
+                            vars[z[0]] = unescape(z[1]);
                         }
-                    </script>
-                </t>
+                        var x = ['sitepage', 'sitepages', 'section', 'subsection', 'subsubsection'];
+                        var z = {'sitepage': 'page', 'sitepages': 'topage'};
+                        for (var i in x) {
+                            var y = document.getElementsByClassName(z[x[i]] || x[i])
+                            for (var j=0; j&lt;y.length; ++j)
+                                y[j].textContent = vars[x[i]];
+                        }
+
+                        var index = vars['webpage'].split('.', 4)[3];
+                        var header = document.getElementById('minimal_layout_report_headers');
+                        if(header){
+                            var companyHeader = header.children[index];
+                            header.textContent = '';
+                            header.appendChild(companyHeader);
+                        }
+                        var footer = document.getElementById('minimal_layout_report_footers');
+                        if(footer){
+                            var companyFooter = footer.children[index];
+                            footer.textContent = '';
+                            footer.appendChild(companyFooter);
+                        }
+                    }
+                </script>
             </head>
-            <body class="container" t-att-onload="subst_needed and 'subst()'">
+            <body class="container" t-att-onload="subst and 'subst()'">
                 <t t-raw="body"/>
             </body>
         </html>
@@ -300,7 +297,7 @@
                     </div>
                 </t>
                 <div name="address" t-att-class="colclass">
-                    <t t-raw="address"/>
+                    <t t-esc="address"/>
                 </div>
             </div>
         </t>

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -49,7 +49,7 @@
                 <t t-call-assets="web.report_assets_common" t-js="false"/>
                 <t t-call-assets="web.assets_common" t-css="false"/>
                 <style>
-                    <t t-raw="preview_css"/>
+                    <t t-out="preview_css"/>
 
                     /**
                         Some css is overridden as it doesn't work properly in the preview.
@@ -279,7 +279,7 @@
                 </script>
             </head>
             <body class="container" t-att-onload="subst and 'subst()'">
-                <t t-raw="body"/>
+                <t t-out="body"/>
             </body>
         </html>
     </template>
@@ -293,7 +293,7 @@
                 <t t-if="information_block">
                     <t t-set="colclass" t-value="'col-5 offset-1'"/>
                     <div name="information_block" class="col-6">
-                        <t t-raw="information_block"/>
+                        <t t-out="information_block"/>
                     </div>
                 </t>
                 <div name="address" t-att-class="colclass">

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -239,9 +239,9 @@
 
     <template id="minimal_layout">
         &lt;!DOCTYPE html&gt;
-        <t t-raw="'&lt;base href=%s&gt;' % base_url"/>
         <html style="height: 0;">
             <head>
+                <base t-att-href="base_url"/>
                 <t t-call-assets="web.report_assets_pdf" t-js="false"/>
                 <t t-call-assets="web.report_assets_common" t-js="false"/>
                 <t t-call-assets="web.report_assets_pdf" t-css="false"/>

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -27,7 +27,7 @@
             <body t-att-class="'container' if not full_width else 'container-fluid'">
                 <div id="wrapwrap">
                     <main>
-                        <t t-raw="0"/>
+                        <t t-out="0"/>
                     </main>
                 </div>
             </body>
@@ -91,7 +91,7 @@
             </head>
             <body t-att-class="'container' if not full_width else 'container-fluid'">
                 <div id="wrapwrap">
-                        <t t-raw="0"/>
+                        <t t-out="0"/>
                 </div>
             </body>
         </html>
@@ -100,14 +100,14 @@
     <template id="html_container">
         <t t-set="body_classname" t-value="'container'"/>
         <t t-call="web.report_layout">
-            <t t-raw="0"/>
+            <t t-out="0"/>
         </t>
     </template>
 
     <template id="html_preview_container">
         <t t-set="body_classname" t-value="'container'"/>
         <t t-call="web.report_preview_layout">
-            <t t-raw="0"/>
+            <t t-out="0"/>
         </t>
     </template>
 
@@ -323,7 +323,7 @@
 
         <div t-attf-class="o_company_#{company.id}_layout article o_report_layout_background" t-att-data-oe-model="o and o._name" t-att-data-oe-id="o and o.id" t-att-data-oe-lang="o and o.env.context.get('lang')">
             <t t-call="web.address_layout"/>
-            <t t-raw="0"/>
+            <t t-out="0"/>
         </div>
 
         <div t-attf-class="o_company_#{company.id}_layout footer o_background_footer">
@@ -373,7 +373,7 @@
                 <!-- This div ensures that the address is not cropped by the header. -->
                 <t t-call="web.address_layout"/>
             </div>
-            <t t-raw="0"/>
+            <t t-out="0"/>
         </div>
 
         <div t-attf-class="footer o_boxed_footer o_company_#{company.id}_layout">
@@ -422,7 +422,7 @@
 
         <div t-attf-class="article o_report_layout_clean o_company_#{company.id}_layout"  t-att-data-oe-model="o and o._name" t-att-data-oe-id="o and o.id" t-att-data-oe-lang="o and o.env.context.get('lang')">
             <t t-call="web.address_layout"/>
-            <t t-raw="0"/>
+            <t t-out="0"/>
         </div>
 
         <div t-attf-class="footer o_clean_footer o_company_#{company.id}_layout">
@@ -473,7 +473,7 @@
                 <!-- This div ensures that the address is not cropped by the header. -->
                 <t t-call="web.address_layout"/>
             </div>
-            <t t-raw="0"/>
+            <t t-out="0"/>
         </div>
 
         <div t-attf-class="footer o_standard_footer o_company_#{company.id}_layout">
@@ -520,8 +520,8 @@
             </t>
         </t>
 
-        <t t-if="company.external_report_layout_id" t-call="{{company.external_report_layout_id.key}}"><t t-raw="0"/></t>
-        <t t-else="else" t-call="web.external_layout_standard"><t t-raw="0"/></t>
+        <t t-if="company.external_report_layout_id" t-call="{{company.external_report_layout_id.key}}"><t t-out="0"/></t>
+        <t t-else="else" t-call="web.external_layout_standard"><t t-out="0"/></t>
 
     </template>
 
@@ -559,7 +559,7 @@
             </div>
         </div>
         <div class="article" t-att-data-oe-model="o and o._name" t-att-data-oe-id="o and o.id" t-att-data-oe-lang="o and o.env.context.get('lang')">
-          <t t-raw="0"/>
+          <t t-out="0"/>
         </div>
     </template>
 
@@ -567,7 +567,7 @@
         <t t-call="web.html_container">
             <t t-if="not o" t-set="o" t-value="doc"/>
             <div class="article" t-att-data-oe-model="o and o._name" t-att-data-oe-id="o and o.id" t-att-data-oe-lang="o and o.env.context.get('lang')">
-                <t t-raw="0"/>
+                <t t-out="0"/>
             </div>
         </t>
     </template>

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -22,10 +22,10 @@
                     };
                 </script>
 
-                <t t-raw="head or ''"/>
+                <t t-out="head or ''"/>
             </head>
             <body t-att-class="body_classname">
-                <t t-raw="0"/>
+                <t t-out="0"/>
             </body>
         </html>
     </template>
@@ -41,7 +41,7 @@
         </xpath>
         <xpath expr="//head/script[@id='web.layout.odooscript']" position="after">
             <script type="text/javascript">
-                odoo.session_info = <t t-raw="json.dumps(request.env['ir.http'].get_frontend_session_info())"/>;
+                odoo.session_info = <t t-out="json.dumps(request.env['ir.http'].get_frontend_session_info())"/>;
                 if (!/(^|;\s)tz=/.test(document.cookie)) {
                     const userTZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
                     document.cookie = `tz=${userTZ}; path=/`;
@@ -53,7 +53,7 @@
             <t t-call-assets="web.assets_common_lazy" t-css="false" lazy_load="True"/>
             <t t-call-assets="web.assets_frontend_lazy" t-css="false" lazy_load="True"/>
         </xpath>
-        <xpath expr="//t[@t-raw='0']" position="replace">
+        <xpath expr="//t[@t-out='0']" position="replace">
             <div id="wrapwrap" t-attf-class="#{pageName or ''}">
                 <header t-if="not no_header" id="top" data-anchor="true">
                     <img class="img-responsive d-block mx-auto"
@@ -61,7 +61,7 @@
                         alt="Logo"/>
                 </header>
                 <main>
-                    <t t-raw="0"/>
+                    <t t-out="0"/>
                 </main>
                 <footer t-if="not no_footer" id="bottom" data-anchor="true" t-attf-class="bg-light o_footer">
                     <div id="footer"/>
@@ -118,7 +118,7 @@
                         <div t-attf-class="text-center pb-3 border-bottom {{'mb-3' if form_small else 'mb-4'}}">
                             <img t-attf-src="/web/binary/company_logo{{ '?dbname='+db if db else '' }}" alt="Logo" style="max-height:120px; max-width: 100%; width:auto"/>
                         </div>
-                        <t t-raw="0"/>
+                        <t t-out="0"/>
                         <div class="text-center small mt-4 pt-3 border-top" t-if="not disable_footer">
                             <t t-if="not disable_database_manager">
                                 <a class="border-right pr-2 mr-1" href="/web/database/manager">Manage Databases</a>
@@ -286,7 +286,7 @@
         <t t-call="web.layout">
             <t t-set="head_web">
                 <script type="text/javascript">
-                    odoo.session_info = <t t-raw="json.dumps(session_info)"/>;
+                    odoo.session_info = <t t-out="json.dumps(session_info)"/>;
                     odoo.reloadMenus = () => fetch(`/web/webclient/load_menus/${odoo.session_info.cache_hashes.load_menus}`).then(res => res.json());
                     odoo.loadMenusPromise = odoo.reloadMenus();
                 </script>

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -94,7 +94,7 @@
             </a>
         </t>
         <t t-set="final_message">Powered by %s%s</t>
-        <t t-raw="final_message % (odoo_logo, _message and ('- %s' % _message) or '')"/>
+        <t t-out="final_message % (odoo_logo, _message and ('- ' + _message) or '')"/>
     </template>
     <template id="brand_promotion" name="Brand Promotion">
         <div class="o_brand_promotion">

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -101,7 +101,7 @@ class Website(Home):
         """
         if not redirect and request.params.get('login_success'):
             if request.env['res.users'].browse(uid).has_group('base.group_user'):
-                redirect = b'/web?' + request.httprequest.query_string
+                redirect = '/web?' + request.httprequest.query_string.decode()
             else:
                 redirect = '/my'
         return super()._login_redirect(uid, redirect=redirect)

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -117,10 +117,10 @@ class Website(models.Model):
     partner_id = fields.Many2one(related='user_id.partner_id', string='Public Partner', readonly=False)
     menu_id = fields.Many2one('website.menu', compute='_compute_menu', string='Main Menu')
     homepage_id = fields.Many2one('website.page', string='Homepage')
-    custom_code_head = fields.Text('Custom <head> code')
-    custom_code_footer = fields.Text('Custom end of <body> code')
+    custom_code_head = fields.Html('Custom <head> code', sanitize=False)
+    custom_code_footer = fields.Html('Custom end of <body> code', sanitize=False)
 
-    robots_txt = fields.Text('Robots.txt', translate=False, groups='website.group_website_designer')
+    robots_txt = fields.Html('Robots.txt', translate=False, groups='website.group_website_designer', sanitize=False)
 
     def _default_favicon(self):
         img_path = get_resource_path('web', 'static/src/img/favicon.ico')

--- a/addons/website/tests/test_qweb.py
+++ b/addons/website/tests/test_qweb.py
@@ -69,7 +69,7 @@ class TestQweb(TransactionCaseWithUserDemo):
         <img src="http://test.cdn/website/static/img.png" loading="lazy"/>
         <a href="http://test.external.link/link">x</a>
         <a href="http://test.cdn/web/content/local_link">x</a>
-        <span style="background-image: url('http://test.cdn/web/image/2')">xxx</span>
+        <span style="background-image: url(&#39;http://test.cdn/web/image/2&#39;)">xxx</span>
         <div widget="html"><span class="toto">
                 span<span class="fa"></span><img src="http://test.cdn/web/image/1" loading="lazy">
             </span></div>

--- a/addons/website/tests/test_views.py
+++ b/addons/website/tests/test_views.py
@@ -220,7 +220,7 @@ class TestViewSaving(TestViewSavingCommon):
         self.assertIn(replacement, view.arch, 'common text node should not be escaped server side')
         self.assertIn(
             replacement,
-            view._render().decode('utf-8').replace(u'&', u'&amp;'),
+            str(view._render().decode('utf-8')).replace(u'&', u'&amp;'),
             'text node characters wrongly unescaped when rendering'
         )
 

--- a/addons/website/views/snippets/s_dynamic_snippet.xml
+++ b/addons/website/views/snippets/s_dynamic_snippet.xml
@@ -39,7 +39,7 @@
                 <we-button data-select-data-attribute="2">2</we-button>
                 <we-button data-select-data-attribute="3">3</we-button>
             </we-select>
-            <t t-raw="0"/>
+            <t t-out="0"/>
         </div>
     </template>
     <template id="s_dynamic_snippet_options" inherit_id="website.snippet_options">

--- a/addons/website/views/snippets/s_dynamic_snippet_carousel.xml
+++ b/addons/website/views/snippets/s_dynamic_snippet_carousel.xml
@@ -13,7 +13,7 @@
             <we-input string="Slider Speed"
                   data-select-data-attribute="1s" data-name="speed_opt" data-attribute-name="carouselInterval" data-no-preview="true"
                   data-unit="s" data-save-unit="ms" data-step="0.1"/>
-            <t t-raw="0"/>
+            <t t-out="0"/>
         </t>
     </template>
     <template id="s_dynamic_snippet_carousel_options" inherit_id="website.snippet_options">

--- a/addons/website/views/snippets/s_popup.xml
+++ b/addons/website/views/snippets/s_popup.xml
@@ -59,11 +59,11 @@
             </we-select>
         </t>
         <div data-js="SnippetPopup" data-selector=".s_popup" data-exclude="#website_cookies_bar" data-target=".modal">
-            <t t-raw="base_popup_options"/>
-            <t t-raw="extra_popup_options"/>
+            <t t-out="base_popup_options"/>
+            <t t-out="extra_popup_options"/>
         </div>
         <div data-js="SnippetPopup" data-selector=".s_popup#website_cookies_bar" data-target=".modal">
-            <t t-raw="base_popup_options"/>
+            <t t-out="base_popup_options"/>
         </div>
     </xpath>
 </template>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -214,7 +214,7 @@
 <!-- Navbar Nav -->
 <template id="navbar_nav" name="Navbar Nav">
     <ul id="top_menu" t-attf-class="nav navbar-nav o_menu_loading #{_nav_class}">
-        <t t-raw="0"/>
+        <t t-out="0"/>
     </ul>
 </template>
 
@@ -1336,7 +1336,7 @@
 <template id="login_layout" inherit_id="web.login_layout" name="Website Login Layout" priority="20">
     <xpath expr="t" position="replace">
         <t t-call="website.layout">
-            <div class="oe_website_login_container" t-raw="0"/>
+            <div class="oe_website_login_container" t-out="0"/>
         </t>
     </xpath>
 </template>
@@ -1932,7 +1932,7 @@
          t-attf-class="o_record_cover_container d-flex flex-column h-100 o_colored_level o_cc #{_cp.get('background_color_class')} #{use_size and _cp.get('resize_class')} #{use_text_align and _cp.get('text_align_class')} #{additionnal_classes}">
         <div t-attf-class="o_record_cover_component o_record_cover_image #{snippet_autofocus and 'o_we_snippet_autofocus'}" t-attf-style="background-image: #{_bg};"/>
         <div t-if="use_filters" t-attf-class="o_record_cover_component o_record_cover_filter oe_black" t-attf-style="opacity: #{_cp.get('opacity', 0.0)};"/>
-        <t t-raw="0"/>
+        <t t-out="0"/>
     </div>
 </template>
 
@@ -1944,7 +1944,7 @@
             <button class="btn btn-success js_publish_btn">Published</button>
             <button type="button" t-attf-class="btn btn-default dropdown-toggle dropdown-toggle-split" t-att-id="'dopprod-%s' % object.id" data-toggle="dropdown"/>
             <div class="dropdown-menu" role="menu" t-att-aria-labelledby="'dopprod-%s' % object.id">
-                <t t-raw="0"/>
+                <t t-out="0"/>
                 <a role="menuitem" t-attf-href="/web#view_type=form&amp;model=#{object._name}&amp;id=#{object.id}&amp;action=#{action}&amp;menu_id=#{menu or object.env['ir.model.data'].xmlid_to_res_id('website.menu_website_configuration')}"
                     title='Edit in backend' class="dropdown-item" t-if="publish_edit">Edit</a>
             </div>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -54,7 +54,7 @@
             <t t-if="not additional_title and main_object and 'name' in main_object">
                 <t t-set="additional_title" t-value="main_object.name"/>
             </t>
-            <t t-set="default_title"> <t t-if="additional_title"><t t-raw="additional_title"/> | </t><t t-raw="(website or res_company).name"/> </t>
+            <t t-set="default_title"> <t t-if="additional_title"><t t-out="additional_title"/> | </t><t t-out="(website or res_company).name"/> </t>
             <t t-set="seo_object" t-value="seo_object or main_object"/>
             <t t-if="seo_object and 'website_meta_title' in seo_object and seo_object.website_meta_title">
                 <t t-set="title" t-value="seo_object.website_meta_title"/>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -176,10 +176,10 @@
 
 <template id="custom_code_layout" name="Custom Code Layout" inherit_id="website.layout" priority="55">
     <xpath expr="//head" position="inside">
-        <t t-raw="website.custom_code_head"/>
+        <t t-out="website.custom_code_head"/>
     </xpath>
     <xpath expr="//body" position="inside">
-        <t t-raw="website.custom_code_footer"/>
+        <t t-out="website.custom_code_footer"/>
     </xpath>
 </template>
 
@@ -1995,7 +1995,7 @@
               </t>
               <t t-if="version">
                 <h1><t t-esc="res_company.name"/>
-                    <small>Odoo Version <t t-raw="version.get('server_version')"/></small>
+                    <small>Odoo Version <t t-out="version.get('server_version')"/></small>
                 </h1>
                 <p>
                     Information about the <t t-esc="res_company.name"/> instance of Odoo, the <a target="_blank" href="https://www.odoo.com">Open Source ERP</a>.
@@ -2011,12 +2011,12 @@
                 <dl class="dl-horizontal" t-foreach="apps" t-as="app">
                     <dt>
                         <a t-att-href="app.website" t-if="app.website">
-                            <t t-raw="app.shortdesc"/>
+                            <t t-out="app.shortdesc"/>
                         </a>
-                        <span t-raw="app.shortdesc" t-if="not app.website"/>
+                        <span t-out="app.shortdesc" t-if="not app.website"/>
                     </dt>
                     <dd>
-                        <span t-raw="app.summary"/>
+                        <span t-out="app.summary"/>
                     </dd><dd class="text-muted" groups='base.group_no_one'>
                         Technical name: <span t-field="app.name"/>, author: <span t-field="app.author"/>
                     </dd>
@@ -2027,11 +2027,11 @@
                     <dl class="dl-horizontal" t-foreach="l10n" t-as="app">
                         <dt>
                             <a t-attf-href="https://www.odoo.com/page/accounting/#{app.name}">
-                                <t t-raw="app.shortdesc"/>
+                                <t t-out="app.shortdesc"/>
                             </a>
                         </dt>
                         <dd>
-                            <span t-raw="app.summary"/>
+                            <span t-out="app.summary"/>
                         </dd><dd class="text-muted" groups='base.group_no_one'>
                             Technical name: <span t-field="app.name"/>, author: <span t-field="app.author"/>
                         </dd>
@@ -2240,7 +2240,7 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
 #   custom   #
 ##############
 
-<t t-raw="request.website.sudo().robots_txt" />
+<t t-out="request.website.sudo().robots_txt" />
 </t>
 </template>
 
@@ -2255,7 +2255,7 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
 
 <template id="sitemap_xml">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 <urlset t-attf-xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-    <t t-raw="content"/>
+    <t t-out="content"/>
 </urlset>
 </template>
 

--- a/addons/website_blog/views/website_blog_templates.xml
+++ b/addons/website_blog/views/website_blog_templates.xml
@@ -6,7 +6,7 @@
 <template id="index" name="Blog Navigation">
     <t t-call="website.layout">
         <div id="wrap" class="js_blog website_blog">
-            <t t-raw="0"/>
+            <t t-out="0"/>
 
             <!-- Droppable-area shared across all blog's pages -->
             <t t-set="oe_structure_blog_footer_description">Visible in all blogs' pages</t>

--- a/addons/website_event/views/event_templates_page.xml
+++ b/addons/website_event/views/event_templates_page.xml
@@ -62,7 +62,7 @@
                     </div>
                 </nav>
             </t>
-            <t t-raw="0"/>
+            <t t-out="0"/>
             <t t-set="editor_sub_message">Following content will appear on all events.</t>
             <div class="oe_structure oe_empty" id="oe_structure_website_event_layout_1" t-att-data-editor-sub-message="editor_sub_message"/>
         </div>

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -22,7 +22,7 @@
                     <t t-call="website_event.registration_template"/>
                 </div>
             </t>
-            <t t-raw="0"/>
+            <t t-out="0"/>
         </div>
     </t>
 </template>

--- a/addons/website_event/views/event_templates_widgets.xml
+++ b/addons/website_event/views/event_templates_widgets.xml
@@ -13,7 +13,7 @@
                 <input t-if="search != 'search' and search_value != 'all'" type="hidden"
                     t-att-name="search" t-att-value="search_value"/>
             </t>
-            <t t-raw="0"/>
+            <t t-out="0"/>
         </form>
     </xpath>
 </template>

--- a/addons/website_event_meet/views/event_meet_templates_list.xml
+++ b/addons/website_event_meet/views/event_meet_templates_list.xml
@@ -87,7 +87,7 @@
                     <div class="col">
                         <h5 t-esc="meeting_room.name"/>
                         <div class="text-muted mb-2"><i class="fa fa-globe"/> <span t-esc="meeting_room.room_lang_id.name"/></div>
-                        <span t-if="meeting_room.summary" t-raw="meeting_room.summary"/>
+                        <span t-if="meeting_room.summary" t-field="meeting_room.summary"/>
                     </div>
                 </div>
             </div>

--- a/addons/website_event_track/views/event_templates.xml
+++ b/addons/website_event_track/views/event_templates.xml
@@ -19,7 +19,7 @@
     <xpath expr='//t[@t-call="website.layout"]' position="inside">
         <t t-set="pageName" t-value="'event'"/>
         <t t-set="head">
-            <t t-raw="head"/>
+            <t t-out="head"/>
             <t t-call="website_event_track.pwa_manifest"/>
         </t>
     </xpath>
@@ -29,7 +29,7 @@
     <xpath expr='//t[@t-call="website.layout"]' position="inside">
         <t t-set="pageName" t-value="'event'"/>
         <t t-set="head">
-            <t t-raw="head"/>
+            <t t-out="head"/>
             <t t-call="website_event_track.pwa_manifest"/>
         </t>
     </xpath>

--- a/addons/website_event_track_quiz/views/event_leaderboard_templates.xml
+++ b/addons/website_event_track_quiz/views/event_leaderboard_templates.xml
@@ -41,7 +41,7 @@
             <a t-att-href=" pager['page_previous']['url'] if pager['page']['num'] != 1 else None" class="page-link"><i class="fa fa-caret-left"/></a>
         </li>
         <t t-foreach="pager['pages']" t-as="page">
-            <li t-attf-class="page-item #{'active disabled bg-primary rounded-circle' if page['num'] == pager['page']['num'] else ''}"> <a t-att-href="page['url']" class="page-link" t-raw="page['num']"></a></li>
+            <li t-attf-class="page-item #{'active disabled bg-primary rounded-circle' if page['num'] == pager['page']['num'] else ''}"> <a t-att-href="page['url']" class="page-link" t-out="page['num']"/></li>
         </t>
         <li t-attf-class="page-item o_wprofile_pager_arrow #{'disabled' if pager['page']['num'] == pager['page_count'] else ''}">
             <a t-att-href="pager['page_next']['url'] if pager['page']['num'] != pager['page_count'] else None" class="page-link"><i class="fa fa-caret-right"/></a>

--- a/addons/website_forum/views/ir_qweb.xml
+++ b/addons/website_forum/views/ir_qweb.xml
@@ -21,7 +21,7 @@
                     <span class="fa fa-trophy badge-bronze ml-2" role="img" aria-label="Bronze badge" title="Bronze badge"/>
                     <t t-esc="object.bronze_badge"/>
                 </div>
-                <t t-raw="0"/>
+                <t t-out="0"/>
                 <div t-if="options.get('UserBio')" class="mt-2">
                     <div class="o_forum_tooltip_line" t-if="object.partner_id.country_id or object.partner_id.city">
                         <span t-field="object.partner_id.city"/><span t-if="object.partner_id.city and object.partner_id.country_id">, </span><span t-field="object.partner_id.country_id"/>

--- a/addons/website_forum/views/ir_qweb.xml
+++ b/addons/website_forum/views/ir_qweb.xml
@@ -12,7 +12,7 @@
                 </div>
                 <b class="mt-4"><i class="fa fa-diamond text-secondary"/> <t t-esc="object.karma"/></b>
                 <div t-if="options.get('badges')" style="display: inline-block">
-                    <t t-raw="separator"/>
+                    <t t-esc="separator"/>
                     <b>|</b>
                     <span class="fa fa-trophy badge-gold ml-2" role="img" aria-label="Gold badge" title="Gold badge"/>
                     <t t-esc="object.gold_badge"/>

--- a/addons/website_forum/views/website_forum.xml
+++ b/addons/website_forum/views/website_forum.xml
@@ -286,7 +286,7 @@
         </div>
     </div>
     <!--  Display post's content in moderation mode-->
-    <div><t t-raw="post_content"/></div>
+    <div><t t-out="post_content"/></div>
 </template>
 
 <template id="display_post">
@@ -754,10 +754,9 @@
                     <t t-set="_search_and_tag_str"><t t-if="search and tag">&amp;nbsp;and&amp;nbsp;</t></t>
                     <t t-set="_tag_str"><t t-if="tag">using the <span class="badge badge-light" t-esc="tag.name"/> tag</t></t>
                     <t t-set="result_msg">
-                        Sorry, we could not find any <b>%s</b> result <b>
-                        %s</b> %s%s%s.
+                        Sorry, we could not find any <b>%s</b> result <b>%s</b> %s%s%s.
                     </t>
-                    <span t-raw="result_msg % (_filters_str.strip(), _my_str.strip(), _search_str.strip(), _search_and_tag_str.strip(), _tag_str.strip())"/>
+                    <span t-out="result_msg % (_filters_str.strip(), _my_str.strip(), _search_str.strip(), _search_and_tag_str.strip(), _tag_str.strip())"/>
                 </div>
 
                 <t t-elif="not tag and not search and no_filters">

--- a/addons/website_forum/views/website_forum.xml
+++ b/addons/website_forum/views/website_forum.xml
@@ -90,7 +90,7 @@
                                     <li t-elif="tags" class="breadcrumb-item">All Tags</li>
                                 </ol>
                             </nav>
-                            <t t-raw="0"/>
+                            <t t-out="0"/>
                         </div>
                         <aside t-if="uid" class="d-none d-lg-flex justify-content-end col-auto">
                             <t t-call="website_forum.user_sidebar"/>
@@ -1021,7 +1021,7 @@
             t-att-data-karma="forum.karma_downvote"
             t-att-data-can-downvote="can_downvote"
             aria-label="Negative vote" title="Negative vote"/>
-        <t t-raw="0"/>
+        <t t-out="0"/>
     </div>
 </template>
 

--- a/addons/website_google_map/controllers/main.py
+++ b/addons/website_google_map/controllers/main.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-import json
-
 from odoo import http
 from odoo.http import request
-from odoo.tools import html_escape as escape
+from odoo.tools.json import scriptsafe
 
 
 class GoogleMap(http.Controller):
@@ -39,13 +37,12 @@ class GoogleMap(http.Controller):
             "partners": []
         }
         for partner in partners.with_context(show_address=True):
-            # TODO in master, do not use `escape` but `t-esc` in the qweb template.
             partner_data["partners"].append({
                 'id': partner.id,
-                'name': escape(partner.name),
-                'address': escape('\n'.join(partner.name_get()[0][1].split('\n')[1:])),
-                'latitude': escape(str(partner.partner_latitude)),
-                'longitude': escape(str(partner.partner_longitude)),
+                'name': partner.name,
+                'address': '\n'.join(partner.name_get()[0][1].split('\n')[1:]),
+                'latitude': str(partner.partner_latitude),
+                'longitude': str(partner.partner_longitude),
             })
         if 'customers' in post.get('partner_url', ''):
             partner_url = '/customers/'
@@ -55,7 +52,7 @@ class GoogleMap(http.Controller):
         google_maps_api_key = request.website.google_maps_api_key
         values = {
             'partner_url': partner_url,
-            'partner_data': json.dumps(partner_data),
+            'partner_data': scriptsafe.dumps(partner_data),
             'google_maps_api_key': google_maps_api_key,
         }
         return request.render("website_google_map.google_map", values)

--- a/addons/website_google_map/views/google_map_templates.xml
+++ b/addons/website_google_map/views/google_map_templates.xml
@@ -11,7 +11,7 @@
     </head>
     <body t-att-data-partner-url="partner_url or None">
         <script>
-            var odoo_partner_data = <t t-raw="partner_data"/>;
+            var odoo_partner_data = <t t-out="partner_data"/>;
         </script>
         <div id="odoo-google-map"></div>
         <t t-if="google_maps_api_key">

--- a/addons/website_mail_channel/views/website_mail_channel_templates.xml
+++ b/addons/website_mail_channel/views/website_mail_channel_templates.xml
@@ -199,7 +199,7 @@
                                 <t t-if="not message.author_id"><t t-esc="message.email_from"/></t>
                                 - <i class="fa fa-calendar" role="img" aria-label="Date" title="Date"/> <span t-field="message.date"/>
                             </small>
-                            <div t-raw="message.body"/>
+                            <div t-out="message.body"/>
 
                             <div>
                                 <p t-if="attachments" class="mt8">

--- a/addons/website_partner/views/website_partner_templates.xml
+++ b/addons/website_partner/views/website_partner_templates.xml
@@ -24,7 +24,7 @@
                  "fields": ["address", "website", "phone", "email"]
              }'/>
         </address>
-        <t t-raw="left_column or ''"/>
+        <t t-out="left_column or ''"/>
     </div>
     <div class="col-lg-8 mt32">
         <t t-if="partner">
@@ -34,7 +34,7 @@
                 <div class="css_non_editable_mode_hidden" t-field="partner.website_short_description"/>
             </t>
         </t>
-        <t t-raw="right_column or ''"/>
+        <t t-out="right_column or ''"/>
     </div>
 </template>
 </odoo>

--- a/addons/website_profile/views/website_profile.xml
+++ b/addons/website_profile/views/website_profile.xml
@@ -613,7 +613,7 @@
                 <a t-att-href=" pager['page_previous']['url'] if pager['page']['num'] != 1 else None" class="page-link"><i class="fa fa-caret-left"/></a>
             </li>
             <t t-foreach="pager['pages']" t-as="page">
-                <li t-attf-class="page-item #{'active disabled bg-primary rounded-circle' if page['num'] == pager['page']['num'] else ''}"> <a t-att-href="page['url']" class="page-link" t-raw="page['num']"></a></li>
+                <li t-attf-class="page-item #{'active disabled bg-primary rounded-circle' if page['num'] == pager['page']['num'] else ''}"> <a t-att-href="page['url']" class="page-link" t-out="page['num']"/></li>
             </t>
             <li t-attf-class="page-item o_wprofile_pager_arrow #{'disabled' if pager['page']['num'] == pager['page_count'] else ''}">
                 <a t-att-href="pager['page_next']['url'] if pager['page']['num'] != pager['page_count'] else None" class="page-link"><i class="fa fa-caret-right"/></a>

--- a/addons/website_sale/models/product.py
+++ b/addons/website_sale/models/product.py
@@ -16,7 +16,7 @@ class ProductRibbon(models.Model):
     def name_get(self):
         return [(ribbon.id, '%s (#%d)' % (tools.html2plaintext(ribbon.html), ribbon.id)) for ribbon in self]
 
-    html = fields.Char(string='Ribbon html', required=True, translate=True)
+    html = fields.Html(string='Ribbon html', required=True, translate=True, sanitize=False)
     bg_color = fields.Char(string='Ribbon background color', required=False)
     text_color = fields.Char(string='Ribbon text color', required=False)
     html_class = fields.Char(string='Ribbon class', required=True, default='')

--- a/addons/website_sale/models/product_image.py
+++ b/addons/website_sale/models/product_image.py
@@ -22,7 +22,7 @@ class ProductImage(models.Model):
     product_variant_id = fields.Many2one('product.product', "Product Variant", index=True, ondelete='cascade')
     video_url = fields.Char('Video URL',
                             help='URL of a video for showcasing your product.')
-    embed_code = fields.Char(compute="_compute_embed_code")
+    embed_code = fields.Html(compute="_compute_embed_code", sanitize=False)
 
     can_image_1024_be_zoomed = fields.Boolean("Can Image 1024 be zoomed", compute='_compute_can_image_1024_be_zoomed', store=True)
 

--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -125,6 +125,28 @@
         </field>
     </record>
 
+    <!-- Product ribbon -->
+    <record id="product_ribbon_form_view" model="ir.ui.view">
+        <field name="name">product.ribbon form view</field>
+        <field name="model">product.ribbon</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="html" widget="char"/>
+                            <field name="text_color"/>
+                        </group>
+                        <group>
+                            <field name="html_class"/>
+                            <field name="bg_color"/>
+                        </group>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
     <!-- Product Public Categories -->
     <record id="product_public_category_form_view" model="ir.ui.view">
         <field name="name">product.public.category.form</field>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -213,7 +213,7 @@
             <t t-set="bg_color" t-value="td_product['ribbon']['bg_color'] or ''"/>
             <t t-set="text_color" t-value="td_product['ribbon']['text_color']"/>
             <t t-set="bg_class" t-value="td_product['ribbon']['html_class']"/>
-            <span t-attf-class="o_ribbon #{bg_class}" t-attf-style="#{text_color and ('color: %s; ' % text_color)}#{bg_color and 'background-color:' + bg_color}" t-raw="td_product['ribbon']['html'] or ''"/>
+            <span t-attf-class="o_ribbon #{bg_class}" t-attf-style="#{text_color and ('color: %s; ' % text_color)}#{bg_color and 'background-color:' + bg_color}" t-out="td_product['ribbon']['html'] or ''"/>
         </form>
     </template>
 
@@ -357,7 +357,7 @@
                 <span class="d-none d-lg-inline font-weight-bold text-muted">Sort By:</span>
                 <a role="button" href="#" class="dropdown-toggle btn btn-light border-0 px-0 text-muted align-baseline" data-toggle="dropdown">
                     <span class="d-none d-lg-inline">
-                        <t t-if='len(website_sale_sortable_current)'>
+                        <t t-if='website_sale_sortable_current'>
                             <t t-esc="website_sale_sortable_current[0][0]"/>
                         </t>
                         <t t-else='1'>
@@ -369,7 +369,7 @@
                 <div class="dropdown-menu dropdown-menu-right" role="menu">
                     <t t-foreach="website_sale_sortable" t-as="sortby">
                         <a role="menuitem" rel="noindex,nofollow" t-att-href="keep('/shop', order=sortby[1])" class="dropdown-item">
-                            <span t-raw="sortby[0]"/>
+                            <span t-out="sortby[0]"/>
                         </a>
                     </t>
                 </div>
@@ -1778,13 +1778,13 @@
                         <i class="fa fa-pencil"></i>
                     </a>
                     <t t-if="payment_tx_id.state == 'pending'">
-                        <t t-raw="payment_tx_id.acquirer_id.sudo().pending_msg"/>
+                        <t t-out="payment_tx_id.acquirer_id.sudo().pending_msg"/>
                     </t>
                     <t t-if="payment_tx_id.state == 'done'">
-                        <span t-if='payment_tx_id.acquirer_id.sudo().done_msg' t-raw="payment_tx_id.acquirer_id.sudo().done_msg"/>
+                        <span t-if='payment_tx_id.acquirer_id.sudo().done_msg' t-out="payment_tx_id.acquirer_id.sudo().done_msg"/>
                     </t>
                     <t t-if="payment_tx_id.state == 'cancel'">
-                        <t t-raw="payment_tx_id.acquirer_id.sudo().cancel_msg"/>
+                        <t t-out="payment_tx_id.acquirer_id.sudo().cancel_msg"/>
                     </t>
                     <t t-if="payment_tx_id.state == 'authorized'">
                         <span>Your payment has been authorized.</span>
@@ -1849,7 +1849,7 @@
                     <t t-foreach="product_images" t-as="product_image">
                         <div t-attf-class="carousel-item h-100#{' active' if product_image_first else ''}">
                             <div t-if="product_image._name == 'product.image' and product_image.embed_code" class="d-flex align-items-center justify-content-center h-100 embed-responsive embed-responsive-16by9">
-                                <t t-raw="product_image.embed_code"/>
+                                <t t-out="product_image.embed_code"/>
                             </div>
                             <div  t-else="" t-field="product_image.image_1920" class="d-flex align-items-center justify-content-center h-100" t-options='{"widget": "image", "preview_image": "image_1024", "class": "product_detail_img mh-100", "alt-field": "name", "zoom": product_image.can_image_1024_be_zoomed and "image_1920", "itemprop": "image"}'/>
                         </div>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -155,7 +155,7 @@
             <form t-attf-class="o_wsale_products_searchbar_form o_wait_lazy_js #{_classes}" t-att-action="action if action else '/shop'" method="get" t-att-data-snippet="_snippet">
                 <t>$0</t>
                 <input name="order" type="hidden" class="o_wsale_search_order_by" value=""/>
-                <t t-raw="0"/>
+                <t t-out="0"/>
             </form>
         </xpath>
     </template>
@@ -934,7 +934,7 @@
     <!-- We use this template where we want to give the user a link to the product of a sale order line. -->
     <template id="cart_line_product_link" name="Shopping Cart Line Product Link">
         <a t-att-href="line.product_id.website_url">
-            <t t-raw="0"/>
+            <t t-out="0"/>
         </a>
     </template>
 

--- a/addons/website_slides/data/mail_templates.xml
+++ b/addons/website_slides/data/mail_templates.xml
@@ -27,7 +27,7 @@
     <!-- CONTENT -->
     <tr>
         <td style="min-width: 590px;">
-            <t t-raw="message.body"/>
+            <t t-out="message.body"/>
             <div style="margin: 32px 0px 32px 0px; text-align: center;">
                 <a t-att-href="record.channel_id.website_url"
                     style="background-color: #875A7B; padding: 8px 16px 8px 16px; text-decoration: none; color: #fff; border-radius: 5px; font-size:13px;">
@@ -39,7 +39,7 @@
             </div>
             <div>&amp;nbsp;</div>
             <div t-if="signature" style="font-size: 13px;">
-                <div t-raw="signature"/>
+                <div t-out="signature"/>
             </div>
         </td>
     </tr>

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -181,7 +181,7 @@ class Slide(models.Model):
     likes = fields.Integer('Likes', compute='_compute_user_info', store=True, compute_sudo=False)
     dislikes = fields.Integer('Dislikes', compute='_compute_user_info', store=True, compute_sudo=False)
     user_vote = fields.Integer('User vote', compute='_compute_user_info', compute_sudo=False)
-    embed_code = fields.Text('Embed Code', readonly=True, compute='_compute_embed_code')
+    embed_code = fields.Html('Embed Code', readonly=True, compute='_compute_embed_code', sanitize=False)
     # views
     embedcount_ids = fields.One2many('slide.embed', 'slide_id', string="Embed Count")
     slide_views = fields.Integer('# of Website Views', store=True, compute="_compute_slide_views")

--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -258,10 +258,10 @@
         <img t-if="slide.slide_type == 'infographic'"
             t-att-src="website.image_url(slide, 'image_1024')" class="img-fluid" style="width:100%" t-att-alt="slide.name"/>
         <div t-if="slide.slide_type in ('presentation', 'document')" class="embed-responsive embed-responsive-4by3 embed-responsive-item mb8" style="height: 600px;">
-            <t t-raw="slide.embed_code"/>
+            <t t-esc="slide.embed_code"/>
         </div>
         <div t-if="slide.slide_type == 'video' and slide.document_id" class="embed-responsive embed-responsive-16by9 embed-responsive-item mb8">
-            <t t-raw="slide.embed_code"/>
+            <t t-esc="slide.embed_code"/>
         </div>
         <div t-if="slide.slide_type == 'webpage'" class="bg-white p-3">
             <div t-field="slide.html_content"/>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -179,7 +179,8 @@ todo_include_todos = False
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
-    'werkzeug': ('http://werkzeug.pocoo.org/docs/', None),
+    'werkzeug': ('https://werkzeug.palletsprojects.com/', None),
+    'markupsafe': ('https://markupsafe.palletsprojects.com/', None),
 }
 
 github_user = 'odoo'

--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -20,11 +20,11 @@ except ImportError:
     # `sassc` executable in the path.
     libsass = None
 
-from .qweb import escape
 from odoo import SUPERUSER_ID
 from odoo.http import request
 from odoo.modules.module import get_resource_path
 from odoo.tools import func, misc, transpile_javascript, is_odoo_module, SourceMapGenerator
+from odoo.tools.misc import html_escape as escape
 from odoo.tools.pycompat import to_text
 
 _logger = logging.getLogger(__name__)

--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -16,7 +16,7 @@ from odoo.tools.misc import get_lang
 from odoo.http import request
 from odoo.modules.module import get_resource_path
 
-from odoo.addons.base.models.qweb import QWeb, Contextifier
+from odoo.addons.base.models.qweb import QWeb, Contextifier, MarkupSafeBytes
 from odoo.addons.base.models.assetsbundle import AssetsBundle
 from odoo.addons.base.models.ir_asset import can_aggregate, STYLE_EXTENSIONS, SCRIPT_EXTENSIONS
 
@@ -83,7 +83,7 @@ class IrQWeb(models.AbstractModel, QWeb):
                     'style': 'page-break-after: always'
                 }))
 
-        return b''.join(html.tostring(f) for f in fragments)
+        return MarkupSafeBytes(b''.join(html.tostring(f) for f in fragments))
 
     def default_values(self):
         """ attributes add to the values for each computed template

--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -2,7 +2,6 @@
 from __future__ import print_function
 import ast
 import copy
-import json
 import logging
 from collections import OrderedDict
 from time import time

--- a/odoo/addons/base/tests/test_qweb.py
+++ b/odoo/addons/base/tests/test_qweb.py
@@ -649,7 +649,7 @@ class TestQWeb(TransactionCase):
             result = doc.find('result[@id="{}"]'.format(template)).text
             self.assertEqual(
                 qweb._render(template, values=params, load=loader).strip(),
-                (result or u'').strip().encode('utf-8'),
+                (result or u'').strip().replace('&quot;', '&#34;').encode('utf-8'),
                 template
             )
 

--- a/odoo/addons/base/tests/test_qweb.py
+++ b/odoo/addons/base/tests/test_qweb.py
@@ -12,7 +12,7 @@ from lxml.builder import E
 from odoo.modules import get_module_resource
 from odoo.tests.common import TransactionCase
 from odoo.addons.base.models.qweb import QWebException
-from odoo.tools import misc, ustr
+from odoo.tools import misc, mute_logger
 
 
 class TestQWebTField(TransactionCase):
@@ -631,6 +631,7 @@ class TestQWeb(TransactionCase):
 
         return lambda: self.run_test_file(os.path.join(path, f))
 
+    @mute_logger('odoo.addons.base.models.qweb') # tests t-raw which is deprecated
     def run_test_file(self, path):
         self.env.user.tz = 'Europe/Brussels'
         doc = etree.parse(path).getroot()

--- a/odoo/addons/base/tests/test_qweb.py
+++ b/odoo/addons/base/tests/test_qweb.py
@@ -82,7 +82,7 @@ class TestQWebTField(TransactionCase):
                 <t t-name="base.dummy">
                     <root>
                         <script type="application/javascript">
-                            var s = <t t-raw="json.dumps({'key': malicious})"/>;
+                            var s = <t t-esc="json.dumps({'key': malicious})"/>;
                         </script>
                     </root>
                 </t>

--- a/odoo/addons/base/views/ir_qweb_widget_templates.xml
+++ b/odoo/addons/base/views/ir_qweb_widget_templates.xml
@@ -23,7 +23,7 @@
         <div itemprop="address" itemscope="itemscope" itemtype="http://schema.org/PostalAddress">
             <div t-if="address and 'address' in fields" class="d-flex align-items-baseline">
                 <i t-if="not options.get('no_marker')" class="fa fa-map-marker fa-fw" role="img" aria-label="Address" title="Address"/>
-                <span class="w-100 o_force_ltr d-block" itemprop="streetAddress" t-raw="address.replace('\n', options.get('no_tag_br') and ', ' or '&lt;br/&gt;')"/>
+                <span class="w-100 o_force_ltr d-block" itemprop="streetAddress" t-esc="address"/>
             </div>
             <div t-if="city and 'city' in fields" class="d-flex align-items-baseline">
                 <i t-if="not options.get('no_marker')" class="fa fa-map-marker fa-fw" role="img" aria-label="Address" title="Address"/>

--- a/odoo/addons/base/views/onboarding_views.xml
+++ b/odoo/addons/base/views/onboarding_views.xml
@@ -33,7 +33,7 @@
                         <i class="fa fa-times" title="Close the onboarding panel" />
                     </a>
                     <div class="o_onboarding_steps">
-                        <t t-raw="0" />
+                        <t t-out="0" />
                     </div>
                     <div t-att-class="'o_onboarding_completed_message text-center' + (' o_onboarding_steps_done' if state.get('onboarding_state') in ('done', 'just_done') else '') + (' o_onboarding_steps_just_done' if state.get('onboarding_state') == 'just_done' else '')">
                         <i class="fa fa-check text-success mr8" />

--- a/odoo/addons/test_converter/tests/test_html.py
+++ b/odoo/addons/test_converter/tests/test_html.py
@@ -199,7 +199,7 @@ class TestTextExport(TestBasicExport):
         """)
         self.assertEqual(value, """<br>
         fgdkls;hjas;lj &lt;b&gt;fdslkj&lt;/b&gt; d;lasjfa lkdja &lt;a href=http://spam.com&gt;lfks&lt;/a&gt;<br>
-        fldkjsfhs &lt;i style=&quot;color: red&quot;&gt;&lt;a href=&quot;http://spamspam.com&quot;&gt;fldskjh&lt;/a&gt;&lt;/i&gt;<br>
+        fldkjsfhs &lt;i style=&#34;color: red&#34;&gt;&lt;a href=&#34;http://spamspam.com&#34;&gt;fldskjh&lt;/a&gt;&lt;/i&gt;<br>
         """)
 
 
@@ -245,7 +245,7 @@ class TestSelectionExport(TestBasicExport):
     def test_selection(self):
         converter = self.get_converter('selection_str')
         value = converter('C')
-        self.assertEqual(value, u"Qu'est-ce qu'il fout ce maudit pancake, tabernacle ?")
+        self.assertEqual(value, u"Qu&#39;est-ce qu&#39;il fout ce maudit pancake, tabernacle ?")
 
 
 class TestHTMLExport(TestBasicExport):

--- a/odoo/addons/test_converter/tests/test_html.py
+++ b/odoo/addons/test_converter/tests/test_html.py
@@ -167,6 +167,7 @@ class TestCurrencyExport(TestExport):
 
 
 class TestTextExport(TestBasicExport):
+    maxDiff = None
     def test_text(self):
         converter = self.get_converter('text')
 

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -4,18 +4,19 @@
 import base64
 import collections
 import logging
-from lxml.html import clean
 import random
 import re
 import socket
 import threading
 import time
-
 from email.utils import getaddresses
-from lxml import etree
 from urllib.parse import urlparse
-from werkzeug import urls
+
 import idna
+import markupsafe
+from lxml import etree
+from lxml.html import clean
+from werkzeug import urls
 
 import odoo
 from odoo.loglevels import ustr
@@ -249,7 +250,7 @@ def html_sanitize(src, silent=True, sanitize_tags=True, sanitize_attributes=Fals
     if cleaned.startswith(u'<div>') and cleaned.endswith(u'</div>'):
         cleaned = cleaned[5:-6]
 
-    return cleaned
+    return markupsafe.Markup(cleaned)
 
 # ----------------------------------------------------------
 # HTML/Text management

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -373,8 +373,7 @@ def plaintext2html(text, container_tag=False):
     text = misc.html_escape(ustr(text))
 
     # 1. replace \n and \r
-    text = text.replace('\n', '<br/>')
-    text = text.replace('\r', '<br/>')
+    text = re.sub(r'(\r\n|\r|\n)', '<br/>', text)
 
     # 2. clickable links
     text = html_keep_url(text)
@@ -382,16 +381,16 @@ def plaintext2html(text, container_tag=False):
     # 3-4: form paragraphs
     idx = 0
     final = '<p>'
-    br_tags = re.compile(r'(([<]\s*[bB][rR]\s*\/?[>]\s*){2,})')
+    br_tags = re.compile(r'(([<]\s*[bB][rR]\s*/?[>]\s*){2,})')
     for item in re.finditer(br_tags, text):
         final += text[idx:item.start()] + '</p><p>'
         idx = item.end()
     final += text[idx:] + '</p>'
 
     # 5. container
-    if container_tag:
+    if container_tag: # FIXME: validate that container_tag is just a simple tag?
         final = '<%s>%s</%s>' % (container_tag, final, container_tag)
-    return ustr(final)
+    return markupsafe.Markup(final)
 
 def append_content_to_html(html, content, plaintext=True, preserve=False, container_tag=False):
     """ Append extra content at the end of an HTML snippet, trying
@@ -428,8 +427,8 @@ def append_content_to_html(html, content, plaintext=True, preserve=False, contai
     if insert_location == -1:
         insert_location = html.find('</html>')
     if insert_location == -1:
-        return '%s%s' % (html, content)
-    return '%s%s%s' % (html[:insert_location], content, html[insert_location:])
+        return markupsafe.Markup('%s%s' % (html, content))
+    return markupsafe.Markup('%s%s%s' % (html[:insert_location], content, html[insert_location:]))
 
 
 def prepend_html_content(html_body, html_content):

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -34,6 +34,7 @@ from operator import itemgetter
 
 import babel
 import babel.dates
+import markupsafe
 import passlib.utils
 import pytz
 import werkzeug.utils
@@ -1188,13 +1189,7 @@ def ignore(*exc):
     except exc:
         pass
 
-# Avoid DeprecationWarning while still remaining compatible with werkzeug pre-0.9
-if parse_version(getattr(werkzeug, '__version__', '0.0')) < parse_version('0.9.0'):
-    def html_escape(text):
-        return werkzeug.utils.escape(text, quote=True)
-else:
-    def html_escape(text):
-        return werkzeug.utils.escape(text)
+html_escape = markupsafe.escape
 
 def get_lang(env, lang_code=False):
     """

--- a/odoo/tools/pycompat.py
+++ b/odoo/tools/pycompat.py
@@ -35,4 +35,7 @@ def to_text(source):
     if isinstance(source, bytes):
         return source.decode('utf-8')
 
+    if isinstance(source, str):
+        return source
+
     return str(source)

--- a/odoo/tools/template_inheritance.py
+++ b/odoo/tools/template_inheritance.py
@@ -6,7 +6,8 @@ import itertools
 import logging
 
 from odoo.tools.translate import _
-from odoo.tools import SKIPPED_ELEMENT_TYPES
+from odoo.tools import SKIPPED_ELEMENT_TYPES, html_escape
+
 _logger = logging.getLogger(__name__)
 
 
@@ -107,8 +108,7 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
         """
         if len(spec):
             raise ValueError(
-                _("Invalid specification for moved nodes: '%s'") %
-                etree.tostring(spec)
+                _("Invalid specification for moved nodes: %r", etree.tostring(spec, encoding='unicode'))
             )
         pre_locate(spec)
         to_extract = locate_node(source, spec)
@@ -117,8 +117,7 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
             return to_extract
         else:
             raise ValueError(
-                _("Element '%s' cannot be located in parent view") %
-                etree.tostring(spec)
+                _("Element %r cannot be located in parent view", etree.tostring(spec, encoding='unicode'))
             )
 
     while len(specs):
@@ -225,7 +224,7 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
 
         else:
             attrs = ''.join([
-                ' %s="%s"' % (attr, spec.get(attr))
+                ' %s="%s"' % (attr, html_escape(spec.get(attr)))
                 for attr in spec.attrib
                 if attr != 'position'
             ])


### PR DESCRIPTION
`t-raw` is a relatively regular source of issues, not just because it
gets misused (though that happens) but because it's a form of action
at a distance: a commit adds a `t-raw` with a checked input, this gets
validated and merged, then the *input* gets modified or overridden or
... and the devs & reviewers don't realize it will end up in a
`t-raw`... and we've got an injection vector.

The markupsafe package (on which we already have a hard dependency)
turns out to have a solution for that: if the parameter to
`markupsafe.escape` has a `__html__` method, it will just call that.

It also provides `markupsafe.Markup` which defines exactly one method,
and furthermore will automatically escape the parameters to its
methods (which can be a bit disconcerting for some) as well as
formatting parameters e.g.

    Markup("foo %s %s") % (a, b)

will automatically escape `a` and `b` before they're merged into the
format string, and will return a markup. Obviously that doesn't work
the other way around (because `str.__mod__` and `str.format` always
return a string). It does work for concatenation though.

This means if we can use `markupsafe.escape` as the standard escape
function (which is a good idea since werkzeug [is deprecating
`werkzeug.utils.escape`
anyway](https://github.com/pallets/werkzeug/issues/1758)) we can
leverage this property by requiring the *sources* to be properly
tagged for them to be directly injectible, this means in the scenario
above the payload will either be properly escaped OOTB or it will
break the existing system, but either way it should not be a
*security* risk. And we can easily flag mentions of `Markup` or
`__html__` for security review.

This PR updates `qweb` to use `markupsafe.escape` as its escaping
function, and adds a warning to `t-raw`. It also updates a number of
APIs to make them markup-safe by default:

* html_escape (that's actually what `markupsafe.escape` does on all of its own)
* html_sanitize
* the output of HTML fields
* scriptsafe JSON
* nl2br (which internally escapes its input if necessary)
* qweb markup bodies e.g. `<t t-set="thing">body</t>` the value is markup-safe
* qweb *output*, however `qweb._render` returns *binary data*, for the
  most part this is invisible because we keep using `to_text` and
  `ustr` everywhere and those decode bytes to text automatically, but
  `Markup` inherits from `str` so we can't just have qweb return a
  `Markup`, it generates garbage. Therefore it returns
  `MarkupSafeBytes`

`to_text` was also updated to let `Markup` instances pass through
unmolested. `ustr`, however, was not.

New wrapper types:

`MarkupSafeBytes` is used as the output of `qweb._render`. It extends
`bytes` as `Markup` extends `str`, though it doesn't redefine all the
utility escaping `Markup` does. For the most part:

* It decodes to a `Markup`.
* It defines an `__html__` which decodes to and returns a `Markup`.

`_ScriptSafe` is the new output of the scriptsafe JSON module. It
defines its own `__html__` which applies script-safe escaping at point
of use, it doesn't use the `Markup` wrapper to avoid issues of
unescaping and double-escaping related to attributes, with which
script-safe escaping is not compatible.

A few other notes:

* `to_text` was updated to let `Markup` objects pass through
  unmodified, `ustr` was not updated thus.
* The `Text` fields used through `t-raw` were converted to `Html(...,
  sanitized=False)` (at least when they could not be sanitized
  e.g. header contents and friends).
* Digest was completely untested, but the test I added is not entirely
  reliable, sometimes records go missing and I'm not really sure why.
* Running Odoo with `-b` might be a good idea: while Python 3 removed
  implicit conversions between text and bytes, this means
  `str(b'foo')` now generates the value `"b'foo'"`. Because `Markup`
  extends `str` it has essentially the same behaviour, and passing
  *bytes* to `Markup` is basically a garbage generator.
