### PR TITLE
[FIX] repair: remove empty line_ids

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -346,7 +346,6 @@ class Repair(models.Model):
                     'partner_shipping_id': repair.address_id.id,
                     'currency_id': currency.id,
                     'narration': narration,
-                    'line_ids': [],
                     'invoice_origin': repair.name,
                     'repair_ids': [(4, repair.id)],
                     'invoice_line_ids': [],


### PR DESCRIPTION
After updating Odoo source code to latest version recently, we noticed that when creating invoices from Repair Orders no longer create the invoice lines with it. This was replicated in a 14.0 runbot.

With some searching we found that this is due to the changes in https://github.com/odoo/odoo/pull/67667/commits/734e066372f7e8cf8696c534ce06877f67cef453, which modifies the funcionality to adapt to some journal related things, which I believe the proposed the changes in this PR won't affect.

The problem comes from the use of `if 'line_ids' in vals:` when `if vals.get('line_ids'):` was previously used, the former condition is met when `line_ids` is `[]` whereas the latter isn't.

In the case of repair orders (I don't know if this happens anywhere else, probably?), `line_ids` is empty https://github.com/odoo/odoo/blob/14.0/addons/repair/models/repair.py#L343-L354 and `invoice_line_ids` is filled for the invoice, but since it enters the condition with its `[]` value, the values of `invoice_line_ids` get nuked and we end up with no lines.

Here's a gif of the replication in a 14.0e runbot
![no_invoice_lines](https://user-images.githubusercontent.com/47854752/112173342-c39c9780-8bf5-11eb-851c-3689e3caf451.gif)


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
(in https://github.com/odoo/odoo/pull/68244)
