### PR TITLE
[IMP] hr,hr_fleet: Departure Documents

### DIFF
--- a/addons/hr/wizard/hr_departure_wizard.py
+++ b/addons/hr/wizard/hr_departure_wizard.py
@@ -28,3 +28,4 @@ class HrDepartureWizard(models.TransientModel):
             private_address = employee.address_home_id
             if private_address and private_address.active and not self.env['res.users'].search([('partner_id', '=', private_address.id)]):
                 private_address.toggle_active()
+        return True

--- a/addons/hr_fleet/wizard/hr_departure_wizard.py
+++ b/addons/hr_fleet/wizard/hr_departure_wizard.py
@@ -10,9 +10,10 @@ class HrDepartureWizard(models.TransientModel):
     release_campany_car = fields.Boolean("Release Company Car", default=True)
 
     def action_register_departure(self):
-        super(HrDepartureWizard, self).action_register_departure()
+        res = super(HrDepartureWizard, self).action_register_departure()
         if self.release_campany_car:
             self._free_campany_car()
+        return res
 
     def _free_campany_car(self):
         """Find all fleet.vehichle.assignation.log records that link to the employee, if there is no 


### PR DESCRIPTION
Add a way to easily send a departing/departed employee his documents
without login access.

When archiving an employee an option will be available opening a form to
send en email containing a link to a document share (valid 2 weeks) for all
of the employees document (payslips). Alternatively an action has also
been added to the employee form.

Task ID: 2476837