### PR TITLE
[FIX] point_of_sale: correctly assign product in move

### DIFF
--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -138,10 +138,8 @@ class StockPicking(models.Model):
                                     self.env['stock.move.line'].create(ml_vals)
                     else:
                         move._action_assign()
-                        sum_of_lots = 0
                         for move_line in move.move_line_ids:
                             move_line.qty_done = move_line.product_uom_qty
-                            sum_of_lots += move_line.product_uom_qty
                         if float_compare(move.product_uom_qty, move.quantity_done, precision_rounding=move.product_uom.rounding) > 0:
                             remaining_qty = move.product_uom_qty - move.quantity_done
                             ml_vals = move._prepare_move_line_vals()
@@ -149,6 +147,14 @@ class StockPicking(models.Model):
                             self.env['stock.move.line'].create(ml_vals)
 
                 else:
+                    move._action_assign()
+                    for move_line in move.move_line_ids:
+                        move_line.qty_done = move_line.product_uom_qty
+                    if float_compare(move.product_uom_qty, move.quantity_done, precision_rounding=move.product_uom.rounding) > 0:
+                        remaining_qty = move.product_uom_qty - move.quantity_done
+                        ml_vals = move._prepare_move_line_vals()
+                        ml_vals.update({'qty_done':remaining_qty})
+                        self.env['stock.move.line'].create(ml_vals)
                     move.quantity_done = move.product_uom_qty
 
     def _send_confirmation_email(self):

--- a/addons/point_of_sale/tests/test_pos_stock_account.py
+++ b/addons/point_of_sale/tests/test_pos_stock_account.py
@@ -201,3 +201,47 @@ class TestPoSStock(TestPoSCommon):
 
         self.assertTrue(receivable_line_cash.full_reconcile_id, msg='Cash receivable line should be fully-reconciled.')
         self.assertTrue(output_line.full_reconcile_id, msg='The stock output account line should be fully-reconciled.')
+
+    def test_03_order_product_w_owner(self):
+        """
+        Test order via POS a product having stock owner.
+        """
+
+        self.product4 = self.create_product('Product 3', self.categ_basic, 30.0, 15.0)
+        inventory = self.env['stock.inventory'].create({
+            'name': 'Inventory adjustment'
+        })
+        self.env['stock.inventory.line'].create({
+            'product_id': self.product4.id,
+            'product_uom_id': self.env.ref('uom.product_uom_unit').id,
+            'inventory_id': inventory.id,
+            'product_qty': 10,
+            'partner_id': self.partner_a.id,
+            'location_id': self.stock_location_components.id,
+        })
+        inventory._action_start()
+        inventory.action_validate()
+
+        self.open_new_session()
+
+        # create orders
+        orders = []
+        orders.append(self.create_ui_order_data([(self.product4, 1)]))
+
+        # sync orders
+        order = self.env['pos.order'].create_from_ui(orders)
+
+        # check values before closing the session
+        self.assertEqual(1, self.pos_session.order_count)
+
+        # check product qty_available after syncing the order
+        self.assertEqual(self.product4.qty_available, 9)
+
+        # picking and stock moves should be in done state
+        for order in self.pos_session.order_ids:
+            self.assertEqual(order.picking_ids[0].state, 'done', 'Picking should be in done state.')
+            self.assertTrue(all(state == 'done' for state in order.picking_ids[0].move_lines.mapped('state')), 'Move Lines should be in done state.' )
+            self.assertTrue(self.partner_a == order.picking_ids[0].move_lines[0].move_line_ids[0].owner_id, 'Move Lines Owner should be taken into account.' )
+
+        # close the session
+        self.pos_session.action_pos_session_validate()


### PR DESCRIPTION
1. Have a [DEMO] product in stock with an owner
2. Make a PoS order with [DEMO]

The system will use the stock without owner.

opw-2480341

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
