### PR TITLE
[IMP] crm: add probability on lead tree

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -365,11 +365,11 @@
                         domain="[('share', '=', False)]"/>
                     <field name="team_id" optional="show"/>
                     <field name="active" invisible="1"/>
-                    <field name="probability" invisible="1"/>
                     <field name="campaign_id" optional="hide"/>
                     <field name="referred" invisible="1"/>
                     <field name="medium_id" optional="hide"/>
                     <field name="source_id" optional="hide"/>
+                    <field name="probability" string="Probability (%)" optional="hide"/>
                     <field name="message_needaction" invisible="1"/>
                     <field name="tag_ids" optional="hide" widget="many2many_tags" options="{'color_field': 'color'}"/>
                     <field name="priority" optional="hide"/>
@@ -723,7 +723,7 @@
                     <field name="recurring_plan" optional="hide"/>
                     <field name="stage_id" optional="show" decoration-bf="1"/>
                     <field name="active" invisible="1"/>
-                    <field name="probability" optional="hide"/>
+                    <field name="probability" string="Probability (%)" optional="hide"/>
                     <field name="tag_ids" optional="hide" widget="many2many_tags" options="{'color_field': 'color'}"/>
                     <field name="referred" invisible="1"/>
                     <field name="message_needaction" invisible="1"/>


### PR DESCRIPTION
PURPOSE
With the removal of lead scores, the probability is now the tool we want users to see as their 
"quality indicator" for their leads. We thus need to display it.

CURRENT
In crm probability field is not displaying in lead tree view.

TO BE
With this commit, we now display probability field (optional="hide") in lead tree view.

**TaskID: 2496347**

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
