### PR TITLE
[IMP] mail: improve URL detection

### DIFF
--- a/addons/mail/static/src/js/utils.js
+++ b/addons/mail/static/src/js/utils.js
@@ -45,7 +45,7 @@ function _parseAndTransform(nodes, transformFunction) {
 
 // Suggested URL Javascript regex of http://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url
 // Adapted to make http(s):// not required if (and only if) www. is given. So `should.notmatch` does not match.
-var urlRegexp = /\b(?:https?:\/\/\d{1,3}(?:\.\d{1,3}){3}|(?:https?:\/\/|(?:www\.))[-a-z0-9@:%._+~#=]{2,256}\.[a-z]{2,13})\b(?:[-a-z0-9@:%_+.~#?&'$//=;]*)/gi;
+var urlRegexp = /\b(?:https?:\/\/\d{1,3}(?:\.\d{1,3}){3}|(?:https?:\/\/|(?:www\.))[-a-z0-9@:%._+~#=\u00C0-\u024F\u1E00-\u1EFF]{2,256}\.[a-z]{2,13})\b(?:[-a-z0-9@:%_+.~#?&'$//=;\u00C0-\u024F\u1E00-\u1EFF]*)/gi;
 /**
  * @param {string} text
  * @param {Object} [attrs={}]


### PR DESCRIPTION
Current URL regexp doesn't support special, but still valid, character like `é`,
`è`, `ỗ`, `ặ`, etc. Url like
`https://tenor.com/view/chỗgiặt-dog-smile-gif-13860250` are not going to be matched correctly.
This commit adds the support for the Latin Extended unicode
block (https://en.wikipedia.org/wiki/Latin_Extended_Additional).

Some relevant stackoverflow discussion:
https://stackoverflow.com/questions/20690499/concrete-javascript-regex-for-accented-characters-diacritics