### PR TITLE
[FIX] account: added a regex verification when adding a partner mapping

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -11772,6 +11772,13 @@ msgid ""
 msgstr ""
 
 #. module: account
+#: code:addons/account/models/account_reconcile_model.py:0
+#, python-format
+msgid ""
+"The following regular expression is invalid to create a partner mapping: %s"
+msgstr ""
+
+#. module: account
 #: code:addons/account/models/chart_template.py:0
 #, python-format
 msgid ""

--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -24,7 +24,15 @@ class AccountReconcileModelPartnerMapping(models.Model):
         for record in self:
             if not (record.narration_regex or record.payment_ref_regex):
                 raise ValidationError(_("Please set at least one of the match texts to create a partner mapping."))
-
+            try:
+                if record.payment_ref_regex:
+                    current_regex = record.payment_ref_regex
+                    re.compile(record.payment_ref_regex)
+                if record.narration_regex:
+                    current_regex = record.narration_regex
+                    re.compile(record.narration_regex) 
+            except re.error:
+                raise ValidationError(_("The following regular expression is invalid to create a partner mapping: %s") % current_regex)
 
 class AccountReconcileModelLine(models.Model):
     _name = 'account.reconcile.model.line'


### PR DESCRIPTION
Steps to reproduce the bug :

- Go to accounting > Configuration > Reconciliation Models
- Create a new reconciliation model
- Select the “Match existing invoices/bills” type
- In the field “Match Invoice/bill with” choose “Label”
- Add a new partner mapping > encode in "Find text in label" an erroneous regex like “*test” > choose any partner
- Go to accounting Dashboard > click on “Bank”
- Create a new Bank statement> add new transaction without selecting “Partner”
- Post the created bank statements > Reconcile it

Problem :
An error is triggered because the regex is wrong.

opw-2473973

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
