### PR TITLE
[FIX] account: Check Move Status Before Posting

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -12382,6 +12382,12 @@ msgstr ""
 #. module: account
 #: code:addons/account/models/account_move.py:0
 #, python-format
+msgid "The entry %s (id %s) is already posted."
+msgstr ""
+
+#. module: account
+#: code:addons/account/models/account_move.py:0
+#, python-format
 msgid "You need to add a line before posting."
 msgstr ""
 

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2227,6 +2227,8 @@ class AccountMove(models.Model):
         if not self.env.su and not self.env.user.has_group('account.group_account_invoice'):
             raise AccessError(_("You don't have the access rights to post an invoice."))
         for move in self:
+            if move.state == 'posted':
+                raise UserError(_('The entry %s (id %s) is already posted.') % (move.name, move.id))
             if not move.line_ids.filtered(lambda line: not line.display_type):
                 raise UserError(_('You need to add a line before posting.'))
             if move.auto_post and move.date > fields.Date.today():

--- a/addons/account/tests/test_reconciliation.py
+++ b/addons/account/tests/test_reconciliation.py
@@ -2309,7 +2309,7 @@ class TestReconciliationExec(TestReconciliation):
                 'currency_id': self.currency_usd_id,
             }
         ])
-        move_product.post()
+        move_payment.post()
 
         # We are reconciling a move line in currency A with a move line in currency B and putting
         # the rest in a writeoff, this test ensure that the debit/credit value of the writeoff is

--- a/addons/delivery/tests/test_delivery_stock_move.py
+++ b/addons/delivery/tests/test_delivery_stock_move.py
@@ -61,8 +61,6 @@ class StockMoveInvoice(AccountingTestCase):
         self.invoice.post()
 
         # I pay the invoice.
-        self.invoice = self.sale_prepaid.invoice_ids
-        self.invoice.post()
         self.journal = self.AccountJournal.search([('type', '=', 'cash'), ('company_id', '=', self.sale_prepaid.company_id.id)], limit=1)
 
         register_payments = self.env['account.payment.register'].with_context(active_ids=self.invoice.ids).create({


### PR DESCRIPTION
Beforehand, if two users independently opened a draft
invoice on their respective sessions, then both of them
clicked on the "Post" button, then the invoice was
posted twice.
On a more general aspect, the view currently "prevents" users
from posting moves several times, but technically speaking,
nothing stops users from posting moves several times.

Now, after checking that the user indeed has the right to post
a move, the next check is about verifying that the move is
not already posted.

opw-2479201

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
