### PR TITLE
[FIX] crm: avoid to display false in case of void subject

### DIFF
--- a/addons/crm/i18n/crm.pot
+++ b/addons/crm/i18n/crm.pot
@@ -1228,6 +1228,12 @@ msgid "From %(source_name)s : %(source_subject)s"
 msgstr ""
 
 #. module: crm
+#: code:addons/crm/models/crm_lead.py:0
+#, python-format
+msgid "From %(source_name)s"
+msgstr ""
+
+#. module: crm
 #: model_terms:ir.ui.view,arch_db:crm.view_crm_case_leads_filter
 #: model_terms:ir.ui.view,arch_db:crm.view_crm_case_my_activities_filter
 #: model_terms:ir.ui.view,arch_db:crm.view_crm_case_opportunities_filter

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1045,13 +1045,13 @@ class Lead(models.Model):
         self.ensure_one()
         for opportunity in opportunities:
             for message in opportunity.message_ids:
+                if message.subject:
+                    subject = _("From %(source_name)s : %(source_subject)s", source_name=opportunity.name, source_subject=message.subject)
+                else:
+                    subject = _("From %(source_name)s", source_name=opportunity.name)
                 message.write({
                     'res_id': self.id,
-                    'subject': _(
-                        "From %(source_name)s : %(source_subject)s",
-                        source_name=opportunity.name,
-                        source_subject=message.subject
-                    )
+                    'subject': subject,
                 })
         return True
 


### PR DESCRIPTION
**Before this commit:**

If there is no subject for message, it effectively displays "False" in case of
void subject.

**After this commit:**

If there is no subject for message, it will not display "False" in case of void
subject.

Tasks-2156170