### PR TITLE
[FIX] account: don't allow two Bills from the same Vendor with the same Reference

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1629,7 +1629,6 @@ class AccountMove(models.Model):
                 AND move2.company_id = journal.company_id
                 AND move2.commercial_partner_id = partner.commercial_partner_id
                 AND move2.move_type = move.move_type
-                AND (move.invoice_date is NULL OR move2.invoice_date = move.invoice_date)
                 AND move2.id != move.id
             WHERE move.id IN %s
         ''', [tuple(moves.ids)])


### PR DESCRIPTION
Support ticket #2492862
Closes #68367

Restores the behavior in previous Odoo versions.
Allowing to enter the same bill twice gives too much space for user
error.

The case where there can be two different bills with the same number is
not valid in most jurisdictions, and can easily be solved by having the
user append the year to the bill reference.
Allowing it introduces much more risk, and is not a good trade-off.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
