### PR TITLE
[FIX] mail: display desired company logo in email

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2383,7 +2383,10 @@ class MailThread(models.AbstractModel):
             if add_sign:
                 signature = "<p>-- <br/>%s</p>" % author.name
 
-        company = self.company_id.sudo() if self and 'company_id' in self else user.company_id
+        # company value should fall back on env.company if:
+        # - no company_id field on record
+        # - company_id field available but not set
+        company = self.company_id.sudo() if self and 'company_id' in self and self.company_id else self.env.company
         if company.website:
             website_url = 'http://%s' % company.website if not company.website.lower().startswith(('http:', 'https:')) else company.website
         else:

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -12,6 +12,7 @@ from odoo.api import call_kw
 from odoo.exceptions import AccessError
 from odoo.tests import tagged
 from odoo.tools import mute_logger, formataddr
+from odoo.tests.common import users
 
 
 @tagged('mail_post')
@@ -40,6 +41,43 @@ class TestMessagePost(BaseFunctionalTest, TestRecipients, MockEmails):
         # Use call_kw as shortcut to simulate a RPC call.
         messageId = call_kw(self.env['mail.channel'], 'message_post', [test_channel.id], {'body': 'test'})
         self.assertTrue(isinstance(messageId, int))
+
+    @users('employee')
+    def test_notify_prepare_template_context_company_value(self):
+        """ Verify that the template context company value is right
+        after switching the env company or if a company_id is set
+        on mail record.
+        """
+        current_user = self.env.user
+        main_company = current_user.company_id
+        other_company = self.env['res.company'].with_user(self.user_admin).create({'name': 'Company B'})
+        current_user.sudo().write({'company_ids': [(4, other_company.id)]})
+        test_record = self.env['mail.test.multi.company'].with_user(self.user_admin).create({
+            'name': 'Multi Company Record',
+            'company_id': False,
+        })
+
+        # self.env.company.id = Main Company    AND    test_record.company_id = False
+        self.assertEqual(self.env.company.id, main_company.id)
+        self.assertEqual(test_record.company_id.id, False)
+        template_values = test_record._notify_prepare_template_context(test_record.message_ids, {})
+        self.assertEqual(template_values.get('company').id, self.env.company.id)
+
+        # self.env.company.id = Other Company    AND    test_record.company_id = False
+        current_user.company_id = other_company
+        test_record = self.env['mail.test.multi.company'].browse(test_record.id)
+        self.assertEqual(self.env.company.id, other_company.id)
+        self.assertEqual(test_record.company_id.id, False)
+        template_values = test_record._notify_prepare_template_context(test_record.message_ids, {})
+        self.assertEqual(template_values.get('company').id, self.env.company.id)
+
+        # self.env.company.id = Other Company    AND    test_record.company_id = Main Company
+        test_record.company_id = main_company
+        test_record = self.env['mail.test.multi.company'].browse(test_record.id)
+        self.assertEqual(self.env.company.id, other_company.id)
+        self.assertEqual(test_record.company_id.id, main_company.id)
+        template_values = test_record._notify_prepare_template_context(test_record.message_ids, {})
+        self.assertEqual(template_values.get('company').id, main_company.id)
 
     def test_notify_recipients_internals(self):
         pdata = self._generate_notify_recipients(self.partner_1 | self.partner_employee)


### PR DESCRIPTION
Issue

	- Install 'Accounting' module
	- Switch to "My Company (Chicago)"
	- Create an invoice
	- Set invoice date to 1/1/21 and
	- Set Due date to 1/3/21
	- Add any product and 'Confirm' invoice
	- Go to customer profile
	- Click on 'Due' stat button
	- Click on 'Send by mail'

	In received email, logo display is of "My Company (San Francisco)".

Cause

	Env company not used.
	Instead, logo of customer.company is used if mail type have company_id field,
	else will fallback on user.company_id
	Also, if customer.company_id is null, it will fallback on '0':
	/logo.png?company=%s' % (company.id or 0)

Solution

	Add field company_id to kwargs when calling message_post in case
	want to force company_id.

opw-2474114