### PR TITLE
[FIX] project: keep create enabled in dependent task

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1396,28 +1396,17 @@ class Task(models.Model):
             'context': self._context
         }
 
+    # ------------
+    # Actions
+    # ------------
+
     def action_open_task(self):
         return {
-            'name': _('View Task'),
             'view_mode': 'form',
             'res_model': 'project.task',
             'res_id': self.id,
             'type': 'ir.actions.act_window',
             'context': self._context
-        }
-
-    # ------------
-    # Actions
-    # ------------
-
-    def action_open_task_form(self):
-        """ Opens the form view of the task """
-        return {
-            'view_mode': 'form',
-            'res_model': 'project.task',
-            'res_id': self.id,
-            'type': 'ir.actions.act_window',
-            'context': dict(self._context, create=False)
         }
 
     def action_recurring_tasks(self):

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -801,7 +801,7 @@
                                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
                                     <field name="kanban_state" widget="state_selection" optional="hide" />
                                     <field name="stage_id" optional="show" />
-                                    <button class="oe_link float-right" string="View Task" name="action_open_task_form" type="object"/>
+                                    <button class="oe_link float-right" string="View Task" name="action_open_task" type="object"/>
                                 </tree>
                             </field>
                         </page>


### PR DESCRIPTION
Prior to this commit:

Once the user clicked on View Task in the "Blocked By" task list, the
Create button in the form view of the targetted task is hidden. Also,
in the subtask notebook the user is not able to create additionnal
subtasks.

Reason:

In the action, the create argument is set to False.

After this commit:

We merge the two action_open_task and action_open_task_form into a
unique one. We remove the create set to false.

Related PR : #66740

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
