### PR TITLE
base: allow using another postgres schema than public

### DIFF
--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -24,7 +24,7 @@ def existing_tables(cr, tablenames):
           JOIN pg_namespace n ON (n.oid = c.relnamespace)
          WHERE c.relname IN %s
            AND c.relkind IN ('r', 'v', 'm')
-           AND n.nspname = 'public'
+           AND n.nspname = current_schema
     """
     cr.execute(query, [tuple(tablenames)])
     return [row[0] for row in cr.fetchall()]
@@ -43,7 +43,7 @@ def table_kind(cr, tablename):
           FROM pg_class c
           JOIN pg_namespace n ON (n.oid = c.relnamespace)
          WHERE c.relname = %s
-           AND n.nspname = 'public'
+           AND n.nspname = current_schema
     """
     cr.execute(query, (tablename,))
     return cr.fetchone()[0] if cr.rowcount else None


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Before 1721ec1363 and fdc4ef97c9d09, Odoo did work fine when the
user had another default schema than 'public'.
This commit restores this behaviour by searching
for existing objects in the user's current schema,
which is the first in the schema search path and
the one used when no schema is specified when
creating objects.

Current behavior before PR:

Odoo works only with the `public` postgres schema

Desired behavior after PR is merged:

Odoo works with any other default schema.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
