### PR TITLE
[FIX] crm: Converting and merging leads into opportunities

### DIFF
--- a/addons/crm/wizard/crm_lead_to_opportunity.py
+++ b/addons/crm/wizard/crm_lead_to_opportunity.py
@@ -20,7 +20,7 @@ class Lead2OpportunityPartner(models.TransientModel):
         """
         result = super(Lead2OpportunityPartner, self).default_get(fields)
         if self._context.get('active_id'):
-            tomerge = {int(self._context['active_id'])}
+            tomerge = set(self._context.get('active_ids')) or {int(self._context['active_id'])}
 
             partner_id = result.get('partner_id')
             lead = self.env['crm.lead'].browse(self._context['active_id'])
@@ -173,8 +173,6 @@ class Lead2OpportunityMassConvert(models.TransientModel):
             res['action'] = 'each_exist_or_create'
         if 'name' in fields:
             res['name'] = 'convert'
-        if 'opportunity_ids' in fields:
-            res['opportunity_ids'] = False
         return res
 
     user_ids = fields.Many2many('res.users', string='Salesmen')


### PR DESCRIPTION
Steps to reproduce the bug:
    
- Let's consider two crm.lead records C1, C2
- Go to the tree view of Leads (CRM > Leads)
- Select C1, C2 and click on the action server Convert to Opportunities
- Choose Merge with existing opportunities
- Click on Convert to opportunities
    
Bug:
    
The following error message was raised
    
Please select more than one element (lead or opportunity) from the list view.

opw:2486883