### PR TITLE
[FIX] sale_management: fix pricelist computation for optional products

### DIFF
--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -192,11 +192,19 @@ class SaleOrderOption(models.Model):
             return [('line_id', '=', False)]
         return [('line_id', '!=', False)]
 
-    @api.onchange('product_id', 'uom_id')
+    @api.onchange('product_id', 'uom_id', 'quantity')
     def _onchange_product_id(self):
         if not self.product_id:
             return
-        product = self.product_id.with_context(lang=self.order_id.partner_id.lang)
+        product = self.product_id.with_context(
+            lang=self.order_id.partner_id.lang,
+            partner=self.order_id.partner_id,
+            quantity=self.quantity,
+            date=self.order_id.date_order,
+            pricelist=self.order_id.pricelist_id.id,
+            uom=self.uom_id.id,
+            fiscal_position=self.env.context.get('fiscal_position')
+        )
         self.name = product.get_product_multiline_description_sale()
         self.uom_id = self.uom_id or product.uom_id
         domain = {'uom_id': [('category_id', '=', self.product_id.uom_id.category_id.id)]}


### PR DESCRIPTION
1. Have a product with cost A
2. Have a pricelist which modify the price of the product to B based on
the quantity
3. Create a sale order with the pricelist. Under the "Optional
Products" tab add the product and match the pricelist requirements

No price modification will occur, because there is no reaction to the
quantity change

opw-2480696

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
