### PR TITLE
[IMP] core: Deprecate cr.autocommit(True)

### DIFF
--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -398,6 +398,11 @@ class Cursor(BaseCursor):
     @check
     def autocommit(self, on):
         if on:
+            warnings.warn(
+                "Since Odoo 13.0, the ORM delays UPDATE queries for "
+                "performance reasons. Since then, using the ORM with "
+                " autocommit(True) is unsafe, as computed fields may not be "
+                "fully computed at commit.", DeprecationWarning, stacklevel=2)
             isolation_level = ISOLATION_LEVEL_AUTOCOMMIT
         else:
             # If a serializable cursor was requested, we


### PR DESCRIPTION
Since v14 and the refactor of the internal synchronisation between the
cache and the database, it is unsafe set the cursor to autocommit. The
function have been deprecated for removal in the future.

Task: 2442905

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
