### PR TITLE
do not show empty badge in badge widget

### DIFF
--- a/addons/web/static/src/scss/fields.scss
+++ b/addons/web/static/src/scss/fields.scss
@@ -522,7 +522,7 @@
         display: inline-block;
     }
 
-    &.o_field_badge {
+    &.o_field_badge:not(.o_field_empty) {
         border: 0;
         font-size: 12px;
         user-select: none;


### PR DESCRIPTION
PURPOSE
Badge widget displays empty badge pill with gray color, while if there is no value on field then it should not display anything.

SPEC
If there is not value on field then do not display anything on badge widget.

TASK 2475472



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
