### PR TITLE
[FIX] translate.py: import model from CSV correctly


### DIFF
--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -581,7 +581,8 @@ class CSVFileReader:
                 # res_id is an external id and must follow <module>.<name>
                 entry["module"], entry["imd_name"] = entry["res_id"].split(".")
                 entry["res_id"] = None
-            entry["imd_model"] = entry["name"].split(":")[0]
+            if entry["type"] == "model" or entry["type"] == "model_terms":
+                entry["imd_model"] = entry["name"].partition(',')[0]
 
             if entry["type"] == "code":
                 if entry["src"] == self.prev_code_src:


### PR DESCRIPTION

When importing transtlation from CSV, we:

- cut at `:` character to get the model
- used a model for types other than model and model_terms

This caused error that do not happen in PO import because:

- the model is before the `,` character
- the imd_model column is constrained to 64 characters, and a name that
  is not a model could be over that size.

With this changeset, the CSV import match better current PO import.

opw-2439029
