### PR TITLE
[FIX] stock_account,sale_mrp,sale_stock: consider consu kit for COGS

### DIFF
--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -556,6 +556,9 @@ class TestSaleMrpFlow(common.SavepointCase):
         self.assertEqual(so.invoice_status, 'to invoice', 'Sale MRP: so invoice_status should be "to invoice" after complete delivery of a kit')
 
     def test_02_sale_mrp_anglo_saxon(self):
+        self._test_sale_mrp_anglo_saxon('product')
+
+    def _test_sale_mrp_anglo_saxon(self, finished_product_type):
         """Test the price unit of a kit"""
         # This test will check that the correct journal entries are created when a stockable product in real time valuation
         # and in fifo cost method is sold in a company using anglo-saxon.
@@ -591,7 +594,7 @@ class TestSaleMrpFlow(common.SavepointCase):
         Product = self.env['product.product']
         self.finished_product = Product.create({
                 'name': 'Finished product',
-                'type': 'product',
+                'type': finished_product_type,
                 'uom_id': self.uom_unit.id,
                 'invoice_policy': 'delivery',
                 'categ_id': self.category.id})
@@ -1458,6 +1461,9 @@ class TestSaleMrpFlow(common.SavepointCase):
         move_component_kg = order.picking_ids[0].move_lines - move_component_unit
         self.assertEquals(move_component_unit.product_uom_qty, 0.5)
         self.assertEquals(move_component_kg.product_uom_qty, 0.583)
+
+    def test_12_sale_mrp_anglo_saxon_consu_kit(self):
+        self._test_sale_mrp_anglo_saxon('consu')
 
     def test_product_type_service_1(self):
         route_manufacture = self.warehouse.manufacture_pull_id.route_id.id

--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -108,6 +108,8 @@ class AccountMoveLine(models.Model):
         self.ensure_one()
         return not self.is_anglo_saxon_line and super(AccountMoveLine, self)._sale_can_be_reinvoice()
 
+    def _eligible_for_cogs(self):
+        return super()._eligible_for_cogs() or any(p.type == 'product' and p.valuation == 'real_time' for p in self.sale_line_ids.move_ids.product_id)
 
     def _stock_account_get_anglo_saxon_price_unit(self):
         self.ensure_one()

--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -112,7 +112,7 @@ class AccountMove(models.Model):
             for line in move.invoice_line_ids:
 
                 # Filter out lines being not eligible for COGS.
-                if line.product_id.type != 'product' or line.product_id.valuation != 'real_time':
+                if not line._eligible_for_cogs():
                     continue
 
                 # Retrieve accounts needed to generate the COGS.
@@ -233,6 +233,10 @@ class AccountMoveLine(models.Model):
             if accounts['stock_input']:
                 return accounts['stock_input']
         return super(AccountMoveLine, self)._get_computed_account()
+
+    def _eligible_for_cogs(self):
+        self.ensure_one()
+        return self.product_id.type == 'product' and self.product_id.valuation == 'real_time'
 
     def _stock_account_get_anglo_saxon_price_unit(self):
         self.ensure_one()


### PR DESCRIPTION
Suppose a consumable product that has a kit BoM. Since we have:
https://github.com/odoo/odoo/blob/65a3ffb12429e30ef911a981809b0f050f9c924d/addons/stock_account/models/account_move.py#L101-L103
The line will be ignored. However, one of the component could be a
storable product. In such a case, the line should not be skipped.