### PR TITLE
[IMP] mail: empty inbox design improvement

### DIFF
--- a/addons/mail/static/src/components/message_list/message_list.scss
+++ b/addons/mail/static/src/components/message_list/message_list.scss
@@ -15,6 +15,10 @@
     &:not(.o-empty) {
         padding-bottom: 15px;
     }
+
+    .o_view_nocontent {
+        position: unset !important;
+    }
 }
 
 .o_MessageList_empty {
@@ -78,7 +82,6 @@
 
 .o_MessageList_empty {
     text-align: center;
-    font-style: italic;
     color: $text-muted;
 }
 

--- a/addons/mail/static/src/components/message_list/message_list.xml
+++ b/addons/mail/static/src/components/message_list/message_list.xml
@@ -6,34 +6,38 @@
             <t t-if="threadView">
                 <!-- No result messages -->
                 <t t-if="threadView.nonEmptyMessages.length === 0">
-                    <div class="o_MessageList_empty o_MessageList_item">
-                        <t t-if="threadView.thread === env.messaging.inbox">
-                            <div class="o_MessageList_emptyTitle">
-                                Congratulations, your inbox is empty
-                            </div>
-                            New messages appear here.
-                        </t>
-                        <t t-elif="threadView.thread === env.messaging.starred">
-                            <div class="o_MessageList_emptyTitle">
-                                No starred messages
-                            </div>
-                            You can mark any message as 'starred', and it shows up in this mailbox.
-                        </t>
-                        <t t-elif="threadView.thread === env.messaging.history">
-                            <div class="o_MessageList_emptyTitle o-neutral-face-icon">
-                                No history messages
-                            </div>
-                            Messages marked as read will appear in the history.
-                        </t>
-                        <t t-elif="threadView.thread === env.messaging.moderation">
-                            <div class="o_MessageList_emptyTitle">
-                                You have no messages to moderate.
-                            </div>
-                            Messages pending moderation appear here.
-                        </t>
-                        <t t-else="">
-                            There are no messages in this conversation.
-                        </t>
+                    <div class="o_view_nocontent">
+                        <div class="o_MessageList_empty o_MessageList_item o_nocontent_help">
+                            <t t-if="threadView.thread === env.messaging.inbox">
+                                <!-- Test -->
+                                <div id="o_mail_test"/>
+                                <div class="o_MessageList_emptyTitle o_view_nocontent_smiling_face">
+                                    Congratulations, your inbox is empty
+                                </div>
+                                New messages appear here.
+                            </t>
+                            <t t-elif="threadView.thread === env.messaging.starred">
+                                <div class="o_MessageList_emptyTitle">
+                                    No starred messages
+                                </div>
+                                You can mark any message as 'starred', and it shows up in this mailbox.
+                            </t>
+                            <t t-elif="threadView.thread === env.messaging.history">
+                                <div class="o_MessageList_emptyTitle o-neutral-face-icon">
+                                    No history messages
+                                </div>
+                                Messages marked as read will appear in the history.
+                            </t>
+                            <t t-elif="threadView.thread === env.messaging.moderation">
+                                <div class="o_MessageList_emptyTitle">
+                                    You have no messages to moderate.
+                                </div>
+                                Messages pending moderation appear here.
+                            </t>
+                            <t t-else="">
+                                There are no messages in this conversation.
+                            </t>
+                        </div>
                     </div>
                 </t>
                 <!-- LOADING (if order asc)-->


### PR DESCRIPTION
The design of the empty inbox of the 'Discuss' app has been improved by
adding an image that would give the user a sense of accomplishment and
by changing the font-styles previously found in that user case, in 
order to improve this text in terms of design.

In this way, in this commit we will be using the 'smiling_face.svg',
invoked by the class '.o_view_nocontent_smiling_face', which we
already use in Odoo, in situations where the user has no contents.

--

task-2440593

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
