### PR TITLE
Revert "[FIX] hr_contract: update date_end when closing contract"

### DIFF
--- a/addons/hr_contract/models/hr_contract.py
+++ b/addons/hr_contract/models/hr_contract.py
@@ -164,7 +164,7 @@ class Contract(models.Model):
         if vals.get('state') == 'open':
             self._assign_open_contract()
         if vals.get('state') == 'close':
-            for contract in self:
+            for contract in self.filtered(lambda c: not c.date_end):
                 contract.date_end = max(date.today(), contract.date_start)
 
         calendar = vals.get('resource_calendar_id')


### PR DESCRIPTION
This reverts commit 825b533ec964fd8a9923dd4d2091f122b92d8759.

For the following reasons:
- This is a behavior change on a stable release. See our stable policy:
  https://github.com/odoo/odoo/wiki/Contributing#what-does-stable-mean
- If a contract end date is set, it's erased when moving the contract afterward.
- There is a cron which is moving the expired contracts automatically,
  this will rewrite the end date on it, which is not a big deal, but this
  is useless.
- Modifying the contract end date also unlink all the work entries that are
  outside of the new contract period. If there is an open payslip, it also
  recomputes the worked days lines, and the payslip lines.
  That way, it's possible to recompute a payslip by introducing unpaid
  time off inside of it. If the payroll officers are checking the payslips
  at that time, and don't notice it (already checked, etc...), then at the
  validation, this could lead to some more serious issues (wrong net salary
  paid to the employee, wrong accounting entries, wrong declaration to the
  state, etc).

If the contract end date is badly configured, this is normal that the
reporting is wrong. No need to add some magic that people don't understand,
that could lead to wrong behaviors later on the process.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
