### PR TITLE
[FIX] mrp_subcontracting: convert qty to BoM UoM

### DIFF
--- a/addons/mrp_subcontracting/wizard/mrp_product_produce.py
+++ b/addons/mrp_subcontracting/wizard/mrp_product_produce.py
@@ -26,7 +26,8 @@ class MrpProductProduce(models.TransientModel):
                 lambda move: move.state not in ('done', 'cancel')
             )
             for move in moves:
-                qty_to_consume = wizard._prepare_component_quantity(move, wizard.qty_producing)
+                qty_producing = wizard.product_uom_id._compute_quantity(wizard.qty_producing, wizard.production_id.product_uom_id)
+                qty_to_consume = wizard._prepare_component_quantity(move, qty_producing)
                 vals = wizard._generate_lines_values(move, qty_to_consume)
                 line_values += vals
         self.env['mrp.product.produce.line'].create(line_values)


### PR DESCRIPTION
When validating a quantity received from a subcontractor, if the UoM
used is different than the UoM of the BoM, the MO state will not become
'Done'. Moreover, the quantities consumed are incorrect.

To reproduce the error:
(Need purchase)
1. In Settings, enable
    - Multi-Warehouses
    - Units of Measure
2. Create two products P_prod and P_compo
    - P_compo is consumable
3. Create a BoM
    - Product: P_prod
    - BoM Type: Subcontracting
    - Components: P_compo
4. Create a RfQ
    - Vendor: BoM's subcontractor
    - Products: 100 Units of P_prod
5. Confirm, Open Receipt
6. On P_prod line, click on details symbol
7. Add a line:
    To: WH/Stock
    Done: 5
    UoM: Dozens
8. Validate the delivery without backorder
9. Open Inventory, add "Archived" filter
10. Open Subcontracting > line linked to current RfQ

Error: The MO is in progess instead of done. Moreover, 5 units of
P_compo are consumed. However, it was 5 dozens, so it should be 60 units
consumed. Also, another line has appeared and its values make no sense.

The issue comes from the quantity producing defined on step 7. The
module considers that the UoM of the quantity is the same than P_prod's
UoM in BoM. This quantity must be converted.

OPW-2453342