### PR TITLE
account: Add support for multi-VAT

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -249,7 +249,7 @@ class AccountBankStatement(models.Model):
     is_valid_balance_start = fields.Boolean(string="Is Valid Balance Start", store=True,
         compute="_compute_is_valid_balance_start",
         help="Technical field to display a warning message in case starting balance is different than previous ending balance")
-    country_code = fields.Char(related='company_id.country_id.code')
+    country_code = fields.Char(related='company_id.account_fiscal_country_id.code')
 
     def write(self, values):
         res = super(AccountBankStatement, self).write(values)
@@ -549,7 +549,7 @@ class AccountBankStatementLine(models.Model):
         compute='_compute_is_reconciled',
         help="Technical field indicating if the statement line is already reconciled.")
     state = fields.Selection(related='statement_id.state', string='Status', readonly=True)
-    country_code = fields.Char(related='company_id.country_id.code')
+    country_code = fields.Char(related='company_id.account_fiscal_country_id.code')
 
     # -------------------------------------------------------------------------
     # HELPERS

--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -118,7 +118,7 @@ class AccountJournal(models.Model):
     currency_id = fields.Many2one('res.currency', help='The currency used to enter statement', string="Currency")
     company_id = fields.Many2one('res.company', string='Company', required=True, readonly=True, index=True, default=lambda self: self.env.company,
         help="Company related to this journal")
-    country_code = fields.Char(related='company_id.country_id.code', readonly=True)
+    country_code = fields.Char(related='company_id.account_fiscal_country_id.code', readonly=True)
 
     refund_sequence = fields.Boolean(string='Dedicated Credit Note Sequence', help="Check this box if you don't want to share the same sequence for invoices and credit notes made from this journal", default=False)
     sequence_override_regex = fields.Text(help="Technical field used to enforce complex sequence composition that the system would normally misunderstand.\n"\

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -184,7 +184,7 @@ class AccountMove(models.Model):
         string='Partner', change_default=True)
     commercial_partner_id = fields.Many2one('res.partner', string='Commercial Entity', store=True, readonly=True,
         compute='_compute_commercial_partner_id')
-    country_code = fields.Char(related='company_id.country_id.code', readonly=True)
+    country_code = fields.Char(related='company_id.account_fiscal_country_id.code', readonly=True)
     user_id = fields.Many2one(string='User', related='invoice_user_id',
         help='Technical field used to fit the generic behavior in mail templates.')
     is_move_sent = fields.Boolean(

--- a/addons/account/models/account_partial_reconcile.py
+++ b/addons/account/models/account_partial_reconcile.py
@@ -486,6 +486,7 @@ class AccountPartialReconcile(models.Model):
                     'line_ids': [],
                     'tax_cash_basis_rec_id': partial.id,
                     'tax_cash_basis_move_id': move.id,
+                    'fiscal_position_id': move.fiscal_position_id,
                 }
 
                 # Tracking of lines grouped all together.

--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -129,7 +129,7 @@ class AccountPayment(models.Model):
     require_partner_bank_account = fields.Boolean(
         compute='_compute_show_require_partner_bank',
         help="Technical field used to know whether the field `partner_bank_id` needs to be required or not in the payments form views")
-    country_code = fields.Char(related='company_id.country_id.code')
+    country_code = fields.Char(related='company_id.account_fiscal_country_id.code')
 
     _sql_constraints = [
         (

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -244,11 +244,11 @@ class AccountChartTemplate(models.Model):
             ).unlink()
 
             # delete account, journal, tax, fiscal position and reconciliation model
-            models_to_delete = ['account.reconcile.model', 'account.fiscal.position', 'account.tax', 'account.move', 'account.journal', 'account.group']
+            models_to_delete = ['account.reconcile.model', 'account.fiscal.position', 'account.move.line', 'account.move', 'account.journal', 'account.tax', 'account.group']
             for model in models_to_delete:
                 res = self.env[model].sudo().search([('company_id', '=', company.id)])
                 if len(res):
-                    res.unlink()
+                    res.with_context(force_delete=True).unlink()
             existing_accounts.unlink()
 
         company.write({'currency_id': self.currency_id.id,
@@ -339,11 +339,11 @@ class AccountChartTemplate(models.Model):
         the provided company (meaning hence that its chart of accounts cannot
         be changed anymore).
         """
-        model_to_check = ['account.move.line', 'account.payment', 'account.bank.statement']
+        model_to_check = ['account.payment', 'account.bank.statement']
         for model in model_to_check:
             if self.env[model].sudo().search([('company_id', '=', company_id.id)], limit=1):
                 return True
-        if self.env['account.move'].sudo().search([('company_id', '=', company_id.id), ('name', '!=', '/')], limit=1):
+        if self.env['account.move'].sudo().search([('company_id', '=', company_id.id), ('state', '!=', 'draft')], limit=1):
             return True
         return False
 

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -31,6 +31,7 @@ class AccountFiscalPosition(models.Model):
     note = fields.Text('Notes', translate=True, help="Legal mentions that have to be printed on the invoices.")
     auto_apply = fields.Boolean(string='Detect Automatically', help="Apply automatically this fiscal position.")
     vat_required = fields.Boolean(string='VAT required', help="Apply only if partner has a VAT number.")
+    company_country_id = fields.Many2one(string="Company Country", related='company_id.country_id')
     country_id = fields.Many2one('res.country', string='Country',
         help="Apply only if delivery country matches.")
     country_group_id = fields.Many2one('res.country.group', string='Country Group',
@@ -40,6 +41,7 @@ class AccountFiscalPosition(models.Model):
     zip_to = fields.Char(string='Zip Range To')
     # To be used in hiding the 'Federal States' field('attrs' in view side) when selected 'Country' has 0 states.
     states_count = fields.Integer(compute='_compute_states_count')
+    foreign_vat = fields.Char(string="Foreign Tax ID", help="The tax ID of your company in the region mapped by this fiscal position.")
 
     def _compute_states_count(self):
         for position in self:
@@ -50,6 +52,19 @@ class AccountFiscalPosition(models.Model):
         for position in self:
             if position.zip_from and position.zip_to and position.zip_from > position.zip_to:
                 raise ValidationError(_('Invalid "Zip Range", please configure it properly.'))
+
+    @api.constrains('country_id', 'state_ids', 'foreign_vat')
+    def _validate_foreign_vat_country(self):
+        for record in self:
+            if record.foreign_vat and record.country_id == record.company_id.account_fiscal_country_id:
+                if record.foreign_vat == record.company_id.vat:
+                    raise ValidationError(_("You cannot create a fiscal position within your fiscal country with the same VAT number as the main one set on your company."))
+
+                if not record.state_ids:
+                    if record.company_id.country_id.state_ids:
+                        raise ValidationError(_("You cannot create a fiscal position with a foreign VAT within your fiscal country without assigning it a state."))
+                    else:
+                        raise ValidationError(_("You cannot create a fiscal position with a foreign VAT within your fiscal country."))
 
     def map_tax(self, taxes, product=None, partner=None):
         if not self:

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -61,7 +61,7 @@ class AccountFiscalPosition(models.Model):
                     raise ValidationError(_("You cannot create a fiscal position within your fiscal country with the same VAT number as the main one set on your company."))
 
                 if not record.state_ids:
-                    if record.company_id.country_id.state_ids:
+                    if record.company_id.account_fiscal_country_id.state_ids:
                         raise ValidationError(_("You cannot create a fiscal position with a foreign VAT within your fiscal country without assigning it a state."))
                     else:
                         raise ValidationError(_("You cannot create a fiscal position with a foreign VAT within your fiscal country."))

--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -134,7 +134,7 @@ class ResConfigSettings(models.TransientModel):
         config_parameter='account.use_invoice_terms')
 
     # Technical field to hide country specific fields from accounting configuration
-    country_code = fields.Char(related='company_id.country_id.code', readonly=True)
+    country_code = fields.Char(related='company_id.account_fiscal_country_id.code', readonly=True)
 
     def set_values(self):
         super(ResConfigSettings, self).set_values()

--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -132,7 +132,7 @@ class SequenceMixin(models.AbstractModel):
         self.ensure_one()
         return "00000000"
 
-    def _get_last_sequence(self, relaxed=False):
+    def _get_last_sequence(self, relaxed=False, with_prefix=None):
         """Retrieve the previous sequence.
 
         This is done by taking the number with the greatest alphabetical value within
@@ -149,6 +149,7 @@ class SequenceMixin(models.AbstractModel):
         :param relaxed: this should be set to True when a previous request didn't find
             something without. This allows to find a pattern from a previous period, and
             try to adapt it for the new period.
+        :param with_prefix: The sequence prefix to restrict the search on, if any.
 
         :return: the string of the previous sequence or None if there wasn't any.
         """
@@ -159,6 +160,9 @@ class SequenceMixin(models.AbstractModel):
         if self.id or self.id.origin:
             where_string += " AND id != %(id)s "
             param['id'] = self.id or self.id.origin
+        if with_prefix:
+            where_string += " AND sequence_prefix = %(with_prefix)s "
+            param['with_prefix'] = with_prefix
 
         query = """
             UPDATE {table} SET write_date = write_date WHERE id = (
@@ -239,3 +243,14 @@ class SequenceMixin(models.AbstractModel):
 
         self[self._sequence_field] = format.format(**format_values)
         self._compute_split_sequence()
+
+    def _is_last_from_seq_chain(self):
+        """Tells whether or not this element is the last one of the sequence chain.
+        :return: True if it is the last element of the chain.
+        """
+        last_sequence = self._get_last_sequence(with_prefix=self.sequence_prefix)
+        if not last_sequence:
+            return True
+        seq_format, seq_format_values = self._get_sequence_format_param(last_sequence)
+        seq_format_values['seq'] += 1
+        return seq_format.format(**seq_format_values) == self.name

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -66,7 +66,7 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         cls.tax_tags = cls.env['account.account.tag'].create({
             'name': 'tax_tag_%s' % str(i),
             'applicability': 'taxes',
-            'country_id': cls.fake_country.id,
+            'country_id': cls.company_data['company'].account_fiscal_country_id.id,
         } for i in range(8))
 
         cls.cash_basis_tax_a_third_amount = cls.env['account.tax'].create({

--- a/addons/account/tests/test_tax_report.py
+++ b/addons/account/tests/test_tax_report.py
@@ -18,10 +18,6 @@ class TaxReportTest(AccountTestInvoicingCommon):
             'name': "The Principality of Zeon",
             'code': 'ZZ',
         })
-        cls.test_country_3 = cls.env['res.country'].create({
-            'name': "Alagaësia",
-            'code': 'QQ',
-        })
 
         cls.tax_report_1 = cls.env['account.tax.report'].create({
             'name': "Tax report 1",
@@ -132,6 +128,7 @@ class TaxReportTest(AccountTestInvoicingCommon):
             'amount_type': 'percent',
             'amount': 25,
             'type_tax_use': 'sale',
+            'country_id': self.tax_report_1.country_id.id,
             'invoice_repartition_line_ids': [
                 (0,0, {
                     'factor_percent': 100,
@@ -156,6 +153,9 @@ class TaxReportTest(AccountTestInvoicingCommon):
                 }),
             ],
         })
+
+        # Make sure the fiscal country allows using this tax directly
+        self.env.company.account_fiscal_country_id = self.tax_report_1.country_id.id
 
         test_invoice = self.env['account.move'].create({
             'move_type': 'out_invoice',

--- a/addons/account/tests/test_templates_consistency.py
+++ b/addons/account/tests/test_templates_consistency.py
@@ -40,7 +40,7 @@ class AccountingTestTemplConsistency(TransactionCase):
         '''Test fields consistency for ('account.tax', 'account.tax.template')
         '''
         self.check_fields_consistency('account.tax.template', 'account.tax', exceptions=['chart_template_id'])
-        self.check_fields_consistency('account.tax', 'account.tax.template', exceptions=['company_id'])
+        self.check_fields_consistency('account.tax', 'account.tax.template', exceptions=['company_id', 'country_id'])
         self.check_fields_consistency('account.tax.repartition.line.template', 'account.tax.repartition.line', exceptions=['plus_report_line_ids', 'minus_report_line_ids'])
         self.check_fields_consistency('account.tax.repartition.line', 'account.tax.repartition.line.template', exceptions=['tag_ids', 'country_id', 'company_id', 'sequence'])
 
@@ -49,7 +49,7 @@ class AccountingTestTemplConsistency(TransactionCase):
         '''
         #main
         self.check_fields_consistency('account.fiscal.position.template', 'account.fiscal.position', exceptions=['chart_template_id'])
-        self.check_fields_consistency('account.fiscal.position', 'account.fiscal.position.template', exceptions=['active', 'company_id', 'states_count'])
+        self.check_fields_consistency('account.fiscal.position', 'account.fiscal.position.template', exceptions=['active', 'company_id', 'states_count', 'foreign_vat'])
         #taxes
         self.check_fields_consistency('account.fiscal.position.tax.template', 'account.fiscal.position.tax')
         self.check_fields_consistency('account.fiscal.position.tax', 'account.fiscal.position.tax.template')

--- a/addons/account/tests/test_tour.py
+++ b/addons/account/tests/test_tour.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
 import odoo.tests
 
 
@@ -7,6 +8,19 @@ import odoo.tests
 class TestUi(odoo.tests.HttpCase):
 
     def test_01_account_tour(self):
+        # Reset country and fiscal country, so that fields added by localizations are
+        # hidden and non-required, and don't make the tour crash.
+        # Also remove default taxes from the company and its accounts, to avoid inconsistencies
+        # with empty fiscal country.
+        self.env.company.write({
+            'country_id': None, # Also resets account_fiscal_country_id
+            'account_sale_tax_id': None,
+            'account_purchase_tax_id': None,
+        })
+        account_with_taxes = self.env['account.account'].search([('tax_ids', '!=', False), ('company_id', '=', self.env.company.id)])
+        account_with_taxes.write({
+            'tax_ids': [Command.clear()],
+        })
         # This tour doesn't work with demo data on runbot
         all_moves = self.env['account.move'].search([('move_type', '!=', 'entry')])
         all_moves.button_draft()

--- a/addons/account/tests/test_tour.py
+++ b/addons/account/tests/test_tour.py
@@ -10,6 +10,5 @@ class TestUi(odoo.tests.HttpCase):
         # This tour doesn't work with demo data on runbot
         all_moves = self.env['account.move'].search([('move_type', '!=', 'entry')])
         all_moves.button_draft()
-        all_moves.posted_before = False
-        all_moves.unlink()
+        all_moves.with_context(force_delete=True).unlink()
         self.start_tour("/web", 'account_tour', login="admin")

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -674,6 +674,7 @@
                         <field name="display_inactive_currency_warning" invisible="1"/>
                         <field name="statement_id" invisible="1"/>
                         <field name="payment_id" invisible="1"/>
+                        <field name="tax_country_id" invisible="1"/>
 
                         <div class="oe_title">
                             <!-- Invoice draft header -->
@@ -816,7 +817,7 @@
                                         <field name="price_unit" string="Price"/>
                                         <field name="discount" string="Disc.%" optional="hide"/>
                                         <field name="tax_ids" widget="many2many_tags"
-                                               domain="[('type_tax_use', '=?', parent.invoice_filter_type_domain), ('company_id', '=', parent.company_id)]"
+                                               domain="[('type_tax_use', '=?', parent.invoice_filter_type_domain), ('company_id', '=', parent.company_id), ('country_id', '=', parent.tax_country_id)]"
                                                context="{'append_type_to_tax_name': not parent.invoice_filter_type_domain}"
                                                options="{'no_create': True}"
                                                optional="show"/>
@@ -1034,8 +1035,7 @@
                                         <field name="credit"
                                                sum="Total Credit"
                                                attrs="{'invisible': [('display_type', 'in', ('line_section', 'line_note'))]}"/>
-                                        <field name="tax_fiscal_country_id" invisible="1"/>
-                                        <field name="tax_tag_ids" widget="many2many_tags" string="Tax Grids" optional="show" domain="[('country_id', '=', tax_fiscal_country_id), ('applicability', '=', 'taxes')]"/>
+                                        <field name="tax_tag_ids" widget="many2many_tags" string="Tax Grids" optional="show" domain="[('country_id', '=', parent.tax_country_id), ('applicability', '=', 'taxes')]"/>
                                         <field name="tax_tag_invert" readonly="1" optional="hide" groups="base.group_no_one"/>
 
                                         <!-- Buttons -->
@@ -1144,6 +1144,7 @@
                                                attrs="{'invisible': [('move_type', '!=', 'entry')]}" />
                                     </group>
                                     <group>
+                                        <field name="fiscal_position_id"/>
                                         <field name="company_id" groups="base.group_multi_company" required="1"/>
                                     </group>
                                 </group>

--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -27,11 +27,10 @@
                     <field name="factor_percent" attrs="{'invisible': [('repartition_type', '=', 'base')]}"/>
                     <field name="repartition_type"/>
                     <field name="account_id" attrs="{'invisible': [('repartition_type', '=', 'base')]}" options="{'no_create': True}"/>
-                    <field name="tag_ids" widget="many2many_tags" options="{'no_create': True}" domain="[('applicability', '=', 'taxes'), ('country_id', '=', tax_fiscal_country_id)]"/>
+                    <field name="tag_ids" widget="many2many_tags" options="{'no_create': True}" domain="[('applicability', '=', 'taxes'), ('country_id', '=', parent.country_id)]"/>
                     <field name="use_in_tax_closing"
                            optional="hidden"
                            attrs="{'invisible': [('repartition_type', '=', 'base')]}"/>
-                    <field name="tax_fiscal_country_id" invisible="1"/>
                     <field name="company_id" invisible="1"/>
                 </tree>
             </field>
@@ -135,7 +134,6 @@
                     <notebook>
                         <page string="Definition" name="definition">
                             <div attrs="{'invisible': [('amount_type', '=', 'group')]}">
-                                <field name="tax_fiscal_country_id" invisible="1"/>
                                 <field name="country_code" invisible="1"/>
                                 <group string="Distribution for Invoices">
                                     <field name="invoice_repartition_line_ids" nolabel="1" context="{'default_company_id': company_id}"/>
@@ -160,6 +158,7 @@
                                     <field name="tax_group_id"/>
                                     <field name="analytic" attrs="{'invisible':[('amount_type','=', 'group')]}" groups="analytic.group_analytic_accounting" />
                                     <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
+                                    <field name="country_id" required="True"/>
                                 </group>
                                 <group name="advanced_booleans">
                                     <field name="price_include" attrs="{'invisible':[('amount_type','=', 'group')]}" />

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -12,17 +12,21 @@
                     <group>
                         <group>
                             <field name="active" invisible="1"/>
+                            <field name="states_count" invisible="1"/>
+                            <field name="company_country_id" invisible="1"/>
                             <field name="name"/>
                             <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
                         </group>
                         <group>
                             <field name="auto_apply"/>
-                            <field name="states_count" invisible="1"/>
                             <field name="vat_required" attrs="{'invisible': [('auto_apply', '!=', True)]}"/>
                             <field name="country_group_id" attrs="{'invisible': [('auto_apply', '!=', True)]}"/>
-                            <field name="country_id" attrs="{'invisible': [('auto_apply', '!=', True)]}" options="{'no_open': True, 'no_create': True}"/>
+                            <field name="foreign_vat"/>
+                            <field name="country_id"
+                                attrs="{'invisible': [('auto_apply', '!=', True), ('foreign_vat', '=', False)], 'required': [('foreign_vat', '!=', False)]}"
+                                options="{'no_open': True, 'no_create': True}"/>
                             <field name="state_ids" widget="many2many_tags" domain="[('country_id', '=', country_id)]"
-                                attrs="{'invisible': ['|', '|', ('auto_apply', '!=', True), ('country_id', '=', False), ('states_count', '=', 0)]}"/>
+                                attrs="{'invisible': ['|', '|', '&amp;', ('auto_apply', '!=', True), ('foreign_vat', '=', False), ('country_id', '=', False), ('states_count', '=', 0)]}"/>
                             <label for="zip_from" string="Zip Range"
                                 attrs="{'invisible': ['|', ('auto_apply', '!=', True), ('country_id', '=', False)]}"/>
                             <div attrs="{'invisible': ['|', ('auto_apply', '!=', True), ('country_id', '=', False)]}">
@@ -39,8 +43,22 @@
                         <group>
                             <field name="tax_ids" widget="one2many" nolabel="1" context="{'append_type_to_tax_name': True}">
                                 <tree name="tax_map_tree" string="Tax Mapping" editable="bottom">
-                                    <field name="tax_src_id" domain="[('type_tax_use', '!=', 'none'), '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]" context="{'append_type_to_tax_name': True}"/>
-                                    <field name="tax_dest_id" domain="[('type_tax_use', '!=', 'none'), '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]" context="{'append_type_to_tax_name': True}"/>
+                                    <field name="tax_src_id"
+                                        domain="[
+                                            ('type_tax_use', '!=', 'none'),
+                                            ('country_id', '=', parent.company_country_id),
+                                            '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)
+                                        ]"
+                                        context="{'append_type_to_tax_name': True}"
+                                    />
+
+                                    <field name="tax_dest_id"
+                                        domain="[
+                                            ('type_tax_use', '!=', 'none'),
+                                            ('country_id', '=', parent.country_id if parent.foreign_vat else parent.company_country_id),
+                                            '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]"
+                                        context="{'append_type_to_tax_name': True}"
+                                    />
                                 </tree>
                                 <form name="tax_map_form" string="Tax Mapping">
                                     <group>

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -8,7 +8,7 @@
                 <t t-set="address">
                     <address t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}' />
                     <div t-if="o.partner_id.vat" class="mt16">
-                        <t t-if="o.company_id.country_id.vat_label" t-esc="o.company_id.country_id.vat_label" id="inv_tax_id_label"/>
+                        <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-esc="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
                         <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/></div>
                 </t>
                 <div class="page">

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -4,6 +4,7 @@
         <template id="report_invoice_document">
             <t t-call="web.external_layout">
                 <t t-set="o" t-value="o.with_context(lang=lang)" />
+                <t t-set="forced_vat" t-value="o.fiscal_position_id.foreign_vat"/> <!-- So that it appears in the footer of the report instead of the company VAT if it's set -->
                 <t t-set="address">
                     <address t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}' />
                     <div t-if="o.partner_id.vat" class="mt16">

--- a/addons/account/views/res_company_views.xml
+++ b/addons/account/views/res_company_views.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='country_id']" position="after">
                 <field name="country_code" invisible="1"/>
+                <field name="account_enabled_tax_country_ids" invisible="1"/>
             </xpath>
         </field>
     </record>

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -103,7 +103,7 @@ class AccountPaymentRegister(models.TransientModel):
     require_partner_bank_account = fields.Boolean(
         compute='_compute_show_require_partner_bank',
         help="Technical field used to know whether the field `partner_bank_id` needs to be required or not in the payments form views")
-    country_code = fields.Char(related='company_id.country_id.code', readonly=True)
+    country_code = fields.Char(related='company_id.account_fiscal_country_id.code', readonly=True)
 
     # -------------------------------------------------------------------------
     # HELPERS
@@ -353,12 +353,12 @@ class AccountPaymentRegister(models.TransientModel):
     # -------------------------------------------------------------------------
     # LOW-LEVEL METHODS
     # -------------------------------------------------------------------------
-    
+
     @api.model
     def default_get(self, fields_list):
         # OVERRIDE
         res = super().default_get(fields_list)
-        
+
         if 'line_ids' in fields_list and 'line_ids' not in res:
 
             # Retrieve moves to pay from the context.
@@ -397,7 +397,7 @@ class AccountPaymentRegister(models.TransientModel):
                 raise UserError(_("You can't register payments for journal items being either all inbound, either all outbound."))
 
             res['line_ids'] = [(6, 0, available_lines.ids)]
-        
+
         return res
 
     # -------------------------------------------------------------------------

--- a/addons/account_edi/models/account_journal.py
+++ b/addons/account_edi/models/account_journal.py
@@ -37,7 +37,7 @@ class AccountJournal(models.Model):
         else:
             return super().write(vals)
 
-    @api.depends('type', 'company_id', 'company_id.country_id')
+    @api.depends('type', 'company_id', 'company_id.account_fiscal_country_id')
     def _compute_compatible_edi_ids(self):
         edi_formats = self.env['account.edi.format'].search([])
 
@@ -45,7 +45,7 @@ class AccountJournal(models.Model):
             compatible_edis = edi_formats.filtered(lambda e: e._is_compatible_with_journal(journal))
             journal.compatible_edi_ids += compatible_edis
 
-    @api.depends('type', 'company_id', 'company_id.country_id')
+    @api.depends('type', 'company_id', 'company_id.account_fiscal_country_id')
     def _compute_edi_format_ids(self):
         edi_formats = self.env['account.edi.format'].search([])
 

--- a/addons/base_vat/models/__init__.py
+++ b/addons/base_vat/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import account_fiscal_position
 from . import res_config_settings
 from . import res_company
 from . import res_partner

--- a/addons/base_vat/models/account_fiscal_position.py
+++ b/addons/base_vat/models/account_fiscal_position.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+from odoo import api, models, _
+from odoo.exceptions import ValidationError
+
+
+class AccountFiscalPosition(models.Model):
+    _inherit = 'account.fiscal.position'
+
+    @api.constrains('country_id', 'foreign_vat')
+    def _validate_foreign_vat(self):
+        for record in self:
+            if not record.foreign_vat:
+                continue
+
+            checked_country_code = self.env['res.partner']._run_vat_test(record.foreign_vat, record.country_id)
+
+            if checked_country_code and checked_country_code != record.country_id.code.lower():
+                raise ValidationError(_("The country detected for this foreign VAT number does not match the one set on this fiscal position."))
+
+            if not checked_country_code:
+                fp_label = _("fiscal position [%s]", record.name)
+                error_message = self.env['res.partner']._build_vat_error_message(record.country_id.code.lower(), record.foreign_vat, fp_label)
+                raise ValidationError(error_message)

--- a/addons/l10n_ae/data/l10n_ae_chart_data.xml
+++ b/addons/l10n_ae/data/l10n_ae_chart_data.xml
@@ -10,5 +10,6 @@
          <field name="transfer_account_code_prefix">100</field>
          <field name="currency_id" ref="base.AED" />
          <field name="complete_tax_set" eval="True"/>
+         <field name="country_id" ref="base.ae"/>
      </record>
 </odoo>

--- a/addons/l10n_ae/views/report_invoice_templates.xml
+++ b/addons/l10n_ae/views/report_invoice_templates.xml
@@ -2,16 +2,16 @@
 <odoo>
     <template id="report_invoice_document" inherit_id="account.report_invoice_document">
         <xpath expr="//p[@name='payment_term']" position="after">
-            <p t-if="o.company_id.country_id.code == 'AE' and o.partner_id.country_id.code != 'AE' and o.env.ref('l10n_ae.gcc_countries_group') in o.partner_id.country_id.country_group_ids">
+            <p t-if="o.company_id.account_fiscal_country_id.code == 'AE' and o.partner_id.country_id.code != 'AE' and o.env.ref('l10n_ae.gcc_countries_group') in o.partner_id.country_id.country_group_ids">
                 Supply between <b>United Arad Emirates</b> and <b><span t-field="o.partner_id.country_id.name"/></b>
             </p>
         </xpath>
         <xpath expr="//h2/span" position="before">
-            <span t-if="o.company_id.country_id.code == 'AE' and o.move_type in ['out_invoice', 'out_refund']">Tax</span>
+            <span t-if="o.company_id.account_fiscal_country_id.code == 'AE' and o.move_type in ['out_invoice', 'out_refund']">Tax</span>
         </xpath>
 
         <xpath expr="//div[hasclass('clearfix')]" position="after">
-            <div t-if="o.company_id.country_id.code == 'AE' and o.currency_id != o.company_id.currency_id" id="aed_amounts" class="row clearfix ml-auto my-3 text-nowrap table">
+            <div t-if="o.company_id.account_fiscal_country_id.code == 'AE' and o.currency_id != o.company_id.currency_id" id="aed_amounts" class="row clearfix ml-auto my-3 text-nowrap table">
                 <t t-set="aed_rate" t-value="o.env['res.currency']._get_conversion_rate(o.currency_id, o.company_id.currency_id, o.company_id, o.invoice_date or datetime.date.today())"/>
                 <div name="exchange_rate" class="col-auto">
                     <strong>Exchange Rate</strong>

--- a/addons/l10n_ar/data/account_chart_template_data.xml
+++ b/addons/l10n_ar/data/account_chart_template_data.xml
@@ -1,13 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <odoo>
 
-    <record model="account.chart.template" id="l10nar_base_chart_template">
+    <record id="l10nar_base_chart_template" model="account.chart.template">
         <field name="name">Plan Contable Genérico Argentina Monotributista / Base</field>
         <field name="currency_id" ref="base.ARS"/>
         <field name="bank_account_code_prefix">1.1.1.02.</field>
         <field name="cash_account_code_prefix">1.1.1.01.</field>
         <field name="code_digits">12</field>
         <field name="transfer_account_code_prefix">6.0.00.00.</field>
+        <field name="country_id" ref="base.ar"/>
     </record>
 
     <record id="l10nar_ex_chart_template" model="account.chart.template">
@@ -18,6 +19,7 @@
         <field name="cash_account_code_prefix">1.1.1.01.</field>
         <field name="code_digits">12</field>
         <field name="transfer_account_code_prefix">6.0.00.00.</field>
+        <field name="country_id" ref="base.ar"/>
     </record>
 
     <record id="l10nar_ri_chart_template" model="account.chart.template">
@@ -28,6 +30,7 @@
         <field name="cash_account_code_prefix">1.1.1.01.</field>
         <field name="code_digits">12</field>
         <field name="transfer_account_code_prefix">6.0.00.00.</field>
+        <field name="country_id" ref="base.ar"/>
     </record>
 
 </odoo>

--- a/addons/l10n_ar/models/account_fiscal_position.py
+++ b/addons/l10n_ar/models/account_fiscal_position.py
@@ -39,7 +39,7 @@ class AccountFiscalPosition(models.Model):
 
     @api.onchange('l10n_ar_afip_responsibility_type_ids', 'country_group_id', 'country_id', 'zip_from', 'zip_to')
     def _onchange_afip_responsibility(self):
-        if self.company_id.country_id.code == "AR":
+        if self.company_id.account_fiscal_country_id.code == "AR":
             if self.l10n_ar_afip_responsibility_type_ids and any(['country_group_id', 'country_id', 'zip_from', 'zip_to']):
                 return {'warning': {
                     'title': _("Warning"),

--- a/addons/l10n_ar/models/account_journal.py
+++ b/addons/l10n_ar/models/account_journal.py
@@ -107,7 +107,7 @@ class AccountJournal(models.Model):
                     'l10n_latam_use_documents')
     def _check_afip_configurations(self):
         """ Do not let the user update the journal if it already contains confirmed invoices """
-        journals = self.filtered(lambda x: x.company_id.country_id.code == "AR" and x.type in ['sale', 'purchase'])
+        journals = self.filtered(lambda x: x.company_id.account_fiscal_country_id.code == "AR" and x.type in ['sale', 'purchase'])
         invoices = self.env['account.move'].search([('journal_id', 'in', journals.ids), ('posted_before', '=', True)], limit=1)
         if invoices:
             raise ValidationError(
@@ -118,7 +118,7 @@ class AccountJournal(models.Model):
     def _check_afip_pos_number(self):
         to_review = self.filtered(
             lambda x: x.type == 'sale' and x.l10n_latam_use_documents and
-            x.company_id.country_id.code == "AR")
+            x.company_id.account_fiscal_country_id.code == "AR")
 
         if to_review.filtered(lambda x: x.l10n_ar_afip_pos_number == 0):
             raise ValidationError(_('Please define an AFIP POS number'))

--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -38,7 +38,7 @@ class AccountMove(models.Model):
     @api.constrains('move_type', 'journal_id')
     def _check_moves_use_documents(self):
         """ Do not let to create not invoices entries in journals that use documents """
-        not_invoices = self.filtered(lambda x: x.company_id.country_id.code == "AR" and x.journal_id.type in ['sale', 'purchase'] and x.l10n_latam_use_documents and not x.is_invoice())
+        not_invoices = self.filtered(lambda x: x.company_id.account_fiscal_country_id.code == "AR" and x.journal_id.type in ['sale', 'purchase'] and x.l10n_latam_use_documents and not x.is_invoice())
         if not_invoices:
             raise ValidationError(_("The selected Journal can't be used in this transaction, please select one that doesn't use documents as these are just for Invoices."))
 
@@ -62,7 +62,7 @@ class AccountMove(models.Model):
 
     @api.depends('invoice_line_ids', 'invoice_line_ids.product_id', 'invoice_line_ids.product_id.type', 'journal_id')
     def _compute_l10n_ar_afip_concept(self):
-        recs_afip = self.filtered(lambda x: x.company_id.country_id.code == "AR" and x.l10n_latam_use_documents)
+        recs_afip = self.filtered(lambda x: x.company_id.account_fiscal_country_id.code == "AR" and x.l10n_latam_use_documents)
         for rec in recs_afip:
             rec.l10n_ar_afip_concept = rec._get_concept()
         remaining = self - recs_afip
@@ -89,7 +89,7 @@ class AccountMove(models.Model):
     def _get_l10n_latam_documents_domain(self):
         self.ensure_one()
         domain = super()._get_l10n_latam_documents_domain()
-        if self.journal_id.company_id.country_id.code == "AR":
+        if self.journal_id.company_id.account_fiscal_country_id.code == "AR":
             letters = self.journal_id._get_journal_letter(counterpart_partner=self.partner_id.commercial_partner_id)
             domain += ['|', ('l10n_ar_letter', '=', False), ('l10n_ar_letter', 'in', letters)]
             codes = self.journal_id._get_journal_codes()
@@ -125,7 +125,7 @@ class AccountMove(models.Model):
 
     @api.onchange('partner_id')
     def _onchange_afip_responsibility(self):
-        if self.company_id.country_id.code == 'AR' and self.l10n_latam_use_documents and self.partner_id \
+        if self.company_id.account_fiscal_country_id.code == 'AR' and self.l10n_latam_use_documents and self.partner_id \
            and not self.partner_id.l10n_ar_afip_responsibility_type_id:
             return {'warning': {
                 'title': _('Missing Partner Configuration'),
@@ -136,7 +136,7 @@ class AccountMove(models.Model):
     def _onchange_partner_journal(self):
         """ This method is used when the invoice is created from the sale or subscription """
         expo_journals = ['FEERCEL', 'FEEWS', 'FEERCELP']
-        for rec in self.filtered(lambda x: x.company_id.country_id.code == "AR" and x.journal_id.type == 'sale'
+        for rec in self.filtered(lambda x: x.company_id.account_fiscal_country_id.code == "AR" and x.journal_id.type == 'sale'
                                  and x.l10n_latam_use_documents and x.partner_id.l10n_ar_afip_responsibility_type_id):
             res_code = rec.partner_id.l10n_ar_afip_responsibility_type_id.code
             domain = [('company_id', '=', rec.company_id.id), ('l10n_latam_use_documents', '=', True), ('type', '=', 'sale')]
@@ -158,7 +158,7 @@ class AccountMove(models.Model):
                 raise RedirectWarning(msg, action.id, _('Go to Journals'))
 
     def _post(self, soft=True):
-        ar_invoices = self.filtered(lambda x: x.company_id.country_id.code == "AR" and x.l10n_latam_use_documents)
+        ar_invoices = self.filtered(lambda x: x.company_id.account_fiscal_country_id.code == "AR" and x.l10n_latam_use_documents)
         for rec in ar_invoices:
             rec.l10n_ar_afip_responsibility_type_id = rec.commercial_partner_id.l10n_ar_afip_responsibility_type_id.id
             if rec.company_id.currency_id == rec.currency_id:
@@ -220,7 +220,7 @@ class AccountMove(models.Model):
 
     def _get_last_sequence_domain(self, relaxed=False):
         where_string, param = super(AccountMove, self)._get_last_sequence_domain(relaxed)
-        if self.company_id.country_id.code == "AR" and self.l10n_latam_use_documents:
+        if self.company_id.account_fiscal_country_id.code == "AR" and self.l10n_latam_use_documents:
             if not self.journal_id.l10n_ar_share_sequences:
                 where_string += " AND l10n_latam_document_type_id = %(l10n_latam_document_type_id)s"
                 param['l10n_latam_document_type_id'] = self.l10n_latam_document_type_id.id or 0
@@ -286,6 +286,6 @@ class AccountMove(models.Model):
 
     def _get_name_invoice_report(self):
         self.ensure_one()
-        if self.l10n_latam_use_documents and self.company_id.country_id.code == 'AR':
+        if self.l10n_latam_use_documents and self.company_id.account_fiscal_country_id.code == 'AR':
             return 'l10n_ar.report_invoice_document'
         return super()._get_name_invoice_report()

--- a/addons/l10n_ar/views/l10n_latam_document_type_view.xml
+++ b/addons/l10n_ar/views/l10n_latam_document_type_view.xml
@@ -31,7 +31,7 @@
         <field name="arch" type="xml">
             <field name='code' position="after">
                 <field name='l10n_ar_letter'/>
-                <filter string="Argentinean Documents" name="localization" domain="[('country_id.code', '=', 'AR')]"/>
+                <filter string="Argentinean Documents" name="localization" domain="[('country_id', '=', %(base.ar)d)]"/>
             </field>
             <group>
                 <filter string="Document Letter" name="l10n_ar_letter" context="{'group_by':'l10n_ar_letter'}"/>

--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -184,7 +184,7 @@
 
                     <!-- (17) CUIT -->
                     <t t-if="o.partner_id.vat and o.partner_id.l10n_latam_identification_type_id and o.partner_id.l10n_latam_identification_type_id.l10n_ar_afip_code != '99'">
-                        <br/><strong><t t-esc="o.partner_id.l10n_latam_identification_type_id.name or o.company_id.country_id.vat_label" id="inv_tax_id_label"/>:</strong> <span t-esc="o.partner_id.l10n_ar_formatted_vat if o.partner_id.l10n_latam_identification_type_id.is_vat else o.partner_id.vat"/>
+                        <br/><strong><t t-esc="o.partner_id.l10n_latam_identification_type_id.name or o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>:</strong> <span t-esc="o.partner_id.l10n_ar_formatted_vat if o.partner_id.l10n_latam_identification_type_id.is_vat else o.partner_id.vat"/>
                     </t>
 
                 </div>

--- a/addons/l10n_at/data/account_account_template.xml
+++ b/addons/l10n_at/data/account_account_template.xml
@@ -15,6 +15,7 @@
             <field name="cash_account_code_prefix">270</field>
             <field name="transfer_account_code_prefix">288</field>
             <field name="currency_id" ref="base.EUR"/>
+            <field name="country_id" ref="base.at"/>
         </record>
         <record id="chart_at_template_transfer_288" model="account.account.template">
             <field name="chart_template_id" ref="l10n_at_chart_template"/>
@@ -1033,7 +1034,7 @@
           <field name="user_type_id" ref="account.data_account_type_current_liabilities" />
           <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PCVIII1')])]" />
         </record>
-        
+
         <record id="chart_at_template_3530" model="account.account.template">
           <field name="name">Verrechnungskonto Finanzamt</field>
           <field name="code">3530</field>
@@ -1043,7 +1044,7 @@
           <field name="tag_ids" eval="[(6, 0, [ref('l10n_at.account_tag_l10n_at_PCVIII1')])]" />
           <field eval="[(6,0,[])]" name="tax_ids"/>
         </record>
-        
+
         <record id="chart_at_template_3540" model="account.account.template">
           <field name="name">Verrechnung Lohnsteuer</field>
           <field name="code">3540</field>

--- a/addons/l10n_au/data/l10n_au_chart_data.xml
+++ b/addons/l10n_au/data/l10n_au_chart_data.xml
@@ -7,5 +7,6 @@
         <field name="transfer_account_code_prefix">11170</field>
         <field name="code_digits">5</field>
         <field name="currency_id" ref="base.AUD"/>
+        <field name="country_id" ref="base.au"/>
     </record>
 </odoo>

--- a/addons/l10n_be/data/account_chart_template_data.xml
+++ b/addons/l10n_be/data/account_chart_template_data.xml
@@ -8,5 +8,6 @@
             <field name="transfer_account_code_prefix">580</field>
             <field name="currency_id" ref="base.EUR"/>
             <field name="spoken_languages" eval="'nl_BE;nl_NL;fr_FR;fr_BE;de_DE'"/>
+            <field name="country_id" ref="base.be"/>
         </record>
 </odoo>

--- a/addons/l10n_be_edi/test_xml_file/efff_test.xml
+++ b/addons/l10n_be_edi/test_xml_file/efff_test.xml
@@ -13,9 +13,9 @@
     <cbc:LineCountNumeric>1</cbc:LineCountNumeric>
     <cac:AccountingSupplierParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="GLN">BE0123456789</cbc:EndpointID>
+            <cbc:EndpointID schemeID="GLN">BE0477472701</cbc:EndpointID>
             <cac:PartyIdentification>
-                <cbc:ID schemeAgencyName="KBO" schemeAgencyID="BE">123456789</cbc:ID>
+                <cbc:ID schemeAgencyName="KBO" schemeAgencyID="BE">477472701</cbc:ID>
             </cac:PartyIdentification>
             <cac:PartyName>
                 <cbc:Name>The best supplier</cbc:Name>

--- a/addons/l10n_be_edi/tests/test_ubl.py
+++ b/addons/l10n_be_edi/tests/test_ubl.py
@@ -49,7 +49,7 @@ class TestL10nBeEdi(AccountEdiTestCommon):
             'children_tax_ids': [(6, 0, (cls.tax_10_include + cls.tax_20).ids)],
         })
 
-        cls.partner_a.vat = 'BE0123456789'
+        cls.partner_a.vat = 'BE0477472701'
 
         # ==== Invoice ====
 

--- a/addons/l10n_bo/data/l10n_bo_chart_data.xml
+++ b/addons/l10n_bo/data/l10n_bo_chart_data.xml
@@ -9,5 +9,6 @@
         <field name="cash_account_code_prefix">111</field>
         <field name="transfer_account_code_prefix">117</field>
         <field name="currency_id" ref="base.BOB"/>
+        <field name="country_id" ref="base.bo"/>
     </record>
 </odoo>

--- a/addons/l10n_br/data/l10n_br_chart_data.xml
+++ b/addons/l10n_br/data/l10n_br_chart_data.xml
@@ -9,5 +9,6 @@
         <field name="cash_account_code_prefix">1.01.01.01.00</field>
         <field name="transfer_account_code_prefix">1.01.01.12.00</field>
 		<field name="currency_id" ref="base.BRL"/>
+        <field name="country_id" ref="base.br"/>
 	</record>
 </odoo>

--- a/addons/l10n_ca/data/account_chart_template_data.xml
+++ b/addons/l10n_ca/data/account_chart_template_data.xml
@@ -10,5 +10,6 @@
         <field name="currency_id" ref="base.CAD"/>
         <field name="use_anglo_saxon" eval="True"/>
         <field name="spoken_languages" eval="'fr_FR;fr_CA'"/>
+        <field name="country_id" ref="base.ca"/>
     </record>
 </odoo>

--- a/addons/l10n_ca/views/report_invoice.xml
+++ b/addons/l10n_ca/views/report_invoice.xml
@@ -1,7 +1,7 @@
 <odoo>
     <template id="l10n_ca_report_invoice_document_inherit" inherit_id="account.report_invoice_document">
         <div t-if="o.partner_id.vat" position="after">
-            <t t-if="o.company_id.country_id.code == 'CA' and o.partner_id.l10n_ca_pst" class="mt16">
+            <t t-if="o.company_id.account_fiscal_country_id.code == 'CA' and o.partner_id.l10n_ca_pst" class="mt16">
                 <div>PST: <span t-field="o.partner_id.l10n_ca_pst"/></div>
             </t>
         </div>

--- a/addons/l10n_ch/data/l10n_ch_chart_data.xml
+++ b/addons/l10n_ch/data/l10n_ch_chart_data.xml
@@ -12,6 +12,7 @@
             <field name="transfer_account_code_prefix">1090</field>
             <field name="currency_id" ref="base.CHF"/>
             <field name="spoken_languages" eval="'it_IT;de_DE;de_CH'"/>
+            <field name="country_id" ref="base.ch"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_ch/models/account_bank_statement.py
+++ b/addons/l10n_ch/models/account_bank_statement.py
@@ -9,7 +9,7 @@ class AccountBankStatementLine(models.Model):
     _inherit = "account.bank.statement.line"
 
     def _find_or_create_bank_account(self):
-        if self.company_id.country_id.code == 'CH' and _is_l10n_ch_postal(self.account_number):
+        if self.company_id.account_fiscal_country_id.code == 'CH' and _is_l10n_ch_postal(self.account_number):
             bank_account = self.env['res.partner.bank'].search(
                 [('company_id', '=', self.company_id.id),
                  ('sanitized_acc_number', 'like', self.account_number + '%'),

--- a/addons/l10n_ch/models/account_invoice.py
+++ b/addons/l10n_ch/models/account_invoice.py
@@ -244,7 +244,7 @@ class AccountMove(models.Model):
     @api.depends('move_type', 'partner_bank_id', 'payment_reference')
     def _compute_l10n_ch_isr_needs_fixing(self):
         for inv in self:
-            if inv.move_type == 'in_invoice' and inv.company_id.country_id.code == "CH":
+            if inv.move_type == 'in_invoice' and inv.company_id.account_fiscal_country_id.code == "CH":
                 partner_bank = inv.partner_bank_id
                 needs_isr_ref = partner_bank._is_qr_iban() or partner_bank._is_isr_issuer()
                 if needs_isr_ref and not inv._has_isr_ref():

--- a/addons/l10n_ch/models/res_bank.py
+++ b/addons/l10n_ch/models/res_bank.py
@@ -52,7 +52,7 @@ class ResPartnerBank(models.Model):
     # fields to configure ISR payment slip generation
     l10n_ch_isr_subscription_chf = fields.Char(string='CHF ISR Subscription Number', help='The subscription number provided by the bank or Postfinance to identify the bank, used to generate ISR in CHF. eg. 01-162-8')
     l10n_ch_isr_subscription_eur = fields.Char(string='EUR ISR Subscription Number', help='The subscription number provided by the bank or Postfinance to identify the bank, used to generate ISR in EUR. eg. 03-162-5')
-    l10n_ch_show_subscription = fields.Boolean(compute='_compute_l10n_ch_show_subscription', default=lambda self: self.env.company.country_id.code == 'CH')
+    l10n_ch_show_subscription = fields.Boolean(compute='_compute_l10n_ch_show_subscription', default=lambda self: self.env.company.account_fiscal_country_id.code == 'CH')
 
     def _is_isr_issuer(self):
         return (_is_l10n_ch_isr_issuer(self.l10n_ch_postal, 'CHF')
@@ -92,9 +92,9 @@ class ResPartnerBank(models.Model):
             if bank.partner_id:
                 bank.l10n_ch_show_subscription = bool(bank.partner_id.ref_company_ids)
             elif bank.company_id:
-                bank.l10n_ch_show_subscription = bank.company_id.country_id.code == 'CH'
+                bank.l10n_ch_show_subscription = bank.company_id.account_fiscal_country_id.code == 'CH'
             else:
-                bank.l10n_ch_show_subscription = self.env.company.country_id.code == 'CH'
+                bank.l10n_ch_show_subscription = self.env.company.account_fiscal_country_id.code == 'CH'
 
     @api.depends('acc_number', 'acc_type')
     def _compute_sanitized_acc_number(self):

--- a/addons/l10n_cl/data/l10n_cl_chart_data.xml
+++ b/addons/l10n_cl/data/l10n_cl_chart_data.xml
@@ -125,6 +125,7 @@
         <field name="code_digits">6</field>
         <field name="currency_id" ref="base.CLP"/>
         <field name="use_anglo_saxon" eval="True" />
+        <field name="country_id" ref="base.cl"/>
     </record>
 
     <record id="account_11700" model="account.account.template">

--- a/addons/l10n_cl/models/account_chart_template.py
+++ b/addons/l10n_cl/models/account_chart_template.py
@@ -10,6 +10,6 @@ class AccountChartTemplate(models.Model):
     def _load(self, sale_tax_rate, purchase_tax_rate, company):
         """ Set tax calculation rounding method required in Chilean localization"""
         res = super()._load(sale_tax_rate, purchase_tax_rate, company)
-        if company.country_id.code == 'CL':
+        if company.account_fiscal_country_id.code == 'CL':
             company.write({'tax_calculation_rounding_method': 'round_globally'})
         return res

--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -17,7 +17,7 @@ class AccountMove(models.Model):
 
     def _get_l10n_latam_documents_domain(self):
         self.ensure_one()
-        if self.journal_id.company_id.country_id != self.env.ref('base.cl') or not \
+        if self.journal_id.company_id.account_fiscal_country_id != self.env.ref('base.cl') or not \
                 self.journal_id.l10n_latam_use_documents:
             return super()._get_l10n_latam_documents_domain()
         if self.journal_id.type == 'sale':
@@ -46,7 +46,7 @@ class AccountMove(models.Model):
 
     def _check_document_types_post(self):
         for rec in self.filtered(
-                lambda r: r.company_id.country_id.code == "CL" and
+                lambda r: r.company_id.account_fiscal_country_id.code == "CL" and
                           r.journal_id.type in ['sale', 'purchase']):
             tax_payer_type = rec.partner_id.l10n_cl_sii_taxpayer_type
             vat = rec.partner_id.vat
@@ -104,14 +104,14 @@ class AccountMove(models.Model):
     def _get_starting_sequence(self):
         """ If use documents then will create a new starting sequence using the document type code prefix and the
         journal document number with a 6 padding number """
-        if self.journal_id.l10n_latam_use_documents and self.env.company.country_id.code == "CL":
+        if self.journal_id.l10n_latam_use_documents and self.env.company.account_fiscal_country_id.code == "CL":
             if self.l10n_latam_document_type_id:
                 return self._l10n_cl_get_formatted_sequence()
         return super()._get_starting_sequence()
 
     def _get_last_sequence_domain(self, relaxed=False):
         where_string, param = super(AccountMove, self)._get_last_sequence_domain(relaxed)
-        if self.company_id.country_id.code == "CL" and self.l10n_latam_use_documents:
+        if self.company_id.account_fiscal_country_id.code == "CL" and self.l10n_latam_use_documents:
             where_string = where_string.replace('journal_id = %(journal_id)s AND', '')
             where_string += ' AND l10n_latam_document_type_id = %(l10n_latam_document_type_id)s AND ' \
                             'company_id = %(company_id)s AND move_type IN (\'out_invoice\', \'out_refund\')'
@@ -121,6 +121,6 @@ class AccountMove(models.Model):
 
     def _get_name_invoice_report(self):
         self.ensure_one()
-        if self.l10n_latam_use_documents and self.company_id.country_id.code == 'CL':
+        if self.l10n_latam_use_documents and self.company_id.account_fiscal_country_id.code == 'CL':
             return 'l10n_cl.report_invoice_document'
         return super()._get_name_invoice_report()

--- a/addons/l10n_cl/models/res_company.py
+++ b/addons/l10n_cl/models/res_company.py
@@ -9,4 +9,4 @@ class ResCompany(models.Model):
     def _localization_use_documents(self):
         """ Chilean localization use documents """
         self.ensure_one()
-        return self.country_id.code == "CL" or super()._localization_use_documents()
+        return self.account_fiscal_country_id.code == "CL" or super()._localization_use_documents()

--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -92,7 +92,7 @@
 
                 <t t-if="o.partner_id.vat and o.partner_id.l10n_latam_identification_type_id">
                     <strong>
-                        <t t-esc="o.partner_id.l10n_latam_identification_type_id.name or o.company_id.country_id.vat_label" id="inv_tax_id_label"/>:
+                        <t t-esc="o.partner_id.l10n_latam_identification_type_id.name or o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>:
                     </strong>
                     <span t-esc="o.partner_id.vat"/>
                     <br/>

--- a/addons/l10n_cn/data/l10n_cn_chart_data.xml
+++ b/addons/l10n_cn/data/l10n_cn_chart_data.xml
@@ -4,7 +4,7 @@
 <!--
 
      Copyright (C) 2012-2012 南京盈通 ccdos@intoerp.com <small business chart>
-     
+
 会计科目表模板( 小企业会计准则2011)
 
 科目表依据：
@@ -21,6 +21,7 @@ http://kjs.mof.gov.cn/zhengwuxinxi/zhengcefabu/201111/t20111107_605525.html
             <field name="bank_account_code_prefix">1002</field>
             <field name="transfer_account_code_prefix">1012</field>
             <field name="spoken_languages" eval="'en_US'"/>
+            <field name="country_id" ref="base.cn"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_co/data/l10n_co_chart_data.xml
+++ b/addons/l10n_co/data/l10n_co_chart_data.xml
@@ -8,6 +8,7 @@
         <field name="bank_account_code_prefix">1110</field>
         <field name="cash_account_code_prefix">1105</field>
         <field name="transfer_account_code_prefix">1115</field>
+        <field name="country_id" ref="base.co"/>
     </record>
 
 </odoo>

--- a/addons/l10n_cr/data/l10n_cr_chart_data.xml
+++ b/addons/l10n_cr/data/l10n_cr_chart_data.xml
@@ -8,5 +8,6 @@
             <field name="cash_account_code_prefix">0-1111</field>
             <field name="transfer_account_code_prefix">0-1114</field>
             <field name="currency_id" ref="base.CRC"/>
+            <field name="country_id" ref="base.cr"/>
         </record>
 </odoo>

--- a/addons/l10n_cz/data/l10n_cz_coa_data.xml
+++ b/addons/l10n_cz/data/l10n_cz_coa_data.xml
@@ -9,6 +9,7 @@
             <field name="cash_account_code_prefix">211</field>
             <field name="transfer_account_code_prefix">261</field>
             <field name="currency_id" ref="base.CZK"/>
+            <field name="country_id" ref="base.cz"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_de/models/chart_template.py
+++ b/addons/l10n_de/models/chart_template.py
@@ -8,7 +8,7 @@ class AccountChartTemplate(models.Model):
     @api.model
     def _prepare_transfer_account_for_direct_creation(self, name, company):
         res = super(AccountChartTemplate, self)._prepare_transfer_account_for_direct_creation(name, company)
-        if company.country_id.code == 'DE':
+        if company.account_fiscal_country_id.code == 'DE':
             xml_id = self.env.ref('l10n_de.tag_de_asset_bs_B_III_2').id
             res.setdefault('tag_ids', [])
             res['tag_ids'].append((4, xml_id))
@@ -17,7 +17,7 @@ class AccountChartTemplate(models.Model):
     # Write paperformat and report template used on company
     def _load(self, sale_tax_rate, purchase_tax_rate, company):
         res = super(AccountChartTemplate, self)._load(sale_tax_rate, purchase_tax_rate, company)
-        if company.country_id.code == 'DE':
+        if company.account_fiscal_country_id.code == 'DE':
             company.write({'external_report_layout_id': self.env.ref('l10n_de.external_layout_din5008').id,
             'paperformat_id': self.env.ref('l10n_de.paperformat_euro_din').id})
         return res

--- a/addons/l10n_de/models/datev.py
+++ b/addons/l10n_de/models/datev.py
@@ -26,7 +26,7 @@ class AccountMove(models.Model):
         for invoice in self.filtered(lambda move: move.is_invoice()):
             for line in invoice.invoice_line_ids:
                 account_tax = line.account_id.tax_ids.ids
-                if account_tax and invoice.company_id.country_id.code == 'DE':
+                if account_tax and invoice.company_id.account_fiscal_country_id.code == 'DE':
                     account_name = line.account_id.name
                     for tax in line.tax_ids:
                         if tax.id not in account_tax:
@@ -43,7 +43,7 @@ class ProductTemplate(models.Model):
          invoicing to not be blocked by the above constraint"""
         result = super(ProductTemplate, self)._get_product_accounts()
         company = self.env.company
-        if company.country_id.code == "DE":
+        if company.account_fiscal_country_id.code == "DE":
             if not self.property_account_income_id:
                 taxes = self.taxes_id.filtered(lambda t: t.company_id == company)
                 if not result['income'] or (result['income'].tax_ids and taxes and taxes[0] not in result['income'].tax_ids):

--- a/addons/l10n_de/report/din5008_report.xml
+++ b/addons/l10n_de/report/din5008_report.xml
@@ -98,7 +98,7 @@
                             <li t-if="company.phone"><i class="fa fa-phone"/> <span t-field="company.phone"/></li>
                             <li t-if="company.email"><i class="fa fa-at"/> <span t-field="company.email"/></li>
                             <li t-if="company.website"><i class="fa fa-globe"/> <span t-field="company.website"/></li>
-                            <li t-if="company.vat"><i class="fa fa-building-o"/><t t-esc="company.country_id.vat_label or 'Tax ID'"/>: <span t-field="company.vat"/></li>
+                            <li t-if="company.vat"><i class="fa fa-building-o"/><t t-esc="company.account_fiscal_country_id.vat_label or 'Tax ID'"/>: <span t-field="company.vat"/></li>
                         </ul>
                         <div t-field="company.report_footer"/>
                     </div>

--- a/addons/l10n_de_skr03/data/l10n_de_skr03_chart_data.xml
+++ b/addons/l10n_de_skr03/data/l10n_de_skr03_chart_data.xml
@@ -7,6 +7,7 @@
             <field name="bank_account_code_prefix">120</field>
             <field name="transfer_account_code_prefix">1360</field>
             <field name="currency_id" ref="base.EUR"/>
+            <field name="country_id" ref="base.de"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_de_skr04/data/l10n_de_skr04_chart_data.xml
+++ b/addons/l10n_de_skr04/data/l10n_de_skr04_chart_data.xml
@@ -7,6 +7,7 @@
             <field name="bank_account_code_prefix">180</field>
             <field name="transfer_account_code_prefix">1460</field>
             <field name="currency_id" ref="base.EUR"/>
+            <field name="country_id" ref="base.de"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_dk/data/l10n_dk_chart_template_data.xml
+++ b/addons/l10n_dk/data/l10n_dk_chart_template_data.xml
@@ -5,8 +5,9 @@
         <field name="code_digits">4</field>
         <field name="currency_id" ref="base.DKK"/>
         <field name="use_anglo_saxon" eval="True"/>
-        <field name="cash_account_code_prefix">681</field> 
+        <field name="cash_account_code_prefix">681</field>
         <field name="bank_account_code_prefix">682</field>
         <field name="transfer_account_code_prefix">683</field>
+        <field name="country_id" ref="base.dk"/>
     </record>
 </odoo>

--- a/addons/l10n_dk/models/account_chart_template.py
+++ b/addons/l10n_dk/models/account_chart_template.py
@@ -10,7 +10,7 @@ class AccountChartTemplate(models.Model):
     @api.model
     def _prepare_transfer_account_for_direct_creation(self, name, company):
         res = super(AccountChartTemplate, self)._prepare_transfer_account_for_direct_creation(name, company)
-        if company.country_id.code == 'DK':
+        if company.account_fiscal_country_id.code == 'DK':
             account_tag_liquidity = self.env.ref('l10n_dk.account_tag_liquidity')
             res['tag_ids'] = [(6, 0, account_tag_liquidity.ids)]
             res['name'] = 'Bank i transfer'

--- a/addons/l10n_dk/models/account_journal.py
+++ b/addons/l10n_dk/models/account_journal.py
@@ -12,7 +12,7 @@ class AccountJournal(models.Model):
         # OVERRIDE
         account_vals = super()._prepare_liquidity_account_vals(company, code, vals)
 
-        if company.country_id.code == 'DK':
+        if company.account_fiscal_country_id.code == 'DK':
             # Ensure the newly liquidity accounts have the right account tag in order to be part
             # of the Danish financial reports.
             account_vals.setdefault('tag_ids', [])

--- a/addons/l10n_do/data/l10n_do_chart_data.xml
+++ b/addons/l10n_do/data/l10n_do_chart_data.xml
@@ -10,5 +10,6 @@
         <field name="bank_account_code_prefix">110102</field>
         <field name="transfer_account_code_prefix">11010100</field>
         <field name="currency_id" ref="base.DOP"/>
+        <field name="country_id" ref="base.do"/>
     </record>
 </odoo>

--- a/addons/l10n_do/models/chart_template.py
+++ b/addons/l10n_do/models/chart_template.py
@@ -9,7 +9,7 @@ class AccountChartTemplate(models.Model):
 
     @api.model
     def _get_default_bank_journals_data(self):
-        if self.env.company.country_id and self.env.company.country_id.code.upper() == 'DO':
+        if self.env.company.account_fiscal_country_id.code == 'DO':
             return [
                 {'acc_name': _('Cash'), 'account_type': 'cash'},
                 {'acc_name': _('Caja Chica'), 'account_type': 'cash'},

--- a/addons/l10n_dz/data/account_chart_template_data.xml
+++ b/addons/l10n_dz/data/account_chart_template_data.xml
@@ -8,6 +8,7 @@
         <field name="bank_account_code_prefix">512</field>
         <field name="cash_account_code_prefix">53</field>
         <field name="transfer_account_code_prefix">58</field>
+        <field name="country_id" ref="base.dz"/>
     </record>
 
 </odoo>

--- a/addons/l10n_ec/data/l10n_ec_chart_data.xml
+++ b/addons/l10n_ec/data/l10n_ec_chart_data.xml
@@ -7,5 +7,6 @@
       <field name="cash_account_code_prefix">10.01.01</field>
       <field name="transfer_account_code_prefix">10.01.03</field>
       <field name="code_digits" eval="6"/>
+      <field name="country_id" ref="base.ec"/>
     </record>
 </odoo>

--- a/addons/l10n_es/data/account_chart_template_data.xml
+++ b/addons/l10n_es/data/account_chart_template_data.xml
@@ -8,6 +8,7 @@
             <field name="cash_account_code_prefix">570</field>
             <field name="bank_account_code_prefix">572</field>
             <field name="transfer_account_code_prefix">572999</field>
+            <field name="country_id" ref="base.es"/>
         </record>
 
         <record id="account_chart_template_pymes" model="account.chart.template">
@@ -18,6 +19,7 @@
             <field name="bank_account_code_prefix">572</field>
             <field name="transfer_account_code_prefix">572999</field>
             <field name="parent_id" ref="account_chart_template_common"/>
+            <field name="country_id" ref="base.es"/>
         </record>
 
         <record id="account_chart_template_assoc" model="account.chart.template">
@@ -28,6 +30,7 @@
         <field name="bank_account_code_prefix">572</field>
         <field name="transfer_account_code_prefix">572999</field>
         <field name="parent_id" ref="account_chart_template_common"/>
+        <field name="country_id" ref="base.es"/>
     </record>
 
     <record id="account_chart_template_full" model="account.chart.template">
@@ -38,6 +41,7 @@
         <field name="bank_account_code_prefix">572</field>
         <field name="transfer_account_code_prefix">572999</field>
         <field name="parent_id" ref="account_chart_template_common"/>
+        <field name="country_id" ref="base.es"/>
     </record>
     </data>
 </odoo>

--- a/addons/l10n_et/data/l10n_et_chart_data.xml
+++ b/addons/l10n_et/data/l10n_et_chart_data.xml
@@ -9,5 +9,6 @@
         <field name="bank_account_code_prefix">211</field>
         <field name="cash_account_code_prefix">211</field>
         <field name="transfer_account_code_prefix">212</field>
+        <field name="country_id" ref="base.et"/>
     </record>
 </odoo>

--- a/addons/l10n_eu_service/models/res_config_settings.py
+++ b/addons/l10n_eu_service/models/res_config_settings.py
@@ -11,4 +11,4 @@ class ResConfigSettings(models.TransientModel):
 
     @api.depends('company_id')
     def _compute_l10n_eu_services_european_country(self):
-        self.l10n_eu_services_eu_country = self.company_id.country_id in self.env.ref('base.europe').country_ids
+        self.l10n_eu_services_eu_country = self.company_id.account_fiscal_country_id in self.env.ref('base.europe').country_ids

--- a/addons/l10n_eu_service/wizard/wizard.py
+++ b/addons/l10n_eu_service/wizard/wizard.py
@@ -36,7 +36,7 @@ class l10n_eu_service(models.TransientModel):
     def _default_done_country_ids(self):
         user = self.env.user
         eu_country_group = self._get_eu_res_country_group()
-        return eu_country_group.country_ids - self._default_todo_country_ids() - user.company_id.country_id
+        return eu_country_group.country_ids - self._default_todo_country_ids() - user.company_id.account_fiscal_country_id
 
     def _default_todo_country_ids(self):
         user = self.env.user
@@ -45,7 +45,7 @@ class l10n_eu_service(models.TransientModel):
             [('country_id', 'in', eu_country_group.country_ids.ids),
              ('vat_required', '=', False), ('auto_apply', '=', True),
              ('company_id', '=', user.company_id.id)])
-        return eu_country_group.country_ids - eu_fiscal.mapped('country_id') - user.company_id.country_id
+        return eu_country_group.country_ids - eu_fiscal.mapped('country_id') - user.company_id.account_fiscal_country_id
 
     company_id = fields.Many2one(
         'res.company', string='Company', required=True, default=_get_default_company_id)

--- a/addons/l10n_fi/data/account_chart_template_data.xml
+++ b/addons/l10n_fi/data/account_chart_template_data.xml
@@ -9,5 +9,6 @@
         <field name="transfer_account_code_prefix">1950</field>
         <field name="code_digits">4</field>
         <field name="currency_id" ref="base.EUR"/>
+        <field name="country_id" ref="base.fi"/>
     </record>
 </odoo>

--- a/addons/l10n_fr/data/l10n_fr_chart_data.xml
+++ b/addons/l10n_fr/data/l10n_fr_chart_data.xml
@@ -9,5 +9,6 @@
         <field name="cash_account_code_prefix">53</field>
         <field name="transfer_account_code_prefix">58</field>
         <field name="complete_tax_set" eval="True" />
+        <field name="country_id" ref="base.fr"/>
     </record>
 </odoo>

--- a/addons/l10n_fr/models/account_chart_template.py
+++ b/addons/l10n_fr/models/account_chart_template.py
@@ -11,7 +11,7 @@ class AccountChartTemplate(models.Model):
     def _prepare_all_journals(self, acc_template_ref, company, journals_dict=None):
         journal_data = super(AccountChartTemplate, self)._prepare_all_journals(
             acc_template_ref, company, journals_dict)
-        if company.country_id.code != 'FR':
+        if company.account_fiscal_country_id.code != 'FR':
             return journal_data
 
         for journal in journal_data:

--- a/addons/l10n_fr/models/res_company.py
+++ b/addons/l10n_fr/models/res_company.py
@@ -15,9 +15,6 @@ class ResCompany(models.Model):
     def _get_unalterable_country(self):
         return ['FR', 'MF', 'MQ', 'NC', 'PF', 'RE', 'GF', 'GP', 'TF'] # These codes correspond to France and DOM-TOM.
 
-    def _is_vat_french(self):
-        return self.vat and self.vat.startswith('FR') and len(self.vat) == 13
-
     def _is_accounting_unalterable(self):
         if not self.vat and not self.country_id:
             return False

--- a/addons/l10n_fr_fec/wizard/account_fr_fec.py
+++ b/addons/l10n_fr_fec/wizard/account_fr_fec.py
@@ -91,7 +91,7 @@ class AccountFrFec(models.TransientModel):
             http://www.douane.gouv.fr/articles/a11024-tva-dans-les-dom
         """
         dom_tom_group = self.env.ref('l10n_fr.dom-tom')
-        is_dom_tom = company.country_id.code in dom_tom_group.country_ids.mapped('code')
+        is_dom_tom = company.account_fiscal_country_id.code in dom_tom_group.country_ids.mapped('code')
         if not is_dom_tom and not company.vat:
             raise UserError(_("Missing VAT number for company %s", company.name))
         if not is_dom_tom and company.vat[0:2] != 'FR':

--- a/addons/l10n_generic_coa/data/l10n_generic_coa.xml
+++ b/addons/l10n_generic_coa/data/l10n_generic_coa.xml
@@ -8,5 +8,6 @@
         <field name="cash_account_code_prefix">1015</field>
         <field name="transfer_account_code_prefix">1017</field>
         <field name="currency_id" ref="base.USD"/>
+        <field name="country_id" ref="base.us"/>
     </record>
 </odoo>

--- a/addons/l10n_gr/data/l10n_gr_chart_data.xml
+++ b/addons/l10n_gr/data/l10n_gr_chart_data.xml
@@ -10,5 +10,6 @@
             <field name="transfer_account_code_prefix">38.07</field>
             <field name="code_digits">6</field>
             <field name="currency_id" ref="base.EUR"/>
+            <field name="country_id" ref="base.gr"/>
         </record>
 </odoo>

--- a/addons/l10n_gt/data/l10n_gt_chart_data.xml
+++ b/addons/l10n_gt/data/l10n_gt_chart_data.xml
@@ -8,6 +8,7 @@
             <field name="transfer_account_code_prefix">1.0.03.01</field>
             <field name="code_digits">9</field>
             <field name="currency_id" ref="base.GTQ"/>
+            <field name="country_id" ref="base.gt"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_hk/data/account_chart_template_data.xml
+++ b/addons/l10n_hk/data/account_chart_template_data.xml
@@ -12,5 +12,6 @@
         <field name="transfer_account_code_prefix">111220</field>
         <field name="code_digits">6</field>
         <field name="currency_id" ref="base.HKD" />
+        <field name="country_id" ref="base.hk"/>
     </record>
 </odoo>

--- a/addons/l10n_hn/data/l10n_hn_chart_data.xml
+++ b/addons/l10n_hn/data/l10n_hn_chart_data.xml
@@ -8,6 +8,7 @@
             <field name="transfer_account_code_prefix">1.1.01.00</field>
             <field name="code_digits">9</field>
             <field name="currency_id" ref="base.HNL"/>
+            <field name="country_id" ref="base.hn"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_hr/data/l10n_hr_chart_data.xml
+++ b/addons/l10n_hr/data/l10n_hr_chart_data.xml
@@ -12,6 +12,7 @@
             <field name="transfer_account_code_prefix">1009</field>
             <field name="currency_id" ref="base.HRK"/>
             <field name="code_digits">0</field>
+            <field name="country_id" ref="base.hr"/>
         </record>
 
     </data>

--- a/addons/l10n_hu/data/l10n_hu_chart_data.xml
+++ b/addons/l10n_hu/data/l10n_hu_chart_data.xml
@@ -9,5 +9,6 @@
         <field name="bank_account_code_prefix">384</field>
         <field name="transfer_account_code_prefix">389</field>
         <field name="currency_id" ref="base.HUF"/>
+        <field name="country_id" ref="base.hu"/>
     </record>
 </odoo>

--- a/addons/l10n_id/data/account_chart_template_data.xml
+++ b/addons/l10n_id/data/account_chart_template_data.xml
@@ -8,5 +8,6 @@
         <field name="code_digits">8</field>
         <field name="currency_id" ref="base.IDR"/>
         <field name="spoken_languages" eval="'id_ID'"/>
+        <field name="country_id" ref="base.id"/>
     </record>
 </odoo>

--- a/addons/l10n_ie/data/account_chart_template.xml
+++ b/addons/l10n_ie/data/account_chart_template.xml
@@ -10,6 +10,7 @@
         <field name="transfer_account_code_prefix">1220</field>
         <field name="code_digits">6</field>
         <field name="currency_id" ref="base.EUR"/>
+        <field name="country_id" ref="base.ie"/>
     </record>
 
 </odoo>

--- a/addons/l10n_il/data/account_chart_template_data.xml
+++ b/addons/l10n_il/data/account_chart_template_data.xml
@@ -8,5 +8,6 @@
         <field name="code_digits">6</field>
         <field name="currency_id" ref="base.ILS"/>
         <field name="spoken_languages" eval="'he_IL'"/>
+        <field name="country_id" ref="base.il"/>
     </record>
 </odoo>

--- a/addons/l10n_in/data/l10n_in_chart_data.xml
+++ b/addons/l10n_in/data/l10n_in_chart_data.xml
@@ -9,6 +9,7 @@
             <field name="transfer_account_code_prefix">1008</field>
             <field name="code_digits">6</field>
             <field name="currency_id" ref="base.INR"/>
+            <field name="country_id" ref="base.in"/>
         </record>
 
         <record id="sgst_tag_account" model="account.account.tag">

--- a/addons/l10n_in/models/account.py
+++ b/addons/l10n_in/models/account.py
@@ -18,7 +18,7 @@ class AccountJournal(models.Model):
         """
         result = super().name_get()
         result_dict = dict(result)
-        indian_journals = self.filtered(lambda j: j.company_id.country_id.code == 'IN' and
+        indian_journals = self.filtered(lambda j: j.company_id.account_fiscal_country_id.code == 'IN' and
             j.l10n_in_gstin_partner_id and j.l10n_in_gstin_partner_id.vat)
         for journal in indian_journals:
             name = result_dict[journal.id]
@@ -32,7 +32,7 @@ class AccountMoveLine(models.Model):
 
     @api.depends('move_id.line_ids', 'move_id.line_ids.tax_line_id', 'move_id.line_ids.debit', 'move_id.line_ids.credit')
     def _compute_tax_base_amount(self):
-        aml = self.filtered(lambda l: l.company_id.country_id.code == 'IN' and l.tax_line_id  and l.product_id)
+        aml = self.filtered(lambda l: l.company_id.account_fiscal_country_id.code == 'IN' and l.tax_line_id  and l.product_id)
         for move_line in aml:
             base_lines = move_line.move_id.line_ids.filtered(lambda line: move_line.tax_line_id in line.tax_ids and move_line.product_id == line.product_id)
             move_line.tax_base_amount = abs(sum(base_lines.mapped('balance')))
@@ -49,7 +49,7 @@ class AccountTax(models.Model):
     def get_grouping_key(self, invoice_tax_val):
         """ Returns a string that will be used to group account.invoice.tax sharing the same properties"""
         key = super(AccountTax, self).get_grouping_key(invoice_tax_val)
-        if self.company_id.country_id.code == 'IN':
+        if self.company_id.account_fiscal_country_id.code == 'IN':
             key += "-%s-%s"% (invoice_tax_val.get('l10n_in_product_id', False),
                 invoice_tax_val.get('l10n_in_uom_id', False))
         return key

--- a/addons/l10n_in/views/account_invoice_views.xml
+++ b/addons/l10n_in/views/account_invoice_views.xml
@@ -6,9 +6,9 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='ref']" position="after">
-                <field name="l10n_in_company_country_code" invisible="1"/>
+                <field name="country_code" invisible="1"/>
                 <field name="l10n_in_gst_treatment"
-                    attrs="{'invisible': ['|', ('l10n_in_company_country_code', '!=', 'IN'), ('move_type', '=', 'entry')], 'required': [('l10n_in_company_country_code', '=', 'IN'), ('move_type', '!=', 'entry')]}"/>
+                    attrs="{'invisible': ['|', ('country_code', '!=', 'IN'), ('move_type', '=', 'entry')], 'required': [('country_code', '=', 'IN'), ('move_type', '!=', 'entry')]}"/>
             </xpath>
             <xpath expr="//page[@id='other_tab']/group[@id='other_tab_group']" position="after">
                 <group string="Export India" attrs="{'invisible': ['|', ('l10n_in_gst_treatment', 'not in', ['overseas', 'deemed_export']), ('move_type', 'not in', ['out_invoice', 'out_refund'])]}">
@@ -25,7 +25,7 @@
             <xpath expr="//field[@name='partner_id']" position="after">
                 <field name="l10n_in_reseller_partner_id"
                        groups="l10n_in.group_l10n_in_reseller"
-                       attrs="{'invisible': ['|', '|',('move_type', 'not in', ('out_invoice', 'out_refund')), ('l10n_in_company_country_code', '!=', 'IN'), ('move_type', '=', 'entry')]}"
+                       attrs="{'invisible': ['|', '|',('move_type', 'not in', ('out_invoice', 'out_refund')), ('country_code', '!=', 'IN'), ('move_type', '=', 'entry')]}"
                        />
             </xpath>
         </field>

--- a/addons/l10n_in/views/report_invoice.xml
+++ b/addons/l10n_in/views/report_invoice.xml
@@ -3,13 +3,13 @@
     <template id="l10n_in_report_invoice_document_inherit" inherit_id="account.report_invoice_document">
 
         <xpath expr="//span[@t-field='o.partner_id.vat']" position="attributes">
-            <attribute name="t-if">o.company_id.country_id.code != 'IN'</attribute>
+            <attribute name="t-if">o.company_id.account_fiscal_country_id.code != 'IN'</attribute>
         </xpath>
         <xpath expr="//span[@t-field='o.partner_id.vat']" position="after">
-            <span t-field="o.l10n_in_gstin" t-if="o.company_id.country_id.code == 'IN'"/>
+            <span t-field="o.l10n_in_gstin" t-if="o.company_id.account_fiscal_country_id.code == 'IN'"/>
         </xpath>
         <xpath expr="//t[@t-set='address']" position="inside">
-            <t t-if="o.company_id.country_id.code == 'IN' and o.l10n_in_state_id" class="mt16">
+            <t t-if="o.company_id.account_fiscal_country_id.code == 'IN' and o.l10n_in_state_id" class="mt16">
                 <t t-if="o.move_type in ('in_invoice', 'in_refund')">
                     Destination of supply: <span t-esc="o.l10n_in_state_id.name"/>
                 </t>
@@ -19,7 +19,7 @@
             </t>
         </xpath>
         <xpath expr="//p[@t-if='o.narration']" position="before">
-            <t t-if="o.company_id.country_id.code == 'IN'">
+            <t t-if="o.company_id.account_fiscal_country_id.code == 'IN'">
                 <p id="total_in_words" class="mb16">
                     <strong>Total (In Words): </strong>
                     <span t-field="o.amount_total_words"/>
@@ -28,13 +28,13 @@
         </xpath>
 
         <xpath expr="//table[@name='invoice_line_table']/thead/tr/th[1]" position="after">
-            <t t-if="o.company_id.country_id.code == 'IN'">
+            <t t-if="o.company_id.account_fiscal_country_id.code == 'IN'">
                 <th>HSN/SAC</th>
             </t>
         </xpath>
 
         <xpath expr="//t[@name='account_invoice_line_accountable']/td[1]" position="after">
-            <td t-if="o.company_id.country_id.code == 'IN'">
+            <td t-if="o.company_id.account_fiscal_country_id.code == 'IN'">
               <span t-if="line.product_id.l10n_in_hsn_code" t-field="line.product_id.l10n_in_hsn_code"></span>
             </td>
         </xpath>

--- a/addons/l10n_in/views/report_template.xml
+++ b/addons/l10n_in/views/report_template.xml
@@ -3,36 +3,13 @@
     <!-- get vat from journal_id for all layout -->
     <template id="l10n_in_external_layout" inherit_id="web.external_layout">
         <xpath expr="//t[@t-if='company.external_report_layout_id']" position="before">
-            <t t-if="o and 'journal_id' in o and company.country_id.code == 'IN'">
-                <t t-set="vat" t-value="o.journal_id.l10n_in_gstin_partner_id.vat"/>
+            <t t-if="o and 'journal_id' in o and company.country_id.code == 'IN' and o.journal_id.l10n_in_gstin_partner_id.vat">
+                <t t-set="forced_vat" t-value="o.journal_id.l10n_in_gstin_partner_id.vat"/>
             </t>
-            <t t-elif="o and 'l10n_in_journal_id' in o and company.country_id.code == 'IN'">
-                <t t-set="vat" t-value="o.l10n_in_journal_id.l10n_in_gstin_partner_id.vat"/>
+            <t t-elif="o and 'l10n_in_journal_id' in o and company.country_id.code == 'IN' and o.l10n_in_journal_id.l10n_in_gstin_partner_id.vat">
+                <t t-set="forced_vat" t-value="o.l10n_in_journal_id.l10n_in_gstin_partner_id.vat"/>
             </t>
         </xpath>
     </template>
 
-    <template id="l10n_in_external_layout_standard" inherit_id="web.external_layout_standard">
-        <xpath expr="//li[@t-if='company.vat']" position="replace">
-            <li t-if="vat or company.vat" class="list-inline-item d-inline"><t t-esc="company.country_id.vat_label or 'Tax ID'"/>: <span t-esc="vat or company.vat"/></li>
-        </xpath>
-    </template>
-
-    <template id="l10n_in_external_layout_clean" inherit_id="web.external_layout_clean">
-        <xpath expr="//li[@t-if='company.vat']" position="replace">
-            <li t-if="vat or company.vat"><t t-esc="company.country_id.vat_label or 'Tax ID'"/>: <span t-esc="vat or company.vat"/></li>
-        </xpath>
-    </template>
-
-    <template id="l10n_in_external_layout_boxed" inherit_id="web.external_layout_boxed">
-        <xpath expr="//li[@t-if='company.vat']" position="replace">
-            <li t-if="vat or company.vat" class="list-inline-item"><t t-esc="company.country_id.vat_label or 'Tax ID'"/>: <span t-esc="vat or company.vat"/></li>
-        </xpath>
-    </template>
-
-    <template id="l10n_in_external_layout_background" inherit_id="web.external_layout_background">
-        <xpath expr="//li[@t-if='company.vat']" position="replace">
-            <li t-if="vat or company.vat" class="list-inline-item"><i class="fa fa-building-o" role="img" aria-label="Fiscal number"/><t t-esc="company.country_id.vat_label or 'Tax ID'"/>: <span t-esc="vat or company.vat"/></li>
-        </xpath>
-    </template>
 </odoo>

--- a/addons/l10n_in_pos/models/pos_order.py
+++ b/addons/l10n_in_pos/models/pos_order.py
@@ -11,7 +11,7 @@ class PosOrder(models.Model):
     def _get_account_move_line_group_data_type_key(self, data_type, values, options={}):
         res = super(PosOrder, self)._get_account_move_line_group_data_type_key(data_type, values, options)
         if data_type == 'tax' and res:
-            if self.env['account.tax'].browse(values['tax_line_id']).company_id.country_id.code == 'IN':
+            if self.env['account.tax'].browse(values['tax_line_id']).company_id.account_fiscal_country_id.code == 'IN':
                 return res + (values['product_uom_id'], values['product_id'])
         return res
 

--- a/addons/l10n_in_purchase/models/purchase_order.py
+++ b/addons/l10n_in_purchase/models/purchase_order.py
@@ -19,7 +19,7 @@ class PurchaseOrder(models.Model):
             ('special_economic_zone', 'Special Economic Zone'),
             ('deemed_export', 'Deemed Export')
         ], string="GST Treatment", states=Purchase.READONLY_STATES)
-    l10n_in_company_country_code = fields.Char(related='company_id.country_id.code', string="Country code")
+    l10n_in_company_country_code = fields.Char(related='company_id.account_fiscal_country_id.code', string="Country code")
 
     @api.onchange('company_id')
     def l10n_in_onchange_company_id(self):

--- a/addons/l10n_in_purchase/views/report_purchase_order.xml
+++ b/addons/l10n_in_purchase/views/report_purchase_order.xml
@@ -5,7 +5,7 @@
         <xpath expr="//t[@t-foreach='o.order_line']//td[@id='product']" position="replace">
             <td>
                 <span t-field="line.name"/>
-                <t t-if="line.product_id.l10n_in_hsn_code and o.company_id.country_id.code == 'IN'">
+                <t t-if="line.product_id.l10n_in_hsn_code and o.company_id.account_fiscal_country_id.code == 'IN'">
                     <h6>
                         <strong class="ml16">HSN/SAC Code:</strong>
                         <span t-field="line.product_id.l10n_in_hsn_code"/>
@@ -19,7 +19,7 @@
         <xpath expr="//t[@t-foreach='o.order_line']//td[@id='product']" position="replace">
             <td>
                 <span t-field="order_line.name"/>
-                <t t-if="order_line.product_id.l10n_in_hsn_code and o.company_id.country_id.code == 'IN'">
+                <t t-if="order_line.product_id.l10n_in_hsn_code and o.company_id.account_fiscal_country_id.code == 'IN'">
                     <h6>
                         <strong class="ml16">HSN/SAC Code:</strong>
                         <span t-field="order_line.product_id.l10n_in_hsn_code"/>

--- a/addons/l10n_in_sale/models/sale_order.py
+++ b/addons/l10n_in_sale/models/sale_order.py
@@ -19,7 +19,7 @@ class SaleOrder(models.Model):
             ('special_economic_zone', 'Special Economic Zone'),
             ('deemed_export', 'Deemed Export'),
         ], string="GST Treatment", readonly=True, states={'draft': [('readonly', False)], 'sent': [('readonly', False)]}, compute="_compute_l10n_in_gst_treatment", store=True)
-    l10n_in_company_country_code = fields.Char(related='company_id.country_id.code', string="Country code")
+    l10n_in_company_country_code = fields.Char(related='company_id.account_fiscal_country_id.code', string="Country code")
 
     @api.depends('partner_id')
     def _compute_l10n_in_gst_treatment(self):

--- a/addons/l10n_in_stock/views/report_stockpicking_operations.xml
+++ b/addons/l10n_in_stock/views/report_stockpicking_operations.xml
@@ -3,7 +3,7 @@
 
     <template id="gst_report_picking_inherit" inherit_id="stock.report_picking">
         <xpath expr="//span[@t-field='ml.product_id.description_picking']" position="after">
-            <t t-if="ml.product_id and ml.product_id.l10n_in_hsn_code and o.company_id.country_id.code == 'IN'"><h6><strong class="ml16">HSN/SAC Code:</strong> <span t-field="ml.product_id.l10n_in_hsn_code"/></h6></t>
+            <t t-if="ml.product_id and ml.product_id.l10n_in_hsn_code and o.company_id.account_fiscal_country_id.code == 'IN'"><h6><strong class="ml16">HSN/SAC Code:</strong> <span t-field="ml.product_id.l10n_in_hsn_code"/></h6></t>
         </xpath>
     </template>
 

--- a/addons/l10n_it/data/l10n_it_chart_data.xml
+++ b/addons/l10n_it/data/l10n_it_chart_data.xml
@@ -7,6 +7,7 @@
             <field name="bank_account_code_prefix">182</field>
             <field name="transfer_account_code_prefix">183</field>
             <field name="currency_id" ref="base.EUR"/>
+            <field name="country_id" ref="base.it"/>
         </record>
 
 </odoo>

--- a/addons/l10n_it_stock_ddt/models/account_invoice.py
+++ b/addons/l10n_it_stock_ddt/models/account_invoice.py
@@ -57,7 +57,7 @@ class AccountMove(models.Model):
 
     @api.depends('invoice_line_ids', 'invoice_line_ids.sale_line_ids')
     def _compute_ddt_ids(self):
-        it_out_invoices = self.filtered(lambda i: i.move_type == 'out_invoice' and i.company_id.country_id.code == 'IT')
+        it_out_invoices = self.filtered(lambda i: i.move_type == 'out_invoice' and i.company_id.account_fiscal_country_id.code == 'IT')
         for invoice in it_out_invoices:
             invoice_line_pickings = invoice._get_ddt_values()
             pickings = self.env['stock.picking']

--- a/addons/l10n_it_stock_ddt/models/stock_picking.py
+++ b/addons/l10n_it_stock_ddt/models/stock_picking.py
@@ -20,7 +20,7 @@ class StockPicking(models.Model):
                                                 default="sender", string='Transport Method')
     l10n_it_transport_method_details = fields.Char('Transport Note')
     l10n_it_parcels = fields.Integer(string="Parcels", default=1)
-    l10n_it_country_code = fields.Char(related="company_id.country_id.code")
+    l10n_it_country_code = fields.Char(related="company_id.account_fiscal_country_id.code")
     l10n_it_ddt_number = fields.Char('DDT Number', readonly=True)
 
     def _action_done(self):

--- a/addons/l10n_it_stock_ddt/report/l10n_it_ddt_report.xml
+++ b/addons/l10n_it_stock_ddt/report/l10n_it_ddt_report.xml
@@ -24,7 +24,7 @@
                                     <span><strong>Customer Address:</strong></span>
                                     <div t-field="o.partner_id"
                                            t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
-                                    <p t-if="o.partner_id.vat"><t t-esc="o.company_id.country_id.vat_label or 'Pta IVA'"/>: <span t-field="o.partner_id.vat"/></p>
+                                    <p t-if="o.partner_id.vat"><t t-esc="o.company_id.account_fiscal_country_id.vat_label or 'Pta IVA'"/>: <span t-field="o.partner_id.vat"/></p>
                                 </div>
                             </div>
                         </div>

--- a/addons/l10n_jp/data/l10n_jp_chart_data.xml
+++ b/addons/l10n_jp/data/l10n_jp_chart_data.xml
@@ -8,5 +8,6 @@
         <field name="cash_account_code_prefix">A11105</field>
         <field name="transfer_account_code_prefix">A11109</field>
         <field name="currency_id" ref="base.JPY"/>
+        <field name="country_id" ref="base.jp"/>
     </record>
 </odoo>

--- a/addons/l10n_latam_base/models/res_partner.py
+++ b/addons/l10n_latam_base/models/res_partner.py
@@ -23,7 +23,7 @@ class ResPartner(models.Model):
 
     @api.onchange('country_id')
     def _onchange_country(self):
-        country = self.country_id or self.company_id.country_id or self.env.company.country_id
+        country = self.country_id or self.company_id.account_fiscal_country_id or self.env.company.account_fiscal_country_id
         identification_type = self.l10n_latam_identification_type_id
         if not identification_type or (identification_type.country_id != country):
             self.l10n_latam_identification_type_id = self.env['l10n_latam.identification.type'].search(

--- a/addons/l10n_latam_invoice_document/models/account_move.py
+++ b/addons/l10n_latam_invoice_document/models/account_move.py
@@ -203,7 +203,7 @@ class AccountMove(models.Model):
             internal_types = ['credit_note']
         else:
             internal_types = ['invoice', 'debit_note']
-        return [('internal_type', 'in', internal_types), ('country_id', '=', self.company_id.country_id.id)]
+        return [('internal_type', 'in', internal_types), ('country_id', '=', self.company_id.account_fiscal_country_id.id)]
 
     @api.depends('journal_id', 'partner_id', 'company_id', 'move_type')
     def _compute_l10n_latam_available_document_types(self):

--- a/addons/l10n_lt/data/account_chart_template_data.xml
+++ b/addons/l10n_lt/data/account_chart_template_data.xml
@@ -14,5 +14,6 @@
         <field name="bank_account_code_prefix">271</field>
         <field name="cash_account_code_prefix">272</field>
         <field name="transfer_account_code_prefix">273</field>
+        <field name="country_id" ref="base.lt"/>
     </record>
 </odoo>

--- a/addons/l10n_lu/data/l10n_lu_chart_data.xml
+++ b/addons/l10n_lu/data/l10n_lu_chart_data.xml
@@ -10,5 +10,6 @@
             <field name="code_digits">6</field>
             <field name="currency_id" ref="base.EUR"/>
             <field name="spoken_languages" eval="'fr_FR;fr_BE;de_DE'"/>
+            <field name="country_id" ref="base.lu"/>
         </record>
 </odoo>

--- a/addons/l10n_lu/models/account_chart_template.py
+++ b/addons/l10n_lu/models/account_chart_template.py
@@ -12,6 +12,6 @@ class AccountChartTemplate(models.Model):
         journal_data = super(AccountChartTemplate, self)._prepare_all_journals(
             acc_template_ref, company, journals_dict)
         for journal in journal_data:
-            if journal['type'] in ('sale', 'purchase') and company.country_id.code == "LU":
+            if journal['type'] in ('sale', 'purchase') and company.account_fiscal_country_id.code == "LU":
                 journal.update({'refund_sequence': True})
         return journal_data

--- a/addons/l10n_ma/data/l10n_ma_chart_data.xml
+++ b/addons/l10n_ma/data/l10n_ma_chart_data.xml
@@ -15,6 +15,7 @@
         <field name="bank_account_code_prefix">5141</field>
         <field name="cash_account_code_prefix">5161</field>
         <field name="transfer_account_code_prefix">5115</field>
+        <field name="country_id" ref="base.ma"/>
     </record>
 
   <record id="pcg_1111" model="account.account.template">

--- a/addons/l10n_mn/data/account_chart_template_data.xml
+++ b/addons/l10n_mn/data/account_chart_template_data.xml
@@ -11,6 +11,7 @@
         <field name="code_digits">8</field>
         <field name="currency_id" ref="base.MNT"/>
         <field name="use_anglo_saxon" eval="True"/>
+        <field name="country_id" ref="base.mn"/>
     </record>
 
 </odoo>

--- a/addons/l10n_mx/data/l10n_mx_chart_data.xml
+++ b/addons/l10n_mx/data/l10n_mx_chart_data.xml
@@ -12,6 +12,7 @@
         <field name="code_digits">3</field>
         <field name="currency_id" ref="base.MXN"/>
         <field name="use_anglo_saxon" eval="True"/>
+        <field name="country_id" ref="base.mx"/>
     </record>
     </data>
 </odoo>

--- a/addons/l10n_mx/models/account.py
+++ b/addons/l10n_mx/models/account.py
@@ -13,7 +13,7 @@ class AccountJournal(models.Model):
         # OVERRIDE
         account_vals = super()._prepare_liquidity_account_vals(company, code, vals)
 
-        if company.country_id.code == 'MX':
+        if company.account_fiscal_country_id.code == 'MX':
             # When preparing the values to use when creating the default debit and credit accounts of a
             # liquidity journal, set the correct tags for the mexican localization.
             account_vals.setdefault('tag_ids', [])

--- a/addons/l10n_mx/models/chart_template.py
+++ b/addons/l10n_mx/models/chart_template.py
@@ -42,7 +42,7 @@ class AccountChartTemplate(models.Model):
     @api.model
     def _prepare_transfer_account_for_direct_creation(self, name, company):
         res = super(AccountChartTemplate, self)._prepare_transfer_account_for_direct_creation(name, company)
-        if company.country_id.code == 'MX':
+        if company.account_fiscal_country_id.code == 'MX':
             xml_id = self.env.ref('l10n_mx.account_tag_102_01').id
             res.setdefault('tag_ids', [])
             res['tag_ids'].append((4, xml_id))

--- a/addons/l10n_nl/data/account_chart_template.xml
+++ b/addons/l10n_nl/data/account_chart_template.xml
@@ -10,6 +10,7 @@
             <field name="transfer_account_code_prefix">1060</field>
             <field name="code_digits">6</field>
             <field name="currency_id" ref="base.EUR"/>
+            <field name="country_id" ref="base.nl"/>
         </record>
 
     </data>

--- a/addons/l10n_nl/models/account_chart_template.py
+++ b/addons/l10n_nl/models/account_chart_template.py
@@ -9,7 +9,7 @@ class AccountChartTemplate(models.Model):
     def _load(self, sale_tax_rate, purchase_tax_rate, company):
         # Add tag to 999999 account
         res = super(AccountChartTemplate, self)._load(sale_tax_rate, purchase_tax_rate, company)
-        if company.country_id.code == 'NL':
+        if company.account_fiscal_country_id.code == 'NL':
             account = self.env['account.account'].search([('code', '=', '999999'), ('company_id', '=', self.env.company.id)])
             if account:
                 account.tag_ids = [(4, self.env.ref('l10n_nl.account_tag_12').id)]
@@ -18,7 +18,7 @@ class AccountChartTemplate(models.Model):
     @api.model
     def _prepare_transfer_account_for_direct_creation(self, name, company):
         res = super(AccountChartTemplate, self)._prepare_transfer_account_for_direct_creation(name, company)
-        if company.country_id.code == 'NL':
+        if company.account_fiscal_country_id.code == 'NL':
             xml_id = self.env.ref('l10n_nl.account_tag_25').id
             res.setdefault('tag_ids', [])
             res['tag_ids'].append((4, xml_id))

--- a/addons/l10n_nl/models/account_journal.py
+++ b/addons/l10n_nl/models/account_journal.py
@@ -11,7 +11,7 @@ class AccountJournal(models.Model):
         # OVERRIDE
         account_vals = super()._prepare_liquidity_account_vals(company, code, vals)
 
-        if company.country_id.code == 'NL':
+        if company.account_fiscal_country_id.code == 'NL':
             # Ensure the newly liquidity accounts have the right account tag in order to be part
             # of the Dutch financial reports.
             account_vals.setdefault('tag_ids', [])

--- a/addons/l10n_no/data/l10n_no_chart_data.xml
+++ b/addons/l10n_no/data/l10n_no_chart_data.xml
@@ -14,6 +14,7 @@
         <field name="transfer_account_code_prefix">1940</field>
         <field name="code_digits">4</field>
         <field name="currency_id" ref="base.NOK"/>
+        <field name="country_id" ref="base.no"/>
     </record>
 
     </data>

--- a/addons/l10n_nz/data/l10n_nz_chart_data.xml
+++ b/addons/l10n_nz/data/l10n_nz_chart_data.xml
@@ -10,6 +10,7 @@
         <field name="transfer_account_code_prefix">11170</field>
         <field name="code_digits">5</field>
         <field name="currency_id" ref="base.NZD"/>
+        <field name="country_id" ref="base.nz"/>
     </record>
 
 </data>

--- a/addons/l10n_pa/data/l10n_pa_chart_data.xml
+++ b/addons/l10n_pa/data/l10n_pa_chart_data.xml
@@ -8,6 +8,7 @@
         <field name="transfer_account_code_prefix">112.</field>
         <field name="code_digits">7</field>
         <field name="currency_id" ref="base.PAB"/>
+        <field name="country_id" ref="base.pa"/>
     </record>
     <!-- Account Templates -->
 

--- a/addons/l10n_pe/data/l10n_pe_chart_data.xml
+++ b/addons/l10n_pe/data/l10n_pe_chart_data.xml
@@ -7,5 +7,6 @@
         <field name="transfer_account_code_prefix">1051</field>
         <field name="code_digits">7</field>
         <field name="currency_id" ref="base.PEN"/>
+        <field name="country_id" ref="base.pe"/>
     </record>
 </odoo>

--- a/addons/l10n_pl/data/l10n_pl_chart_data.xml
+++ b/addons/l10n_pl/data/l10n_pl_chart_data.xml
@@ -20,6 +20,7 @@
             <field name="bank_account_code_prefix">11-000-000</field>
             <field name="cash_account_code_prefix">12-000-000</field>
             <field name="transfer_account_code_prefix">11-090-000</field>
+            <field name="country_id" ref="base.pl"/>
         </record>
 
 </data>

--- a/addons/l10n_pt/data/l10n_pt_chart_data.xml
+++ b/addons/l10n_pt/data/l10n_pt_chart_data.xml
@@ -8,6 +8,7 @@
         <field name="bank_account_code_prefix">12</field>
         <field name="transfer_account_code_prefix">15</field>
         <field name="currency_id" ref="base.EUR"/>
+        <field name="country_id" ref="base.pt"/>
     </record>
 
     <record id="chart_13" model="account.account.template">
@@ -208,7 +209,7 @@
       <field name="user_type_id" ref="account.data_account_type_current_liabilities" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
-    
+
     <record id="chart_2221" model="account.account.template">
       <field name="code">2221</field>
       <field name="name">Fornecedores gerais</field>
@@ -334,7 +335,7 @@
       <field name="user_type_id" ref="account.data_account_type_current_liabilities" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
-    
+
     <record id="chart_2433" model="account.account.template">
       <field name="code">2433</field>
       <field name="name">Iva liquidado</field>
@@ -348,7 +349,7 @@
       <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
-    
+
     <record id="chart_2435" model="account.account.template">
       <field name="code">2435</field>
       <field name="name">Iva apuramento</field>
@@ -691,7 +692,7 @@
       <field name="user_type_id" ref="account.data_account_type_expenses" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
-    
+
     <record id="chart_313" model="account.account.template">
       <field name="code">313</field>
       <field name="name">Activos biológicos</field>
@@ -1111,7 +1112,7 @@
       <field name="user_type_id" ref="account.data_account_type_current_assets" />
       <field name="chart_template_id" ref="pt_chart_template"/>
     </record>
-    
+
     <record id="chart_444" model="account.account.template">
       <field name="code">444</field>
       <field name="name">Propriedade industrial</field>

--- a/addons/l10n_ro/data/l10n_ro_chart_data.xml
+++ b/addons/l10n_ro/data/l10n_ro_chart_data.xml
@@ -10,5 +10,6 @@
         <field name="transfer_account_code_prefix">581</field>
         <field name="code_digits">6</field>
         <field name="currency_id" ref="base.RON"/>
+        <field name="country_id" ref="base.ro"/>
     </record>
 </odoo>

--- a/addons/l10n_sa/data/account_chart_template_data.xml
+++ b/addons/l10n_sa/data/account_chart_template_data.xml
@@ -8,5 +8,6 @@
             <field name="code_digits">6</field>
             <field name="currency_id" ref="base.SAR"/>
             <field name="spoken_languages" eval="'en_US;ar_EG;ar_SY'"/>
+            <field name="country_id" ref="base.sa"/>
         </record>
 </odoo>

--- a/addons/l10n_se/data/account_chart_template_before_accounts.xml
+++ b/addons/l10n_se/data/account_chart_template_before_accounts.xml
@@ -9,6 +9,7 @@
             <field name="transfer_account_code_prefix">194</field>
             <field name="code_digits">4</field>
             <field name="complete_tax_set" eval="True"/>
+            <field name="country_id" ref="base.se"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_se/models/res_company.py
+++ b/addons/l10n_se/models/res_company.py
@@ -13,7 +13,7 @@ class ResCompany(models.Model):
     @api.depends('vat')
     def _compute_org_number(self):
         for company in self:
-            if company.country_id.code == "SE" and company.vat:
+            if company.account_fiscal_country_id.code == "SE" and company.vat:
                 org_number = re.sub(r'\D', '', company.vat)[:-2]
                 org_number = org_number[:6] + '-' + org_number[6:]
 

--- a/addons/l10n_sg/data/l10n_sg_chart_data.xml
+++ b/addons/l10n_sg/data/l10n_sg_chart_data.xml
@@ -9,6 +9,7 @@
             <field name="transfer_account_code_prefix">101100</field>
             <field name="code_digits">6</field>
             <field name="currency_id" ref="base.SGD" />
+            <field name="country_id" ref="base.sg"/>
         </record>
 
         <record model="account.account.template" id="account_account_696">

--- a/addons/l10n_si/data/l10n_si_chart_data.xml
+++ b/addons/l10n_si/data/l10n_si_chart_data.xml
@@ -9,5 +9,6 @@
         <field name="transfer_account_code_prefix">109</field>
         <field name="code_digits">6</field>
         <field name="currency_id" ref="base.EUR"/>
+        <field name="country_id" ref="base.si"/>
     </record>
 </odoo>

--- a/addons/l10n_sk/data/l10n_sk_coa_data.xml
+++ b/addons/l10n_sk/data/l10n_sk_coa_data.xml
@@ -9,6 +9,7 @@
             <field name="cash_account_code_prefix">211</field>
             <field name="transfer_account_code_prefix">261</field>
             <field name="currency_id" ref="base.EUR"/>
+            <field name="country_id" ref="base.sk"/>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_th/data/l10n_th_chart_data.xml
+++ b/addons/l10n_th/data/l10n_th_chart_data.xml
@@ -16,5 +16,6 @@
     <field name="bank_account_code_prefix">1110</field>
     <field name="transfer_account_code_prefix">16</field>
     <field name="currency_id" ref="base.THB"/>
+    <field name="country_id" ref="base.th"/>
 </record>
 </odoo>

--- a/addons/l10n_tr/data/l10n_tr_chart_data.xml
+++ b/addons/l10n_tr/data/l10n_tr_chart_data.xml
@@ -8,6 +8,7 @@
         <field name="transfer_account_code_prefix">103</field>
         <field name="code_digits">6</field>
         <field name="currency_id" ref="base.TRY"/>
+        <field name="country_id" ref="base.tr"/>
     </record>
 
 </odoo>

--- a/addons/l10n_ua/data/account_chart_template.xml
+++ b/addons/l10n_ua/data/account_chart_template.xml
@@ -8,6 +8,7 @@
         <field name="transfer_account_code_prefix">333</field>
         <field name="code_digits">6</field>
         <field name="currency_id" ref="base.UAH"/>
+        <field name="country_id" ref="base.ua"/>
     </record>
 
     <record id="l10n_ua_ias_chart_template" model="account.chart.template">
@@ -17,5 +18,6 @@
         <field name="transfer_account_code_prefix">1119</field>
         <field name="code_digits">6</field>
         <field name="currency_id" ref="base.UAH"/>
+        <field name="country_id" ref="base.ua"/>
     </record>
 </odoo>

--- a/addons/l10n_uk/data/l10n_uk_chart_data.xml
+++ b/addons/l10n_uk/data/l10n_uk_chart_data.xml
@@ -10,5 +10,6 @@
             <field name="transfer_account_code_prefix">1220</field>
             <field name="code_digits">6</field>
             <field name="currency_id" ref="base.GBP"/>
+            <field name="country_id" ref="base.uk"/>
         </record>
 </odoo>

--- a/addons/l10n_uy/data/l10n_uy_chart_data.xml
+++ b/addons/l10n_uy/data/l10n_uy_chart_data.xml
@@ -10,6 +10,7 @@
             <field name="cash_account_code_prefix">1112</field>
             <field name="transfer_account_code_prefix">11120</field>
             <field name="currency_id" ref="base.UYU"/>
+            <field name="country_id" ref="base.uy"/>
         </record>
 
     </data>

--- a/addons/l10n_ve/data/l10n_ve_chart_data.xml
+++ b/addons/l10n_ve/data/l10n_ve_chart_data.xml
@@ -8,6 +8,7 @@
         <field name="transfer_account_code_prefix">1129003</field>
         <field name="code_digits">7</field>
         <field name="currency_id" ref="base.VEF"/>
+        <field name="country_id" ref="base.ve"/>
     </record>
   </data>
 </odoo>

--- a/addons/l10n_vn/data/l10n_vn_chart_data.xml
+++ b/addons/l10n_vn/data/l10n_vn_chart_data.xml
@@ -13,6 +13,7 @@
         <field name="transfer_account_code_prefix">113</field>
         <field name="spoken_languages" eval="'vi_VN'"/>
         <field name="use_anglo_saxon" eval="True"/>
+        <field name="country_id" ref="base.vn"/>
     </record>
 </data>
 </odoo>

--- a/addons/l10n_za/data/account_chart_template_data.xml
+++ b/addons/l10n_za/data/account_chart_template_data.xml
@@ -10,6 +10,7 @@
         <field name="transfer_account_code_prefix">1010</field>
         <field name="code_digits">6</field>
         <field name="currency_id" ref="base.ZAR"/>
+        <field name="country_id" ref="base.za"/>
     </record>
 
 </odoo>

--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -6,7 +6,7 @@
         <t t-set="address">
             <div t-field="o.partner_id"
             t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
-            <p t-if="o.partner_id.vat"><t t-esc="o.company_id.country_id.vat_label or 'Tax ID'"/>: <span t-field="o.partner_id.vat"/></p>
+            <p t-if="o.partner_id.vat"><t t-esc="o.company_id.account_fiscal_country_id.vat_label or 'Tax ID'"/>: <span t-field="o.partner_id.vat"/></p>
         </t>
         <t t-if="o.dest_address_id">
             <t t-set="information_block">

--- a/addons/purchase/report/purchase_quotation_templates.xml
+++ b/addons/purchase/report/purchase_quotation_templates.xml
@@ -6,7 +6,7 @@
         <t t-set="address">
             <div t-field="o.partner_id"
             t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
-            <p t-if="o.partner_id.vat"><t t-esc="o.company_id.country_id.vat_label or 'Tax ID'"/>: <span t-field="o.partner_id.vat"/></p>
+            <p t-if="o.partner_id.vat"><t t-esc="o.company_id.account_fiscal_country_id.vat_label or 'Tax ID'"/>: <span t-field="o.partner_id.vat"/></p>
         </t>
         <t t-if="o.dest_address_id">
             <t t-set="information_block">

--- a/addons/sale/report/sale_report_templates.xml
+++ b/addons/sale/report/sale_report_templates.xml
@@ -6,7 +6,7 @@
         <t t-set="address">
             <div t-field="doc.partner_id"
                 t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}' />
-            <p t-if="doc.partner_id.vat"><t t-esc="doc.company_id.country_id.vat_label or 'Tax ID'"/>: <span t-field="doc.partner_id.vat"/></p>
+            <p t-if="doc.partner_id.vat"><t t-esc="doc.company_id.account_fiscal_country_id.vat_label or 'Tax ID'"/>: <span t-field="doc.partner_id.vat"/></p>
         </t>
         <t t-if="doc.partner_shipping_id == doc.partner_invoice_id
                              and doc.partner_invoice_id != doc.partner_id

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -335,7 +335,12 @@
                     <li t-if="company.phone" class="list-inline-item"><i class="fa fa-phone" role="img" aria-label="Phone" title="Phone"/> <span class="o_force_ltr" t-field="company.phone"/></li>
                     <li t-if="company.email" class="list-inline-item"><i class="fa fa-at" role="img" aria-label="Email" title="Email"/> <span t-field="company.email"/></li>
                     <li t-if="company.website" class="list-inline-item"><i class="fa fa-globe" role="img" aria-label="Website" title="Website"/> <span t-field="company.website"/></li>
-                    <li t-if="company.vat" class="list-inline-item"><i class="fa fa-building-o" role="img" aria-label="Fiscal number"/><t t-esc="company.country_id.vat_label or 'Tax ID'"/>: <span t-field="company.vat"/></li>
+                    <li t-if="forced_vat or company.vat" class="list-inline-item">
+                        <i class="fa fa-building-o" role="img" aria-label="Fiscal number"/>
+                        <t t-esc="company.country_id.vat_label or 'Tax ID'"/>:
+                        <span t-if="forced_vat" t-esc="forced_vat"/>
+                        <span t-else="" t-field="company.vat"/>
+                    </li>
                 </ul>
                 <div t-field="company.report_footer"/>
                 <div t-if="report_type == 'pdf'" class="text-muted">
@@ -380,7 +385,11 @@
                     <li t-if="company.phone" class="list-inline-item"><span class="o_force_ltr" t-field="company.phone"/></li>
                     <li t-if="company.email" class="list-inline-item"><span t-field="company.email"/></li>
                     <li t-if="company.website" class="list-inline-item"><span t-field="company.website"/></li>
-                    <li t-if="company.vat" class="list-inline-item"><t t-esc="company.country_id.vat_label or 'Tax ID'"/>: <span t-field="company.vat"/></li>
+                    <li t-if="forced_vat or company.vat" class="list-inline-item">
+                        <t t-esc="company.country_id.vat_label or 'Tax ID'"/>:
+                        <span t-if="forced_vat" t-esc="forced_vat"/>
+                        <span t-else="" t-field="company.vat"/>
+                    </li>
                 </ul>
                 <div t-field="company.report_footer"/>
                 <div t-if="report_type == 'pdf'">
@@ -400,7 +409,11 @@
                 <div class="col-5 offset-1" name="company_address">
                     <ul class="list-unstyled">
                         <strong><li t-if="company.name"><span t-field="company.name"/></li></strong>
-                        <li t-if="company.vat"><t t-esc="company.country_id.vat_label or 'Tax ID'"/>: <span t-field="company.vat"/></li>
+                        <li t-if="forced_vat or company.vat">
+                            <t t-esc="company.country_id.vat_label or 'Tax ID'"/>:
+                            <span t-if="forced_vat" t-esc="forced_vat"/>
+                            <span t-else="" t-field="company.vat"/>
+                        </li>
                         <li t-if="company.phone">Tel: <span class="o_force_ltr" t-field="company.phone"/></li>
                         <li t-if="company.email"><span t-field="company.email"/></li>
                         <li t-if="company.website"><span t-field="company.website"/></li>
@@ -474,7 +487,11 @@
                     <li t-if="company.phone" class="list-inline-item d-inline"><span class="o_force_ltr" t-field="company.phone"/></li>
                     <li t-if="company.email" class="list-inline-item d-inline"><span t-field="company.email"/></li>
                     <li t-if="company.website" class="list-inline-item d-inline"><span t-field="company.website"/></li>
-                    <li t-if="company.vat" class="list-inline-item d-inline"><t t-esc="company.country_id.vat_label or 'Tax ID'"/>: <span t-field="company.vat"/></li>
+                    <li t-if="forced_vat or company.vat" class="list-inline-item d-inline">
+                        <t t-esc="company.country_id.vat_label or 'Tax ID'"/>:
+                        <span t-if="forced_vat" t-esc="forced_vat"/>
+                        <span t-else="" t-field="company.vat"/>
+                    </li>
                 </ul>
 
                 <div name="financial_infos">


### PR DESCRIPTION
This is the community part of a task aiming to allow submitting tax reports in foreign coutnries as well, with different VAT numbers per region. Multiple commits are available for clarity ;)

Task 2304238


[IMP] account: allow deleting moves that were posted before it they are the last element of the sequence chain

We don't check anymore that a move has been posted before in order to allow its deletion. Instead, we look at its sequence: if it's set and is not at the end of the sequence chain it belongs to, we know removing the move will create a gap, whatever the move state, so we forbid it.

If the user really wants to remove the move anyway, it is possible, by manually emptying the name of the move to delete. This way, he won't have any sequence anymore, and will be deletable. Users should however, rather rely on move cancellations and reversals, just for the sake of a cleaner accounting.

[IMP] account: introduce foreign VAT fiscal positions 
Such fiscal positions define an alternate VAT for a specific region. When foreign_vat is set, a country must be set on the fiscal position; it'll be used to know for which tax report the fiscal position must be available as an alternate VAT (in the tax report; see enterprise branch). Note that it is possible to defined several foreign VATs for the same country, as long as they belong to different states within that country.

Note that this new feature is only for FOREIGN stuff; so, when you have to submit a tax report in different regions than yours. For example if you have a Belgian accounting, have French customers, and have a French VAT in addition to your Belgian VAT, to submit a tax report in France. For domestic operations, simply use your the vat field of your company, just like before.

[IMP] account: add country_id on taxes and filter them on invoices
The invoices now compute the country from which they should accept the taxes: it's either the one defined by fiscal_position_id.country_id (if fiscal_position_id is a foreign VAT fiscal position, i.e. it defines a foreign_vat value), or the company's account_fiscal_country_id.

Taxes from other countries are filtered from the view; we don't want them to be available there. There is also a constraint ensuring that. Same goes for tax repartition lines and tags from other countries.

We don't want to mix taxes, tags and foreign VAT fiscal positions from different countries, as it would break the tax report in enterprise. Doing this ensures the tax report can efficiently discriminate the move lines between the different regions whose report they have to appear in.

[IMP] account: add country_id to account.chart.template
This is done so that the taxes are created in the right country, and the fiscal country is initialized in a consistent way when instantiating the CoA on the company.

[IMP] account: print foreign VAT on invoice instead of company VAT if one is defined

[IMP] web: allow forcing company vat on document templates
This is done to allow the use of foreign vat fiscal position on invoices: in that case, we don't want to use the company VAT, but the value of fiscal_position_id.foreign_vat. So, when such a value exists, the invoice simply set the force_vat variable to the right value.

[IMP] base_vat: also validate VAT of foreign VAT fiscal positions
We generalize the code formerly only done for res.partner so that the foreign_vat field of account.fiscal.position can be checked in the same way.

[IMP] l10n_*: set newly-introduced country_id field on chart templates

[IMP] account, account_edi, l10n_*, purchase, sale: Generalize the use of account_fiscal_country_id
Before, account_fiscal_country_id was only use for tax operations; and country_id was used for all the other accounting stuff. Now, with the new ability to use foreign tax reports (with foreign VAT fiscal positions), we can generalize the fiscal country, sot that it is the one that needs to be used for the whole accounting. Since foreign tax reports were not supported before, account_fiscal_country_id is already set on existing database as the country for the "main" accounting, so the impact of this change is small.