### PR TITLE
[FIX] l10n_ar: fix account group code prefix

### DIFF
--- a/addons/l10n_ar/data/account_group_data.xml
+++ b/addons/l10n_ar/data/account_group_data.xml
@@ -72,7 +72,7 @@
   <record model="account.group" id="account_group_bienes_de_cambio">
     <field name="name">Bienes de Cambio</field>
     <field name="parent_id" ref="account_group_activo_corriente"/>
-    <field name="code_prefix">1.1.4</field>
+    <field name="code_prefix">1.1.6</field>
   </record>
   <record model="account.group" id="account_group_activo_no_corriente">
     <field name="name">Activo no corriente</field>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
The account group prefix code 1.1.4 was duplicate, we change the one for "Bienes de Cambio" to 1.1.6


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
