### PR TITLE
[FIX] web: do not display falsy url field widgets

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -1695,6 +1695,9 @@ var UrlWidget = InputField.extend({
      * @private
      */
     _renderReadonly: function () {
+        if (!this.value) {
+            return;
+        }
         let href = this.value;
         if (this.value && !this.websitePath) {
             const regex = /^(?:[fF]|[hH][tT])[tT][pP][sS]?:\/\//;

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -2108,6 +2108,29 @@ QUnit.module('basic_fields', {
         list.destroy();
     });
 
+    QUnit.test('url widget with falsy value', async function (assert) {
+        assert.expect(4);
+
+        this.data.partner.records[0].foo = false;
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: '<form><field name="foo" widget="url"/></form>',
+            res_id: 1,
+        });
+
+        assert.containsOnce(form, 'div.o_field_widget[name=foo]');
+        assert.strictEqual(form.$('.o_field_widget[name=foo]').text(), "");
+
+        await testUtils.form.clickEdit(form);
+
+        assert.containsOnce(form, 'input.o_field_widget[name=foo]');
+        assert.strictEqual(form.$('.o_field_widget[name=foo]').val(), "");
+
+        form.destroy();
+    });
+
     QUnit.module('CopyClipboard');
 
     QUnit.test('Char & Text Fields: Copy to clipboard button', async function (assert) {


### PR DESCRIPTION
Before this fix, unset char fields with the url widget in form view
displayed "false", whereas they should simply be empty. This is a
side-effect of commit [1], which aims at reducing the shift between
readonly and edit modes in form views.

[1] https://github.com/odoo/odoo/commit/288b24cbdf54ac0dbee7e012f074fac9a0c68238

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
