### PR TITLE
[FIX] account: Order on bank statements

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -207,7 +207,7 @@ class AccountBankStatement(models.Model):
             # will find the record itself, so we have to add a condition in the search to ignore self.id
             if not isinstance(st.id, models.NewId):
                 domain.extend(['|', '&', ('id', '<', st.id), ('date', '=', st.date), '&', ('id', '!=', st.id), ('date', '!=', st.date)])
-            previous_statement = self.search(domain, limit=1)
+            previous_statement = self.search(domain, order='date desc, id desc, name desc', limit=1)
             st.previous_statement_id = previous_statement.id
 
     name = fields.Char(string='Reference', states={'open': [('readonly', False)]}, copy=False, readonly=True)


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider two bank statements:
   - BS1 (date: 29/03/21, name: Z, id=1, ending balance: 100€)
   - BS2 (date: 29/03/21, name: A, id=2, ending balance: 200€)
- Create a new bank statement

Bug:

The default starting balance was 100€ instead of 200€

opw:2481413