### PR TITLE
[FIX] sms: fix record rule on sms_template

### DIFF
--- a/addons/calendar_sms/security/sms_security.xml
+++ b/addons/calendar_sms/security/sms_security.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="ir_rule_sms_template_system" model="ir.rule">
-        <field name="name">SMS Template: system administrator CUD on calendar event templates</field>
+        <field name="name">SMS Template: unnecessary rule for system group</field>
         <field name="model_id" ref="sms.model_sms_template"/>
         <field name="groups" eval="[(4, ref('base.group_system'))]"/>
-        <field name="domain_force">[('model_id.model', '=', 'calendar.event')]</field>
+        <!-- TDE NOTE: remove me in master, broken fix from odoo/odoo#64626 -->
+        <field name="domain_force">[(1, '=', 1)]</field>
         <field name="perm_read" eval="False"/>
     </record>
 </odoo>

--- a/addons/calendar_sms/security/sms_security.xml
+++ b/addons/calendar_sms/security/sms_security.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="ir_rule_sms_template_system" model="ir.rule">
-        <field name="name">SMS Template: system administrator CRUD on calendar event templates</field>
+        <field name="name">SMS Template: system administrator CUD on calendar event templates</field>
         <field name="model_id" ref="sms.model_sms_template"/>
         <field name="groups" eval="[(4, ref('base.group_system'))]"/>
         <field name="domain_force">[('model_id.model', '=', 'calendar.event')]</field>
+        <field name="perm_read" eval="False"/>
     </record>
 </odoo>

--- a/addons/crm_sms/security/sms_security.xml
+++ b/addons/crm_sms/security/sms_security.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="ir_rule_sms_template_sale_manager" model="ir.rule">
-        <field name="name">SMS Template: sale manager CRUD on opportunity / partner templates</field>
+        <field name="name">SMS Template: sale manager CUD on opportunity / partner templates</field>
         <field name="model_id" ref="sms.model_sms_template"/>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_manager'))]"/>
         <field name="domain_force">[('model_id.model', 'in', ('crm.lead', 'res.partner'))]</field>
+        <field name="perm_read" eval="False"/>
     </record>
 </odoo>

--- a/addons/event_sms/security/sms_security.xml
+++ b/addons/event_sms/security/sms_security.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="ir_rule_sms_template_event_manager" model="ir.rule">
-        <field name="name">SMS Template: event manager CRUD on event / registrations templates</field>
+        <field name="name">SMS Template: event manager CUD on event / registrations templates</field>
         <field name="model_id" ref="sms.model_sms_template"/>
         <field name="groups" eval="[(4, ref('event.group_event_manager'))]"/>
         <field name="domain_force">[('model_id.model', 'in', ('event.event', 'event.registration'))]</field>
+        <field name="perm_read" eval="False"/>
     </record>
 </odoo>

--- a/addons/hr_presence/__manifest__.py
+++ b/addons/hr_presence/__manifest__.py
@@ -19,6 +19,7 @@ Allows to contact directly the employee in case of unjustified absence.
     'depends': ['hr', 'hr_holidays', 'sms'],
     'data': [
         'security/sms_security.xml',
+        'security/ir.model.access.csv',
         'data/ir_actions_server.xml',
         'views/hr_employee_views.xml',
         'data/sms_data.xml',

--- a/addons/hr_presence/security/ir.model.access.csv
+++ b/addons/hr_presence/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_sms_template_hr_manager,access.sms.template.hr.manager,sms.model_sms_template,hr.group_hr_manager,1,1,1,1

--- a/addons/hr_presence/security/sms_security.xml
+++ b/addons/hr_presence/security/sms_security.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="ir_rule_sms_template_hr_manager" model="ir.rule">
-        <field name="name">SMS Template: hr manager CRUD on employee templates</field>
+        <field name="name">SMS Template: hr manager CUD on employee templates</field>
         <field name="model_id" ref="sms.model_sms_template"/>
         <field name="groups" eval="[(4, ref('hr.group_hr_manager'))]"/>
         <field name="domain_force">[('model_id.model', '=', 'hr.employee')]</field>
+        <field name="perm_read" eval="False"/>
     </record>
 </odoo>

--- a/addons/sms/tests/__init__.py
+++ b/addons/sms/tests/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import common
+from . import test_sms_template

--- a/addons/sms/tests/test_sms_template.py
+++ b/addons/sms/tests/test_sms_template.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import SavepointCase, users
+from odoo.addons.test_mail.tests.common import mail_new_test_user
+from odoo.tests import tagged
+from odoo.exceptions import AccessError
+
+
+@tagged('post_install')
+class TestSmsTemplateAccessRights(SavepointCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user_admin = mail_new_test_user(cls.env, login='user_system', groups='base.group_system')
+        cls.basic_user = mail_new_test_user(cls.env, login='user_employee', groups='base.group_user')
+        sms_enabled_models = cls.env['ir.model'].search([('is_mail_thread_sms', '=', True), ('transient', '=', False)])
+        vals = []
+        for model in sms_enabled_models:
+            vals.append({
+                'name': 'SMS Template ' + model.name,
+                'body': 'Body Test',
+                'model_id': model.id,
+            })
+        cls.sms_templates = cls.env['sms.template'].create(vals)
+
+    @users('user_employee')
+    def test_access_rights_user_sms_template(self):
+        # Check if a member of group_user can only read on sms.template
+        for sms_template in self.env['sms.template'].browse(self.sms_templates.ids):
+            self.assertTrue(bool(sms_template.name))
+            with self.assertRaises(AccessError):
+                sms_template.write({'name': 'Update Template'})
+            with self.assertRaises(AccessError):
+                self.env['sms.template'].create({
+                    'name': 'New SMS Template ' + sms_template.model_id.name,
+                    'body': 'Body Test',
+                    'model_id': sms_template.model_id.id,
+                })
+            with self.assertRaises(AccessError):
+                sms_template.unlink()
+
+    @users('user_system')
+    def test_access_rights_manager_sms_template(self):
+        admin = self.env.ref('base.user_admin')
+        for sms_template in self.env['sms.template'].browse(self.sms_templates.ids):
+            self.assertTrue(bool(sms_template.name))
+            sms_template.write({'body': 'New body from admin'})
+            self.env['sms.template'].create({
+                'name': 'New SMS Template ' + sms_template.model_id.name,
+                'body': 'Body Test',
+                'model_id': sms_template.model_id.id,
+            })
+
+            # check admin is allowed to read all templates since he can be a member of
+            # other groups applying restrictions based on the model
+            self.assertTrue(bool(self.env['sms.template'].with_user(admin).browse(sms_template.ids).name))
+
+            sms_template.unlink()

--- a/addons/stock_sms/security/sms_security.xml
+++ b/addons/stock_sms/security/sms_security.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="ir_rule_sms_template_stock_manager" model="ir.rule">
-        <field name="name">SMS Template: stock manager CRUD on stock picking templates</field>
+        <field name="name">SMS Template: stock manager CUD on stock picking templates</field>
         <field name="model_id" ref="sms.model_sms_template"/>
         <field name="groups" eval="[(4, ref('stock.group_stock_manager'))]"/>
         <field name="domain_force">[('model_id.model', '=', 'stock.picking')]</field>
+        <field name="perm_read" eval="False"/>
     </record>
 </odoo>


### PR DESCRIPTION
These record rules were meant to restrict access to certain model
to create/write/unlink, but not read.
This was leading to issues when others models were trying to read
a template.
Unit test were also added to the sms module to ensure that a member
of group_user can always read a sms template.

task-2191254
