### PR TITLE
[FIX] stock: impossible to set quantity zero

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -466,7 +466,7 @@ class StockMoveLine(models.Model):
                             # checkboxes on the picking type, he's allowed to enter tracked
                             # products without a `lot_id`.
                             continue
-                    elif ml.move_id.inventory_id:
+                    elif ml.move_id.inventory_id or self.env.context.get('inventory_mode'):
                         # If an inventory adjustment is linked, the user is allowed to enter
                         # tracked products without a `lot_id`.
                         continue


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Create product with tracking none
- create a quant A
- change tracking to lot
- set quant A to zero --> Impossible

@amoyaux 



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
