### PR TITLE
[FIX] survey: do not always get answer_score

### DIFF
--- a/addons/survey/models/survey_user.py
+++ b/addons/survey/models/survey_user.py
@@ -529,8 +529,8 @@ class SurveyUserInputLine(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:
-            score_vals = self._get_answer_score_values(vals)
             if not vals.get('answer_score'):
+                score_vals = self._get_answer_score_values(vals)
                 vals.update(score_vals)
         return super(SurveyUserInputLine, self).create(vals_list)
 
@@ -544,8 +544,8 @@ class SurveyUserInputLine(models.Model):
                 'question_id': line.question_id.id,
                 **vals_copy
             }
-            score_vals = self._get_answer_score_values(getter_params, compute_speed_score=False)
             if not vals_copy.get('answer_score'):
+                score_vals = self._get_answer_score_values(getter_params, compute_speed_score=False)
                 vals_copy.update(score_vals)
             res = super(SurveyUserInputLine, line).write(vals_copy) and res
         return res


### PR DESCRIPTION
Before this commit, 
1: It was always calling method `_get_answer_score_values`
even if we were getting `answer_score` in `vals`.
2: It was always accessing `user_input_id` and `question_id` from `vals` on
and write method which might not exists in `vals`.

With this Commit,
1: we are calling method `_get_answer_score_values` when its 
necessary get values for `answer_is_correct` and `answer_score`.
2: use `user_input_id` and `question_id` from `self`
if it is not available in `vals` to get values for `answer_is_correct` and
`answer_score`.

Fixes: #67429

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
