### PR TITLE
[FIX] Aged receivable report: prevent small rest due to rounding issue

### DIFF
--- a/addons/account/report/account_aged_partner_balance.py
+++ b/addons/account/report/account_aged_partner_balance.py
@@ -143,16 +143,17 @@ class ReportAgedPartnerBalance(models.AbstractModel):
                 partner_id = line.partner_id.id or False
                 if partner_id not in partners_amount:
                     partners_amount[partner_id] = 0.0
-                line_amount = line.company_id.currency_id._convert(line.balance, user_currency, user_company, date_from)
+                line_amount = line.company_id.currency_id._convert(line.balance, user_currency, user_company, date_from, round = False)
                 if user_currency.is_zero(line_amount):
                     continue
                 for partial_line in line.matched_debit_ids:
                     if partial_line.max_date <= date_from:
-                        line_amount += partial_line.company_id.currency_id._convert(partial_line.amount, user_currency, user_company, date_from)
+                        line_amount += partial_line.company_id.currency_id._convert(partial_line.amount, user_currency, user_company, date_from, round = False)
                 for partial_line in line.matched_credit_ids:
                     if partial_line.max_date <= date_from:
-                        line_amount -= partial_line.company_id.currency_id._convert(partial_line.amount, user_currency, user_company, date_from)
+                        line_amount -= partial_line.company_id.currency_id._convert(partial_line.amount, user_currency, user_company, date_from, round = False)
 
+                line_amount = user_currency.round(line_amount)
                 if not self.env.company.currency_id.is_zero(line_amount):
                     partners_amount[partner_id] += line_amount
                     lines.setdefault(partner_id, [])
@@ -182,15 +183,16 @@ class ReportAgedPartnerBalance(models.AbstractModel):
             partner_id = line.partner_id.id or False
             if partner_id not in undue_amounts:
                 undue_amounts[partner_id] = 0.0
-            line_amount = line.company_id.currency_id._convert(line.balance, user_currency, user_company, date_from)
+            line_amount = line.company_id.currency_id._convert(line.balance, user_currency, user_company, date_from, round = False)
             if user_currency.is_zero(line_amount):
                 continue
             for partial_line in line.matched_debit_ids:
                 if partial_line.max_date <= date_from:
-                    line_amount += partial_line.company_id.currency_id._convert(partial_line.amount, user_currency, user_company, date_from)
+                    line_amount += partial_line.company_id.currency_id._convert(partial_line.amount, user_currency, user_company, date_from, round = False)
             for partial_line in line.matched_credit_ids:
                 if partial_line.max_date <= date_from:
-                    line_amount -= partial_line.company_id.currency_id._convert(partial_line.amount, user_currency, user_company, date_from)
+                    line_amount -= partial_line.company_id.currency_id._convert(partial_line.amount, user_currency, user_company, date_from, round = False)
+            line_amount = user_currency.round(line_amount)
             if not self.env.company.currency_id.is_zero(line_amount):
                 undue_amounts[partner_id] += line_amount
                 lines.setdefault(partner_id, [])


### PR DESCRIPTION
When two companies with different currency are selected, the Aged Receivable can show "paid" invoices
with few cents like 0.01 or 0.02 due to rounding issue. When we have selected two companies and show
the report, the system will try to convert the values coming from invoices from the second company to
the primary company currency. It sums invoice aml and payment aml to check if they balance each other.
Since all aml are converted and rounded before summing it can introduce a small gap of 1 or 2 cents.

Now we are doing the rounding after the sum to not introduce this gap.

opw-2387600