### PR TITLE
[FIX] mail: use template lang on layout and display name

### DIFF
--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -261,9 +261,16 @@ class MailTemplate(models.Model):
                 _logger.warning('QWeb template %s not found when sending template %s. Sending without layouting.' % (notif_layout, self.name))
             else:
                 record = self.env[self.model].browse(res_id)
+                model = self.env['ir.model']._get(record._name)
+
+                if self.lang:
+                    lang = self._render_lang([res_id])[res_id]
+                    template = template.with_context(lang=lang)
+                    model = model.with_context(lang=lang)
+
                 template_ctx = {
                     'message': self.env['mail.message'].sudo().new(dict(body=values['body_html'], record_name=record.display_name)),
-                    'model_description': self.env['ir.model']._get(record._name).display_name,
+                    'model_description': model.display_name,
                     'company': 'company_id' in record and record['company_id'] or self.env.company,
                     'record': record,
                 }


### PR DESCRIPTION
Steps:
- Install sale
- Go to Settings / Translations / Languages
- Activate Dutch
- Go to Settings / Users & Companies / Users
- Edit demo
  - Language: Dutch
- Go to Sales
- Create a quotation:
  - Customer: demo
- Go to Settings / Technical / Automation / Scheduled Actions
- Create a new action:
  - Model: Sales Order
  - Python code:
  ```python
  last_id = model.search([], order='id desc', limit=1)[0].id
  env.ref('sale.email_template_edi_sale').send_mail(last_id, notif_layout='mail.mail_notification_paynow')
  ```
- Click "Run Manually"
- Go to Settings / Technical / Email / Emails
- Open the last email you just sent

Bug:
Parts of the email are not in Dutch

Explanation:
This commit makes a template pass the rendering language to the layout
and the display name when calling `template.send_mail()`.

opw:2467640