### PR TITLE
[FIX] stock: Running scheduler doesn't update

### DIFF
--- a/addons/stock/wizard/stock_scheduler_compute.py
+++ b/addons/stock/wizard/stock_scheduler_compute.py
@@ -45,4 +45,4 @@ class StockSchedulerCompute(models.TransientModel):
     def procure_calculation(self):
         threaded_calculation = threading.Thread(target=self._procure_calculation_orderpoint, args=())
         threaded_calculation.start()
-        return {'type': 'ir.actions.act_window_close'}
+        return {'type': 'ir.actions.client', 'tag': 'reload'}


### PR DESCRIPTION
When running the scheduler, the informations in the inventory dashbord were not updated.

opw:2486591