### PR TITLE
[IMP] survey: display no question message for live session

### DIFF
--- a/addons/survey/controllers/survey_session_manage.py
+++ b/addons/survey/controllers/survey_session_manage.py
@@ -46,6 +46,8 @@ class UserInputSession(http.Controller):
         - If the state of the session is 'ready'
           We render a template allowing the host to showcase the different options of the session
           and to actually start the session.
+          If there are no questions, a "void content" is displayed instead to avoid displaying a
+          blank survey.
         - If the state of the session is 'in_progress'
           We render a template allowing the host to show the question results, display the attendees
           leaderboard or go to the next question of the session. """
@@ -57,6 +59,11 @@ class UserInputSession(http.Controller):
             return NotFound()
 
         if survey.session_state == 'ready':
+            if not survey.question_ids:
+                return request.render('survey.survey_void_content', {
+                    'survey': survey,
+                    'answer': request.env['survey.user_input'],
+                })
             return request.render('survey.user_input_session_open', {
                 'survey': survey
             })

--- a/addons/survey/views/survey_templates_management.xml
+++ b/addons/survey/views/survey_templates_management.xml
@@ -27,11 +27,15 @@
             <div class="wrap">
                 <div class="container">
                     <div class="jumbotron mt32">
-                        <h1><span t-field="survey.title"/> survey is void</h1>
-                        <p>Please make sure you have at least one question in your survey. You also need at least one section if you chose the "Page per section" layout.<br />
+                        <h1><span t-field="survey.title"/> survey is empty</h1>
+                        <p t-if="env.user.has_group('survey.group_survey_user')">
+                            Please make sure you have at least one question in your survey. You also need at least one section if you chose the "Page per section" layout.<br />
                             <a t-att-href="'/web#view_type=form&amp;model=survey.survey&amp;id=%s&amp;action=survey.action_survey_form' % survey.id"
                                 class="btn btn-secondary"
                                 groups="survey.group_survey_manager">Edit in backend</a>
+                        </p>
+                        <p t-else="">
+                            No question yet, come back later.
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
PURPOSE

Before this commit, the survey host had no indication that his survey
has no questions. After this commit, he will be displayed with that
indication.
Before this commit, someone who took the survey had a message implying
him to modify the survey to add questions. After this commit the message
will say 'No question yet, come back later'.

LINKS

Task ID : 2456372


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
