### PR TITLE
[FIX] stock: disable auto-trigger scheduler with ir.config_parameter

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1758,6 +1758,9 @@ class StockMove(models.Model):
 
     def _trigger_scheduler(self):
         """ Check for auto-triggered orderpoints and trigger them. """
+        if not self or self.env['ir.config_parameter'].sudo().get_param('stock.no_auto_scheduler'):
+            return
+
         orderpoints_by_company = defaultdict(lambda: self.env['stock.warehouse.orderpoint'])
         for move in self:
             orderpoint = self.env['stock.warehouse.orderpoint'].search([


### PR DESCRIPTION
Currently we automatically check reordering rules when a product cannot be
completely reserved, which allows to have a replenishment document for the
product without needing to run scheduler. This is unwanted for some users.
In this commit, we allow to disable this by adding a parameter to
ir.config_parameter. To disable it, set a parameter with name
"stock.no_auto_scheduler".

opw 2458507

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
