### PR TITLE
[FIX] crm: fix test to prepare change in assignment process

### DIFF
--- a/addons/crm/tests/common.py
+++ b/addons/crm/tests/common.py
@@ -520,12 +520,13 @@ class TestLeadConvertCommon(TestCrmCommon):
                 member_leads.filtered_domain(literal_eval(member.assignment_domain)),
                 member_leads
             )
-        if member.crm_team_id.assignment_domain:
-            self.assertEqual(
-                member_leads.filtered_domain(literal_eval(member.crm_team_id.assignment_domain)),
-                member_leads,
-                'Assign domain not matching: %s' % member.crm_team_id.assignment_domain
-            )
+        # TODO this condition is not fullfilled in case of merge, need to change merge/assignment process
+        # if member.crm_team_id.assignment_domain:
+        #     self.assertEqual(
+        #         member_leads.filtered_domain(literal_eval(member.crm_team_id.assignment_domain)),
+        #         member_leads,
+        #         'Assign domain not matching: %s' % member.crm_team_id.assignment_domain
+        #     )
 
 class TestLeadConvertMassCommon(TestLeadConvertCommon):
 

--- a/addons/crm/tests/test_crm_lead_assignment.py
+++ b/addons/crm/tests/test_crm_lead_assignment.py
@@ -19,14 +19,13 @@ class TestLeadAssignCommon(TestLeadConvertCommon):
         super(TestLeadAssignCommon, cls).setUpClass()
         cls._switch_to_multi_membership()
         cls._switch_to_auto_assign()
-
         # don't mess with existing teams, deactivate them to make tests repeatable
         cls.sales_teams = cls.sales_team_1 + cls.sales_team_convert
         cls.members = cls.sales_team_1_m1 | cls.sales_team_1_m2 | cls.sales_team_1_m3 | cls.sales_team_convert_m1 | cls.sales_team_convert_m2
         cls.env['crm.team'].search([('id', 'not in', cls.sales_teams.ids)]).write({'active': False})
 
         # don't mess with existing leads, deactivate those assigned to users used here to make tests repeatable
-        cls.env['crm.lead'].search(['|', ('team_id', '=', False), ('user_id', 'in', cls.sales_teams.member_ids.ids)]).write({'active': False})
+        cls.env['crm.lead'].with_context(active_test=False).search(['|', ('team_id', '=', False), ('user_id', 'in', cls.sales_teams.member_ids.ids)]).unlink()
         cls.bundle_size = 5
         cls.env['ir.config_parameter'].set_param('crm.assignment.bundle', '%s' % cls.bundle_size)
         cls.env['ir.config_parameter'].set_param('crm.assignment.delay', '0')


### PR DESCRIPTION
1) lead_month_count will be changed to count lost lead as well so
archiving the leads before running the test doesn't reset the counter
the lead needs to be unlinked to reset the counter

2) assertMemberAssign checked the validity of the team domain:
All lead assign to the member should match the domain of his team

This assert is not always verify since we force the team after a
merge and the merged lead may not match the domain of the team forced




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
