### PR TITLE
[FIX] mail: command suggestion should only show if '/' is first char

### DIFF
--- a/addons/mail/static/src/components/composer/composer_tests.js
+++ b/addons/mail/static/src/components/composer/composer_tests.js
@@ -778,8 +778,8 @@ QUnit.test("channel with no commands should not prompt any command suggestions o
     );
 });
 
-QUnit.test('use a command after some text', async function (assert) {
-    assert.expect(5);
+QUnit.test('command suggestion should only open if command is the first character', async function (assert) {
+    assert.expect(4);
 
     this.data['mail.channel'].records.push({ channel_type: 'channel', id: 20 });
     this.data['mail.channel_command'].records.push(
@@ -821,18 +821,10 @@ QUnit.test('use a command after some text', async function (assert) {
         document.querySelector(`.o_ComposerTextInput_textarea`)
             .dispatchEvent(new window.KeyboardEvent('keyup'));
     });
-    assert.containsOnce(
+    assert.containsNone(
         document.body,
         '.o_ComposerSuggestion',
-        "should have a command suggestion"
-    );
-    await afterNextRender(() =>
-        document.querySelector('.o_ComposerSuggestion').click()
-    );
-    assert.strictEqual(
-        document.querySelector(`.o_ComposerTextInput_textarea`).value.replace(/\s/, " "),
-        "bluhbluh /who ",
-        "text content of composer should have previous content + used command + additional whitespace afterwards"
+        "should not have a command suggestion"
     );
 });
 

--- a/addons/mail/static/src/models/composer/composer.js
+++ b/addons/mail/static/src/models/composer/composer.js
@@ -720,6 +720,9 @@ function factory(dependencies) {
                     continue;
                 }
                 const candidateChar = this.textInputContent[candidatePosition];
+                if (candidateChar === '/' && candidatePosition !== 0) {
+                    continue;
+                }
                 if (!suggestionDelimiters.includes(candidateChar)) {
                     continue;
                 }


### PR DESCRIPTION
PURPOSE:

command suggestion should only open if a command is the first char.

SPECIFICATION:

command suggestion should only open if a command is the first char.

Task-2487518

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
