### PR TITLE
[FIX] l10n_cl: restore missing l10n_latam_document_number from cl tree view

### DIFF
--- a/addons/l10n_cl/views/account_move_view.xml
+++ b/addons/l10n_cl/views/account_move_view.xml
@@ -21,6 +21,7 @@
         <field name="arch" type="xml">
             <tree decoration-info="state == 'draft'" default_order="create_date" string="Invoices and Refunds" decoration-muted="state == 'cancel'" js_class="account_tree">
                 <field name="l10n_latam_document_type_id_code"/>
+                <field name="l10n_latam_document_number" string="Folio"/>
                 <field name="partner_id_vat"/>
                 <field name="partner_id"/>
                 <field name="invoice_date" optional="show"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The folio number is missing in the tree view.  This was present in 13.0 but somehow was lost during forward

Current behavior before PR:
In the l10n-cl invoice tree view, the invoice number (folio) is missing 

Desired behavior after PR is merged:
The invoice number is visible in the tree view again (as in 13).

This should be forwarded to the master branch as well.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
