### PR TITLE
[MERGE] survey: fix certification layout

### DIFF
--- a/addons/survey/static/src/scss/survey_reports.scss
+++ b/addons/survey/static/src/scss/survey_reports.scss
@@ -28,13 +28,11 @@
 }
 
 #o_survey_certification.certification-wrapper {
-    width: 297mm;
-    height: 210mm;
     background-color: #875A7B;
     position: relative;
     display: flex;
-    margin-left: -15px;
-    margin-right: -15px;
+    margin-left: -4mm;
+    margin-right: -4mm;
 
     &.blue {
         background-color: #263e86;

--- a/addons/survey/views/survey_reports.xml
+++ b/addons/survey/views/survey_reports.xml
@@ -14,6 +14,7 @@
             <field name="header_line" eval="False"/>
             <field name="header_spacing">0</field>
             <field name="disable_shrinking" eval="True"/>
+            <field name="dpi">96</field>
         </record>
         <!-- QWeb Reports -->
         <record id="certification_report" model="ir.actions.report">

--- a/addons/survey/views/survey_reports.xml
+++ b/addons/survey/views/survey_reports.xml
@@ -13,6 +13,7 @@
             <field name="margin_right">0</field>
             <field name="header_line" eval="False"/>
             <field name="header_spacing">0</field>
+            <field name="disable_shrinking" eval="True"/>
         </record>
         <!-- QWeb Reports -->
         <record id="certification_report" model="ir.actions.report">

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -324,6 +324,8 @@ class IrActionsReport(models.Model):
                 command_args.extend(['--orientation', str(paperformat_id.orientation)])
             if paperformat_id.header_line:
                 command_args.extend(['--header-line'])
+            if paperformat_id.disable_shrinking:
+                command_args.extend(['--disable-smart-shrinking'])
 
         if landscape:
             command_args.extend(['--orientation', 'landscape'])

--- a/odoo/addons/base/models/report_paperformat.py
+++ b/odoo/addons/base/models/report_paperformat.py
@@ -182,6 +182,7 @@ class report_paperformat(models.Model):
         ], 'Orientation', default='Landscape')
     header_line = fields.Boolean('Display a header line', default=False)
     header_spacing = fields.Integer('Header spacing', default=35)
+    disable_shrinking = fields.Boolean('Disable smart shrinking')
     dpi = fields.Integer('Output DPI', required=True, default=90)
     report_ids = fields.One2many('ir.actions.report', 'paperformat_id', 'Associated reports', help="Explicitly associated reports")
     print_page_width = fields.Float('Print page width (mm)', compute='_compute_print_page_size')


### PR DESCRIPTION
Generated PDF was shrunk down, not taking up the full width and size of the A4
format, leaving big margins on right and top. Setting `disable-smart-shrinking`
to `True` helps with this, but layout is slightly too big.  Setting `dpi` to
`96` and removing the `width` and `height` on the parent element fully fixes
the issue.

This merge also adds a boolean field `disable_shrinking` in model `report.paperformat`.
If set to True it adds one argument `--disable-smart-shrinking` in commands
that prevents the pdf shrinking. See issue[1] for more information.

This options is utilized for printing survey certificaiton.

Task ID-2483393
COM PR odoo/odoo#68188
UPGPR odoo/upgrade#2293

issue[1] - wkhtmltopdf/wkhtmltopdf#3226
