### PR TITLE
[FIX] website_sale: fix product grid tables layout

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -5,7 +5,10 @@ $o-wsale-products-layout-grid-gutter-width: $grid-gutter-width / 2 !default;
 $o-wsale-products-layout-grid-gutter-width: min($grid-gutter-width / 2, $o-wsale-products-layout-grid-gutter-width);
 
 @mixin wsale-break-table-to-list() {
-    table, tbody, td, tr {
+    .o_wsale_products_grid_table_wrapper > table,
+    .o_wsale_products_grid_table_wrapper > table > tbody,
+    .o_wsale_products_grid_table_wrapper > table > tbody > tr,
+    .o_wsale_products_grid_table_wrapper > table > tbody > tr > td {
         display: block;
         width: 100%;
     }
@@ -177,19 +180,22 @@ $o-wsale-products-layout-grid-gutter-width: min($grid-gutter-width / 2, $o-wsale
 }
 
 #products_grid {
-    .table {
+    .o_wsale_products_grid_table_wrapper > .table {
         table-layout: fixed;
 
-        td {
-            margin-top: $o-wsale-products-layout-grid-gutter-width; // For list and mobile design
-            padding: 0;
+        > tbody {
+            > tr > td {
+                margin-top: $o-wsale-products-layout-grid-gutter-width; // For list and mobile design
+                padding: 0;
 
-            @if $o-wsale-products-layout-grid-gutter-width <= 0 {
-                border: $card-border-width solid $card-border-color;
+                @if $o-wsale-products-layout-grid-gutter-width <= 0 {
+                    border: $card-border-width solid $card-border-color;
+                }
             }
-        }
-        tr:first-child td:first-child {
-            margin-top: 0; // For list and mobile design
+
+            > tr:first-child > td:first-child {
+                margin-top: 0; // For list and mobile design
+            }
         }
 
         .o_wsale_product_grid_wrapper {


### PR DESCRIPTION
Before this commit (optional product modal in the shop page with view list enable)
![FireShot Capture 867 - FireShot Capture 864 - Shop - My Website - localhost jpg (1143×4223) - ](https://user-images.githubusercontent.com/52911687/113133764-505fda80-9220-11eb-9df1-4c8904819656.jpg)

Before this commit, on the /shop page, tables inside modals (e.g.
modal optional product) were modified by the CSS of the table of the
product grid. After this commit, the CSS is modified to only target
the product grid table.

task-2492086

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
