### PR TITLE
[FIX] website_sale: remove remaining parts of recenlty viewed products

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1205,46 +1205,6 @@ class WebsiteSale(http.Controller):
     # --------------------------------------------------------------------------
     # Products Recently Viewed
     # --------------------------------------------------------------------------
-    @http.route('/shop/products/recently_viewed', type='json', auth='public', website=True)
-    def products_recently_viewed(self, **kwargs):
-        return self._get_products_recently_viewed()
-
-    def _get_products_recently_viewed(self):
-        """
-        Returns list of recently viewed products according to current user
-        """
-        max_number_of_product_for_carousel = 12
-        visitor = request.env['website.visitor']._get_visitor_from_request()
-        if visitor:
-            excluded_products = request.website.sale_get_order().mapped('order_line.product_id.id')
-            products = request.env['website.track'].sudo().read_group(
-                [('visitor_id', '=', visitor.id), ('product_id', '!=', False), ('product_id.website_published', '=', True), ('product_id', 'not in', excluded_products)],
-                ['product_id', 'visit_datetime:max'], ['product_id'], limit=max_number_of_product_for_carousel, orderby='visit_datetime DESC')
-            products_ids = [product['product_id'][0] for product in products]
-            if products_ids:
-                viewed_products = request.env['product.product'].with_context(display_default_code=False).browse(products_ids)
-
-                FieldMonetary = request.env['ir.qweb.field.monetary']
-                monetary_options = {
-                    'display_currency': request.website.get_current_pricelist().currency_id,
-                }
-                rating = request.website.viewref('website_sale.product_comment').active
-                res = {'products': []}
-                for product in viewed_products:
-                    combination_info = product._get_combination_info_variant()
-                    res_product = product.read(['id', 'name', 'website_url'])[0]
-                    res_product.update(combination_info)
-                    res_product['price'] = FieldMonetary.value_to_html(res_product['price'], monetary_options)
-                    if rating:
-                        res_product['rating'] = request.env["ir.ui.view"]._render_template('portal_rating.rating_widget_stars_static', values={
-                            'rating_avg': product.rating_avg,
-                            'rating_count': product.rating_count,
-                        })
-                    res['products'].append(res_product)
-
-                return res
-        return {}
-
     @http.route('/shop/products/recently_viewed_update', type='json', auth='public', website=True)
     def products_recently_viewed_update(self, product_id, **kwargs):
         res = {}
@@ -1260,4 +1220,4 @@ class WebsiteSale(http.Controller):
         visitor_sudo = request.env['website.visitor']._get_visitor_from_request()
         if visitor_sudo:
             request.env['website.track'].sudo().search([('visitor_id', '=', visitor_sudo.id), ('product_id', '=', product_id)]).unlink()
-        return self._get_products_recently_viewed()
+        return {}

--- a/addons/website_sale/static/src/js/website_sale.editor.js
+++ b/addons/website_sale/static/src/js/website_sale.editor.js
@@ -695,29 +695,4 @@ options.registry.WebsiteSaleProductsItem = options.Class.extend({
         }).then(reload);
     },
 });
-
-options.registry.ProductsRecentlyViewed = options.Class.extend({
-    /**
-     * @override
-     */
-    onBuilt: function () {
-        this.displayNotification({
-            type: 'info',
-            title: '',
-            message: _t('The snippet will be visible once one has seen one product'),
-        });
-    },
-    /**
-     * @override
-     */
-    onTargetShow: async function () {
-        this.$target.removeClass('d-none');
-    },
-    /**
-     * @override
-     */
-    onTargetHide: function () {
-        this.$target.addClass('d-none');
-    },
-});
 });

--- a/addons/website_sale/static/src/scss/website_sale.editor.scss
+++ b/addons/website_sale/static/src/scss/website_sale.editor.scss
@@ -34,7 +34,3 @@
     vertical-align: middle;
     border-radius: 50%;
 }
-
-.oe_drop_zone + .s_wsale_products_recently_viewed {
-    display: block !important;
-}

--- a/addons/website_sale/views/snippets/snippets.xml
+++ b/addons/website_sale/views/snippets/snippets.xml
@@ -88,8 +88,6 @@
                         data-no-preview="true"
                         data-reload="/"/>
         </div>
-
-        <div data-js="ProductsRecentlyViewed" data-selector=".s_wsale_products_recently_viewed"/>
     </xpath>
 </template>
 


### PR DESCRIPTION
Before this commit some references to the old recently viewed products
snippet were remaining.

After this commit there are no references to the old recently viewed
products snippet anymore.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
