### PR TITLE
disable autofill on input elements

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -274,7 +274,7 @@ var InputField = DebouncedField.extend({
             inputAttrs = _.extend(inputAttrs, { type: 'password', autocomplete: this.attrs.autocomplete || 'new-password' });
             inputVal = this.value || '';
         } else {
-            inputAttrs = _.extend(inputAttrs, { type: 'text', autocomplete: this.attrs.autocomplete || 'none'});
+            inputAttrs = _.extend(inputAttrs, { type: 'text', autocomplete: this.attrs.autocomplete || 'off'});
             inputVal = this._formatValue(this.value);
         }
 

--- a/addons/web/static/tests/views/form_tests.js
+++ b/addons/web/static/tests/views/form_tests.js
@@ -7412,7 +7412,7 @@ QUnit.module('Views', {
         });
 
         await testUtils.form.clickEdit(form);
-        assert.hasAttrValue(form.$('input[name="display_name"]'), 'autocomplete', 'none',
+        assert.hasAttrValue(form.$('input[name="display_name"]'), 'autocomplete', 'off',
             "attribute autocomplete should be set to none by default");
         form.destroy();
     });


### PR DESCRIPTION
PURPOSE
Prevent browsers from suggesting date(time) that have been used in the past.
Indeed, chances are those where used at a specific time and aren't of any use later on.

SPEC
On the back-end, block browsers (Chrome, Firefox and if possible others such as Brave, Edge, ... => Not sure if it's browser-specific) from displaying this autocomplete popup.
It should still work on the Website

TASK 2462676



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
