### PR TITLE
[FIX] website_event: use website domain

### DIFF
--- a/addons/website_event/models/__init__.py
+++ b/addons/website_event/models/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
 from . import event
+from . import mail_thread

--- a/addons/website_event/models/mail_thread.py
+++ b/addons/website_event/models/mail_thread.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+class MailThread(models.AbstractModel):
+    _inherit = 'mail.thread'
+
+    def _replace_local_links(self, html, base_url=None):
+        ctx = self.env.context
+        if not base_url and ctx.get('active_model') == 'event.event' and 'active_id' in ctx:
+            domain = self.env['event.event'].browse(ctx['active_id']).website_id.domain
+            base_url = ("http://%s" % domain) if domain else None
+        return super()._replace_local_links(html, base_url=base_url)


### PR DESCRIPTION
In multicompany, the links included in the mail don't use the the
website domain. This can lead to 403 errors.

To reproduce the error:
(Let C01 be the current company and W01 the company of C01)
1. In Settings > Website, add a domain (e.g., www.yourcompany.com)
2. Connect to the DB using the domain as URL
3. Create a second company C02
4. Switch to C02
5. In Settings > Website, create a website W02
    - Add a domain (e.g., www.secondcompany.com)
6. Create an event E:
    - Website: W02
    - In Communication, add a line:
        - Email Template: "Event: Registration"
        - Unit: Immediately
        - Trigger: After each registration
7. Confirm and Publish E
8. Create and Confirm a new Attendee

Error: the email "Event: Registration" has been sent (see in logs). But
the "View Event" button redirects to a page using C01's domain. As a
result, the server will consider that W01 must be loaded and that the
current company is C01. However, since E belongs to C02, it will lead to
a 403 error page.

OPW-2446219