### PR TITLE
[FIX] hr_skills: Employee resume alignment on mobile

### DIFF
--- a/addons/hr_skills/static/src/css/hr_skills.scss
+++ b/addons/hr_skills/static/src/css/hr_skills.scss
@@ -56,7 +56,7 @@
             }
         }
 
-        .o_resume_line_desc {
+        .o_resume_line_title, .o_resume_line_desc {
             white-space: normal;
         }
 


### PR DESCRIPTION
Before this commit, you had to scroll horizontally to see
some options like "add" and "delete" in the "resumé" tab.
It's because long titles aren't break to the next line.

.o_resume_line_title had "white-space: nowrap" property because
of list view global rules.

Steps to reproduce:
- Go to "Employee"
- Select "Mitchell Admin"
- See "Université Libre de Bruxelles - Polytechnique" as title

Task-ID: 1929043