### PR TITLE
[FIX] web: display right value for reamining days widget

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -986,7 +986,7 @@ const RemainingDays = AbstractField.extend({
         // timezone), to get a meaningful delta for the user
         const nowUTC = moment().utc();
         const nowUserTZ = nowUTC.clone().add(session.getTZOffset(nowUTC), 'minutes');
-        const valueUserTZ = this.value.clone().add(session.getTZOffset(this.value), 'minutes');
+        const valueUserTZ = this.value.clone();
         const diffDays = valueUserTZ.startOf('day').diff(nowUserTZ.startOf('day'), 'days');
         let text;
         if (Math.abs(diffDays) > 99) {


### PR DESCRIPTION
Issue

	- Install 'Project' module
	- Set user timezone to 'US/Pacific'
	- Change (if needed) browser timezone to 'San Francisco'
	- Create a new task and set deadline date to today
	- Go back to list kanban view

	The new task have 'Yesterday' (instead of 'Today') tag

Cause

	RemainingDays widget (that display the tag) is adding
	an offset regarding the session timezone to the value
	(of the field), however, the value have already the
	offset added.

Solution

	Don't add offset to date value.

opw-2480482