### PR TITLE
[IMP] web_editor: make toolbar fixed on top of editable on mobile

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/odoo-editor.css
+++ b/addons/web_editor/static/lib/odoo-editor/odoo-editor.css
@@ -159,6 +159,18 @@
 .oe-toolbar #style .dropdown-menu {
     text-align: left;
 }
+@media only screen and (max-width: 767px) {
+    .oe-toolbar {
+        position: relative;
+        visibility: visible;
+        width: 100%;
+        border-radius: 0;
+        background-color: white;
+    }
+    .oe-toolbar .btn {
+        color: black;
+    }
+}
 /* Content styling */
 
 li.oe-nested {

--- a/addons/web_editor/static/lib/odoo-editor/odoo-editor.js
+++ b/addons/web_editor/static/lib/odoo-editor/odoo-editor.js
@@ -2464,6 +2464,8 @@ var exportVariable = (function (exports) {
 
             this.document = options.document || document;
 
+            this.isMobile = matchMedia('(max-width: 767px)').matches;
+
             // Keyboard type detection, happens only at the first keydown event.
             this.keyboardType = KEYBOARD_TYPES.UNKNOWN;
 
@@ -2560,6 +2562,9 @@ var exportVariable = (function (exports) {
                         this.document.execCommand(ev.target.name, false, ev.target.value);
                         this.updateColorpickerLabels();
                     });
+                }
+                if (this.isMobile) {
+                    this.editable.before(this.toolbar);
                 }
             }
         }
@@ -3819,11 +3824,13 @@ var exportVariable = (function (exports) {
             if (!sel.anchorNode) {
                 show = false;
             }
-            if (show !== undefined && this.options.autohideToolbar) {
-                this.toolbar.style.visibility = show ? 'visible' : 'hidden';
-            }
-            if (show === false && this.options.autohideToolbar) {
-                return;
+            if (this.options.autohideToolbar) {
+                if (show !== undefined && !this.isMobile) {
+                    this.toolbar.style.visibility = show ? 'visible' : 'hidden';
+                }
+                if (show === false) {
+                    return;
+                }
             }
             const paragraphDropdownButton = this.toolbar.querySelector('#paragraphDropdownButton');
             for (const commandState of [
@@ -3897,7 +3904,7 @@ var exportVariable = (function (exports) {
             undoButton && undoButton.classList.toggle('disabled', !this.historyCanUndo());
             const redoButton = this.toolbar.querySelector('#redo');
             redoButton && redoButton.classList.toggle('disabled', !this.historyCanRedo());
-            if (this.options.autohideToolbar) {
+            if (this.options.autohideToolbar && !this.isMobile) {
                 this._positionToolbar();
             }
         }

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -147,7 +147,11 @@ const Wysiwyg = Widget.extend({
 
         return _super.apply(this, arguments).then(() => {
             if (this.options.autohideToolbar) {
-                $(document.body).append(this.toolbar.$el);
+                if (this.odooEditor.isMobile) {
+                    $(this.odooEditor.editable).before(this.toolbar.$el);
+                } else {
+                    $(document.body).append(this.toolbar.$el);
+                }
             }
         });
     },

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -31,24 +31,9 @@ const Wysiwyg = Widget.extend({
     xmlDependencies: [
     ],
     defaultOptions: {
-        'focus': false,
-        'toolbar': [
-            ['style', ['style']],
-            ['font', ['bold', 'italic', 'underline', 'clear']],
-            ['fontsize', ['fontsize']],
-            ['color', ['color']],
-            ['para', ['ul', 'ol', 'paragraph']],
-            ['table', ['table']],
-            ['insert', ['link', 'picture']],
-            ['history', ['undo', 'redo']],
-        ],
-        'styleWithSpan': false,
-        'inlinemedia': ['p'],
-        'lang': 'odoo',
-        'colors': customColors,
-        recordInfo: {
-            context: {},
-        },
+        lang: 'odoo',
+        colors: customColors,
+        recordInfo: {context: {}},
     },
     init: function (parent, options) {
         this._super.apply(this, arguments);
@@ -1022,10 +1007,6 @@ const Wysiwyg = Widget.extend({
     _editorOptions: function () {
         var self = this;
         var options = Object.assign({}, this.defaultOptions, this.options);
-        if (this.options.generateOptions) {
-            options = this.options.generateOptions(options);
-        }
-        options.airPopover = options.toolbar;
         options.onChange = function (html, $editable) {
             $editable.trigger('content_changed');
             self.trigger_up('wysiwyg_change');

--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -129,6 +129,21 @@ $o-we-zindex: $o-we-overlay-zindex + 1 !default;
         max-width: 150px;
     }
 }
+@media only screen and (max-width: 767px) {
+    .oe-toolbar {
+        background-color: white;
+
+        .btn {
+            color: black;
+        }
+        &::before {
+            display: none;
+        }
+        &::after {
+            display: none;
+        }
+    }
+}
 
 .oe_edited_link {
     position: relative;

--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -124,16 +124,12 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
             var hasFullEdit = parseInt($("#karma").val()) >= editorKarma;
 
             var options = {
-                height: 200,
-                minHeight: 80,
                 toolbarTemplate: 'website_forum.web_editor_toolbar',
-                styleWithSpan: false,
                 recordInfo: {
                     context: self._getContext(),
                     res_model: 'forum.post',
                     res_id: +window.location.pathname.split('-').pop(),
                 },
-                disableFullMediaDialog: true,
                 resizable: true,
             };
             if (!hasFullEdit) {


### PR DESCRIPTION
Mobile browsers implement their own floating toolbar in text selections. As a consequence, Odoo Editor's floating toolbar ends up mingled with the native one, making it hard to use.
This PR replaces the floating toolbar on mobile devices with a static toolbar on top of the editor and adapts styles accordingly.
In addition it removes unused options passed to the editor, which belonged to Summernote.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
