### PR TITLE
Master view validation install rco

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -420,13 +420,14 @@ actual arch.
                     combined_archs = combined_archs[0]
                 for view_arch in combined_archs:
                     check = valid_view(view_arch, env=self.env, model=view.model)
-                    view_name = ('%s (%s)' % (view.name, view.xml_id)) if view.xml_id else view.name
                     if not check:
+                        view_name = ('%s (%s)' % (view.name, view.xml_id)) if view.xml_id else view.name
                         raise ValidationError(_(
                             'Invalid view %(name)s definition in %(file)s',
                             name=view_name, file=view.arch_fs
                         ))
                     if check == "Warning":
+                        view_name = ('%s (%s)' % (view.name, view.xml_id)) if view.xml_id else view.name
                         _logger.warning('Invalid view %s definition in %s \n%s', view_name, view.arch_fs, view.arch)
             except ValueError as e:
                 lines = etree.tostring(combined_arch, encoding='unicode').splitlines(keepends=True)

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -504,6 +504,16 @@ actual arch.
                 values['name'] = "%s %s" % (values.get('model'), values['type'])
             # Create might be called with either `arch` (xml files), `arch_base` (form view) or `arch_db`.
             values['arch_prev'] = values.get('arch_base') or values.get('arch_db') or values.get('arch')
+            # write on arch: bypass _inverse_arch()
+            if 'arch' in values:
+                values['arch_db'] = values.pop('arch')
+                if 'install_filename' in self._context:
+                    # we store the relative path to the resource instead of the absolute path, if found
+                    # (it will be missing e.g. when importing data-only modules using base_import_module)
+                    path_info = get_resource_from_path(self._context['install_filename'])
+                    if path_info:
+                        values['arch_fs'] = '/'.join(path_info[0:2])
+                        values['arch_updated'] = False
             values.update(self._compute_defaults(values))
 
         self.clear_caches()

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -952,7 +952,9 @@ actual arch.
         if model not in self.env:
             self.handle_view_error(_('Model not found: %(model)s', model=model), node)
 
-        self._postprocess_on_change(model, node)
+        if not validate:
+            # validation mode does not care about on_change
+            self._postprocess_on_change(model, node)
 
         name_manager = NameManager(validate, self.env[model])
         self.postprocess(node, [], editable, name_manager)
@@ -960,7 +962,9 @@ actual arch.
         name_manager.check_view_fields(self)
         name_manager.update_view_fields()
 
-        self._postprocess_access_rights(model, node)
+        if not validate:
+            # validation mode does not care about access rights
+            self._postprocess_access_rights(model, node)
 
         return etree.tostring(node, encoding="unicode").replace('\t', ''), name_manager
 


### PR DESCRIPTION
**[FIX] base: useless view validations when validate=False**

When a view is created/modified, it is required to validate it, the
validation checks the syntax, the inheritances, the fields, etc. When a
view is rendered there are a few more steps to perform like to (dis)able
the `edit` button from a view form if the user only have `read`
accesses. Those postprocess are useless when the view is validated and
should only be performed when the view is rendered.

---

**[FIX] base: compute view.xml_id only when needed**

This is a pure technical fix, comuting `view.xml_id` is only needed when
we need to show it when there is a problem with the view. In most cases
there are no problem, the view parses without errors or warnings.
Computing the `view_id` is not free as it needs to be retrieved from the
database.

---

**[IMP] base: optimize read_combined() via the cache**

The ORM `read()` method does two things:

* It calls `_read()` which fetches the data from the database and save
  it in the cache.
* It calls `_read_format()` to retrieve the data from the cache and
  return it using the `read` format.

As all the data is in cache already, fetching them from the database is
redundant. Using the cache right away is safe and makes read_combined()
20% faster, _check_xml() 10% faster and total installation 5% faster.

---

**[IMP] base: bypass _inverse_arch() in view creation**

By default, whatever is wrote on `arch` is handled by its `inverse_arch`
inverse method which write on the `arch_db` low-level field. When
writing on a arch, the cache is cleared which lead to performences loose
because the arch needs to be re-fetched.

This optimization bypasses the inverse method on view creation, this is
safe as there is nothing wrong in the cache and  makes view creation 20%
faster, and installation 7% faster.