### PR TITLE
[FIX] web: empty fields don't increase row height

### DIFF
--- a/addons/web/static/src/scss/fields.scss
+++ b/addons/web/static/src/scss/fields.scss
@@ -12,8 +12,8 @@
 }
 
 // Empty
-.o_field_empty:empty {
-    min-height: $font-size-base * $line-height-base;
+.o_field_empty {
+    display: none;
 }
 
 // Numbers

--- a/addons/web/static/src/scss/form_view.scss
+++ b/addons/web/static/src/scss/form_view.scss
@@ -54,6 +54,10 @@
         float: right!important;
     }
 
+    .o_field_empty:empty {
+        min-height: $font-size-base * $line-height-base;
+    }
+
     .o_row {
         &, &.o_field_widget { // Some field may want to use o_row as root and these rules must prevalue
             display: flex;


### PR DESCRIPTION
Commit [1] tweaked the empty (unset) fields css rules s.t. they
have a non null height in readonly, to reduce the shift between
readonly and editable form view. This only concerns form view,
but the changed rule also applied in list view. As a consequence,
empty fields increased the rows height in list views.

https://github.com/odoo/odoo/commit/288b24cbdf54ac0dbee7e012f074fac9a0c68238

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
