### PR TITLE
[FIX] payment_payulatam: use "Round half to even" method in signature

### DIFF
--- a/addons/payment_payulatam/models/payment.py
+++ b/addons/payment_payulatam/models/payment.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import decimal
 import logging
 import uuid
 
@@ -37,8 +38,9 @@ class PaymentAcquirerPayulatam(models.Model):
             data_string = ('~').join((self.payulatam_api_key, self.payulatam_merchant_id, values['referenceCode'],
                                       str(values['amount']), values['currency']))
         else:
+            rounded_amount = decimal.Decimal(values.get('TX_VALUE')).quantize(decimal.Decimal('0.1'), decimal.ROUND_HALF_EVEN)
             data_string = ('~').join((self.payulatam_api_key, self.payulatam_merchant_id, values['referenceCode'],
-                                      str(float(values.get('TX_VALUE'))), values['currency'], values.get('transactionState')))
+                                      str(rounded_amount), values['currency'], values.get('transactionState')))
         return md5(data_string.encode('utf-8')).hexdigest()
 
     @api.multi


### PR DESCRIPTION
Steps:
- Install l10n_ar, website_sale
- Go to Website / Configuration / eCommerce / Payment Acquirers
- Install PayUlatam
- Edit PayUlatam:
  - Argentinian credentials: http://developers.payulatam.com/en/web_checkout/sandbox.html
- Go to Website / Configuration / Settings
- Check Multi-Currencies
- Save
- Click Currencies
- Edit all currencies:
  - Rates:
    - Edit or create the current rate:
      - Rate: 1.000000
- Go to Website / Products / Pricelists
- Create an ARS pricelist and make it selectable
- Go to Website / Products / Products
- Create a product (1):
  - Sales Price: 15.75
  - No taxes
- Click "Published On Website"
- Select your new ARS pricelist
- Add (1) to Cart
- Process Checkout
- Select PayUlatam
- Pay Now
- Use this info to process the checkout: http://developers.payulatam.com/en/web_checkout/sandbox.html
- Pagar (Pay)
- Regresar al sitio de la tienda (Back to the store website)

Bug:
500: PayUlatam: invalid sign

Explanation:
From PayU's documentation:
> 2. Response page
> Signature validation
> In order to get the new value new_value you always should approximate
> the TX_VALUE to a decimal, using the rounding method "Round half to
> even"
http://developers.payulatam.com/en/web_checkout/integration.html

opw:2457240