### PR TITLE
[FIX] web_editor, website: solve broken link popover test

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -1203,9 +1203,9 @@ options.registry.menu_data = options.Class.extend({
       *
       * @override
       */
-     onBlur: function () {
-         this.$target.popover('hide');
-     },
+    onBlur: function () {
+        this.$target.popover('hide');
+    },
 });
 
 options.registry.company_data = options.Class.extend({

--- a/addons/website/static/src/js/widgets/link_popover_widget.js
+++ b/addons/website/static/src/js/widgets/link_popover_widget.js
@@ -58,7 +58,6 @@ const NavbarLinkPopoverWidget = weWidgets.LinkPopoverWidget.extend({
             }).then(function () {
                 self.$target.attr('href', link.url);
                 $menu.text(link.text);
-                self._loadAsyncLinkPreview();
             });
         });
         dialog.open();

--- a/addons/website/static/tests/tours/edit_link_popover.js
+++ b/addons/website/static/tests/tours/edit_link_popover.js
@@ -97,10 +97,10 @@ tour.register('edit_link_popover', {
     {
         content: "Click on the Home menu again",
         trigger: '#top_menu a:contains("Home")',
+        extra_trigger: '#top_menu a:contains("Home")[href="/contactus"]', // href should be changed
     },
     {
         content: "Popover should be shown with updated preview data",
-        extra_trigger: '#top_menu a:contains("Home")[href="/contactus"]', // href should be changed
         trigger: '.o_edit_menu_popover .o_we_url_link:contains("Contact Us")',
         run: function () {}, // it's a check
     },


### PR DESCRIPTION
- The test was clicking on a link "too soon" in some cases (editing a
  link then immediatly clicking on it while the save action is not fully
  performed). Ideally, this should probably be more robust around the
  save action to first edit the link synchronously then perform the
  actual save in DB but this can be checked later on.

- Removed useless popover update while it was hidden.

- Make sure that two consecutive update of the popover only updates its
  UI relying on the last asked data.

- Make sure the popover correctly clean what it did once destroyed
  (however, it is never actually destroyed for now... to check later).

