### PR TITLE
[FIX] web: fix progressbar filter on kanban state

### DIFF
--- a/addons/web/static/src/js/views/kanban/kanban_column_progressbar.js
+++ b/addons/web/static/src/js/views/kanban/kanban_column_progressbar.js
@@ -89,6 +89,7 @@ var KanbanColumnProgressBar = Widget.extend({
      * Computes the count of each sub group and the total count
      */
     computeCounters() {
+        debugger;
         const subgroupCounts = {};
         for (const key of Object.keys(this.colors)) {
             const subgroupCount = this.columnState.progressBarValues.counts[key] || 0;
@@ -98,7 +99,7 @@ var KanbanColumnProgressBar = Widget.extend({
                     activeFilter: this.activeFilter
                 });
             }
-            subgroupCounts[key] = this.activeFilter.value === key ? this.columnState.count : subgroupCount;
+            subgroupCounts[key] = this.activeFilter.value === key && key === '__false' ? this.columnState.count : subgroupCount;
         }
 
         this.groupCount = this.columnState.count;
@@ -177,6 +178,7 @@ var KanbanColumnProgressBar = Widget.extend({
             $bar.removeClass('o_bar_has_records transition-off');
             window.getComputedStyle($bar[0]).getPropertyValue('width'); // Force reflow so that animations work
             if (count > 0) {
+                debugger;
                 $bar.addClass('o_bar_has_records');
                 // Make sure every bar that has records has some space
                 // and that everything adds up to 100%

--- a/addons/web/static/src/js/views/kanban/kanban_column_progressbar.js
+++ b/addons/web/static/src/js/views/kanban/kanban_column_progressbar.js
@@ -91,6 +91,7 @@ var KanbanColumnProgressBar = Widget.extend({
     computeCounters() {
         debugger;
         const subgroupCounts = {};
+        let allsubgroupCount = 0;
         for (const key of Object.keys(this.colors)) {
             const subgroupCount = this.columnState.progressBarValues.counts[key] || 0;
             if (this.activeFilter.value === key && this.columnState.count === 0 && subgroupCount <= 0) {
@@ -100,6 +101,16 @@ var KanbanColumnProgressBar = Widget.extend({
                 });
             }
             subgroupCounts[key] = this.activeFilter.value === key && key === '__false' ? this.columnState.count : subgroupCount;
+            allsubgroupCount += subgroupCount;
+        }
+
+        const colorValues = _.pick(this.colors, ['planned', 'today', 'overdue']);
+        const subvalueCounts = _.pick(this.columnState.progressBarValues.counts, ['planned', 'today', 'overdue']);
+        let allsubCount = 0;
+        for(const key of Object.keys(colorValues)) {
+            const subvalueCount = subvalueCounts[key] || 0;
+            allsubCount += subvalueCount;
+            // subgroupCounts.__false = allsubgroupCount < allsubCount ? allsubCount - allsubgroupCount : this.columnState.count;
         }
 
         this.groupCount = this.columnState.count;

--- a/addons/web/static/src/js/views/kanban/kanban_column_progressbar.js
+++ b/addons/web/static/src/js/views/kanban/kanban_column_progressbar.js
@@ -92,10 +92,13 @@ var KanbanColumnProgressBar = Widget.extend({
         const subgroupCounts = {};
         for (const key of Object.keys(this.colors)) {
             const subgroupCount = this.columnState.progressBarValues.counts[key] || 0;
-            if (this.activeFilter.value === key && subgroupCount === 0) {
+            if (this.activeFilter.value === key && this.columnState.count === 0 && subgroupCount <= 0) {
                 this.activeFilter = {};
+                this.trigger_up('kanban_load_column_records', {
+                    activeFilter: this.activeFilter
+                });
             }
-            subgroupCounts[key] = subgroupCount;
+            subgroupCounts[key] = this.activeFilter.value === key ? this.columnState.count : subgroupCount;
         }
 
         this.groupCount = this.columnState.count;

--- a/addons/web/static/src/js/views/kanban/kanban_model.js
+++ b/addons/web/static/src/js/views/kanban/kanban_model.js
@@ -386,10 +386,12 @@ var KanbanModel = BasicModel.extend({
      * @returns {Promise<Object>}
      */
     async _readProgressBarGroup(list, options) {
+        debugger;
         const groupsDef = this._readGroup(list, options);
         const progressBarDef = this._readProgressBar(list);
         const [groups, progressBar] = await Promise.all([groupsDef, progressBarDef]);
         list.data.forEach(groupId => {
+            debugger;
             const group = this.localData[groupId];
 
             const valuesCount = progressBar[group.value] || {};

--- a/addons/web/static/src/js/views/kanban/kanban_model.js
+++ b/addons/web/static/src/js/views/kanban/kanban_model.js
@@ -489,6 +489,11 @@ var KanbanModel = BasicModel.extend({
                // reload the progressbars
                return def;
            }
+           if (element.activeFilter && element.activeFilter.value) {
+               // We must not read_group when an active filter (and thus
+               // a domain extension) is applied to the list datapoint.
+               return def;
+           }
        }
         // If we updated a record, then we must potentially update columns'
         // progressbars, so we need to load groups info again

--- a/addons/web/static/src/js/views/kanban/kanban_model.js
+++ b/addons/web/static/src/js/views/kanban/kanban_model.js
@@ -489,11 +489,6 @@ var KanbanModel = BasicModel.extend({
                // reload the progressbars
                return def;
            }
-           if (element.activeFilter) {
-               // We must not read_group when an active filter (and thus
-               // a domain extension) is applied to the list datapoint.
-               return def;
-           }
        }
         // If we updated a record, then we must potentially update columns'
         // progressbars, so we need to load groups info again

--- a/addons/web/static/tests/views/kanban_tests.js
+++ b/addons/web/static/tests/views/kanban_tests.js
@@ -5865,9 +5865,11 @@ QUnit.module('Views', {
     QUnit.test('column progressbars active filter should remove from old column when record drag and drop to new column', async function (assert) {
         assert.expect(5);
 
-        this.data.partner.records.push({id: 5, bar: false, foo: "gnap", product_id: 5, state: "gnap"});
-        this.data.partner.records.push({id: 6, bar: false, foo: "blip", product_id: 5, state: "blip"});
-        this.data.partner.records.push({id: 7, bar: false, foo: "blip", product_id: 5, state: "blip"});
+        this.data.partner.records.push(...[
+            {id: 5, bar: false, foo: "gnap", product_id: 5, state: "gnap"},
+            {id: 6, bar: false, foo: "blip", product_id: 5, state: "blip"},
+            {id: 7, bar: false, foo: "blip", product_id: 5, state: "blip"},
+        ]);
 
         const kanban = await createView({
             View: KanbanView,
@@ -6306,7 +6308,7 @@ QUnit.module('Views', {
     });
 
     QUnit.test('RPCs when (de)activating kanban view progressbar filters', async function (assert) {
-        assert.expect(14);
+        assert.expect(10);
 
         const kanban = await createView({
             View: KanbanView,
@@ -6345,12 +6347,8 @@ QUnit.module('Views', {
             // activate filter
             '/web/dataset/search_read',
             // activate another filter (switching)
-            'web_read_group',
-            'read_progress_bar',
             '/web/dataset/search_read',
             // deactivate active filter
-            'web_read_group',
-            'read_progress_bar',
             '/web/dataset/search_read',
             'web_read_group',
             'read_progress_bar',


### PR DESCRIPTION
Currently, In kanban state when we filter the record and move it
to another stage, then the previous column counter drops to zero
and remaining records are not displaying

So in this commit, if we move the record to other stage then the
previous column records which are not match to current filter are
displayed

TaskId: 2454209

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
