### PR TITLE
[FIX] project: display right color on 'deadline' date

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -628,10 +628,10 @@
                                         <t t-set="date_format" t-value="'MM/DD/YY'" />
                                         <t t-set="date" t-value=""/>
                                         <!-- color of the span -->
-                                        <t t-if="record.date_deadline.raw_value and moment(record.date_deadline.raw_value.toISOString()).startOf('day') lt moment().startOf('day')">
+                                        <t t-if="record.date_deadline.raw_value and moment(record.date_deadline.raw_value.toISOString()).utc().startOf('day') lt moment().utc().startOf('day')">
                                             <t t-set="deadline_class" t-value="'oe_kanban_text_red'" />
                                         </t>
-                                        <t t-elif="record.date_deadline.raw_value and moment(record.date_deadline.raw_value.toISOString()).startOf('day') lt moment().endOf('day')">
+                                        <t t-elif="record.date_deadline.raw_value and moment(record.date_deadline.raw_value.toISOString()).utc().startOf('day') lt moment().utc().endOf('day')">
                                             <t t-set="deadline_class" t-value="'text-warning font-weight-bold'" />
                                         </t>
                                         <!-- Date value -->


### PR DESCRIPTION
Issue

	- Install 'Project' module
	- Set user timezone to 'US/Pacific'
	- Change (if needed) browser timezone to 'San Fransisco'
	- Create a new task and set deadline date to today
	- Go back to list kanban view

	The new task have deadline date in 'red' (instead of 'yellow')

Solution

	Compare dates (record value and moment start/end of day) as utc dates.

opw-2480482