### PR TITLE
[FIX] sale: allow select any product combination

### DIFF
--- a/addons/sale/static/src/js/variant_mixin.js
+++ b/addons/sale/static/src/js/variant_mixin.js
@@ -341,7 +341,6 @@ var VariantMixin = {
         $parent
             .find('option, input, label')
             .removeClass('css_not_available')
-            .prop('disabled', false)
             .attr('title', function () { return $(this).data('value_name') || ''; })
             .data('excluded-by', '');
 
@@ -414,7 +413,6 @@ var VariantMixin = {
             .find('option[value=' + attributeValueId + '], input[value=' + attributeValueId + ']');
         $input.addClass('css_not_available');
         $input.closest('label').addClass('css_not_available');
-        $input.prop('disabled', true);
 
         if (excludedBy && attributeNames) {
             var $target = $input.is('option') ? $input : $input.closest('label').add($input);


### PR DESCRIPTION
Issue

	- Install 'Sale', 'Inventory' and
	  'Sale Product Configurator' module
	- Create a product X with the following attributes:
	  attr1 : val1, val2
	  attr2 : val3, val4
	- Click on 'Configure Variant'
	- Select val3 and add exclude for val1
	- Select val4 and add exclude for val2
	- Go to 'Sales' and create a 'Sale Order'
	- Select product X (a wizard should open)

	Can't change option combination.

Cause

	Options combination (that are not allowed) are disabled.
	This commit introduce the error:
	https://github.com/odoo/odoo/commit/6150311b72089e3fbae6bc27551bc7f4792e68dd

Solution

	revert commit.

opw-2478854