### PR TITLE
[FIX] core: protect computed fields based on the `states` attr

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -46,6 +46,7 @@ def transfer_field_to_modifiers(field, modifiers):
     for attr in ('invisible', 'readonly', 'required'):
         state_exceptions[attr] = []
         default_values[attr] = bool(field.get(attr))
+        default_values[attr] = field.get(attr)
     for state, modifs in field.get("states", {}).items():
         for modif in modifs:
             if default_values[modif[0]] != modif[1]:

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -989,7 +989,7 @@ actual arch.
                     node.getparent().remove(node)
                     # no point processing view-level ``groups`` anymore, return
                     return
-                node_info['editable'] = node_info['editable'] and field.is_editable() and (
+                node_info['editable'] = node_info['editable'] and field.editable and (
                     node.get('readonly') not in ('1', 'True')
                     or get_dict_asts(node.get('attrs') or "{}")
                 )

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -712,7 +712,8 @@ class Field(MetaField('DummyField', (object,), {})):
             return field_help.get(self.name) or self.help
         return self.help
 
-    def is_editable(self):
+    @property
+    def editable(self):
         """ Return whether the field can be editable in a view. """
         return not self.readonly or self.states and any(
             'readonly' in item for items in self.states.values() for item in items

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3611,7 +3611,7 @@ Fields:
                 records_to_inverse[field] = self.filtered('id')
             if field.relational or self._field_inverses[field]:
                 relational_names.append(fname)
-            if field.inverse or (field.compute and not field.readonly):
+            if field.inverse or (field.compute and field.editable):
                 if field.store or field.type not in ('one2many', 'many2many'):
                     # Protect the field from being recomputed while being
                     # inversed. In the case of non-stored x2many fields, the
@@ -3843,7 +3843,7 @@ Fields:
                     inversed[key] = val
                     inversed_fields.add(field)
                 # protect non-readonly computed fields against (re)computation
-                if field.compute and not field.readonly:
+                if field.compute and field.editable:
                     protected.update(self.pool.field_computed.get(field, [field]))
 
             data_list.append(data)


### PR DESCRIPTION
Only looking at `readonly` is not enough because the field can still be
editable when `states` is changing the value of that attribute.

Also take the opportunity to change to function `is_editable` to an
attribute `editable` to improve readability.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
