### PR TITLE
[FIX] mail: detect a bigger range of URL in messages

### DIFF
--- a/addons/mail/static/src/js/utils.js
+++ b/addons/mail/static/src/js/utils.js
@@ -27,7 +27,8 @@ function _parseAndTransform(nodes, transformFunction) {
 
 // Suggested URL Javascript regex of http://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url
 // Adapted to make http(s):// not required if (and only if) www. is given. So `should.notmatch` does not match.
-var urlRegexp = /\b(?:https?:\/\/\d{1,3}(?:\.\d{1,3}){3}|(?:https?:\/\/|(?:www\.))[-a-z0-9@:%._+~#=]{2,256}\.[a-z]{2,13})\b(?:[-a-z0-9@:%_+.~#?&'$//=;]*)/gi;
+// And further extended to include Latin-1 Supplement, Latin Extended-A, Latin Extended-B and Latin Extended Additional.
+var urlRegexp = /\b(?:https?:\/\/\d{1,3}(?:\.\d{1,3}){3}|(?:https?:\/\/|(?:www\.))[-a-z0-9@:%._+~#=\u00C0-\u024F\u1E00-\u1EFF]{2,256}\.[a-z]{2,13})\b(?:[-a-z0-9@:%_+.~#?&'$//=;\u00C0-\u024F\u1E00-\u1EFF]*)/gi;
 function linkify(text, attrs) {
     attrs = attrs || {};
     if (attrs.target === undefined) {

--- a/addons/mail/static/tests/mail_utils_tests.js
+++ b/addons/mail/static/tests/mail_utils_tests.js
@@ -8,7 +8,7 @@ QUnit.module('mail', {}, function () {
 QUnit.module('Mail utils');
 
 QUnit.test('add_link utility function', function (assert) {
-    assert.expect(15);
+    assert.expect(19);
 
     var testInputs = {
         'http://admin:password@example.com:8/%2020': true,
@@ -20,6 +20,8 @@ QUnit.test('add_link utility function', function (assert) {
         'fhttps://test.example.com/test': false,
         "https://www.transifex.com/odoo/odoo-11/translate/#fr/lunch?q=text%3A'La+Tartiflette'": true,
         'https://www.transifex.com/odoo/odoo-11/translate/#fr/$/119303430?q=text%3ATartiflette': true,
+        'https://tenor.com/view/chỗgiặt-dog-smile-gif-13860250': true,
+        'http://www.boîtenoire.be': true,
     };
 
     _.each(testInputs, function (willLinkify, content) {


### PR DESCRIPTION
Current URL regexp doesn't support special, but still valid, character like `é`,
`è`, `ỗ`, `ặ`, etc.

Url like `https://tenor.com/view/chỗgiặt-dog-smile-gif-13860250` are not going
to be matched correctly.

This commit adds the support for Latin-1 Supplement, Latin Extended-A,
Latin Extended-B and Latin Extended Additional unicode.

Some relevant stackoverflow discussion:
https://stackoverflow.com/questions/20690499/concrete-javascript-regex-for-accented-characters-diacritics

task-2088895
