### PR TITLE
[IMP] (hr, sale)_timesheet, (sale_)project: generic improvements in view

### DIFF
--- a/addons/hr_timesheet/report/project_report.py
+++ b/addons/hr_timesheet/report/project_report.py
@@ -14,15 +14,14 @@ class ReportProjectTaskUser(models.Model):
 
     def _select(self):
         return super(ReportProjectTaskUser, self)._select() + """,
-            progress as progress,
+            (t.effective_hours * 100) / NULLIF(planned_hours, 0) as progress,
             t.effective_hours as hours_effective,
             t.planned_hours - t.effective_hours - t.subtask_effective_hours as remaining_hours,
-            planned_hours as hours_planned"""
+            NULLIF(planned_hours, 0) as hours_planned"""
 
     def _group_by(self):
         return super(ReportProjectTaskUser, self)._group_by() + """,
             remaining_hours,
             t.effective_hours,
-            progress,
             planned_hours
             """

--- a/addons/hr_timesheet/views/project_views.xml
+++ b/addons/hr_timesheet/views/project_views.xml
@@ -246,9 +246,6 @@
                         <a name="%(act_hr_timesheet_line_by_project)d" type="action">Timesheets</a>
                     </div>
                 </xpath>
-                <xpath expr="//div[a[@name='action_view_account_analytic_line']]" position="attributes">
-                    <attribute name="t-if">record.analytic_account_id.raw_value and !record.allow_timesheets.raw_value</attribute>
-                </xpath>
             </field>
         </record>
 

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -450,13 +450,6 @@ class Project(models.Model):
         action['display_name'] = self.name
         return action
 
-    def action_view_account_analytic_line(self):
-        """ return the action to see all the analytic lines of the project's analytic account """
-        action = self.env["ir.actions.actions"]._for_xml_id("analytic.account_analytic_line_action")
-        action['context'] = {'default_account_id': self.analytic_account_id.id}
-        action['domain'] = [('account_id', '=', self.analytic_account_id.id)]
-        return action
-
     def action_view_all_rating(self):
         """ return the action to see all the rating of the project and activate default filters"""
         action = self.env['ir.actions.act_window']._for_xml_id('project.rating_rating_action_view_project_rating')

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -232,13 +232,11 @@
             <field name="arch" type="xml">
                 <form string="Project" delete="0">
                     <header>
-                        <button name="%(portal.portal_share_action)d" string="Share" type="action" class="oe_highlight oe_read_only" groups="project.group_project_manager"/>
+                        <button name="%(portal.portal_share_action)d" string="Share" type="action" class="oe_highlight oe_read_only" groups="project.group_project_manager"
+                        attrs="{'invisible': [('privacy_visibility', '!=', 'portal')]}"/>
                     </header>
                 <sheet string="Project">
                     <div class="oe_button_box" name="button_box" groups="base.group_user">
-                        <button  class="oe_stat_button" name="attachment_tree_view" type="object" icon="fa-file-text-o">
-                            <field string="Documents" name="doc_count" widget="statinfo"/>
-                        </button>
                         <button class="oe_stat_button" type="action"
                             name="%(act_project_project_2_project_task_all)d" icon="fa-tasks">
                             <field string="Tasks In Progress" name="task_count" widget="statinfo" options="{'label_field': 'label_tasks'}"/>
@@ -517,6 +515,7 @@
                     <field name="analytic_account_id"/>
                     <field name="date"/>
                     <field name="doc_count"/>
+                    <field name="privacy_visibility"/>
                     <templates>
                         <t t-name="kanban-box">
                             <div t-attf-class="#{kanban_color(record.color.raw_value)} oe_kanban_global_click o_has_icon">
@@ -569,9 +568,6 @@
                                                 <div role="menuitem">
                                                     <a name="%(action_project_task_burndown_chart_report)d" type="action">Burndown Chart</a>
                                                 </div>
-                                                <div role="menuitem" t-if="record.analytic_account_id.raw_value" groups="analytic.group_analytic_accounting">
-                                                    <a name="action_view_account_analytic_line" type="object">Profitability</a>
-                                                </div>
                                             </div>
                                         </div>
                                         <div class="o_kanban_card_manage_settings row" groups="project.group_project_manager">
@@ -579,7 +575,7 @@
                                                 <ul class="oe_kanban_colorpicker" data-field="color" role="popup"/>
                                             </div>
                                             <div role="menuitem" class="col-4">
-                                                <a class="dropdown-item" role="menuitem" name="%(portal.portal_share_action)d" type="action">Share</a>
+                                                <a t-if="record.privacy_visibility.raw_value == 'portal'" class="dropdown-item" role="menuitem" name="%(portal.portal_share_action)d" type="action">Share</a>
                                                 <a class="dropdown-item" role="menuitem" type="edit">Edit</a>
                                             </div>
                                         </div>
@@ -852,7 +848,7 @@
             <field name="arch" type="xml">
                 <form>
                     <group>
-                        <field name="name" string = "Task Title"/>
+                        <field name="name" string = "Task Title" placeholder="e.g. New Design"/>
                         <field name="user_id" options="{'no_open': True,'no_create': True}" domain="[('share', '=', False)]"/>
                         <field name="company_id" invisible="1"/>
                         <field name="parent_id" invisible="1" groups="base.group_no_one"/>
@@ -982,7 +978,7 @@
                     <field name="date_deadline" optional="hide" widget="remaining_days" attrs="{'invisible': [('is_closed', '=', True)]}"/>
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="show"/>
                     <field name="kanban_state" widget="state_selection" optional="hide" readonly="1"/>
-                    <field name="stage_id" invisible="context.get('set_visible',False)" optional="show" readonly="1"/>
+                    <field name="stage_id" invisible="context.get('set_visible',False)" optional="show" readonly="not context.get('default_project_id')"/>
                     <field name="recurrence_id" invisible="1" />
                 </tree>
             </field>

--- a/addons/sale_project/models/product.py
+++ b/addons/sale_project/models/product.py
@@ -9,7 +9,7 @@ class ProductTemplate(models.Model):
     _inherit = 'product.template'
 
     service_tracking = fields.Selection([
-        ('no', 'Don\'t create task'),
+        ('no', 'Don\'t create a task'),
         ('task_global_project', 'Create a task in an existing project'),
         ('task_in_project', 'Create a task in sales order\'s project'),
         ('project_only', 'Create a new project but no task')],

--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -102,9 +102,6 @@ class SaleOrder(models.Model):
 
     def action_view_project_ids(self):
         self.ensure_one()
-        if len(self.project_ids) == 1 and self.project_overview:
-            return self.project_id.action_view_account_analytic_line()
-
         view_form_id = self.env.ref('project.edit_project').id
         view_kanban_id = self.env.ref('project.view_project_kanban').id
         action = {

--- a/addons/sale_timesheet/static/src/scss/sale_timesheet.scss
+++ b/addons/sale_timesheet/static/src/scss/sale_timesheet.scss
@@ -17,6 +17,14 @@ $canceled-color: gray;
         text-align: right;
         float: none;
         width: auto;
+        box-shadow: unset;
+        margin-left: -$o-horizontal-padding - 1;
+        @include media-breakpoint-between(lg, xl, $o-extra-grid-breakpoints) {
+            margin-left: (-$o-horizontal-padding*2) - 1;
+        }
+        > .btn.oe_stat_button {
+            border-bottom: 1px solid #ced4da;
+        }
     }
 
     .o_profitability_wrapper {

--- a/addons/sale_timesheet/views/hr_timesheet_templates.xml
+++ b/addons/sale_timesheet/views/hr_timesheet_templates.xml
@@ -22,7 +22,7 @@
                     <div class="o_timesheet_plan_sale_timesheet">
                         <div class="o_timesheet_plan_sale_timesheet_dashboard">
 
-                            <div class="o_timesheet_plan_stat_buttons oe_button_box o_not_full">
+                            <div class="o_timesheet_plan_stat_buttons oe_button_box o_not_full d-flex justify-content-end flex-row flex-wrap">
                                 <t t-foreach="stat_buttons" t-as="stat_button">
                                     <a class="btn oe_stat_button"
                                        type="action"

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -91,9 +91,6 @@
                 <field name="sale_order_id" invisible="1"/>
                 <field name="pricing_type" invisible="1"/>
             </xpath>
-            <xpath expr="//div[a[@name='action_view_account_analytic_line']]" position="attributes">
-                <attribute name="t-if">record.analytic_account_id.raw_value and !record.allow_timesheets.raw_value and record.allow_billable.raw_value</attribute>
-            </xpath>
             <xpath expr="//div[hasclass('o_kanban_manage_reporting')]" position="inside">
                 <div t-if="record.allow_timesheets.raw_value and record.allow_billable.raw_value" role="menuitem" groups="project.group_project_manager">
                     <a name="action_view_timesheet" type="object">Costs / Revenues</a>


### PR DESCRIPTION
Purpose of this PR is to do the generic improvement for the
refactoring of some module's view.

So in this commit, done the following changes:
- Reporting > Tasks Analysis , average progress of each task display correctly
- In project overview:
  - state button is fit correctly in report view
- In task quick create, added placeholder for name field
- In Product form view:
  - service_tarcking field: rename 'don't create task' into 'don't create a task'
  - display the share button if privacy_visibility should be portal
  - remove the 'Documents' stat button
- In Tasks list view, allow users to edit the stage of the task in batch if the project is in the context
- In project kanban view, remove the 'profitability' link and the corresponding stat button on sale.order

task-2458123

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
