### PR TITLE
Added support for peertube to web_editor and website_slides

### DIFF
--- a/addons/web_editor/static/src/js/editor/rte.summernote.js
+++ b/addons/web_editor/static/src/js/editor/rte.summernote.js
@@ -1050,7 +1050,7 @@ $.summernote.lang.odoo = {
       videoLink: _t('Video Link'),
       insert: _t('Insert Video'),
       url: _t('Video URL?'),
-      providers: _t('(YouTube, Vimeo, Vine, Instagram, DailyMotion or Youku)')
+      providers: _t('(YouTube, Vimeo, Vine, Instagram, DailyMotion, Youku or PeerTube)')
     },
     table: {
       table: _t('Table')

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
@@ -1460,6 +1460,7 @@ var VideoWidget = MediaWidget.extend({
             vimeo: /\/\/(player.)?vimeo.com\/([a-z]*\/)*([0-9]{6,11})[?]?.*/,
             dailymotion: /.+dailymotion.com\/(video|hub|embed)\/([^_?]+)[^#]*(#video=([^_&]+))?/,
             youku: /(.*).youku\.com\/(v_show\/id_|embed\/)(.+)/,
+            peerTube: /\/\/(.*)\/videos\/(?:watch|embed)\/([^?]*)/,
         };
         const matches = _.mapObject(regexes, regex => url.match(regex));
         const autoplay = options.autoplay ? '?autoplay=1&mute=1' : '?autoplay=0';
@@ -1494,8 +1495,11 @@ var VideoWidget = MediaWidget.extend({
             const videoId = matches.youku[3].indexOf('.html?') >= 0 ? matches.youku[3].substring(0, matches.youku[3].indexOf('.html?')) : matches.youku[3];
             embedURL = `//player.youku.com/embed/${videoId}`;
             type = 'youku';
+        } else if (matches.peerTube && matches.peerTube[1].length){
+                  const peerTubeAutoplay = autoplay.replace('mute', 'muted');
+                  embedURL = `//${matches.peerTube[1]}/videos/embed/${matches.peerTube[2]}${peerTubeAutoplay}${loop}`;
+                  type = 'peertube';
         }
-
         return {type: type, embedURL: embedURL};
     },
 });

--- a/addons/website_slides/__manifest__.py
+++ b/addons/website_slides/__manifest__.py
@@ -14,7 +14,7 @@ Featuring
 
  * Integrated course and lesson management
  * Fullscreen navigation
- * Support Youtube videos, Google documents, PDF, images, web pages
+ * Support Youtube & PeerTube videos, Google documents, PDF, images, web pages
  * Test knowledge with quizzes
  * Filter and Tag
  * Statistics

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -1054,7 +1054,7 @@ class WebsiteSlides(WebsiteProfile):
         unused, document_id = Slide._find_document_data_from_url(data['url'])
         preview = {}
         if not document_id:
-            preview['error'] = _('Please enter valid youtube or google doc url')
+            preview['error'] = _('Please enter valid youtube, google doc or peertube url')
             return preview
         existing_slide = Slide.search([('channel_id', '=', int(data['channel_id'])), ('document_id', '=', document_id)], limit=1)
         if existing_slide:

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -344,7 +344,7 @@ class Slide(models.Model):
                 record.embed_code = '<iframe src="%s" class="o_wslides_iframe_viewer" allowFullScreen="true" height="%s" width="%s" frameborder="0"></iframe>' % (slide_url, 315, 420)
             elif record.slide_type == 'video' and record.document_id:
                 if not record.mime_type:
-                    if re.search('\/videos\/(?:watch|embed)\/.*', record.url):
+                    if re.search('r\/videos\/(?:watch|embed)\/.*', record.url):
                         embedurl = re.sub('watch', 'embed', record.url)
                         record.embed_code = '<iframe src="%s?api=1" frameborder="0" sandbox="allow-same-origin allow-scripts" allowfullscreen="allowfullscreen"></iframe>' % (embedurl)
                     else:
@@ -757,7 +757,7 @@ class Slide(models.Model):
             split_path = url_obj.path.split('/')
             if len(split_path) >= 3 and split_path[1] in ('v', 'embed'):
                 return ('youtube', split_path[2])
-        peertube = re.match('.*\/videos\/(?:watch|embed)\/(.*)', url_obj.to_url())
+        peertube = re.match(r'.*\/videos\/(?:watch|embed)\/(.*)', url_obj.to_url())
         if peertube:
             return ('peertube', peertube.group(1))
         expr = re.compile(r'(^https:\/\/docs.google.com|^https:\/\/drive.google.com).*\/d\/([^\/]*)')
@@ -772,12 +772,12 @@ class Slide(models.Model):
         document_source, document_id = self._find_document_data_from_url(url)
         if document_source and hasattr(self, '_parse_%s_document' % document_source):
             if document_source == 'peertube':
-                return getattr(self, '_parse_%s_document' % document_source)(document_id,url, only_preview_fields)
+                return getattr(self, '_parse_%s_document' % document_source)(document_id, url, only_preview_fields)
             else:
                 return getattr(self, '_parse_%s_document' % document_source)(document_id, only_preview_fields)
             return {'error': _('Unknown document')}
 
-    def _parse_peertube_document(self, document_id,url, only_preview_fields):
+    def _parse_peertube_document(self, document_id, url, only_preview_fields):
         base_url = re.search(r'(.*)(?:\/videos\/.*)', url).group(1)
         fetch_res = self._fetch_data(base_url+'/api/v1/videos/'+document_id, {}, 'json')
         if fetch_res.get('error'):
@@ -805,7 +805,7 @@ class Slide(models.Model):
                 'description': fetch_res['values'].get('description'),
                 'mime_type': False,
             })
-        return {'values': values}  
+        return {'values': values}
 
     def _parse_youtube_document(self, document_id, only_preview_fields):
         """ If we receive a duration (YT video), we use it to determine the slide duration.

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -344,8 +344,8 @@ class Slide(models.Model):
                 record.embed_code = '<iframe src="%s" class="o_wslides_iframe_viewer" allowFullScreen="true" height="%s" width="%s" frameborder="0"></iframe>' % (slide_url, 315, 420)
             elif record.slide_type == 'video' and record.document_id:
                 if not record.mime_type:
-                    if re.search('\/videos\/(?:watch|embed)\/.*',record.url):
-                        embedurl = re.sub('watch','embed', record.url)
+                    if re.search('\/videos\/(?:watch|embed)\/.*', record.url):
+                        embedurl = re.sub('watch', 'embed', record.url)
                         record.embed_code = '<iframe src="%s?api=1" frameborder="0" sandbox="allow-same-origin allow-scripts" allowfullscreen="allowfullscreen"></iframe>' % (embedurl)
                     else:
                         # embed youtube video
@@ -757,10 +757,9 @@ class Slide(models.Model):
             split_path = url_obj.path.split('/')
             if len(split_path) >= 3 and split_path[1] in ('v', 'embed'):
                 return ('youtube', split_path[2])
-        peertube = re.match('.*\/videos\/(?:watch|embed)\/(.*)',url_obj.to_url())
+        peertube = re.match('.*\/videos\/(?:watch|embed)\/(.*)', url_obj.to_url())
         if peertube:
-            return ('peertube',peertube.group(1))
-        
+            return ('peertube', peertube.group(1))
         expr = re.compile(r'(^https:\/\/docs.google.com|^https:\/\/drive.google.com).*\/d\/([^\/]*)')
         arg = expr.match(url)
         document_id = arg and arg.group(2) or False
@@ -778,9 +777,9 @@ class Slide(models.Model):
                 return getattr(self, '_parse_%s_document' % document_source)(document_id, only_preview_fields)
             return {'error': _('Unknown document')}
 
-    def _parse_peertube_document(self,document_id,url,only_preview_fields):
-        base_url = re.search('(.*)(?:\/videos\/.*)',url).group(1)
-        fetch_res = self._fetch_data(base_url+'/api/v1/videos/'+document_id,{}, 'json')
+    def _parse_peertube_document(self, document_id,url, only_preview_fields):
+        base_url = re.search(r'(.*)(?:\/videos\/.*)', url).group(1)
+        fetch_res = self._fetch_data(base_url+'/api/v1/videos/'+document_id, {}, 'json')
         if fetch_res.get('error'):
             #return {'error': self._extractpeertube_error_message(fetch_res.get('error'))}
             return {'error': 'PeerTube error'}
@@ -802,12 +801,11 @@ class Slide(models.Model):
 
             values.update({
                 'name': fetch_res['values'].get('name'),
-                'image_1920':  self._fetch_data(base_url + fetch_res['values'].get('thumbnailPath'),{}, 'image')['values'],
+                'image_1920':  self._fetch_data(base_url + fetch_res['values'].get('thumbnailPath'), {}, 'image')['values'],
                 'description': fetch_res['values'].get('description'),
                 'mime_type': False,
             })
-        return {'values': values}            
-
+        return {'values': values}  
 
     def _parse_youtube_document(self, document_id, only_preview_fields):
         """ If we receive a duration (YT video), we use it to determine the slide duration.

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -169,7 +169,7 @@ class Slide(models.Model):
         help="The document type will be set automatically based on the document URL and properties (e.g. height and width for presentation and document).")
     datas = fields.Binary('Content', attachment=True)
     url = fields.Char('Document URL', help="Youtube or Google Document URL")
-    document_id = fields.Char('Document ID', help="Youtube or Google Document ID")
+    document_id = fields.Char('Document ID', help="Youtube, Google Document or PeerTube ID")
     link_ids = fields.One2many('slide.slide.link', 'slide_id', string="External URL for this slide")
     slide_resource_ids = fields.One2many('slide.slide.resource', 'slide_id', string="Additional Resource for this slide")
     slide_resource_downloadable = fields.Boolean('Allow Download', default=True, help="Allow the user to download the content of the slide.")
@@ -200,6 +200,7 @@ class Slide(models.Model):
     nbr_webpage = fields.Integer("Number of Webpages", compute='_compute_slides_statistics', store=True)
     nbr_quiz = fields.Integer("Number of Quizs", compute="_compute_slides_statistics", store=True)
     total_slides = fields.Integer(compute='_compute_slides_statistics', store=True)
+
 
     _sql_constraints = [
         ('exclusion_html_content_and_url', "CHECK(html_content IS NULL OR url IS NULL)", "A slide is either filled with a document url or HTML content. Not both.")
@@ -343,10 +344,14 @@ class Slide(models.Model):
                 record.embed_code = '<iframe src="%s" class="o_wslides_iframe_viewer" allowFullScreen="true" height="%s" width="%s" frameborder="0"></iframe>' % (slide_url, 315, 420)
             elif record.slide_type == 'video' and record.document_id:
                 if not record.mime_type:
-                    # embed youtube video
-                    query = urls.url_parse(record.url).query
-                    query = query + '&theme=light' if query else 'theme=light'
-                    record.embed_code = '<iframe src="//www.youtube-nocookie.com/embed/%s?%s" allowFullScreen="true" frameborder="0"></iframe>' % (record.document_id, query)
+                    if re.search('\/videos\/(?:watch|embed)\/.*',record.url):
+                        embedurl = re.sub('watch','embed', record.url)
+                        record.embed_code = '<iframe src="%s?api=1" frameborder="0" sandbox="allow-same-origin allow-scripts" allowfullscreen="allowfullscreen"></iframe>' % (embedurl)
+                    else:
+                        # embed youtube video
+                        query = urls.url_parse(record.url).query
+                        query = query + '&theme=light' if query else 'theme=light'
+                        record.embed_code = '<iframe src="//www.youtube-nocookie.com/embed/%s?%s" allowFullScreen="true" frameborder="0"></iframe>' % (record.document_id, query)
                 else:
                     # embed google doc video
                     record.embed_code = '<iframe src="//drive.google.com/file/d/%s/preview" allowFullScreen="true" frameborder="0"></iframe>' % (record.document_id)
@@ -362,7 +367,7 @@ class Slide(models.Model):
                 raise Warning(res.get('error'))
             values = res['values']
             if not values.get('document_id'):
-                raise Warning(_('Please enter valid Youtube or Google Doc URL'))
+                raise Warning(_('Please enter valid Youtube,  Google Doc or PeerTube URL'))
             for key, value in values.items():
                 self[key] = value
 
@@ -752,7 +757,10 @@ class Slide(models.Model):
             split_path = url_obj.path.split('/')
             if len(split_path) >= 3 and split_path[1] in ('v', 'embed'):
                 return ('youtube', split_path[2])
-
+        peertube = re.match('.*\/videos\/(?:watch|embed)\/(.*)',url_obj.to_url())
+        if peertube:
+            return ('peertube',peertube.group(1))
+        
         expr = re.compile(r'(^https:\/\/docs.google.com|^https:\/\/drive.google.com).*\/d\/([^\/]*)')
         arg = expr.match(url)
         document_id = arg and arg.group(2) or False
@@ -764,8 +772,42 @@ class Slide(models.Model):
     def _parse_document_url(self, url, only_preview_fields=False):
         document_source, document_id = self._find_document_data_from_url(url)
         if document_source and hasattr(self, '_parse_%s_document' % document_source):
-            return getattr(self, '_parse_%s_document' % document_source)(document_id, only_preview_fields)
-        return {'error': _('Unknown document')}
+            if document_source == 'peertube':
+                return getattr(self, '_parse_%s_document' % document_source)(document_id,url, only_preview_fields)
+            else:
+                return getattr(self, '_parse_%s_document' % document_source)(document_id, only_preview_fields)
+            return {'error': _('Unknown document')}
+
+    def _parse_peertube_document(self,document_id,url,only_preview_fields):
+        base_url = re.search('(.*)(?:\/videos\/.*)',url).group(1)
+        fetch_res = self._fetch_data(base_url+'/api/v1/videos/'+document_id,{}, 'json')
+        if fetch_res.get('error'):
+            #return {'error': self._extractpeertube_error_message(fetch_res.get('error'))}
+            return {'error': 'PeerTube error'}
+
+        values = {'slide_type': 'video', 'document_id': document_id}
+        if not fetch_res['values']:
+            return {'error': _('Please enter valid Youtube, Google Doc or PeerTube URL')}
+        values['completion_time'] = (int(fetch_res['values'].get('duration')))/3600
+        if fetch_res['values'].get('previewPath'):
+            snippet = base_url + fetch_res['values'].get('previewPath')
+            if only_preview_fields:
+                values.update({
+                    'url_src': snippet,
+                    'title': fetch_res['values'].get('name'),
+                    'description': fetch_res['values'].get('description')
+                })
+
+                return values
+
+            values.update({
+                'name': fetch_res['values'].get('name'),
+                'image_1920':  self._fetch_data(base_url + fetch_res['values'].get('thumbnailPath'),{}, 'image')['values'],
+                'description': fetch_res['values'].get('description'),
+                'mime_type': False,
+            })
+        return {'values': values}            
+
 
     def _parse_youtube_document(self, document_id, only_preview_fields):
         """ If we receive a duration (YT video), we use it to determine the slide duration.
@@ -779,7 +821,7 @@ class Slide(models.Model):
         values = {'slide_type': 'video', 'document_id': document_id}
         items = fetch_res['values'].get('items')
         if not items:
-            return {'error': _('Please enter valid Youtube or Google Doc URL')}
+            return {'error': _('Please enter valid Youtube, Google Doc or PeerTube URL')}
         youtube_values = items[0]
 
         youtube_duration = youtube_values.get('contentDetails', {}).get('duration')

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -344,7 +344,7 @@ class Slide(models.Model):
                 record.embed_code = '<iframe src="%s" class="o_wslides_iframe_viewer" allowFullScreen="true" height="%s" width="%s" frameborder="0"></iframe>' % (slide_url, 315, 420)
             elif record.slide_type == 'video' and record.document_id:
                 if not record.mime_type:
-                    if re.search('r\/videos\/(?:watch|embed)\/.*', record.url):
+                    if re.search(r'\/videos\/(?:watch|embed)\/.*', record.url):
                         embedurl = re.sub('watch', 'embed', record.url)
                         record.embed_code = '<iframe src="%s?api=1" frameborder="0" sandbox="allow-same-origin allow-scripts" allowfullscreen="allowfullscreen"></iframe>' % (embedurl)
                     else:

--- a/addons/website_slides/static/src/xml/website_slides_fullscreen.xml
+++ b/addons/website_slides/static/src/xml/website_slides_fullscreen.xml
@@ -15,7 +15,7 @@
 
     <t t-name="website.slides.fullscreen.video">
         <div class="player embed-responsive embed-responsive-16by9 embed-responsive-item h-100">
-            <iframe t-att-id="'youtube-player' + widget.slide.id" t-att-src="widget.slide.embedUrl" allowFullScreen="true" frameborder="0" enablejsapi="1" autoplay="1" allow="autoplay"></iframe>
+            <iframe t-att-id="'video-player' + widget.slide.id" t-att-src="widget.slide.embedUrl" allowFullScreen="true" frameborder="0" enablejsapi="1" autoplay="1" allow="autoplay"></iframe>
         </div>
     </t>
 

--- a/addons/website_slides/static/src/xml/website_slides_upload.xml
+++ b/addons/website_slides/static/src/xml/website_slides_upload.xml
@@ -143,8 +143,8 @@
                 <div class="row">
                     <div id="o_wslides_js_slide_upload_left_column" class="col-md-6">
                         <div class="form-group">
-                            <label for="url" class="col-form-label">Youtube Link</label>
-                            <input id="url" name="url" class="form-control" placeholder="Youtube Video URL" required="required"/>
+                            <label for="url" class="col-form-label">Youtube/PeerTube Link</label>
+                            <input id="url" name="url" class="form-control" placeholder="Youtube/PeerTube Video URL" required="required"/>
                         </div>
                         <canvas id="data_canvas" class="d-none"></canvas>
                         <t t-call="website.slide.upload.modal.common"/>
@@ -153,9 +153,10 @@
                         <div class="img-thumbnail h-100">
                             <div class="o_slide_tutorial p-3">
                                 <div class="h5">How to upload your videos ?</div>
-                                <div class="mx-3 my-4">First, upload your videos on YouTube and mark them as <strong>unlisted</strong>. This way, they will be secured.</div>
-                                <div class="mx-3 my-4">What does <strong>unlisted</strong> means? The YouTube "unlisted" means it is a video which can be viewed only by the users with the link to it. Your video will never come up in the search results nor on your channel.</div>
-                                <div class="mx-3 my-4"><a href="https://support.google.com/youtube/answer/157177" target="_blank" >Change video privacy settings</a></div>
+                                <div class="mx-3 my-4">First, upload your videos on YouTube/PeerTube and mark them as <strong>unlisted</strong>. This way, they will be secured.</div>
+                                <div class="mx-3 my-4">What does <strong>unlisted</strong> means? The YouTube/PeerTube "unlisted" means it is a video which can be viewed only by the users with the link to it. Your video will never come up in the search results nor on your channel.</div>
+                                <div class="mx-3 my-4"><a href="https://support.google.com/youtube/answer/157177" target="_blank" >Change Youtube video privacy settings</a></div>
+                                <div class="mx-3 my-4"><a href="https://docs.joinpeertube.org/use-create-upload-video?id=video-confidentiality-options-what-do-they-mean" target="_blank" >Change PeerTube video privacy settings</a></div>
                             </div>
                             <div class="o_slide_preview d-none">
                                 <img src="/website_slides/static/src/img/document.png" id="slide-image" title="Content Preview" alt="Content Preview" class="img-fluid"/>

--- a/doc/cla/corporate/jumpingb-bean.md
+++ b/doc/cla/corporate/jumpingb-bean.md
@@ -1,0 +1,16 @@
+South Africa, 2021-03-27
+
+Jumping Bean agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+*  Mark Clarke> mark@jumpingbean.co.za https://github.com/mxc
+
+List of contributors:
+
+*  Mark Clarke mark@jumpingbean.co.za https://github.com/mxc
+

--- a/doc/cla/corporate/jumpingb-bean.md
+++ b/doc/cla/corporate/jumpingb-bean.md
@@ -8,9 +8,9 @@ declaration.
 
 Signed,
 
-*  Mark Clarke> mark@jumpingbean.co.za https://github.com/mxc
+*  Mark Clarke> dev@jumpingbean.co.za https://github.com/mxc
 
 List of contributors:
 
-*  Mark Clarke mark@jumpingbean.co.za https://github.com/mxc
+*  Mark Clarke dev@jumpingbean.co.za https://github.com/mxc
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
These changes add support for PeerTube hosted videos. The ability to host videos on one's own infrastructure, under ones own control, free from concerns about 3rd party provider's whims and enigmatic content banning algorithms greatly reduces the risk to any organisation that has built a business that depends on such services. 

Current behavior before PR:
PeerTube videos are not supported in web_editor and website_slides

Desired behavior after PR is merged:
Full support for PeerTube hosted videos in Odoo.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
