### PR TITLE
[IMP] - account, * : clarify the UX of warnings on partner.

### DIFF
--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -136,7 +136,7 @@
                         <separator string="Warning on the Invoice" colspan="4"/>
                         <field name="invoice_warn" nolabel="1" />
                         <field name="invoice_warn_msg" colspan="3" nolabel="1"
-                                attrs="{'required':[('invoice_warn', '!=', False), ('invoice_warn','!=','no-message')],'readonly':[('invoice_warn','=','no-message')]}"/>
+                            attrs="{'required':[('invoice_warn','!=', False), ('invoice_warn','!=','no-message')], 'invisible':[('invoice_warn','in',(False,'no-message'))]}"/>
                     </group>
                 </page>
             </field>

--- a/addons/purchase/views/res_partner_views.xml
+++ b/addons/purchase/views/res_partner_views.xml
@@ -91,7 +91,7 @@
                         <separator string="Warning on the Purchase Order" colspan="4"/>
                         <field name="purchase_warn" nolabel="1" />
                         <field name="purchase_warn_msg" colspan="3" nolabel="1"
-                                attrs="{'required':[('purchase_warn', '!=', False), ('purchase_warn','!=','no-message')],'readonly':[('purchase_warn','=','no-message')]}"/>
+                            attrs="{'required':[('purchase_warn','!=', False), ('purchase_warn','!=','no-message')], 'invisible':[('purchase_warn','in',(False,'no-message'))]}"/>
                     </group>
                 </page>
             </field>

--- a/addons/sale/views/res_partner_views.xml
+++ b/addons/sale/views/res_partner_views.xml
@@ -51,7 +51,7 @@
                         <separator string="Warning on the Sales Order" colspan="4" />
                             <field name="sale_warn" nolabel="1" />
                             <field name="sale_warn_msg" colspan="3" nolabel="1"
-                                    attrs="{'required':[('sale_warn', '!=', False), ('sale_warn','!=','no-message')],'readonly':[('sale_warn','=','no-message')]}"/>
+                                    attrs="{'required':[('sale_warn','!=', False), ('sale_warn','!=','no-message')], 'invisible':[('sale_warn','in',(False,'no-message'))]}"/>
                     </group>
                 </page>
             </field>

--- a/addons/stock/views/res_partner_views.xml
+++ b/addons/stock/views/res_partner_views.xml
@@ -31,7 +31,7 @@
                     <separator string="Warning on the Picking" colspan="4"/>
                     <field name="picking_warn" nolabel="1" />
                     <field name="picking_warn_msg" colspan="3" nolabel="1" 
-                            attrs="{'required':[('picking_warn', '!=', False), ('picking_warn','!=','no-message')],'readonly':[('picking_warn','=','no-message')]}"/>
+                        attrs="{'required':[('picking_warn','!=', False), ('picking_warn','!=','no-message')], 'invisible':[('picking_warn','in',(False,'no-message'))]}"/>
                 </group>
             </page>
         </field>


### PR DESCRIPTION
*, purchase, sale, stock.

  Before, the warning messages, if any, were always visible below the
  warning option (emplty selection, No message, Warning, Blocking Message),
  making it unclear for the user when selecting No message and seeing
  the error message just below (as readonly).
  
  Now, make the message invisible if the message option is empty or No Message.
  Therefore the user is not confused by not relevant message, and it eases
  the message editing process (before, user could see readonly message and
  change selection field value before editing).
  
  Task ID - 2481450
  COM PR - odoo/odoo#68417

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr