### PR TITLE
[FIX] hr_work_entry: Exclude leave work entries from attendance inter…

### DIFF
--- a/addons/resource/models/resource.py
+++ b/addons/resource/models/resource.py
@@ -670,7 +670,7 @@ class ResourceCalendar(models.Model):
         if compute_leaves:
             intervals = self._work_intervals_batch(from_datetime, to_datetime, domain=domain)[False]
         else:
-            intervals = self._attendance_intervals_batch(from_datetime, to_datetime)[False]
+            intervals = self._attendance_intervals_batch(from_datetime, to_datetime, domain=domain)[False]
 
         return self._get_days_data(intervals, day_total)
 


### PR DESCRIPTION
…vals

Purpose
=======

If a resource.calendar is populated with work and leave attendances,
only take the work attendance when calling _attendance_intervals_batch.

Otherwise, this could lead to inconsistent behaviors, for example
when computed the out of contract days on a payslip.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
