### PR TITLE
[FIX] tools.file_path: correctly handle the `addons/` prefix

### DIFF
--- a/odoo/addons/base/tests/test_misc.py
+++ b/odoo/addons/base/tests/test_misc.py
@@ -389,6 +389,7 @@ class TestAddonsFileAccess(BaseCase):
         self.assertEqual(__file__, file_path(relpath, filter_ext=('.py',)))
 
         # leading 'addons/' is ignored if present
+        self.assertTrue(file_path("addons/web/__init__.py"))
         relpath = os.path.join('addons', relpath) # 'addons/base/tests/test_misc.py'
         self.assertEqual(__file__, file_path(relpath))
 
@@ -431,6 +432,7 @@ class TestAddonsFileAccess(BaseCase):
         self.assertCanRead(relpath, test_needle.encode(), mode='rb', filter_ext=('.py',))
 
         # leading 'addons/' is ignored if present
+        self.assertCanRead("addons/web/__init__.py", "import")
         relpath = os.path.join('addons', relpath) # 'addons/base/tests/test_misc.py'
         self.assertCanRead(relpath, test_needle)
 

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -168,7 +168,7 @@ def file_path(file_path, filter_ext=('',)):
         # final path sep required to avoid partial match
         parent_path = os.path.normpath(os.path.normcase(addons_dir)) + os.sep
         fpath = (normalized_path if is_abs else
-                 os.path.normpath(os.path.normcase(os.path.join(parent_path, file_path))))
+                 os.path.normpath(os.path.normcase(os.path.join(parent_path, normalized_path))))
         if fpath.startswith(parent_path) and os.path.exists(fpath):
             return fpath
 


### PR DESCRIPTION
The tests passed because the path with the prefix is valid at root_path.