### PR TITLE
[IMP] account,website_sale: improved ux of terms and conditions.

### DIFF
--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -200,3 +200,15 @@ class ResConfigSettings(models.TransientModel):
             # We display the preview button only if the terms_type is html in the setting but also on the company
             # to avoid landing on an error page (see terms.py controller)
             setting.preview_ready = self.env.company.terms_type == 'html' and setting.terms_type == 'html'
+
+    def action_update_terms(self):
+        self.ensure_one()
+        return {
+            'name': _('Update Terms & Conditions'),
+            'type': 'ir.actions.act_window',
+            'view_mode': 'form',
+            'res_model': 'res.company',
+            'view_id': self.env.ref("account.res_company_view_form_terms", False).id,
+            'target': 'new',
+            'res_id': self.company_id.id,
+        }

--- a/addons/account/views/res_company_views.xml
+++ b/addons/account/views/res_company_views.xml
@@ -11,4 +11,22 @@
             </xpath>
         </field>
     </record>
+
+    <record id="res_company_view_form_terms" model="ir.ui.view">
+        <field name="name">res.company.view.form.terms</field>
+        <field name="model">res.company</field>
+        <field name="priority">1000</field>
+        <field name="arch" type="xml">
+            <form>
+                <group>
+                    <field name="invoice_terms_html" class="oe_account_terms" nolabel="1"/>
+                </group>
+                <footer>
+                    <button string="Save" special="save" class="btn-primary"/>
+                    <button string="Discard" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
 </odoo>

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -288,24 +288,23 @@
                                     <label for="use_invoice_terms"/>
                                     <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
                                     <div class="text-muted">
-                                        Show standard terms &amp; conditions on invoices/orders
+                                        Add your terms &amp; conditions at the bottom of invoices/orders/quotations
                                     </div>
                                     <div class="content-group" attrs="{'invisible': [('use_invoice_terms','=',False)]}">
                                         <div class="mt16">
                                             <field name="terms_type" class="o_light_label" widget="radio"/>
-                                            <div class="d-flex">
+                                            <div>
                                                 <field name="invoice_terms"
                                                        attrs="{'invisible': [('terms_type', '=', 'html')]}"
-                                                       class="oe_account_terms"
-                                                       placeholder="Insert your terms &amp; conditions here..."/>
-                                                <field name="invoice_terms_html"
-                                                       attrs="{'invisible': [('terms_type', '=', 'plain')]}"
-                                                       class="oe_account_terms"
+                                                       class="oe_account_terms mt-5 w-100"
                                                        placeholder="Insert your terms &amp; conditions here..."/>
                                             </div>
+                                            <div class="mt8" attrs="{'invisible': [('terms_type', '!=', 'html')]}">
+                                                <button name="action_update_terms" icon="fa-arrow-right" type="object" string="Update Terms" class="btn-link"/>
+                                            </div>
                                             <field name="preview_ready" invisible="1"/>
-                                            <div attrs="{'invisible': [('preview_ready', '=', False)]}">
-                                                <a href="/terms">
+                                            <div class="mt4 ml-1" attrs="{'invisible': [('preview_ready', '=', False)]}">
+                                                <a class="btn-link" href="/terms" role="button">
                                                     <i class="fa fa-arrow-right"></i>
                                                     Preview
                                                 </a>

--- a/addons/account/views/terms_template.xml
+++ b/addons/account/views/terms_template.xml
@@ -23,4 +23,36 @@
                 </div>
         </t>
     </template>
+
+    <template id="account_default_terms_and_conditions">
+        <div>
+            <h1>STANDARD TERMS AND CONDITIONS OF SALE</h1>
+            <p>You should update this document to reflect your T&amp;C.</p>
+            <p>Below text serves as a suggestion and doesn’t engage Odoo S.A. responsibility.</p>
+            <ol>
+                <li>
+                    The client explicitly waives its own standard terms and conditions, even if these were drawn up after these standard terms and conditions of sale. In order to be valid, any derogation must be expressly agreed to in advance in writing.
+                </li>
+                <li>
+                    Our invoices are payable within 21 working days, unless another payment timeframe is indicated on either the invoice or the order. In the event of non-payment by the due date, <t t-esc="company_name"/> reserves the right to request a fixed interest payment amounting to 10% of the sum remaining due. <t t-esc="company_name"/> will be authorized to suspend any provision of services without prior warning in the event of late payment.
+                </li>
+                <li>
+                    If a payment is still outstanding more than sixty (60) days after the due payment date, <t t-esc="company_name"/> reserves the right to call on the services of a debt recovery company. All legal expenses will be payable by the client.
+                </li>
+                <li>
+                    Certain countries apply withholding at source on the amount of invoices, in accordance with their internal legislation. Any withholding at source will be paid by the client to the tax authorities. Under no circumstances can <t t-esc="company_name"/> become involved in costs related to a country's legislation. The amount of the invoice will therefore be due to <t t-esc="company_name"/> in its entirety and does not include any costs relating to the legislation of the country in which the client is located.
+                </li>
+                <li>
+                    <t t-esc="company_name"/> undertakes to do its best to supply performant services in due time in accordance with the agreed timeframes. However, none of its obligations can be considered as being an obligation to achieve results. <t t-esc="company_name"/> cannot under any circumstances, be required by the client to appear as a third party in the context of any claim for damages filed against the client by an end consumer.
+                </li>
+                <li>
+                    In order for it to be admissible, <t t-esc="company_name"/> must be notified of any claim by means of a letter sent by recorded delivery to its registered office within 8 days of the delivery of the goods or the provision of the services.
+                </li>
+                <li>
+                    All our contractual relations will be governed exclusively by <t t-esc="company_country"/> law.
+                </li>
+            </ol>
+        </div>
+    </template>
+
 </odoo>

--- a/addons/website_sale/__init__.py
+++ b/addons/website_sale/__init__.py
@@ -6,7 +6,7 @@ from . import models
 from . import wizard
 from . import report
 
-def pre_init_hook(cr):
+def _post_init_hook(cr, registry):
     env = api.Environment(cr, SUPERUSER_ID, {})
     terms_conditions = env['ir.config_parameter'].get_param('account.use_invoice_terms')
     if not terms_conditions:

--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -36,7 +36,7 @@
     ],
     'installable': True,
     'application': True,
-    'pre_init_hook': 'pre_init_hook',
+    'post_init_hook': '_post_init_hook',
     'uninstall_hook': 'uninstall_hook',
     'assets': {
         'web.assets_frontend': [

--- a/addons/website_sale/models/res_config_settings.py
+++ b/addons/website_sale/models/res_config_settings.py
@@ -30,6 +30,12 @@ class ResConfigSettings(models.TransientModel):
     cart_abandoned_delay = fields.Float("Abandoned Delay", help="Number of hours after which the cart is considered abandoned.",
                                         related='website_id.cart_abandoned_delay', readonly=False)
     cart_add_on_page = fields.Boolean("Stay on page after adding to cart", related='website_id.cart_add_on_page', readonly=False)
+    terms_url = fields.Char(compute='_compute_terms_url', string="URL", help="A preview will be available at this URL.")
+
+    @api.depends('website_id')
+    def _compute_terms_url(self):
+        for record in self:
+            record.terms_url = '%s/terms' % record.website_id.get_base_url()
 
     @api.model
     def get_values(self):
@@ -70,3 +76,11 @@ class ResConfigSettings(models.TransientModel):
             self.update({
                 'group_product_pricelist': True,
             })
+
+    def action_update_terms(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_url',
+            'url': '/terms?enable_editor=1',
+            'target': 'self',
+        }

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -1,6 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
+    <record id="res_config_settings_view_form_web_terms" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.account.web.terms</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form"/>
+        <field name="groups_id" eval="[Command.link(ref('website.group_website_designer'))]"/>
+        <field name="arch" type="xml">
+            <xpath expr="//button[@name='action_update_terms']" position="replace">
+                <div class="mt8" attrs="{'invisible': [('terms_type', '!=', 'html')]}">
+                    <strong class="align-top">URL: </strong><field name="terms_url"/>
+                    <div>
+                        <button name='action_update_terms' icon="fa-arrow-right" type="object" string="Edit in Website Builder" class="btn-link"/>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
     <record id="res_config_settings_view_form" model="ir.ui.view">
         <field name="name">res.config.settings.view.form.inherit.website.sale</field>
         <field name="model">res.config.settings</field>


### PR DESCRIPTION
Currently in the settings of Invoicing(account) if the user wants his terms
and conditions, as web then pad was there that pad, was not responsive.

So after this commit, if the user has rights for the website builder then it
will open a website builder page where the user can edit terms and conditions on
a web page. If the user does not have rights to website builder then that same
will open in a pop-up window.

In that terms and conditions, the template of default terms and conditions is
also added, that template will appear with the current company's name and
country, however, the user can edit that.

**Task-id - :- 2414659**