### PR TITLE
[FIX] account: count in dashboard statement lines marked 'to_check'

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -431,7 +431,7 @@ class account_journal(models.Model):
     def to_check_ids(self):
         self.ensure_one()
         domain = self.env['account.move.line']._get_suspense_moves_domain()
-        domain += [('journal_id', '=', self.id),('statement_line_id.is_reconciled', '=', False)]
+        domain.append(('journal_id', '=', self.id))
         statement_line_ids = self.env['account.move.line'].search(domain).mapped('statement_line_id')
         return statement_line_ids
 


### PR DESCRIPTION
1. Reconcile of a bank statement, checking the "To
check" box on the manual operation before validation
2. Go to accounting dashboard

The statement line will not be counted in the "to check" action.
This occur because the action only filter on reconciled moves

opw-2475663

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
