### PR TITLE
[FIX] product_email_template: avoid traceback when referring to "object"

### DIFF
--- a/addons/product_email_template/views/product_views.xml
+++ b/addons/product_email_template/views/product_views.xml
@@ -11,10 +11,10 @@
                 </xpath>
                 <xpath expr="//group[@name='email_template_and_project']" position="inside">
                     <field name="email_template_id" string="Email Template" help="Send a product-specific email once the invoice is validated"
-                        domain="[('model','=','product.template')]"
+                        domain="[('model','=','account.move')]"
                         context="{
                             'form_view_ref':'product_email_template.email_template_form_simplified',
-                            'default_model': 'product.template',
+                            'default_model': 'account.move',
                             'default_subject': name,
                             'default_name': name,
                         }"/>


### PR DESCRIPTION
1. Activate 'Deliver Content by Email' in the Sales>Configuration>Settings
2. Create a mail template with Product Template for 'Applies to' and
a dynamic field (e.g. ${object.company_id.name}) in the body
3. Add this mail template on a [DEMO] product 'Automatic Email at
Invoice' field, in the Sales tab
4. Create an invoice with [DEMO], confirm it.
5. If the ID of the invoice does not exist as a product.product, you get a
traceback

The reason is that the model used for the template rendering is the
one specified on the template, but the res_id given to the composer
is the one from the invoice.

opw-2476169

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
