### PR TITLE
[FIX] l10n_lt: remove duplicate translation

### DIFF
--- a/addons/l10n_lt/i18n_extra/l10n_lt.pot
+++ b/addons/l10n_lt/i18n_extra/l10n_lt.pot
@@ -995,11 +995,6 @@ msgid "Liabilities under Short-Term Loan Agreements"
 msgstr ""
 
 #. module: l10n_lt
-#: model:account.account.template,name:l10n_lt.account_chart_template_lithuania_liquidity_transfer
-msgid "Liquidity Transfer"
-msgstr ""
-
-#. module: l10n_lt
 #: model:account.account.template,name:l10n_lt.account_account_template_4220
 msgid "Long-Term Liabilities under Loan Agreements"
 msgstr ""


### PR DESCRIPTION
Removed duplicate translation which was blocking loading of
Translations.

Fixes: #68552

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
