### PR TITLE
[FIX] website_blog: fit the size of the Dexter effect darkening area

### DIFF
--- a/addons/website_blog/static/src/snippets/s_blog_posts/000.scss
+++ b/addons/website_blog/static/src/snippets/s_blog_posts/000.scss
@@ -94,15 +94,16 @@
             }
         }
         &.s_blog_posts_effect_dexter .s_blog_posts_post {
-            &::before {
-                content: "";
-                @include o-position-absolute($grid-gutter-width/2, $grid-gutter-width/2, $grid-gutter-width/2, $grid-gutter-width/2);
-                background: linear-gradient(to bottom, darken(theme-color('secondary'), 10%) 0%, darken(theme-color('secondary'), 30%) 100%);
-            }
             .o_record_cover_container {
                 transition: opacity 0.35s;
             }
             figcaption {
+                &::before {
+                    content: "";
+                    @include o-position-absolute(0, 0, 0, 0);
+                    background: linear-gradient(to bottom, darken(theme-color('secondary'), 10%) 0%, darken(theme-color('secondary'), 30%) 100%);
+                    z-index: -1;
+                }
                 padding: 3em;
                 text-align: left;
                 &:after {


### PR DESCRIPTION
Before this commit the darkening area of the Dexter effect was spanning
1 pixel too high and 1 pixel too low, which made it visible when the
blog post was not hovered.

After this commit the darkening area is moved inside the right element
thus not requiring magic numbers for truncating the area.
This also fixes the display of the darkening area behind the rounded
corners that the old blog snippet had with the Dexter effect.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
