### PR TITLE
[FIX][14.0] Fix account_edi_ubl partner search using VAT

### DIFF
--- a/addons/account_edi_ubl/models/account_edi_format.py
+++ b/addons/account_edi_ubl/models/account_edi_format.py
@@ -101,7 +101,7 @@ class AccountEdiFormat(models.Model):
                 if elements:
                     partner_mail = elements[0].text
                     domains.append([('email', '=', partner_mail)])
-                elements = partner_element.xpath('//cac:AccountingSupplierParty/cac:Party//cbc:ID', namespaces=namespaces)
+                elements = partner_element.xpath('//cac:AccountingSupplierParty/cac:Party//cbc:CompanyID', namespaces=namespaces)
                 if elements:
                     partner_id = elements[0].text
                     domains.append([('vat', 'like', partner_id)])

--- a/addons/l10n_be_edi/test_xml_file/efff_test.xml
+++ b/addons/l10n_be_edi/test_xml_file/efff_test.xml
@@ -30,7 +30,7 @@
             </cac:PostalAddress>
             <cac:PartyLegalEntity>
                 <cbc:RegistrationName>The best supplier</cbc:RegistrationName>
-                <cbc:CompanyID>12345689</cbc:CompanyID>
+                <cbc:CompanyID>477472701</cbc:CompanyID>
             </cac:PartyLegalEntity>
         </cac:Party>
     </cac:AccountingSupplierParty>

--- a/doc/cla/corporate/acsone.md
+++ b/doc/cla/corporate/acsone.md
@@ -30,3 +30,4 @@ Denis Robinet denis.robinet@acsone.eu https://github.com/RobinetDenisAcsone
 Benoit Aimont benoit.aimont@acsone.eu https://github.com/baimont
 Bejaoui Souheil souheil.bejaoui@acsone.eu https://github.com/sbejaoui
 Nans Lefebvre nans.lefebvre@acsone.eu https://github.com/len-foss
+Régis Pirard regis.pirard@acsone.eu https://github.com/regispirard


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

When importing an XML UBL invoice, the partner is supposed to be automatically completed on the invoice.
But, in my case, it is never found in the database, although it was previously created.

In my database, the partner : 
* has a different name than the one in the XML file
* has no phone or email completed
* has a the correct VAT number

I expect Odoo to find the partner based on the VAT number and to complete the invoice with it, but it never happens.


**Current behavior before PR:**
The function search for a partner using data form the invoice using a domain made of : partner name, phone, email or vat.

For the VAT part, this code looks for the VAT number in the invoice file :+1: 


                elements = partner_element.xpath('//cac:AccountingSupplierParty/cac:Party//cbc:ID', namespaces=namespaces)

                if elements:

                    partner_id = elements[0].text

                    domains.append([('vat', 'like', partner_id)])

 In odoo_l10n_be_edi, the text xml file is like this (see https://github.com/odoo/odoo/blob/14.0/addons/l10n_be_edi/test_xml_file/efff_test.xml) : 

 <cac:AccountingSupplierParty>

        <cac:Party>

            <cbc:EndpointID schemeID="GLN">BE0123456789</cbc:EndpointID>

            <cac:PartyIdentification>

                <cbc:ID schemeAgencyName="KBO" schemeAgencyID="BE">123456789</cbc:ID>

            </cac:PartyIdentification>

            <cac:PartyName>

                <cbc:Name>The best supplier</cbc:Name>

            </cac:PartyName>

            <cac:PostalAddress>

                <cbc:StreetName>Chemin de Odoo 34</cbc:StreetName>

                <cbc:CityName>Odoo Ville</cbc:CityName>

                <cbc:PostalZone>7777</cbc:PostalZone>

                <cac:Country>

                    <cbc:IdentificationCode>BE</cbc:IdentificationCode>

                </cac:Country>

            </cac:PostalAddress>

            <cac:PartyLegalEntity>

                <cbc:RegistrationName>The best supplier</cbc:RegistrationName>

                <cbc:CompanyID>12345689</cbc:CompanyID>

            </cac:PartyLegalEntity>

        </cac:Party>

    </cac:AccountingSupplierParty>


In this file, //cac:AccountingSupplierParty/cac:Party//cbc:ID' is 123456789

Meaning that, in the previous function, we write a domain like this : domains.append([('vat', 'like', '123456789')])

But in some UBL 2.0 file (see http://www.datypic.com/sc/ubl20/e-ns19_Invoice.html for example), we may have : 

   <cac:AccountingSupplierParty>

      <cbc:CustomerAssignedAccountID>CO001</cbc:CustomerAssignedAccountID>

      <cac:Party>

         <cac:PartyName>

            <cbc:Name>Consortial</cbc:Name>

         </cac:PartyName>

         <cac:PostalAddress>

            <cbc:StreetName>Busy Street</cbc:StreetName>

            <cbc:BuildingName>Thereabouts</cbc:BuildingName>

            <cbc:BuildingNumber>56A</cbc:BuildingNumber>

            <cbc:CityName>Farthing</cbc:CityName>

            <cbc:PostalZone>AA99 1BB</cbc:PostalZone>

            <cbc:CountrySubentity>Heremouthshire</cbc:CountrySubentity>

            <cac:AddressLine>

               <cbc:Line>The Roundabout</cbc:Line>

            </cac:AddressLine>

            <cac:Country>

               <cbc:IdentificationCode>GB</cbc:IdentificationCode>

            </cac:Country>

         </cac:PostalAddress>

         <cac:PartyTaxScheme>

            <cbc:RegistrationName>Farthing Purchasing Consortia</cbc:RegistrationName>

            <cbc:CompanyID>175 269 2355</cbc:CompanyID>

            <cbc:ExemptionReason>N/A</cbc:ExemptionReason>

            <cac:TaxScheme>

               <cbc:ID>VAT</cbc:ID>

               <cbc:TaxTypeCode>VAT</cbc:TaxTypeCode>

            </cac:TaxScheme>

         </cac:PartyTaxScheme>

         <cac:Contact>

            <cbc:Name>Mrs Bouquet</cbc:Name>

            <cbc:Telephone>0158 1233714</cbc:Telephone>

            <cbc:Telefax>0158 1233856</cbc:Telefax>

            <cbc:ElectronicMail>bouquet@fpconsortial.co.uk</cbc:ElectronicMail>

         </cac:Contact>

      </cac:Party>

   </cac:AccountingSupplierParty>

In this file, //cac:AccountingSupplierParty/cac:Party//cbc:ID' first occurence is in : 
cac:AccountingSupplierParty / cac:Party / <cac:PartyTaxScheme> 
=> <cbc: ID>VAT</cbc:ID>

Meaning that the domain will look like this : domains.append([('vat', 'like', 'VAT')])

**Desired behavior after PR is merged:**

We should base our search on CompanyID : //cac:AccountingSupplierParty/cac:Party//cbc:CompanyID

CompanyID is supposed to be the VAT identification of the partner / supplier.



--- update --
Fixing sample file l10n_be_edi/test_xml_file/efff_test.xml.

Company ID is 123456789.
A "7" is missing in <cbc:CompanyID>12345689</cbc:CompanyID> in the sample file efff_test.xml.

Also, note that the sample file is missing a <cac:PartyTaxScheme> part, and we are reading CompanyID in <cac:PartyLegalEntity>.

See also http://nw.e-fff.be/fichiers-dexemple/ for other sample files.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
