### PR TITLE
13.0 doc type translate with less chars

### DIFF
--- a/addons/l10n_cl/i18n/es.po
+++ b/addons/l10n_cl/i18n/es.po
@@ -255,7 +255,7 @@ msgstr "Notas de Débito"
 #. module: l10n_cl
 #: model:ir.model.fields,field_description:l10n_cl.field_account_move__l10n_latam_document_type_id_code
 msgid "Doc Type"
-msgstr "Tipo documento"
+msgstr "T.doc"
 
 #. module: l10n_cl
 #: code:addons/l10n_cl/models/account_move.py:0


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Enhance view reducing "doc type" column size

Current behavior before PR:
The column Doc Type, once translated take up too much space in the list, truncating other essential information in the list

Desired behavior after PR is merged:
The with of the column Doc Type (first left) is reduced and the report is seen without the need of zooming it



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
