### PR TITLE
[FIX] web: update the values on the form when the dialog is closed without refreshing the browser

### DIFF
--- a/addons/web/static/src/js/views/view_dialogs.js
+++ b/addons/web/static/src/js/views/view_dialogs.js
@@ -118,6 +118,8 @@ var FormViewDialog = ViewDialog.extend({
                         self.form_view.model.discardChanges(self.form_view.handle, {
                             rollback: self.shouldSaveLocally,
                         });
+                    } else {
+                        self._save().then(self.close.bind(self));
                     }
                 },
             }];


### PR DESCRIPTION
 **Description of the issue/feature this PR addresses:**

**Current behavior before PR:**

No update the values on the form when the dialog is closed without refreshing the browser

**Desired behavior after PR is merged:**

Update the values on the form when the dialog is closed without refreshing the browser



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
