### PR TITLE
[FIX] service: autocommit when creating database

### DIFF
--- a/odoo/service/db.py
+++ b/odoo/service/db.py
@@ -104,6 +104,7 @@ def _create_empty_database(name):
             raise DatabaseExists("database %r already exists!" % (name,))
         else:
             # database-altering operations cannot be executed inside a transaction
+            cr.rollback()
             cr._cnx.autocommit = True
 
             # 'C' collate is only safe with template0, but provides more useful indexes


### PR DESCRIPTION
Creating a database from the Odoo CLI miserably fails with the error
"psycopg2.ProgrammingError: set_session cannot be used inside a
transaction".

Setting con.autocommit = True fails if some transaction is already
started, which is the case when creating a database.  The fix consists
in rolling back the existing transaction (with only a SELECT) before
switching to autocommit.

Fixes an issue introduced via #68491