### PR TITLE
[FIX] pos_hr: fix "select cashier" popup location

### DIFF
--- a/addons/pos_hr/static/src/css/pos.css
+++ b/addons/pos_hr/static/src/css/pos.css
@@ -103,8 +103,6 @@
     }
     .pos .popups .popup-selection {
         width: 90%;
-        left: initial;
-        right: initial;
     }
     .pos .login-barcode-text {
         color: #adb5bd;


### PR DESCRIPTION
1. Have a POS with Authorized Employees
2. Startup POS sesssion with an Android phone
3. Click "Select Cashier"

The popup will open partially out of screen,
forcing the user to manually drag it to to center
in order to select a cashier

opw-2476496

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
