### PR TITLE
[12.0][IMP] payment - enable extension of redirect form method for payment acquirer submit form.

### DIFF
--- a/addons/payment/static/src/js/payment_form.js
+++ b/addons/payment/static/src/js/payment_form.js
@@ -165,7 +165,7 @@ odoo.define('payment.payment_form', function (require) {
                             if (result) {
                                 // if the server sent us the html form, we create a form element
                                 var newForm = document.createElement('form');
-                                newForm.setAttribute("method", "post"); // set it to post
+                                newForm.setAttribute("method", self._get_redirect_form_method());
                                 newForm.setAttribute("provider", checked_radio.dataset.provider);
                                 newForm.hidden = true; // hide it
                                 newForm.innerHTML = result; // put the html sent by the server inside the form
@@ -215,6 +215,15 @@ odoo.define('payment.payment_form', function (require) {
                 );
                 this.enableButton(button);
             }
+        },
+        /**
+         * Called when submitting payment acquirer form.
+         * By default returns http method "post"
+         * @returns {string}
+         * @private
+         */
+        _get_redirect_form_method: function(){
+            return "post";
         },
         // event handler when clicking on the button to add a new payment method
         addPmEvent: function (ev) {


### PR DESCRIPTION
It should be possible to override payment provider redirec form method




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
