### PR TITLE
[FIX] crm: display right partner and action when convert lead

### DIFF
--- a/addons/crm/tests/test_crm_lead_convert.py
+++ b/addons/crm/tests/test_crm_lead_convert.py
@@ -5,6 +5,29 @@ from odoo import SUPERUSER_ID
 from odoo.addons.crm.tests import common as crm_common
 from odoo.fields import Datetime
 from odoo.tests.common import tagged, users
+from odoo.tests.common import Form
+
+@tagged('lead_manage')
+class TestLeadConvertForm(crm_common.TestLeadConvertCommon):
+
+    @users('user_sales_manager')
+    def test_form_action_default(self):
+        """ Test Lead._find_matching_partner() """
+        lead = self.env['crm.lead'].browse(self.lead_1.ids)
+        customer = self.env['res.partner'].create({
+            "name": "Amy Wong",
+            "email": '"Amy, PhD Student, Wong" Tiny <AMY.WONG@test.example.com>'
+        })
+
+        wizard = Form(self.env['crm.lead2opportunity.partner'].with_context({
+            'active_model': 'crm.lead',
+            'active_id': lead.id,
+            'active_ids': lead.ids,
+        }))
+
+        self.assertEqual(wizard.name, 'convert')
+        self.assertEqual(wizard.action, 'exist')
+        self.assertEqual(wizard.partner_id, customer)
 
 
 @tagged('lead_manage')

--- a/addons/crm/tests/test_crm_lead_convert.py
+++ b/addons/crm/tests/test_crm_lead_convert.py
@@ -29,6 +29,32 @@ class TestLeadConvertForm(crm_common.TestLeadConvertCommon):
         self.assertEqual(wizard.action, 'exist')
         self.assertEqual(wizard.partner_id, customer)
 
+    @users('user_sales_manager')
+    def test_form_name_onchange(self):
+        """ Test Lead._find_matching_partner() """
+        lead = self.env['crm.lead'].browse(self.lead_1.ids)
+        lead_dup = lead.copy({'name': 'Duplicate'})
+        customer = self.env['res.partner'].create({
+            "name": "Amy Wong",
+            "email": '"Amy, PhD Student, Wong" Tiny <AMY.WONG@test.example.com>'
+        })
+
+        wizard = Form(self.env['crm.lead2opportunity.partner'].with_context({
+            'active_model': 'crm.lead',
+            'active_id': lead.id,
+            'active_ids': lead.ids,
+        }))
+
+        self.assertEqual(wizard.name, 'merge')
+        self.assertEqual(wizard.action, 'exist')
+        self.assertEqual(wizard.partner_id, customer)
+        self.assertEqual(wizard.duplicated_lead_ids[:], lead + lead_dup)
+
+        wizard.name = 'convert'
+        wizard.action = 'create'
+        self.assertEqual(wizard.action, 'create', 'Should keep user input')
+        self.assertEqual(wizard.name, 'convert', 'Should keep user input')
+
 
 @tagged('lead_manage')
 class TestLeadConvert(crm_common.TestLeadConvertCommon):

--- a/addons/crm/wizard/crm_lead_to_opportunity.py
+++ b/addons/crm/wizard/crm_lead_to_opportunity.py
@@ -50,7 +50,8 @@ class Lead2OpportunityPartner(models.TransientModel):
     @api.depends('duplicated_lead_ids')
     def _compute_name(self):
         for convert in self:
-            convert.name = 'merge' if convert.duplicated_lead_ids and len(convert.duplicated_lead_ids) >= 2 else 'convert'
+            if not convert.name:
+                convert.name = 'merge' if convert.duplicated_lead_ids and len(convert.duplicated_lead_ids) >= 2 else 'convert'
 
     @api.depends('lead_id')
     def _compute_action(self):

--- a/addons/crm/wizard/crm_lead_to_opportunity.py
+++ b/addons/crm/wizard/crm_lead_to_opportunity.py
@@ -77,7 +77,7 @@ class Lead2OpportunityPartner(models.TransientModel):
                 convert.lead_id.partner_id.email if convert.lead_id.partner_id.email else convert.lead_id.email_from,
                 include_lost=True).ids
 
-    @api.depends('action')
+    @api.depends('action', 'lead_id')
     def _compute_partner_id(self):
         for convert in self:
             if convert.action == 'exist':

--- a/addons/crm/wizard/crm_lead_to_opportunity_views.xml
+++ b/addons/crm/wizard/crm_lead_to_opportunity_views.xml
@@ -13,6 +13,7 @@
                     <field name="team_id" widget="selection"/>
                 </group>
                 <group string="Opportunities" attrs="{'invisible': [('name', '!=', 'merge')]}">
+                    <field name="lead_id" invisible="1"/>
                     <field name="duplicated_lead_ids" nolabel="1">
                         <tree>
                             <field name="create_date" widget="date"/>


### PR DESCRIPTION
Issue

	- In CRM settings, activate 'Leads' feature
	- Go to CRM -> Leads and open a Lead.
	- In customer section;
	- Select 'Link to an existing customer'
	- Select 'Deco Addict' as customer

	if related to an existing customer,
	neither the action or partner_id field  is set to the right value.

Cause

	Due to missing 'lead_id' field in template, the partner_id field
	is not recomputed since action is not recomputed.

Solution

	Add 'lead_id' field as invisible.

opw-2439722