### PR TITLE
[FIX] base_vat: Don't always pass VAT check when validating the VAT of a partner without country_id

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -152,10 +152,9 @@ class ResPartner(models.Model):
             if not check_func(vat_country, vat_number):
                 #if fails, check with country code from country
                 country_code = partner.commercial_partner_id.country_id.code
-                if country_code:
-                    if not check_func(country_code.lower(), partner.vat):
-                        msg = partner._construct_constraint_msg(country_code.lower())
-                        raise ValidationError(msg)
+                if not  country_code or not check_func(country_code.lower(), partner.vat):
+                    msg = partner._construct_constraint_msg(country_code.lower() if country_code else None)
+                    raise ValidationError(msg)
 
     def _construct_constraint_msg(self, country_code):
         self.ensure_one()

--- a/addons/base_vat/tests/test_validate_ruc.py
+++ b/addons/base_vat/tests/test_validate_ruc.py
@@ -55,3 +55,32 @@ class TestStructure(common.TransactionCase):
         with patch.object(vatnumber, 'check_vies', mock_check_vies):
             self.env.user.company_id.vat_check_vies = True
             company.vat = "BE0987654321"
+
+    def test_vat_syntactic_validation(self):
+        """ Tests VAT validation (both successes and failures), with the different country
+        detection cases possible.
+        """
+        # Disable VIES; syntactic verification is enough for this test case
+        self.env.user.company_id.vat_check_vies = False
+
+        test_partner =self.env['res.partner'].create({'name': "John Dex"})
+
+        # VAT starting with country code: use the starting country code
+        test_partner.write({'vat': 'BE0477472701', 'country_id': self.env.ref('base.fr').id})
+        test_partner.write({'vat': 'BE0477472701', 'country_id': None})
+
+        with self.assertRaises(ValidationError):
+            test_partner.write({'vat': 'BE42', 'country_id': self.env.ref('base.fr').id})
+
+        with self.assertRaises(ValidationError):
+            test_partner.write({'vat': 'BE42', 'country_id': None})
+
+        # No country code in VAT: use the partner's country
+        test_partner.write({'vat': '0477472701', 'country_id': self.env.ref('base.be').id})
+
+        with self.assertRaises(ValidationError):
+            test_partner.write({'vat': '42', 'country_id': self.env.ref('base.be').id})
+
+        # If no country can be guessed: VAT number cannot be validated
+        with self.assertRaises(ValidationError):
+            test_partner.write({'vat': '0477472701', 'country_id': None})


### PR DESCRIPTION
Before this, when making a partner without any country_id, any VAT could be set to it, which was inconsistent with the module's purpose.
