### PR TITLE
[FIX] fleet: compute contract name correctly

### DIFF
--- a/addons/fleet/models/fleet_vehicle_cost.py
+++ b/addons/fleet/models/fleet_vehicle_cost.py
@@ -59,7 +59,7 @@ class FleetVehicleLogContract(models.Model):
     def _compute_contract_name(self):
         for record in self:
             name = record.vehicle_id.name
-            if record.cost_subtype_id.name:
+            if name and record.cost_subtype_id.name:
                 name = record.cost_subtype_id.name + ' ' + name
             record.name = name
 


### PR DESCRIPTION
Steps to reproduce the Bug:

- Fleet > Contracts > Create new contract and select Type


Bug:

`TypeError: can only concatenate str (not "bool") to str`

Fix:
Now we are concatenation vehicle's name if vehicle_id is selected.

Fixes: #67796

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
