### PR TITLE
[FIX] point_of_sale: fix customer search when a field contains line break

### DIFF
--- a/addons/point_of_sale/static/src/js/db.js
+++ b/addons/point_of_sale/static/src/js/db.js
@@ -228,7 +228,7 @@ var PosDB = core.Class.extend({
         if(partner.vat){
             str += '|' + partner.vat;
         }
-        str = '' + partner.id + ':' + str.replace(':','') + '\n';
+        str = '' + partner.id + ':' + str.replace(':', '').replace(/\n/g, ' ') + '\n';
         return str;
     },
     add_partners: function(partners){


### PR DESCRIPTION
- Install contacts & point_of_sale
- Go to Contacts and import a contact from an Excel file with the following data:
  /!\ The street field should contain a line break /!\

  | Name | Phone | Street |
  | -------- | --------- | -------- |
  | Test    | 123456 | Multiline<br />Street |

- Open a POS session
- Go to Customer selection page
- Search for "123456"
The imported res.partner will not be found by his phone.

A partner search in POS is working with a regex search on a string containing all partners.
This string is supposed to contain 1 line for each partner and a line is formatted as followed:

  id:name|barcode|address|phone|mobile|email|vat

However, in this case, partner's address contains a line break, resulting on a line like this:

  id:name|barcode|address (part before line break)
  address (part after line break)|phone|mobile|email|vat

This partner is defined in 2 lines and all data from the second line cannot be matched with regex.

opw-2477994

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
