### PR TITLE
[FIX] calendar_sms: fix naming issue

### DIFF
--- a/addons/calendar_sms/models/calendar_alarm_manager.py
+++ b/addons/calendar_sms/models/calendar_alarm_manager.py
@@ -12,7 +12,7 @@ class AlarmManager(models.AbstractModel):
         """ Cron method, overridden here to send SMS reminders as well
         """
         super()._send_reminder()
-        alarms_by_event = self._get_events_by_alarm_to_notify(ttype='sms')
+        alarms_by_event = self._get_events_by_alarm_to_notify('sms')
         if not alarms_by_event:
             return
 


### PR DESCRIPTION
Fix naming issue as "ttype" was replaced by "alarm_type"
Linked COM PR: odoo/odoo#68443
