### PR TITLE
[FIX] account: Journal Entry  displayd as invoice

### DIFF
--- a/addons/account/views/report_payment_receipt_templates.xml
+++ b/addons/account/views/report_payment_receipt_templates.xml
@@ -46,12 +46,14 @@
                         <tr t-foreach="o.move_id._get_reconciled_invoices_partials()" t-as="rec">
                             <t t-set="amount" t-value="rec[1]"/>
                             <t t-set="inv" t-value="rec[2].move_id"/>
-                            <td><span t-field="inv.invoice_date"/></td>
-                            <td><span t-field="inv.name"/></td>
-                            <td><span t-field="inv.ref"/></td>
-                            <td class="text-right"><span t-field="inv.amount_total"/></td>
-                            <td class="text-right"><span t-esc="amount" t-options="{'widget': 'monetary', 'display_currency': inv.currency_id}"/></td>
-                            <td class="text-right"><span t-field="inv.amount_residual"/></td>
+                            <t t-if="inv.move_type != 'entry'">
+                                <td><span t-field="inv.invoice_date"/></td>
+                                <td><span t-field="inv.name"/></td>
+                                <td><span t-field="inv.ref"/></td>
+                                <td class="text-right"><span t-field="inv.amount_total"/></td>
+                                <td class="text-right"><span t-esc="amount" t-options="{'widget': 'monetary', 'display_currency': inv.currency_id}"/></td>
+                                <td class="text-right"><span t-field="inv.amount_residual"/></td>
+                            </t>
                         </tr>
                     </tbody>
                 </table>


### PR DESCRIPTION
Steps to reproduce the bug:

1/ Create an opening balance Journal Entry with debit 100$ "121000 Account Receivable" and credit 100$ on another account
2/ Create an invoice for 150$
3/ Register a payment of 250$ for this invoice
4/ Reconcile the Journal Item of the payment (with "121000 Account Receivable" as account) with the opening balance => this line should be now fully reconcile
5/ Go to the payment and try to print the payment receipt

Bug:

The opening balance was shown as an invoice

opw:2448349