### PR TITLE
[FIX] website_blog: fit the size of the Dexter effect darkening area

### DIFF
--- a/addons/website_blog/static/src/snippets/s_latest_posts/001.scss
+++ b/addons/website_blog/static/src/snippets/s_latest_posts/001.scss
@@ -112,15 +112,16 @@
                 }
             }
             &.s_latest_posts_effect_dexter .s_latest_posts_post {
-                &::before {
-                    content: "";
-                    @include o-position-absolute(0, $grid-gutter-width/2, 0, $grid-gutter-width/2);
-                    background: linear-gradient(to bottom, darken(theme-color('secondary'), 10%) 0%, darken(theme-color('secondary'), 30%) 100%);
-                }
                 .o_record_cover_container {
                     transition: opacity 0.35s;
                 }
                 figcaption {
+                    &::before {
+                        content: "";
+                        @include o-position-absolute(0, 0, 0, 0);
+                        background: linear-gradient(to bottom, darken(theme-color('secondary'), 10%) 0%, darken(theme-color('secondary'), 30%) 100%);
+                        z-index: -1;
+                    }
                     padding: 3em;
                     text-align: left;
                     &:after {


### PR DESCRIPTION
Before this commit the darkening area of the Dexter effect is visible
through the rounded corners when the blog post was not hovered.

After this commit the darkening area is moved inside the right element
thus not requiring magic numbers for truncating the area and fixing the
display of the darkening area behind the rounded corners.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
