### PR TITLE
[FIX] account: restore the behaviour of _create_invoice_from_single_a…

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -624,7 +624,8 @@ class AccountJournal(models.Model):
 
             :returns: the created invoice.
         """
-        return self.create_invoice_from_attachment(attachment.ids)
+        invoice_action = self.create_invoice_from_attachment(attachment.ids)
+        return self.env['account.move'].browse(invoice_action['res_id'])
 
     def _create_secure_sequence(self, sequence_fields):
         """This function creates a no_gap sequence on each journal in self that will ensure


### PR DESCRIPTION
…ttachment

Introduced by https://github.com/odoo/odoo/pull/65510

_create_invoice_from_single_attachment should return the invoice and not the action returned by _create_invoice_from_attachment.
This commit aims to restore the original behaviour.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
