### PR TITLE
[13.0][FIX] l10n_es: Create tax group for non deductible VAT

### DIFF
--- a/addons/l10n_es/data/account_data.xml
+++ b/addons/l10n_es/data/account_data.xml
@@ -60,5 +60,8 @@
         <record id="tax_group_iva_10-5" model="account.tax.group">
             <field name="name">IVA 10,5% REAGYP</field>
         </record>
+        <record id="tax_group_iva_nd" model="account.tax.group">
+            <field name="name">IVA no deducible</field>
+        </record>
     </data>
 </odoo>

--- a/addons/l10n_es/data/account_tax_data.xml
+++ b/addons/l10n_es/data/account_tax_data.xml
@@ -1813,7 +1813,7 @@
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount" eval="21"/>
         <field name="amount_type">percent</field>
-        <field name="tax_group_id" ref="tax_group_iva_21"/>
+        <field name="tax_group_id" ref="tax_group_iva_nd"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
@@ -1844,7 +1844,7 @@
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount" eval="10"/>
         <field name="amount_type">percent</field>
-        <field name="tax_group_id" ref="tax_group_iva_10"/>
+        <field name="tax_group_id" ref="tax_group_iva_nd"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,
@@ -1875,7 +1875,7 @@
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount" eval="4"/>
         <field name="amount_type">percent</field>
-        <field name="tax_group_id" ref="tax_group_iva_4"/>
+        <field name="tax_group_id" ref="tax_group_iva_nd"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'factor_percent': 100,


### PR DESCRIPTION
Previously on v12, every tax was added in an account.invoice.tax line, being clear about the amount of each one.

![Selección_004](https://user-images.githubusercontent.com/7165771/113324593-964b9a00-9317-11eb-8262-0480758f0494.png)

Now on v13, that table has dissappeared, and the tax summary at the footer is grouped by tax group, resulting in a mix of all taxes with the same percentage. This is not usually a problem, as the same percentage taxes are not included at the same time in the same invoice, except an exception: non deductible VAT.

For this case, we can have several lines with the same percentage as deductible or non deductible, and all being mixed in the footer.

![Selección_005](https://user-images.githubusercontent.com/7165771/113324615-9cda1180-9317-11eb-9afd-919f6404796b.png)

For avoiding the problem, we create a new tax group, and use it for non deductible VAT taxes. We can consider to add 3 groups, one per percentage of non deductible VAT, but it's an overhead that doesn't add too much value (the 95% percent of the non deductible is 21%), and even if having several of them in the same invoice, to see the total amount grouped as "IVA no deducible" is not a big deal.

@Tecnativa TT29009