### PR TITLE
Map & Dynamic snippets cleanup

### DIFF
--- a/addons/website/static/src/snippets/s_dynamic_snippet/options.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/options.js
@@ -74,10 +74,10 @@ const dynamicSnippetOptions = options.Class.extend({
      */
     _refreshPublicWidgets: function () {
         return this._super.apply(this, arguments).then(() => {
-            const templateKeys = this.$el ? this.$el.find("we-select[data-attribute-name='templateKey'] we-selection-items we-button") : [];
+            const selectedTemplateId = this.$target.get(0).dataset['templateKey'];
             this.$target.find('.missing_option_warning').toggleClass(
                 'd-none',
-                templateKeys.length > 0
+                !!this.dynamicFilterTemplates[selectedTemplateId]
             );
         });
     },

--- a/addons/website/views/snippets/s_dynamic_snippet.xml
+++ b/addons/website/views/snippets/s_dynamic_snippet.xml
@@ -19,7 +19,7 @@
     </template>
     <template id="website.s_dynamic_snippet_options_template">
         <div t-attf-data-js="#{snippet_name}" t-attf-data-selector="#{snippet_selector}" data-no-preview="true">
-            <we-select string="Filter" data-name="filter_opt" data-attribute-name="filterId">
+            <we-select string="Filter" data-name="filter_opt" data-attribute-name="filterId" data-no-preview="true">
             </we-select>
             <we-select string="Template" data-name="template_opt" data-attribute-name="templateKey" data-no-preview="true">
             </we-select>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -108,8 +108,9 @@
                 <div class="o_panel_header">Dynamic Content</div>
                 <div class="o_panel_body">
                     <t id="form_form_hook"/>
-                    <t t-snippet="website.s_map" t-thumbnail="/website/static/src/img/snippets_thumbs/s_map.svg"/>
-                    <t t-snippet="website.s_google_map" t-thumbnail="/website/static/src/img/snippets_thumbs/s_google_map.svg"/>
+                    <t t-set="google_maps_api_key" t-value="request.env['website'].get_current_website().google_maps_api_key"/>
+                    <t t-if="debug or not google_maps_api_key" t-snippet="website.s_map" t-thumbnail="/website/static/src/img/snippets_thumbs/s_map.svg"/>
+                    <t t-if="debug or google_maps_api_key" t-snippet="website.s_google_map" t-thumbnail="/website/static/src/img/snippets_thumbs/s_google_map.svg"/>
                     <t t-if="debug" t-snippet="website.s_dynamic_snippet" t-thumbnail="/website/static/src/img/snippets_thumbs/s_dynamic_snippet.svg"/>
                     <t t-if="debug" t-snippet="website.s_dynamic_snippet_carousel" t-thumbnail="/website/static/src/img/snippets_thumbs/s_dynamic_carousel.svg"/>
                     <t id="sale_products_hook"/>

--- a/addons/website_blog/static/src/snippets/s_blog_posts/000.scss
+++ b/addons/website_blog/static/src/snippets/s_blog_posts/000.scss
@@ -96,7 +96,7 @@
         &.s_blog_posts_effect_dexter .s_blog_posts_post {
             &::before {
                 content: "";
-                @include o-position-absolute(0, $grid-gutter-width/2, 0, $grid-gutter-width/2);
+                @include o-position-absolute($grid-gutter-width/2, $grid-gutter-width/2, $grid-gutter-width/2, $grid-gutter-width/2);
                 background: linear-gradient(to bottom, darken(theme-color('secondary'), 10%) 0%, darken(theme-color('secondary'), 30%) 100%);
             }
             .o_record_cover_container {

--- a/addons/website_blog/views/snippets/s_blog_posts.xml
+++ b/addons/website_blog/views/snippets/s_blog_posts.xml
@@ -69,7 +69,7 @@
                 <t t-set="_record" t-value="record"/>
                 <t t-set="_resize_height" t-value="512"/>
                 <t t-set="_resize_width" t-value="512"/>
-                <t t-set="additionnal_classes" t-value="'loading_container thumb'"/>
+                <t t-set="additionnal_classes" t-value="'thumb'"/>
             </t>
         </a>
     </figure>
@@ -84,7 +84,7 @@
                     <t t-set="_record" t-value="record"/>
                     <t t-set="_resize_height" t-value="256"/>
                     <t t-set="_resize_width" t-value="256"/>
-                    <t t-set="additionnal_classes" t-value="'loading_container thumb'"/>
+                    <t t-set="additionnal_classes" t-value="'thumb'"/>
                 </t>
             </a>
             <div class="card-body">

--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/options.js
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/options.js
@@ -63,7 +63,14 @@ const dynamicSnippetProductsOptions = s_dynamic_snippet_carousel_options.extend(
         const productCategoriesSelectorEl = uiFragment.querySelector('[data-name="product_category_opt"]');
         return this._renderSelectUserValueWidgetButtons(productCategoriesSelectorEl, this.productCategories);
     },
-
+    /**
+     * @override
+     * @private
+     */
+    _setOptionsDefaultValues: function () {
+        this._setOptionValue('productCategoryId', 'all');
+        this._super.apply(this, arguments);
+    },
 });
 
 options.registry.dynamic_snippet_products = dynamicSnippetProductsOptions;

--- a/addons/website_sale/views/snippets/s_dynamic_snippet_products.xml
+++ b/addons/website_sale/views/snippets/s_dynamic_snippet_products.xml
@@ -5,11 +5,6 @@
             <t t-set="snippet_name" t-value="'s_dynamic_snippet_products'"/>
         </t>
     </template>
-    <template id="s_dynamic_snippet_template" inherit_id="website.s_dynamic_snippet_template">
-        <xpath expr="section" position="attributes">
-            <attribute t-if="snippet_name == 's_dynamic_snippet_products'" name="data-product-category-id">all</attribute>
-        </xpath>
-    </template>
     <template id="s_dynamic_snippet_products_options" inherit_id="website.snippet_options">
         <xpath expr="." position="inside">
             <t t-call="website.dynamic_snippet_carousel_options_template">


### PR DESCRIPTION
Miscellaneous fixes for dynamic snippets:
- removed unused CSS in blog snippet
- adapted condition of warning about missing template
- disabled preview on filter selection (which sometimes caused a blocking loader to be displayed)
- map snippet availability according to key
- fix the Dexter effect of the blog snippet

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
