### PR TITLE
applyXManyChange may have undefined view but a viewType

### DIFF
--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -1948,7 +1948,7 @@ var BasicModel = AbstractModel.extend({
             case 'UPDATE':
                 list._changes.push({operation: 'UPDATE', id: command.id});
                 if (command.data) {
-                    defs.push(this._applyChange(command.id, command.data, { viewType: view.type }));
+                    defs.push(this._applyChange(command.id, command.data, { viewType: view ? view.type : viewType }));
                 }
                 break;
             case 'FORGET':

--- a/doc/cla/individual/kmagusiak.md
+++ b/doc/cla/individual/kmagusiak.md
@@ -1,0 +1,11 @@
+Belgium, 2021-03-03
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Krzysztof Magusiak chris.magusiak@gmail.com https://github.com/kmagusiak


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
During the development of a custom module, we have an issue with updating an X2many field. Variable is undefined when calling this._setValue from an extended AbstractField.

Current behavior before PR:
The variable view is undefined.

Desired behavior after PR is merged:
Use another already initialized variable viewType which has a value.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
