### PR TITLE
[FIX] mass_mailing: reentrant trigger for multi batch

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -677,6 +677,9 @@ class MassMailing(models.Model):
             if len(mass_mailing._get_remaining_recipients()) > 0:
                 mass_mailing.state = 'sending'
                 mass_mailing.action_send_mail()
+                # Re-trigger the cron to process remaining recipients
+                cron = self.env.ref('mass_mailing.ir_cron_mass_mailing_queue')
+                cron._trigger(fields.Datetime.now() + relativedelta(hours=1))
             else:
                 mass_mailing.write({
                     'state': 'done',


### PR DESCRIPTION
When sending emails for a mail campain, it is possible the mail queue
doesn't send a message to every recipiant in the same cron batch job.
Before the introduction of triggers, the cron was resuming partial
campaign very hours. The triggers broke it as they scheduled a single
batch.
