### PR TITLE
[FIX] mail: add boolean_toggle widget

### DIFF
--- a/addons/mail/views/mail_channel_views.xml
+++ b/addons/mail/views/mail_channel_views.xml
@@ -108,7 +108,7 @@
                             </h1>
                         </div>
                         <group class="o_label_nowrap">
-                            <field name="active" invisible="1"/>
+                            <field name="active" widget="boolean_toggle"/>
                             <field name="email_send"/>
                             <field name="moderation" attrs="{'invisible': [('email_send', '=', False)]}"/>
                             <field name="description" placeholder="Topics discussed in this group..."/>


### PR DESCRIPTION
Model `mail.channel` already have `active` field but It was hidden on
the view, which doesn't makes any sense as end user can not know if
the record is archived or not.

Now, we add option to archive record through toggle button.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
