### PR TITLE
[FIX] translate.py: CSV export correct module name


### DIFF
--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -1070,7 +1070,8 @@ class TranslationModuleReader:
                 continue
 
             for record in records:
-                xml_name = "%s.%s" % (imd_per_id[record.id].module, imd_per_id[record.id].name)
+                module = imd_per_id[record.id].module
+                xml_name = "%s.%s" % (module, imd_per_id[record.id].name)
                 for field_name, field in record._fields.items():
                     if field.translate:
                         name = model + "," + field_name


### PR DESCRIPTION
Correct small typo that the module when exporting translations as CSV
file might have been the wrong module because we used variable from
previous loop.

This did not seem to cause any issue since in this given case in import
we got the module from the part before . in XML ID ({module}.{name})
that was right.

found when working on opw-2439029