### PR TITLE
[FIX] transifex: escape ' in urls

### DIFF
--- a/addons/transifex/models/ir_translation.py
+++ b/addons/transifex/models/ir_translation.py
@@ -75,7 +75,7 @@ class IrTranslation(models.Model):
                     continue
 
                 # e.g. https://www.transifex.com/odoo/odoo-10/translate/#fr/sale/42?q=text:'Sale+Order'
-                src = werkzeug.urls.url_quote_plus(translation.src[:50].replace("\n", "").replace("'", ""))
+                src = werkzeug.urls.url_quote_plus(translation.src[:50].replace("\n", "").replace("'", "\\'"))
                 src = f"'{src}'" if "+" in src else src
                 translation.transifex_url = "%(url)s/%(project)s/translate/#%(lang)s/%(module)s/42?q=%(src)s" % {
                     'url': base_url,


### PR DESCRIPTION
Translation `Let's go`
Makes a Transifex search `text:'Let\'s go'`
That should be converted to `q=text%3A'Let%5C%27s+go'` in the URL

Removing the ' works from time to time but not always
