### PR TITLE
[IMP] hr_timesheet, project: back2basic improvements

### DIFF
--- a/addons/hr_timesheet/__init__.py
+++ b/addons/hr_timesheet/__init__.py
@@ -9,22 +9,9 @@ from . import wizard
 from odoo import api, fields, SUPERUSER_ID, _
 
 
-def create_internal_project(cr, registry):
+def post_init(cr, registry):
     env = api.Environment(cr, SUPERUSER_ID, {})
 
     # allow_timesheets is set by default, but erased for existing projects at
     # installation, as there is no analytic account for them.
     env['project.project'].search([]).write({'allow_timesheets': True})
-
-    admin = env.ref('base.user_admin', raise_if_not_found=False)
-    if not admin:
-        return
-    project_ids = env['res.company'].search([])._create_internal_project_task()
-    env['account.analytic.line'].create([{
-        'name': _("Analysis"),
-        'user_id': admin.id,
-        'date': fields.datetime.today(),
-        'unit_amount': 0,
-        'project_id': task.project_id.id,
-        'task_id': task.id,
-    } for task in project_ids.task_ids.filtered(lambda t: t.company_id in admin.employee_ids.company_id)])

--- a/addons/hr_timesheet/__manifest__.py
+++ b/addons/hr_timesheet/__manifest__.py
@@ -42,7 +42,7 @@ up a management by affair.
     'installable': True,
     'application': False,
     'auto_install': False,
-    'post_init_hook': 'create_internal_project',
+    'post_init_hook': 'post_init',
     'assets': {
         'web.assets_backend': [
             'hr_timesheet/static/src/scss/timesheets_task_form.scss',

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -585,7 +585,7 @@ class Task(models.Model):
     kanban_state = fields.Selection([
         ('normal', 'In Progress'),
         ('done', 'Ready'),
-        ('blocked', 'Blocked')], string='Kanban State',
+        ('blocked', 'Blocked')], string='Status',
         copy=False, default='normal', required=True)
     kanban_state_label = fields.Char(compute='_compute_kanban_state_label', string='Kanban State Label', tracking=True)
     create_date = fields.Datetime("Created On", readonly=True, index=True)

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -419,7 +419,7 @@
                     <field name="name" string="Name" class="font-weight-bold"/>
                     <field name="user_id" optional="show" string="Project Manager" widget="many2one_avatar_user"/>
                     <field name="partner_id" optional="show" string="Customer"/>
-                    <field name="analytic_account_id" optional="hide"/>
+                    <field name="analytic_account_id" optional="hide" groups="analytic.group_analytic_accounting"/>
                     <field name="privacy_visibility" optional="hide"/>
                     <field name="label_tasks" optional="hide"/>
                     <field name="company_id" optional="show"  groups="base.group_multi_company"/>


### PR DESCRIPTION
Currently, In the project module -> tasks, there is a column named "Kanban
state" which is confusing where anywhere else we speak about task status; In
the project dashboard, when starting the project app from scratch with
timesheet app configured, the only data shown is the internal project that is
not very meaningful regarding project management.

So in this commit, I have renamed the "Kanban state" column to "Status"; Project
app do not show internal project when the timesheet app is configured. Instead,
it shows sample data as there is no project.

Task ID: 2451722

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
