### PR TITLE
[FIX] purchase: Fix Auto-Complete search on vendor bills

### DIFF
--- a/addons/purchase/report/purchase_bill.py
+++ b/addons/purchase/report/purchase_bill.py
@@ -60,5 +60,4 @@ class PurchaseBillUnion(models.Model):
         domain = []
         if name:
             domain = ['|', ('name', operator, name), ('reference', operator, name)]
-        purchase_bills_union_ids = self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
-        return self.browse(purchase_bills_union_ids).name_get()
+        return self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)

--- a/doc/cla/corporate/sprint-it.md
+++ b/doc/cla/corporate/sprint-it.md
@@ -16,3 +16,4 @@ Elmeri Niemelä niemela.elmeri@gmail.com https://github.com/elmeriniemela
 Ivan Avdouevski ivan.avdouevski@sprintit.fi https://github.com/sprintit
 Johan Tötterman johan.totterman@sprintit.fi https://github.com/juppe
 Roy Nurmi roy.nurmi@sprintit.fi 
+Miika Rouvinen miika.rouvinen@sprintit.fi https://github.com/miikar


### PR DESCRIPTION
Problem:
- Create vendor bill
- Edit vendor bill in draft state
- Selecting Auto-Complete to search for existing purchase orders and bills causes error, which prevents the selection

Solution:
- removed what seems to be a redundant name_get call when searching purchase order / bill union
- previous commit related to this issue https://github.com/odoo/odoo/commit/87cbd4be261a426cb28ed6c1de7941c6b751521f

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
