### PR TITLE
[IMP] point_of_sale: fix attribute type default value

### DIFF
--- a/addons/point_of_sale/views/product_view.xml
+++ b/addons/point_of_sale/views/product_view.xml
@@ -19,7 +19,7 @@
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">product.template</field>
         <field name="view_mode">kanban,tree,form,activity</field>
-        <field name="context" eval="{'search_default_filter_to_availabe_pos': 1, 'default_available_in_pos': True}"/>
+        <field name="context" eval="{'search_default_filter_to_availabe_pos': 1, 'default_available_in_pos': True, 'create_variant_never': 'no_variant'}"/>
     </record>
     <record id="product_product_action" model="ir.actions.act_window">
         <field name="name">Product Variants</field>
@@ -46,6 +46,18 @@
         <field name="search_view_id" ref="product.product_category_search_view"/>
         <field name="view_id" ref="product.product_category_list_view"/>
     </record>
+
+    <record id="product_template_only_form_view" model="ir.ui.view">
+        <field name="name">product.template.only.form.inherit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_only_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='attribute_line_ids']//field[@name='attribute_id']" position="attributes">
+                <attribute name="context">{'default_create_variant': context.get('create_variant_never', 'always')}</attribute>
+            </xpath>
+        </field>
+    </record>
+
 
     <record id="product_template_form_view" model="ir.ui.view">
         <field name="name">product.template.form.inherit</field>


### PR DESCRIPTION
When you are creating product attributes from the point_of-sale menu
item, the default type of attribute is never.

Those changes has been done because, there is a new feature that show a
product configurator in POS for a product having attributes "never".

TASK-ID: 2342501

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
