### PR TITLE
[FIX] sale_coupon: translate email subject and template

### DIFF
--- a/addons/sale_coupon/data/sale_coupon_email_data.xml
+++ b/addons/sale_coupon/data/sale_coupon_email_data.xml
@@ -7,6 +7,7 @@
          <field name="subject">Your reward coupon from ${object.program_id.company_id.name} </field>
          <field name="email_from">${object.program_id.company_id.email|safe}</field>
          <field name="partner_to">${object.partner_id.id}</field>
+         <field name="lang">${object.partner_id.lang}</field>
          <field name="body_html" type="html">
 <table border="0" cellpadding="0" cellspacing="0" style="width:100%; margin:0px auto;"><tbody>
     <tr><td valign="top" style="text-align: center; font-size: 14px;">

--- a/addons/sale_coupon/i18n/sale_coupon.pot
+++ b/addons/sale_coupon/i18n/sale_coupon.pot
@@ -45,6 +45,12 @@ msgid "10% Discount"
 msgstr ""
 
 #. module: sale_coupon
+#: code:addons/sale_coupon/wizard/sale_coupon_generate.py:35
+#, python-format
+msgid "%s, a coupon has been generated for you"
+msgstr ""
+
+#. module: sale_coupon
 #: model:product.product,name:sale_coupon.product_product_10_percent_discount
 #: model:product.template,name:sale_coupon.product_product_10_percent_discount_product_template
 msgid "10.0% discount on total amount"

--- a/addons/sale_coupon/wizard/sale_coupon_generate.py
+++ b/addons/sale_coupon/wizard/sale_coupon_generate.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 from odoo.tools.safe_eval import safe_eval
 
 
@@ -31,7 +31,9 @@ class SaleCouponGenerate(models.TransientModel):
             for partner in self.env['res.partner'].search(safe_eval(self.partners_domain)):
                 vals.update({'partner_id': partner.id})
                 coupon = self.env['sale.coupon'].create(vals)
-                subject = '%s, a coupon has been generated for you' % (partner.name)
+                context = dict(lang=partner.lang)
+                subject = _('%s, a coupon has been generated for you') % (partner.name)
+                del context
                 template = self.env.ref('sale_coupon.mail_template_sale_coupon', raise_if_not_found=False)
                 if template:
                     template.send_mail(coupon.id, email_values={'email_to': partner.email, 'email_from': self.env.user.email or '', 'subject': subject,})


### PR DESCRIPTION
Steps:
- Install Sales
- Go to Settings / Translations / Languages
- Install Dutch
- Go to Settings / Users & Companies / Users
- Change demo's language to Dutch
- Go to Sales / Configuration / Settings
- Activate Coupons & Promotions
- Go to Sales / Products / Coupon Programs
- Create a new Coupon Program
- Click Generate Coupon
  - Generation Type: Number of Selected Customers
  - Matching rule: Name contains demo
- Generate
- Go to Settings / Technical / Email / Emails
- Open the email you just sent

Bug:
Parts of the email are not translated

Explanation:
The `lang` field is used to determine the template's language. Coupon
emails where missing one.
Also, the subject of the email wasn't translated.

opw:2467640