### PR TITLE
[FIX] web_editor: use escape for image rendering

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
@@ -261,11 +261,11 @@ var LinkDialog = Dialog.extend({
     _getData: function () {
         var $url = this.$('input[name="url"]');
         var url = $url.val();
-        var label = this.$('input[name="label"]').val() || url;
+        var label = _.escape(this.$('input[name="label"]').val() || url);
 
         if (label && this.data.images) {
             for (var i = 0; i < this.data.images.length; i++) {
-                label = label.replace('<', "&lt;").replace('>', "&gt;").replace(/\[IMG\]/, this.data.images[i].outerHTML);
+                label = label.replace(/\[IMG\]/, this.data.images[i].outerHTML);
             }
         }
 


### PR DESCRIPTION
To properly escape all tags and not just the first one
And move the escape before the loop to apply for everybody
This avoid weird preview with selected content rendered (had effect only on preview)
