### PR TITLE
[FIX] ht_fleet: Changing mobility card

### DIFF
--- a/addons/hr_fleet/models/fleet_vehicle.py
+++ b/addons/hr_fleet/models/fleet_vehicle.py
@@ -9,7 +9,22 @@ class FleetVehicle(models.Model):
 
     mobility_card = fields.Char(compute='_compute_mobility_card', store=True)
 
-    @api.depends('driver_id', 'driver_id.user_ids.employee_id.mobility_card')
+    @api.depends('driver_id')
     def _compute_mobility_card(self):
         for vehicle in self:
-            vehicle.mobility_card = vehicle.driver_id.user_ids[:1].employee_id.mobility_card
+            employee = self.env['hr.employee']
+            if vehicle.driver_id:
+                employee = employee.search([('address_home_id', '=', vehicle.driver_id.id)], limit=1)
+                if not employee:
+                    employee = employee.search([('user_id.partner_id', '=', vehicle.driver_id.id)], limit=1)
+            vehicle.mobility_card = employee.mobility_card
+
+class HrEmployee(models.Model):
+    _inherit = "hr.employee"
+
+    def write(self, vals):
+        res = super().write(vals)
+        if 'mobility_card' in vals:
+            vehicles = self.env['fleet.vehicle'].search([('driver_id', 'in', (self.user_id.partner_id | self.sudo().address_home_id).ids)])
+            vehicles._compute_mobility_card()
+        return res


### PR DESCRIPTION
Steps to reproduce the bug:
    
    - Let's consider an employee E and two partners P1, P2
    - P1 is the private address of E and P2 is the partner linked to the user of E
    - Let's consider two vehicles V1, V2
    - The driver of V1 is P1 and the driver of V2 is P2
    - Change the mobility card of E
    
Bug:
    
The mobility card of V1 was not updated but the mobility card of V2 was updated.
The number of cars computed by _compute_employee_cars_count was doubled.

opw:2431316