### PR TITLE
[IMP] core: New 'capture_trigger' test helper

### DIFF
--- a/addons/mass_mailing/tests/test_mailing_internals.py
+++ b/addons/mass_mailing/tests/test_mailing_internals.py
@@ -6,6 +6,7 @@ from datetime import datetime
 
 from freezegun import freeze_time
 
+from odoo.addons.base.tests.test_ir_cron import CronMixinCase
 from odoo.addons.mass_mailing.tests.common import MassMailCommon
 from odoo.tests.common import users, Form
 from odoo.tools import formataddr, mute_logger
@@ -125,7 +126,7 @@ class TestMassMailValues(MassMailCommon):
         self.assertEqual(mailing_form.mailing_model_real, 'res.partner')
 
 
-class TestMassMailFeatures(MassMailCommon):
+class TestMassMailFeatures(MassMailCommon, CronMixinCase):
 
     @classmethod
     def setUpClass(cls):
@@ -176,7 +177,7 @@ class TestMassMailFeatures(MassMailCommon):
         """ Technical test to ensure the cron is triggered at the correct
         time """
 
-        ir_cron_triggers = self.env['ir.cron.trigger'].sudo()
+        cron_id = self.env.ref('mass_mailing.ir_cron_mass_mailing_queue').id
         partner = self.env['res.partner'].create({
             'name': 'Jean-Alphonce',
             'email': 'jeanalph@example.com',
@@ -196,17 +197,14 @@ class TestMassMailFeatures(MassMailCommon):
         with freeze_time(now):
             for (test, truth) in [(False, now), (then, then)]:
                 with self.subTest(schedule_date=test):
-                    triggers_before = ir_cron_triggers.search([])
-                    mailing = self.env['mailing.mailing'].create({
-                        **common_mailing_values,
-                        'schedule_date': test,
-                    })
-                    mailing.action_put_in_queue()
-
-                    triggers_after = ir_cron_triggers.search([])
-                    new_triggers = triggers_after - triggers_before
-                    new_triggers.ensure_one()
-                    self.assertLessEqual(new_triggers.call_at, truth)
+                    with self.capture_triggers(cron_id) as capt:
+                        mailing = self.env['mailing.mailing'].create({
+                            **common_mailing_values,
+                            'schedule_date': test,
+                        })
+                        mailing.action_put_in_queue()
+                    capt.records.ensure_one()
+                    self.assertLessEqual(capt.records.call_at, truth)
 
     @users('user_marketing')
     @mute_logger('odoo.addons.mail.models.mail_mail')

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -148,6 +148,27 @@ def new_test_user(env, login='', groups='base.group_user', context=None, **kwarg
 
     return env['res.users'].with_context(**context).create(create_values)
 
+
+class RecordCapturer:
+    def __init__(self, model, domain):
+        self._model = model
+        self._domain = domain
+
+    def __enter__(self):
+        self._before = self._model.search(self._domain)
+        self._after = None
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        if exc_type is None:
+            self._after = self._model.search(self._domain) - self._before
+
+    @property
+    def records(self):
+        if self._after is None:
+            return self._model.search(self._domain) - self._before
+        return self._after
+
 # ------------------------------------------------------------
 # Main classes
 # ------------------------------------------------------------


### PR DESCRIPTION
When testing cron triggers, it is common to get the newly created
triggers in order to validate they exist and are scheduled are the right
moment.

This new helper is a context manager that capture all triggers or
triggers created for a specific cron. The created triggers are
accessible via the context's object `triggers` recordset attribute.

The various tests have been updated so they use that new helper.