### PR TITLE
[FIX] base: View error reporting can lack a context

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -390,10 +390,12 @@ actual arch.
                     continue
                 view_doc = etree.fromstring(view_arch_utf8)
             except ValueError as e:
-                raise ValidationError(_(
+                err = ValidationError(_(
                     "Error while validating view:\n\n%(error)s",
                     error=tools.ustr(e),
-                )).with_traceback(e.__traceback__) from None
+                )).with_traceback(e.__traceback__)
+                err.context = None
+                raise err from None
 
             try:
                 # verify that all fields used are valid, etc.

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -684,7 +684,7 @@ form: module.record_id""" % (xml_id,)
                 msg = "while parsing {file}:{viewline}\n{err}\n\nView error context:\n{context}\n".format(
                     file=rec.getroottree().docinfo.URL,
                     viewline=rec.sourceline,
-                    context=pprint.pformat(err.context),
+                    context=pprint.pformat(getattr(err, 'context', None) or '-no context-'),
                     err=err.args[0],
                 )
                 _logger.debug(msg, exc_info=True)


### PR DESCRIPTION
A context is attached to the ValidationError object when elements in the
view arch are broken. This context helps to locate the error in the
source file. When the view processing fails outside of the arch
evaluation, such context is missing.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
