### PR TITLE
[FIX] sale: leave invoice onchanges management to account module

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -489,11 +489,7 @@ class SaleOrder(models.Model):
             .default_get(['journal_id'])['journal_id'])
         if not journal_id:
             raise UserError(_('Please define an accounting sales journal for this company.'))
-        vinvoice = self.env['account.invoice'].new({'partner_id': self.partner_invoice_id.id, 'type': 'out_invoice'})
-        # Get partner extra fields
-        vinvoice._onchange_partner_id()
-        invoice_vals = vinvoice._convert_to_write(vinvoice._cache)
-        invoice_vals.update({
+        return {
             'name': (self.client_order_ref or '')[:2000],
             'origin': self.name,
             'type': 'out_invoice',
@@ -502,14 +498,14 @@ class SaleOrder(models.Model):
             'journal_id': journal_id,
             'currency_id': self.pricelist_id.currency_id.id,
             'comment': self.note,
+            'partner_id': self.partner_invoice_id.id,
             'payment_term_id': self.payment_term_id.id,
             'fiscal_position_id': self.fiscal_position_id.id or self.partner_invoice_id.property_account_position_id.id,
             'company_id': company_id,
             'user_id': self.user_id and self.user_id.id,
             'team_id': self.team_id.id,
             'transaction_ids': [(6, 0, self.transaction_ids.ids)],
-        })
-        return invoice_vals
+        }
 
     @api.multi
     def print_quotation(self):


### PR DESCRIPTION
There is already a logic to trigger onchanges on newly created invoices, with a clean
overridable method.  We shouldn't duplicate this invoice onchange magic in sale, where
it is managed incorrectly (the onchanges are triggered with incomplete record data,
some defaults may be missing, ...)

Fixes #56439

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
