### PR TITLE
[FIX] project: set task's company using project's company

### DIFF
--- a/addons/project/i18n/project.pot
+++ b/addons/project/i18n/project.pot
@@ -2954,6 +2954,12 @@ msgid "You cannot delete a project containing tasks. You can either archive it o
 msgstr ""
 
 #. module: project
+#: code:addons/project/models/project.py:628
+#, python-format
+msgid "Your task must be in the same company as its project."
+msgstr ""
+
+#. module: project
 #: model_terms:ir.actions.act_window,help:project.open_view_project_all
 msgid "activate a sample project"
 msgstr ""


### PR DESCRIPTION
When fetching emails, the automatic creation of task sets the wrong
company.

To reproduce the error:
(Let C01 be the current company. Enable debug mode)
1. In Settings:
    - Enable External Email Servers
        - Set an alias domain (e.g., devodoo.com)
    - (If running locally, configure an incoming mail server)
2. Create a second company C02 and switch to C02
3. Create a project P
    - Set a project email (e.g., superproject@devodoo.com)
    - Add a column
4. Switch to C01
5. Send an email to superproject@superodoo.com
6. In Settings > Technical > Automation > Scheduled Actions, open "Mail:
Fetchmail Service"
7. Run it manually
8. Switch to C02 and open P

Error: A task should exist (from step 5). An SQL query reveals the
problem: the task is created, is linked to project P but the
`company_id` field is not correct (C01 instead of C02).

This fix is a partial backport of 070174658da1705def9bbd24d6de73c4013d662c
(This commit is applied from 13.0)

OPW-2404762