### PR TITLE
[FIX] account: removing redundant _check_lock_date at button_cancel()

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -392,7 +392,6 @@ class AccountMove(models.Model):
                        'SET state=%s '\
                        'WHERE id IN %s', ('draft', tuple(self.ids),))
             self.invalidate_cache()
-        self._check_lock_date()
         return True
 
     @api.multi


### PR DESCRIPTION
Main
-

At commit https://github.com/odoo/odoo/commit/9f172a61e0f2c
it was added prior updating the Journal Entry

![Screen Shot 2021-03-29 at 3 15 14](https://user-images.githubusercontent.com/7598010/112814909-0074ee00-903d-11eb-9e93-122b3dc69143.png)



At commit https://github.com/odoo/odoo/commit/8ffc0c9f81487
it was added again after updating the Journal Entry

![Screen Shot 2021-03-29 at 3 14 55](https://user-images.githubusercontent.com/7598010/112814853-f226d200-903c-11eb-91a6-523d612383ab.png)


Each commit was added without knowing of each other and they end up
being merged in to the same method.

For a few records being deleted this is not a big deal but when
deleting a lot of records this become a hassle.

OPW
-
2494401

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
