### PR TITLE
[FIX] payment{,_stripe_sca}: special character in reference


### DIFF
--- a/addons/payment/views/payment_portal_templates.xml
+++ b/addons/payment/views/payment_portal_templates.xml
@@ -55,8 +55,11 @@
                             <p><b>Amount:</b> <t t-esc="amount" t-options="{'widget': 'monetary', 'display_currency': currency}"/></p>
                             <t t-call="payment.payment_tokens_list" t-if="reference and amount and currency">
                                 <t t-set="mode" t-value="'payment'"/>
+                                <t t-set="_overriden_reference" t-value="reference"/>
+                                <t t-set="reference" t-value="quote_plus(reference).replace('+','%20')"/>
                                 <t t-set="prepare_tx_url" t-value="'/website_payment/transaction/v2/' + str(amount) + '/' + str(currency.id) + '/' + reference"/>
                                 <t t-set="form_action" t-value="'/website_payment/token/v2/' + str(amount) + '/' + str(currency.id) + '/' + reference"/>
+                                <t t-set="reference" t-value="_overriden_reference"/>
                             </t>
                             <div t-if="not acquirers" class="alert alert-danger" role="alert">
                                 <p>No payment acquirer found.</p>

--- a/addons/payment_stripe_sca/models/payment.py
+++ b/addons/payment_stripe_sca/models/payment.py
@@ -34,9 +34,9 @@ class PaymentAcquirerStripeSCA(models.Model):
             "line_items[][name]": tx_values["reference"],
             "client_reference_id": tx_values["reference"],
             "success_url": urls.url_join(base_url, StripeController._success_url)
-            + "?reference=%s" % tx_values["reference"],
+            + "?reference=%s" % urls.url_quote_plus(tx_values["reference"]),
             "cancel_url": urls.url_join(base_url, StripeController._cancel_url)
-            + "?reference=%s" % tx_values["reference"],
+            + "?reference=%s" % urls.url_quote_plus(tx_values["reference"]),
             "payment_intent_data[description]": tx_values["reference"],
             "customer_email": tx_values.get("partner_email") or tx_values.get("billing_partner_email"),
         }


### PR DESCRIPTION

Special character in reference (eg. '#' character in invoice sequence)
might cause error for payment acquirer.

For example with stripe we get the error on:

    {'error': {'code': 'url_invalid',
     'doc_url': 'https://stripe.com/docs/error-codes/url-invalid',
     'message': 'Not a valid URL', 'param': 'success_url',
     'type': 'invalid_request_error'}}

Or an error because prepare_tx_url is broken.

With this changeset, when a payment reference is used inside an url, we
quote it.

opw-2479658
