### PR TITLE
[IMP] auth_signup: don't update templates unnecessarily

### DIFF
--- a/addons/auth_signup/models/res_users.py
+++ b/addons/auth_signup/models/res_users.py
@@ -194,7 +194,8 @@ class ResUsers(models.Model):
             'partner_to': False,
             'scheduled_date': False,
         }
-        template.write(template_values)
+        if any(template[field] != value for (field, value) in template_values.items()):
+            template.write(template_values)
 
         for user in self:
             if not user.email:


### PR DESCRIPTION
Calling write() on a record will touch it and update its `write_date`, even if all the field values are identical to the current values.

Let's not touch the mail template unless we have a reason to.