### PR TITLE
[FIX] {stock,mrp_subcontracting}_account: change stock move at the end

### DIFF
--- a/addons/mrp_subcontracting_account/models/stock_picking.py
+++ b/addons/mrp_subcontracting_account/models/stock_picking.py
@@ -25,13 +25,12 @@ class StockPicking(models.Model):
         return vals
 
 
-class StockMove(models.Model):
-    _inherit = 'stock.move'
+class StockValuationLayer(models.Model):
+    _inherit = 'stock.valuation.layer'
 
-    def _prepare_common_svl_vals(self):
+    def _update_stock_move(self):
         # if we are subcontracting we want to have the receipt move
         # on the svl, not the MO
-        vals = super()._prepare_common_svl_vals()
-        if self.move_dest_ids and self.move_dest_ids[0].is_subcontract:
-            vals['stock_move_id'] = self.move_dest_ids[0].id
-        return vals
+        super()._update_stock_move()
+        if self.stock_move_id.move_dest_ids and self.stock_move_id.move_dest_ids[0].is_subcontract:
+            self.stock_move_id = self.stock_move_id.move_dest_ids[0].id

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -275,6 +275,10 @@ class StockMove(models.Model):
 
         stock_valuation_layers._check_company()
 
+        # Special update for subcontracting and landed cost
+        for svl in stock_valuation_layers:
+            svl._update_stock_move()
+
         # For every in move, run the vacuum for the linked product.
         products_to_vacuum = valued_moves['in'].mapped('product_id')
         company = valued_moves['in'].mapped('company_id') and valued_moves['in'].mapped('company_id')[0] or self.env.company

--- a/addons/stock_account/models/stock_valuation_layer.py
+++ b/addons/stock_account/models/stock_valuation_layer.py
@@ -37,3 +37,6 @@ class StockValuationLayer(models.Model):
             self._table, ['product_id', 'remaining_qty', 'stock_move_id', 'company_id', 'create_date']
         )
 
+    def _update_stock_move(self):
+        """ To be overriden in mrp subcontracting"""
+        return True


### PR DESCRIPTION
Commit fa3e3851f3e486f8c99d714d1b0c8f50e923ee37 change the stock move
linked to stock layer in case it's a subcontracting one. The idea is to
link the stock valuation layer to the receipt and not to the production
order. This was the only way to see the receipt in the candidate list to
apply a landed cost.

But the previously quoted commit updated the stock move before the
creation of the accounting entry when the subcontracted product is
valuated 'automated'. This result to a non-creation of accounting
entries as the receipt move is made from the subcontracting location to
Stock, and thus not considered as to be valued.

This commit keeps the update stock move mechanism but after the
accounting entries creation.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
