### PR TITLE
[FIX] l10n_latam_invoice_document: only trigger constraint when partn…

### DIFF
--- a/addons/l10n_latam_invoice_document/models/account_move.py
+++ b/addons/l10n_latam_invoice_document/models/account_move.py
@@ -255,7 +255,8 @@ class AccountMove(models.Model):
         """ The constraint _check_unique_sequence_number is valid for customer bills but not valid for us on vendor
         bills because the uniqueness must be per partner and also because we want to validate on entry creation and
         not on entry validation """
-        for rec in self.filtered(lambda x: x.is_purchase_document() and x.l10n_latam_use_documents and x.l10n_latam_document_number):
+        for rec in self.filtered(lambda x: x.is_purchase_document() and x.l10n_latam_use_documents
+                                           and x.l10n_latam_document_number and x.commercial_partner_id):
             domain = [
                 ('type', '=', rec.type),
                 # by validating name we validate l10n_latam_document_number and l10n_latam_document_type_id


### PR DESCRIPTION
…er_id is set

Before, when importing twice the same invoice, or even with the more
theoretical possibility of having the same number for different partners,
the constraint would be triggered, giving unnecessary problems when
importing vendor bills with an uncertain partner_id.

If we check the logic followed in the regular accounting on the ref field,
it only triggers when a partner is set, so we can follow the same logic here.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
