### PR TITLE
[FIX] sale: mark transaction as paid if invoices paid

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -798,11 +798,6 @@ class SaleOrder(models.Model):
                 order.with_context(force_send=True).message_post_with_template(template_id, composition_mode='comment', email_layout_xmlid="mail.mail_notification_paynow")
 
     def action_done(self):
-        for order in self:
-            tx = order.sudo().transaction_ids.get_last_transaction()
-            if tx and tx.state == 'pending' and tx.acquirer_id.provider == 'transfer':
-                tx._set_transaction_done()
-                tx.write({'is_processed': True})
         return self.write({'state': 'done'})
 
     def action_unlock(self):


### PR DESCRIPTION
On Website, if a Sales Order is locked, the latter is considered as
paid, even if the associated invoice is waiting for a payment.

To reproduce the error:
(Need sale_management,stock)
1. In Settings, enable "Lock Confirmed Sales"
2. On Webshop, add a product to the cart and process checkout
    - Pay with Wire Transfer
3. Go to Sales module and confirm the associated sales order
4. Confirm the SO
5. Validate the delivery
6. Create and Post the invoice (Regular invoice)
7. Back to SO, click on "Customer Preview"

Error: On Website, the Sales Order is marked as paid ("Your payment has
been successfully processed. Thank you!") but none payment has been
registered (on the same page, the invoice is marked as "Waiting
Payment").

When the SO is locked, the associated transaction is automatically
marked as 'done'. This should be done when the SO is fully invoiced and
when these invoices are fully paid.

OPW-2389373