### PR TITLE
[FIX] l10n_latam_invoice_document: IVA on b2c invoices

### DIFF
--- a/addons/l10n_latam_invoice_document/models/account_move.py
+++ b/addons/l10n_latam_invoice_document/models/account_move.py
@@ -228,7 +228,7 @@ class AccountMove(models.Model):
             # generate a tax line.
             zero_taxes = set()
             for line in move.line_ids:
-                for tax in line.tax_ids.flatten_taxes_hierarchy():
+                for tax in line.l10n_latam_tax_ids.flatten_taxes_hierarchy():
                     if tax.tax_group_id not in res or tax.id in zero_taxes:
                         res.setdefault(tax.tax_group_id, {'base': 0.0, 'amount': 0.0})
                         res[tax.tax_group_id]['base'] += tax_balance_multiplicator * (line.amount_currency if line.currency_id else line.balance)


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
For b2c invoices, we mustn't show the IVA information on the reports

**Current behavior before PR:**
If you print an invoice for a "consumidor final" with an invoice line with IVA you will notice that it is shown on the report.

**Desired behavior after PR is merged:**
Not show the IVA taxes on the invoices report.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
