### PR TITLE
[IMP] l10n_ar: Update website reference

### DIFF
--- a/addons/l10n_ar/__manifest__.py
+++ b/addons/l10n_ar/__manifest__.py
@@ -66,6 +66,7 @@ Master Data:
 * Partners: Consumidor Final and AFIP
 """,
     'author': 'ADHOC SA',
+    'website': 'https://www.odoo.com/documentation/user/13.0/accounting/fiscal_localizations/localizations/argentina.html'
     'category': 'Localization',
     'depends': [
         'l10n_latam_invoice_document',


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The website is now referenced to Odoo's website, with the most updated documentation.
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
