### PR TITLE
Master list editable renderer bug fix ges

### DIFF
--- a/addons/web/static/src/js/views/list/list_editable_renderer.js
+++ b/addons/web/static/src/js/views/list/list_editable_renderer.js
@@ -273,6 +273,19 @@ ListRenderer.include({
                     $(row).insertAfter($editedRow);
                 });
 
+                // Call on_attach_callback methods on widgets that implement it
+                if (self._isInDom) {
+                    for (const handle in self.allFieldWidgets) {
+                        if (handle !== id) {
+                            self.allFieldWidgets[handle].forEach(widget => {
+                                if (widget.on_attach_callback) {
+                                    widget.on_attach_callback();
+                                }
+                            });
+                        }
+                    }
+                }
+
                 if (self.currentRow !== null) {
                     var newRowIndex = $editedRow.prop('rowIndex') - 1;
                     self.currentRow = newRowIndex;

--- a/addons/web/static/src/js/views/list/list_editable_renderer.js
+++ b/addons/web/static/src/js/views/list/list_editable_renderer.js
@@ -230,6 +230,11 @@ ListRenderer.include({
                 }
             });
 
+             // Keep ref of the current row's widgets 
+             const currentRowFieldWidgets = self.allFieldWidgets[id];
+             // Remove it from the list just for a clean start for generating the new content (avoid later memory leak)
+             delete self.allFieldWidgets[id];
+
             // re-render whole body (outside the dom)
             self.defs = [];
             var $newBody = self._renderBody();
@@ -237,6 +242,12 @@ ListRenderer.include({
             delete self.defs;
 
             return Promise.all(defs).then(function () {
+                // All the field widgets have now be recreated, but we don't want the current row's ones.
+                // We destroy it and get it back from our reference. 
+                // This manipulation avoids a memory leak, where field widgets in the current row wouldn't be destroyed and were kept in memory.
+                self._destroyFieldWidgets(id);
+                self.allFieldWidgets[id] = currentRowFieldWidgets;
+
                 // update registered modifiers to edit 'mode' because the call to
                 // _renderBody set baseModeByRecord as 'readonly'
                 _.each(self.columns, function (node) {

--- a/addons/web/static/tests/fields/relational_fields/field_one2many_tests.js
+++ b/addons/web/static/tests/fields/relational_fields/field_one2many_tests.js
@@ -9835,6 +9835,43 @@ QUnit.module('fields', {}, function () {
             form.destroy();
             delete fieldRegistry.map.my_relational_field;
         });
+
+        QUnit.test("Editable list's field widgets call on_attach_callback on row update", async function (assert) {
+            // We use here a badge widget (owl component, does have a on_attach_callback method) and check its decoration
+            // is properly managed in this scenario.       
+            assert.expect(3);
+
+            this.data.partner.records[0].p = [1, 2];
+            const form = await createView({
+                View: FormView,
+                model: 'partner',
+                data: this.data,
+                arch: `
+                    <form>
+                        <field name="p">
+                            <tree editable="bottom">
+                                <field name="int_field"/>
+                                <field name="color" widget="badge" decoration-warning="int_field == 9"/>
+                            </tree>
+                        </field>
+                    </form>`,
+                res_id: 1,
+            });
+
+            assert.containsN(form, '.o_data_row', 2);
+            assert.hasClass(form.$('.o_data_row:nth(1) .o_field_badge'), 'bg-warning-light');
+
+            await testUtils.dom.click(form.$('.o_data_row .o_data_cell:first'));
+            await testUtils.owlCompatibilityExtraNextTick();
+            await testUtils.fields.editInput(form.$('.o_selected_row .o_field_integer'), '44');
+            await testUtils.owlCompatibilityExtraNextTick();
+
+            assert.hasClass(form.$('.o_data_row:nth(1) .o_field_badge'), 'bg-warning-light');
+
+            form.destroy();
+            delete fieldRegistry.map.my_field;
+        });
+
     });
 });
 });


### PR DESCRIPTION
Fixes two bugs in the list editable when used as a one2many representation. 
Both in the confirmUpdate function. 
First, the on_attach_callback would not be called after widgets are recreated. 
Second, a memory leak tied to the implementation of the one2many list update 
    => destroy and recreate all rows but current.
          The current row widgets are recreated as well and need to be destroyed.
 