### PR TITLE
[FIX] website_sale: fix phone formatting on contact created from webs…

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -15,6 +15,7 @@ from odoo.addons.website.controllers.main import Website
 from odoo.addons.sale.controllers.product_configurator import ProductConfiguratorController
 from odoo.addons.website_form.controllers.main import WebsiteForm
 from odoo.osv import expression
+from odoo.addons.phone_validation.tools.phone_validation import phone_format
 
 _logger = logging.getLogger(__name__)
 
@@ -677,6 +678,8 @@ class WebsiteSale(ProductConfiguratorController):
         # IF POSTED
         if 'submitted' in kw:
             pre_values = self.values_preprocess(order, mode, kw)
+            country = request.env['res.country'].search([('id', '=', pre_values['country_id'])])
+            pre_values['phone'] = phone_format(pre_values['phone'], country.code ,country.phone_code)
             errors, error_msg = self.checkout_form_validate(mode, kw, pre_values)
             post, errors, error_msg = self.values_postprocess(order, mode, pre_values, errors, error_msg)
 


### PR DESCRIPTION
…ite order

Steps to follow to reproduce the bug:
- Without logging, with a public user
- Go to eCommerce
- Add any item to cart
- Go to cart and click on process checkout
- Fill in the form and for the phone number don't enter the prefix code of the country
- Click on next
- Then, log in as Admin
- Go to contact
- Search for the created contact

Problem:
The phone number is not formatted with the country code prefix

Solution :
Format the encoded phone number with the phone_format function before creating the res_partner

opw-2476932

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
