### PR TITLE
Master qweb v2 chm

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -429,7 +429,7 @@ class AccountBankStatement(models.Model):
                 self.env['ir.attachment'].create({
                     'name': statement.name and _("Bank Statement %s.pdf", statement.name) or _("Bank Statement.pdf"),
                     'type': 'binary',
-                    'datas': base64.encodebytes(content),
+                    'raw': content.encode(),
                     'res_model': statement._name,
                     'res_id': statement.id
                 })

--- a/addons/account_edi_facturx/models/account_edi_format.py
+++ b/addons/account_edi_facturx/models/account_edi_format.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from lxml import etree
 from PyPDF2 import PdfFileReader
 import base64
+import markupsafe
 
 import io
 
@@ -65,12 +66,12 @@ class AccountEdiFormat(models.Model):
             'is_html_empty': is_html_empty,
         }
 
-        xml_content = b"<?xml version='1.0' encoding='UTF-8'?>"
+        xml_content = markupsafe.Markup("<?xml version='1.0' encoding='UTF-8'?>")
         xml_content += self.env.ref('account_edi_facturx.account_invoice_facturx_export')._render(template_values)
         xml_name = '%s_facturx.xml' % (invoice.name.replace('/', '_'))
         return self.env['ir.attachment'].create({
             'name': xml_name,
-            'datas': base64.encodebytes(xml_content),
+            'raw': xml_content.encode(),
             'mimetype': 'application/xml'
         })
 

--- a/addons/account_edi_ubl/models/account_edi_format.py
+++ b/addons/account_edi_ubl/models/account_edi_format.py
@@ -8,6 +8,7 @@ from pathlib import PureWindowsPath
 
 import base64
 import logging
+import markupsafe
 
 _logger = logging.getLogger(__name__)
 
@@ -204,12 +205,12 @@ class AccountEdiFormat(models.Model):
     def _export_ubl(self, invoice):
         self.ensure_one()
         # Create file content.
-        xml_content = b"<?xml version='1.0' encoding='UTF-8'?>"
+        xml_content = markupsafe.Markup("<?xml version='1.0' encoding='UTF-8'?>")
         xml_content += self.env.ref('account_edi_ubl.export_ubl_invoice')._render(self._get_ubl_values(invoice))
         xml_name = '%s_ubl_2_1.xml' % (invoice.name.replace('/', '_'))
         return self.env['ir.attachment'].create({
             'name': xml_name,
-            'datas': base64.encodebytes(xml_content),
+            'raw': xml_content.encode(),
             'res_model': 'account.move',
             'res_id': invoice.id,
             'mimetype': 'application/xml'

--- a/addons/hr/tests/test_multi_company.py
+++ b/addons/hr/tests/test_multi_company.py
@@ -26,8 +26,8 @@ class TestMultiCompany(TestHrCommon):
         content, content_type = self.env.ref('hr.hr_employee_print_badge').with_user(self.res_users_hr_officer).with_context(
             allowed_company_ids=[self.company_1.id, self.company_2.id]
         )._render_qweb_pdf(res_ids=self.employees.ids)
-        self.assertIn(b'Bidule', content)
-        self.assertIn(b'Machin', content)
+        self.assertIn('Bidule', content)
+        self.assertIn('Machin', content)
 
     def test_single_company_report(self):
         with self.assertRaises(QWebException):  # CacheMiss followed by AccessError

--- a/addons/l10n_be_edi/models/account_edi_format.py
+++ b/addons/l10n_be_edi/models/account_edi_format.py
@@ -3,6 +3,7 @@
 from odoo import models
 
 import base64
+import markupsafe
 
 
 class AccountEdiFormat(models.Model):
@@ -21,12 +22,12 @@ class AccountEdiFormat(models.Model):
     def _export_efff(self, invoice):
         self.ensure_one()
         # Create file content.
-        xml_content = b"<?xml version='1.0' encoding='UTF-8'?>"
+        xml_content = markupsafe.Markup("<?xml version='1.0' encoding='UTF-8'?>")
         xml_content += self.env.ref('l10n_be_edi.export_efff_invoice')._render(self._get_efff_values(invoice))
         xml_name = '%s.xml' % invoice._get_efff_name()
         return self.env['ir.attachment'].create({
             'name': xml_name,
-            'datas': base64.encodebytes(xml_content),
+            'raw': xml_content.encode(),
             'mimetype': 'application/xml',
         })
 

--- a/addons/l10n_it_edi/models/account_invoice.py
+++ b/addons/l10n_it_edi/models/account_invoice.py
@@ -65,13 +65,13 @@ class AccountMove(models.Model):
         self.ensure_one()
         report_name = self.env['account.edi.format']._l10n_it_edi_generate_electronic_invoice_filename(self)
 
-        data = b"<?xml version='1.0' encoding='UTF-8'?>" + self._export_as_xml()
+        data = "<?xml version='1.0' encoding='UTF-8'?>" + str(self._export_as_xml())
         description = _('Italian invoice: %s', self.move_type)
         attachment = self.env['ir.attachment'].create({
             'name': report_name,
             'res_id': self.id,
             'res_model': self._name,
-            'datas': base64.encodebytes(data),
+            'raw': data.encode(),
             'description': description,
             'type': 'binary',
             })

--- a/addons/l10n_it_edi_sdicoop/models/account_edi_format.py
+++ b/addons/l10n_it_edi_sdicoop/models/account_edi_format.py
@@ -110,7 +110,7 @@ class AccountEdiFormat(models.Model):
 
         to_send = {}
         for invoice in invoices:
-            xml = b"<?xml version='1.0' encoding='UTF-8'?>" + invoice._export_as_xml()
+            xml = "<?xml version='1.0' encoding='UTF-8'?>" + str(invoice._export_as_xml())
             filename = self._l10n_it_edi_generate_electronic_invoice_filename(invoice)
             attachment = self.env['ir.attachment'].create({
                 'name': filename,

--- a/addons/l10n_nl_edi/models/account_edi_format.py
+++ b/addons/l10n_nl_edi/models/account_edi_format.py
@@ -3,6 +3,7 @@
 from odoo import models, _
 
 import base64
+import markupsafe
 
 
 class AccountEdiFormat(models.Model):
@@ -65,13 +66,13 @@ class AccountEdiFormat(models.Model):
     def _export_nlcius(self, invoice):
         self.ensure_one()
         # Create file content.
-        xml_content = b"<?xml version='1.0' encoding='UTF-8'?>"
+        xml_content = markupsafe.Markup("<?xml version='1.0' encoding='UTF-8'?>")
         xml_content += self.env.ref('l10n_nl_edi.export_nlcius_invoice')._render(self._get_nlcius_values(invoice))
         vat = invoice.company_id.partner_id.commercial_partner_id.vat
         xml_name = 'nlcius-%s%s%s.xml' % (vat or '', '-' if vat else '', invoice.name.replace('/', '_'))
         return self.env['ir.attachment'].create({
             'name': xml_name,
-            'datas': base64.encodebytes(xml_content),
+            'raw': xml_content.encode(),
             'res_model': 'account.move',
             'res_id': invoice.id,
             'mimetype': 'application/xml'

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -214,7 +214,7 @@ class MailTemplate(models.Model):
                         result, format = res
 
                     # TODO in trunk, change return format to binary to match message_post expected format
-                    result = base64.b64encode(result)
+                    result = base64.b64encode(result.encode())
                     if not report_name:
                         report_name = 'report.' + report_service
                     ext = "." + format

--- a/addons/mail/tests/test_mail_render.py
+++ b/addons/mail/tests/test_mail_render.py
@@ -196,7 +196,7 @@ class TestMailRender(common.MailCommon):
                 partner._name,
                 partner.ids,
                 engine='qweb_view',
-            )[partner.id].decode()
+            )[partner.id]
             self.assertEqual(rendered, expected)
 
     @users('employee')
@@ -278,7 +278,7 @@ class TestMailRender(common.MailCommon):
             result = MailRenderMixin._render_template(
                 src, partner._name, partner.ids, engine=engine,
             )[partner.id]
-            self.assertEqual(expected, result if engine == 'jinja' else result.decode())  # tde: checkme
+            self.assertEqual(expected, result if engine == 'jinja' else result)  # tde: checkme
 
         # code xml
         srces = [
@@ -290,7 +290,7 @@ class TestMailRender(common.MailCommon):
             result = MailRenderMixin._render_template(
                 src, partner._name, partner.ids, engine=engine,
             )[partner.id]
-            self.assertEqual(expected, result if engine == 'jinja' else result.decode())  # tde: checkme
+            self.assertEqual(expected, result if engine == 'jinja' else result)  # tde: checkme
 
         # condition block xml
         src = """<b>Test</b>

--- a/addons/mass_mailing/wizard/mail_compose_message.py
+++ b/addons/mass_mailing/wizard/mail_compose_message.py
@@ -77,7 +77,7 @@ class MailComposeMessage(models.TransientModel):
                     'email': mail_to or mail_values.get('email_to'),
                 }
                 if mail_values.get('body_html') and mass_mail_layout:
-                    mail_values['body_html'] = mass_mail_layout._render({'body': mail_values['body_html']}, engine='ir.qweb', minimal_qcontext=True).decode()
+                    mail_values['body_html'] = mass_mail_layout._render({'body': mail_values['body_html']}, engine='ir.qweb', minimal_qcontext=True)
                 # propagate ignored state to trace when still-born
                 if mail_values.get('state') == 'cancel':
                     trace_vals['ignored'] = fields.Datetime.now()

--- a/addons/pos_mercury/models/pos_mercury_transaction.py
+++ b/addons/pos_mercury/models/pos_mercury_transaction.py
@@ -46,7 +46,7 @@ class MercuryTransaction(models.Model):
         data['memo'] = "Odoo " + service.common.exp_version()['server_version']
 
     def _do_request(self, template, data):
-        xml_transaction = self.env.ref(template)._render(data).decode()
+        xml_transaction = self.env.ref(template)._render(data)
 
         if not data['merchant_id'] or not data['merchant_pwd']:
             return "not setup"

--- a/addons/stock/tests/test_report.py
+++ b/addons/stock/tests/test_report.py
@@ -54,10 +54,10 @@ class TestReports(TestReportsCommon):
             'company_id': self.env.company.id,
         })
         report = self.env.ref('stock.label_lot_template')
-        target = b'\n\n\n^XA\n^FO100,50\n^A0N,44,33^FD[C418]Mellohi^FS\n^FO100,100\n^A0N,44,33^FDLN/SN:Volume-Beta^FS\n^FO100,150^BY3\n^BCN,100,Y,N,N\n^FDVolume-Beta^FS\n^XZ\n\n\n'
+        target = '\n\n\n^XA\n^FO100,50\n^A0N,44,33^FD[C418]Mellohi^FS\n^FO100,100\n^A0N,44,33^FDLN/SN:Volume-Beta^FS\n^FO100,150^BY3\n^BCN,100,Y,N,N\n^FDVolume-Beta^FS\n^XZ\n\n\n'
 
         rendering, qweb_type = report._render_qweb_text(lot1.id)
-        self.assertEqual(target, rendering.replace(b' ', b''), 'The rendering is not good')
+        self.assertEqual(target, rendering.replace(' ', ''), 'The rendering is not good')
         self.assertEqual(qweb_type, 'text', 'the report type is not good')
 
     def test_report_quantity_1(self):

--- a/addons/test_website/tests/test_reset_views.py
+++ b/addons/test_website/tests/test_reset_views.py
@@ -5,7 +5,7 @@ import odoo.tests
 from odoo.tools import mute_logger
 
 
-def break_view(view, fr='<p>placeholder</p>', to='<p t-field="not.exist"/>'):
+def break_view(view, fr='<p>placeholder</p>', to='<p t-field="no_record.exist"/>'):
     view.arch = view.arch.replace(fr, to)
 
 
@@ -44,8 +44,8 @@ class TestWebsiteResetViews(odoo.tests.HttpCase):
     def test_02_reset_specific_view_controller(self):
         total_views = self.View.search_count([('type', '=', 'qweb')])
         # Trigger COW then break the QWEB XML on it
-        # `t-att-data="not.exist"` will test the case where exception.html contains branding
-        break_view(self.test_view.with_context(website_id=1), to='<p t-att-data="not.exist" />')
+        # `t-att-data="no_record.exist"` will test the case where exception.html contains branding
+        break_view(self.test_view.with_context(website_id=1), to='<p t-att-data="no_record.exist" />')
         self.assertEqual(total_views + 1, self.View.search_count([('type', '=', 'qweb')]), "Missing COW view")
         self.fix_it('/test_view')
 
@@ -79,12 +79,12 @@ class TestWebsiteResetViews(odoo.tests.HttpCase):
     #     self.assertEqual(total_views + 1, self.View.search_count([('type', '=', 'qweb')]), "Missing COW view (1)")
     #     self.fix_it('/test_view')
 
-    # also mute ir.ui.view as `get_view_id()` will raise "Could not find view object with xml_id 'not.exist'""
+    # also mute ir.ui.view as `get_view_id()` will raise "Could not find view object with xml_id 'no_record.exist'""
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.addons.website.models.ir_ui_view')
     def test_06_reset_specific_view_controller_inexisting_template(self):
         total_views = self.View.search_count([('type', '=', 'qweb')])
         # Trigger COW then break the QWEB XML on it
-        break_view(self.test_view.with_context(website_id=1), to='<t t-call="not.exist"/>')
+        break_view(self.test_view.with_context(website_id=1), to='<t t-call="no_record.exist"/>')
         self.assertEqual(total_views + 1, self.View.search_count([('type', '=', 'qweb')]), "Missing COW view (2)")
         self.fix_it('/test_view')
 

--- a/addons/web/models/ir_qweb.py
+++ b/addons/web/models/ir_qweb.py
@@ -4,6 +4,7 @@
 import hashlib
 from collections import OrderedDict
 from werkzeug.urls import url_quote
+from markupsafe import Markup as M
 
 from odoo import api, models
 from odoo.tools import pycompat
@@ -105,7 +106,7 @@ class Image(models.AbstractModel):
                 img.append('"')
         img.append('/>')
 
-        return u''.join(img)
+        return M(''.join(img))
 
 class ImageUrlConverter(models.AbstractModel):
     _description = 'Qweb Field Image'

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -806,7 +806,7 @@ class ResCompany(models.Model):
         company_styles = template_style._render({
             'company_ids': company_ids,
         })
-        return base64.b64encode((company_styles))
+        return base64.b64encode(company_styles.encode())
 
     def _update_asset_style(self):
         asset_attachment = self.env.ref('web.asset_styles_company_report', raise_if_not_found=False)

--- a/addons/web/static/lib/qweb/qweb-test-attributes.xml
+++ b/addons/web/static/lib/qweb/qweb-test-attributes.xml
@@ -5,9 +5,9 @@
     <result id="static"><![CDATA[<div foo="a" bar="b" baz="c"></div>]]></result>
 
     <t t-name="static-void">
-        <img src="/test.jpg" alt="Test"/>
+        <img src="/test.jpg" alt="Test" loading="lazy"/>
     </t>
-    <result id="static-void"><![CDATA[<img src="/test.jpg" alt="Test"/>]]></result>
+    <result id="static-void"><![CDATA[<img src="/test.jpg" alt="Test" loading="lazy"/>]]></result>
 
     <t t-name="fixed-literal">
         <div t-att-foo="'bar'"/>

--- a/addons/web/static/lib/qweb/qweb-test-call.xml
+++ b/addons/web/static/lib/qweb/qweb-test-call.xml
@@ -32,6 +32,27 @@
     </t>
     <result id="with-used-setbody">ok</result>
 
+    <t t-name="_call-with-body-arch-lookup">
+        <section t-raw="0"/>
+    </t>
+
+    <t t-name="call-without-body-arch-lookup">
+        <t t-call="_call-with-body-arch-lookup"/>
+    </t>
+    <result id="call-without-body-arch-lookup"><![CDATA[<section></section>]]></result>
+
+    <t t-name="call-with-body-arch-lookup">
+        <t t-call="_call-with-body-arch-lookup">
+            <div><span class="toto" t-esc="value"/></div>
+        </t>
+    </t>
+    <params id="call-with-body-arch-lookup">
+        {"value": "ok"}
+    </params>
+    <result id="call-with-body-arch-lookup"><![CDATA[<section>
+            <div><span class="toto">ok</span></div>
+        </section>]]></result>
+
     <!--
         postfix to call removed because Python impl appends all whitespace
         following called template's root to template result (+= element.tail)

--- a/addons/web/static/lib/qweb/qweb-test-output.xml
+++ b/addons/web/static/lib/qweb/qweb-test-output.xml
@@ -28,6 +28,11 @@
     </t>
     <result id="raw-literal">ok</result>
 
+    <t t-name="raw-number">
+        <t t-raw="1"/>
+    </t>
+    <result id="raw-number">1</result>
+
     <t t-name="raw-variable">
         <t t-raw="var"/>
     </t>

--- a/addons/web/static/lib/qweb/qweb-test-set.xml
+++ b/addons/web/static/lib/qweb/qweb-test-set.xml
@@ -39,6 +39,15 @@
         ok
     </result>
 
+    <t t-name="set-from-body-arch-lookup">
+        <t t-set="stuff"><div><span t-esc="value"/></div></t>
+        <t t-raw="stuff"/>
+    </t>
+    <params id="set-from-body-arch-lookup">
+        {"value": "ok"}
+    </params>
+    <result id="set-from-body-arch-lookup"><![CDATA[<div><span>ok</span></div>]]></result>
+
     <t t-name="set-empty-body">
         <t t-set="stuff"/>
         <t t-esc="stuff"/>

--- a/addons/web_editor/models/ir_qweb.py
+++ b/addons/web_editor/models/ir_qweb.py
@@ -8,7 +8,6 @@ as well as render a few fields differently.
 Also, adds methods to convert values back to Odoo models.
 """
 
-import ast
 import babel
 import base64
 import io
@@ -47,7 +46,7 @@ class QWeb(models.AbstractModel):
 
     # compile directives
 
-    def _compile_node(self, el, options):
+    def _compile_node(self, el, options, indent):
         snippet_key = options.get('snippet-key')
         if snippet_key == options['template'] \
                 or options.get('snippet-sub-call-key') == options['template']:
@@ -64,56 +63,58 @@ class QWeb(models.AbstractModel):
                 # The first node might be a call to a sub template
                 sub_call = el.get('t-call')
                 if sub_call:
-                    el.set('t-call-options', f"{{'snippet-key': '{snippet_key}', 'snippet-sub-call-key': '{sub_call}'}}")
+                    el.set('t-options', f"{{'snippet-key': '{snippet_key}', 'snippet-sub-call-key': '{sub_call}'}}")
                 # If it already has a data-snippet it is a saved snippet.
                 # Do not override it.
                 elif 'data-snippet' not in el.attrib:
                     el.attrib['data-snippet'] = snippet_key.split('.', 1)[-1]
 
-        return super()._compile_node(el, options)
+        return super()._compile_node(el, options, indent)
 
-    def _compile_directive_snippet(self, el, options):
+    def _compile_directive_snippet(self, el, options, indent):
         key = el.attrib.pop('t-snippet')
         el.set('t-call', key)
-        el.set('t-call-options', "{'snippet-key': '" + key + "'}")
+        el.set('t-options', "{'snippet-key': '" + key + "'}")
         View = self.env['ir.ui.view'].sudo()
         view_id = View.get_view_id(key)
         name = View.browse(view_id).name
         thumbnail = el.attrib.pop('t-thumbnail', "oe-thumbnail")
-        div = u'<div name="%s" data-oe-type="snippet" data-oe-thumbnail="%s" data-oe-snippet-id="%s" data-oe-keywords="%s">' % (
+        div = '<div name="%s" data-oe-type="snippet" data-oe-thumbnail="%s" data-oe-snippet-id="%s" data-oe-keywords="%s">' % (
             escape(pycompat.to_text(name)),
             escape(pycompat.to_text(thumbnail)),
             escape(pycompat.to_text(view_id)),
             escape(pycompat.to_text(el.findtext('keywords')))
         )
-        return [self._append(ast.Str(div))] + self._compile_node(el, options) + [self._append(ast.Str(u'</div>'))]
+        self._appendText(div, options)
+        code = self._compile_node(el, options, indent)
+        self._appendText('</div>', options)
+        return code
 
-    def _compile_directive_snippet_call(self, el, options):
+    def _compile_directive_snippet_call(self, el, options, indent):
         key = el.attrib.pop('t-snippet-call')
         el.set('t-call', key)
-        el.set('t-call-options', "{'snippet-key': '" + key + "'}")
-        return self._compile_node(el, options)
+        el.set('t-options', "{'snippet-key': '" + key + "'}")
+        return self._compile_node(el, options, indent)
 
-    def _compile_directive_install(self, el, options):
+    def _compile_directive_install(self, el, options, indent):
         if self.user_has_groups('base.group_system'):
             module = self.env['ir.module.module'].search([('name', '=', el.attrib.get('t-install'))])
             if not module or module.state == 'installed':
                 return []
             name = el.attrib.get('string') or 'Snippet'
             thumbnail = el.attrib.pop('t-thumbnail', 'oe-thumbnail')
-            div = u'<div name="%s" data-oe-type="snippet" data-module-id="%s" data-oe-thumbnail="%s"><section/></div>' % (
+            div = '<div name="%s" data-oe-type="snippet" data-module-id="%s" data-oe-thumbnail="%s"><section/></div>' % (
                 escape(pycompat.to_text(name)),
                 module.id,
                 escape(pycompat.to_text(thumbnail))
             )
-            return [self._append(ast.Str(div))]
-        else:
-            return []
+            self._appendText(div, options)
+        return []
 
-    def _compile_directive_tag(self, el, options):
+    def _compile_directive_tag(self, el, options, indent):
         if el.get('t-placeholder'):
             el.set('t-att-placeholder', el.attrib.pop('t-placeholder'))
-        return super(QWeb, self)._compile_directive_tag(el, options)
+        return super(QWeb, self)._compile_directive_tag(el, options, indent)
 
     # order and ignore
 
@@ -589,7 +590,7 @@ def _realize_padding(it):
     # leftover padding irrelevant as the output will be stripped
 
 
-def _wrap(element, output, wrapper=u''):
+def _wrap(element, output, wrapper=''):
     """ Recursively extracts text from ``element`` (via _element_to_text), and
     wraps it all in ``wrapper``. Extracted text is added to ``output``
 
@@ -605,7 +606,7 @@ def _wrap(element, output, wrapper=u''):
 
 def _element_to_text(e, output):
     if e.tag == 'br':
-        output.append(u'\n')
+        output.append('\n')
     elif e.tag in _PADDED_BLOCK:
         _wrap(e, output, 2)
     elif e.tag in _MISC_BLOCK:

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -173,7 +173,7 @@ class Website(Home):
 
         def create_sitemap(url, content):
             return Attachment.create({
-                'datas': base64.b64encode(content),
+                'raw': content.encode(),
                 'mimetype': mimetype,
                 'type': 'binary',
                 'name': url,

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -380,7 +380,7 @@ class Http(models.AbstractModel):
                 # in the view, either the error is in a child view or the code
                 # contains branding (<div t-att-data="request.browse('ok')"/>).
                 et = view.with_context(inherit_branding=False)._get_combined_arch()
-                node = et.xpath(exception.path)
+                node = et.xpath(exception.path) if exception.path else et
                 line = node is not None and etree.tostring(node[0], encoding='unicode')
                 if line:
                     values['view'] = View._views_get(exception_template).filtered(

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -413,7 +413,7 @@ class Website(models.Model):
                 try:
                     view_id = self.env['website'].with_context(website_id=website.id).viewref(snippet)
                     if view_id:
-                        el = html.fromstring(view_id._render(values=cta_data).decode())
+                        el = html.fromstring(view_id._render(values=cta_data))
 
                         # Add the data-snippet attribute to identify the snippet
                         # for compatibility code

--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -27,8 +27,7 @@ class Menu(models.Model):
         for menu in self:
             if menu.is_mega_menu:
                 if not menu.mega_menu_content:
-                    default_content = self.env['ir.ui.view']._render_template('website.s_mega_menu_multi_menus')
-                    menu.mega_menu_content = default_content.decode()
+                    menu.mega_menu_content = self.env['ir.ui.view']._render_template('website.s_mega_menu_multi_menus')
             else:
                 menu.mega_menu_content = False
                 menu.mega_menu_classes = False

--- a/addons/website/models/website_snippet_filter.py
+++ b/addons/website/models/website_snippet_filter.py
@@ -77,7 +77,7 @@ class WebsiteSnippetFilter(models.Model):
             records=records,
             is_sample=is_sample,
         ))
-        return [ET.tostring(el, encoding='unicode') for el in ET.fromstring(b'<root>%s</root>' % content).getchildren()]
+        return [ET.tostring(el, encoding='unicode') for el in ET.fromstring('<root>%s</root>' % str(content)).getchildren()]
 
     def _prepare_values(self, limit=None, search_domain=None):
         """Gets the data and returns it the right format for render."""

--- a/addons/website/tests/test_qweb.py
+++ b/addons/website/tests/test_qweb.py
@@ -17,6 +17,22 @@ class TestQweb(TransactionCaseWithUserDemo):
                            get_module_resource(module, *args),
                            {}, 'init', False, 'test')
 
+    def test_qweb_post_processing_att(self):
+        t = self.env['ir.ui.view'].create({
+            'name': 'test',
+            'type': 'qweb',
+            'arch_db': '''<t t-name="attr-escaping">
+                <img src="http://test.external.img/img.png"/>
+                <img t-att-src="url"/>
+            </t>'''
+        })
+        result = """
+                <img src="http://test.external.img/img.png" loading="lazy"/>
+                <img src="http://test.external.img/img2.png" loading="lazy"/>
+            """
+        rendered = str(self.env['ir.qweb']._render(t.id, {'url': 'http://test.external.img/img2.png'}), 'utf-8')
+        self.assertEqual(rendered.strip(), result.strip())
+
     def test_qweb_cdn(self):
         self._load('website', 'tests', 'template_qweb_test.xml')
 

--- a/addons/website/tests/test_qweb.py
+++ b/addons/website/tests/test_qweb.py
@@ -30,7 +30,7 @@ class TestQweb(TransactionCaseWithUserDemo):
                 <img src="http://test.external.img/img.png" loading="lazy"/>
                 <img src="http://test.external.img/img2.png" loading="lazy"/>
             """
-        rendered = str(self.env['ir.qweb']._render(t.id, {'url': 'http://test.external.img/img2.png'}), 'utf-8')
+        rendered = self.env['ir.qweb']._render(t.id, {'url': 'http://test.external.img/img2.png'})
         self.assertEqual(rendered.strip(), result.strip())
 
     def test_qweb_cdn(self):
@@ -54,7 +54,7 @@ class TestQweb(TransactionCaseWithUserDemo):
         asset_xmlid = asset_data.attrib.get('data-asset-bundle')
         asset_version = asset_data.attrib.get('data-asset-version')
 
-        html = html.strip().decode('utf8')
+        html = html.strip()
         html = re.sub(r'\?unique=[^"]+', '', html).encode('utf8')
 
         attachments = demo_env['ir.attachment'].search([('url', '=like', '/web/assets/%-%/website.test_bundle.%')])

--- a/addons/website/tests/test_views.py
+++ b/addons/website/tests/test_views.py
@@ -211,7 +211,7 @@ class TestViewSaving(TestViewSavingCommon):
         )
         self.assertIn(
             replacement,
-            view._render().decode('utf-8'),
+            view._render(),
             'inline script should not be escaped when rendering'
         )
         # common text nodes should be be escaped client side
@@ -220,7 +220,7 @@ class TestViewSaving(TestViewSavingCommon):
         self.assertIn(replacement, view.arch, 'common text node should not be escaped server side')
         self.assertIn(
             replacement,
-            str(view._render().decode('utf-8')).replace(u'&', u'&amp;'),
+            str(view._render()).replace(u'&', u'&amp;'),
             'text node characters wrongly unescaped when rendering'
         )
 

--- a/addons/website_forum/models/forum.py
+++ b/addons/website_forum/models/forum.py
@@ -180,7 +180,7 @@ class Forum(models.Model):
             forum.count_flagged_posts = self.env['forum.post'].search_count(domain)
 
     def _set_default_faq(self):
-        self.faq = self.env['ir.ui.view']._render_template('website_forum.faq_accordion', {"forum": self}).decode('utf-8')
+        self.faq = self.env['ir.ui.view']._render_template('website_forum.faq_accordion', {"forum": self})
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from collections import OrderedDict
 from datetime import datetime
 from subprocess import Popen, PIPE
 import base64
@@ -151,7 +150,7 @@ class AssetsBundle(object):
                                                     extension='')
                 else:
                     href = attachment.url
-                attr = OrderedDict([
+                attr = dict([
                     ["type", "text/css"],
                     ["rel", "stylesheet"],
                     ["href", href],
@@ -167,7 +166,7 @@ class AssetsBundle(object):
         if js and self.javascripts:
             js_attachment = self.js(is_minified=not is_debug_assets)
             src = self.get_debug_asset_url(name=js_attachment.name, extension='') if is_debug_assets else js_attachment[0].url
-            attr = OrderedDict([
+            attr = dict([
                 ["async", "async" if async_load else None],
                 ["defer", "defer" if defer_load or lazy_load else None],
                 ["type", "text/javascript"],
@@ -819,14 +818,14 @@ class JavascriptAsset(WebAsset):
 
     def to_node(self):
         if self.url:
-            return ("script", OrderedDict([
+            return ("script", dict([
                 ["type", "text/javascript"],
                 ["src", self.html_url],
                 ['data-asset-bundle', self.bundle.name],
                 ['data-asset-version', self.bundle.version],
             ]), None)
         else:
-            return ("script", OrderedDict([
+            return ("script", dict([
                 ["type", "text/javascript"],
                 ["charset", "utf-8"],
                 ['data-asset-bundle', self.bundle.name],
@@ -922,7 +921,7 @@ class StylesheetAsset(WebAsset):
 
     def to_node(self):
         if self.url:
-            attr = OrderedDict([
+            attr = dict([
                 ["type", "text/css"],
                 ["rel", "stylesheet"],
                 ["href", self.html_url],
@@ -932,7 +931,7 @@ class StylesheetAsset(WebAsset):
             ])
             return ("link", attr, None)
         else:
-            attr = OrderedDict([
+            attr = dict([
                 ["type", "text/css"],
                 ["media", escape(to_text(self.media)) if self.media else None],
                 ['data-asset-bundle', self.bundle.name],

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -818,9 +818,6 @@ class IrActionsReport(models.Model):
 
         html = self_sudo.with_context(context)._render_qweb_html(res_ids, data=data)[0]
 
-        # Ensure the current document is utf-8 encoded.
-        html = html.decode('utf-8')
-
         bodies, html_ids, header, footer, specific_paperformat_args = self_sudo.with_context(context)._prepare_html(html)
 
         if self_sudo.attachment and set(res_ids) != set(html_ids):

--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -1,25 +1,40 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
-import ast
+from textwrap import dedent
 import copy
 import logging
-from collections import OrderedDict
+import re
+import reprlib
+import markupsafe
 from time import time
-
-from lxml import html
-from lxml import etree
+from lxml import html, etree
 
 from odoo import api, models, tools
-from odoo.tools.safe_eval import assert_valid_codeobj, _BUILTINS, _SAFE_OPCODES
+from odoo.tools.safe_eval import check_values, assert_valid_codeobj, _BUILTINS, to_opcodes, _EXPR_OPCODES, _BLACKLIST
 from odoo.tools.misc import get_lang
 from odoo.http import request
 from odoo.modules.module import get_resource_path
 
-from odoo.addons.base.models.qweb import QWeb, Contextifier, MarkupSafeBytes
+from odoo.addons.base.models.qweb import QWeb, MarkupSafeBytes
 from odoo.addons.base.models.assetsbundle import AssetsBundle
 from odoo.addons.base.models.ir_asset import can_aggregate, STYLE_EXTENSIONS, SCRIPT_EXTENSIONS
 
 _logger = logging.getLogger(__name__)
+
+
+_SAFE_QWEB_OPCODES = _EXPR_OPCODES.union(to_opcodes([
+    'MAKE_FUNCTION', 'CALL_FUNCTION', 'CALL_FUNCTION_KW', 'CALL_FUNCTION_EX',
+    'CALL_METHOD', 'LOAD_METHOD',
+
+    'GET_ITER', 'FOR_ITER', 'YIELD_VALUE',
+    'JUMP_FORWARD', 'JUMP_ABSOLUTE',
+    'JUMP_IF_FALSE_OR_POP', 'JUMP_IF_TRUE_OR_POP', 'POP_JUMP_IF_FALSE', 'POP_JUMP_IF_TRUE',
+
+    'LOAD_NAME', 'LOAD_ATTR',
+    'LOAD_FAST', 'STORE_FAST', 'UNPACK_SEQUENCE',
+    'STORE_SUBSCR',
+    'LOAD_GLOBAL',
+])) - _BLACKLIST
 
 
 class IrQWeb(models.AbstractModel, QWeb):
@@ -34,29 +49,37 @@ class IrQWeb(models.AbstractModel, QWeb):
     _name = 'ir.qweb'
     _description = 'Qweb'
 
+    _available_objects = dict(_BUILTINS)
+    _empty_lines = re.compile(r'\n\s*\n')
+
     @api.model
-    def _render(self, id_or_xml_id, values=None, **options):
-        """ render(id_or_xml_id, values, **options)
+    def _render(self, template, values=None, **options):
+        """ render(template, values, **options)
 
         Render the template specified by the given name.
 
-        :param id_or_xml_id: name or etree (see get_template)
+        :param template: etree, xml_id, template name (see _get_template)
+            * Call the method ``load`` is not an etree.
         :param dict values: template values to be used for rendering
         :param options: used to compile the template (the dict available for the rendering is frozen)
             * ``load`` (function) overrides the load method
-            * ``profile`` (float) profile the rendering (use astor lib) (filter
-              profile line with time ms >= profile)
-        """
 
+        :returns: bytes marked as markup-safe (decode to :class:`MarkupSafeBytes`
+                  instead of `str`)
+        :rtype: MarkupSafeBytes
+        """
         context = dict(self.env.context, dev_mode='qweb' in tools.config['dev_mode'])
         context.update(options)
 
-        result = super(IrQWeb, self)._render(id_or_xml_id, values=values, **context)
+        result = super(IrQWeb, self)._render(template, values=values, **context).decode('utf-8')
 
-        if b'data-pagebreak=' not in result:
-            return result
+        if not values or not values.get('__keep_empty_lines'):
+            result = IrQWeb._empty_lines.sub('\n', result.strip())
 
-        fragments = html.fragments_fromstring(result.decode('utf-8'))
+        if 'data-pagebreak=' not in result:
+            return MarkupSafeBytes(result.encode('utf-8'))
+
+        fragments = html.fragments_fromstring(result)
 
         for fragment in fragments:
             for row in fragment.iterfind('.//tr[@data-pagebreak]'):
@@ -84,13 +107,6 @@ class IrQWeb(models.AbstractModel, QWeb):
 
         return MarkupSafeBytes(b''.join(html.tostring(f) for f in fragments))
 
-    def default_values(self):
-        """ attributes add to the values for each computed template
-        """
-        default = super(IrQWeb, self).default_values()
-        default.update(request=request, cache_assets=round(time()/180), true=True, false=False) # true and false added for backward compatibility to remove after v10
-        return default
-
     # assume cache will be invalidated by third party on write to ir.ui.view
     def _get_template_cache_keys(self):
         """ Return the list of context keys to use for caching ``_get_template``. """
@@ -101,12 +117,12 @@ class IrQWeb(models.AbstractModel, QWeb):
         'xml' not in tools.config['dev_mode'],
         tools.ormcache('id_or_xml_id', 'tuple(options.get(k) for k in self._get_template_cache_keys())'),
     )
-    def compile(self, id_or_xml_id, options):
+    def _compile(self, id_or_xml_id, options):
         try:
             id_or_xml_id = int(id_or_xml_id)
         except:
             pass
-        return super(IrQWeb, self).compile(id_or_xml_id, options=options)
+        return super(IrQWeb, self)._compile(id_or_xml_id, options=options)
 
     def _load(self, name, options):
         lang = options.get('lang', get_lang(self.env).code)
@@ -131,152 +147,81 @@ class IrQWeb(models.AbstractModel, QWeb):
             for node in view:
                 if node.get('t-name'):
                     node.set('t-name', str(name))
-            return view
+            return (view, view_id)
         else:
-            return template
+            return (template, view_id)
 
     # order
 
     def _directives_eval_order(self):
         directives = super(IrQWeb, self)._directives_eval_order()
+        directives.insert(directives.index('foreach'), 'groups')
         directives.insert(directives.index('call'), 'lang')
         directives.insert(directives.index('field'), 'call-assets')
         return directives
 
+    # compile
+
+    def _compile_node(self, el, options, indent):
+        if el.get("groups"):
+            el.set("t-groups", el.attrib.pop("groups"))
+        return super(IrQWeb, self)._compile_node(el, options, indent)
+
     # compile directives
 
-    def _compile_directive_lang(self, el, options):
-        lang = el.attrib.pop('t-lang', get_lang(self.env).code)
-        if el.get('t-call-options'):
-            el.set('t-call-options', el.get('t-call-options')[0:-1] + u', "lang": %s}' % lang)
-        else:
-            el.set('t-call-options', u'{"lang": %s}' % lang)
-        return self._compile_node(el, options)
+    def _compile_directive_groups(self, el, options, indent):
+        """Compile `t-groups` expressions into a python code as a list of
+        strings.
 
-    def _compile_directive_call_assets(self, el, options):
+        The code will contain the condition `if self.user_has_groups(groups)`
+        part that wrap the rest of the compiled code of this element.
+        """
+        groups = el.attrib.pop('t-groups')
+        code = self._flushText(options, indent)
+        code.append(self._indent(f"if self.user_has_groups({repr(groups)}):", indent))
+        code.extend(self._compile_directives(el, options, indent + 1) + self._flushText(options, indent + 1) or [self._indent('pass', indent + 1)])
+        return code
+
+    def _compile_directive_lang(self, el, options, indent):
+        el.attrib['t-options-lang'] = el.attrib.pop('t-lang')
+        return self._compile_node(el, options, indent)
+
+    def _compile_directive_call_assets(self, el, options, indent):
         """ This special 't-call' tag can be used in order to aggregate/minify javascript and css assets"""
         if len(el):
             raise SyntaxError("t-call-assets cannot contain children nodes")
 
-        # nodes = self._get_asset_nodes(bundle, options, css=css, js=js, debug=values.get('debug'), async=async, values=values)
-        #
-        # for index, (tagName, t_attrs, content) in enumerate(nodes):
-        #     if index:
-        #         append('\n        ')
-        #     append('<')
-        #     append(tagName)
-        #
-        #     self._post_processing_att(tagName, t_attrs, options)
-        #     for name, value in t_attrs.items():
-        #         if value or isinstance(value, string_types)):
-        #             append(u' ')
-        #             append(name)
-        #             append(u'="')
-        #             append(escape(pycompat.to_text((value)))
-        #             append(u'"')
-        #
-        #     if not content and tagName in self._void_elements:
-        #         append('/>')
-        #     else:
-        #         append('>')
-        #         if content:
-        #           append(content)
-        #         append('</')
-        #         append(tagName)
-        #         append('>')
-        #
-        space = el.getprevious() is not None and el.getprevious().tail or el.getparent().text
-        sep = u'\n' + space.rsplit('\n').pop()
-        return [
-            ast.Assign(
-                targets=[ast.Name(id='nodes', ctx=ast.Store())],
-                value=ast.Call(
-                    func=ast.Attribute(
-                        value=ast.Name(id='self', ctx=ast.Load()),
-                        attr='_get_asset_nodes',
-                        ctx=ast.Load()
-                    ),
-                    args=[
-                        ast.Str(el.get('t-call-assets')),
-                        ast.Name(id='options', ctx=ast.Load()),
-                    ],
-                    keywords=[
-                        ast.keyword('css', self._get_attr_bool(el.get('t-css', True))),
-                        ast.keyword('js', self._get_attr_bool(el.get('t-js', True))),
-                        ast.keyword('debug', ast.Call(
-                            func=ast.Attribute(
-                                value=ast.Name(id='values', ctx=ast.Load()),
-                                attr='get',
-                                ctx=ast.Load()
-                            ),
-                            args=[ast.Str('debug')],
-                            keywords=[], starargs=None, kwargs=None
-                        )),
-                        ast.keyword('async_load', self._get_attr_bool(el.get('async_load', False))),
-                        ast.keyword('defer_load', self._get_attr_bool(el.get('defer_load', False))),
-                        ast.keyword('lazy_load', self._get_attr_bool(el.get('lazy_load', False))),
-                        ast.keyword('media', ast.Constant(el.get('media'))),
-                    ],
-                    starargs=None, kwargs=None
-                )
-            ),
-            ast.For(
-                target=ast.Tuple(elts=[
-                    ast.Name(id='index', ctx=ast.Store()),
-                    ast.Tuple(elts=[
-                        ast.Name(id='tagName', ctx=ast.Store()),
-                        ast.Name(id='t_attrs', ctx=ast.Store()),
-                        ast.Name(id='content', ctx=ast.Store())
-                    ], ctx=ast.Store())
-                ], ctx=ast.Store()),
-                iter=ast.Call(
-                    func=ast.Name(id='enumerate', ctx=ast.Load()),
-                    args=[ast.Name(id='nodes', ctx=ast.Load())],
-                    keywords=[],
-                    starargs=None, kwargs=None
-                ),
-                body=[
-                    ast.If(
-                        test=ast.Name(id='index', ctx=ast.Load()),
-                        body=[self._append(ast.Str(sep))],
-                        orelse=[]
-                    ),
-                    self._append(ast.Str(u'<')),
-                    self._append(ast.Name(id='tagName', ctx=ast.Load())),
-                ] + self._append_attributes() + [
-                    ast.If(
-                        test=ast.BoolOp(
-                            op=ast.And(),
-                            values=[
-                                ast.UnaryOp(ast.Not(), ast.Name(id='content', ctx=ast.Load()), lineno=0, col_offset=0),
-                                ast.Compare(
-                                    left=ast.Name(id='tagName', ctx=ast.Load()),
-                                    ops=[ast.In()],
-                                    comparators=[ast.Attribute(
-                                        value=ast.Name(id='self', ctx=ast.Load()),
-                                        attr='_void_elements',
-                                        ctx=ast.Load()
-                                    )]
-                                ),
-                            ]
-                        ),
-                        body=[self._append(ast.Str(u'/>'))],
-                        orelse=[
-                            self._append(ast.Str(u'>')),
-                            ast.If(
-                                test=ast.Name(id='content', ctx=ast.Load()),
-                                body=[self._append(ast.Name(id='content', ctx=ast.Load()))],
-                                orelse=[]
-                            ),
-                            self._append(ast.Str(u'</')),
-                            self._append(ast.Name(id='tagName', ctx=ast.Load())),
-                            self._append(ast.Str(u'>')),
-                        ]
-                    )
-                ],
-                orelse=[]
-            )
-        ]
+        code = self._flushText(options, indent)
+        code.append(self._indent(dedent("""
+            t_call_assets_nodes = self._get_asset_nodes(%(xmlid)s, compile_options, css=%(css)s, js=%(js)s, debug=values.get("debug"), async_load=%(async_load)s, defer_load=%(defer_load)s, lazy_load=%(lazy_load)s, media=%(media)s)
+            for index, (tagName, attrs, content) in enumerate(t_call_assets_nodes):
+                if index:
+                    yield '\\n        '
+                yield '<'
+                yield tagName
+            """).strip() % {
+                'xmlid': repr(el.get('t-call-assets')),
+                'css': self._compile_bool(el.get('t-css', True)),
+                'js': self._compile_bool(el.get('t-js', True)),
+                'async_load': self._compile_bool(el.get('async_load', False)),
+                'defer_load': self._compile_bool(el.get('defer_load', False)),
+                'lazy_load': self._compile_bool(el.get('lazy_load', False)),
+                'media': repr(el.get('media')) if el.get('media') else False,
+            }, indent))
+        code.extend(self._compile_attributes(options, indent + 1))
+        code.append(self._indent(dedent("""
+                if not content and tagName in self._void_elements:
+                    yield '/>'
+                else:
+                    yield '>'
+                    if content:
+                      yield content
+                    yield '</'
+                    yield tagName
+                    yield '>'
+                """).strip(), indent + 1))
+
+        return code
 
     # method called by computing code
 
@@ -385,7 +330,7 @@ class IrQWeb(models.AbstractModel, QWeb):
         model = 'ir.qweb.field.' + field_options['type']
         converter = self.env[model] if model in self.env else self.env['ir.qweb.field']
 
-        # get content
+        # get content (the return values from fields are considered to be markup safe)
         content = converter.record_to_html(record, field_name, field_options)
         attributes = converter.attributes(record, field_name, field_options, values)
 
@@ -403,40 +348,34 @@ class IrQWeb(models.AbstractModel, QWeb):
         model = 'ir.qweb.field.' + field_options['type']
         converter = self.env[model] if model in self.env else self.env['ir.qweb.field']
 
-        # get content
+        # get content (the return values from widget are considered to be markup safe)
         content = converter.value_to_html(value, field_options)
-        attributes = OrderedDict()
+        attributes = {}
         attributes['data-oe-type'] = field_options['type']
         attributes['data-oe-expression'] = field_options['expression']
 
         return (attributes, content, None)
 
-    # compile expression add safe_eval
+    def _prepare_values(self, values, options):
+        """ Prepare the context that will be sent to the evaluated function.
 
-    def _compile_expr(self, expr):
-        """ Compiles a purported Python expression to ast, verifies that it's safe
-        (according to safe_eval's semantics) and alter its variable references to
-        access values data instead
+        :param values: template values to be used for rendering
+        :param options: frozen dict of compilation parameters.
         """
-        # string must be stripped otherwise whitespace before the start for
-        # formatting purpose are going to break parse/compile
-        st = ast.parse(expr.strip(), mode='eval')
-        assert_valid_codeobj(
-            _SAFE_OPCODES,
-            compile(st, '<>', 'eval'), # could be expr, but eval *should* be fine
-            expr
-        )
+        check_values(values)
+        values['true'] = True
+        values['false'] = False
+        if 'request' not in values:
+            values['request'] = request
+        return super(IrQWeb, self)._prepare_values(values, options)
 
-        # ast.Expression().body -> expr
-        return Contextifier(_BUILTINS).visit(st).body
+    def _compile_expr(self, expr, raise_on_missing=False):
+        """ Compiles a purported Python expression to compiled code, verifies
+        that it's safe (according to safe_eval's semantics) and alter its
+        variable references to access values data instead
 
-    def _get_attr_bool(self, attr, default=False):
-        if attr:
-            if attr is True:
-                return ast.Constant(True)
-            attr = attr.lower()
-            if attr in ('false', '0'):
-                return ast.Constant(False)
-            elif attr in ('true', '1'):
-                return ast.Constant(True)
-        return ast.Constant(attr if attr is False else bool(default))
+        :param expr: string
+        """
+        namespace_expr = super(IrQWeb, self)._compile_expr(expr, raise_on_missing=raise_on_missing)
+        assert_valid_codeobj(_SAFE_QWEB_OPCODES, compile(namespace_expr, '<>', 'eval'), expr)
+        return namespace_expr

--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -2,7 +2,6 @@
 import base64
 import logging
 import re
-from collections import OrderedDict
 from io import BytesIO
 
 import babel
@@ -81,9 +80,9 @@ class FieldConverter(models.AbstractModel):
         * ``readonly``, has this attribute if the field is readonly
         * ``expression``, the original expression
 
-        :returns: OrderedDict (attribute name, attribute value).
+        :returns: dict (attribute name, attribute value).
         """
-        data = OrderedDict()
+        data = {}
         field = record._fields[field_name]
 
         if not options['inherit_branding'] and not options['translate']:
@@ -139,7 +138,7 @@ class IntegerConverter(models.AbstractModel):
 
     @api.model
     def value_to_html(self, value, options):
-        return pycompat.to_text(self.user_lang().format('%d', value, grouping=True).replace(r'-', u'-\N{ZERO WIDTH NO-BREAK SPACE}'))
+        return pycompat.to_text(self.user_lang().format('%d', value, grouping=True).replace(r'-', '-\N{ZERO WIDTH NO-BREAK SPACE}'))
 
 
 class FloatConverter(models.AbstractModel):
@@ -168,7 +167,7 @@ class FloatConverter(models.AbstractModel):
             value = float_utils.float_round(value, precision_digits=precision)
             fmt = '%.{precision}f'.format(precision=precision)
 
-        formatted = self.user_lang().format(fmt, value, grouping=True).replace(r'-', u'-\N{ZERO WIDTH NO-BREAK SPACE}')
+        formatted = self.user_lang().format(fmt, value, grouping=True).replace(r'-', '-\N{ZERO WIDTH NO-BREAK SPACE}')
 
         # %f does not strip trailing zeroes. %g does but its precision causes
         # it to switch to scientific notation starting at a million *and* to
@@ -245,11 +244,11 @@ class DateTimeConverter(models.AbstractModel):
             pattern = options['format']
         else:
             if options.get('time_only'):
-                strftime_pattern = (u"%s" % (lang.time_format))
+                strftime_pattern = ("%s" % (lang.time_format))
             elif options.get('date_only'):
-                strftime_pattern = (u"%s" % (lang.date_format))
+                strftime_pattern = ("%s" % (lang.date_format))
             else:
-                strftime_pattern = (u"%s %s" % (lang.date_format, lang.time_format))
+                strftime_pattern = ("%s %s" % (lang.date_format, lang.time_format))
 
             pattern = posix_to_ldml(strftime_pattern, locale=locale)
 
@@ -296,7 +295,7 @@ class SelectionConverter(models.AbstractModel):
     def value_to_html(self, value, options):
         if not value:
             return ''
-        return escape(pycompat.to_text(options['selection'][value]) or u'')
+        return escape(pycompat.to_text(options['selection'][value]) or '')
 
     @api.model
     def record_to_html(self, record, field_name, options):
@@ -346,11 +345,11 @@ class HTMLConverter(models.AbstractModel):
         # use pos processing for all nodes with attributes
         for element in body.iter():
             if element.attrib:
-                attrib = OrderedDict(element.attrib)
+                attrib = dict(element.attrib)
                 attrib = irQweb._post_processing_att(element.tag, attrib, options.get('template_options'))
                 element.attrib.clear()
                 element.attrib.update(attrib)
-        return etree.tostring(body, encoding='unicode', method='html')[6:-7]
+        return M(etree.tostring(body, encoding='unicode', method='html')[6:-7])
 
 
 class ImageConverter(models.AbstractModel):
@@ -376,7 +375,7 @@ class ImageConverter(models.AbstractModel):
         except: # image.verify() throws "suitable exceptions", I have no idea what they are
             raise ValueError("Invalid image content")
 
-        return u'<img src="data:%s;base64,%s">' % (Image.MIME[image.format], value.decode('ascii'))
+        return M('<img src="data:%s;base64,%s">' % (Image.MIME[image.format], value.decode('ascii')))
 
 class ImageUrlConverter(models.AbstractModel):
     """ ``image_url`` widget rendering, inserts an image tag in the
@@ -388,7 +387,7 @@ class ImageUrlConverter(models.AbstractModel):
 
     @api.model
     def value_to_html(self, value, options):
-        return u'<img src="%s">' % (value)
+        return M('<img src="%s">' % (value))
 
 class MonetaryConverter(models.AbstractModel):
     """ ``monetary`` converter, has a mandatory option
@@ -444,13 +443,13 @@ class MonetaryConverter(models.AbstractModel):
 
         lang = self.user_lang()
         formatted_amount = lang.format(fmt, display_currency.round(value),
-                                grouping=True, monetary=True).replace(r' ', u'\N{NO-BREAK SPACE}').replace(r'-', u'-\N{ZERO WIDTH NO-BREAK SPACE}')
+                                grouping=True, monetary=True).replace(r' ', '\N{NO-BREAK SPACE}').replace(r'-', '-\N{ZERO WIDTH NO-BREAK SPACE}')
 
-        pre = post = u''
+        pre = post = ''
         if display_currency.position == 'before':
-            pre = u'{symbol}\N{NO-BREAK SPACE}'.format(symbol=display_currency.symbol or '')
+            pre = '{symbol}\N{NO-BREAK SPACE}'.format(symbol=display_currency.symbol or '')
         else:
-            post = u'\N{NO-BREAK SPACE}{symbol}'.format(symbol=display_currency.symbol or '')
+            post = '\N{NO-BREAK SPACE}{symbol}'.format(symbol=display_currency.symbol or '')
 
         return M('{pre}<span class="oe_currency_value">{0}</span>{post}').format(formatted_amount, pre=pre, post=post)
 
@@ -571,13 +570,13 @@ class DurationConverter(models.AbstractModel):
                 if not v and (secs_per_unit > factor or secs_per_unit < round_to):
                     continue
                 if len(sections):
-                    sections.append(u':')
-                sections.append(u"%02.0f" % int(round(v)))
-            return u''.join(sections)
+                    sections.append(':')
+                sections.append("%02.0f" % int(round(v)))
+            return ''.join(sections)
 
         if value < 0:
             r = -r
-            sections.append(u'-')
+            sections.append('-')
         for unit, label, secs_per_unit in TIMEDELTA_UNITS:
             v, r = divmod(r, secs_per_unit)
             if not v:
@@ -592,7 +591,7 @@ class DurationConverter(models.AbstractModel):
             if section:
                 sections.append(section)
 
-        return u' '.join(sections)
+        return ' '.join(sections)
 
 
 class RelativeDatetimeConverter(models.AbstractModel):

--- a/odoo/addons/base/models/qweb.py
+++ b/odoo/addons/base/models/qweb.py
@@ -984,7 +984,8 @@ class QWeb(object):
         else:
             # Etree will remove the ns prefixes indirection by inlining the corresponding
             # nsmap definition into the tag attribute. Restore the tag and prefix here.
-            # Note: we do not support namespace dynamic attributes.
+            # Note: we do not support namespace dynamic attributes, we need a default URI
+            # on the root and use attribute directive t-att="{'xmlns:example': value}".
             unqualified_el_tag = etree.QName(el.tag).localname
             el_tag = unqualified_el_tag
             if el.prefix:

--- a/odoo/addons/base/models/qweb.py
+++ b/odoo/addons/base/models/qweb.py
@@ -92,24 +92,6 @@ _FORMAT_REGEX = re.compile(r'(?:#\{(.+?)\})|(?:\{\{(.+?)\}\})') # ( ruby-style )
 _VARNAME_REGEX = re.compile(r'\W')
 
 
-class MarkupSafeBytes(bytes):
-    __slots__ = ()
-
-    def __new__(cls, source):
-        assert isinstance(source, bytes)
-        return super().__new__(cls, source)
-
-    def __html__(self):
-        return self.decode()
-
-    def __str__(self):
-        raise NotImplementedError(
-            "Bytes should not be stringified, only repr'd (tried to stringify %s)" % repr(self)
-        )
-
-    def decode(self, encoding='utf-8', errors='strict'):
-        return Markup(super().decode(encoding, errors))
-
 ####################################
 ###             QWeb             ###
 ####################################
@@ -137,8 +119,8 @@ class QWeb(object):
             * ``load`` (function) overrides the load method (returns: (template, ref))
             * ``profile`` (boolean) profile the rendering
 
-        :returns: str as MarkupSafeBytes
-        :rtype: MarkupSafeBytes
+        :returns: str as Markup
+        :rtype: markupsafe.Markup
         """
         if values and 0 in values:
             raise ValueError('values[0] should be unset when call the _render method and only set into the template.')
@@ -146,7 +128,7 @@ class QWeb(object):
         rendering = render_template(self, values or {})
         result = ''.join(rendering)
 
-        return MarkupSafeBytes(result.encode('utf8'))
+        return Markup(result)
 
     def _compile(self, template, options):
         """ Compile the given template into a rendering function (generator)::

--- a/odoo/addons/base/models/qweb.py
+++ b/odoo/addons/base/models/qweb.py
@@ -3,209 +3,69 @@ import ast
 import logging
 import os.path
 import re
-import reprlib
 import traceback
+import builtins
+import token
+import tokenize
+import io
 
-from collections import OrderedDict
+from markupsafe import Markup, escape
 from collections.abc import Sized, Mapping
-from functools import reduce
-from itertools import tee, count
-from textwrap import dedent
-
-import itertools
-
+from itertools import count, chain
+from textwrap import dedent, indent as _indent
 from lxml import etree
-from markupsafe import escape, Markup
 from psycopg2.extensions import TransactionRollbackError
 
 from odoo.tools import pycompat, freehash
-from odoo.tools.safe_eval import check_values
-
-import builtins
-builtin_defaults = {name: getattr(builtins, name) for name in dir(builtins)}
-
-try:
-    import astor
-except ImportError:
-    astor = None
-
-from odoo.tools.parse_version import parse_version
-
-unsafe_eval = eval
 
 _logger = logging.getLogger(__name__)
+
+# same list as for `--dev-mode`
+SUPPORTED_DEBUGGERS = ['pdb', 'ipbd', 'pudb', 'wdb']
+token.QWEB = token.NT_OFFSET - 1
+token.tok_name[token.QWEB] = 'QWEB'
 
 ####################################
 ###          qweb tools          ###
 ####################################
 
-
-class Contextifier(ast.NodeTransformer):
-    """ For user-provided template expressions, replaces any ``name`` by
-    :sampe:`values.get('{name}')` so all variable accesses are
-    performed on the values rather than in the "native" values
-    """
-
-    # some people apparently put lambdas in template expressions. Turns out
-    # the AST -> bytecode compiler does *not* appreciate parameters of lambdas
-    # being converted from names to subscript expressions, and most likely the
-    # reference to those parameters inside the lambda's body should probably
-    # remain as-is. Because we're transforming an AST, the structure should
-    # be lexical, so just store a set of "safe" parameter names and recurse
-    # through the lambda using a new NodeTransformer
-    def __init__(self, params=()):
-        super(Contextifier, self).__init__()
-        self._safe_names = tuple(params)
-
-    def visit_Name(self, node):
-        if node.id in self._safe_names:
-            return node
-
-        return ast.copy_location(
-            # values.get(name)
-            ast.Call(
-                func=ast.Attribute(
-                    value=ast.Name(id='values', ctx=ast.Load()),
-                    attr='get',
-                    ctx=ast.Load()
-                ),
-                args=[ast.Str(node.id)], keywords=[],
-                starargs=None, kwargs=None
-            ),
-            node
-        )
-
-    def visit_Lambda(self, node):
-        args = node.args
-        # assume we don't have any tuple parameter, just names
-        names = [arg.arg for arg in args.args]
-        if args.vararg: names.append(args.vararg)
-        if args.kwarg: names.append(args.kwarg)
-        # remap defaults in case there's any
-        return ast.copy_location(ast.Lambda(
-            args=ast.arguments(
-                args=args.args,
-                defaults=[self.visit(default) for default in args.defaults],
-                vararg=args.vararg,
-                kwarg=args.kwarg,
-                # assume we don't have any, not sure it's even possible to
-                # handle that cross-version
-                kwonlyargs=[],
-                kw_defaults=[],
-                posonlyargs=[],
-            ),
-            body=Contextifier(self._safe_names + tuple(names)).visit(node.body)
-        ), node)
-
-    # "lambda problem" also exists with comprehensions
-    def _visit_comp(self, node):
-        # CompExp(?, comprehension* generators)
-        # comprehension = (expr target, expr iter, expr* ifs)
-
-        # collect names in generators.target
-        names = tuple(
-            node.id
-            for gen in node.generators
-            for node in ast.walk(gen.target)
-            if isinstance(node, ast.Name)
-        )
-        transformer = Contextifier(self._safe_names + names)
-        # copy node
-        newnode = ast.copy_location(type(node)(), node)
-        # then visit the comp ignoring those names, transformation is
-        # probably expensive but shouldn't be many comprehensions
-        for field, value in ast.iter_fields(node):
-            # map transformation of comprehensions
-            if isinstance(value, list):
-                setattr(newnode, field, [transformer.visit(v) for v in value])
-            else: # set transformation of key/value/expr fields
-                setattr(newnode, field, transformer.visit(value))
-        return newnode
-    visit_GeneratorExp = visit_ListComp = visit_SetComp = visit_DictComp = _visit_comp
-
-
 class QWebException(Exception):
-    def __init__(self, message, error=None, path=None, html=None, name=None, astmod=None):
+    def __init__(self, message, qweb, options, error=None, template=None, path=None, code=None):
         self.error = error
-        self.message = message
+        self.name = template
+        self.code = code if options.get('dev_mode') else None
         self.path = path
-        self.html = html
-        self.name = name
+        self.html = None
+        if template is not None and path and ':' not in path:
+            element = qweb._get_template(template, options)[0]
+            nodes = element.getroottree().xpath(self.path)
+            if nodes:
+                node = nodes[0]
+                node[:] = []
+                node.text = None
+                self.html = etree.tostring(node, encoding='unicode')
         self.stack = traceback.format_exc()
-        if astmod:
-            if astor:
-                self.code = astor.to_source(astmod)
-            else:
-                self.code = "Please install astor to display the compiled code"
-                self.stack += "\nInstall `astor` for compiled source information."
-        else:
-            self.code = None
 
-        if self.error:
+        self.message = message
+        if self.error is not None:
             self.message = "%s\n%s: %s" % (self.message, self.error.__class__.__name__, self.error)
-        if self.name:
+        if self.name is not None:
             self.message = "%s\nTemplate: %s" % (self.message, self.name)
-        if self.path:
+        if self.path is not None:
             self.message = "%s\nPath: %s" % (self.message, self.path)
-        if self.html:
+        if self.html is not None:
             self.message = "%s\nNode: %s" % (self.message, self.html)
 
         super(QWebException, self).__init__(message)
 
     def __str__(self):
         message = "%s\n%s\n%s" % (self.error, self.stack, self.message)
-        if self.code:
+        if self.code is not None:
             message = "%s\nCompiled code:\n%s" % (message, self.code)
         return message
 
     def __repr__(self):
         return str(self)
-
-def foreach_iterator(base_ctx, enum, name):
-    ctx = base_ctx.copy()
-    if not enum:
-        return
-    if isinstance(enum, int):
-        enum = range(enum)
-    size = None
-    if isinstance(enum, Sized):
-        ctx["%s_size" % name] = size = len(enum)
-    if isinstance(enum, Mapping):
-        enum = enum.items()
-    else:
-        enum = zip(*tee(enum))
-    value_key = '%s_value' % name
-    index_key = '%s_index' % name
-    first_key = '%s_first' % name
-    last_key = '%s_last' % name
-    parity_key = '%s_parity' % name
-    even_key = '%s_even' % name
-    odd_key = '%s_odd' % name
-    for index, (item, value) in enumerate(enum):
-        ctx[name] = item
-        ctx[value_key] = value
-        ctx[index_key] = index
-        ctx[first_key] = index == 0
-        if size is not None:
-            ctx[last_key] = index + 1 == size
-        if index % 2:
-            ctx[parity_key] = 'odd'
-            ctx[even_key] = False
-            ctx[odd_key] = True
-        else:
-            ctx[parity_key] = 'even'
-            ctx[even_key] = True
-            ctx[odd_key] = False
-        yield ctx
-    # copy changed items back into source context (?)
-    # FIXME: maybe values could provide a ChainMap-style clone?
-    for k in list(base_ctx):
-        base_ctx[k] = ctx[k]
-
-_FORMAT_REGEX = re.compile(
-    # ( ruby-style )|(  jinja-style  )
-    r'(?:#\{(.+?)\})|(?:\{\{(.+?)\}\})')
-
 
 class frozendict(dict):
     """ An implementation of an immutable dictionary. """
@@ -226,6 +86,11 @@ class frozendict(dict):
     def __hash__(self):
         return hash(frozenset((key, freehash(val)) for key, val in self.items()))
 
+unsafe_eval = eval
+
+_FORMAT_REGEX = re.compile(r'(?:#\{(.+?)\})|(?:\{\{(.+?)\}\})') # ( ruby-style )|(  jinja-style  )
+_VARNAME_REGEX = re.compile(r'\W')
+
 
 class MarkupSafeBytes(bytes):
     __slots__ = ()
@@ -239,7 +104,7 @@ class MarkupSafeBytes(bytes):
 
     def __str__(self):
         raise NotImplementedError(
-            "Bytes should not be stringified, only repr'd (tried to stringify %s)" % reprlib.repr(self)
+            "Bytes should not be stringified, only repr'd (tried to stringify %s)" % repr(self)
         )
 
     def decode(self, encoding='utf-8', errors='strict'):
@@ -251,141 +116,145 @@ class MarkupSafeBytes(bytes):
 
 
 class QWeb(object):
-    _empty_line = re.compile(r'\n\s*\n')
     __slots__ = ()
 
     _void_elements = frozenset([
         'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'keygen',
         'link', 'menuitem', 'meta', 'param', 'source', 'track', 'wbr'])
     _name_gen = count()
+    # _available_objects builtins is not security safe (it's dangerous), is overridden by ir_qweb to only expose the safe_eval builtins.
+    _available_objects = {k: v for k, v in vars(builtins).items() if not k.startswith('_')}
+    _allowed_keyword = ['False', 'None', 'True', 'and', 'as', 'elif', 'else', 'for', 'if', 'in', 'is', 'not', 'or']
 
     def _render(self, template, values=None, **options):
-        """Render the template specified by the given name.
+        """ render(template, values, **options)
+
+        Render the template specified by the given name.
 
         :param template: template identifier
         :param dict values: template values to be used for rendering
         :param options: used to compile the template (the dict available for the rendering is frozen)
-            * ``load`` (function) overrides the load method
-            * ``profile`` (float) profile the rendering (use astor lib) (filter
-              profile line with time ms >= profile)
-        :returns: bytes marked as markup-safe (decode to :class:`markupsafe.Markup`
-                  instead of `str`)
+            * ``load`` (function) overrides the load method (returns: (template, ref))
+            * ``profile`` (boolean) profile the rendering
+
+        :returns: str as MarkupSafeBytes
         :rtype: MarkupSafeBytes
         """
-        values = values or {}
-        body = []
-        self.compile(template, options)(self, body.append, values)
-        joined = u''.join(body)
-        if not values.get('__keep_empty_lines'):
-            joined = QWeb._empty_line.sub('\n', joined.strip())
-        return MarkupSafeBytes(joined.encode('utf8'))
+        if values and 0 in values:
+            raise ValueError('values[0] should be unset when call the _render method and only set into the template.')
+        render_template = self._compile(template, options)
+        rendering = render_template(self, values or {})
+        result = ''.join(rendering)
 
-    def compile(self, template, options):
-        """ Compile the given template into a rendering function::
+        return MarkupSafeBytes(result.encode('utf8'))
 
-            render(qweb, append, values)
+    def _compile(self, template, options):
+        """ Compile the given template into a rendering function (generator)::
 
-        where ``qweb`` is a QWeb instance, ``append`` is a unary function to
-        collect strings into a result, and ``values`` are the values to render.
+            render(qweb, values)
+
+        where ``qweb`` is a QWeb instance and ``values`` are the values to render.
         """
         if options is None:
             options = {}
 
+        element, document, ref = self._get_template(template, options)
+        if not ref:
+            ref = element.get('t-name', str(document))
+
+        options['ref'] = ref
+        if 'profile' in options:
+            options['document'] = document if isinstance(document, str) else str(document, 'utf-8')
+
         _options = dict(options)
         options = frozendict(options)
 
-        element, document = self.get_template(template, options)
-        name = element.get('t-name', 'unknown')
-
         _options['template'] = template
-        _options['ast_calls'] = []
         _options['root'] = element.getroottree()
         _options['last_path_node'] = None
         if not options.get('nsmap'):
             _options['nsmap'] = {}
 
-        # generate ast
+        # generate code
 
-        astmod = self._base_module()
+        def_name = f"template_{ref}" if isinstance(ref, int) else "template"
+
         try:
-            body = self._compile_node(element, _options)
-            ast_calls = _options['ast_calls']
-            _options['ast_calls'] = []
-            def_name = self._create_def(_options, body, prefix='template_%s' % name.replace('.', '_'))
-            _options['ast_calls'] += ast_calls
+            _options['_text_concat'] = []
+            self._appendText("", _options) # To ensure the template function is a generator and doesn't become a regular function
+            code_lines = ([f"def {def_name}(self, values, log):"] +
+                self._compile_node(element, _options, 1) +
+                self._flushText(_options, 1))
         except QWebException as e:
             raise e
         except Exception as e:
-            path = _options['last_path_node']
-            element, document = self.get_template(template, options)
-            node = element.getroottree().xpath(path) if ':' not in path else None
-            raise QWebException("Error when compiling AST", e, path, node and etree.tostring(node[0], encoding='unicode'), name)
-        astmod.body.extend(_options['ast_calls'])
+            raise QWebException("Error when compiling xml template", self, options,
+                error=e, template=template, path=_options.get('last_path_node'))
 
-        if 'profile' in options:
-            self._profiling(astmod, _options)
+        try:
+            code = '\n'.join(code_lines)
+        except QWebException as e:
+            raise e
+        except Exception as e:
+            code = '\n'.join(map(str, code_lines))
+            raise QWebException("Error when compiling xml template", self, options,
+                error=e, template=template, code=code)
 
-        ast.fix_missing_locations(astmod)
-
-        # compile ast
+        # compile code and defined default values
 
         try:
             # noinspection PyBroadException
-            ns = {}
-            unsafe_eval(compile(astmod, '<template>', 'exec'), ns)
-            compiled = ns[def_name]
+            compiled = compile(code, f'<{def_name}>', 'exec')
+            globals_dict = self._prepare_globals({}, options)
+            globals_dict['__builtins__'] = globals_dict # So that unknown/unsafe builtins are never added.
+            unsafe_eval(compiled, globals_dict)
+            compiled_fn = globals_dict[def_name]
         except QWebException as e:
             raise e
         except Exception as e:
-            path = _options['last_path_node']
-            element, document = self.get_template(template, options)
-            node = element.getroottree().xpath(path)
-            raise QWebException("Error when compiling AST", e, path, node and etree.tostring(node[0], encoding='unicode'), name)
+            raise QWebException("Error when compiling xml template", self, options,
+                error=e, template=template, code=code)
 
         # return the wrapped function
 
-        def _compiled_fn(self, append, values):
-            log = {'last_path_node': None}
-            new = self.default_values()
-            new.update(values)
-            check_values(new)
+        def render_template(self, values):
             try:
-                return compiled(self, append, new, options, log)
+                log = {'last_path_node': None}
+                values = self._prepare_values(values, options)
+                yield from compiled_fn(self, values, log)
             except (QWebException, TransactionRollbackError) as e:
                 raise e
             except Exception as e:
-                path = log['last_path_node']
-                element, document = self.get_template(template, options)
-                node = element.getroottree().xpath(path) if ':' not in path else None
-                raise QWebException("Error to render compiling AST", e, path, node and etree.tostring(node[0], encoding='unicode'), name)
+                raise QWebException("Error when render the template", self, options,
+                    error=e, template=template, path=log.get('last_path_node'), code=code)
 
-        return _compiled_fn
+        return render_template
 
-    def default_values(self):
-        """ Return attributes added to the values for each computed template. """
-        return {'format': self.format}
-
-    def get_template(self, template, options):
-        """ Retrieve the given template, and return it as a pair ``(element,
-        document)``, where ``element`` is an etree, and ``document`` is the
-        string document that contains ``element``.
+    def _get_template(self, template, options):
+        """ Retrieve the given template, and return it as a tuple ``(element,
+        document, ref)``, where ``element`` is an etree, ``document`` is the
+        string document that contains ``element``, and ``ref`` if the uniq
+        reference of the template (id, t-name or template).
         """
+        ref = template
         if isinstance(template, etree._Element):
-            document = template
-            template = etree.tostring(template)
-            return (document, template)
+            element = template
+            document = etree.tostring(template)
+            return (element, document, template.get('t-name'))
         else:
             try:
-                document = options.get('load', self._load)(template, options)
+                loaded = options.get('load', self._load)(template, options)
+                if not loaded:
+                    raise ValueError("Can not load template '%s'" % template)
+                document, ref = loaded
             except QWebException as e:
                 raise e
             except Exception as e:
                 template = options.get('caller_template', template)
-                path = options.get('last_path_node')
-                raise QWebException("load could not load template", e, path, name=template)
+                raise QWebException("load could not load template", self, options, e, template)
 
         if document is None:
-            raise QWebException("Template not found", name=template)
+            raise QWebException("Template not found", self, options, template=template)
 
         if isinstance(document, etree._Element):
             element = document
@@ -397,274 +266,92 @@ class QWeb(object):
 
         for node in element:
             if node.get('t-name') == str(template):
-                return (node, document)
-        return (element, document)
+                return (node, document, ref)
+        return (element, document, ref)
 
     def _load(self, template, options):
         """ Load a given template. """
-        return template
+        return (template, None)
 
-    # public method for template dynamic values
+    # values for running time
 
-    def format(self, value, formating, *args, **kwargs):
-        format = getattr(self, '_format_func_%s' % formating, None)
-        if not format:
-            raise ValueError("Unknown format '%s'" % (formating,))
-        return format(value, *args, **kwargs)
+    def _prepare_values(self, values, options):
+        """ Prepare the context that will sent to the compiled and evaluated
+        function.
+
+        :param values: template values to be used for rendering
+        :param options: frozen dict of compilation parameters.
+        """
+        return values
+
+    def _prepare_globals(self, globals_dict, options):
+        """ Prepare the global context that will sent to eval the qweb generated
+        code.
+
+        :param values: template values to be used for rendering
+        :param options: frozen dict of compilation parameters.
+        """
+        globals_dict['Sized'] = Sized
+        globals_dict['Mapping'] = Mapping
+        globals_dict['Markup'] = Markup
+        globals_dict['escape'] = escape
+        globals_dict['type'] = type
+        globals_dict['compile_options'] = options
+        globals_dict.update(self._available_objects)
+        return globals_dict
 
     # compute helpers
 
-    def _profiling(self, astmod, options):
-        """ Add profiling code into the givne module AST. """
-        if not astor:
-            _logger.warning("Please install astor to display the code profiling")
-            return
-        code_line = astor.to_source(astmod)
+    def _appendText(self, text, options):
+        """ Add an item (converts to a string) to the list.
+            This will be concatenated and added during a call to the
+            `_flushText` method. This makes it possible to return only one
+            yield containing all the parts."""
+        options['_text_concat'].append(self._compile_to_str(text))
 
-        # code = $code_lines.split(u"\n")
-        astmod.body.insert(0, ast.Assign(
-            targets=[ast.Name(id='code', ctx=ast.Store())],
-            value=ast.Call(
-                func=ast.Attribute(
-                    value=ast.Str(code_line),
-                    attr='split',
-                    ctx=ast.Load()
-                ),
-                args=[ast.Str("\n")], keywords=[],
-                starargs=None, kwargs=None
-            )
-        ))
-        code_line = [[l, False] for l in code_line.split('\n')]
+    def _flushText(self, options, indent):
+        """Concatenate all the textual chunks added by the `_appendText`
+            method into a single yield."""
+        text_concat = options['_text_concat']
+        if text_concat:
+            text = ''.join(text_concat)
+            text_concat.clear()
+            return [f"{'    ' * indent}yield {repr(text)}"]
+        else:
+            return []
 
-        # profiling = {}
-        astmod.body.insert(0, ast.Assign(
-            targets=[ast.Name(id='profiling', ctx=ast.Store())],
-            value=ast.Dict(keys=[], values=[])
-        ))
-        astmod.body.insert(0, ast.parse("from time import time").body[0])
-
-        line_id = [0]
-        def prof(code, time):
-            line_id[0] += 1
-
-            # profiling.setdefault($line_id, time() - $time)
-            return ast.Expr(ast.Call(
-                func=ast.Attribute(
-                    value=ast.Name(id='profiling', ctx=ast.Load()),
-                    attr='setdefault',
-                    ctx=ast.Load()
-                ),
-                args=[
-                    ast.Num(line_id[0]),
-                    ast.BinOp(
-                        left=ast.Call(
-                            func=ast.Name(id='time', ctx=ast.Load()),
-                            args=[],
-                            keywords=[], starargs=None, kwargs=None
-                        ),
-                        op=ast.Sub(),
-                        right=ast.Name(id=time, ctx=ast.Load())
-                    )
-                ],
-                keywords=[], starargs=None, kwargs=None
-            ))
-
-        def profile(body):
-            profile_body = []
-            for code in body:
-                time = self._make_name('time')
-
-                # $time = time()
-                profile_body.append(
-                    ast.Assign(
-                        targets=[ast.Name(id=time, ctx=ast.Store())],
-                        value=ast.Call(
-                            func=ast.Name(id='time', ctx=ast.Load()),
-                            args=[],
-                            keywords=[], starargs=None, kwargs=None
-                        )
-                    )
-                )
-                profile_body.append(code)
-                profline = prof(code, time)
-                # log body of if, else and loop
-                if hasattr(code, 'body'):
-                    code.body = [profline] + profile(code.body)
-                    if hasattr(code, 'orelse'):
-                        code.orelse = [profline] + profile(code.orelse)
-                profile_body.append(profline)
-
-            return profile_body
-
-        for call in options['ast_calls']:
-            call.body = profile(call.body)
-
-        options['ast_calls'][0].body = ast.parse(dedent("""
-            global profiling
-            profiling = {}
-            """)).body + options['ast_calls'][0].body
-
-        p = float(options.get('profile'))
-        options['ast_calls'][0].body.extend(ast.parse(dedent("""
-            total = 0
-            prof_total = 0
-            code_profile = []
-            line_id = 0
-            for line in code:
-                if not line:
-                    if %s <= 0: print ("")
-                    continue
-                if line.startswith('def ') or line.startswith('from ') or line.startswith('import '):
-                    if %s <= 0: print ("      \t", line)
-                    continue
-                line_id += 1
-                total += profiling.get(line_id, 0)
-                dt = round(profiling.get(line_id, -1)*1000000)/1000
-                if %s <= dt:
-                    prof_total += profiling.get(line_id, 0)
-                    display = "%%.2f\t" %% dt
-                    print ((" " * (7 - len(display))) + display, line)
-                elif dt < 0 and %s <= 0:
-                    print ("     ?\t", line)
-            print ("'%s' Total: %%d/%%d" %% (round(prof_total*1000), round(total*1000)))
-            """ % (p, p, p, p, str(options['template']).replace('"', ' ')))).body)
-
-    def _base_module(self):
-        """ Base module supporting qweb template functions (provides basic
-        imports and utilities), returned as a Python AST.
-        Currently provides:
-        * collections
-        Define:
-        * escape, Markup
-        * to_text (empty string for a None or False, otherwise unicode string)
-        """
-        return ast.parse(dedent("""
-            from collections import OrderedDict
-            from html import unescape # not sure whether this one or werkzeug's is better
-            from markupsafe import escape, Markup
-            from odoo.tools.pycompat import to_text
-            from odoo.addons.base.models.qweb import foreach_iterator
-            """))
-
-    def _create_def(self, options, body, prefix='fn', lineno=None):
-        """ Generate (and globally store) a rendering function definition AST
-        and return its name. The function takes parameters ``self``, ``append``,
-        ``values``, ``options``, and ``log``. If ``body`` is empty, the function
-        simply returns ``None``.
-        """
-        #assert body, "To create a compiled function 'body' ast list can't be empty"
-
-        name = self._make_name(prefix)
-
-        # def $name(self, append, values, options, log)
-        fn = ast.FunctionDef(
-            name=name,
-            args=ast.arguments(args=[
-                ast.arg(arg='self', annotation=None),
-                ast.arg(arg='append', annotation=None),
-                ast.arg(arg='values', annotation=None),
-                ast.arg(arg='options', annotation=None),
-                ast.arg(arg='log', annotation=None),
-            ], defaults=[], vararg=None, kwarg=None, posonlyargs=[], kwonlyargs=[], kw_defaults=[]),
-            body=body or [ast.Return()],
-            decorator_list=[])
-        if lineno is not None:
-            fn.lineno = lineno
-
-        options['ast_calls'].append(fn)
-
-        return name
-
-    def _call_def(self, name, append='append', values='values'):
-        # $name(self, append, values, options, log)
-        return ast.Call(
-            func=ast.Name(id=name, ctx=ast.Load()),
-            args=[
-                ast.Name(id='self', ctx=ast.Load()),
-                ast.Name(id=append, ctx=ast.Load()) if isinstance(append, str) else append,
-                ast.Name(id=values, ctx=ast.Load()),
-                ast.Name(id='options', ctx=ast.Load()),
-                ast.Name(id='log', ctx=ast.Load()),
-            ],
-            keywords=[], starargs=None, kwargs=None
-        )
-
-    def _append(self, item):
-        assert isinstance(item, ast.expr)
-        # append(ast item)
-        return ast.Expr(ast.Call(
-            func=ast.Name(id='append', ctx=ast.Load()),
-            args=[item], keywords=[],
-            starargs=None, kwargs=None
-        ))
-
-    def _extend(self, items):
-        # for x in iterator:
-        #     append(x)
-        var = self._make_name()
-        return ast.For(
-            target=ast.Name(id=var, ctx=ast.Store()),
-            iter=items,
-            body=[ast.Expr(ast.Call(
-                func=ast.Name(id='append', ctx=ast.Load()),
-                args=[ast.Name(id=var, ctx=ast.Load())], keywords=[],
-                starargs=None, kwargs=None
-            ))],
-            orelse=[]
-        )
-
-    def _if_content_is_not_Falsy(self, body, orelse):
-        return ast.If(
-                # if content is not None and content is not False
-                test=ast.BoolOp(
-                    op=ast.And(),
-                    values=[
-                        ast.Compare(
-                            left=ast.Name(id='content', ctx=ast.Load()),
-                            ops=[ast.IsNot()],
-                            comparators=[ast.Constant(None)]
-                        ),
-                        ast.Compare(
-                            left=ast.Name(id='content', ctx=ast.Load()),
-                            ops=[ast.IsNot()],
-                            comparators=[ast.Constant(False)]
-                        )
-                    ]
-                ),
-                # append(escape($content))
-                body=body or [ast.Pass()],
-                # append(body default value)
-                orelse=orelse,
-            )
+    def _indent(self, code, indent):
+        """Indent the code to respect the python syntax."""
+        return _indent(code, '    ' * indent)
 
     def _make_name(self, prefix='var'):
-        return "%s_%s" % (prefix, next(self._name_gen))
+        """Generates a unique name."""
+        return f"{prefix}_{next(self._name_gen)}"
 
-    def _compile_node(self, el, options):
-        """ Compile the given element.
+    def _compile_node(self, el, options, indent):
+        """ Compile the given element into python code.
 
-        :return: list of AST nodes
+            The t-* attributes (directives) will be converted to a python instruction. If there
+            are no t-* attributes, the element will be considered static.
+
+            Directives are compiled using the order provided by the
+            ``_directives_eval_order`` method (an create the
+            ``options['iter_directives']`` iterator).
+            For compilation, the directives supported are those with a
+            compilation method ``_compile_directive_*``
+
+        :return: list of string
         """
+        # if tag don't have qweb attributes don't use directives
+        if self._is_static_node(el, options):
+            return self._compile_static_node(el, options, indent)
+
         path = options['root'].getpath(el)
         if options['last_path_node'] != path:
             options['last_path_node'] = path
-            # options['last_path_node'] = $path
-            body = [ast.Assign(
-                targets=[ast.Subscript(
-                    value=ast.Name(id='log', ctx=ast.Load()),
-                    slice=ast.Index(ast.Str('last_path_node')),
-                    ctx=ast.Store())],
-                value=ast.Str(path)
-            )]
+            body = [self._indent(f'log["last_path_node"] = {repr(path)}', indent)]
         else:
             body = []
-
-        if el.get("groups"):
-            el.set("t-groups", el.attrib.pop("groups"))
-
-        # if tag don't have qweb attributes don't use directives
-        if self._is_static_node(el, options):
-            return self._compile_static_node(el, options)
 
         # create an iterator on directives to compile in order
         options['iter_directives'] = iter(self._directives_eval_order() + [None])
@@ -673,121 +360,266 @@ class QWeb(object):
         if not ({'t-out', 't-esc', 't-raw', 't-field'} & set(el.attrib)):
             el.set('t-content', 'True')
 
-        return body + self._compile_directives(el, options)
+        return body + self._compile_directives(el, options, indent)
 
-    def _compile_directives(self, el, options):
+    def _compile_directives(self, el, options, indent):
         """ Compile the given element, following the directives given in the
-        iterator ``options['iter_directives']``.
+        iterator ``options['iter_directives']`` create by `_compile_node``
+        method.
 
-        :return: list of AST nodes
+        :return: list of code lines
         """
+
+        if self._is_static_node(el, options):
+            el.attrib.pop('t-tag', None)
+            el.attrib.pop('t-content', None)
+            return self._compile_static_node(el, options, indent)
+
         # compile the first directive present on the element
         for directive in options['iter_directives']:
             if ('t-' + directive) in el.attrib:
                 mname = directive.replace('-', '_')
-                compile_handler = getattr(self, '_compile_directive_%s' % mname, None)
+                compile_handler = getattr(self, f'_compile_directive_{mname}', None)
+                return compile_handler(el, options, indent)
 
-                interpret_handler = 'render_tag_%s' % mname
-                if hasattr(self, interpret_handler):
-                    _logger.warning(
-                        "Directive '%s' must be AST-compiled. Dynamic interpreter %s will ignored",
-                        mname, interpret_handler
-                    )
-
-                return compile_handler(el, options)
-
-        # all directives have been compiled, there should be none left
-        if any(att.startswith('t-') for att in el.attrib):
-            raise NameError("Unknown directive on %s" % etree.tostring(el, encoding='unicode'))
         return []
 
-    def _values_var(self, varname, ctx):
-        # # values[$varname]
-        return ast.Subscript(
-            value=ast.Name(id='values', ctx=ast.Load()),
-            slice=ast.Index(varname),
-            ctx=ctx
-        )
+    def _compile_options(self, el, varname, options, indent):
+        """
+        compile t-options and add to the dict the t-options-xxx values
+        """
+        t_options = el.attrib.pop('t-options', None)
+        directive = ''
+        if t_options:
+            directive = f't-options="{t_options}"'
 
-    def _append_attributes(self):
-        # t_attrs = self._post_processing_att(tagName, t_attrs, options)
-        # for name, value in t_attrs.items():
-        #     if value or isinstance(value, string_types)):
-        #         [...]
-        # always generates double-quoted attributes
-        return [
-            ast.Assign(
-                targets=[ast.Name(id='t_attrs', ctx=ast.Store())],
-                value=ast.Call(
-                    func=ast.Attribute(
-                        value=ast.Name(id='self', ctx=ast.Load()),
-                        attr='_post_processing_att',
-                        ctx=ast.Load()
-                    ),
-                    args=[
-                        ast.Name(id='tagName', ctx=ast.Load()),
-                        ast.Name(id='t_attrs', ctx=ast.Load()),
-                        ast.Name(id='options', ctx=ast.Load()),
-                    ], keywords=[],
-                    starargs=None, kwargs=None
-                )
-            ),
-            ast.For(
-                target=ast.Tuple(elts=[ast.Name(id='name', ctx=ast.Store()), ast.Name(id='value', ctx=ast.Store())], ctx=ast.Store()),
-                iter=ast.Call(
-                    func=ast.Attribute(
-                        value=ast.Name(id='t_attrs', ctx=ast.Load()),
-                        attr='items',
-                        ctx=ast.Load()
-                        ),
-                    args=[], keywords=[],
-                    starargs=None, kwargs=None
-                ),
-                body=[ast.If(
-                    test=ast.BoolOp(
-                        op=ast.Or(),
-                        values=[
-                            ast.Name(id='value', ctx=ast.Load()),
-                            ast.Call(
-                                func=ast.Name(id='isinstance', ctx=ast.Load()),
-                                args=[
-                                    ast.Name(id='value', ctx=ast.Load()),
-                                    ast.Name(id='str', ctx=ast.Load())
-                                ],
-                                keywords=[],
-                                starargs=None, kwargs=None
-                            )
-                        ]
-                    ),
-                    body=[
-                        # append(' ')
-                        self._append(ast.Str(u' ')),
-                        # append(name)
-                        self._append(ast.Name('name', ast.Load())),
-                        # append('="')
-                        self._append(ast.Str(u'="')),
-                        # append(escape(str(...)))
-                        self._append(ast.Call(
-                            func=ast.Name('escape', ast.Load()),
-                            args=[ast.Call(
-                                # stringified because regular Markup processing
-                                # is invalid for attributes
-                                func=ast.Name('str', ast.Load()),
-                                args=[ast.BoolOp( # value or ''
-                                    op=ast.Or(),
-                                    values=[ast.Name('value', ast.Load()), ast.Str('')]
-                                )], keywords=[]
-                            )],
-                            keywords=[]
-                        )),
-                        # append('"')
-                        self._append(ast.Str(u'"')),
-                    ],
-                    orelse=[]
-                )],
-                orelse=[]
-            )
-        ]
+        code = []
+        dict_arg = []
+        for key in list(el.attrib):
+            if key.startswith('t-options-'):
+                value = el.attrib.pop(key)
+                directive += f' {key}={repr(value)}'
+                option_name = key[10:]
+                dict_arg.append(f'{repr(option_name)}:{self._compile_expr(value)}')
+
+        if t_options and dict_arg:
+            code.append(self._indent(f"{varname} = {{**{self._compile_expr(t_options)}, {', '.join(dict_arg)}}}", indent))
+        elif dict_arg:
+            code.append(self._indent(f"{varname} = {{{', '.join(dict_arg)}}}", indent))
+        elif t_options:
+            code.append(self._indent(f"{varname} = {self._compile_expr(t_options)}", indent))
+
+        return code
+
+    def _compile_format(self, expr):
+        """ Parses the provided format string and compiles it to a single
+        expression python, uses string with format method.
+        Use format is faster to concat string and values.
+        """
+        text = ''
+        values = []
+        base_idx = 0
+        for m in _FORMAT_REGEX.finditer(expr):
+            literal = expr[base_idx:m.start()]
+            if literal:
+                text += literal.replace('{', '{{').replace("}", "}}")
+            text += '{}'
+            values.append(f'self._compile_to_str({self._compile_expr(m.group(1) or m.group(2))})')
+            base_idx = m.end()
+        # string past last regex match
+        literal = expr[base_idx:]
+        if literal:
+            text += literal.replace('{', '{{').replace("}", "}}")
+
+        code = repr(text)
+        if values:
+            code += f'.format({", ".join(values)})'
+        return code
+
+    def _compile_expr_tokens(self, tokens, allowed_keys, raise_on_missing=False):
+        """ Transform the list of token coming into a python instruction in
+            textual form by adding the namepaces for the dynamic values.
+
+            Example: `5 + a + b.c` to be `5 + values.get('a') + values['b'].c`
+            Unknown values are considered to be None, but using `values['b']`
+            gives a clear error message in cases where there is an attribute for
+            example (have a `KeyError: 'b'`, instead of `AttributeError: 'NoneType'
+            object has no attribute 'c'`).
+
+            @returns str
+        """
+        # Finds and extracts the current "scope"'s "allowed values": values
+        # which should not be accessed through the environment's namespace:
+        # * the local variables of a lambda should be accessed directly e.g.
+        #     lambda a: a + b should be compiled to lambda a: a + values['b'],
+        #     since a is local to the lambda it has to be accessed directly
+        #     but b needs to be accessed through the rendering environment
+        # * similarly for a comprehensions [a + b for a in c] should be
+        #     compiledto [a + values.get('b') for a in values.get('c')]
+        # to avoid the risk of confusion between nested lambdas / comprehensions,
+        # this is currently performed independently at each level of brackets
+        # nesting (hence the function being recursive).
+        index = 0
+        open_bracket_index = -1
+        bracket_depth = 0
+        while index < len(tokens):
+            t = tokens[index]
+            if t.exact_type in [token.LPAR, token.LSQB, token.LBRACE]:
+                bracket_depth += 1
+            if t.exact_type in [token.RPAR, token.RSQB, token.RBRACE]:
+                bracket_depth -= 1
+            elif bracket_depth == 0 and t.exact_type == token.NAME:
+                string = t.string
+                if string == 'lambda': # lambda => allowed values for the current bracket depth
+                    i = index + 1
+                    while i < len(tokens):
+                        t = tokens[i]
+                        if t.exact_type == token.NAME:
+                            allowed_keys.append(t.string)
+                        elif t.exact_type == token.COMMA:
+                            pass
+                        elif t.exact_type == token.COLON:
+                            break
+                        elif t.exact_type == token.EQUAL:
+                            raise NotImplementedError('Lambda default values are not supported')
+                        else:
+                            raise NotImplementedError('This lambda code style is not implemented.')
+                        i += 1
+                elif string == 'for': # list comprehensions => allowed values for the current bracket depth
+                    i = index + 1
+                    while len(tokens) > i:
+                        t = tokens[i]
+                        if t.exact_type == token.NAME:
+                            if t.string == 'in':
+                                break
+                            allowed_keys.append(t.string)
+                        elif t.exact_type in [token.COMMA, token.LPAR, token.RPAR]:
+                            pass
+                        else:
+                            raise NotImplementedError('This loop code style is not implemented.')
+                        i += 1
+
+            index += 1
+
+        # Use bracket to nest structures.
+        # Recursively processes the "sub-scopes", and replace their content with
+        # a compiled node. During this recursive call we add to the allowed
+        # values the values provided by the list comprehension, lambda, etc.,
+        # previously extracted.
+        index = 0
+        open_bracket_index = -1
+        bracket_depth = 0
+
+        while index < len(tokens):
+            t = tokens[index]
+            string = t.string
+
+            if t.exact_type in [token.LPAR, token.LSQB, token.LBRACE]:
+                if bracket_depth == 0:
+                    open_bracket_index = index
+                bracket_depth += 1
+            elif t.exact_type in [token.RPAR, token.RSQB, token.RBRACE]:
+                bracket_depth -= 1
+                if bracket_depth == 0:
+                    code = self._compile_expr_tokens(tokens[open_bracket_index + 1:index], list(allowed_keys), raise_on_missing)
+                    code = tokens[open_bracket_index].string + code + t.string
+                    tokens[open_bracket_index:index + 1] = [tokenize.TokenInfo(token.QWEB, code, tokens[open_bracket_index].start, t.end, '')]
+                    index = open_bracket_index
+
+            index += 1
+
+        # The keys will be namespaced by values if they are not allowed. In
+        # order to have a clear keyError message, this will be replaced by
+        # values['key'] for certain cases (for example if an attribute is called
+        # key.attrib, or an index key[0] ...)
+        code = []
+        index = 0
+        pos = tokens and tokens[0].start # to keep indent when use expr on multi line
+        while index < len(tokens):
+            t = tokens[index]
+            string = t.string
+
+            if t.start[0] != pos[0]:
+                pos = (t.start[0], 0)
+            space = t.start[1] - pos[1]
+            if space:
+                code.append(' ' * space)
+            pos = t.start
+
+            if t.exact_type == token.NAME:
+                if string == 'lambda': # lambda => allowed values
+                    code.append('lambda ')
+                    index += 1
+                    while index < len(tokens):
+                        t = tokens[index]
+                        if t.exact_type in [token.COMMA, token.NAME, token.COLON]:
+                            code.append(t.string)
+                        if t.exact_type == token.COLON:
+                            break
+                        index += 1
+                    if t.end[0] != pos[0]:
+                        pos = (t.end[0], 0)
+                    else:
+                        pos = t.end
+                elif string in allowed_keys:
+                    code.append(string)
+                elif index + 1 < len(tokens) and tokens[index + 1].exact_type == token.EQUAL: # function kw
+                    code.append(string)
+                elif index > 0 and tokens[index - 1] and tokens[index - 1].exact_type == token.DOT:
+                    code.append(string)
+                elif raise_on_missing or index + 1 < len(tokens) and tokens[index + 1].exact_type in [token.DOT, token.LPAR, token.LSQB, 'qweb']:
+                    # Should have values['product'].price to raise an error when get
+                    # the 'product' value and not an 'NoneType' object has no
+                    # attribute 'price' error.
+                    code.append(f'values[{repr(string)}]')
+                else:
+                    # not assignation allowed, only getter
+                    code.append(f'values.get({repr(string)})')
+            elif t.type not in [tokenize.ENCODING, token.ENDMARKER, token.DEDENT]:
+                code.append(string)
+
+            if t.end[0] != pos[0]:
+                pos = (t.end[0], 0)
+            else:
+                pos = t.end
+
+            index += 1
+
+        return ''.join(code)
+
+    def _compile_expr(self, expr, raise_on_missing=False):
+        """Transform string coming into a python instruction in textual form by
+        adding the namepaces for the dynamic values.
+        This method tokenize the string and call ``_compile_expr_tokens``
+        method.
+        """
+        readable = io.BytesIO(expr.strip().encode('utf-8'))
+        try:
+            tokens = list(tokenize.tokenize(readable.readline))
+        except tokenize.TokenError:
+            raise ValueError(f"Can not compile expression: {expr}")
+
+        expression = self._compile_expr_tokens(tokens, self._allowed_keyword + list(self._available_objects.keys()), raise_on_missing=raise_on_missing)
+
+        return f"({expression})"
+
+    def _compile_bool(self, attr, default=False):
+        """Convert the statements as a boolean."""
+        if attr:
+            if attr is True:
+                return True
+            attr = attr.lower()
+            if attr in ('false', '0'):
+                return False
+            elif attr in ('true', '1'):
+                return True
+        return bool(default)
+
+    def _compile_to_str(self, expr):
+        """ Generates a text value (an instance of text_type) from an arbitrary
+            source.
+        """
+        return pycompat.to_text(expr)
 
     # order
 
@@ -806,8 +638,9 @@ class QWeb(object):
         """
         return [
             'debug',
-            'groups', 'foreach', 'if', 'elif', 'else',
-            'field', 'out', 'esc', 'raw',
+            'foreach',
+            'if', 'elif', 'else',
+            'field', 'esc', 'raw', 'out',
             'tag',
             'call',
             'set',
@@ -815,18 +648,18 @@ class QWeb(object):
         ]
 
     def _is_static_node(self, el, options):
-        """ Test whether the given element is purely static, i.e., does not
-        require dynamic rendering for its attributes.
+        """ Test whether the given element is purely static, i.e. (there
+        are no t-* attributes), does not require dynamic rendering for its
+        attributes.
         """
-        return not any(att.startswith('t-') for att in el.attrib)
+        return el.tag != 't' and not any(att.startswith('t-') and att not in ['t-tag', 't-content'] for att in el.attrib)
 
     # compile
 
-    def _compile_static_node(self, el, options):
-        """ Compile a purely static element into a list of AST nodes. """
+    def _compile_static_node(self, el, options, indent):
+        """ Compile a purely static element into a list of string. """
         if not el.nsmap:
             unqualified_el_tag = el_tag = el.tag
-            content = self._compile_directive_content(el, options)
             attrib = self._post_processing_att(el.tag, el.attrib, options)
         else:
             # Etree will remove the ns prefixes indirection by inlining the corresponding
@@ -834,7 +667,7 @@ class QWeb(object):
             unqualified_el_tag = etree.QName(el.tag).localname
             el_tag = unqualified_el_tag
             if el.prefix:
-                el_tag = '%s:%s' % (el.prefix, el_tag)
+                el_tag = f'{el.prefix}:{el_tag}'
 
             attrib = {}
             # If `el` introduced new namespaces, write them as attribute by using the
@@ -843,17 +676,17 @@ class QWeb(object):
                 if ns_prefix is None:
                     attrib['xmlns'] = ns_definition
                 else:
-                    attrib['xmlns:%s' % ns_prefix] = ns_definition
+                    attrib[f'xmlns:{ns_prefix}'] = ns_definition
 
             # Etree will also remove the ns prefixes indirection in the attributes. As we only have
             # the namespace definition, we'll use an nsmap where the keys are the definitions and
             # the values the prefixes in order to get back the right prefix and restore it.
-            ns = itertools.chain(options['nsmap'].items(), el.nsmap.items())
+            ns = chain(options['nsmap'].items(), el.nsmap.items())
             nsprefixmap = {v: k for k, v in ns}
             for key, value in el.attrib.items():
                 attrib_qname = etree.QName(key)
                 if attrib_qname.namespace:
-                    attrib['%s:%s' % (nsprefixmap[attrib_qname.namespace], attrib_qname.localname)] = value
+                    attrib[f'{nsprefixmap[attrib_qname.namespace]}:{attrib_qname.localname}'] = value
                 else:
                     attrib[key] = value
 
@@ -864,120 +697,107 @@ class QWeb(object):
             # want changes done in deeper recursion to bevisible in earlier ones, we'll pass
             # a copy before continuing the recursion and restore the original afterwards.
             original_nsmap = dict(options['nsmap'])
+
+        if unqualified_el_tag != 't':
+            attributes = ''.join(f' {str(name)}="{str(escape(str(value)))}"'
+                                for name, value in attrib.items() if value or isinstance(value, str))
+            self._appendText(f'<{el_tag}{attributes}', options)
+            if unqualified_el_tag in self._void_elements:
+                self._appendText('/>', options)
+            else:
+                self._appendText('>', options)
+
+        if el.nsmap:
             options['nsmap'].update(el.nsmap)
-            content = self._compile_directive_content(el, options)
+            body = self._compile_directive_content(el, options, indent)
             options['nsmap'] = original_nsmap
-
-        if unqualified_el_tag == 't':
-            return content
-        tag = u'<%s%s' % (el_tag, u''.join([u' %s="%s"' % (name, escape(pycompat.to_text(value))) for name, value in attrib.items()]))
-        if unqualified_el_tag in self._void_elements:
-            return [self._append(ast.Str(tag + '/>'))] + content
         else:
-            return [self._append(ast.Str(tag + '>'))] + content + [self._append(ast.Str('</%s>' % el_tag))]
+            body = self._compile_directive_content(el, options, indent)
 
-    def _compile_static_attributes(self, el, options):
-        """ Compile the static attributes of the given element into a list of
-        pairs (name, expression AST). """
+        if unqualified_el_tag != 't':
+            if unqualified_el_tag not in self._void_elements:
+                self._appendText(f'</{el_tag}>', options)
+
+        return body
+
+    def _compile_attributes(self, options, indent):
+        """Generates the part of the code that post-process the attributes
+        (this is ``attrs`` in the compiled code) during rendering time.
+        """
+        # Use str(value) to change Markup into str and escape it, then use str
+        # to avoid the escaping of the other html content.
+        body = self._flushText(options, indent)
+        body.append(self._indent(dedent("""
+            attrs = self._post_processing_att(tagName, attrs, compile_options)
+            for name, value in attrs.items():
+                if value or isinstance(value, str):
+                    yield f' {str(escape(str(name)))}="{str(escape(str(value)))}"'
+        """).strip(), indent))
+        return body
+
+    def _compile_static_attributes(self, el, options, indent):
+        """ Compile the static and dynamc attributes of the given element.
+
+        We do not support namespaced dynamic attributes.
+        """
         # Etree will also remove the ns prefixes indirection in the attributes. As we only have
         # the namespace definition, we'll use an nsmap where the keys are the definitions and
         # the values the prefixes in order to get back the right prefix and restore it.
-        nsprefixmap = {v: k for k, v in itertools.chain(options['nsmap'].items(), el.nsmap.items())}
+        nsprefixmap = {v: k for k, v in chain(options['nsmap'].items(), el.nsmap.items())}
 
-        nodes = []
+        code = []
         for key, value in el.attrib.items():
             if not key.startswith('t-'):
                 attrib_qname = etree.QName(key)
                 if attrib_qname.namespace:
-                    key = '%s:%s' % (nsprefixmap[attrib_qname.namespace], attrib_qname.localname)
-                nodes.append((key, ast.Str(value)))
-        return nodes
+                    key = f'{nsprefixmap[attrib_qname.namespace]}:{attrib_qname.localname}'
+                code.append(self._indent(f'attrs[{repr(key)}] = {repr(value)}', indent))
+        return code
 
-    def _compile_dynamic_attributes(self, el, options):
-        """ Compile the dynamic attributes of the given element into a list of
-        pairs (name, expression AST).
+    def _compile_dynamic_attributes(self, el, options, indent):
+        """ Compile the dynamic attributes of the given element into a list
+        string (this is adding elements to ``attrs`` in the compiled code).
 
         We do not support namespaced dynamic attributes.
         """
-        nodes = []
+        code = []
         for name, value in el.attrib.items():
-            if name.startswith('t-attf-'):
-                nodes.append((name[7:], self._compile_format(value)))
-            elif name.startswith('t-att-'):
-                nodes.append((name[6:], self._compile_expr(value)))
-            elif name == 't-att':
-                # self._get_dynamic_att($tag, $value, options, values)
-                nodes.append(ast.Call(
-                    func=ast.Attribute(
-                        value=ast.Name(id='self', ctx=ast.Load()),
-                        attr='_get_dynamic_att',
-                        ctx=ast.Load()
-                    ),
-                    args=[
-                        ast.Str(el.tag),
-                        self._compile_expr(value),
-                        ast.Name(id='options', ctx=ast.Load()),
-                        ast.Name(id='values', ctx=ast.Load()),
-                    ], keywords=[],
-                    starargs=None, kwargs=None
-                ))
-        return nodes
 
-    def _compile_all_attributes(self, el, options, attr_already_created=False):
-        """ Compile the attributes of the given elements into a list of AST nodes. """
-        body = []
+            if name.startswith('t-attf-'):
+                code.append(self._indent(f"attrs[{repr(name[7:])}] = {self._compile_format(value)}", indent))
+            elif name.startswith('t-att-'):
+                code.append(self._indent(f"attrs[{repr(name[6:])}] = {self._compile_expr(value)}", indent))
+            elif name == 't-att':
+                code.append(self._indent(dedent(f"""
+                    atts_value = {self._compile_expr(value)}
+                    if isinstance(atts_value, dict):
+                        attrs.update(atts_value)
+                    elif isinstance(atts_value, (list, tuple)) and not isinstance(atts_value[0], (list, tuple)):
+                        attrs.update([atts_value])
+                    elif isinstance(atts_value, (list, tuple)):
+                        attrs.update(dict(atts_value))
+                    """), indent))
+        return code
+
+    def _compile_all_attributes(self, el, options, indent, attr_already_created=False):
+        """ Compile the attributes (static and dynamic) of the given elements
+        into a list of str.
+        (this compiled The code will create the ``attrs`` in the compiled code).
+        """
+        code = []
         if any(name.startswith('t-att') or not name.startswith('t-') for name, value in el.attrib.items()):
             if not attr_already_created:
                 attr_already_created = True
-                body.append(
-                    # t_attrs = OrderedDict()
-                    ast.Assign(
-                        targets=[ast.Name(id='t_attrs', ctx=ast.Store())],
-                        value=ast.Call(
-                            func=ast.Name(id='OrderedDict', ctx=ast.Load()),
-                            args=[],
-                            keywords=[], starargs=None, kwargs=None
-                        )
-                    )
-                )
-
-            items = self._compile_static_attributes(el, options) + self._compile_dynamic_attributes(el, options)
-            for item in items:
-                if isinstance(item, tuple):
-                    # t_attrs[$name] = $value
-                    body.append(ast.Assign(
-                        targets=[ast.Subscript(
-                            value=ast.Name(id='t_attrs', ctx=ast.Load()),
-                            slice=ast.Index(ast.Str(item[0])),
-                            ctx=ast.Store()
-                        )],
-                        value=item[1]
-                    ))
-                elif item:
-                    # t_attrs.update($item)
-                    body.append(ast.Expr(ast.Call(
-                        func=ast.Attribute(
-                            value=ast.Name(id='t_attrs', ctx=ast.Load()),
-                            attr='update',
-                            ctx=ast.Load()
-                        ),
-                        args=[item],
-                        keywords=[],
-                        starargs=None, kwargs=None
-                    )))
-
+                code.append(self._indent("attrs = {}", indent))
+            code.extend(self._compile_static_attributes(el, options, indent))
+            code.extend(self._compile_dynamic_attributes(el, options, indent))
         if attr_already_created:
-            # tagName = $el.tag
-            body.append(ast.Assign(
-                targets=[ast.Name(id='tagName', ctx=ast.Store())],
-                value=ast.Str(el.tag))
-            )
-            body.extend(self._append_attributes())
+            code.append(self._indent(f"tagName = {repr(el.tag)}", indent))
+            code.extend(self._compile_attributes(options, indent))
+        return code
 
-        return body
-
-    def _compile_tag(self, el, content, options, attr_already_created=False):
-        """ Compile the tag of the given element into a list of AST nodes. """
+    def _compile_tag_open(self, el, options, indent, attr_already_created=False):
+        """ Compile the opening tag of the given element into a list of string. """
         extra_attrib = {}
         if not el.nsmap:
             unqualified_el_tag = el_tag = el.tag
@@ -989,7 +809,7 @@ class QWeb(object):
             unqualified_el_tag = etree.QName(el.tag).localname
             el_tag = unqualified_el_tag
             if el.prefix:
-                el_tag = '%s:%s' % (el.prefix, el_tag)
+                el_tag = f'{el.prefix}:{el_tag}'
 
             # If `el` introduced new namespaces, write them as attribute by using the
             # `extra_attrib` dict.
@@ -997,139 +817,187 @@ class QWeb(object):
                 if ns_prefix is None:
                     extra_attrib['xmlns'] = ns_definition
                 else:
-                    extra_attrib['xmlns:%s' % ns_prefix] = ns_definition
+                    extra_attrib[f'xmlns:{ns_prefix}'] = ns_definition
 
-        if unqualified_el_tag == 't':
-            return content
+        code = []
+        if unqualified_el_tag != 't':
+            attributes = ''.join(f' {str(name)}="{str(escape(self._compile_to_str(value)))}"'
+                                for name, value in extra_attrib.items())
+            self._appendText("<{}{}".format(el_tag, attributes), options)
+            code.extend(self._compile_all_attributes(el, options, indent, attr_already_created))
+            if unqualified_el_tag in self._void_elements:
+                self._appendText('/>', options)
+            else:
+                self._appendText('>', options)
 
-        body = [self._append(ast.Str(u'<%s%s' % (el_tag, u''.join([u' %s="%s"' % (name, escape(pycompat.to_text(value))) for name, value in extra_attrib.items()]))))]
-        body.extend(self._compile_all_attributes(el, options, attr_already_created))
-        if unqualified_el_tag in self._void_elements:
-            body.append(self._append(ast.Str(u'/>')))
-            body.extend(content)
+        return code
+
+    def _compile_tag_close(self, el, options):
+        """ Compile the closing tag of the given element into a list of string. """
+        if not el.nsmap:
+            unqualified_el_tag = el_tag = el.tag
         else:
-            body.append(self._append(ast.Str(u'>')))
-            body.extend(content)
-            body.append(self._append(ast.Str(u'</%s>' % el_tag)))
-        return body
+            unqualified_el_tag = etree.QName(el.tag).localname
+            el_tag = unqualified_el_tag
+            if el.prefix:
+                el_tag = f'{el.prefix}:{el_tag}'
+
+        if unqualified_el_tag != 't' and el_tag not in self._void_elements:
+            self._appendText(f'</{el_tag}>', options)
+        return []
 
     # compile directives
 
-    def _compile_directive_debug(self, el, options):
-        debugger = el.attrib.pop('t-debug')
-        body = self._compile_directives(el, options)
-        if options['dev_mode']:
-            body = ast.parse("__import__('%s').set_trace()" % re.sub(r'[^a-zA-Z]', '', debugger)).body + body  # pdb, ipdb, pudb, ...
-        else:
-            _logger.warning("@t-debug in template is only available in dev mode options")
-        return body
+    def _compile_directive_debug(self, el, options, indent):
+        """Compile `t-debug` expressions into a python code as a list of
+        strings.
 
-    def _compile_directive_tag(self, el, options):
+        The code will contains the call to the debugger chosen from the valid
+        list.
+        """
+        debugger = el.attrib.pop('t-debug')
+        code = []
+        if options.get('dev_mode'):
+            code.append(self._indent(f"self._debug_trace({repr(debugger)}, compile_options)", indent))
+        else:
+            _logger.warning("@t-debug in template is only available in qweb dev mode options")
+        code.extend(self._compile_directives(el, options, indent))
+        return code
+
+    def _compile_directive_tag(self, el, options, indent):
+        """Compile the element tag into a python code as a list of strings.
+
+        The code will contains the opening tag, namespace, static and dynamic
+        attributes and closing tag.
+        """
         el.attrib.pop('t-tag', None)
+
+        code = self._compile_tag_open(el, options, indent, False)
 
         # Update the dict of inherited namespaces before continuing the recursion. Note:
         # since `options['nsmap']` is a dict (and therefore mutable) and we do **not**
         # want changes done in deeper recursion to bevisible in earlier ones, we'll pass
         # a copy before continuing the recursion and restore the original afterwards.
-        original_nsmap = dict(options['nsmap'])
         if el.nsmap:
-            options['nsmap'].update(el.nsmap)
-        content = self._compile_directives(el, options)
-        if el.nsmap:
-            options['nsmap'] = original_nsmap
-        return self._compile_tag(el, content, options, False)
+            code.extend(self._compile_directives(el, dict(options, nsmap=el.nsmap), indent))
+        else:
+            code.extend(self._compile_directives(el, options, indent))
 
-    def _compile_directive_set(self, el, options):
+        code.extend(self._compile_tag_close(el, options))
+
+        return code
+
+    def _compile_directive_set(self, el, options, indent):
+        """Compile `t-set` expressions into a python code as a list of
+        strings.
+
+        There are 3 kinds of `t-set`:
+        * `t-value` containing python code;
+        * `t-valuef` containing strings to format;
+        * whose value is the content of the tag (being Markup safe).
+
+        The code will contain the assignment of the dynamically generated value.
+        """
         varname = el.attrib.pop('t-set')
+        code = self._flushText(options, indent)
 
         if 't-value' in el.attrib:
-            value = self._compile_expr(el.attrib.pop('t-value') or 'None')
+            if varname == '0':
+                raise ValueError('t-set="0" should not contains t-value or t-valuef')
+            expr = el.attrib.pop('t-value') or 'None'
+            expr = self._compile_expr(expr)
         elif 't-valuef' in el.attrib:
-            value = self._compile_format(el.attrib.pop('t-valuef'))
+            if varname == '0':
+                raise ValueError('t-set="0" should not contains t-value or t-valuef')
+            exprf = el.attrib.pop('t-valuef')
+            expr = self._compile_format(exprf)
         else:
             # set the content as value
-            body = self._compile_directive_content(el, options)
-            if body:
-                def_name = self._create_def(options, body, prefix='set', lineno=el.sourceline)
-                # ''.join($varset)
-                joined = ast.Call(
-                    func=ast.Attribute(value=ast.Str(u''), attr='join', ctx=ast.Load()),
-                    args=[ast.Name(id='content', ctx=ast.Load())], keywords=[]
-                )
-                # Markup(_): rendering of content is considered safe
-                safe = ast.Call(
-                    func=ast.Name(id='Markup', ctx=ast.Load()),
-                    args=[joined], keywords=[]
-                )
-                return [
-                    # content = []
-                    ast.Assign(
-                        targets=[ast.Name(id='content', ctx=ast.Store())],
-                        value=ast.List(elts=[], ctx=ast.Load())
-                    ),
-                    # set(self, $varset.append)
-                    ast.Expr(self._call_def(
-                        def_name,
-                        append=ast.Attribute(
-                            value=ast.Name(id='content', ctx=ast.Load()),
-                            attr='append',
-                            ctx=ast.Load()
-                        )
-                    )),
-                    # $varset = _
-                    ast.Assign(targets=[self._values_var(ast.Str(varname), ctx=ast.Store())], value=safe)
-                ]
-
+            def_name = f"qweb_t_set_{re.sub(_VARNAME_REGEX, '_', options['last_path_node'])}"
+            content = self._compile_directive_content(el, options, indent + 1) + self._flushText(options, indent + 1)
+            if content:
+                code.append(self._indent(f"def {def_name}():", indent))
+                code.extend(content)
+                expr = f"Markup(''.join({def_name}()))"
             else:
-                value = ast.Str(u'')
+                expr = "''"
 
-        # $varset = $value
-        return [ast.Assign(
-            targets=[self._values_var(ast.Str(varname), ctx=ast.Store())],
-            value=value
-        )]
+        code.append(self._indent(f"values[{repr(varname)}] = {expr}", indent))
+        return code
 
-    def _compile_directive_content(self, el, options):
-        body = []
+    def _compile_directive_content(self, el, options, indent):
+        """Compiles the content of the element (is the technical `t-content`
+        directive created by QWeb) into a python code as a list of
+        strings.
+
+        The code will contains the text content of the node or the compliled
+        code from the recursive call of ``_compile_node``.
+        """
         if el.text is not None:
-            body.append(self._append(ast.Str(pycompat.to_text(el.text))))
+            self._appendText(el.text, options)
+        body = []
         if el.getchildren():
             for item in el:
                 # ignore comments & processing instructions
                 if isinstance(item, etree._Comment):
                     continue
-                body.extend(self._compile_node(item, options))
-                body.extend(self._compile_tail(item))
+                body.extend(self._compile_node(item, options, indent))
+                if item.tail is not None:
+                    self._appendText(item.tail, options)
         return body
 
-    def _compile_directive_else(self, el, options):
+    def _compile_directive_else(self, el, options, indent):
+        """Compile `t-else` expressions into a python code as a list of strings.
+
+        This method is linked with the `t-if` directive.
+        The code will contain the compiled code of the element (without `else`
+        python part).
+        """
         if el.attrib.pop('t-else') == '_t_skip_else_':
             return []
         if not options.pop('t_if', None):
             raise ValueError("t-else directive must be preceded by t-if directive")
-        compiled = self._compile_directives(el, options)
+        compiled = self._compile_directives(el, options, indent)
         el.attrib['t-else'] = '_t_skip_else_'
         return compiled
 
-    def _compile_directive_elif(self, el, options):
-        _elif = el.attrib.pop('t-elif')
+    def _compile_directive_elif(self, el, options, indent):
+        """Compile `t-eif` expressions into a python code as a list of strings.
+
+        This method is linked with the `t-if` directive.
+        The code will contain the compiled code of the element (without `else`
+        python part).
+        """
+        _elif = el.attrib['t-elif']
         if _elif == '_t_skip_else_':
+            el.attrib.pop('t-elif')
             return []
         if not options.pop('t_if', None):
             raise ValueError("t-elif directive must be preceded by t-if directive")
-        el.attrib['t-if'] = _elif
-        compiled = self._compile_directive_if(el, options)
+        compiled = self._compile_directive_if(el, options, indent)
         el.attrib['t-elif'] = '_t_skip_else_'
         return compiled
 
-    def _compile_directive_if(self, el, options):
+    def _compile_directive_if(self, el, options, indent):
+        """Compile `t-if` expressions into a python code as a list of strings.
+
+        The code will contain the condition `if`, `else` and `elif` part that
+        wrap the rest of the compiled code of this element.
+        """
+        if 't-elif' in el.attrib:
+            expr = el.attrib.pop('t-elif')
+        else:
+            expr = el.attrib.pop('t-if')
+
+        code = self._flushText(options, indent)
+        content_if = self._compile_directives(el, options, indent + 1) + self._flushText(options, indent + 1)
+
         orelse = []
         next_el = el.getnext()
         comments_to_remove = []
         while isinstance(next_el, etree._Comment):
             comments_to_remove.append(next_el)
             next_el = next_el.getnext()
-
         if next_el is not None and {'t-else', 't-elif'} & set(next_el.attrib):
             parent = el.getparent()
             for comment in comments_to_remove:
@@ -1137,651 +1005,349 @@ class QWeb(object):
             if el.tail and not el.tail.isspace():
                 raise ValueError("Unexpected non-whitespace characters between t-if and t-else directives")
             el.tail = None
-            orelse = self._compile_node(next_el, dict(options, t_if=True))
-        return [
-            # if $t-if:
-            #    next tag directive
-            # else:
-            #    $t-else
-            ast.If(
-                test=self._compile_expr(el.attrib.pop('t-if')),
-                body=self._compile_directives(el, options) or [ast.Pass()],
-                orelse=orelse
+            orelse = self._compile_node(next_el, dict(options, t_if=True), indent + 1) + self._flushText(options, indent + 1)
+
+        code.append(self._indent(f"if {self._compile_expr(expr)}:", indent))
+        code.extend(content_if or [self._indent('pass', indent + 1)])
+        if orelse:
+            code.append(self._indent("else:", indent))
+            code.extend(orelse)
+        return code
+
+    def _compile_directive_foreach(self, el, options, indent):
+        """Compile `t-foreach` expressions into a python code as a list of
+        strings.
+
+        `t-as` is used to define the key name.
+        `t-foreach` compiled value can be an iterable, an dictionary or a
+        number.
+
+        The code will contain loop `for` that wrap the rest of the compiled
+        code of this element.
+        Some key into values dictionary are create automatically:
+            *_size, *_index, *_value, *_first, *_last, *_odd, *_even, *_parity
+        """
+        expr_foreach = el.attrib.pop('t-foreach')
+        expr_as = el.attrib.pop('t-as')
+
+        code = self._flushText(options, indent)
+        content_foreach = self._compile_directives(el, options, indent + 1) + self._flushText(options, indent + 1)
+
+        t_foreach = self._make_name('t_foreach')
+        size = self._make_name('size')
+        has_value = self._make_name('has_value')
+
+        if expr_foreach.isdigit():
+            code.append(self._indent(dedent(f"""
+                values[{repr(expr_as + '_size')}] = {size} = {int(expr_foreach)}
+                {t_foreach} = range({size})
+                {has_value} = False
+            """).strip(), indent))
+        else:
+            code.append(self._indent(dedent(f"""
+                {t_foreach} = {self._compile_expr(expr_foreach)} or []
+                if isinstance({t_foreach}, Sized):
+                    values[{repr(expr_as + '_size')}] = {size} = len({t_foreach})
+                elif type({t_foreach}) == int:
+                    values[{repr(expr_as + '_size')}] = {size} = {t_foreach}
+                    {t_foreach} = range({size})
+                else:
+                    {size} = None
+                {has_value} = False
+                if isinstance({t_foreach}, Mapping):
+                    {t_foreach} = {t_foreach}.items()
+                    {has_value} = True
+            """).strip(), indent))
+
+        code.append(self._indent(dedent(f"""
+                for index, item in enumerate({t_foreach}):
+                    values[{repr(expr_as + '_index')}] = index
+                    if {has_value}:
+                        values[{repr(expr_as)}], values[{repr(expr_as + '_value')}] = item
+                    else:
+                        values[{repr(expr_as)}] = values[{repr(expr_as + '_value')}] = item
+                    values[{repr(expr_as + '_first')}] = values[{repr(expr_as + '_index')}] == 0
+                    if {size} is not None:
+                        values[{repr(expr_as + '_last')}] = index + 1 == {size}
+                    values[{repr(expr_as + '_odd')}] = index % 2
+                    values[{repr(expr_as + '_even')}] = not values[{repr(expr_as + '_odd')}]
+                    values[{repr(expr_as + '_parity')}] = 'odd' if values[{repr(expr_as + '_odd')}] else 'even'
+            """), indent))
+
+        code.append(self._indent(f'log["last_path_node"] = {repr(options["root"].getpath(el))} ', indent + 1))
+        code.extend(content_foreach or self._indent('continue', indent + 1))
+
+        return code
+
+    def _compile_directive_out(self, el, options, indent):
+        """Compile `t-out` expressions into a python code as a list of
+        strings.
+
+        The output can have some rendering option with `t-options-widget` or
+        `t-options={'widget': ...}. The compiled code will call ``_get_widget``
+        method at rendering time.
+
+        The code will contain evalution and rendering of the compiled value. If
+        the compiled value is None or False, the tag is not added to the render
+        (Except if the widget forces rendering or there is default content.).
+        """
+        ttype = 't-out'
+        expr = el.attrib.pop('t-out', None)
+        if expr is None:
+            # deprecated use.
+            ttype = 't-esc'
+            expr = el.attrib.pop('t-esc', None)
+            if expr is None:
+                ttype = 't-raw'
+                expr = el.attrib.pop('t-raw')
+
+        code = self._flushText(options, indent)
+        code_options = self._compile_options(el, 't_out_t_options', options, indent)
+        code.extend(code_options)
+
+        if expr == "0":
+            if code_options:
+                code.append(self._indent("content = Markup(''.join(values.get('0', [])))", indent))
+            else:
+                code.extend(code_options)
+                code.extend(self._compile_tag_open(el, options, indent))
+                code.extend(self._flushText(options, indent))
+                code.append(self._indent("yield from values.get('0', [])", indent))
+                code.extend(self._compile_tag_close(el, options))
+                return code
+        else:
+            code.append(self._indent(f"content = {self._compile_expr(expr)}", indent))
+
+        if code_options:
+            code.append(self._indent(f"attrs, content, force_display = self._get_widget(content, {repr(expr)}, {repr(el.tag)}, t_out_t_options, compile_options, values)", indent))
+        else:
+            code.append(self._indent("force_display = None", indent))
+
+            if ttype == 't-esc':
+                # deprecated use.
+                code.append(self._indent(dedent("""
+                    if content is not None and content is not False:
+                        content = str(content)
+                """), indent))
+            elif ttype == 't-raw':
+                # deprecated use.
+                code.append(self._indent(dedent("""
+                    if content is not None and content is not False:
+                        content = Markup(content)
+                """), indent))
+
+        code.extend(self._compile_widget_value(el, options, indent, without_attributes=not code_options))
+        return code
+
+    def _compile_directive_esc(self, el, options, indent):
+        # deprecated use.
+        if options.get('dev_mode'):
+            _logger.warning(
+                "Found deprecated directive @t-esc=%r in template %r. Replace by "
+                "@t-out, and explicitely wrap content in `str` if "
+                "necessary (which likely is not the case)",
+                el.get('t-esc'),
+                options.get('ref', '<unknown>'),
             )
-        ]
+        return self._compile_directive_out(el, options, indent)
 
-    def _compile_directive_groups(self, el, options):
-        return [
-            # if self.user_has_groups($groups):
-            #    next tag directive
-            ast.If(
-                test=ast.Call(
-                    func=ast.Attribute(
-                        value=ast.Name(id='self', ctx=ast.Load()),
-                        attr='user_has_groups',
-                        ctx=ast.Load()
-                    ),
-                    args=[ast.Str(el.attrib.pop('t-groups'))], keywords=[],
-                    starargs=None, kwargs=None
-                ),
-                body=self._compile_directives(el, options) or [ast.Pass()],
-                orelse=[]
-            )
-        ]
-
-    def _compile_directive_foreach(self, el, options):
-        expr = self._compile_expr(el.attrib.pop('t-foreach'))
-        varname = el.attrib.pop('t-as').replace('.', '_')
-        values = self._make_name('values')
-
-        # create function $foreach
-        def_name = self._create_def(options, self._compile_directives(el, options), prefix='foreach', lineno=el.sourceline)
-
-        # for $values in foreach_iterator(values, $expr, $varname):
-        #     $foreach(self, append, $values, options)
-        return [ast.For(
-            target=ast.Name(id=values, ctx=ast.Store()),
-            iter=ast.Call(
-                func=ast.Name(id='foreach_iterator', ctx=ast.Load()),
-                args=[ast.Name(id='values', ctx=ast.Load()), expr, ast.Str(varname)],
-                keywords=[], starargs=None, kwargs=None
-            ),
-            body=[ast.Expr(self._call_def(def_name, values=values))],
-            orelse=[]
-        )]
-
-    def _compile_tail(self, el):
-        return el.tail is not None and [self._append(ast.Str(pycompat.to_text(el.tail)))] or []
-
-    def _compile_directive_esc(self, el, options):
-        el.attrib['t-out'] = el.attrib.pop('t-esc')
-        return self._compile_directive_out(el, options)
-    def _compile_directive_out(self, el, options):
-        field_options = self._compile_widget_options(el)
-        content = self._compile_widget(el, el.attrib.pop('t-out'), field_options)
-        if not field_options:
-            # if content is not False and if content is not None:
-            #     content = escape(pycompat.to_text(content))
-            content.append(self._if_content_is_not_Falsy([
-                ast.Assign(
-                    targets=[ast.Name(id='content', ctx=ast.Store())],
-                    value=ast.Call(
-                        func=ast.Name(id='escape', ctx=ast.Load()),
-                        args=[ast.Call(
-                            func=ast.Name(id='to_text', ctx=ast.Load()),
-                            args=[ast.Name(id='content', ctx=ast.Load())], keywords=[],
-                            starargs=None, kwargs=None
-                        )],
-                        keywords=[],
-                        starargs=None, kwargs=None
-                    )
-                )],
-                []
-            ))
-        return content + self._compile_widget_value(el, options)
-
-    def _compile_directive_raw(self, el, options):
+    def _compile_directive_raw(self, el, options, indent):
+        # deprecated use.
         _logger.warning(
             "Found deprecated directive @t-raw=%r in template %r. Replace by "
-            "@t-out, and explicitely wrap content in `markupsafe.Markup` if "
+            "@t-out, and explicitely wrap content in `Markup` if "
             "necessary (which likely is not the case)",
             el.get('t-raw'),
-            options.get('template', '<unknown>'),
+            options.get('ref', '<unknown>'),
         )
-        field_options = self._compile_widget_options(el)
-        content = self._compile_widget(el, el.attrib.pop('t-raw'), field_options)
-        return content + self._compile_widget_value(el, options)
+        return self._compile_directive_out(el, options, indent)
 
-    def _compile_widget(self, el, expression, field_options):
-        if field_options:
-            return [
-                # value = t-(out|esc|raw)
-                ast.Assign(
-                    targets=[ast.Name(id='content', ctx=ast.Store())],
-                    value=self._compile_expr0(expression)
-                ),
-                # t_attrs, content, force_display = self._get_widget(value, expression, tagName, field options, template options, values)
-                ast.Assign(
-                    targets=[ast.Tuple(elts=[
-                        ast.Name(id='t_attrs', ctx=ast.Store()),
-                        ast.Name(id='content', ctx=ast.Store()),
-                        ast.Name(id='force_display', ctx=ast.Store())
-                    ], ctx=ast.Store())],
-                    value=ast.Call(
-                        func=ast.Attribute(
-                            value=ast.Name(id='self', ctx=ast.Load()),
-                            attr='_get_widget',
-                            ctx=ast.Load()
-                        ),
-                        args=[
-                            ast.Name(id='content', ctx=ast.Load()),
-                            ast.Str(expression),
-                            ast.Str(el.tag),
-                            field_options,
-                            ast.Name(id='options', ctx=ast.Load()),
-                            ast.Name(id='values', ctx=ast.Load()),
-                        ],
-                        keywords=[], starargs=None, kwargs=None
-                    )
-                )
-            ]
+    def _compile_directive_field(self, el, options, indent):
+        """Compile `t-field` expressions into a python code as a list of
+        strings.
 
-        return [
-            # t_attrs, content, force_display = OrderedDict(), t-(out|esc|raw), None
-            ast.Assign(
-                targets=[ast.Tuple(elts=[
-                    ast.Name(id='t_attrs', ctx=ast.Store()),
-                    ast.Name(id='content', ctx=ast.Store()),
-                    ast.Name(id='force_display', ctx=ast.Store()),
-                ], ctx=ast.Store())],
-                value=ast.Tuple(elts=[
-                    ast.Call(
-                        func=ast.Name(id='OrderedDict', ctx=ast.Load()),
-                        args=[],
-                        keywords=[], starargs=None, kwargs=None
-                    ),
-                    self._compile_expr0(expression),
-                    ast.Constant(None),
-                ], ctx=ast.Load())
-            )
-        ]
+        The compiled code will call ``_get_field`` method at rendering time
+        using the type of value supplied by the field. This behavior can be
+        changed with `t-options-widget` or `t-options={'widget': ...}.
 
-    def _compile_widget_options(self, el):
+        The code will contain evalution and rendering of the compiled value
+        value from the record field. If the compiled value is None or False,
+        the tag is not added to the render
+        (Except if the widget forces rendering or there is default content.).
         """
-        compile t-options and add to the dict the t-options-xxx values
-        """
-        options = el.attrib.pop('t-options', None)
-        # the options can be None, a dict {}, or the method dict()
-        ast_options = options and self._compile_expr(options) or ast.Dict(keys=[], values=[])
-
-        # convert ast.Call from dict() into ast.Dict
-        if isinstance(ast_options, ast.Call):
-            ast_options = ast.Dict(
-                keys=[ast.Str(k.arg) for k in ast_options.keywords],
-                values=[k.value for k in ast_options.keywords]
-            )
-
-        for complete_key in OrderedDict(el.attrib):
-            if complete_key.startswith('t-options-'):
-                key = complete_key[10:]
-                value = self._compile_expr(el.attrib.pop(complete_key))
-
-                replacement = False
-                for astStr in ast_options.keys:
-                    if astStr.s == key:
-                        ast_options.values[ast_options.keys.index(astStr)] = value
-                        replacement = True
-                        break
-
-                if not replacement:
-                    ast_options.keys.append(ast.Str(key))
-                    ast_options.values.append(value)
-
-        return ast_options if ast_options and ast_options.keys else None
-
-    def _compile_directive_field(self, el, options):
-        """ Compile something like ``<span t-field="record.phone">+1 555 555 8069</span>`` """
-        node_name = el.tag
-        assert node_name not in ("table", "tbody", "thead", "tfoot", "tr", "td",
+        tagName = el.tag
+        assert tagName not in ("table", "tbody", "thead", "tfoot", "tr", "td",
                                  "li", "ul", "ol", "dl", "dt", "dd"),\
-            "RTE widgets do not work correctly on %r elements" % node_name
-        assert node_name != 't',\
+            "RTE widgets do not work correctly on %r elements" % tagName
+        assert tagName != 't',\
             "t-field can not be used on a t element, provide an actual HTML node"
         assert "." in el.get('t-field'),\
             "t-field must have at least a dot like 'record.field_name'"
 
         expression = el.attrib.pop('t-field')
-        field_options = self._compile_widget_options(el) or ast.Dict(keys=[], values=[])
         record, field_name = expression.rsplit('.', 1)
 
-        return [
-            # t_attrs, content, force_display = self._get_field(record, field_name, expression, tagName, field options, template options, values)
-            ast.Assign(
-                targets=[ast.Tuple(elts=[
-                    ast.Name(id='t_attrs', ctx=ast.Store()),
-                    ast.Name(id='content', ctx=ast.Store()),
-                    ast.Name(id='force_display', ctx=ast.Store())
-                ], ctx=ast.Store())],
-                value=ast.Call(
-                    func=ast.Attribute(
-                        value=ast.Name(id='self', ctx=ast.Load()),
-                        attr='_get_field',
-                        ctx=ast.Load()
-                    ),
-                    args=[
-                        self._compile_expr(record),
-                        ast.Str(field_name),
-                        ast.Str(expression),
-                        ast.Str(node_name),
-                        field_options,
-                        ast.Name(id='options', ctx=ast.Load()),
-                        ast.Name(id='values', ctx=ast.Load()),
-                    ],
-                    keywords=[], starargs=None, kwargs=None
-                )
-            )
-        ] + self._compile_widget_value(el, options)
+        code = []
+        code_options = self._compile_options(el, 't_field_t_options', options, indent)
+        if code_options:
+            code.extend(code_options)
+        else:
+            code.append(self._indent('t_field_t_options = {}', indent))
 
-    def _compile_widget_value(self, el, options):
-        # if force_display:
-        #    display the tag without content
-        orelse = [ast.If(
-            test=ast.Name(id='force_display', ctx=ast.Load()),
-            body=self._compile_tag(el, [], options, True) or [ast.Pass()],
-            orelse=[],
-        )]
+        code.append(self._indent(f"attrs, content, force_display = self._get_field({self._compile_expr(record, raise_on_missing=True)}, {repr(field_name)}, {repr(expression)}, {repr(tagName)}, t_field_t_options, compile_options, values)", indent))
+        code.append(self._indent("content = self._compile_to_str(content)", indent))
+        code.extend(self._compile_widget_value(el, options, indent))
+        return code
 
-        # default content
-        default_content = self._make_name('default_content')
-        body = self._compile_directive_content(el, options)
-        if body:
-            orelse = [
-                # default_content = []
-                ast.Assign(
-                    targets=[ast.Name(id=default_content, ctx=ast.Store())],
-                    value=ast.List(elts=[], ctx=ast.Load())
-                ),
-                # body_call_content(self, default_content.append, values, options)
-                ast.Expr(self._call_def(
-                    self._create_def(options, body, prefix='body_call_content', lineno=el.sourceline),
-                    append=ast.Attribute(
-                        value=ast.Name(id=default_content, ctx=ast.Load()),
-                        attr='append',
-                        ctx=ast.Load()
-                    )
-                )),
-                # default_content = u''.join(default_content)
-                ast.Assign(
-                    targets=[ast.Name(id=default_content, ctx=ast.Store())],
-                    value=ast.Call(
-                        func=ast.Attribute(
-                            value=ast.Str(u''),
-                            attr='join',
-                            ctx=ast.Load()
-                        ),
-                        args=[
-                            ast.Name(id=default_content, ctx=ast.Load())
-                        ],
-                        keywords=[], starargs=None, kwargs=None
-                    )
-                ),
-                # if default_content:
-                #    display the tag with default content
-                # elif force_display:
-                #    display the tag without content
-                ast.If(
-                    test=ast.Name(id=default_content, ctx=ast.Load()),
-                    body=self._compile_tag(el, [self._append(ast.Name(id=default_content, ctx=ast.Load()))], options, True) or [ast.Pass()],
-                    orelse=orelse,
-                )
-            ]
+    def _compile_widget_value(self, el, options, indent=0, without_attributes=False):
+        """Take care of part of the compilation of `t-out` and `t-field` (and
+        the technical directive `t-tag). This is the part that takes care of
+        whether or not created the tags and the default content of the element.
+        """
+        el.attrib.pop('t-tag', None)
 
-        # if content is not None:
-        #    display the tag (to_text(content))
-        # else
-        #    if default_content:
-        #       display the tag with default content
-        #    elif force_display:
-        #       display the tag without content
-        return [self._if_content_is_not_Falsy(
-            body=self._compile_tag(el, [self._append(
-                ast.Call(
-                    func=ast.Name(id='to_text', ctx=ast.Load()),
-                    args=[ast.Name(id='content', ctx=ast.Load())], keywords=[],
-                    starargs=None, kwargs=None
-                )
-            )], options, True),
-            orelse=orelse,
-        )]
+        code = self._flushText(options, indent)
+        code.append(self._indent("if content is not None and content is not False:", indent))
+        code.extend(self._compile_tag_open(el, options, indent + 1, not without_attributes))
+        code.extend(self._flushText(options, indent + 1))
+        # Use str to avoid the escaping of the other html content.
+        code.append(self._indent("yield str(escape(content))", indent + 1))
+        code.extend(self._compile_tag_close(el, options))
+        code.extend(self._flushText(options, indent + 1))
 
-    def _compile_directive_call(self, el, options):
-        tmpl = el.attrib.pop('t-call')
+        default_body = self._compile_directive_content(el, options, indent + 1)
+        if default_body or options['_text_concat']:
+            # default content
+            _text_concat = list(options['_text_concat'])
+            options['_text_concat'].clear()
+            code.append(self._indent("else:", indent))
+            code.extend(self._compile_tag_open(el, options, indent + 1, not without_attributes))
+            code.extend(default_body)
+            options['_text_concat'].extend(_text_concat)
+            code.extend(self._compile_tag_close(el, options))
+            code.extend(self._flushText(options, indent + 1))
+        else:
+            content = (self._compile_tag_open(el, options, indent + 1, not without_attributes) +
+                self._compile_tag_close(el, options) +
+                self._flushText(options, indent + 2))
+            if content:
+                code.append(self._indent("elif force_display:", indent))
+                code.extend(content)
+
+        return code
+
+    def _compile_directive_call(self, el, options, indent):
+        """Compile `t-call` expressions into a python code as a list of
+        strings.
+
+        `t-call` allow formating string dynamic at rendering time.
+        Can use `t-options` used to call and render the sub-template at
+        rendering time.
+        The sub-template is called with a copy of the rendering values
+        dictionary. The dictionary contains the key 0 coming from the
+        compilation of the contents of this element
+
+        The code will contain the call of the template and a function from the
+        compilation of the content of this element.
+        """
+        expr = el.attrib.pop('t-call')
         _values = self._make_name('values_copy')
-        call_options = el.attrib.pop('t-call-options', None)
+
+        if el.attrib.get('t-call-options'): # retro-compatibility
+            el.attrib.set('t-options', el.attrib.pop('t-call-options'))
+
         nsmap = options.get('nsmap')
 
+        code = self._flushText(options, indent)
+        code_options = self._compile_options(el, 't_call_t_options', options, indent)
+        code.extend(code_options)
 
-        content = [
-            # values_copy = values.copy()
-            ast.Assign(
-                targets=[ast.Name(id=_values, ctx=ast.Store())],
-                value=ast.Call(
-                    func=ast.Attribute(
-                        value=ast.Name(id='values', ctx=ast.Load()),
-                        attr='copy',
-                        ctx=ast.Load()
-                    ),
-                    args=[], keywords=[],
-                    starargs=None, kwargs=None
-                )
-            )
-        ]
-
-        body = self._compile_directive_content(el, options)
-        if body:
-            def_name = self._create_def(options, body, prefix='body_call_content', lineno=el.sourceline)
-
-            # call_content = []
-            content.append(
-                ast.Assign(
-                    targets=[ast.Name(id='call_content', ctx=ast.Store())],
-                    value=ast.List(elts=[], ctx=ast.Load())
-                )
-            )
-            # body_call_content(self, call_content.append, values, options)
-            content.append(
-                ast.Expr(self._call_def(
-                    def_name,
-                    append=ast.Attribute(
-                        value=ast.Name(id='call_content', ctx=ast.Load()),
-                        attr='append',
-                        ctx=ast.Load()
-                    ),
-                    values=_values
-                ))
-            )
-            # values_copy[0] = call_content
-            content.append(
-                ast.Assign(
-                    targets=[ast.Subscript(
-                        value=ast.Name(id=_values, ctx=ast.Load()),
-                        slice=ast.Index(ast.Num(0)),
-                        ctx=ast.Store()
-                    )],
-                    value=ast.Name(id='call_content', ctx=ast.Load())
-                )
-            )
+        # content (t-out="0" and variables)
+        def_name = "t_call_content"
+        content = self._compile_directive_content(el, options, indent + 1)
+        if content and not options['_text_concat']:
+            self._appendText('', options) # To ensure the template function is a generator and doesn't become a regular function
+        content.extend(self._flushText(options, indent + 1))
+        if content:
+            code.append(self._indent(f"def {def_name}(self, values, log):", indent))
+            code.extend(content)
+            code.append(self._indent("t_call_values = values.copy()", indent))
+            code.append(self._indent(f"t_call_values['0'] = Markup(''.join({def_name}(self, t_call_values, log)))", indent))
         else:
-            # values_copy[0] = []
-            content.append(
-                ast.Assign(
-                    targets=[ast.Subscript(
-                        value=ast.Name(id=_values, ctx=ast.Load()),
-                        slice=ast.Index(ast.Num(0)),
-                        ctx=ast.Store()
-                    )],
-                    value=ast.List(elts=[], ctx=ast.Load())
-                )
-            )
+            code.append(self._indent("t_call_values = values.copy()", indent))
+            code.append(self._indent("t_call_values['0'] = Markup()", indent))
 
-        name_options = self._make_name('options')
-        # copy the original dict of options to pass to the callee
-        content.append(
-            # options_ = options.copy()
-            ast.Assign(
-                targets=[ast.Name(id=name_options, ctx=ast.Store())],
-                value=ast.Call(
-                    func=ast.Attribute(
-                        value=ast.Name(id='options', ctx=ast.Load()),
-                        attr='copy',
-                        ctx=ast.Load()
-                    ),
-                    args=[], keywords=[], starargs=None, kwargs=None
-                )
-            )
-        )
-        if nsmap or call_options:
+        # options
+        code.append(self._indent(dedent(f"""
+            t_call_options = compile_options.copy()
+            t_call_options.update({{'caller_template': {repr(str(options.get('template')))}, 'last_path_node': {repr(str(options['root'].getpath(el)))} }})
+            """).strip(), indent))
+        if nsmap:
+            # update this dict with the current nsmap so that the callee know
+            # if he outputting the xmlns attributes is relevenat or not
+            nsmap = []
+            for key, value in options['nsmap'].items():
+                if isinstance(key, str):
+                    nsmap.append(f'{repr(key)}:{repr(value)}')
+                else:
+                    nsmap.append(f'None:{repr(value)}')
+            code.append(self._indent(f"t_call_options.update(nsmap={{{', '.join(nsmap)}}})", indent))
 
-            if call_options:
-                # update this dict with the content of `t-call-options`
-                content.extend([
-                    # options_.update(template options)
-                    ast.Expr(ast.Call(
-                        func=ast.Attribute(
-                            value=ast.Name(id=name_options, ctx=ast.Load()),
-                            attr='update',
-                            ctx=ast.Load()
-                        ),
-                        args=[self._compile_expr(call_options)],
-                        keywords=[], starargs=None, kwargs=None
-                    )),
+        template = self._compile_format(expr)
 
-                    # if options.get('lang') != options_.get('lang'):
-                    #   self = self.with_context(lang=options.get('lang'))
-                    ast.If(
-                        test=ast.Compare(
-                            left=ast.Call(
-                                func=ast.Attribute(
-                                    value=ast.Name(id='options', ctx=ast.Load()),
-                                    attr='get',
-                                    ctx=ast.Load()
-                                ),
-                                args=[ast.Str("lang")], keywords=[],
-                                starargs=None, kwargs=None
-                            ),
-                            ops=[ast.NotEq()],
-                            comparators=[ast.Call(
-                                func=ast.Attribute(
-                                    value=ast.Name(id=name_options, ctx=ast.Load()),
-                                    attr='get',
-                                    ctx=ast.Load()
-                                ),
-                                args=[ast.Str("lang")], keywords=[],
-                                starargs=None, kwargs=None
-                            )]
-                        ),
-                        body=[
-                            ast.Assign(
-                                targets=[ast.Name(id='self', ctx=ast.Store())],
-                                value=ast.Call(
-                                    func=ast.Attribute(
-                                        value=ast.Name(id='self', ctx=ast.Load()),
-                                        attr='with_context',
-                                        ctx=ast.Load()
-                                    ),
-                                    args=[],
-                                    keywords=[ast.keyword('lang', ast.Call(
-                                        func=ast.Attribute(
-                                            value=ast.Name(id=name_options, ctx=ast.Load()),
-                                            attr='get',
-                                            ctx=ast.Load()
-                                        ),
-                                        args=[ast.Str("lang")], keywords=[],
-                                        starargs=None, kwargs=None
-                                    ))],
-                                    starargs=None, kwargs=None
-                                )
-                            )],
-                        orelse=[],
-                    )
-                ])
+        # call
+        if code_options:
+            code.append(self._indent("t_call_options.update(t_call_t_options)", indent))
+            code.append(self._indent(dedent(f"""
+                if compile_options.get('lang') != t_call_options.get('lang'):
+                    self_lang = self.with_context(lang=t_call_options.get('lang'))
+                    yield from self_lang._compile({template}, t_call_options)(self_lang, t_call_values)
+                else:
+                    yield from self._compile({template}, t_call_options)(self, t_call_values)
+                """).strip(), indent))
+        else:
+            code.append(self._indent(f"yield from self._compile({template}, t_call_options)(self, t_call_values)", indent))
 
-            if nsmap:
-                # update this dict with the current nsmap so that the callee know
-                # if he outputting the xmlns attributes is relevenat or not
 
-                # make the nsmap an ast dict
-                keys = []
-                values = []
-                for key, value in options['nsmap'].items():
-                    if isinstance(key, str):
-                        keys.append(ast.Str(s=key))
-                    elif key is None:
-                        keys.append(ast.Constant(None))
-                    values.append(ast.Str(s=value))
-
-                # {'nsmap': {None: 'xmlns def'}}
-                nsmap_ast_dict = ast.Dict(
-                    keys=[ast.Str(s='nsmap')],
-                    values=[ast.Dict(keys=keys, values=values)]
-                )
-
-                # options_.update(nsmap_ast_dict)
-                content.append(
-                    ast.Expr(ast.Call(
-                        func=ast.Attribute(
-                            value=ast.Name(id=name_options, ctx=ast.Load()),
-                            attr='update',
-                            ctx=ast.Load()
-                        ),
-                        args=[nsmap_ast_dict],
-                        keywords=[], starargs=None, kwargs=None
-                    ))
-                )
-
-        # options_.update({
-        #     'caller_template': str(options.get('template')),
-        #     'last_path_node': str(options['root'].getpath(el)),
-        # })
-        content.append(
-            ast.Expr(ast.Call(
-                func=ast.Attribute(
-                    value=ast.Name(id=name_options, ctx=ast.Load()),
-                    attr='update',
-                    ctx=ast.Load()
-                ),
-                args=[
-                    ast.Dict(
-                        keys=[ast.Str(s='caller_template'), ast.Str(s='last_path_node')],
-                        values=[
-                            ast.Str(s=str(options.get('template'))),
-                            ast.Str(s=str(options['root'].getpath(el))),
-                        ]
-                    )
-                ],
-                keywords=[], starargs=None, kwargs=None
-            ))
-        )
-
-        # self.compile($tmpl, options)(self, append, values_copy)
-        content.append(
-            ast.Expr(ast.Call(
-                func=ast.Call(
-                    func=ast.Attribute(
-                        value=ast.Name(id='self', ctx=ast.Load()),
-                        attr='compile',
-                        ctx=ast.Load()
-                    ),
-                    args=[
-                        self._compile_format(str(tmpl)),
-                        ast.Name(id=name_options, ctx=ast.Load()),
-                    ],
-                    keywords=[], starargs=None, kwargs=None
-                ),
-                args=[
-                    ast.Name(id='self', ctx=ast.Load()),
-                    ast.Name(id='append', ctx=ast.Load()),
-                    ast.Name(id=_values, ctx=ast.Load())
-                ],
-                keywords=[], starargs=None, kwargs=None
-            ))
-        )
-        return content
+        return code
 
     # method called by computing code
 
-    def _get_dynamic_att(self, tagName, atts, options, values):
-        if isinstance(atts, OrderedDict):
-            return atts
-        if isinstance(atts, (list, tuple)) and not isinstance(atts[0], (list, tuple)):
-            atts = [atts]
-        if isinstance(atts, (list, tuple)):
-            atts = OrderedDict(atts)
-        return atts
-
     def _post_processing_att(self, tagName, atts, options):
-        """ Method called by the compiled code. This method may be overwrited
-            to filter or modify the attributes after they are compiled.
+        """ Method called at compile time for the static node and called at
+            runing time for the dynamic attributes.
 
-            @returns OrderedDict
+            This method may be overwrited to filter or modify the attributes
+            (during compilation for static node or after they compilation in
+            the case of dynamic elements).
+
+            @returns dict
         """
         return atts
 
     def _get_field(self, record, field_name, expression, tagName, field_options, options, values):
-        """
+        """Method called at compile time to return the field value.
+
         :returns: tuple:
-            * OrderedDict: attributes
+            * dict: attributes
             * string or None: content
             * boolean: force_display display the tag if the content and default_content are None
         """
         return self._get_widget(getattr(record, field_name, None), expression, tagName, field_options, options, values)
 
     def _get_widget(self, value, expression, tagName, field_options, options, values):
-        """
+        """Method called at compile time to return the widget value.
+
         :returns: tuple:
-            * OrderedDict: attributes
+            * dict: attributes
             * string or None: content
             * boolean: force_display display the tag if the content and default_content are None
         """
-        return (OrderedDict(), value, False)
+        return ({}, value, False)
 
-    # compile expression
-
-    def _compile_strexpr(self, expr):
-        return ast.Call(
-            func=ast.Name(id='str', ctx=ast.Load()),
-            args=[
-                ast.Call(
-                    func=ast.Name(id='to_text', ctx=ast.Load()),
-                    args=[self._compile_expr(expr)], keywords=[],
-                )
-            ], keywords=[]
-        )
-
-    def _compile_expr0(self, expr):
-        if expr == "0":
-            # u''.join(values.get(0, []))
-            joined = ast.Call(
-                func=ast.Attribute(
-                    value=ast.Str(u''),
-                    attr='join',
-                    ctx=ast.Load()
-                ),
-                args=[
-                    ast.Call(
-                        func=ast.Attribute(
-                            value=ast.Name(id='values', ctx=ast.Load()),
-                            attr='get',
-                            ctx=ast.Load()
-                        ),
-                        args=[ast.Num(0), ast.List(elts=[], ctx=ast.Load())], keywords=[],
-                        starargs=None, kwargs=None
-                    )
-                ],
-                keywords=[], starargs=None, kwargs=None
-            )
-            # Markup(...): 0 is a rendered body, so should be safe
-            return ast.Call(
-                func=ast.Name(id='Markup', ctx=ast.Load()),
-                args=[joined], keywords=[]
-            )
-        return self._compile_expr(expr)
-
-    def _compile_format(self, f):
-        """ Parses the provided format string and compiles it to a single
-        expression ast, uses string concatenation via "+".
-        """
-        assert isinstance(f, str), "format strings can't be bytes"
-        elts = []
-        base_idx = 0
-        for m in _FORMAT_REGEX.finditer(f):
-            literal = f[base_idx:m.start()]
-            if literal:
-                elts.append(ast.Str(literal))
-
-            expr = m.group(1) or m.group(2)
-            elts.append(self._compile_strexpr(expr))
-            base_idx = m.end()
-        # string past last regex match
-        literal = f[base_idx:]
-        if literal:
-            elts.append(ast.Str(literal))
-
-        return reduce(lambda acc, it: ast.BinOp(
-            left=acc,
-            op=ast.Add(),
-            right=it
-        ), elts)
-
-    def _compile_expr(self, expr):
-        """ Compiles a purported Python expression to ast, and alter its
-        variable references to access values data instead exept for
-        python buildins.
-        This compile method is unsafe!
-        Can be overridden to use a safe eval method.
-        """
-        # string must be stripped otherwise whitespace before the start for
-        # formatting purpose are going to break parse/compile
-        st = ast.parse(expr.strip(), mode='eval')
-        # ast.Expression().body -> expr
-        return Contextifier(builtin_defaults).visit(st).body
+    def _debug_trace(self, debugger, options):
+        """Method called at compile time to load debugger."""
+        if debugger in SUPPORTED_DEBUGGERS:
+            __import__(debugger).set_trace()
+        else:
+            raise QWebException(f"unsupported t-debug value: {debugger}", self, options)

--- a/odoo/addons/base/tests/test_qweb.py
+++ b/odoo/addons/base/tests/test_qweb.py
@@ -91,7 +91,7 @@ class TestQWebTField(TransactionCase):
                 </t>
             """
         })
-        rendered = view._render({'malicious': '1</script><script>alert("pwned")</script><script>'}).decode()
+        rendered = view._render({'malicious': '1</script><script>alert("pwned")</script><script>'})
         self.assertIn('alert', rendered, "%r doesn't seem to be rendered" % rendered)
         doc = etree.fromstring(rendered)
         self.assertEqual(len(doc.xpath('//script')), 1)
@@ -526,10 +526,10 @@ class TestQWebNS(TransactionCase):
         # check that the t-call did its work
         cac_lines = result_etree.findall('.//cac:line', namespaces={'cac': 'urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2'})
         self.assertEqual(len(cac_lines), 2)
-        self.assertEqual(result.count(b'Appel'), 2)
+        self.assertEqual(result.count('Appel'), 2)
 
         # check that the t-call dit not output again the xmlns declaration
-        self.assertEqual(result.count(b'xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"'), 1)
+        self.assertEqual(result.count('xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"'), 1)
 
     def test_render_static_xml_with_extension(self):
         """ Test the extension of a view by an xpath expression on a ns prefixed element.
@@ -641,7 +641,7 @@ class TestQWebNS(TransactionCase):
         })
 
         rendered = view2.with_context(lang=current_lang)._render().strip()
-        self.assertEqual(rendered, b'9/000/000*00')
+        self.assertEqual(rendered, '9/000/000*00')
 
     def test_render_barcode(self):
         partner = self.env['res.partner'].create({
@@ -655,16 +655,16 @@ class TestQWebNS(TransactionCase):
         })
 
         view.arch = u"""<div t-field="partner.barcode" t-options="{'widget': 'barcode', 'width': 100, 'height': 30}"/>"""
-        rendered = view._render(values={'partner': partner}).strip().decode()
+        rendered = view._render(values={'partner': partner}).strip()
         self.assertRegex(rendered, r'<div><img alt="Barcode test" src="data:image/png;base64,\S+"></div>')
 
         partner.barcode = '4012345678901'
         view.arch = u"""<div t-field="partner.barcode" t-options="{'widget': 'barcode', 'symbology': 'EAN13', 'width': 100, 'height': 30, 'img_style': 'width:100%;', 'img_alt': 'Barcode'}"/>"""
-        ean_rendered = view._render(values={'partner': partner}).strip().decode()
+        ean_rendered = view._render(values={'partner': partner}).strip()
         self.assertRegex(ean_rendered, r'<div><img style="width:100%;" alt="Barcode" src="data:image/png;base64,\S+"></div>')
 
         view.arch = u"""<div t-field="partner.barcode" t-options="{'widget': 'barcode', 'symbology': 'auto', 'width': 100, 'height': 30, 'img_style': 'width:100%;', 'img_alt': 'Barcode'}"/>"""
-        auto_rendered = view._render(values={'partner': partner}).strip().decode()
+        auto_rendered = view._render(values={'partner': partner}).strip()
         self.assertRegex(auto_rendered, r'<div><img style="width:100%;" alt="Barcode" src="data:image/png;base64,\S+"></div>')
 
 class TestQWebBasic(TransactionCase):
@@ -740,7 +740,7 @@ class TestQWebBasic(TransactionCase):
                     [2: 1 1]
         """
 
-        rendered = str(self.env['ir.qweb']._render(t.id), 'utf-8')
+        rendered = self.env['ir.qweb']._render(t.id)
         self.assertEqual(rendered.strip(), result.strip())
 
     def test_foreach_iter_dict(self):
@@ -758,7 +758,7 @@ class TestQWebBasic(TransactionCase):
                     [2: c 1]
         """
 
-        rendered = str(self.env['ir.qweb']._render(t.id), 'utf-8')
+        rendered = self.env['ir.qweb']._render(t.id)
         self.assertEqual(rendered.strip(), result.strip())
 
     def test_att_escaping_1(self):
@@ -775,7 +775,7 @@ class TestQWebBasic(TransactionCase):
                 <div toto="a&#39;b&#34;c">2</div>
             """
         values = {'json': json_scriptsafe, 'bibi': dict(a='string', b=1), 'toto': "a'b\"c"}
-        rendered = str(self.env['ir.qweb']._render(t.id, values), 'utf-8')
+        rendered = self.env['ir.qweb']._render(t.id, values)
         self.assertEqual(rendered.strip(), result.strip())
 
     def test_att_escaping_2(self):
@@ -792,7 +792,7 @@ class TestQWebBasic(TransactionCase):
                 <div abc=" &amp;#34;yes&amp;#34; &lt;span a=&#34;b&#34;&gt; | &lt;/span&gt;-efg- ">123</div>
             """
         values = {'add_abc': '"yes"', 'efg': '-efg-'}
-        rendered = str(self.env['ir.qweb']._render(t.id, values), 'utf-8')
+        rendered = self.env['ir.qweb']._render(t.id, values)
         self.assertEqual(rendered.strip(), result.strip())
 
     def test_attf_escaping_1(self):
@@ -807,7 +807,7 @@ class TestQWebBasic(TransactionCase):
                 <div bibi="a, b &gt; c &gt; a&#39; &gt; b&#34;c">1</div>
             """
         values = {'d': "a' > b\"c"}
-        rendered = str(self.env['ir.qweb']._render(t.id, values), 'utf-8')
+        rendered = self.env['ir.qweb']._render(t.id, values)
         self.assertEqual(rendered.strip(), result.strip())
 
     def test_attf_escaping_2(self):
@@ -824,7 +824,7 @@ class TestQWebBasic(TransactionCase):
                 <a href="/link/odoo/">link2</a>
             """
         values = {'url': 'odoo', 'other': True}
-        rendered = str(self.env['ir.qweb']._render(t.id, values), 'utf-8')
+        rendered = self.env['ir.qweb']._render(t.id, values)
         self.assertEqual(rendered.strip(), result.strip())
 
     def test_attf_escaping_3(self):
@@ -840,7 +840,7 @@ class TestQWebBasic(TransactionCase):
                 <div abc="abc &#34;yes&#34; { other }">123</div>
             """
         values = {'val': '"yes"'}
-        rendered = str(self.env['ir.qweb']._render(t.id, values), 'utf-8')
+        rendered = self.env['ir.qweb']._render(t.id, values)
         self.assertEqual(rendered.strip(), result.strip())
 
     def test_set_body_1(self):
@@ -856,7 +856,7 @@ class TestQWebBasic(TransactionCase):
                 <div abc=" &lt;span a=&#34;b&#34;&gt; [&amp;#34;yes&amp;#34;] &lt;/span&gt; ">123</div>
             """
         values = {'add_abc': '"yes"'}
-        rendered = str(self.env['ir.qweb']._render(t.id, values), 'utf-8')
+        rendered = self.env['ir.qweb']._render(t.id, values)
         self.assertEqual(rendered.strip(), result.strip())
 
     def test_set_body_2(self):
@@ -875,7 +875,7 @@ class TestQWebBasic(TransactionCase):
                 <div class="a1"> <span a="b"> toto </span> </div>
                 <div class="a2">[ &lt;span a=&#34;b&#34;&gt; toto &lt;/span&gt; ]</div>
             """
-        rendered = str(self.env['ir.qweb']._render(t.id), 'utf-8')
+        rendered = self.env['ir.qweb']._render(t.id)
         self.assertEqual(rendered.strip(), result.strip())
 
     def test_out_format_1(self):
@@ -890,7 +890,7 @@ class TestQWebBasic(TransactionCase):
         result = u"""
                 <div>Powered by 1-2</div>
         """
-        rendered = str(self.env['ir.qweb']._render(t.id, {'a': 1, 'b': 2}), 'utf-8')
+        rendered = self.env['ir.qweb']._render(t.id, {'a': 1, 'b': 2})
         self.assertEqual(rendered.strip(), result.strip())
 
     def test_out_format_2(self):
@@ -907,7 +907,7 @@ class TestQWebBasic(TransactionCase):
                 <div> <span a="b"> [&#34;yes&#34; , Toto 5] </span> </div>
             """
         values = {'add_abc': '"yes"'}
-        rendered = str(self.env['ir.qweb']._render(t.id, values), 'utf-8')
+        rendered = self.env['ir.qweb']._render(t.id, values)
         self.assertEqual(rendered.strip(), result.strip())
 
     def test_out_format_3(self):
@@ -924,7 +924,7 @@ class TestQWebBasic(TransactionCase):
                 <div>Toto &#34;yes&#34; <span a="b"> a </span> </div>
             """
         values = {'v': '"yes"'}
-        rendered = str(self.env['ir.qweb']._render(t.id, values), 'utf-8')
+        rendered = self.env['ir.qweb']._render(t.id, values)
         self.assertEqual(rendered.strip(), result.strip())
 
     def test_out_format_4(self):
@@ -940,7 +940,7 @@ class TestQWebBasic(TransactionCase):
                 <div>&#34;yes&#34; <span a="b"> a </span> </div>
             """
         values = {'v': '"yes"'}
-        rendered = str(self.env['ir.qweb']._render(t.id, values), 'utf-8')
+        rendered = self.env['ir.qweb']._render(t.id, values)
         self.assertEqual(rendered.strip(), result.strip())
 
     def test_out_format_5(self):
@@ -956,7 +956,7 @@ class TestQWebBasic(TransactionCase):
                 <div> <span a="b"> a </span> &#34;yes&#34;</div>
             """
         values = {'v': '"yes"'}
-        rendered = str(self.env['ir.qweb']._render(t.id, values), 'utf-8')
+        rendered = self.env['ir.qweb']._render(t.id, values)
         self.assertEqual(rendered.strip(), result.strip())
 
     def test_out_format_6(self):
@@ -973,7 +973,7 @@ class TestQWebBasic(TransactionCase):
                 <div><span a="b"> a </span>&#34;yes&#34;</div>
             """
         values = {'v': '"yes"'}
-        rendered = str(self.env['ir.qweb']._render(t.id, values), 'utf-8')
+        rendered = self.env['ir.qweb']._render(t.id, values)
         self.assertEqual(rendered.strip(), result.strip())
 
     def test_out_escape_text(self):
@@ -984,8 +984,8 @@ class TestQWebBasic(TransactionCase):
                 <t t-name="base.dummy"><root><span t-out="text" t-options-widget="'text'"/></root></t>
             """
         })
-        html = str(view1._render({'text': """a
-        b <b>c</b>"""}), 'utf-8')
+        html = view1._render({'text': """a
+        b <b>c</b>"""})
         self.assertEqual(html, """<root><span data-oe-type="text" data-oe-expression="text">a<br>
         b &lt;b&gt;c&lt;/b&gt;</span></root>""")
 
@@ -1002,7 +1002,7 @@ class TestQWebBasic(TransactionCase):
         result = """
                 <div>123</div>
             """
-        rendered = str(self.env['ir.qweb']._render(t.id), 'utf-8')
+        rendered = self.env['ir.qweb']._render(t.id)
         self.assertEqual(rendered.strip(), result.strip())
 
     def test_error_message_1(self):
@@ -1112,7 +1112,7 @@ class TestQWebStaticXml(TransactionCase):
             result = doc.find('result[@id="{}"]'.format(template)).text
             self.assertEqual(
                 qweb._render(template, values=params, load=loader).strip(),
-                (result or u'').strip().replace('&quot;', '&#34;').encode('utf-8'),
+                (result or u'').strip().replace('&quot;', '&#34;'),
                 template
             )
 
@@ -1211,7 +1211,7 @@ class TestEmptyLines(TransactionCase):
             'type': 'qweb',
             'arch_db': self.arch
         })
-        rendered = str(self.env['ir.qweb']._render(t.id), 'utf-8')
+        rendered = self.env['ir.qweb']._render(t.id)
         self.assertFalse(re.compile('^\s+\n').match(rendered))
         self.assertFalse(re.compile('\n\s+\n').match(rendered))
 
@@ -1221,7 +1221,7 @@ class TestEmptyLines(TransactionCase):
             'type': 'qweb',
             'arch_db': self.arch
         })
-        rendered = str(self.env['ir.qweb']._render(t.id, {'__keep_empty_lines': True}), 'utf-8')
+        rendered = self.env['ir.qweb']._render(t.id, {'__keep_empty_lines': True})
         self.assertTrue(re.compile('^\s+\n').match(rendered))
         self.assertTrue(re.compile('\n\s+\n').match(rendered))
 

--- a/odoo/addons/base/tests/test_qweb.py
+++ b/odoo/addons/base/tests/test_qweb.py
@@ -207,6 +207,89 @@ class TestQWebNS(TransactionCase):
 
         self.assertEqual(etree.fromstring(view1._render()), etree.fromstring(expected_result))
 
+    def test_render_static_xml_with_namespace_dynamic(self):
+        """ Test the rendering on a namespaced view with dynamic URI (need default namespace uri).
+        """
+        tempate = u"""
+            <root xmlns:h="https://default.namespace.url/h">
+                <h:table t-att="{'xmlns:h': h1}">
+                    <h:tr>
+                        <h:td t-att="{'xmlns:h': h2}">Apples</h:td>
+                        <h:td>Bananas</h:td>
+                    </h:tr>
+                </h:table>
+            </root>
+        """
+        expected_result = u"""
+            <root xmlns:h="https://default.namespace.url/h">
+                <h:table xmlns:h="%(h1)s">
+                    <h:tr>
+                        <h:td xmlns:h="%(h2)s">Apples</h:td>
+                        <h:td>Bananas</h:td>
+                    </h:tr>
+                </h:table>
+            </root>
+        """
+
+        values = dict(h1="http://www.example.org/table", h2="http://www.w3.org/TD/html4/")
+
+        view1 = self.env['ir.ui.view'].create({
+            'name': "dummy",
+            'type': 'qweb',
+            'arch': u"""
+                <t t-name="base.dummy">%s</t>
+            """ % tempate
+        })
+
+        rendering = view1._render(values, engine='ir.qweb')
+
+        self.assertEqual(etree.fromstring(rendering), etree.fromstring(expected_result % values))
+
+    def test_render_static_xml_with_namespace_dynamic_2(self):
+        """ Test the rendering on a namespaced view with dynamic URI (need default namespace uri).
+        Default URIs must be differents.
+        """
+        tempate = u"""
+            <root xmlns:f="https://default.namespace.url/f" xmlns:h="https://default.namespace.url/h" >
+                <h:table t-att="{'xmlns:h': h1}">
+                    <h:tr>
+                        <h:td t-att="{'xmlns:h': h2}">Apples</h:td>
+                        <h:td>Bananas</h:td>
+                    </h:tr>
+                </h:table>
+                <f:table t-att="{'xmlns:f': f}">
+                    <f:width>80</f:width>
+                </f:table>
+            </root>
+        """
+        expected_result = u"""
+            <root xmlns:f="https://default.namespace.url/f" xmlns:h="https://default.namespace.url/h">
+                <h:table xmlns:h="%(h1)s">
+                    <h:tr>
+                        <h:td xmlns:h="%(h2)s">Apples</h:td>
+                        <h:td>Bananas</h:td>
+                    </h:tr>
+                </h:table>
+                <f:table xmlns:f="%(f)s">
+                    <f:width>80</f:width>
+                </f:table>
+            </root>
+        """
+
+        values = dict(h1="http://www.example.org/table", h2="http://www.w3.org/TD/html4/", f="http://www.example.org/furniture")
+
+        view1 = self.env['ir.ui.view'].create({
+            'name': "dummy",
+            'type': 'qweb',
+            'arch': u"""
+                <t t-name="base.dummy">%s</t>
+            """ % tempate
+        })
+
+        rendering = view1._render(values, engine='ir.qweb')
+
+        self.assertEqual(etree.fromstring(rendering), etree.fromstring(expected_result % values))
+
     def test_render_dynamic_xml_with_namespace_t_esc(self):
         """ Test that rendering a template containing a node having both an ns declaration and a t-esc attribute correctly
         handles the t-esc attribute and keep the ns declaration.

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -229,7 +229,7 @@ class TestViewInheritance(ViewCase):
         self.assertEqual(default_tree, self.view_ids['C'].id)
 
     def test_no_default_view(self):
-        self.assertFalse(self.View.default_view(model='does.not.exist', view_type='form'))
+        self.assertFalse(self.View.default_view(model='no_model.exist', view_type='form'))
         self.assertFalse(self.View.default_view(model=self.model, view_type='graph'))
 
     def test_no_recursion(self):

--- a/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
+++ b/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
@@ -641,7 +641,7 @@ class TestJavascriptAssetsBundle(FileTouchable):
     </head>
     <body>
     </body>
-</html>""" % format_data).encode('utf8'))
+</html>""" % format_data))
 
     def test_21_external_lib_assets_debug_mode(self):
         html = self.env['ir.ui.view']._render_template('test_assetsbundle.template2', {"debug": "assets"})
@@ -672,7 +672,7 @@ class TestJavascriptAssetsBundle(FileTouchable):
     </head>
     <body>
     </body>
-</html>""" % format_data).encode('utf8'))
+</html>""" % format_data))
 
 
 @tagged('-at_install', 'post_install')


### PR DESCRIPTION
[REF] base,*: refactor Qweb engine …

* Remove AST in favor of pure Pyhon. This should make it easier for
developers to understand and create new directives because they do not
need to know AST.

* Remove `t-call-options` as it has been merged into `t-options` for more
consistency. Support for t-call-options is retained.

* Use generators for lists. This increases performances as the rendering
can be sent directly without having to wait for the creation of the
entire list.

* Optimize expressions runtime computation by pre-computing the static
parts.
Example:
`'<' + 'div' + '>' + '<' + dynamic_value + '>'`
Now compiles as:
`'<div><' + dynamic_value + '>'`

Desired behavior after PR is merged:
* Have code that is easier to understand for developers (because most do not know ast);
* Performance improvement (strings are concatenated, orderdict removed, some variable assignments are simplified)
* Add the possibility of being able to easily log the performances.

Other PRs for this change:
- Enterprise: https://github.com/odoo/enterprise/pull/17270
- Upgrade: odoo/upgrade#2454