### PR TITLE
[FIX] mrp: set qty produced on operation

### DIFF
--- a/addons/mrp/models/mrp_routing.py
+++ b/addons/mrp/models/mrp_routing.py
@@ -51,6 +51,7 @@ class MrpRoutingWorkcenter(models.Model):
         for operation in self - manual_ops:
             data = self.env['mrp.workorder'].read_group([
                 ('operation_id', '=', operation.id),
+                ('qty_produced', '>', 0),
                 ('state', '=', 'done')], ['operation_id', 'duration', 'qty_produced'], ['operation_id'],
                 limit=operation.time_mode_batch)
             count_data = dict((item['operation_id'][0], (item['duration'], item['qty_produced'])) for item in data)

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -555,6 +555,7 @@ class MrpWorkorder(models.Model):
                 continue
             workorder.end_all()
             vals = {
+                'qty_produced': workorder.qty_produced or workorder.qty_producing or workorder.qty_production,
                 'state': 'done',
                 'date_finished': end_date,
                 'date_planned_finished': end_date


### PR DESCRIPTION
When marking an operation as done, the quantity produced may be zero.
Therefore, the duration computation will not work.

To reproduce the error:
1. In Settings, enable "Work Orders"
2. Create two products P_prod and P_compo
    - P_compo is consumable and its cost is 100
3. In Manufacturing, edit/create a Work Center WC
    - Cost per hour must be 60
4. Create a Bill of Materials BM
    - Product: P_prod
    - Component: P_compo
    - Operation:
        - Work Center: WC
        - Duration Computation: Compute based on tracked time
        - Based on last 3 work orders
        - Default Duration: 10:00
5. In Structure & Cost, notice that BoM Cost is 110
    - 100 (P_compo's cost)
    - 10 (OP's cost based on default time)
6. Do the following 3 times:
    - Create a MO with P_prod using BM, Confirm
    - In Work Orders, click on Start, then Done
    - Edit the Real Duration of OP: 20:00
    - Mark as Done
7. Back to BM, open Structure & Cost again

Error: BoM Cost is 110, this is incorrect: OP's cost is still 10, it
should be 20 (from step 6).

The problem is the quantity produced for each operation. Since this
quantity is never defined, it remains at 0. Therefore, when computing
the duration, since there is no quantity, the module keeps the default
value.

This fix changes the behavior. When the user marks the operation as done
from the form view, the module defines the quantity produced using the
quantity in production (this quantity may have been defined by the user
through the tablet mode). If this value is also 0, the module will use
the quantity expected by the MO.

`('qty_produced', '>', 0)` is added to avoid lines with zero quantity
produced, which was possible before this fix. Otherwise, the duration
calculation will give wrong values.

OPW-2453996