### PR TITLE
[FIX][12.0] point_of_sale : store tax_ids when refunding orders

### DIFF
--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -40,7 +40,7 @@
                                 <field name="price_unit" widget="monetary"/>
                                 <field name="discount" widget="monetary"/>
                                 <field name="tax_ids_after_fiscal_position" widget="many2many_tags" string="Taxes"/>
-                                <field name="tax_ids" widget="many2many_tags" invisible="1"/>
+                                <field name="tax_ids" widget="many2many_tags" invisible="1" force_save="1"/>
                                 <field name="price_subtotal" widget="monetary" force_save="1"/>
                                 <field name="price_subtotal_incl" widget="monetary" force_save="1"/>
                             </tree>
@@ -53,7 +53,7 @@
                                     <field name="price_subtotal" invisible="1" widget="monetary" force_save="1"/>
                                     <field name="price_subtotal_incl" invisible="1" widget="monetary" force_save="1"/>
                                     <field name="tax_ids_after_fiscal_position" widget="many2many_tags" string="Taxes"/>
-                                    <field name="tax_ids" widget="many2many_tags" invisible="1"/>
+                                    <field name="tax_ids" widget="many2many_tags" invisible="1" force_save="1"/>
                                     <field name="pack_lot_ids" widget="many2many_tags" groups="stock.group_production_lot"/>
                                     <field name="notice"/>
                                 </group>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- Open a PoS session and create an order and mark it as paid.
- in the back office, use the 'refund' button. --> You have a draft ``pos.order`` 
- change a product or add a line, and save the order.

Current behavior before PR:
- the fields ``tax_ids`` is not saved
- the field ``tax_ids_after_fiscal_position`` is so bad computed
- the field ``amount_tax`` of ``pos.order`` is so bad computed.

Desired behavior after PR is merged:
- the field ``tax_ids`` is saved and the other computed fields are correct.


CC : @Yenthe666, @houssine78, @lap-odoo  
CC : @grap, @quentinDupont
apps/deck/#/board/144/card/1341



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
