### PR TITLE
[FIX] website_form: remove dynamic values on save

### DIFF
--- a/addons/website_form/static/src/snippets/s_website_form/000.js
+++ b/addons/website_form/static/src/snippets/s_website_form/000.js
@@ -71,6 +71,7 @@ odoo.define('website_form.s_website_form', function (require) {
                         var $field = self.$target.find('input[name="' + field + '"], textarea[name="' + field + '"]');
                         if (!$field.val()) {
                             $field.val(values[field]);
+                            $field.data('website_form_original_default_value', $field.val());
                         }
                     }
                 });

--- a/addons/website_form/static/src/snippets/s_website_form/options.js
+++ b/addons/website_form/static/src/snippets/s_website_form/options.js
@@ -380,6 +380,14 @@ options.registry.WebsiteFormEditor = FormEditor.extend({
             this.$target.removeClass('d-none');
             this.$message.addClass("d-none");
         }
+
+        // Clear default values coming from data-for/data-values attributes
+        this.$target.find('input[name],textarea[name]').each(function () {
+            var original = $(this).data('website_form_original_default_value');
+            if (original !== undefined && $(this).val() === original) {
+                $(this).val('').removeAttr('value');
+            }
+        });
     },
     /**
      * @override


### PR DESCRIPTION
This fix was not forward ported in master when introduced: #50745

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
