### PR TITLE
[FIX] base: js_transpiler import legacy file

### DIFF
--- a/odoo/addons/test_assetsbundle/tests/test_js_transpiler.py
+++ b/odoo/addons/test_assetsbundle/tests/test_js_transpiler.py
@@ -255,7 +255,10 @@ import Line12  from "@test.Dialog"; //HELLO
 import {Line13}  from "@test.Dialog" //HELLO
 
 
-const test = `import { Line13, Notification } from "../src/Dialog";`
+const test = `import { Line14, Notification } from "../src/Dialog";`
+
+import Line15 from "test/Dialog";
+import Line16 from "test.Dialog.error";
 """
         result = transpile_javascript("/test_assetsbundle/static/src/import.js", input_content)
 
@@ -284,7 +287,10 @@ const Line12 = require("@test.Dialog")[Symbol.for("default")]; //HELLO
 const {Line13} = require("@test.Dialog") //HELLO
 
 
-const test = `import { Line13, Notification } from "../src/Dialog";`
+const test = `import { Line14, Notification } from "../src/Dialog";`
+
+const Line15 = require("test/Dialog");
+const Line16 = require("test.Dialog.error");
 
 return __exports;
 });


### PR DESCRIPTION
In a @odoo-module js file, importing a legacy file that did not have
a key respecting the "module.name" format was not supported.

This commit will support all keys that do not start with a "." or "@".

Supported:
    import X from "some/path"
    import X from "module.name"

Not supported:
    import X from "@some/path"
    import X from "./some/path"
    import X from "../../some/path"

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
