### PR TITLE
[FIX] l10n_it_edi: Error when adding a note on invoice lines

### DIFF
--- a/addons/l10n_it_edi/models/account_invoice.py
+++ b/addons/l10n_it_edi/models/account_invoice.py
@@ -111,7 +111,7 @@ class AccountMove(models.Model):
 
         # <2.2.1>
         for invoice_line in self.invoice_line_ids:
-            if len(invoice_line.tax_ids) != 1:
+            if not invoice_line.display_type and len(invoice_line.tax_ids) != 1:
                 raise UserError(_("You must select one and only one tax by line."))
 
         for tax_line in self.line_ids.filtered(lambda line: line.tax_line_id):


### PR DESCRIPTION
Steps to reproduce the bug:

- Install l10n_it_edi
- Let's consider an italian company C with l10n_it xhart of accounts
- Create a customer invoice I in C and add a line with a price and a tax
- Add a note line
- Confirm I

Bug:

This UserError was raised: You must select one and only one tax by line.

opw:2484338