### PR TITLE
[FIX] avoiding setting auto_delete to true

### DIFF
--- a/addons/auth_signup/models/res_users.py
+++ b/addons/auth_signup/models/res_users.py
@@ -188,7 +188,6 @@ class ResUsers(models.Model):
         template_values = {
             'email_to': '${object.email|safe}',
             'email_cc': False,
-            'auto_delete': True,
             'partner_to': False,
             'scheduled_date': False,
         }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Each time a user is requesting a resetting of his password, the field auto_delete of the linked email template is set to True. No matter what. This goes against the will of the admin users that want to keep track of those mail in order to give support to the users.

I don't see any reason to reset this field to True each time.

Current behavior before PR:
The auto_delete field is set to true each time the action_reset_password function is called

Desired behavior after PR is merged:
Leave the auto_delete field to his value.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
