### PR TITLE
[FIX] website: _handle_exception takes only two arguments

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -197,7 +197,7 @@ class Website(Home):
         try:
             request.website.get_template('website.website_info').name
         except Exception as e:
-            return request.env['ir.http']._handle_exception(e, 404)
+            return request.env['ir.http']._handle_exception(e)
         Module = request.env['ir.module.module'].sudo()
         apps = Module.search([('state', '=', 'installed'), ('application', '=', True)])
         modules = Module.search([('state', '=', 'installed'), ('application', '=', False)])

--- a/doc/cla/corporate/itpp-labs.md
+++ b/doc/cla/corporate/itpp-labs.md
@@ -1,0 +1,15 @@
+Russia, 2021-03-20
+
+IT Projects Labs agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Denis Mudarisov denis.mudarisov@gmail.com https://github.com/trojikman
+
+List of contributors:
+
+Denis Mudarisov denis.mudarisov@gmail.com https://github.com/trojikman


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

fixed passing arguments when handling an exception on the page `/website/info` which rises unexpected error

Current behavior before PR:
if an exception occurs there will be an error saying:
`TypeError: _handle_exception() takes 2 positional arguments but 3 were given`

Desired behavior after PR is merged:

It should show actual exception




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
