### PR TITLE
delivery: choose_delivery_package hook for qty calc

### DIFF
--- a/addons/delivery/wizard/choose_delivery_package.py
+++ b/addons/delivery/wizard/choose_delivery_package.py
@@ -18,8 +18,11 @@ class ChooseDeliveryPackage(models.TransientModel):
         total_weight = 0.0
         for ml in move_line_ids:
             qty = ml.product_uom_id._compute_quantity(ml.qty_done, ml.product_id.uom_id)
-            total_weight += qty * ml.product_id.weight
+            total_weight += self._calc_weight_for_move_line(ml, qty)
         return total_weight
+
+    def _calc_weight_for_move_line(self, move_line, qty):
+        return move_line.product_id.weight * qty
 
     picking_id = fields.Many2one('stock.picking', 'Picking')
     delivery_packaging_id = fields.Many2one('product.packaging', 'Delivery Packaging', check_company=True)


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

There's no way to customize weight computation for "Choose delivery pkg" wizard if not by rewriting the whole `_default_shipping_weight` method.

**Current behavior before PR:**

Weight is computed only based product weight.

**Desired behavior after PR is merged:**

Ease override by changing only the "give me this move line weight" part.
Typical use case: compute weight by packaging details.

Applies to 14.0 and master too.
Talking about master: any plan to consider packaging weight for shipping weight computation?

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
