### PR TITLE
[FIX] calendar: Fix ir.cron access error on calendar.event

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -693,7 +693,7 @@ class Meeting(models.Model):
 
     def _setup_alarms(self):
         """ Schedule cron triggers for future events """
-        cron = self.env.ref('calendar.ir_cron_scheduler_alarm')
+        cron = self.env.ref('calendar.ir_cron_scheduler_alarm').sudo()
         alarm_manager = self.env['calendar.alarm_manager']
         alarm_types = self._get_trigger_alarm_types()
 


### PR DESCRIPTION
Problem
-------
Writing on a calendar.event trigger _setup_alarms that may need
to read on an ir.cron depending on the alarm setup.

Non admin user are not allow to read ir.cron and thus an access
error is trigger.

Solution
--------
Read the cron in sudo mode




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
