### PR TITLE
[FIX] l10n_latam_invoice_document: doc prefix in vendor bill name

### DIFF
--- a/addons/l10n_latam_invoice_document/models/account_move.py
+++ b/addons/l10n_latam_invoice_document/models/account_move.py
@@ -48,6 +48,7 @@ class AccountMove(models.Model):
     l10n_latam_available_document_type_ids = fields.Many2many('l10n_latam.document.type', compute='_compute_l10n_latam_available_document_types')
     l10n_latam_document_type_id = fields.Many2one(
         'l10n_latam.document.type', string='Document Type', readonly=False, auto_join=True, index=True,
+        inverse='_inverse_l10n_latam_document_number',
         states={'posted': [('readonly', True)]}, compute='_compute_l10n_latam_document_type', store=True)
     l10n_latam_sequence_id = fields.Many2one('ir.sequence', compute='_compute_l10n_latam_sequence')
     l10n_latam_document_number = fields.Char(


### PR DESCRIPTION
task 507
----

### Description of the issue/feature this PR addresses:

Update document prefix in the name of the vendor bills after that document type has been updated. origin ticket 36156


> *NOTE: Install l10n_ar in order to have already configured document types.*

1. Create a vendor bill, set the document number and the document type
2. Post the vendor bill
3. Click on `Cancel entry` and then `Reset to draft` buttons
4. Edit the document number and click on the `Post` button, you will see that the vendor bill name has been updated with the new document number 
5. Redo step 3
5. Edit the vendor bill changing the document type to another one and click on the `Post` button

### Current behavior before PR:

The vendor bill name does change when the document number is changed but is not been updated the document prefix in the name when the document type has been changed.

### Desired behavior after PR is merged:

The vendor bill name is updated both when the document number or document type has been updated, this way the document will match with the new document type code prefix.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
