### PR TITLE
[FIX] web: broken listview dropdown on state_selection

### DIFF
--- a/addons/web/static/src/legacy/js/fields/basic_fields.js
+++ b/addons/web/static/src/legacy/js/fields/basic_fields.js
@@ -2682,6 +2682,9 @@ var StateSelectionWidget = AbstractField.extend({
      */
     _setSelection: function (ev) {
         ev.preventDefault();
+        if (this.mode !== 'edit') {
+            ev.stopPropagation();
+        }
         var $item = $(ev.currentTarget);
         var value = String($item.data('value'));
         this._setValue(value);

--- a/addons/web/static/src/legacy/scss/list_view.scss
+++ b/addons/web/static/src/legacy/scss/list_view.scss
@@ -28,7 +28,7 @@
             }
         }
         tbody > tr > td:not(.o_list_record_selector) {
-            &:not(.o_handle_cell):not(.o_list_button) {
+            &:not(.o_handle_cell):not(.o_list_button):not(.o_state_selection_cell) {
                 @include o-text-overflow(table-cell);
                 &.o_list_text {
                     white-space: pre-wrap;

--- a/addons/web/static/tests/legacy/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/legacy/fields/basic_fields_tests.js
@@ -6501,7 +6501,7 @@ QUnit.module('basic_fields', {
     });
 
     QUnit.test('state_selection widget in editable list view', async function (assert) {
-        assert.expect(32);
+        assert.expect(33);
 
         var list = await createView({
             View: ListView,
@@ -6542,6 +6542,7 @@ QUnit.module('basic_fields', {
             "should still have one green status");
         assert.containsNone(list, '.dropdown-menu.state:visible',
             "there should not be a dropdown");
+        assert.containsNone(list, 'tr.o_selected_row', 'should not be in edit mode');
 
         // switch to edit mode and check the result
         $cell = list.$('tbody td.o_state_selection_cell').first();


### PR DESCRIPTION
currently, when clicking on an editable state_selection widget in listview, the
dropdown is  not displayed. this is happening because overflow of cell was
hidden.

after this commit,
now when clicking on an editable state_selection widget in listview, the
dropdown is displayed.  change overflow to visible. also have to stop event to
propagate when select option from drop down is not so formview will for record
will open.

Task - 2485883

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
