### PR TITLE
[FIX] base: generate missing terms ok src dupes


### DIFF
--- a/odoo/addons/base/wizard/base_update_translations.py
+++ b/odoo/addons/base/wizard/base_update_translations.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import tarfile
 import tempfile
 
 from odoo import api, fields, models, tools, _
@@ -31,7 +32,13 @@ class BaseUpdateTranslations(models.TransientModel):
         this = self[0]
         lang_name = self._get_lang_name(this.lang)
         with tempfile.NamedTemporaryFile() as buf:
-            tools.trans_export(this.lang, ['all'], buf, 'po', self._cr)
+            tools.trans_export(this.lang, ['all'], buf, 'tgz', self._cr)
             context = {'create_empty_translation': True}
-            tools.trans_load_data(self._cr, buf, 'po', this.lang, lang_name=lang_name, context=context)
+            buf.seek(0)
+            tar = tarfile.open(fileobj=buf)
+            for file_info in tar:
+                module_file = tar.extractfile(file_info)
+                tools.trans_load_data(self._cr, module_file, 'po', this.lang, lang_name=lang_name,
+                                      module_name=file_info.name.partition('/')[0], context=context)
+            tar.close()
         return {'type': 'ir.actions.act_window_close'}


### PR DESCRIPTION

When using "Generate Missing Terms" we export all translations and
reimport them with `create_empty_translation` so they empty translation
are made available.

But since we export all modules in the same PO file, the same terms that
might have different translation in different modules would get the same
translation value after using "Generate missing terms" which is
unexpected => usually we import/export PO file by module and so a term
translation is unique for one module only.

With this changeset, we import translation module by module.

When testing speed of Generate Missing Terms with 90 modules and 37000
translations, the timing taken change like this:

- original code: 21 seconds
- exporting/importing 1 PO file per module: 45 seconds
- exporting 1 TGZ file total/importing 1 PO file per module: 23 seconds

opw-2439029
