### PR TITLE
[FIX] stock: remove broken doc link

### DIFF
--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -53,7 +53,6 @@
                                 </div>
                                 <div class="o_setting_right_pane">
                                     <label for="module_quality_control"/>
-                                    <a href="https://www.odoo.com/documentation/user/14.0/quality.html" title="Documentation" class="o_doc_link" target="_blank"></a>
                                     <div class="text-muted">
                                         Add quality checks to your transfer operations
                                     </div>


### PR DESCRIPTION
Remove obsolete quality documentation link (added after v14, hence 2
separate PRs).

Related PR: odoo/odoo#68135

Task: 2457087

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
