### PR TITLE
[FIX] pad_project: fix project view

### DIFF
--- a/addons/pad_project/views/project_views.xml
+++ b/addons/pad_project/views/project_views.xml
@@ -20,14 +20,6 @@
         <field name="model">project.project</field>
         <field name="inherit_id" ref="project.edit_project"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='description']" position="attributes">
-                <attribute name="attrs">{'invisible': [('use_pads', '=', True)], 'readonly': [('use_pads', '=', True)]}</attribute>
-            </xpath>
-            <field name="description" position="after">
-                <field name="use_pads" invisible="1"/>
-                <field name="description_pad" widget="pad" nolabel="1"
-                       attrs="{'invisible': [('use_pads', '=', False)], 'readonly': [('use_pads', '=', False)]}"/>
-            </field>
             <xpath expr="//div[@id='rating_settings']" position="after">
                 <div class="col-lg-6 o_setting_box" id="pad_settings">
                     <div class="o_setting_left_pane">


### PR DESCRIPTION
Prior to this commit the install of pad_project crashed because it
tries to add a the description_pad field bellow the description field in
the project form view, which was part of the description notebook that
has beeen removed in #66589.

After this commit the description_pad will not more be added in the project view.

Deletion of the fields in the model will be assessed with the PO.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
