### PR TITLE
[FIX] web: make tag name input field blank on 'Save & New'

### DIFF
--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -388,6 +388,7 @@ var FieldMany2One = AbstractField.extend({
             res_model: this.field.relation,
             domain: this.record.getDomain({fieldName: this.name}),
             context: _.extend({}, this.record.getContext(this.recordParams), context || {}),
+            _createContext: this._createContext.bind(this),
             dynamicFilters: dynamicFilters || [],
             title: (view === 'search' ? _t("Search: ") : _t("Create: ")) + this.string,
             initial_ids: ids,

--- a/addons/web/static/src/js/views/form/form_controller.js
+++ b/addons/web/static/src/js/views/form/form_controller.js
@@ -88,11 +88,11 @@ var FormController = BasicController.extend({
      *                            for the new record.
      * @returns {Promise}
      */
-    createRecord: function (parentID) {
+    createRecord: function (parentID, additionalContext) {
         var self = this;
         var record = this.model.get(this.handle, {raw: true});
         return this.model.load({
-            context: record.getContext(),
+            context: record.getContext({ additionalContext: additionalContext}),
             fields: record.fields,
             fieldsInfo: record.fieldsInfo,
             modelName: this.modelName,

--- a/addons/web/static/src/js/views/view_dialogs.js
+++ b/addons/web/static/src/js/views/view_dialogs.js
@@ -87,6 +87,9 @@ var FormViewDialog = ViewDialog.extend({
      *   well, and in that case, it will be used without loading anything.
      * @param {boolean} [options.shouldSaveLocally] if true, the view dialog
      *   will save locally instead of actually saving (useful for one2manys)
+     * @param {function} [options._createContext] function to get context for name field
+     *   useful for many2many_tags widget where we want to removed default_name field
+     *   context.
      */
     init: function (parent, options) {
         var self = this;
@@ -96,6 +99,7 @@ var FormViewDialog = ViewDialog.extend({
         this.on_saved = options.on_saved || (function () {});
         this.on_remove = options.on_remove || (function () {});
         this.context = options.context;
+        this._createContext = options._createContext;
         this.model = options.model;
         this.parentID = options.parentID;
         this.recordID = options.recordID;
@@ -137,7 +141,12 @@ var FormViewDialog = ViewDialog.extend({
                         classes: "btn-primary",
                         click: function () {
                             self._save()
-                                .then(self.form_view.createRecord.bind(self.form_view, self.parentID))
+                                .then(function () {
+                                    // reset default name field from context when Save & New is clicked, pass additional
+                                    // context so that when getContext is called additional context resets it
+                                    var additionalContext = self._createContext && self._createContext(false) || {};
+                                    self.form_view.createRecord(self.parentID, additionalContext);
+                                })
                                 .then(function () {
                                     if (!self.deletable) {
                                         return;

--- a/addons/web/static/tests/fields/relational_fields/field_many2many_tests.js
+++ b/addons/web/static/tests/fields/relational_fields/field_many2many_tests.js
@@ -1147,6 +1147,50 @@ QUnit.module('fields', {}, function () {
           form.destroy();
         });
 
+        QUnit.test("many2many tags widget: make tag name input field blank on Save&New", async function (assert) {
+            assert.expect(4);
+
+            let defaultGetCall = 0;
+            const form = await createView({
+                View: FormView,
+                model: 'partner',
+                data: this.data,
+                arch: '<form><field name="timmy" widget="many2many_tags"/></form>',
+                archs: {
+                    'partner_type,false,form': '<form><field name="name"/></form>'
+                },
+                res_id: 1,
+                mockRPC: function (route, args) {
+                    if (args.method === 'default_get') {
+                        if (defaultGetCall === 0) {
+                            assert.deepEqual(args.kwargs.context, { default_name: 'hello' },
+                                "context should have default_name with 'hello' as value");
+                        }
+                        if (defaultGetCall === 1) {
+                            assert.deepEqual(args.kwargs.context, {},
+                                "context should have default_name with false as value");
+                        }
+                        defaultGetCall++;
+                    }
+                    return this._super.apply(this, arguments);
+                },
+            });
+
+            await testUtils.form.clickEdit(form);
+
+            await testUtils.fields.editInput($('.o_field_widget input'), 'hello');
+            await testUtils.fields.many2one.clickItem('timmy', 'Create and Edit');
+            assert.strictEqual(document.querySelector('.modal .o_form_view input').value, "hello",
+                "should contain the 'hello' in the tag name input field");
+
+            // Create record with save & new
+            await testUtils.dom.click(document.querySelector('.modal .btn-primary:nth-child(2)'));
+            assert.strictEqual(document.querySelector('.modal .o_form_view input').value, "",
+                "should display the blank value in the tag name input field");
+
+            form.destroy();
+        });
+
         QUnit.test('many2many list add *many* records, remove, re-add', async function (assert) {
             assert.expect(5);
 


### PR DESCRIPTION
before this commit,
Clicking on the 'Save & new' button shows the old value in the
tag name input field instead of the blank value.

after this commit,
Clicking on the 'Save & new' button will show the blank value
in the tag name input field.

TaskID-2323194