### PR TITLE
[FIX] hr_holidays: fix typo in relativedelta days

### DIFF
--- a/addons/hr_holidays/data/hr_holidays_demo.xml
+++ b/addons/hr_holidays/data/hr_holidays_demo.xml
@@ -229,9 +229,9 @@
         <field name="name">Sick day</field>
         <field name="holiday_status_id" ref="holiday_status_sl"/>
         <field eval="(datetime.now() + relativedelta(day=1, weekday=0)).strftime('%Y-%m-%d 01:00:00')" name="date_from"/>
-        <field eval="(datetime.now() + relativedelta(day=1, weekday=0) + relativedelta(day=2)).strftime('%Y-%m-%d 23:00:00')" name="date_to"/>
+        <field eval="(datetime.now() + relativedelta(day=1, weekday=0) + relativedelta(days=2)).strftime('%Y-%m-%d 23:00:00')" name="date_to"/>
         <field eval="(datetime.now() + relativedelta(day=1, weekday=0)).strftime('%Y-%m-%d 01:00:00')" name="request_date_from"/>
-        <field eval="(datetime.now() + relativedelta(day=1, weekday=0) + relativedelta(day=2)).strftime('%Y-%m-%d 23:00:00')" name="request_date_to"/>
+        <field eval="(datetime.now() + relativedelta(day=1, weekday=0) + relativedelta(days=2)).strftime('%Y-%m-%d 23:00:00')" name="request_date_to"/>
         <field name="employee_id" ref="hr.employee_qdp"/>
         <field name="state">confirm</field>
     </record>


### PR DESCRIPTION
In relativedelta, `day` means day of the month and `days` is for number
of days. Today, the demo data failed because the computed `date_to` was
before the `date_from`.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
