### PR TITLE
[FIX] purchase: Vendor bill auto-complete

### DIFF
--- a/addons/purchase/report/purchase_bill.py
+++ b/addons/purchase/report/purchase_bill.py
@@ -60,5 +60,4 @@ class PurchaseBillUnion(models.Model):
         domain = []
         if name:
             domain = ['|', ('name', operator, name), ('reference', operator, name)]
-        purchase_bills_union_ids = self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
-        return self.browse(purchase_bills_union_ids).name_get()
+        return self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Recently this [PR](https://github.com/odoo/odoo/pull/65265) has been forward-ported but in Odoo 14.0 [_name_search](https://github.com/odoo/odoo/commit/1f48130d2bd055835ee428a21922331d126285a3) returns a list of ids

Current behavior before PR:
Create a new vendor bill and click on "Auto-complete" field raises an error
Here's a gif of the replication in a 14.0 runbot
![vendor-error](https://user-images.githubusercontent.com/4355395/112195781-9efeea80-8c0a-11eb-8daa-936e9efc1a4f.gif)
 

Desired behavior after PR is merged:
No error raised and the field works properly



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
(in #68244))
