### PR TITLE
[FIX] mail: unfollow only if the partner is in the channel

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -322,6 +322,9 @@ class Channel(models.Model):
         return self._action_unfollow(self.env.user.partner_id)
 
     def _action_unfollow(self, partner):
+        self.message_unsubscribe(partner.ids)
+        if partner not in self.with_context(active_test=False).channel_partner_ids:
+            return True
         channel_info = self.channel_info('unsubscribe')[0]  # must be computed before leaving the channel (access rights)
         result = self.write({'channel_partner_ids': [(3, partner.id)]})
         # side effect of unsubscribe that wasn't taken into account because


### PR DESCRIPTION
Before the commit, `_action_unfollow()` can be called by `_message_receive_bounce()` and then multiple leave notifications can be sent even if the partner has been removed from the channel, when the partner is a follower of the channel and without a valid email address.

Unfollow action should also remove the partner from the followers, and only be processed if the partner is still a member of the channel.

Task id: 2456233
