### PR TITLE
[MERGE] web: fix quick edit tests

### DIFF
--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -151,13 +151,6 @@ QUnit.module('basic_fields', {
                 }]
             },
         };
-
-        testUtils.mock.patch(FormController, {
-            'multiClickTime': 0,
-        });
-    },
-    afterEach() {
-        testUtils.mock.unpatch(FormController);
     },
 }, function () {
 

--- a/addons/web/static/tests/fields/relational_fields/field_many2one_tests.js
+++ b/addons/web/static/tests/fields/relational_fields/field_many2one_tests.js
@@ -152,13 +152,6 @@ QUnit.module('fields', {}, function () {
                     }]
                 },
             };
-
-            testUtils.mock.patch(FormController, {
-                'multiClickTime': 0,
-            });
-        },
-        afterEach: function () {
-            testUtils.mock.unpatch(FormController);
         },
     }, function () {
         QUnit.module('FieldMany2One');

--- a/addons/web/static/tests/fields/relational_fields/field_one2many_tests.js
+++ b/addons/web/static/tests/fields/relational_fields/field_one2many_tests.js
@@ -163,13 +163,6 @@ QUnit.module('fields', {}, function () {
                     }]
                 },
             };
-
-            testUtils.mock.patch(FormController, {
-                'multiClickTime': 0,
-            });
-        },
-        afterEach: function () {
-            testUtils.mock.unpatch(FormController);
         },
     }, function () {
         QUnit.module('FieldOne2Many');

--- a/addons/web/static/tests/fields/relational_fields_tests.js
+++ b/addons/web/static/tests/fields/relational_fields_tests.js
@@ -170,13 +170,6 @@ QUnit.module('relational_fields', {
                 onchanges: {},
             },
         };
-
-        testUtils.mock.patch(FormController, {
-            'multiClickTime': 0,
-        });
-    },
-    afterEach: function () {
-        testUtils.mock.unpatch(FormController);
     },
 }, function () {
 

--- a/addons/web/static/tests/helpers/test_utils_mock.js
+++ b/addons/web/static/tests/helpers/test_utils_mock.js
@@ -17,6 +17,7 @@ const Bus = require('web.Bus');
 const config = require('web.config');
 const core = require('web.core');
 const dom = require('web.dom');
+const FormController = require('web.FormController');
 const makeTestEnvironment = require('web.test_env');
 const MockServer = require('web.MockServer');
 const RamStorage = require('web.RamStorage');
@@ -366,6 +367,10 @@ async function addMockEnvironmentOwl(Component, params, mockServer) {
         });
     }
 
+    // remove the multi-click delay for the quick edit in form view
+    const initialQuickEditDelay = FormController.prototype.multiClickTime;
+    FormController.prototype.multiClickTime = params.formMultiClickTime || 0;
+
     // make sure the debounce value for input fields is set to 0
     const initialDebounceValue = DebouncedField.prototype.DEBOUNCE;
     DebouncedField.prototype.DEBOUNCE = params.fieldDebounce || 0;
@@ -424,6 +429,8 @@ async function addMockEnvironmentOwl(Component, params, mockServer) {
                 service.destroy();
             }
         });
+
+        FormController.prototype.multiClickTime = initialQuickEditDelay;
 
         DebouncedField.prototype.DEBOUNCE = initialDebounceValue;
         dom.DEBOUNCE = initialDOMDebounceValue;

--- a/addons/web/static/tests/views/form_tests.js
+++ b/addons/web/static/tests/views/form_tests.js
@@ -151,13 +151,6 @@ QUnit.module('Views', {
             type: 'ir.actions.act_window',
             views: [[false, 'kanban'], [false, 'form']],
         }];
-
-        testUtils.mock.patch(FormController, {
-            'multiClickTime': 0,
-        });
-    },
-    afterEach: function () {
-        testUtils.mock.unpatch(FormController);
     },
 }, function () {
 
@@ -11080,10 +11073,6 @@ QUnit.module('Views', {
 
         const MULTI_CLICK_TIME = 50;
 
-        testUtils.mock.patch(FormController, {
-            'multiClickTime': MULTI_CLICK_TIME,
-        });
-
         const form = await createView({
             View: FormView,
             model: 'partner',
@@ -11094,6 +11083,7 @@ QUnit.module('Views', {
                         <field name="display_name"/>
                     </group>
                 </form>`,
+            formMultiClickTime: MULTI_CLICK_TIME,
             res_id: 1,
         });
 
@@ -11125,7 +11115,6 @@ QUnit.module('Views', {
         await concurrency.delay(MULTI_CLICK_TIME);
         assert.containsOnce(form, '.o_form_view.o_form_editable');
 
-        testUtils.mock.unpatch(FormController);
         form.destroy();
     });
 

--- a/addons/web/static/tests/views/form_tests.js
+++ b/addons/web/static/tests/views/form_tests.js
@@ -11125,7 +11125,7 @@ QUnit.module('Views', {
         await concurrency.delay(MULTI_CLICK_TIME);
         assert.containsOnce(form, '.o_form_view.o_form_editable');
 
-        // FormController unpatch done in afterEach
+        testUtils.mock.unpatch(FormController);
         form.destroy();
     });
 

--- a/addons/web_editor/static/tests/field_html_tests.js
+++ b/addons/web_editor/static/tests/field_html_tests.js
@@ -96,13 +96,9 @@ QUnit.module('web_editor', {}, function () {
                     throw 'Wrong template';
                 },
             });
-            testUtils.mock.patch(FormController, {
-                'multiClickTime': 0,
-            });
         },
         afterEach: function () {
             testUtils.mock.unpatch(ajax);
-            testUtils.mock.unpatch(FormController);
         },
     }, function () {
 


### PR DESCRIPTION
This PR ensures that the quick edit multi-click timeout is patched to 0 for every tests, and allow
to set it to a specific value is wanted in a given test. Indeed, before this PR,
a patch done in a module was never unpatched, and some tests executed after
passed in the whole suite, but failed when executed alone, because they also
needed the patch.