### PR TITLE
[FIX] ir.cron: execute jobs in priority order (again)

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -180,6 +180,7 @@ class ir_cron(models.Model):
                     WHERE call_at <= (now() at time zone 'UTC')
                 )
               )
+            ORDER BY priority
         """)
         return cr.dictfetchall()
 
@@ -225,6 +226,7 @@ class ir_cron(models.Model):
                 )
               )
               AND id in %s
+            ORDER BY priority
             LIMIT 1 FOR NO KEY UPDATE SKIP LOCKED
         """, [job_ids])
         return cr.dictfetchone()


### PR DESCRIPTION
The selection mechanism selects 1 job at a time from the jobs that are ready to execute, but while doing this it should respect the `priority` defined on the jobs. Otherwise the field is useless, and the user has no way to ensure that a long-running job does not cause starvation. (Assuming execution resources that are insufficient for 100% of the processing to happen)

The `priority` ordering was apparently lost during the introduction of the trigger mechanism in #62124 via
4b28f1162a85d03f9dbe0338b06758ad151ea6a8.

It was previously taken into account in `_process_jobs()`: 
https://github.com/odoo/odoo/blob/3826a2645b94e0f62c719814c4dbe4cc6502e1f2/odoo/addons/base/models/ir_cron.py#L198

The `ORDER BY` is not strictly necessary in `_get_all_ready_jobs()`, but it seems more consistent for this method to return an ordered list as well, given the semantics of the `priority` field. We don't know what the caller will do with the result.