### PR TITLE
[FIX] crm: lead merged into opportunity should not erase the salesteam

### DIFF
--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -497,11 +497,12 @@ class Team(models.Model):
                     leads_assigned += lead
                     leads_done_ids.add(lead.id)
 
-        leads_assigned._handle_salesmen_assignment(user_ids=None, team_id=self.id)
+        duplicates_to_assign = self.env['crm.lead'].union(*leads_dups_dict.keys())
+        (leads_assigned | duplicates_to_assign)._handle_salesmen_assignment(user_ids=None, team_id=self.id)
 
         for lead in leads.filtered(lambda lead: lead in leads_dups_dict):
             lead_duplicates = leads_dups_dict[lead]
-            merged = lead_duplicates._merge_opportunity(user_id=False, team_id=self.id, max_length=0)
+            merged = lead_duplicates._merge_opportunity(user_id=False, team_id=False, max_length=0)
             leads_dup_ids.update((lead_duplicates - merged).ids)
             leads_merged_ids.add(merged.id)
 


### PR DESCRIPTION
Problem
-------
New lead are automatically assigned to sales team and salesman.
Some of the lead are duplicates of existing opportunity.

If a new lead is merged into an existing opportunity, the opportunity
is the master data and the lead is duplicated. The opportunity
should keep its current sales team assignment.

Before this commit, the merge was forcing the crm team to
the 'current' crm team during auto assignment and thus
it was changing the team of the opportunity

Solution
--------
Assign team to lead to merge before the merge and do not force
the crm team during merge process.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
