### PR TITLE
[FIX] product: always add product name to name_get

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -497,13 +497,12 @@ class ProductProduct(models.Model):
                     temp = _name_get(mydict)
                     if temp not in result:
                         result.append(temp)
-            else:
-                mydict = {
-                          'id': product.id,
-                          'name': name,
-                          'default_code': product.default_code,
-                          }
-                result.append(_name_get(mydict))
+            mydict = {
+                      'id': product.id,
+                      'name': name,
+                      'default_code': product.default_code,
+                      }
+            result.append(_name_get(mydict))
         return result
 
     @api.model

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1071,6 +1071,13 @@ class PurchaseOrderLine(models.Model):
 
         self.price_unit = price_unit
 
+        if seller and seller.product_name:
+            name = seller.product_name
+            code = self._context.get('display_default_code', True) and seller.product_code or False
+            if code:
+                name = '[%s] %s' % (code, name)
+            self.name = name
+
     @api.depends('product_uom', 'product_qty', 'product_id.uom_id')
     def _compute_product_uom_qty(self):
         for line in self:


### PR DESCRIPTION
In RfQ, when searching for a product, if the latter has several supplier
information (with same vendor and different vendor product names/codes),
only the vendor product name of the last supplier information will be
displayed.

To reproduce the error:
(need purchase)
1. Create a product PR
    - Name: SuperProduct
    - In purchase tab, add two supplier information SI01, SI02
        - SI01:
            - Vendor: Partner PA
            - Vendor Product Name: 'A'
            - Vendor Product Code: 'A'
            - Quantity: 1
            - Price: 10
        - SI02:
            - Vendor: The same (PA)
            - Vendor Product Name: 'B'
            - vendor Product Code: 'B'
            - Quantity: 2
            - Price: 15
2. Create a RfQ
    - Vendor: PA
3. Add a line, and in Product field, enter "super"

Error: in the suggestions list, there is only "[B] B". If the user
clicks on it, the Description field will be defined with the same value
while it actually uses the quantity and the price from SI01. Even worse,
suppose SI02 is expired (it is possible to set an end date), the
suggestions list will still contain "[B] B"

When getting the name:
https://github.com/odoo/odoo/blob/824a6515a528cd2b682c3d3504c0d27ed9427cdb/odoo/models.py#L6432
It calls `name_get()`, which returns the list of all possibilities:
`[(SuperProduct_id, "[A] A"), (SuperProduct_id, "[B] B")]` but it then
converts the list in a dictionary. However, since several tuples have
the same key (SuperProduct_id), it will only keep the last value ("[B]
B"). This fix always adds the product name at the end of `name_get()`
result.

OPW-2465075