### PR TITLE
[FIX] account_edi_facturx: wrong ID

### DIFF
--- a/addons/account_edi_facturx/data/facturx_templates.xml
+++ b/addons/account_edi_facturx/data/facturx_templates.xml
@@ -112,7 +112,7 @@
 
                 <!-- Document Headers. -->
                 <rsm:ExchangedDocument>
-                    <ram:ID t-esc="record.ref"/>
+                    <ram:ID t-esc="record.name"/>
                     <ram:TypeCode t-esc="'381' if 'refund' in record.move_type else '380'"/>
                     <ram:IssueDateTime>
                         <udt:DateTimeString format="102" t-esc="format_date(record.invoice_date)"/>

--- a/addons/account_edi_facturx/tests/test_facturx.py
+++ b/addons/account_edi_facturx/tests/test_facturx.py
@@ -66,6 +66,7 @@ class TestAccountEdiFacturx(AccountEdiTestCommon):
                     </GuidelineSpecifiedDocumentContextParameter>
                 </ExchangedDocumentContext>
                 <ExchangedDocument>
+                    <ID>INV/2017/01/0001</ID>
                     <TypeCode>380</TypeCode>
                     <IssueDateTime>
                         <DateTimeString format="102">20170101</DateTimeString>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
ID should be the number of the invoice, especially when it is a customer invoice.

![image](https://user-images.githubusercontent.com/16716992/112968436-98153200-914c-11eb-8121-699e76739a8e.png)

@oco-odoo 



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
