### PR TITLE
[FIX] base: do not inject clear_cache method on res_users.has_group

### DIFF
--- a/doc/cla/individual/petrus-v.md
+++ b/doc/cla/individual/petrus-v.md
@@ -1,0 +1,11 @@
+France, 2021-03-22
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Pierre Verkest pierreverkest84@gmail.com https://github.com/petrus-v

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -176,7 +176,6 @@ class Groups(models.Model):
         # DLE P139
         if self.ids:
             self.env['ir.model.access'].call_cache_clearing_methods()
-            self.env['res.users'].has_group.clear_cache(self.env['res.users'])
         return super(Groups, self).write(vals)
 
 
@@ -522,7 +521,6 @@ class Users(models.Model):
             # `test_00_equipment_multicompany_user`
             self.env['ir.model.access'].call_cache_clearing_methods()
             self.env['ir.rule'].clear_caches()
-            self.has_group.clear_cache(self)
         if any(key.startswith('context_') or key in ('lang', 'tz') for key in values):
             self.context_get.clear_cache(self)
         if any(key in values for key in ['active'] + USER_PRIVATE_FIELDS):
@@ -758,8 +756,6 @@ class Users(models.Model):
                             (SELECT res_id FROM ir_model_data WHERE module=%s AND name=%s)""",
                          (self._uid, module, ext_id))
         return bool(self._cr.fetchone())
-    # for a few places explicitly clearing the has_group cache
-    has_group.clear_cache = _has_group.clear_cache
 
     def action_show_groups(self):
         self.ensure_one()

--- a/odoo/addons/base/tests/test_user_has_group.py
+++ b/odoo/addons/base/tests/test_user_has_group.py
@@ -249,3 +249,28 @@ class TestHasGroup(TransactionCase):
 
         with self.assertRaises(ValidationError):
             user_b.write({"groups_id": [(4, group_C.id)]})
+
+    def test_has_group_cleared_cache_on_write(self):
+        self.registry._clear_cache()
+        self.assertFalse(self.registry.cache, "Ensure ormcache is empty")
+
+        def populate_cache():
+            self.test_user.has_group('test_user_has_group.group0')
+            self.assertTrue(self.registry.cache, "user.has_group cache must be populated")
+
+        populate_cache()
+
+        self.env.ref(self.group0).write({"share": True})
+        self.assertFalse(self.registry.cache, "Writing on group must invalidate user.has_group cache")
+
+        populate_cache()
+        # call_cache_clearing_methods is called in res.groups.write to invalidate
+        # cache before calling its parent class method (`odoo.models.Model.write`)
+        # as explain in the `res.group.write` comment.
+        # This verifies that calling `call_cache_clearing_methods()` invalidates
+        # the ormcache of method `user.has_group()`
+        self.env['ir.model.access'].call_cache_clearing_methods()
+        self.assertFalse(
+            self.registry.cache,
+            "call_cache_clearing_methods() must invalidate user.has_group cache"
+        )


### PR DESCRIPTION
While injecting attribute to a methods this breaks inheritance

Description of the issue/feature this PR addresses:

cf #68106 

Current behavior before PR:

cf #68106 

Desired behavior after PR is merged:

cf #68106 



--
I've signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
