### PR TITLE
14.0 various tour flexibility maintenance mub

### DIFF
--- a/addons/event/static/src/js/tours/event_tour.js
+++ b/addons/event/static/src/js/tours/event_tour.js
@@ -57,20 +57,14 @@ tour.register('event_tour', {
 }, {
     trigger: '.o_event_form_view div[name="event_ticket_ids"] .o_field_x2many_list_row_add a',
     content: _t("Ticket types allow you to distinguish your attendees. Let's <b>create</b> a new one."),
-}, {
-    trigger: '.o_form_button_save',
-    extra_trigger: '.o_event_form_view',
-    content: _t("Awesome! Now, let's <b>save</b> your changes."),
-    position: 'bottom',
-    width: 250,
 }, ...new EventAdditionalTourSteps()._get_website_event_steps(), {
-    trigger: '.o_event_form_view div[name="stage_id"] button:contains("Booked")',
+    trigger: '.o_event_form_view div[name="stage_id"]',
     extra_trigger: 'div.o_form_buttons_view:not(.o_hidden)',
     content: _t("Now that your event is ready, click here to move it to another stage."),
     position: 'bottom',
 }, {
     trigger: 'ol.breadcrumb li.breadcrumb-item:first',
-    extra_trigger: '.o_event_form_view div[name="stage_id"] button.disabled:contains("Booked")',
+    extra_trigger: '.o_event_form_view div[name="stage_id"]',
     content: _t("Use the <b>breadcrumbs</b> to go back to your kanban overview."),
     position: 'bottom',
     run: 'click',

--- a/addons/website_event/i18n/website_event.pot
+++ b/addons/website_event/i18n/website_event.pot
@@ -1086,7 +1086,7 @@ msgstr ""
 #, python-format
 msgid ""
 "With the Edit button, you can <b>customize</b> the web page visitors will "
-"see when registrating."
+"see when registering."
 msgstr ""
 
 #. module: website_event

--- a/addons/website_event/static/src/js/tours/event_tour.js
+++ b/addons/website_event/static/src/js/tours/event_tour.js
@@ -16,13 +16,12 @@ EventAdditionalTourSteps.include({
         this._super.apply(this, arguments);
         return [{
                 trigger: '.o_event_form_view button[name="is_published"]',
-                extra_trigger: 'div.o_form_buttons_view:not(.o_hidden)',
                 content: _t("Use this <b>shortcut</b> to easily access your event web page."),
                 position: 'bottom',
             }, {
                 trigger: 'li#edit-page-menu a',
                 extra_trigger: '.o_wevent_event',
-                content: _t("With the Edit button, you can <b>customize</b> the web page visitors will see when registrating."),
+                content: _t("With the Edit button, you can <b>customize</b> the web page visitors will see when registering."),
                 position: 'bottom',
             }, {
                 trigger: 'div[name="Image - Text"] .oe_snippet_thumbnail',


### PR DESCRIPTION
PURPOSE

currently in the event tour, "go to the website" step should 
already triggers the the save, so this step seems unnecessary, 
there are one wrong spelling "registrating" in Edit button trigger 
and user must have to go on specific stage it's not necessary and 
if user go to any other stage than it should not trigger the next activity.

SPECIFICATION

after this commit user can directly go to "go to website" step 
without save trigger and now spelling will be "registering" 
instead of "registrating" and user move on any specific stage 
and also it trigger the next activity because in normal flow 
user can go to any stage.

TaskId:2461308

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
