### PR TITLE
[FIX]account: error when rest bill to draft

### DIFF
--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -2122,3 +2122,29 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
 
         # Check full reconciliation
         self.assertTrue(all(line.full_reconcile_id for line in lines_to_reconcile), "All tax lines should be fully reconciled")
+
+    def test_caba_undo_reconciliation(self):
+        ''' Make sure there is no traceback like "Record has already been deleted" during the deletion of partials. '''
+        self.cash_basis_transfer_account.reconcile = True
+
+        bill = self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2019-01-01',
+            'date': '2019-01-01',
+            'invoice_line_ids': [(0, 0, {
+                'name': 'line',
+                'account_id': self.company_data['default_account_expense'].id,
+                'price_unit': 1000.0,
+                'tax_ids': [(6, 0, self.cash_basis_tax_a_third_amount.ids)],
+            })],
+        })
+        bill.action_post()
+
+        # Register a payment creating the CABA journal entry on the fly and reconcile it with the tax line.
+        self.env['account.payment.register']\
+            .with_context(active_ids=bill.ids, active_model='account.move')\
+            .create({})\
+            ._create_payments()
+
+        bill.button_draft()


### PR DESCRIPTION
- On accounting settings, activate 'Cash Basis';
- Select a 'Base Tax Received Account';
- Modify a purchase taxes, and set the 'Tax Due' to 'Based on Payment';
- Set a 'Cash Basis Transition Account';
- Be sure that the previously selected account allows reconciliation;
- Create a Vendors Bills, using the modified purchase tax;
- Register a payment;
- Reset to draft the vendors bill.

Before this commit, an error was raised : 'Record does not exist or has
been deleted.'

This occurs because when trying to unlink the partial reconcile, it will
first reverse and unlink the tax cash basis partial reconcile moves.
After when trying to access the partial reconcile to unlink the error is
raised because one is already unlink.

Now, the vendors bill is correctly reset to draft.

opw-2477526