### PR TITLE
[FIX]mrp: correct report name

### DIFF
--- a/addons/mrp/report/mrp_report_bom_structure.xml
+++ b/addons/mrp/report/mrp_report_bom_structure.xml
@@ -5,7 +5,8 @@
             <t t-if="data.get('components') or data.get('lines')">
                 <div class="row">
                     <div class="col-lg-12">
-                        <h1>BoM Structure &amp; Cost</h1>
+                        <h1 style="display:inline;">BoM Structure </h1>
+                        <h1 style="display:inline;" t-if="data['report_structure'] != 'bom_structure'" class="o_mrp_prod_cost">&amp; Cost</h1>
                         <h3>
                             <a href="#" t-if="data['report_type'] == 'html'" t-att-data-res-id="data['product'].id" t-att-data-model="data['product']._name" class="o_mrp_bom_action">
                                 <t t-esc="data['bom_prod_name']"/>


### PR DESCRIPTION
Before this commit,
It was always displaying `BoM Structure & Cost` for BoM Structure and
BoM Structure & Cost report.

With this commit, we are displaying correct report name based on report type.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
