### PR TITLE
[FIX] sale: reposition tooltip to avoid resize flicker

### DIFF
--- a/addons/account/static/src/js/tours/account.js
+++ b/addons/account/static/src/js/tours/account.js
@@ -19,6 +19,7 @@ tour.register('account_tour', {
         trigger: "button[name=action_save_onboarding_company_step]",
         extra_trigger: "a.o_onboarding_step_action[data-method=action_open_base_onboarding_company]",
         content: _t("Looks good. Let's continue."),
+        position: "left",
     }, {
         trigger: "a.o_onboarding_step_action[data-method=action_open_base_document_layout]",
         content: _t("Customize your layout."),
@@ -27,6 +28,7 @@ tour.register('account_tour', {
         trigger: "button[name=document_layout_save]",
         extra_trigger: "a.o_onboarding_step_action[data-method=action_open_base_document_layout]",
         content: _t("Once everything is as you want it, validate."),
+        position: "left",
     }, {
         trigger: "a.o_onboarding_step_action[data-method=action_open_account_onboarding_create_invoice]",
         content: _t("Now, we'll create your first invoice."),
@@ -84,6 +86,7 @@ tour.register('account_tour', {
         trigger: "button[name=send_and_print_action]",
         extra_trigger: "[name=move_type][raw-value=out_invoice]",
         content: _t("Let's send the invoice."),
+        position: "left"
     }
 ]);
 

--- a/addons/purchase/static/src/js/tours/purchase.js
+++ b/addons/purchase/static/src/js/tours/purchase.js
@@ -112,7 +112,7 @@ tour.register('purchase_tour' , {
     trigger: ".modal-footer button[name='action_send_mail']",
     extra_trigger: ".modal-footer button[name='action_send_mail']",
     content: _t("Send the request for quotation to your vendor."),
-    position: "bottom",
+    position: "left",
     run: 'click',
 }, {
     trigger: ".ui-sortable-handle",

--- a/addons/sale/static/src/js/tours/sale.js
+++ b/addons/sale/static/src/js/tours/sale.js
@@ -28,7 +28,7 @@ tour.register("sale_tour", {
 }, {
     trigger: ".modal-content button[name='action_save_onboarding_company_step']",
     content: _t("Looks good. Let's continue."),
-    position: "bottom",
+    position: "left",
 }, {
     trigger: 'a.o_onboarding_step_action.btn[data-method=action_open_base_document_layout]',
     extra_trigger: ".o_sale_order",


### PR DESCRIPTION
The tour bubble "animation" that makes it to bounce up and down can cause
issues when its position is at the edge of the bottom of the screen.

In the sale tour, this would make the window constantly resize to show a
scrollbar and then resize to hide the scrollbar, creating quite a sickening
effect visually.

Task-Id: 2480195