### PR TITLE
[FIX] account: prevent excess calls of _get_lines_onchange_currency

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1264,12 +1264,9 @@ class AccountMove(models.Model):
             total_residual_currency = 0.0
             total = 0.0
             total_currency = 0.0
-            currencies = set()
+            currencies = move._get_lines_onchange_currency().currency_id
 
             for line in move.line_ids:
-                if line.currency_id and line in move._get_lines_onchange_currency():
-                    currencies.add(line.currency_id)
-
                 if move.is_invoice(include_receipts=True):
                     # === Invoices ===
 
@@ -1309,7 +1306,7 @@ class AccountMove(models.Model):
             move.amount_total_signed = abs(total) if move.move_type == 'entry' else -total
             move.amount_residual_signed = total_residual
 
-            currency = len(currencies) == 1 and currencies.pop() or move.company_id.currency_id
+            currency = len(currencies) == 1 and currencies or move.company_id.currency_id
 
             # Compute 'payment_state'.
             new_pmt_state = 'not_paid' if move.move_type != 'entry' else False


### PR DESCRIPTION
That method iterates over move lines:

https://github.com/odoo/odoo/blob/7623a0c771495cd41bf40af37c0d2b6e4beb7cdc/addons/stock_account/models/account_move.py#L16-L18

So, we have O(n^2) complexity at least. It leads to timeout error on invoices
with few hundres products. After this commit it takes 70 seconds to confirm an
invoice with 450 lines:

23527 11.038 56.530
(Number of queries / Query time, sec / Remaining time, sec)

---

https://github.com/odoo/odoo/commit/9e1aec7873a935b287b4b3c5dbc2688acee5422a
opw-2488458

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
