### PR TITLE
[FIX] base_vat: Don't always pass VAT check when validating the VAT of a partner without country_id

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -187,10 +187,9 @@ class ResPartner(models.Model):
             if not check_func(vat_country, vat_number):
                 #if fails, check with country code from country
                 country_code = partner.commercial_partner_id.country_id.code
-                if country_code:
-                    if not check_func(country_code.lower(), partner.vat):
-                        msg = partner._construct_constraint_msg(country_code.lower())
-                        raise ValidationError(msg)
+                if not country_code or not check_func(country_code.lower(), partner.vat):
+                    msg = partner._construct_constraint_msg(country_code.lower() if country_code else None)
+                    raise ValidationError(msg)
 
     def _construct_constraint_msg(self, country_code):
         self.ensure_one()
@@ -212,7 +211,7 @@ class ResPartner(models.Model):
         '''
         # A new VAT number format in Switzerland has been introduced between 2011 and 2013
         # https://www.estv.admin.ch/estv/fr/home/mehrwertsteuer/fachinformationen/steuerpflicht/unternehmens-identifikationsnummer--uid-.html
-        # The old format "TVA 123456" is not valid since 2014 
+        # The old format "TVA 123456" is not valid since 2014
         # Accepted format are: (spaces are ignored)
         #     CHE#########MWST
         #     CHE#########TVA

--- a/addons/base_vat/tests/test_validate_ruc.py
+++ b/addons/base_vat/tests/test_validate_ruc.py
@@ -64,3 +64,32 @@ class TestStructure(common.TransactionCase):
         with patch.object(vatnumber, 'check_vies', mock_check_vies):
             self.env.user.company_id.vat_check_vies = True
             company.vat = "BE0987654321"
+
+    def test_vat_syntactic_validation(self):
+        """ Tests VAT validation (both successes and failures), with the different country
+        detection cases possible.
+        """
+        # Disable VIES; syntactic verification is enough for this test case
+        self.env.user.company_id.vat_check_vies = False
+
+        test_partner =self.env['res.partner'].create({'name': "John Dex"})
+
+        # VAT starting with country code: use the starting country code
+        test_partner.write({'vat': 'BE0477472701', 'country_id': self.env.ref('base.fr').id})
+        test_partner.write({'vat': 'BE0477472701', 'country_id': None})
+
+        with self.assertRaises(ValidationError):
+            test_partner.write({'vat': 'BE42', 'country_id': self.env.ref('base.fr').id})
+
+        with self.assertRaises(ValidationError):
+            test_partner.write({'vat': 'BE42', 'country_id': None})
+
+        # No country code in VAT: use the partner's country
+        test_partner.write({'vat': '0477472701', 'country_id': self.env.ref('base.be').id})
+
+        with self.assertRaises(ValidationError):
+            test_partner.write({'vat': '42', 'country_id': self.env.ref('base.be').id})
+
+        # If no country can be guessed: VAT number cannot be validated
+        with self.assertRaises(ValidationError):
+            test_partner.write({'vat': '0477472701', 'country_id': None})

--- a/addons/l10n_be_edi/test_xml_file/efff_test.xml
+++ b/addons/l10n_be_edi/test_xml_file/efff_test.xml
@@ -13,9 +13,9 @@
     <cbc:LineCountNumeric>1</cbc:LineCountNumeric>
     <cac:AccountingSupplierParty>
         <cac:Party>
-            <cbc:EndpointID schemeID="GLN">BE0123456789</cbc:EndpointID>
+            <cbc:EndpointID schemeID="GLN">BE0477472701</cbc:EndpointID>
             <cac:PartyIdentification>
-                <cbc:ID schemeAgencyName="KBO" schemeAgencyID="BE">123456789</cbc:ID>
+                <cbc:ID schemeAgencyName="KBO" schemeAgencyID="BE">477472701</cbc:ID>
             </cac:PartyIdentification>
             <cac:PartyName>
                 <cbc:Name>The best supplier</cbc:Name>

--- a/addons/l10n_be_edi/tests/test_ubl.py
+++ b/addons/l10n_be_edi/tests/test_ubl.py
@@ -11,7 +11,7 @@ class TestUBL(common.TransactionCase):
         self.env.user.company_id = self.env['res.company'].create({'name': 'MyCompany'})
         self.env.user.company_id.country = self.env.ref('base.be')
         self.env.ref('l10n_be.l10nbe_chart_template').try_loading()
-        self.partner_id = self.env['res.partner'].create({'name': 'TestUser', 'vat': 'BE0123456789'})
+        self.partner_id = self.env['res.partner'].create({'name': 'TestUser', 'vat': 'BE0477472701'})
 
     def test_ubl_invoice_import(self):
         xml_file_path = get_module_resource('l10n_be_edi', 'test_xml_file', 'efff_test.xml')

--- a/odoo/addons/base/tests/test_base.py
+++ b/odoo/addons/base/tests/test_base.py
@@ -335,12 +335,12 @@ class TestBase(TransactionCase):
         for p in (p0, p1, p11, p2, p3):
             self.assertEquals(p.commercial_partner_id, sunhelm, 'Incorrect commercial entity resolution')
             self.assertEquals(p.vat, sunhelm.vat, 'Commercial fields must be automatically synced')
-        sunhelmvat = 'BE0123456789'
+        sunhelmvat = 'BE0123456749'
         sunhelm.write({'vat': sunhelmvat})
         for p in (p0, p1, p11, p2, p3):
             self.assertEquals(p.vat, sunhelmvat, 'Commercial fields must be automatically and recursively synced')
 
-        p1vat = 'BE0987654321'
+        p1vat = 'BE0987654394'
         p1.write({'vat': p1vat})
         for p in (sunhelm, p0, p11, p2, p3):
             self.assertEquals(p.vat, sunhelmvat, 'Sync to children should only work downstream and on commercial entities')
@@ -353,7 +353,7 @@ class TestBase(TransactionCase):
         self.assertEquals(p1.commercial_partner_id, p1, 'Incorrect commercial entity resolution after setting is_company')
 
         # writing on parent should not touch child commercial entities
-        sunhelmvat2 = 'BE0112233445'
+        sunhelmvat2 = 'BE0112233453'
         sunhelm.write({'vat': sunhelmvat2})
         self.assertEquals(p1.vat, p1vat, 'Setting is_company should stop auto-sync of commercial fields')
         self.assertEquals(p0.vat, sunhelmvat2, 'Commercial fields must be automatically synced')


### PR DESCRIPTION
Before this, when making a partner without any country_id, any VAT could be set to it, which was inconsistent with the module's purpose.

X-original-commit: 8c713ed2707cfd3fe2e519a6e6a02d63ae2601e8

Manual forward-port of https://github.com/odoo/odoo/pull/68253 (an enterprise branch was needed from 13.0 on)
