### PR TITLE
[FIX] crm_phone_validation: fix phone formatting of res_partner created outside the form

### DIFF
--- a/addons/crm_phone_validation/models/res_partner.py
+++ b/addons/crm_phone_validation/models/res_partner.py
@@ -17,3 +17,11 @@ class Contact(models.Model):
     def _onchange_mobile_validation(self):
         if self.mobile:
             self.mobile = self.phone_format(self.mobile)
+            
+    @api.model_create_multi
+    def create(self, vals_list):
+        partners = super(Contact, self).create(vals_list)
+        for partner in partners:
+            partner._onchange_mobile_validation()
+            partner._onchange_phone_validation()
+        return partners


### PR DESCRIPTION
Steps to follow to reproduce the bug:
- Install crm
- Go to crm settings
- Activate the “Phone Formatting” and choose "Add international prefix" option
- Create a new contact (without using the form), for example from a new user on e-commerce
- Search for the created contact on the contact App

Problem:
When you create a res_partner outside the form, the phone number is not automatically formatted with the country code prefix. This is because the formatting is done with an on_change which is not executed

Solution :
Override the function create of res_partner to format the encoded phone number by calling phone_format function

opw-2476932

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
