### PR TITLE
[FIX] stock: do not reserve lot for product not tracked anymore

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1093,7 +1093,7 @@ class StockMove(models.Model):
             vals = dict(
                 vals,
                 location_id=reserved_quant.location_id.id,
-                lot_id=reserved_quant.lot_id.id or False,
+                lot_id=self.product_id.tracking != 'none' and reserved_quant.lot_id.id or False,
                 package_id=reserved_quant.package_id.id or False,
                 owner_id =reserved_quant.owner_id.id or False,
             )


### PR DESCRIPTION
- Create a product [DEMO] stored and tracked by SN
- Add some quantity to [DEMO]
- Swtich tracking to 'none' (disable tracking)
- Create a transfer of [DEMO] via sale, manufacture order or manual
transfer, validate the transfer

On the resulting move the Serial number of [DEMO] is shown. This should
not occur as the product is not tracked anymore

opw-2451298

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
