### PR TITLE
[FIX] stock : show complete name of location

### DIFF
--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -112,7 +112,7 @@ class Location(models.Model):
                 children_quants = self.env['stock.quant'].search(['&', '|', ('quantity', '!=', 0), ('reserved_quantity', '!=', 0), ('location_id', 'in', internal_children_locations.ids)])
                 if children_quants and values['active'] == False:
                     raise UserError(_('You still have some product in locations %s') %
-                        (', '.join(children_quants.mapped('location_id.name'))))
+                        (', '.join(children_quants.mapped('location_id.display_name'))))
                 else:
                     super(Location, children_location - self).with_context(do_not_check_quant=True).write({
                         'active': values['active'],


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Archive two warehouse with qants in WH1/Stock and WH2/Stock.
The message is not explicite, `You still have some product in locations Stock, Stock`

@amoyaux


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
