### PR TITLE
[REM] various:remove widget='selection' on many2one fields

### DIFF
--- a/addons/account/views/account_bank_statement_views.xml
+++ b/addons/account/views/account_bank_statement_views.xml
@@ -162,7 +162,7 @@
                             <field name="journal_type" invisible="1"/>
                             <field name="cashbox_start_id" invisible="1"/>
                             <field name="cashbox_end_id" invisible="1"/>
-                            <field name="journal_id" domain="[('type', '=', journal_type)]" attrs="{'readonly': [('move_line_count','!=', 0)]}" widget="selection"/>
+                            <field name="journal_id" domain="[('type', '=', journal_type)]" attrs="{'readonly': [('move_line_count','!=', 0)]}" options="{'no_open': True, 'no_create': True}"/>
                             <field name="date"
                                    attrs="{'readonly': [('state', '!=', 'open')]}"
                                    options="{'datepicker': {'warn_future': true}}"/>

--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -265,7 +265,7 @@
                                 <field name="journal_id"
                                        domain="[('type', 'in', ('bank', 'cash'))]"
                                        attrs="{'readonly': [('state', '!=', 'draft')]}"/>
-                                <field name="payment_method_id" required="1" widget="selection"
+                                <field name="payment_method_id" required="1" options="{'no_open': True, 'no_create': True}"
                                        attrs="{'readonly': [('state', '!=', 'draft')], 'invisible': [('hide_payment_method', '=', True)]}"/>
 
                                 <field name="partner_bank_id" context="{'default_partner_id': partner_id}" string="Customer Bank Account"

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -203,10 +203,10 @@
                     </group>
                 </xpath>
                 <group name="sale" position="inside">
-                    <field string="Payment Terms" name="property_payment_term_id" widget="selection" groups="account.group_account_invoice,account.group_account_readonly"/>
+                    <field string="Payment Terms" name="property_payment_term_id" options="{'no_open': True, 'no_create': True}" groups="account.group_account_invoice,account.group_account_readonly"/>
                 </group>
                 <group name="purchase" position="inside">
-                    <field string="Payment Terms" name="property_supplier_payment_term_id" widget="selection" groups="account.group_account_invoice,account.group_account_readonly"/>
+                    <field string="Payment Terms" name="property_supplier_payment_term_id" options="{'no_open': True, 'no_create': True}" groups="account.group_account_invoice,account.group_account_readonly"/>
                 </group>
             </field>
         </record>

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -36,7 +36,7 @@
                                     <div class="content-group">
                                         <div class="row mt16">
                                             <label for="chart_template_id" string="Package" class="col-lg-3 o_light_label"/>
-                                            <field name="chart_template_id" widget="selection"/>
+                                            <field name="chart_template_id" options="{'no_open': True, 'no_create': True}"/>
                                         </div>
                                         <div class="mt8">
                                             <button name="%(account.open_account_charts_modules)d" icon="fa-arrow-right" type="action" string="Install More Packages" discard="0" class="btn-link"/>

--- a/addons/account/wizard/account_payment_register_views.xml
+++ b/addons/account/wizard/account_payment_register_views.xml
@@ -28,7 +28,7 @@
 
                     <group>
                         <group name="group1">
-                            <field name="journal_id" widget="selection" required="1"/>
+                            <field name="journal_id" options="{'no_open': True, 'no_create': True}" required="1"/>
                             <field name="payment_method_id" widget="radio"
                                    required="1"
                                    attrs="{'invisible': [('hide_payment_method', '=', True)]}"/>

--- a/addons/account/wizard/wizard_tax_adjustments_view.xml
+++ b/addons/account/wizard/wizard_tax_adjustments_view.xml
@@ -11,7 +11,7 @@
             </h1>
             <group>
                 <field name="report_id" invisible="1"/>
-                <field name="tax_report_line_id" widget="selection" domain="[('tag_name', '!=', None)]"/>
+                <field name="tax_report_line_id" options="{'no_open': True, 'no_create': True}" domain="[('tag_name', '!=', None)]"/>
             </group>
             <group>
                 <group>

--- a/addons/account_check_printing/views/res_partner_views.xml
+++ b/addons/account_check_printing/views/res_partner_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.view_partner_property_form"/>
         <field name="arch" type="xml">
             <field name="property_supplier_payment_term_id" position="after">
-                <field name="property_payment_method_id" widget="selection" groups="account.group_account_invoice,account.group_account_readonly"/>
+                <field name="property_payment_method_id" options="{'no_open': True, 'no_create': True}" groups="account.group_account_invoice,account.group_account_readonly"/>
             </field>
         </field>
     </record>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -237,7 +237,7 @@
                             <group>
                                 <field name="user_id"
                                     context="{'default_sales_team_id': team_id}" widget="many2one_avatar_user"/>
-                                <field name="team_id" widget="selection"/>
+                                <field name="team_id" options="{'no_open': True, 'no_create': True}"/>
                                 <field name="type" invisible="1"/>
                             </group>
                             <group name="lead_priority" attrs="{'invisible': [('type', '=', 'opportunity')]}">

--- a/addons/crm/wizard/crm_lead_to_opportunity_views.xml
+++ b/addons/crm/wizard/crm_lead_to_opportunity_views.xml
@@ -10,7 +10,7 @@
                 </group>
                 <group string="Assign this opportunity to">
                     <field name="user_id" domain="[('share', '=', False)]"/>
-                    <field name="team_id" widget="selection"/>
+                    <field name="team_id" options="{'no_open': True, 'no_create': True}"/>
                 </group>
                 <group string="Opportunities" attrs="{'invisible': [('name', '!=', 'merge')]}">
                     <field name="lead_id" invisible="1"/>

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -147,7 +147,7 @@
                             <label for="quantity" attrs="{'invisible': [('product_has_cost', '=', False)]}"/>
                             <div class="o_row" attrs="{'invisible': [('product_has_cost', '=', False)]}">
                                 <field name="quantity" class="oe_inline"/>
-                                <field name="product_uom_id" required="1" widget="selection" class="oe_inline" groups="uom.group_uom"/>
+                                <field name="product_uom_id" required="1" options="{'no_open': True, 'no_create': True}" class="oe_inline" groups="uom.group_uom"/>
                             </div>
 
                             <label for="total_amount" attrs="{'invisible': [('product_has_cost', '=', True)]}"/>

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -166,7 +166,7 @@
                             <div name="mailing_model_id_container">
                                 <div class="row">
                                     <div class="col-xs-12 col-md-3" >
-                                        <field name="mailing_model_id" widget="selection"
+                                        <field name="mailing_model_id" options="{'no_open': True, 'no_create': True}"
                                             attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
                                     </div>
                                     <div attrs="{'invisible': [('mailing_model_name', '!=', 'mailing.list')]}" class="col-xs-12 col-md-9 pt-1">

--- a/addons/membership/wizard/membership_invoice_views.xml
+++ b/addons/membership/wizard/membership_invoice_views.xml
@@ -7,7 +7,7 @@
             <field name="arch" type="xml">
                 <form string="Membership Invoice">
                     <group>
-                        <field name="product_id" domain="[('membership','=',True)]" widget="selection"/>
+                        <field name="product_id" domain="[('membership','=',True)]" options="{'no_open': True, 'no_create': True}"/>
                         <field name="member_price"/>
                     </group>
                     <footer>

--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -450,7 +450,7 @@
                 <sheet>
                     <group>
                         <field name="name"/>
-                        <field name="loss_id" widget="selection"/>
+                        <field name="loss_id" options="{'no_open': True, 'no_create': True}"/>
                     </group>
                 </sheet>
             </form>

--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -581,7 +581,7 @@
                                 </div>
                                 <div class="content-group">
                                     <div class="row mt16" title="Whenever you close a session, one entry is generated in the following accounting journal for all the orders not invoiced. Invoices are recorded in accounting separately.">
-                                        <label string="Sales Journal" for="journal_id" class="col-lg-3 o_light_label" widget="selection"/>
+                                        <label string="Sales Journal" for="journal_id" class="col-lg-3 o_light_label" options="{'no_open': True, 'no_create': True}"/>
                                         <field name="journal_id" required="1" domain="[('company_id', '=', company_id), ('type', '=', 'sale')]" context="{'default_company_id': company_id, 'default_type': 'sale'}"/>
                                     </div>
                                 </div>

--- a/addons/purchase_requisition_stock/views/purchase_requisition_views.xml
+++ b/addons/purchase_requisition_stock/views/purchase_requisition_views.xml
@@ -7,7 +7,7 @@
             <field name="inherit_id" ref="purchase_requisition.view_purchase_requisition_form" />
             <field name="arch" type="xml">
                 <field name="origin" position="after">
-                    <field name="picking_type_id" widget="selection" groups="stock.group_adv_location" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
+                    <field name="picking_type_id" options="{'no_open': True, 'no_create': True}" groups="stock.group_adv_location" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
                 </field>
             </field>
         </record>

--- a/addons/sale_stock/views/sale_order_views.xml
+++ b/addons/sale_stock/views/sale_order_views.xml
@@ -22,7 +22,7 @@
                 </xpath>
                 <xpath expr="//label[@for='commitment_date']" position="before">
                     <field name="warehouse_id" options="{'no_create': True}" groups="stock.group_stock_multi_warehouses" force_save="1"/>
-                    <field name="incoterm" widget="selection" groups="sale_stock.group_display_incoterm"/>
+                    <field name="incoterm" options="{'no_open': True, 'no_create': True}" groups="sale_stock.group_display_incoterm"/>
                     <field name="picking_policy" required="True"/>
                 </xpath>
                 <xpath expr="//span[@name='expected_date_span']" position="attributes">

--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -171,7 +171,7 @@
                         </group>
                         <group>
                             <field name="allowed_location_ids" invisible="1"/>
-                            <field name="warehouse_id" widget="selection" groups="stock.group_stock_multi_locations"/>
+                            <field name="warehouse_id" options="{'no_open': True, 'no_create': True}" groups="stock.group_stock_multi_locations"/>
                             <field name="location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations" domain="[('id', 'in', allowed_location_ids)]"/>
                             <label for="group_id" groups="base.group_no_one"/>
                             <div groups="base.group_no_one">

--- a/addons/stock/wizard/stock_change_product_qty_views.xml
+++ b/addons/stock/wizard/stock_change_product_qty_views.xml
@@ -9,7 +9,7 @@
                     <group>
                         <field name="product_tmpl_id" invisible="1"/>
                         <field name="product_variant_count" invisible="1"/>
-                        <field name="product_id" widget="selection"
+                        <field name="product_id" options="{'no_open': True, 'no_create': True}"
                             domain="[('product_tmpl_id', '=', product_tmpl_id)]"
                             attrs="{'invisible': [('product_variant_count', '=', 1)]}"
                             invisible="context.get('default_product_id')"

--- a/addons/website/views/res_config_settings_views.xml
+++ b/addons/website/views/res_config_settings_views.xml
@@ -17,7 +17,7 @@
                                         Settings on this page will apply to this website
                                     </div>
                                     <div class="mt16">
-                                        <field name="website_id" widget="selection"/>
+                                        <field name="website_id" options="{'no_open': True, 'no_create': True}"/>
                                     </div>
                                     <div>
                                         <button name="action_website_create_new" type="object" string="Create a New Website" class="btn-secondary" icon="fa-arrow-right"/>
@@ -87,7 +87,7 @@
                                         <field name="website_language_count" invisible="1"/>
                                         <div class="mt8" attrs="{'invisible':[('website_language_count', '&lt;', 2)]}">
                                             <label class="o_light_label mr8" string="Default" for="website_default_lang_id"/>
-                                            <field name="website_default_lang_id" widget="selection" attrs="{'required': [('website_id', '!=', False)]}"/>
+                                            <field name="website_default_lang_id" options="{'no_open': True, 'no_create': True}" attrs="{'required': [('website_id', '!=', False)]}"/>
                                         </div>
                                     </div>
                                     <div class="mt8">

--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -39,8 +39,8 @@
                         </div>
                         <div name="other">
                             <group name="other">
-                                <field name="company_id" widget="selection" groups="base.group_multi_company"/>
-                                <field name="default_lang_id" widget="selection" groups="base.group_no_one"/>
+                                <field name="company_id" options="{'no_open': True, 'no_create': True}" groups="base.group_multi_company"/>
+                                <field name="default_lang_id" options="{'no_open': True, 'no_create': True}" groups="base.group_no_one"/>
                             </group>
                         </div>
                         <notebook>

--- a/addons/website_crm_partner_assign/views/res_partner_views.xml
+++ b/addons/website_crm_partner_assign/views/res_partner_views.xml
@@ -134,8 +134,8 @@
                     <group>
                         <group>
                             <separator string="Partner Activation" colspan="2"/>
-                            <field name="grade_id" widget="selection"/>
-                            <field name="activation" widget="selection"/>
+                            <field name="grade_id" options="{'no_open': True, 'no_create': True}"/>
+                            <field name="activation" options="{'no_open': True, 'no_create': True}"/>
                             <field name="partner_weight"/>
                         </group>
                         <group>

--- a/odoo/addons/base/views/ir_module_views.xml
+++ b/odoo/addons/base/views/ir_module_views.xml
@@ -88,7 +88,7 @@
                                 <group>
                                     <field name="has_iap" invisible="1"/>
                                     <field name="website" widget="url" attrs="{'invisible':[('website','=',False)]}"/>
-                                    <field name="category_id" widget="selection"/>
+                                    <field name="category_id" options="{'no_open': True, 'no_create': True}"/>
                                     <field name="summary"/>
                                     <field name="to_buy" invisible="1"/>
                                 </group>


### PR DESCRIPTION
currently, Across Odoo, there are around 40+ many2one fields defined with a
'selection' widget. Since the many2one widget has options to limit record
creation and opening, there is no reason to define a many2one field with a
selection widget. The selection widget does not allow for searching, and is
limited to 100 records.

PURPOSE
to update the definition of any many2one on which we applied a 'selection'
 widget, and instead use the standard many2one widget with disabled
opening/creation instead.

after this commit,
for each many2one field defined with widget="selection",  widget="selection" is
replaced with options="{'no_open': True, 'no_create': True}"

Task : 2476488

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
