### PR TITLE
[FIX] web,mail: convert activitiy dates using user's TZ

### DIFF
--- a/addons/mail/static/src/components/activity/activity.js
+++ b/addons/mail/static/src/components/activity/activity.js
@@ -6,6 +6,7 @@ const components = {
     FileUploader: require('mail/static/src/components/file_uploader/file_uploader.js'),
     MailTemplate: require('mail/static/src/components/mail_template/mail_template.js'),
 };
+const session = require('web.session');
 const useShouldUpdateBasedOnProps = require('mail/static/src/component_hooks/use_should_update_based_on_props/use_should_update_based_on_props.js');
 const useStore = require('mail/static/src/component_hooks/use_store/use_store.js');
 
@@ -69,7 +70,11 @@ class Activity extends Component {
      * @returns {string}
      */
     get delayLabel() {
-        const today = moment().startOf('day');
+        const userTZ = session.user_context['tz']
+        const todayUTC = moment().utc();
+        // Convert using timezone identifier (e.g., "Europe/Brussels") :
+        const todayUserTZ = moment((new Date(todayUTC.format())).toLocaleString("en-US", {timeZone: userTZ}), "M/D/YYYY, h:m:s A")
+        const today = todayUserTZ.startOf('day');
         const momentDeadlineDate = moment(auto_str_to_date(this.activity.dateDeadline));
         // true means no rounding
         const diff = momentDeadlineDate.diff(today, 'days', true);

--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -982,12 +982,12 @@ const RemainingDays = AbstractField.extend({
             this.$el.removeClass('text-bf text-danger text-warning');
             return;
         }
-        // compare the value (in the user timezone) with now (also in the user
-        // timezone), to get a meaningful delta for the user
+        // compare the value with now (in the user timezone)
+        const userTZ = session.user_context['tz']
         const nowUTC = moment().utc();
-        const nowUserTZ = nowUTC.clone().add(session.getTZOffset(nowUTC), 'minutes');
-        const valueUserTZ = this.value.clone().add(session.getTZOffset(this.value), 'minutes');
-        const diffDays = valueUserTZ.startOf('day').diff(nowUserTZ.startOf('day'), 'days');
+        // convert date using timezone identifier (e.g., "Europe/Brussels")
+        const nowUserTZ = moment((new Date(nowUTC.format())).toLocaleString("en-US", {timeZone: userTZ}), "M/D/YYYY, h:m:s A")
+        const diffDays = this.value.startOf('day').diff(nowUserTZ.startOf('day'), 'days');
         let text;
         if (Math.abs(diffDays) > 99) {
             text = this._formatValue(this.value, 'date');


### PR DESCRIPTION
In the preferences, when changing the timezone of the user, the dates are not correctly converted.

To reproduce the error:
(Use demo data)
1. Open CRM
2. In Proposition column, look at "Modern Open Space"
    - Clock is orange
    - Let the cursor over it, it displays "Today"
3. In the top bar, click on the clock (to get the activities)
    - There is one activity today
4. Go to CRM > Sales > My Activities
5. The activity for "Mordern Open Space" is scheduled for Today
    - It will be the same, in the logs, if you open the "Modern Open Space"
6. In user preferences, change the timezone so that the date change to yesterday or tomorrow
    - e.g., "Pacific/Honolulu" (the most easterly), "Pacific/Auckland" (the most westerly)
    - (Here, suppose we choose "Pacific/Honolulu": the date changes to yesterday)
7. If you repeat setps 2-3, all is updated:
    - Clock became green
    - It displays "Planned"
    - There isn't any activity for today
8. Go to CRM > Sales > My Activities

Error: The activity for "Modern Open Space" is scheduled for today. This is incorrect. Click on "Modern Open Space". In the logs, the activity is also scheduled for today (incorrect) and the color of the word 'today' is green (i.e., color for future activities -> also incorrect). 

These values are based on the local machine timezone. It should use the user timezone (as defined in the preferences). Moreover, the deadline date is converted to another timezone while the time set is arbitrary and only the dates are compared. Deadlines should therefore not be converted.

OPW-2392170

**Note**: We should import moment-timezone in future versions to convert dates in a much cleaner way.
```js
var dateTZ = moment((new Date(dateUTC.format())).toLocaleString("en-US", {timeZone: userTZ}), "M/D/YYYY, h:m:s A")
```
would become
```js
var dateTZ = dateUTC.tz(userTZ)
```