### PR TITLE
[FIX] repair: Invoice lines are not added for Repair

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -346,7 +346,6 @@ class Repair(models.Model):
                     'partner_shipping_id': repair.address_id.id,
                     'currency_id': currency.id,
                     'narration': narration,
-                    'line_ids': [],
                     'invoice_origin': repair.name,
                     'repair_ids': [(4, repair.id)],
                     'invoice_line_ids': [],


### PR DESCRIPTION
Steps to reproduce the bug:

- In Repair: create a new repair order
- add some product to "Add' and operation.
- Select option for Invoice Method: Before/After Repair.
- Confirm Repair, finish repair and create invoice.

Bug:

No line was created in the invoice

PS: the invoice_line_ids were popped from function _move_autocomplete_invoice_lines_create

opw:2493091