### PR TITLE
[FIX] sale: avoid order-product company conflicts

### DIFF
--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -54,6 +54,14 @@ class ProductTemplate(models.Model):
         for product in self:
             product.sales_count = float_round(sum([p.sales_count for p in product.with_context(active_test=False).product_variant_ids]), precision_rounding=product.uom_id.rounding)
 
+    @api.constrains("company_id")
+    def _check_sale_order_products_company(self):
+        """Ensure there are no conflicts among companies in sale order and products."""
+        lines = self.sudo().env['sale.order.line'].search([
+            ('product_id.product_tmpl_id', 'in', self.ids),
+        ])
+        lines._check_order_products_company()
+
     @api.multi
     def action_view_sales(self):
         date_from = fields.Datetime.to_string(fields.datetime.combine(fields.datetime.now() - timedelta(days=365), time.min))


### PR DESCRIPTION
Scenario:

- A sale order belongs to company A.
- A product also belongs to company A.
- The user changes the product or sale order company to B.

Problem: impossible to access the sale order anymore.

These checks prevent such changes from happening.

@Tecnativa TT28915