### PR TITLE
[FIX] l10n_ar: Responsibility type "IVA No Alcanzado"

### DIFF
--- a/addons/l10n_ar/data/l10n_ar_afip_responsibility_type_data.xml
+++ b/addons/l10n_ar/data/l10n_ar_afip_responsibility_type_data.xml
@@ -65,4 +65,8 @@
         <field name='name'>Pequeño Contribuyente Eventual Social</field>
         <field name='active' eval="False"/>
     </record>
+    <record model='l10n_ar.afip.responsibility.type' id='res_IVA_NO_ALC'>
+        <field name='code'>99</field>
+        <field name='name'>IVA No Alcanzado</field>
+    </record>
 </odoo>

--- a/addons/l10n_ar/data/res_partner_data.xml
+++ b/addons/l10n_ar/data/res_partner_data.xml
@@ -16,7 +16,7 @@
         <field name="is_company" eval="True"/>
         <field name='l10n_latam_identification_type_id' ref="l10n_ar.it_cuit"/>
         <field name='vat'>33693450239</field>
-        <field name='l10n_ar_afip_responsibility_type_id' ref="res_IVANR"/>
+        <field name='l10n_ar_afip_responsibility_type_id' ref="res_IVA_NO_ALC"/>
         <field name='l10n_ar_special_purchase_document_type_ids' eval='[(4, ref("dc_desp_imp"), False), (4, ref("dc_imp_serv"), False)]'/>
     </record>
 

--- a/addons/l10n_ar/models/account_journal.py
+++ b/addons/l10n_ar/models/account_journal.py
@@ -67,14 +67,9 @@ class AccountJournal(models.Model):
 
         letters = letters_data['issued' if self.type == 'sale' else 'received'][
             self.company_id.l10n_ar_afip_responsibility_type_id.code]
-        if not counterpart_partner:
-            return letters
-
-        if not counterpart_partner.l10n_ar_afip_responsibility_type_id:
-            letters = []
-        else:
-            counterpart_letters = letters_data['issued' if self.type == 'purchase' else 'received'][
-                counterpart_partner.l10n_ar_afip_responsibility_type_id.code]
+        if counterpart_partner:
+            counterpart_letters = letters_data['issued' if self.type == 'purchase' else 'received'].get(
+                counterpart_partner.l10n_ar_afip_responsibility_type_id.code, [])
             letters = list(set(letters) & set(counterpart_letters))
         return letters
 

--- a/addons/l10n_ar/models/account_journal.py
+++ b/addons/l10n_ar/models/account_journal.py
@@ -46,6 +46,7 @@ class AccountJournal(models.Model):
                 '9': ['I'],
                 '10': [],
                 '13': ['C', 'E'],
+                '99': []
             },
             'received': {
                 '1': ['A', 'B', 'C', 'M', 'I'],
@@ -56,6 +57,7 @@ class AccountJournal(models.Model):
                 '9': ['E'],
                 '10': ['E'],
                 '13': ['B', 'C', 'I'],
+                '99': ['B', 'C', 'I']
             },
         }
         if not self.company_id.l10n_ar_afip_responsibility_type_id:


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

- Add a new responsibility type "IVA No Alcanzado" and update the partner "AFIP" with that responsibility.

- Fix a bug when a partner has a not handled responsibility type, returning an empty list as possibles document types.

**Current behavior before PR:**
1. The "AFIP" partner has a wrong responsibility type.
2. If a partner has a responsibility type that we are not handling at the time of returning the allowed letters it will show a traceback error.

**Desired behavior after PR is merged:**
1. The "AFIP" partner has the correct responsibility type (IVA No Alcanzado).
2. If a partner has a responsibility type that we are not handling at the time of returning the allowed letters it will return an empty list so the user will not be able to select any document type.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
