### PR TITLE
[FIX] website_sale: Recursive Partner hierarchies on website_sale

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -692,11 +692,14 @@ class WebsiteSale(http.Controller):
                     can_edit_vat = order.partner_id.can_edit_vat()
                 else:
                     shippings = Partner.search([('id', 'child_of', order.partner_id.commercial_partner_id.ids)])
-                    if partner_id in shippings.mapped('id'):
+                    if order.partner_id.commercial_partner_id.id == partner_id:
+                        mode = ('new', 'shipping')
+                        partner_id = -1
+                    elif partner_id in shippings.mapped('id'):
                         mode = ('edit', 'shipping')
                     else:
                         return Forbidden()
-                if mode:
+                if mode and partner_id != -1:
                     values = Partner.browse(partner_id)
             elif partner_id == -1:
                 mode = ('new', 'shipping')


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's create two partners P1 and P2 where P1 is a company and P2 a child of P1
- P2 is a portal user
- Log with P2 and go to the shop
- Add a product in the cart and process to checkout
- The billing address details of P2 are auto completed, click on next
- For the shipping address, the details of P1 are auto completed, click on next

Bug:

A 403 page was displayed with: You cannot create recursive Partner hierarchies.

opw:2487590