### PR TITLE
[FIX] base_setup: remove unexisting documentation link

### DIFF
--- a/addons/base_setup/views/res_config_settings_views.xml
+++ b/addons/base_setup/views/res_config_settings_views.xml
@@ -140,7 +140,6 @@
                                         <div class="o_setting_right_pane" id="sms_settings">
                                             <div class="o_form_label">
                                             Send SMS
-                                            <a href="https://www.odoo.com/documentation/user/14.0/sms_marketing/overview/integrations_and_template.html" title="Documentation" class="o_doc_link" target="_blank"></a>
                                             <a href="https://www.odoo.com/documentation/user/14.0/sms_marketing/pricing/pricing_and_faq.html" title="Documentation" class="ml-1 o_doc_link" target="_blank"></a>
                                             </div>
                                             <div class="text-muted">


### PR DESCRIPTION
PURPOSE

Remove "?" button near to "Send SMS" in settings  because it leads
to a documentation that has been deprecated.


SPECIFICATIONS

By this commit we will remove the "?" button because when user clicks
on it then they will get a "404 Not Found" error because of the link of that
button leads to a documentation that does not exist or has been
deprecated. 


LINKS
PR #68292
Task 2489666