### PR TITLE
Master stock packaging revamp yhu 2

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -9,7 +9,7 @@ from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
 
 
-from odoo.tools import float_compare
+from odoo.tools import float_compare, float_round
 
 _logger = logging.getLogger(__name__)
 
@@ -719,16 +719,58 @@ class ProductProduct(models.Model):
 class ProductPackaging(models.Model):
     _name = "product.packaging"
     _description = "Product Packaging"
-    _order = 'sequence'
+    _order = 'product_id, sequence, id'
     _check_company_auto = True
 
-    name = fields.Char('Package Type', required=True)
+    name = fields.Char('Product Packaging', required=True)
     sequence = fields.Integer('Sequence', default=1, help="The first in the sequence is the default one.")
     product_id = fields.Many2one('product.product', string='Product', check_company=True)
-    qty = fields.Float('Contained Quantity', help="Quantity of products contained in the packaging.")
+    qty = fields.Float('Contained Quantity', default=1, help="Quantity of products contained in the packaging.")
     barcode = fields.Char('Barcode', copy=False, help="Barcode used for packaging identification. Scan this packaging barcode from a transfer in the Barcode app to move all the contained units")
     product_uom_id = fields.Many2one('uom.uom', related='product_id.uom_id', readonly=True)
     company_id = fields.Many2one('res.company', 'Company', index=True)
+
+    _sql_constraints = [
+        ('positive_qty', 'CHECK(qty > 0)', 'Contained Quantity should be positive.')
+    ]
+
+    def _check_qty(self, product_qty, uom_id, rounding_method="HALF-UP"):
+        """Check if product_qty in given uom is a multiple of the packaging qty.
+        If not, rounding the product_qty to closest multiple of the packaging qty
+        according to the rounding_method "UP", "HALF-UP or "DOWN".
+        """
+        self.ensure_one()
+        default_uom = self.product_id.uom_id
+        packaging_qty = default_uom._compute_quantity(self.qty, uom_id)
+        # We do not use the modulo operator to check if qty is a mltiple of q. Indeed the quantity
+        # per package might be a float, leading to incorrect results. For example:
+        # 8 % 1.6 = 1.5999999999999996
+        # 5.4 % 1.8 = 2.220446049250313e-16
+        if (
+            product_qty
+            and packaging_qty
+            and float_compare(
+                product_qty / packaging_qty,
+                float_round(product_qty / packaging_qty, precision_rounding=1.0),
+                precision_rounding=default_uom.rounding
+            )
+            != 0
+        ):
+            return float_round(
+                product_qty / packaging_qty, precision_rounding=1.0, rounding_method=rounding_method
+            ) * packaging_qty
+        return product_qty
+
+    def _find_suitable_product_packaging(self, product_qty, uom_id):
+        """ try find in `self` if a packaging's qty in given uom is a divisor of
+        the given product_qty. If so, return the one with greatest divisor.
+        """
+        packagings = self.sorted(lambda p: p.qty, reverse=True)
+        for packaging in packagings:
+            new_qty = packaging._check_qty(product_qty, uom_id)
+            if new_qty == product_qty:
+                return packaging
+        return self.env['product.packaging']
 
 
 class SupplierInfo(models.Model):

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -116,7 +116,7 @@
                                 colspan="4"
                                 attrs="{'invisible':['|', ('type', 'not in', ['product', 'consu']), ('product_variant_count', '>', 1), ('is_product_variant', '=', False)]}"
                                 groups="product.group_stock_packaging">
-                                <field name="packaging_ids" nolabel="1" context="{'tree_view_ref':'product.product_packaging_tree_view2', 'form_view_ref':'product.product_packaging_form_view2'}"/>
+                                <field name="packaging_ids" nolabel="1" context="{'tree_view_ref':'product.product_packaging_tree_view2'}"/>
                             </group>
                         </page>
                     </notebook>
@@ -268,7 +268,7 @@
                             </group>
                             <group name="packaging" string="Packaging" groups="product.group_stock_packaging">
                                 <field name="packaging_ids" nolabel="1"
-                                    context="{'tree_view_ref':'product.product_packaging_tree_view2', 'form_view_ref':'product.product_packaging_form_view2'}"/>
+                                    context="{'tree_view_ref':'product.product_packaging_tree_view2'}"/>
                             </group>
                         </group>
                     </sheet>
@@ -501,13 +501,14 @@
             <field name="name">product.packaging.tree.view</field>
             <field name="model">product.packaging</field>
             <field name="arch" type="xml">
-                <tree string="Product Packagings">
+                <tree string="Product Packagings" name="packaging">
                     <field name="sequence" widget="handle"/>
                     <field name="product_id"/>
                     <field name="name" string="Packaging"/>
                     <field name="qty"/>
                     <field name="product_uom_id" options="{'no_open': True, 'no_create': True}" groups="uom.group_uom"/>
-                    <field name="company_id" groups="base.group_multi_company"/>
+                    <field name="barcode" optional="hide"/>
+                    <field name="company_id" groups="base.group_multi_company" optional="hide"/>
                 </tree>
             </field>
         </record>
@@ -519,7 +520,9 @@
             <field name="inherit_id" ref="product.product_packaging_tree_view"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='product_id']" position="replace"/>
-                <xpath expr="//field[@name='sequence']" position="replace"/>
+                <xpath expr="//tree[@name='packaging']" position="attributes">
+                    <attribute name="editable">bottom</attribute>
+                </xpath>
             </field>
         </record>
 

--- a/addons/purchase/__manifest__.py
+++ b/addons/purchase/__manifest__.py
@@ -29,6 +29,7 @@
         'views/portal_templates.xml',
         'report/purchase_order_templates.xml',
         'report/purchase_quotation_templates.xml',
+        'views/product_packaging_views.xml',
     ],
     'demo': [
         'data/purchase_demo.xml',

--- a/addons/purchase/models/product.py
+++ b/addons/purchase/models/product.py
@@ -94,3 +94,9 @@ class ProductSupplierinfo(models.Model):
     @api.onchange('name')
     def _onchange_name(self):
         self.currency_id = self.name.property_purchase_currency_id.id or self.env.company.currency_id.id
+
+
+class ProductPackaging(models.Model):
+    _inherit = 'product.packaging'
+
+    purchase = fields.Boolean("Purchase", default=True, help="If true, the packaging can be used for purchase orders")

--- a/addons/purchase/views/product_packaging_views.xml
+++ b/addons/purchase/views/product_packaging_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="product_packaging_form_view_purchase" model="ir.ui.view">
+        <field name="name">product.packaging.form.view.purchase</field>
+        <field name="model">product.packaging</field>
+        <field name="inherit_id" ref="product.product_packaging_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='group_product']" position="inside">
+                <field name="purchase"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="product_packaging_tree_view_purchase" model="ir.ui.view">
+        <field name="name">product.packaging.tree.view.purchase</field>
+        <field name="model">product.packaging</field>
+        <field name="inherit_id" ref="product.product_packaging_tree_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='product_uom_id']" position="after">
+                <field name="purchase" optional="show"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -247,6 +247,8 @@
                                             'required': [('display_type', '=', False)]
                                         }"
                                         force_save="1" optional="show"/>
+                                    <field name="product_packaging_qty" attrs="{'invisible': ['|', ('product_id', '=', False), ('product_packaging_id', '=', False)]}" groups="product.group_stock_packaging" optional="show"/>
+                                    <field name="product_packaging_id" attrs="{'invisible': [('product_id', '=', False)]}" context="{'default_product_id': product_id, 'tree_view_ref':'product.product_packaging_tree_view', 'form_view_ref':'product.product_packaging_form_view'}" groups="product.group_stock_packaging" optional="show"/>
                                     <field name="price_unit" attrs="{'readonly': [('invoice_lines', '!=', [])]}"/>
                                     <field name="taxes_id" widget="many2many_tags" domain="[('type_tax_use','=','purchase'), ('company_id', '=', parent.company_id)]" context="{'default_type_tax_use': 'purchase', 'search_view_ref': 'account.account_tax_view_search'}" options="{'no_create': True}" optional="show"/>
                                     <field name="price_subtotal" widget="monetary"/>
@@ -270,6 +272,7 @@
                                                 <field name="qty_received_method" invisible="1"/>
                                                 <field name="qty_received" string="Received Quantity" attrs="{'invisible': [('parent.state', 'not in', ('purchase', 'done'))], 'readonly': [('qty_received_method', '!=', 'manual')]}"/>
                                                 <field name="qty_invoiced" string="Billed Quantity" attrs="{'invisible': [('parent.state', 'not in', ('purchase', 'done'))]}"/>
+                                                <field name="product_packaging_id" attrs="{'invisible': [('product_id', '=', False)]}" context="{'default_product_id': product_id, 'tree_view_ref':'product.product_packaging_tree_view', 'form_view_ref':'product.product_packaging_form_view'}" groups="product.group_stock_packaging" />
                                                 <field name="price_unit"/>
                                                 <field name="taxes_id" widget="many2many_tags" domain="[('type_tax_use', '=', 'purchase'), ('company_id', '=', parent.company_id)]" options="{'no_create': True}"/>
                                             </group>

--- a/addons/purchase/views/res_config_settings_views.xml
+++ b/addons/purchase/views/res_config_settings_views.xml
@@ -147,6 +147,19 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="col-12 col-lg-6 o_setting_box"
+                            id="stock_packaging_purchase"
+                            title="Ability to select a package type in purchase orders and to force a quantity that is a multiple of the number of units per package.">
+                            <div class="o_setting_left_pane">
+                                <field name="group_stock_packaging"/>
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label for="group_stock_packaging"/>
+                                <div class="text-muted">
+                                    Purchase products by multiple of unit # per package
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </xpath>

--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -487,6 +487,7 @@ class PurchaseOrderLine(models.Model):
             'warehouse_id': self.order_id.picking_type_id.warehouse_id.id,
             'product_uom_qty': product_uom_qty,
             'product_uom': product_uom.id,
+            'product_packaging_id': self.product_packaging_id.id,
         }
 
     @api.model

--- a/addons/purchase_stock/tests/test_purchase_order_process.py
+++ b/addons/purchase_stock/tests/test_purchase_order_process.py
@@ -27,3 +27,30 @@ class TestPurchaseOrderProcess(PurchaseTestCommon):
 
         # Check that order is cancelled.
         self.assertEqual(po_edit_with_user.state, 'cancel', 'Purchase: PO state should be "Cancel')
+
+    def test_01_packaging_propagation(self):
+        """Create a PO with lines using packaging, check the packaging propagate
+        to its move.
+        """
+        product = self.env['product.product'].create({
+            'name': 'Product with packaging',
+            'type': 'product',
+        })
+
+        packaging = self.env['product.packaging'].create({
+            'name': 'box',
+            'product_id': product.id,
+        })
+
+        po = self.env['purchase.order'].create({
+            'partner_id': self.env['res.partner'].create({'name': 'My Partner'}).id,
+            'order_line': [
+                (0, 0, {
+                    'product_id': product.id,
+                    'product_qty': 1.0,
+                    'product_uom': product.uom_id.id,
+                    'product_packaging_id': packaging.id,
+                })],
+        })
+        po.button_confirm()
+        self.assertEqual(po.order_line.move_ids.product_packaging_id, packaging)

--- a/addons/sale/__manifest__.py
+++ b/addons/sale/__manifest__.py
@@ -36,6 +36,7 @@ This module contains all the common features of Sales Management and eCommerce.
         'views/payment_templates.xml',
         'views/payment_views.xml',
         'views/product_views.xml',
+        'views/product_packaging_views.xml',
         'views/utm_campaign_views.xml',
         'wizard/sale_order_cancel_views.xml',
         'wizard/sale_payment_link_views.xml',

--- a/addons/sale/models/product_product.py
+++ b/addons/sale/models/product_product.py
@@ -71,3 +71,8 @@ class ProductAttributeCustomValue(models.Model):
     _sql_constraints = [
         ('sol_custom_value_unique', 'unique(custom_product_template_attribute_value_id, sale_order_line_id)', "Only one Custom Value is allowed per Attribute Value per Sales Order Line.")
     ]
+
+class ProductPackaging(models.Model):
+    _inherit = 'product.packaging'
+
+    sales = fields.Boolean("Sales", default=True, help="If true, the packaging can be used for sales orders")

--- a/addons/sale/views/product_packaging_views.xml
+++ b/addons/sale/views/product_packaging_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="product_packaging_form_view_sale" model="ir.ui.view">
+        <field name="name">product.packaging.form.view.sale</field>
+        <field name="model">product.packaging</field>
+        <field name="inherit_id" ref="product.product_packaging_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='group_product']" position="inside">
+                <field name="sales"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="product_packaging_tree_view_sale" model="ir.ui.view">
+        <field name="name">product.packaging.tree.view.sale</field>
+        <field name="model">product.packaging</field>
+        <field name="inherit_id" ref="product.product_packaging_tree_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='product_uom_id']" position="after">
+                <field name="sales" optional="show"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -407,6 +407,7 @@
                                             <div name="invoiced_qty" attrs="{'invisible': [('parent.state', 'not in', ['sale', 'done'])]}">
                                                 <field name="qty_invoiced" attrs="{'invisible': [('parent.state', 'not in', ['sale', 'done'])]}"/>
                                             </div>
+                                            <field name="product_packaging_id" attrs="{'invisible': [('product_id', '=', False)]}" context="{'default_product_id': product_id, 'tree_view_ref':'product.product_packaging_tree_view', 'form_view_ref':'product.product_packaging_form_view'}" groups="product.group_stock_packaging" />
                                             <field name="price_unit"/>
                                             <field name="tax_id" widget="many2many_tags" options="{'no_create': True}" context="{'search_view_ref': 'account.account_tax_view_search'}" domain="[('type_tax_use','=','sale'),('company_id','=',parent.company_id)]"
                                                 attrs="{'readonly': [('qty_invoiced', '&gt;', 0)]}"/>
@@ -555,6 +556,8 @@
                                         optional="hide"
                                         attrs="{'readonly': [('parent.state', 'not in', ['draft', 'sent', 'sale'])]}"
                                     />
+                                    <field name="product_packaging_qty" attrs="{'invisible': ['|', ('product_id', '=', False), ('product_packaging_id', '=', False)]}" groups="product.group_stock_packaging" optional="show"/>
+                                    <field name="product_packaging_id" attrs="{'invisible': [('product_id', '=', False)]}" context="{'default_product_id': product_id, 'tree_view_ref':'product.product_packaging_tree_view', 'form_view_ref':'product.product_packaging_form_view'}" groups="product.group_stock_packaging" optional="show"/>
                                     <field
                                         name="price_unit"
                                         attrs="{'readonly': [('qty_invoiced', '&gt;', 0)]}"

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -261,7 +261,6 @@ class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'
 
     qty_delivered_method = fields.Selection(selection_add=[('stock_move', 'Stock Moves')])
-    product_packaging = fields.Many2one( 'product.packaging', string='Package', default=False, check_company=True)
     route_id = fields.Many2one('stock.location.route', string='Route', domain=[('sale_selectable', '=', True)], ondelete='restrict', check_company=True)
     move_ids = fields.One2many('stock.move', 'sale_line_id', string='Stock Moves')
     product_type = fields.Selection(related='product_id.type')
@@ -461,11 +460,6 @@ class SaleOrderLine(models.Model):
     def _onchange_product_id_set_customer_lead(self):
         self.customer_lead = self.product_id.sale_delay
 
-    @api.onchange('product_packaging')
-    def _onchange_product_packaging(self):
-        if self.product_packaging:
-            return self._check_package()
-
     @api.onchange('product_uom_qty')
     def _onchange_product_uom_qty(self):
         # When modifying a one2many, _origin doesn't guarantee that its values will be the ones
@@ -507,6 +501,7 @@ class SaleOrderLine(models.Model):
             'partner_id': self.order_id.partner_shipping_id.id,
             'product_description_variants': self._get_sale_order_line_multiline_description_variants(),
             'company_id': self.order_id.company_id,
+            'product_packaging_id': self.product_packaging_id.id,
         })
         return values
 
@@ -596,38 +591,6 @@ class SaleOrderLine(models.Model):
                 # Trigger the Scheduler for Pickings
                 pickings_to_confirm.action_confirm()
         return True
-
-    def _check_package(self):
-        default_uom = self.product_id.uom_id
-        pack = self.product_packaging
-        qty = self.product_uom_qty
-        q = default_uom._compute_quantity(pack.qty, self.product_uom)
-        # We do not use the modulo operator to check if qty is a mltiple of q. Indeed the quantity
-        # per package might be a float, leading to incorrect results. For example:
-        # 8 % 1.6 = 1.5999999999999996
-        # 5.4 % 1.8 = 2.220446049250313e-16
-        if (
-            qty
-            and q
-            and float_compare(
-                qty / q, float_round(qty / q, precision_rounding=1.0), precision_rounding=0.001
-            )
-            != 0
-        ):
-            newqty = qty - (qty % q) + q
-            return {
-                'warning': {
-                    'title': _('Warning'),
-                    'message': _(
-                        "This product is packaged by %(pack_size).2f %(pack_name)s. You should sell %(quantity).2f %(unit)s.",
-                        pack_size=pack.qty,
-                        pack_name=default_uom.name,
-                        quantity=newqty,
-                        unit=self.product_uom.name
-                    ),
-                },
-            }
-        return {}
 
     def _update_line_quantity(self, values):
         precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -501,7 +501,7 @@ class SaleOrderLine(models.Model):
             'partner_id': self.order_id.partner_shipping_id.id,
             'product_description_variants': self._get_sale_order_line_multiline_description_variants(),
             'company_id': self.order_id.company_id,
-            'product_packaging_id': self.product_packaging_id.id,
+            'product_packaging_id': self.product_packaging_id,
         })
         return values
 

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -1033,3 +1033,30 @@ class TestSaleStock(TestSaleCommon, ValuationReconciliationTestCommon):
         sale_order4.action_confirm()
         self.assertTrue(sale_order4.picking_ids)
         self.assertEqual(sale_order4.picking_ids.state, 'assigned')
+
+    def test_packaging_propagation(self):
+        """Create a SO with lines using packaging, check the packaging propagate
+        to its move.
+        """
+        product = self.env['product.product'].create({
+            'name': 'Product with packaging',
+            'type': 'product',
+        })
+
+        packaging = self.env['product.packaging'].create({
+            'name': 'box',
+            'product_id': product.id,
+        })
+
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [
+                (0, 0, {
+                    'product_id': product.id,
+                    'product_uom_qty': 1.0,
+                    'product_uom': product.uom_id.id,
+                    'product_packaging_id': packaging.id,
+                })],
+        })
+        so.action_confirm()
+        self.assertEqual(so.order_line.move_ids.product_packaging_id, packaging)

--- a/addons/sale_stock/views/sale_order_views.xml
+++ b/addons/sale_stock/views/sale_order_views.xml
@@ -41,12 +41,6 @@
                     <field name="show_json_popover" invisible="1"/>
                     <field string=" " name="json_popover" widget="stock_rescheduling_popover" attrs="{'invisible': [('show_json_popover', '=', False)]}"/>
                 </xpath>
-                <xpath expr="//page/field[@name='order_line']/form/group/group/field[@name='price_unit']" position="before">
-                    <field name="product_packaging" attrs="{'invisible': [('product_id', '=', False)]}" context="{'default_product_id': product_id, 'tree_view_ref':'product.product_packaging_tree_view', 'form_view_ref':'product.product_packaging_form_view'}" domain="[('product_id','=',product_id)]" groups="product.group_stock_packaging" />
-                </xpath>
-                <xpath expr="//page/field[@name='order_line']/tree/field[@name='price_unit']" position="before">
-                    <field name="product_packaging" attrs="{'invisible': [('product_id', '=', False)]}" context="{'default_product_id': product_id, 'tree_view_ref':'product.product_packaging_tree_view', 'form_view_ref':'product.product_packaging_form_view'}" domain="[('product_id','=',product_id)]" groups="product.group_stock_packaging" optional="show"/>
-                </xpath>
                 <xpath expr="//field[@name='order_line']/form/group/group/field[@name='analytic_tag_ids']" position="before">
                     <field name="route_id" groups="stock.group_adv_location" options="{'no_create': True}"/>
                 </xpath>

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -934,6 +934,11 @@ class ProductCategory(models.Model):
         'stock.location.route', string='Total routes', compute='_compute_total_route_ids',
         readonly=True)
     putaway_rule_ids = fields.One2many('stock.putaway.rule', 'category_id', 'Putaway Rules')
+    packaging_reserve_method = fields.Selection([
+        ('full', 'Reserve Only Full Packagings'),
+        ('partial', 'Reserve Partial Packagings'),], string="Reserve Packagings", default='partial',
+        help="Reserve Only Full Packagings: will not reserve partial packagings. If customer orders 2 pallets of 1000 units each and you only have 1600 in stock, then only 1000 will be reserved\n"
+             "Reserve Partial Packagings: allow reserving partial packagings. If customer orders 2 pallets of 1000 units each and you only have 1600 in stock, then 1600 will be reserved")
 
     def _compute_total_route_ids(self):
         for category in self:
@@ -943,6 +948,11 @@ class ProductCategory(models.Model):
                 base_cat = base_cat.parent_id
                 routes |= base_cat.route_ids
             category.total_route_ids = routes
+
+class ProductPackaging(models.Model):
+    _inherit = "product.packaging"
+
+    package_type_id = fields.Many2one('stock.package.type', 'Package Type')
 
 
 class UoM(models.Model):

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -953,6 +953,10 @@ class ProductPackaging(models.Model):
     _inherit = "product.packaging"
 
     package_type_id = fields.Many2one('stock.package.type', 'Package Type')
+    route_ids = fields.Many2many(
+        'stock.location.route', 'stock_location_route_packaging', 'packaging_id', 'route_id', 'Routes',
+        domain=[('packaging_selectable', '=', True)],
+        help="Depending on the modules installed, this will allow you to define the route of the product in this packaging: whether it will be bought, manufactured, replenished on order, etc.")
 
 
 class UoM(models.Model):

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -197,13 +197,18 @@ class Location(models.Model):
             domain = ['|', ('barcode', operator, name), ('complete_name', operator, name)]
         return self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
 
-    def _get_putaway_strategy(self, product, quantity=0, package=None):
+    def _get_putaway_strategy(self, product, quantity=0, package=None, packaging=None):
         """Returns the location where the product has to be put, if any compliant
         putaway strategy is found. Otherwise returns self.
         The quantity should be in the default UOM of the product, it is used when
         no package is specified.
         """
-        package_type = package and package.package_type_id or self.env['stock.package.type']
+        # find package type on package or packaging
+        package_type = self.env['stock.package.type']
+        if package:
+            package_type = package.package_type_id
+        elif packaging:
+            package_type = packaging.package_type_id
 
         putaway_rules = self.env['stock.putaway.rule']
         putaway_rules |= self.putaway_rule_ids.filtered(lambda x: x.product_id == product and (package_type in x.package_type_ids or package_type == x.package_type_ids))

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -337,6 +337,7 @@ class Route(models.Model):
     product_selectable = fields.Boolean('Applicable on Product', default=True, help="When checked, the route will be selectable in the Inventory tab of the Product form.")
     product_categ_selectable = fields.Boolean('Applicable on Product Category', help="When checked, the route will be selectable on the Product Category.")
     warehouse_selectable = fields.Boolean('Applicable on Warehouse', help="When a warehouse is selected for this route, this route should be seen as the default route when products pass through this warehouse.")
+    packaging_selectable = fields.Boolean('Applicable on Packaging', help="When checked, the route will be selectable on the Product Packaging.")
     supplied_wh_id = fields.Many2one('stock.warehouse', 'Supplied Warehouse')
     supplier_wh_id = fields.Many2one('stock.warehouse', 'Supplying Warehouse')
     company_id = fields.Many2one(
@@ -347,6 +348,7 @@ class Route(models.Model):
         'product.template', 'stock_route_product', 'route_id', 'product_id',
         'Products', copy=False, check_company=True)
     categ_ids = fields.Many2many('product.category', 'stock_location_route_categ', 'route_id', 'categ_id', 'Product Categories', copy=False)
+    packaging_ids = fields.Many2many('product.packaging', 'stock_location_route_packaging', 'route_id', 'packaging_id', 'Packagings', copy=False, check_company=True)
     warehouse_domain_ids = fields.One2many('stock.warehouse', compute='_compute_warehouses')
     warehouse_ids = fields.Many2many(
         'stock.warehouse', 'stock_route_warehouse', 'route_id', 'warehouse_id',

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1056,7 +1056,7 @@ class StockMove(models.Model):
         if origin_move_line:
             location_dest = origin_move_line.location_dest_id
         else:
-            location_dest = self.location_dest_id._get_putaway_strategy(self.product_id, quantity=1)
+            location_dest = self.location_dest_id._get_putaway_strategy(self.product_id, quantity=1, packaging=self.product_packaging_id)
         move_line_vals = {
             'picking_id': self.picking_id.id,
             'location_dest_id': location_dest.id,
@@ -1212,7 +1212,7 @@ class StockMove(models.Model):
     def _prepare_move_line_vals(self, quantity=None, reserved_quant=None):
         self.ensure_one()
         # apply putaway
-        location_dest_id = self.location_dest_id._get_putaway_strategy(self.product_id, quantity=quantity or 0).id
+        location_dest_id = self.location_dest_id._get_putaway_strategy(self.product_id, quantity=quantity or 0, packaging=self.product_packaging_id).id
         vals = {
             'move_id': self.id,
             'product_id': self.product_id.id,

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -754,9 +754,9 @@ class StockMove(models.Model):
             # first priority goes to the preferred routes defined on the move itself (e.g. coming from a SO line)
             warehouse_id = move.warehouse_id or move.picking_id.picking_type_id.warehouse_id
             if move.location_dest_id.company_id == self.env.company:
-                rule = self.env['procurement.group']._search_rule(move.route_ids, move.product_id, warehouse_id, domain)
+                rule = self.env['procurement.group']._search_rule(move.route_ids, move.product_packaging_id, move.product_id, warehouse_id, domain)
             else:
-                rule = self.sudo().env['procurement.group']._search_rule(move.route_ids, move.product_id, warehouse_id, domain)
+                rule = self.sudo().env['procurement.group']._search_rule(move.route_ids, move.product_packaging_id, move.product_id, warehouse_id, domain)
             # Make sure it is not returning the return
             if rule and (not move.origin_returned_move_id or move.origin_returned_move_id.location_dest_id.id != rule.location_id.id):
                 new_move = rule._run_push(move)
@@ -1207,6 +1207,7 @@ class StockMove(models.Model):
             'warehouse_id': self.warehouse_id or self.picking_type_id.warehouse_id,
             'priority': self.priority,
             'orderpoint_id': self.orderpoint_id,
+            'product_packaging_id': self.product_packaging_id,
         }
 
     def _prepare_move_line_vals(self, quantity=None, reserved_quant=None):
@@ -1766,7 +1767,7 @@ class StockMove(models.Model):
                 ('location_id', '=', move.location_dest_id.id),
                 ('action', '!=', 'push')
             ]
-            rules = self.env['procurement.group']._search_rule(False, product_id, move.warehouse_id, domain)
+            rules = self.env['procurement.group']._search_rule(False, move.product_packaging_id, product_id, move.warehouse_id, domain)
             if rules:
                 if rules.procure_method in ['make_to_order', 'make_to_stock']:
                     move.procure_method = rules.procure_method

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -313,6 +313,7 @@ class StockRule(models.Model):
             'description_picking': picking_description,
             'priority': values.get('priority', "0"),
             'orderpoint_id': values.get('orderpoint_id') and values['orderpoint_id'].id,
+            'product_packaging_id': values.get('product_packaging_id', False),
         }
         for field in self._get_custom_move_fields():
             if field in values:

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -167,6 +167,7 @@
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='name']" position="after">
                     <field name="package_type_id" groups="stock.group_tracking_lot"/>
+                    <field name="route_ids" groups="stock.group_adv_location" optional="hide" widget="many2many_tags"/>
                 </xpath>
             </field>
         </record>
@@ -178,6 +179,11 @@
             <field name="arch" type="xml">
                 <xpath expr="//label[@for='qty']" position="before">
                     <field name="package_type_id" groups="stock.group_tracking_lot"/>
+                </xpath>
+                <xpath expr="//group[@name='qty']" position="after">
+                    <group name="logistic">
+                        <field name="route_ids" groups="stock.group_adv_location" widget="many2many_tags"/>
+                    </group>
                 </xpath>
             </field>
         </record>

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -18,6 +18,7 @@
                         <field name="route_ids" widget="many2many_tags" groups="stock.group_adv_location"/>
                         <field name="total_route_ids" widget="many2many_tags" groups="stock.group_adv_location" attrs="{'invisible': [('parent_id', '=', False)]}"/>
                         <field name="removal_strategy_id" options="{'no_create': True}"/>
+                        <field name="packaging_reserve_method" widget="radio" groups="product.group_stock_packaging"/>
                     </group>
                 </group>
             </field>
@@ -155,6 +156,28 @@
                 </xpath>
                 <xpath expr="//div[@name='product_lst_price']" position="after">
                     <div t-if="record.type.raw_value == 'product'">On hand: <field name="qty_available"/> <field name="uom_id"/></div>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="product_packaging_tree_view" model="ir.ui.view">
+            <field name="name">product.packaging.tree.view.stock</field>
+            <field name="model">product.packaging</field>
+            <field name="inherit_id" ref="product.product_packaging_tree_view"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='name']" position="after">
+                    <field name="package_type_id" groups="stock.group_tracking_lot"/>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="product_packaging_form_view" model="ir.ui.view">
+            <field name="name">product.packaging.form.view.stock</field>
+            <field name="model">product.packaging</field>
+            <field name="inherit_id" ref="product.product_packaging_form_view"/>
+            <field name="arch" type="xml">
+                <xpath expr="//label[@for='qty']" position="before">
+                    <field name="package_type_id" groups="stock.group_tracking_lot"/>
                 </xpath>
             </field>
         </record>

--- a/addons/stock/views/stock_location_views.xml
+++ b/addons/stock/views/stock_location_views.xml
@@ -196,6 +196,10 @@
                             <div>
                                 <field name="product_selectable" class="oe_inline"/>
                             </div>
+                            <label for="packaging_selectable" string="Packagings"/>
+                            <div>
+                                <field name="packaging_selectable" class="oe_inline"/>
+                            </div>
                         </group>
                         <group>
                             <field name="warehouse_selectable" string="Warehouses"/>

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -37,6 +37,7 @@
                     <field name="product_id"/>
                     <field name="location_id" options="{'no_create': True}" string="From"/>
                     <field name="location_dest_id" options="{'no_create': True}" string="To"/>
+                    <field name="product_packaging_id" optional="hide" groups="product.group_stock_packaging"/>
                     <field name="product_uom_qty"/>
                     <field name="product_uom" options="{'no_open': True, 'no_create': True}" string="Unit of Measure" groups="uom.group_uom"/>
                     <field name="company_id" groups="base.group_multi_company"/>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -155,7 +155,7 @@
                                         <strong class="o_kanban_record_title"><span><t t-esc="record.name.value"/></span></strong>
                                     </div>
                                     <strong>
-                                            <field name="state" widget="label_selection" options="{'classes': {'draft': 'default', 'cancel': 'default', 'none': 'danger', 'waiting': 'warning', 'confirmed': 'warning', 'partially_available': 'warning', 'done': 'success'}}"/>
+                                            <field name="state" widget="label_selection" options="{'classes': {'draft': 'default', 'cancel': 'default', 'waiting': 'warning', 'confirmed': 'warning', 'done': 'success'}}"/>
                                     </strong>
                                 </div>
                                 <div class="o_kanban_record_bottom">
@@ -240,15 +240,15 @@
                     <widget name="signature" string="Sign"
                             attrs="{'invisible': ['|', '|', ('id', '=', False), ('picking_type_code', '!=', 'outgoing'), ('state', '=', 'done')]}"
                             full_name="partner_id" groups="stock.group_stock_sign_delivery"/>
-                    <button name="do_print_picking" string="Print" groups="stock.group_stock_user" type="object" attrs="{'invisible': [('state', 'not in', ('assigned', 'partially_available'))]}"/>
+                    <button name="do_print_picking" string="Print" groups="stock.group_stock_user" type="object" attrs="{'invisible': [('state', '!=', 'assigned')]}"/>
                     <button name="%(action_report_delivery)d" string="Print" attrs="{'invisible': [('state', '!=', 'done')]}" type="action" groups="base.group_user"/>
                     <button name="%(act_stock_return_picking)d" string="Return" attrs="{'invisible': [('state', '!=', 'done')]}" type="action" groups="base.group_user"/>
-                    <button name="do_unreserve" string="Unreserve" groups="base.group_user" type="object" attrs="{'invisible': ['|', '|', '|', ('picking_type_code', '=', 'incoming'), ('immediate_transfer', '=', True), '&amp;', ('state', 'not in', ('assigned', 'partially_available')), ('move_type', '!=', 'one'), '&amp;', ('state', 'not in', ('assigned', 'partially_available', 'confirmed')), ('move_type', '=', 'one')]}"/>
+                    <button name="do_unreserve" string="Unreserve" groups="base.group_user" type="object" attrs="{'invisible': ['|', '|', '|', ('picking_type_code', '=', 'incoming'), ('immediate_transfer', '=', True), '&amp;', ('state', '!=', 'assigned'), ('move_type', '!=', 'one'), '&amp;', ('state', 'not in', ('assigned', 'confirmed')), ('move_type', '=', 'one')]}"/>
                     <button name="button_scrap" type="object" string="Scrap" attrs="{'invisible': ['|', '&amp;', ('picking_type_code', '=', 'incoming'), ('state', '!=', 'done'), '&amp;', ('picking_type_code', '=', 'outgoing'), ('state', '=', 'done')]}"/>
                     <button name="action_toggle_is_locked" attrs="{'invisible': ['|', ('state', 'in', ('draft','cancel')), ('is_locked', '=', False)]}" string="Unlock" groups="stock.group_stock_manager" type="object" help="If the picking is unlocked you can edit initial demand (for a draft picking) or done quantities (for a done picking)."/>
                     <button name="action_toggle_is_locked" attrs="{'invisible': [('is_locked', '=', True)]}" string="Lock" groups="stock.group_stock_manager" type="object"/>
                     <field name="state" widget="statusbar" statusbar_visible="draft,confirmed,assigned,done" />
-                    <button name="action_cancel" attrs="{'invisible': [('state', 'not in', ('assigned', 'confirmed', 'partially_available', 'draft', 'waiting'))]}" string="Cancel" groups="base.group_user" type="object"/>
+                    <button name="action_cancel" attrs="{'invisible': [('state', 'not in', ('assigned', 'confirmed', 'draft', 'waiting'))]}" string="Cancel" groups="base.group_user" type="object"/>
                 </header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
@@ -454,7 +454,7 @@
                     <separator/>
                     <filter name="draft" string="Draft" domain="[('state', '=', 'draft')]" help="Draft Moves"/>
                     <filter name="waiting" string="Waiting" domain="[('state', 'in', ('confirmed', 'waiting'))]" help="Waiting Moves"/>
-                    <filter name="available" string="Ready" domain="[('state', 'in', ('assigned', 'partially_available'))]" help="Assigned Moves"/>
+                    <filter name="available" string="Ready" domain="[('state', '=', 'assigned')]" help="Assigned Moves"/>
                     <filter name="done" string="Done" domain="[('state', '=', 'done')]" help="Pickings already processed"/>
                     <filter name="cancel" string="Cancelled" domain="[('state', '=', 'cancel')]" help="Cancelled Moves"/>
                     <separator/>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -362,6 +362,7 @@
                                     <field name="date_deadline" optional="hide"/>
                                     <field name="is_initial_demand_editable" invisible="1"/>
                                     <field name="is_quantity_done_editable" invisible="1"/>
+                                    <field name="product_packaging_id" groups="product.group_stock_packaging"/>
                                     <field name="product_uom_qty" string="Demand" attrs="{'column_invisible': [('parent.immediate_transfer', '=', True)], 'readonly': ['|', ('is_initial_demand_editable', '=', False), '&amp;', '&amp;', ('show_operations', '=', True), ('is_locked', '=', True), ('is_initial_demand_editable', '=', False)]}"/>
                                     <button type="object" name="action_product_forecast_report" icon="fa-area-chart" attrs="{'invisible': ['|', ('forecast_availability', '&lt;', 0), '|', ('parent.immediate_transfer', '=', True), ('parent.picking_type_code', '=', 'outgoing')]}"/>
                                     <button type="object" name="action_product_forecast_report" icon="fa-area-chart" attrs="{'invisible': ['|', ('forecast_availability', '&gt;=', 0), '|', ('parent.immediate_transfer', '=', True), ('parent.picking_type_code', '=', 'outgoing')]}" class="text-danger"/>


### PR DESCRIPTION
1. add packaging to PO lines
2. packaging on PO/SO lines can be propagate to MO
3. add package type to packaging
4. on picking forms, we can choose to only reserve full packaging. That
means if you want 1 pallet(100 units) and you have 50 units in stock. It
won't be reserved.
1. Apply smart putaway rules on move with packaging.
2. when moves donen't have packagings, and a single unit packaging is
available for the product on that move. We automatically set that
packaging for the move.
1. Route is now can be set to apply on packagings. Bravo!

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
