### PR TITLE
[IMP] calendar: avoid adding additional attendees

### DIFF
--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -137,12 +137,10 @@ class Meeting(models.Model):
             existing_attendees = self.env['calendar.attendee'].search([
                 ('event_id', '=', microsoft_event.odoo_id(self.env)),
                 ('email', 'in', emails)])
-        elif self.env.user.partner_id.email not in emails:
-            commands_attendee += [(0, 0, {'state': 'accepted', 'partner_id': self.env.user.partner_id.id})]
-            commands_partner += [(4, self.env.user.partner_id.id)]
         attendees_by_emails = {a.email: a for a in existing_attendees}
         for attendee in microsoft_attendees:
             email = attendee.get('emailAddress').get('address')
+            email = self.env.user.email if email and email == self.env.user.microsoft_email else email
             state = ATTENDEE_CONVERTER_M2O.get(attendee.get('status').get('response'))
 
             if email in attendees_by_emails:

--- a/addons/microsoft_calendar/models/res_users.py
+++ b/addons/microsoft_calendar/models/res_users.py
@@ -18,6 +18,7 @@ class User(models.Model):
     _inherit = 'res.users'
 
     microsoft_calendar_sync_token = fields.Char('Microsoft Next Sync Token', copy=False)
+    microsoft_email = fields.Char('Microsoft Email Address', copy=False)
     microsoft_synchronization_stopped = fields.Boolean('Outlook Synchronization stopped', copy=False)
 
     def __init__(self, pool, cr):
@@ -92,6 +93,7 @@ class User(models.Model):
                 events, next_sync_token, default_reminders = calendar_service.get_events(token=token)
                 full_sync = True
         self.microsoft_calendar_sync_token = next_sync_token
+        self.microsoft_email = calendar_service.get_microsoft_email_address(token=token)
 
         # Microsoft -> Odoo
         recurrences = events.filter(lambda e: e.is_recurrent())

--- a/addons/microsoft_calendar/utils/microsoft_calendar.py
+++ b/addons/microsoft_calendar/utils/microsoft_calendar.py
@@ -61,6 +61,14 @@ class MicrosoftCalendarService():
         return MicrosoftEvent(events), next_sync_token, default_reminders
 
     @requires_auth_token
+    def get_microsoft_email_address(self, token=None, timeout=TIMEOUT):
+        url = "/v1.0/me"
+        headers = {'Content-type': 'application/json', 'Authorization': 'Bearer %s' % token}
+        params = {}
+        status, data, time = self.microsoft_service._do_request(url, params, headers, method='GET', timeout=timeout)
+        return data['userPrincipalName']
+
+    @requires_auth_token
     def insert(self, values, token=None, timeout=TIMEOUT):
         url = "/v1.0/me/calendar/events"
         headers = {'Content-type': 'application/json', 'Authorization': 'Bearer %s' % token}


### PR DESCRIPTION
recognise the user's Microsoft email in attendee list and change it to the Odoo user without adding an additional attendee.

taskid: 2491394



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
