### PR TITLE
[FIX] web: search autocomplete Date without timezone


### DIFF
--- a/addons/web/static/src/js/views/control_panel/search/search_bar_autocomplete_sources.js
+++ b/addons/web/static/src/js/views/control_panel/search/search_bar_autocomplete_sources.js
@@ -320,7 +320,7 @@ var DateField = Field.extend({
             return Promise.resolve(null);
         }
 
-        var m = moment(v, t === 'datetime' ? 'YYYY-MM-DD HH:mm:ss' : 'YYYY-MM-DD');
+        var m = moment(t === 'datetime' ? v : v.toJSON(), t === 'datetime' ? 'YYYY-MM-DD HH:mm:ss' : 'YYYY-MM-DD');
         if (!m.isValid()) { return Promise.resolve(null); }
         var dateString = field_utils.format[t](m, {type: t});
         var label = this._getAutocompletionLabel(dateString);


### PR DESCRIPTION

When searching on a date field, in saas-12.3 and 13.0 the autocompletion
is done taking into account timezone.

So eg. searching 3/17 with timezone UTC-3 would get us 3/16 at 21:00
which would unexpectedly search the 16th and not 17th.

With this changeset, when autocompleting a date field, we do it without
applying browser timezone as is the case in 12.0 and lower, as well as
14.0 and higher.

opw-2482159
