### PR TITLE
[FIX] web_editor: show XML editor error if rejection value

### DIFF
--- a/addons/web_editor/static/src/js/common/ace.js
+++ b/addons/web_editor/static/src/js/common/ace.js
@@ -629,6 +629,10 @@ var ViewEditor = Widget.extend({
 
         var self = this;
         return Promise.all(defs).guardedCatch(function (results) {
+            // some overrides handle errors themselves
+            if (results === undefined) {
+                return;
+            }
             var error = results[1];
             Dialog.alert(self, '', {
                 title: _t("Server error"),


### PR DESCRIPTION

Override of _saveView on failure does not sent an error message to
display. For example in web_studio an error inside the XML editor is
already displayed.

With this changeset, we don't display an additional error if no
rejection value is received.

note: also fix that in normal use case, we get 'undefined' (we see the
real error in notification).

opw-2460081
