### PR TITLE
[FIX] purchase: not possible to link to purchase order

### DIFF
--- a/addons/purchase/report/purchase_bill.py
+++ b/addons/purchase/report/purchase_bill.py
@@ -61,4 +61,4 @@ class PurchaseBillUnion(models.Model):
         if name:
             domain = ['|', ('name', operator, name), ('reference', operator, name)]
         purchase_bills_union_ids = self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
-        return self.browse(purchase_bills_union_ids).name_get()
+        return purchase_bills_union_ids


### PR DESCRIPTION
Steps to reproduce the bug:

- Create a bill
- Click on Auto complete

Bug:

A traceback was raised.

opw:2490125