### PR TITLE
[FIX]account: correctly process first bill tour

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -602,20 +602,7 @@ class AccountJournal(models.Model):
                 invoice = self.env['account.move'].create({})
             invoice.with_context(no_new_invoice=True).message_post(attachment_ids=[attachment.id])
             invoices += invoice
-
-        action_vals = {
-            'name': _('Generated Documents'),
-            'domain': [('id', 'in', invoices.ids)],
-            'res_model': 'account.move',
-            'views': [[False, "tree"], [False, "form"]],
-            'type': 'ir.actions.act_window',
-            'context': self._context
-        }
-        if len(invoices) == 1:
-            action_vals.update({'res_id': invoices[0].id, 'view_mode': 'form'})
-        else:
-            action_vals['view_mode'] = 'tree,form'
-        return action_vals
+        return invoices
 
     def _create_invoice_from_single_attachment(self, attachment):
         """ Creates an invoice and post the attachment. If the related modules

--- a/addons/account/wizard/account_tour_upload_bill.py
+++ b/addons/account/wizard/account_tour_upload_bill.py
@@ -55,7 +55,8 @@ class AccountTourUploadBill(models.TransientModel):
     def apply(self):
         purchase_journal = self.env['account.journal'].search([('type', '=', 'purchase')], limit=1)
         if self.selection == 'upload':
-            return purchase_journal.with_context(default_journal_id=purchase_journal.id, default_move_type='in_invoice').create_invoice_from_attachment(attachment_ids=self.attachment_ids.ids)
+            bill = purchase_journal.with_context(default_journal_id=purchase_journal.id, default_move_type='in_invoice').create_invoice_from_attachment(attachment_ids=self.attachment_ids.ids)
+            return self._action_list_view_bill(bill.ids)
         elif self.selection == 'sample':
             attachment = self.env['ir.attachment'].create({
                 'type': 'binary',


### PR DESCRIPTION
Steps to reproduce the Bug:

- Accounting Dashboard > First Bill > Continue

Bug:

`AttributeError: 'dict' object has no attribute 'write'`
As It is trying to Write on Bill but the method is returning
dict containing the view.

Fix:

Now we are correctly returning Bills to Process.

Fixes: #66558
Closes: #68187

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
