### PR TITLE
[REM] various:remove widget='selection' on many2one fields

### DIFF
--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -152,8 +152,8 @@
                                     <field name="amount" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
                                     <field name="currency_id" options="{'no_create': True, 'no_open': True}" groups="base.group_multi_currency" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
                                 </div>
-                                <field name="journal_id" widget="selection" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
-                                <field name="destination_journal_id" widget="selection" attrs="{'required': [('payment_type', '=', 'transfer')], 'invisible': [('payment_type', '!=', 'transfer')], 'readonly': [('state', '!=', 'draft')]}"/>
+                                <field name="journal_id" options="{'no_open': True, 'no_create': True}" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
+                                <field name="destination_journal_id" options="{'no_open': True, 'no_create': True}" attrs="{'required': [('payment_type', '=', 'transfer')], 'invisible': [('payment_type', '!=', 'transfer')], 'readonly': [('state', '!=', 'draft')]}"/>
                                 <field name="hide_payment_method" invisible="1"/>
                                 <field name="payment_method_id" string=" " widget="radio" attrs="{'invisible': [('hide_payment_method', '=', True)], 'readonly': [('state', '!=', 'draft')]}" domain="[('payment_type', '=', payment_type)]"/>
                                 <field name="partner_bank_account_id" attrs="{'invisible': [('show_partner_bank_account', '!=', True)], 'required': [('show_partner_bank_account', '=', True), ('state', '=', 'draft')], 'readonly': [('state', '!=', 'draft')]}" context="{'default_partner_id': partner_id}"/>
@@ -258,7 +258,7 @@
                                     <field name="amount"/>
                                     <field name="currency_id" options="{'no_create': True, 'no_open': True}" groups="base.group_multi_currency"/>
                                 </div>
-                                <field name="journal_id" widget="selection" attrs="{'invisible': [('amount', '=', 0)]}"/>
+                                <field name="journal_id" options="{'no_open': True, 'no_create': True}" attrs="{'invisible': [('amount', '=', 0)]}"/>
                                 <field name="hide_payment_method" invisible="1"/>
                                 <field name="payment_method_id" widget="radio" attrs="{'invisible': ['|', ('hide_payment_method', '=', True), ('amount', '=', 0.0)]}"/>
                                 <field name="partner_bank_account_id" attrs="{'invisible': [('show_partner_bank_account', '!=', True)], 'required': [('show_partner_bank_account', '=', True)], 'readonly': [('state', '!=', 'draft')]}" context="{'default_partner_id': partner_id}"/>
@@ -278,7 +278,7 @@
                                         <label for="writeoff_account_id" class="oe_edit_only" string="Post Difference In"/>
                                         <field name="writeoff_account_id" string="Post Difference In" attrs="{'required': [('payment_difference_handling', '=', 'reconcile'), ('payment_difference', '!=', 0.0)]}"/>
                                         <label for="journal_id" string="Journal" attrs="{'invisible': [('amount', '!=', 0)]}"/>
-                                        <field name="journal_id" string="Journal" widget="selection" attrs="{'invisible': [('amount', '!=', 0)]}"/>
+                                        <field name="journal_id" string="Journal" options="{'no_open': True, 'no_create': True}" attrs="{'invisible': [('amount', '!=', 0)]}"/>
                                         <label for="writeoff_label" class="oe_edit_only" string="Label"/>
                                         <field name="writeoff_label" attrs="{'required': [('payment_difference_handling', '=', 'reconcile'), ('payment_difference', '!=', 0.0)]}"/>
                                     </div>
@@ -327,7 +327,7 @@
                                        options="{'no_create': True, 'no_open': True}"
                                        groups="base.group_multi_currency"/>
                             </div>
-                            <field name="journal_id" widget="selection" attrs="{'invisible': [('amount', '=', 0)]}"/>
+                            <field name="journal_id" options="{'no_open': True, 'no_create': True}" attrs="{'invisible': [('amount', '=', 0)]}"/>
                             <field name="hide_payment_method" invisible="1"/>
                             <field name="payment_method_id" widget="radio" attrs="{'invisible': ['|', ('hide_payment_method', '=', True), ('amount', '=', 0.0)]}"/>
                             <field name="partner_bank_account_id" attrs="{'invisible': [('show_partner_bank_account', '!=', True)], 'required': [('show_partner_bank_account', '=', True)]}" context="{'default_partner_id': partner_id}"/>
@@ -350,7 +350,7 @@
                                     <label for="writeoff_account_id" class="oe_edit_only" string="Post Difference In"/>
                                     <field name="writeoff_account_id" string="Post Difference In" attrs="{'required': [('payment_difference_handling', '=', 'reconcile')]}"/>
                                     <label for="journal_id" string="Journal" attrs="{'invisible': [('amount', '!=', 0)]}"/>
-                                    <field name="journal_id" string="Journal" widget="selection" attrs="{'invisible': [('amount', '!=', 0)]}"/>
+                                    <field name="journal_id" string="Journal" options="{'no_open': True, 'no_create': True}" attrs="{'invisible': [('amount', '!=', 0)]}"/>
                                     <label for="writeoff_label" class="oe_edit_only" string="Label"/>
                                     <field name="writeoff_label" attrs="{'required': [('payment_difference_handling', '=', 'reconcile')]}"/>
                                 </div>

--- a/addons/account/views/account_view.xml
+++ b/addons/account/views/account_view.xml
@@ -15,7 +15,7 @@
                            <group>
                              <field name="code" placeholder="code"/>
                              <field name="name"/>
-                             <field name="user_type_id" widget="selection"/>
+                             <field name="user_type_id" options="{'no_open': True, 'no_create': True}"/>
                              <field name="tax_ids" widget="many2many_tags" domain="[('company_id','=',company_id)]"/>
                              <field name="tag_ids" widget="many2many_tags" domain="[('applicability', '!=', 'taxes')]" context="{'default_applicability': 'accounts'}" options="{'no_create_edit': True}"/>
                              <field name="group_id"/>
@@ -621,7 +621,7 @@
                             <field name="journal_type" invisible="1"/>
                             <field name="cashbox_start_id" invisible="1"/>
                             <field name="cashbox_end_id" invisible="1"/>
-                            <field name="journal_id" domain="[('type', '=', journal_type)]" attrs="{'readonly': [('move_line_count','!=', 0)]}" widget="selection"/>
+                            <field name="journal_id" domain="[('type', '=', journal_type)]" attrs="{'readonly': [('move_line_count','!=', 0)]}" options="{'no_open': True, 'no_create': True}"/>
                             <field name="date" options="{'datepicker': {'warn_future': true}}" />
                             <field name="accounting_date" groups="base.group_no_one"/>
                             <field name='company_id' options="{'no_create': True}" groups="base.group_multi_company" />
@@ -906,7 +906,7 @@
                                     <field name="amount" class="oe_inline"/>
                                     <span class="o_form_label oe_inline" attrs="{'invisible':[('amount_type','!=','percentage')]}">%</span>
                                 </div>
-                                <field name="journal_id" domain="[('type', '!=', 'general'), ('company_id', '=', company_id)]" widget="selection"
+                                <field name="journal_id" domain="[('type', '!=', 'general'), ('company_id', '=', company_id)]" options="{'no_open': True, 'no_create': True}"
                                        attrs="{'invisible': [('rule_type', '!=', 'writeoff_button')]}"/>
                             </group>
                         </group>
@@ -923,7 +923,7 @@
                                 <field name="second_tax_id"
                                        string="Tax"
                                        domain="[('company_id', '=', company_id)]"
-                                       widget="selection"
+                                       options="{'no_open': True, 'no_create': True}"
                                        context="{'append_type_to_tax_name': True}"/>
                                 <field name="is_second_tax_price_included" invisible="1"/>
                                 <field name="second_tax_amount_type" invisible="1"/>
@@ -939,7 +939,7 @@
                                     <field name="second_amount" class="oe_inline"/>
                                     <span class="o_form_label oe_inline" attrs="{'invisible':[('amount_type','!=','percentage')]}">%</span>
                                 </div>
-                                <field name="second_journal_id" string="Journal" domain="[('type', '!=', 'general'), ('company_id', '=', company_id)]" widget="selection"
+                                <field name="second_journal_id" string="Journal" domain="[('type', '!=', 'general'), ('company_id', '=', company_id)]" options="{'no_open': True, 'no_create': True}"
                                        attrs="{'invisible': [('rule_type', '!=', 'writeoff_button')]}"/>
                             </group>
                         </group>
@@ -1888,7 +1888,7 @@
                         <field name="name"/>
                         <field name="code"/>
                         <newline/>
-                        <field name="user_type_id" widget="selection"/>
+                        <field name="user_type_id" options="{'no_open': True, 'no_create': True}"/>
                         <field name="currency_id" options="{'no_create': True}" groups="base.group_multi_currency"/>
                         <field name="tag_ids" domain="[('applicability', '!=', 'taxes')]" widget="many2many_tags" context="{'default_applicability': 'accounts'}"/>
                         <field name="reconcile"/>

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -110,7 +110,7 @@
             <field name="arch" type="xml">
                 <field name="email" position="after">
                     <field name="company_id" invisible="1"/>
-                    <field name="property_payment_term_id" widget="selection"/>
+                    <field name="property_payment_term_id" options="{'no_open': True, 'no_create': True}"/>
                     <field name="property_account_position_id" options="{'no_create': True, 'no_open': True}"/>
                 </field>
             </field>
@@ -231,10 +231,10 @@
                     </group>
                 </xpath>
                 <group name="sale" position="inside">
-                    <field string="Payment Terms" name="property_payment_term_id" widget="selection" groups="account.group_account_invoice"/>
+                    <field string="Payment Terms" name="property_payment_term_id" options="{'no_open': True, 'no_create': True}" groups="account.group_account_invoice"/>
                 </group>
                 <group name="purchase" position="inside">
-                    <field string="Payment Terms" name="property_supplier_payment_term_id" widget="selection" groups="account.group_account_invoice"/>
+                    <field string="Payment Terms" name="property_supplier_payment_term_id" options="{'no_open': True, 'no_create': True}" groups="account.group_account_invoice"/>
                 </group>
             </field>
         </record>

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -32,7 +32,7 @@
                                         <div class="content-group">
                                             <div class="row mt16">
                                                 <label for="chart_template_id" string="Package" class="col-lg-3 o_light_label"/>
-                                                <field name="chart_template_id" widget="selection"/>
+                                                <field name="chart_template_id" options="{'no_open': True, 'no_create': True}"/>
                                             </div>
                                             <div>
                                                 <button name="%(account.open_account_charts_modules)d" icon="fa-arrow-right" type="action" string="Install More Packages" class="btn-link"/>

--- a/addons/account/wizard/wizard_tax_adjustments_view.xml
+++ b/addons/account/wizard/wizard_tax_adjustments_view.xml
@@ -15,7 +15,7 @@
                     <field name="adjustment_type"/>
                 </group>
                 <group>
-                    <field name="tax_id" widget="selection"/>
+                    <field name="tax_id" options="{'no_open': True, 'no_create': True}"/>
                 </group>
                 <group string="Accounts">
                     <field name="debit_account_id"/>

--- a/addons/account_voucher/views/account_voucher_views.xml
+++ b/addons/account_voucher/views/account_voucher_views.xml
@@ -129,7 +129,7 @@
                     <separator/>
                     <filter string="To Review" name="toreview" domain="[('state','=','posted')]" help="To Review"/>
                     <field name="partner_id" filter_domain="[('partner_id', 'child_of', self)]"/>
-                    <field name="journal_id" widget="selection" context="{'journal_id': self, 'set_visible':False}" /> <!-- Keep widget=selection on this field to pass numeric `self` value, which is not the case for regular m2o widgets! -->
+                    <field name="journal_id" options="{'no_open': True, 'no_create': True}" context="{'journal_id': self, 'set_visible':False}" /> <!-- Keep widget=selection on this field to pass numeric `self` value, which is not the case for regular m2o widgets! -->
                     <group expand="0" string="Group By">
                         <filter string="Partner" name="partner" domain="[]" context="{'group_by':'partner_id'}"/>
                         <filter string="Journal" name="journal" domain="[]" context="{'group_by':'journal_id'}"/>
@@ -179,7 +179,7 @@
                     <filter string="Draft" name="draft" domain="[('state','=','draft')]" help="Draft Vouchers"/>
                     <filter string="Posted" name="posted" domain="[('state','=','posted')]" help="Posted Vouchers"/>
                     <field name="partner_id" string="Vendor" filter_domain="[('partner_id','child_of',self)]"/>
-                    <field name="journal_id" widget="selection" context="{'journal_id': self, 'set_visible':False}" domain="[('type','=','purchase')]"/> <!-- Keep widget=selection on this field to pass numeric `self` value, which is not the case for regular m2o widgets! -->
+                    <field name="journal_id" options="{'no_open': True, 'no_create': True}" context="{'journal_id': self, 'set_visible':False}" domain="[('type','=','purchase')]"/> <!-- Keep widget=selection on this field to pass numeric `self` value, which is not the case for regular m2o widgets! -->
                     <group expand="0" string="Group By">
                         <filter string="Vendor" name="vendor" domain="[]" context="{'group_by':'partner_id'}"/>
                         <filter string="Journal" name="journal" domain="[]" context="{'group_by':'journal_id'}"/>
@@ -200,7 +200,7 @@
                     <filter string="Draft" name="darft" domain="[('state','=','draft')]" help="Draft Vouchers"/>
                     <filter string="Posted" name="posted" domain="[('state','=','posted')]" help="Posted Vouchers"/>
                     <field name="partner_id" string="Customer" filter_domain="[('partner_id','child_of',self)]"/>
-                    <field name="journal_id" widget="selection" context="{'journal_id': self, 'set_visible':False}" domain="[('type','=','sale')]"/> <!-- Keep widget=selection on this field to pass numeric `self` value, which is not the case for regular m2o widgets! -->
+                    <field name="journal_id" options="{'no_open': True, 'no_create': True}" context="{'journal_id': self, 'set_visible':False}" domain="[('type','=','sale')]"/> <!-- Keep widget=selection on this field to pass numeric `self` value, which is not the case for regular m2o widgets! -->
                     <group expand="0" string="Group By">
                         <filter string="Customer" name="customer" domain="[]" context="{'group_by':'partner_id'}"/>
                         <filter string="Journal" name="journal" domain="[]" context="{'group_by':'journal_id'}"/>
@@ -242,7 +242,7 @@
                         <group>
                             <field name="journal_id"
                                    domain="[('type','=','sale')]"
-                                   widget="selection"
+                                   options="{'no_open': True, 'no_create': True}"
                                    groups="account.group_account_user"/>
                             <field name="date"/>
                             <field name="date_due" attrs="{'invisible':[('pay_now','=','pay_now')]}"/>
@@ -361,7 +361,7 @@
                         <group>
                             <field name="journal_id"
                                    domain="[('type','=','purchase')]"
-                                   widget="selection"
+                                   options="{'no_open': True, 'no_create': True}"
                                    groups="account.group_account_user"/>
                             <field name="date" string="Bill Date"/>
                             <field name="date_due" attrs="{'invisible': [('pay_now', '=', 'pay_now')]}"/>

--- a/addons/crm/report/crm_opportunity_report_views.xml
+++ b/addons/crm/report/crm_opportunity_report_views.xml
@@ -77,10 +77,10 @@
                     <filter string="Date Closed" name="date_closed_filter" date="date_closed"/>
                     <group expand="0" string="Extended Filters">
                         <field name="partner_id" filter_domain="[('partner_id','child_of',self)]"/>
-                        <field name="stage_id" widget="selection" domain="['|', ('team_id', '=', False), ('team_id', '=', 'team_id')]"/>
-                        <field name="campaign_id" widget="selection"/>
-                        <field name="medium_id" widget="selection"/>
-                        <field name="source_id" widget="selection"/>
+                        <field name="stage_id" options="{'no_open': True, 'no_create': True}" domain="['|', ('team_id', '=', False), ('team_id', '=', 'team_id')]"/>
+                        <field name="campaign_id" options="{'no_open': True, 'no_create': True}"/>
+                        <field name="medium_id" options="{'no_open': True, 'no_create': True}"/>
+                        <field name="source_id" options="{'no_open': True, 'no_create': True}"/>
                         <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
                         <newline/>
                         <field name="create_date"/>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -103,7 +103,7 @@
                         <group>
                             <field name="user_id" domain="[('share', '=', False)]"
                                 context="{'default_groups_ref': ['base.group_user', 'base.group_partner_manager', 'sales_team.group_sale_salesman_all_leads'], 'team_id': team_id}"/>
-                            <field name="team_id" widget="selection" domain="[('use_leads','=',True)]"/>
+                            <field name="team_id" options="{'no_open': True, 'no_create': True}" domain="[('use_leads','=',True)]"/>
                             <field name="type" invisible="1"/>
                         </group>
                         <group>
@@ -554,7 +554,7 @@
 
                             <group>
                                 <field name="user_id" context="{'default_groups_ref': ['base.group_user', 'base.group_partner_manager', 'sales_team.group_sale_salesman_all_leads'], 'team_id': team_id}" domain="[('share', '=', False)]"/>
-                                <field name="team_id" widget="selection"/>
+                                <field name="team_id" options="{'no_open': True, 'no_create': True}"/>
                             </group>
                             <group>
                                 <field name="priority" widget="priority"/>

--- a/addons/crm/wizard/crm_lead_to_opportunity_views.xml
+++ b/addons/crm/wizard/crm_lead_to_opportunity_views.xml
@@ -11,7 +11,7 @@
                     </group>
                     <group string="Assign this opportunity to">
                         <field name="user_id" domain="[('share', '=', False)]"/>
-                        <field name="team_id" widget="selection"/>
+                        <field name="team_id" options="{'no_open': True, 'no_create': True}"/>
                     </group>
                     <group string="Opportunities" attrs="{'invisible': [('name', '!=', 'merge')]}">
                         <field name="opportunity_ids" nolabel="1">

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -72,7 +72,7 @@
                             <label for="quantity"/>
                             <div>
                                 <field name="quantity" class="oe_inline"/>
-                                <field name="product_uom_id" widget="selection" class="oe_inline" groups="uom.group_uom"/>
+                                <field name="product_uom_id" options="{'no_open': True, 'no_create': True}" class="oe_inline" groups="uom.group_uom"/>
                             </div>
                             <field name="tax_ids" domain="[('type_tax_use', '=', 'purchase')]" widget="many2many_tags" groups="account.group_account_user"/>
                         </group><group>

--- a/addons/hr_expense/wizard/hr_expense_sheet_register_payment.xml
+++ b/addons/hr_expense/wizard/hr_expense_sheet_register_payment.xml
@@ -13,7 +13,7 @@
                         <group>
                             <group>
                                 <field name="partner_id" required="1" context="{'default_is_company': True, 'default_supplier': True}"/>
-                                <field name="journal_id" widget="selection"/>
+                                <field name="journal_id" options="{'no_open': True, 'no_create': True}"/>
                                 <field name="hide_payment_method" invisible="1"/>
                                 <field name="payment_method_id" widget="radio" attrs="{'invisible': [('hide_payment_method', '=', True)]}"/>
                                 <field name="show_partner_bank_account" invisible="1"/>

--- a/addons/l10n_in_hr_payroll/report/payment_advice_report_view.xml
+++ b/addons/l10n_in_hr_payroll/report/payment_advice_report_view.xml
@@ -46,7 +46,7 @@
                 <newline/>
                  <group expand="0" string="Extended Filters...">
                     <field name="ifsc_code"/>
-                    <field name="bank_id" widget="selection"/>
+                    <field name="bank_id" options="{'no_open': True, 'no_create': True}"/>
                     <field name="employee_bank_no"/>
                     <separator orientation="vertical"/>
                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>

--- a/addons/mass_mailing/views/mass_mailing_views.xml
+++ b/addons/mass_mailing/views/mass_mailing_views.xml
@@ -600,7 +600,7 @@
                             </div>
                             <label for="mailing_model_id" string="Recipients"/>
                             <div>
-                                <field name="mailing_model_id" widget="selection"/>
+                                <field name="mailing_model_id" options="{'no_open': True, 'no_create': True}"/>
                                 <field name="mailing_model_name" invisible="1"/>
                                 <field name="mailing_model_real" invisible="1"/>
                                 <field name="mailing_domain" widget="domain"

--- a/addons/membership/wizard/membership_invoice_views.xml
+++ b/addons/membership/wizard/membership_invoice_views.xml
@@ -7,7 +7,7 @@
             <field name="arch" type="xml">
                 <form string="Membership Invoice">
                     <group>
-                        <field name="product_id" domain="[('membership','=',True)]" widget="selection"/>
+                        <field name="product_id" domain="[('membership','=',True)]" options="{'no_open': True, 'no_create': True}"/>
                         <field name="member_price"/>
                     </group>
                     <footer>

--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -451,7 +451,7 @@
                 <group>
                     <group>
                         <field name="name"/>
-                        <field name="loss_id" widget="selection"/>
+                        <field name="loss_id" options="{'no_open': True, 'no_create': True}"/>
                     </group>
                 </group>
             </form>

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -80,7 +80,7 @@
             <tree string="Work Orders" delete="0" create="0" decoration-success="date_planned_start&gt;=current_date and state == 'ready'" decoration-muted="state in ('done','cancel')" decoration-danger="date_planned_start&lt;current_date and state in ('ready')">
                 <field name="name"/>
                 <field name="date_planned_start"/>
-                <field name="workcenter_id" widget="selection"/>
+                <field name="workcenter_id" options="{'no_open': True, 'no_create': True}"/>
                 <field name="production_id"/>
                 <field name="product_id"/>
                 <field name="qty_production"/>

--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -461,7 +461,7 @@
                                 </div>
                                 <div class="content-group">
                                     <div class="row mt16" title="Whenever you close a session, one entry is generated in the following accounting journal for all the orders not invoiced. Invoices are recorded in accounting separately.">
-                                        <label string="Sales Journal" for="journal_id" class="col-lg-3 o_light_label" widget="selection"/>
+                                        <label string="Sales Journal" for="journal_id" class="col-lg-3 o_light_label" options="{'no_open': True, 'no_create': True}"/>
                                         <field name="journal_id"/>
                                     </div>
                                     <div class="row" groups="account.group_account_user" title="Get one journal item per product rather than one journal item per receipt line. This works for any anonymous order. If the customer is set on the order, one journal item is created for each receipt line. This option is recommended for an easy review of your journal entries when managing lots of orders.">

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -88,7 +88,7 @@
                     <page name="extra" string="Extra Info">
                         <group string="General Information">
                             <field name="company_id" groups="base.group_multi_company"/>
-                            <field name="location_id" widget="selection" groups="stock.group_stock_multi_locations"/>
+                            <field name="location_id" options="{'no_open': True, 'no_create': True}"  groups="stock.group_stock_multi_locations"/>
                             <field name="user_id"/>
                             <field name="pricelist_id" groups="product.group_sale_pricelist"/>
                             <field name="picking_id" readonly="1"/>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -194,7 +194,7 @@
                 <separator/>
                 <filter string="Archived" name="inactive" domain="[('active','=',False)]"/>
                 <field string="Attributes" name="attribute_line_ids" groups="product.group_product_variant"/>
-                <field name="pricelist_id" widget="selection" context="{'pricelist': self}" filter_domain="[]" groups="product.group_sale_pricelist"/> <!-- Keep widget=selection on this field to pass numeric `self` value, which is not the case for regular m2o widgets! -->
+                <field name="pricelist_id" options="{'no_open': True, 'no_create': True}" context="{'pricelist': self}" filter_domain="[]" groups="product.group_sale_pricelist"/> <!-- Keep widget=selection on this field to pass numeric `self` value, which is not the case for regular m2o widgets! -->
                 <separator/>
                 <filter string="Late Activities" name="activities_overdue"
                     domain="[('activity_ids.date_deadline', '&lt;', context_today().strftime('%Y-%m-%d'))]"

--- a/addons/product/wizard/product_price_list_views.xml
+++ b/addons/product/wizard/product_price_list_views.xml
@@ -8,7 +8,7 @@
               <field name="arch" type="xml">
                 <form string="Price List">
                     <group string="Calculate Product Price per Unit Based on Pricelist Version.">
-                        <field name="price_list" widget="selection"/>
+                        <field name="price_list" options="{'no_open': True, 'no_create': True}"/>
                         <field name="qty1"/>
                         <field name="qty2"/>
                         <field name="qty3"/>

--- a/addons/purchase_requisition/views/purchase_requisition_views.xml
+++ b/addons/purchase_requisition/views/purchase_requisition_views.xml
@@ -169,7 +169,7 @@
                     <group>
                         <field name="is_quantity_copy" invisible='1'/>
                         <field name="user_id" attrs="{'readonly': [('state','not in',('draft','in_progress','open'))]}"/>
-                        <field name="type_id" attrs="{'readonly': [('state','!=','draft')]}" widget="selection"/>
+                        <field name="type_id" attrs="{'readonly': [('state','!=','draft')]}" options="{'no_open': True, 'no_create': True}"/>
                         <field name="vendor_id" context="{'search_default_supplier':1, 'default_supplier':1, 'default_customer':0}" domain="[('supplier','=',True)]" attrs="{'required': [('is_quantity_copy', '=', 'none')], 'readonly': [('state', 'in', ['ongoing','done'])]}"/>
                         <field name="currency_id" groups="base.group_multi_currency"/>
                     </group>
@@ -178,7 +178,7 @@
                         <field name="ordering_date" attrs="{'readonly': [('state','not in',('draft','in_progress','open','ongoing'))]}"/>
                         <field name="schedule_date" attrs="{'readonly': [('state','not in',('draft','in_progress','open','ongoing'))]}"/>
                         <field name="origin" placeholder="e.g. PO0025" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
-                        <field name="picking_type_id" widget="selection" groups="stock.group_adv_location" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
+                        <field name="picking_type_id" options="{'no_open': True, 'no_create': True}" groups="stock.group_adv_location" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
                         <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" attrs="{'readonly': [('state','not in',('draft'))]}"/>
                     </group>
                 </group>

--- a/addons/sale_stock/views/account_invoice_views.xml
+++ b/addons/sale_stock/views/account_invoice_views.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <data>
                 <xpath expr="//page[@name='other_info']//field[@name='origin']" position="after">
-                <field name="incoterms_id" widget="selection" groups="sale_stock.group_display_incoterm" invisible="1"/>
+                <field name="incoterms_id" options="{'no_open': True, 'no_create': True}" groups="sale_stock.group_display_incoterm" invisible="1"/>
                 </xpath>
             </data>
         </field>

--- a/addons/sale_stock/views/sale_order_views.xml
+++ b/addons/sale_stock/views/sale_order_views.xml
@@ -21,7 +21,7 @@
                 </xpath>
                 <xpath expr="//field[@name='expected_date']" position="before">
                     <field name="warehouse_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
-                    <field name="incoterm" widget="selection" groups="sale_stock.group_display_incoterm"/>
+                    <field name="incoterm" options="{'no_open': True, 'no_create': True}" groups="sale_stock.group_display_incoterm"/>
                     <field name="picking_policy" required="True"/>
                 </xpath>
                 <xpath expr="//field[@name='commitment_date']" position="after">

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -65,8 +65,8 @@
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='pricelist_id']" position="after">
                     <separator/>
-                    <field name="location_id" widget="selection" context="{'location': self}" filter_domain="[]"/>
-                    <field name="warehouse_id" widget="selection" context="{'warehouse': self}" filter_domain="[]"/>
+                    <field name="location_id" options="{'no_open': True, 'no_create': True}" context="{'location': self}" filter_domain="[]"/>
+                    <field name="warehouse_id" options="{'no_open': True, 'no_create': True}" context="{'warehouse': self}" filter_domain="[]"/>
                     <separator/>
                     <filter name="real_stock_available" string="Available Products" domain="[('qty_available','&gt;',0)]"/>
                     <filter name="real_stock_negative" string="Negative Forecasted Quantity" domain="[('virtual_available','&lt;',0)]"/>
@@ -150,8 +150,8 @@
             <field name="inherit_id" ref="product.product_search_form_view"/>
             <field name="arch" type="xml">
                 <field name="pricelist_id" position="before">
-                    <field name="location_id" widget="selection" context="{'location': self}"/>
-                    <field name="warehouse_id" widget="selection" context="{'warehouse': self}"/>
+                    <field name="location_id" options="{'no_open': True, 'no_create': True}" context="{'location': self}"/>
+                    <field name="warehouse_id" options="{'no_open': True, 'no_create': True}" context="{'warehouse': self}"/>
                 </field>
             </field>
         </record>

--- a/addons/stock/views/stock_warehouse_views.xml
+++ b/addons/stock/views/stock_warehouse_views.xml
@@ -215,7 +215,7 @@
                                 <field name="product_id"/>
                             </group>
                             <group>
-                                <field name="warehouse_id" widget="selection" groups="stock.group_stock_multi_locations"/>
+                                <field name="warehouse_id" options="{'no_open': True, 'no_create': True}" groups="stock.group_stock_multi_locations"/>
                                 <field name="product_uom" options="{'no_open': True, 'no_create': True}" groups="uom.group_uom"/>
                                 <field name="location_id" groups="stock.group_stock_multi_locations"/>
                                 <field name="group_id" groups="stock.group_adv_location"/>

--- a/addons/stock/wizard/stock_change_product_qty_views.xml
+++ b/addons/stock/wizard/stock_change_product_qty_views.xml
@@ -9,7 +9,7 @@
                     <group>
                         <field name="product_tmpl_id" invisible="1"/>
                         <field name="product_variant_count" invisible="1"/>
-                        <field name="product_id" widget="selection"
+                        <field name="product_id" options="{'no_open': True, 'no_create': True}"
                             domain="[('product_tmpl_id', '=', product_tmpl_id)]"
                             attrs="{'readonly': [('product_variant_count', '=', 1)]}"
                             readonly="context.get('default_product_id')"/>

--- a/addons/website/views/res_config_settings_views.xml
+++ b/addons/website/views/res_config_settings_views.xml
@@ -17,7 +17,7 @@
                                         Settings on this page will apply to this website
                                     </div>
                                     <div class="mt16">
-                                        <field name="website_id" widget="selection"/>
+                                        <field name="website_id" options="{'no_open': True, 'no_create': True}"/>
                                     </div>
                                     <div>
                                         <button name="action_website_create_new" type="object" string="Create a New Website" class="btn-secondary" icon="fa-arrow-right"/>
@@ -74,7 +74,7 @@
                                         <field name="language_count" invisible="1"/>
                                         <div class="mt8" attrs="{'invisible':[('language_count', '&lt;', 2)]}">
                                             <label class="o_light_label mr8" string="Default" for="website_default_lang_id"/>
-                                            <field name="website_default_lang_id" widget="selection" attrs="{'required': [('website_id', '!=', False)]}"/>
+                                            <field name="website_default_lang_id" options="{'no_open': True, 'no_create': True}" attrs="{'required': [('website_id', '!=', False)]}"/>
                                         </div>
                                     </div>
                                     <div>

--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -36,8 +36,8 @@
                         <div name="other">
                             <group name="other">
                                 <group>
-                                    <field name="company_id" widget="selection" groups="base.group_multi_company"/>
-                                    <field name="default_lang_id" widget="selection" groups="base.group_no_one"/>
+                                    <field name="company_id" options="{'no_open': True, 'no_create': True}" groups="base.group_multi_company"/>
+                                    <field name="default_lang_id" options="{'no_open': True, 'no_create': True}" groups="base.group_no_one"/>
                                 </group>
                             </group>
                         </div>

--- a/addons/website_crm_partner_assign/views/res_partner_views.xml
+++ b/addons/website_crm_partner_assign/views/res_partner_views.xml
@@ -123,8 +123,8 @@
                     <group>
                         <group>
                             <separator string="Partner Activation" colspan="2"/>
-                            <field name="grade_id" widget="selection"/>
-                            <field name="activation" widget="selection"/>
+                            <field name="grade_id" options="{'no_open': True, 'no_create': True}"/>
+                            <field name="activation" options="{'no_open': True, 'no_create': True}"/>
                             <field name="partner_weight"/>
                         </group>
                         <group>

--- a/doc/howtos/backend.rst
+++ b/doc/howtos/backend.rst
@@ -1101,7 +1101,7 @@ predefined searches. Filters must have one of the following attributes:
         <field name="description" string="Name and description"
                filter_domain="['|', ('name', 'ilike', self), ('description', 'ilike', self)]"/>
         <field name="inventor_id"/>
-        <field name="country_id" widget="selection"/>
+        <field name="country_id" options="{'no_open': True, 'no_create': True}"/>
 
         <filter name="my_ideas" string="My Ideas"
                 domain="[('inventor_id', '=', uid)]"/>

--- a/odoo/addons/base/views/ir_module_views.xml
+++ b/odoo/addons/base/views/ir_module_views.xml
@@ -81,7 +81,7 @@
                             <group>
                                 <group>
                                     <field name="website" widget="url" attrs="{'invisible':[('website','=',False)]}"/>
-                                    <field name="category_id" widget="selection"/>
+                                    <field name="category_id" options="{'no_open': True, 'no_create': True}"/>
                                     <field name="summary"/>
                                     <field name="to_buy" invisible="1"/>
                                 </group>

--- a/odoo/addons/base/views/res_company_views.xml
+++ b/odoo/addons/base/views/res_company_views.xml
@@ -188,7 +188,7 @@
                             placeholder="e.g. Global Business Solutions" />
                         <field name="report_footer" string="Footer"
                             placeholder="e.g. Opening hours, bank accounts (one per line)" />
-                        <field name="paperformat_id" widget="selection" />
+                        <field name="paperformat_id" options="{'no_open': True, 'no_create': True}" />
                     </group>
                     <footer>
                         <button special="save" string="Save"

--- a/odoo/addons/test_main_flows/static/src/js/tour.js
+++ b/odoo/addons/test_main_flows/static/src/js/tour.js
@@ -512,7 +512,7 @@ tour.register('main_flow_tour', {
     content: _t("Register Payment"),
     position: "bottom",
 }, {
-    trigger: "select.o_field_widget[name=journal_id]",
+    trigger: ".o_field_many2one[name=journal_id]",
     extra_trigger: ".modal-dialog",
     content: _t("Select Journal"),
     position: "bottom",
@@ -654,7 +654,7 @@ tour.register('main_flow_tour', {
     content: _t("Register Payment"),
     position: "bottom",
 }, {
-    trigger: "select.o_field_widget[name=journal_id]",
+    trigger: ".o_field_many2one[name=journal_id]",
     extra_trigger: ".modal-dialog",
     content: _t("Select Journal"),
     position: "bottom",


### PR DESCRIPTION
currently, Across Odoo, there are around 40+ many2one fields defined with a
'selection' widget. Since the many2one widget has options to limit record
creation and opening, there is no reason to define a many2one field with a
selection widget. The selection widget does not allow for searching, and is
limited to 100 records.

PURPOSE
to update the definition of any many2one on which we applied a 'selection'
 widget, and instead use the standard many2one widget with disabled
opening/creation instead.

after this commit,
for each many2one field defined with widget="selection",  widget="selection" is
replaced with options="{'no_open': True, 'no_create': True}"

Task : 2476488

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
