### PR TITLE
[13.0][FIX] repair - selecting product on part and/or fee lines results in linking all taxes from product instead of choosing only those taxes belonging to the company for which repair order was created

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -673,7 +673,8 @@ class RepairLine(models.Model):
                     # Check automatic detection
                     fp_id = self.env['account.fiscal.position'].get_fiscal_position(partner.id, delivery_id=self.repair_id.address_id.id)
                     fp = self.env['account.fiscal.position'].browse(fp_id)
-                self.tax_id = fp.map_tax(self.product_id.taxes_id, self.product_id, partner).ids
+                taxes = self.product_id.taxes_id.filtered(lambda x: x.company_id == self.repair_id.company_id)
+                self.tax_id = fp.map_tax(taxes, self.product_id, partner).ids
             warning = False
             if not pricelist:
                 warning = {
@@ -740,7 +741,8 @@ class RepairFee(models.Model):
                 # Check automatic detection
                 fp_id = self.env['account.fiscal.position'].get_fiscal_position(partner.id, delivery_id=self.repair_id.address_id.id)
                 fp = self.env['account.fiscal.position'].browse(fp_id)
-            self.tax_id = fp.map_tax(self.product_id.taxes_id, self.product_id, partner).ids
+            taxes = self.product_id.taxes_id.filtered(lambda x: x.company_id == self.repair_id.company_id)
+            self.tax_id = fp.map_tax(taxes, self.product_id, partner).ids
         if self.product_id:
             if partner:
                 self.name = self.product_id.with_context(lang=partner.lang).display_name


### PR DESCRIPTION
Current behavior before PR:

Selecting product on part and/or fee lines results in linking all taxes from product instead of choosing only those taxes belonging to the company for which repair order was created

Desired behavior after PR is merged:

Selecting product on part and/or fee lines will result in linking only those taxes configured on product which belong to the same company for which repair order was created.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
