### PR TITLE
[FIX] sale_crml: default tags when creating a quotation

### DIFF
--- a/addons/sale_crm/views/crm_lead_views.xml
+++ b/addons/sale_crm/views/crm_lead_views.xml
@@ -12,6 +12,7 @@
                         context="{'search_default_partner_id': partner_id,
                                   'default_partner_id': partner_id,
                                   'default_team_id': team_id,
+                                  'default_tag_ids': tag_ids,
                                   'default_campaign_id': campaign_id,
                                   'default_medium_id': medium_id,
                                   'default_origin': name,


### PR DESCRIPTION
Before this commit, when creating a quotation from a CRM, the tags
weren't copied from the CRM to the quotation.

Now, the tags from the CRM are put it as default on the newly created
quotation. This behaviour is the same on version 13 and new, and it was
also the case on version 11.

opw-2483149
