### PR TITLE
[FIX] stock_account : error if bom is not available

### DIFF
--- a/addons/mrp_account/models/product.py
+++ b/addons/mrp_account/models/product.py
@@ -48,7 +48,7 @@ class ProductProduct(models.Model):
         if stock_moves:
             product_moves = defaultdict(lambda: self.env['stock.move'])
             for sm in stock_moves:
-                product_moves[sm.product_id] |= stock_moves
+                product_moves[sm.product_id] |= sm
             value = 0
             for product, moves in product_moves.items():
                 qty = sum(moves.mapped('product_qty'))


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Create a phantom BOM for product A, 
Sale product A.
Archive the BOM, and create a new for product A.
Valide the picking.
--> Error

Because the bom_line_id should perfect fit with the bom find with _bom_find.

Fine tuning of https://github.com/odoo/odoo/commit/827f65f70634ba7a2e4175f20e5301e514ada0a0

@amoyaux 


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
