### PR TITLE
[IMP] account_edi : Do not overwrite taxes when using the EDI

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3511,11 +3511,23 @@ class AccountMoveLine(models.Model):
     # ONCHANGE METHODS
     # -------------------------------------------------------------------------
 
-    @api.onchange('amount_currency', 'currency_id', 'debit', 'credit', 'tax_ids', 'account_id', 'price_unit')
+    @api.onchange('amount_currency', 'currency_id', 'debit', 'credit', 'tax_ids', 'price_unit')
     def _onchange_mark_recompute_taxes(self):
         ''' Recompute the dynamic onchange based on taxes.
         If the edited line is a tax line, don't recompute anything as the user must be able to
         set a custom value.
+        '''
+        for line in self:
+            if not line.tax_repartition_line_id:
+                line.recompute_tax_line = True
+
+    @api.onchange('account_id')
+    def _onchange_account_id_mark_recompute_taxes(self):
+        ''' Recompute the dynamic onchange based on taxes.
+        If the edited line is a tax line, don't recompute anything as the user must be able to
+        set a custom value.
+        To be overriden in account_edi to not recompute taxes for moves that has been extracted,
+        unless the account has any tax_ids specified on it.
         '''
         for line in self:
             if not line.tax_repartition_line_id:

--- a/addons/account_edi_facturx/models/account_edi_format.py
+++ b/addons/account_edi_facturx/models/account_edi_format.py
@@ -322,4 +322,13 @@ class AccountEdiFormat(models.Model):
                     invoice_line_form.quantity = 1
                     invoice_line_form.price_unit = amount_total_import
 
+            self._force_tax_values(
+                invoice_form,
+                tree,
+                tax_group_node='//ram:ApplicableHeaderTradeSettlement/ram:ApplicableTradeTax',
+                percent_node='.//ram:RateApplicablePercent',
+                value_node='.//ram:CalculatedAmount',
+                namespaces=tree.nsmap,
+            )
+
         return invoice_form.save()

--- a/addons/account_edi_ubl/models/account_edi_format.py
+++ b/addons/account_edi_ubl/models/account_edi_format.py
@@ -173,6 +173,15 @@ class AccountEdiFormat(models.Model):
                             if tax:
                                 invoice_line_form.tax_ids.add(tax)
 
+            self._force_tax_values(
+                invoice_form,
+                tree,
+                tax_group_node='cac:TaxTotal/cac:TaxSubtotal',
+                percent_node='cbc:Percent',
+                value_node='cbc:TaxAmount',
+                namespaces=namespaces,
+            )
+
         invoice = invoice_form.save()
 
         # Regenerate PDF

--- a/addons/l10n_be_edi/tests/test_ubl.py
+++ b/addons/l10n_be_edi/tests/test_ubl.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from odoo.addons.account_edi.tests.common import AccountEdiTestCommon
+from odoo.modules.module import get_module_resource
 
 
 class TestUBL(AccountEdiTestCommon):
@@ -26,3 +27,23 @@ class TestUBL(AccountEdiTestCommon):
         self.assertEqual(invoice.amount_total, 666.50)
         self.assertEqual(invoice.amount_tax, 115.67)
         self.assertEqual(invoice.partner_id, self.partner_a)
+
+    def test_import_do_not_overwrite_tax(self):
+        file_path = get_module_resource('l10n_be_edi', 'test_xml_file', 'efff_test.xml')
+        file = open(file_path, 'rb').read()
+        original_etree = self.get_xml_tree_from_string(file)
+
+        # Add the information about the tax to the xml : with an absurd amount that couldn't be correct
+        applied_xpath = '''
+            <xpath expr="//*[local-name()='TaxTotal']/*[local-name()='TaxSubtotal']/*[local-name()='TaxAmount']" position="replace"
+                xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                <cbc:TaxAmount currencyID="EUR">123456.00</cbc:TaxAmount>
+            </xpath>
+        '''
+
+        etree = self.with_applied_xpath(original_etree, applied_xpath)
+
+        invoice = self.edi_format.with_context(default_move_type='out_invoice')._create_invoice_from_ubl(etree)
+
+        # Ensure that the amount_tax is the one we set in the xml file and not the one computed by odoo
+        self.assertEqual(invoice.amount_tax_signed, 123456.00)

--- a/addons/l10n_it_edi/models/account_edi_format.py
+++ b/addons/l10n_it_edi/models/account_edi_format.py
@@ -535,6 +535,14 @@ class AccountEdiFormat(models.Model):
                         invoice_line_form_discount.name = discount["name"]
                         invoice_line_form_discount.price_unit = discount["amount"]
 
+                self._force_tax_values(
+                    invoice_form,
+                    body_tree,
+                    tax_group_node='DatiBeniServizi/DatiRiepilogo',
+                    percent_node='AliquotaIVA',
+                    value_node='Imposta',
+                )
+
             new_invoice = invoice_form.save()
             new_invoice.l10n_it_send_state = "other"
 


### PR DESCRIPTION
When importing an invoice or bill from the EDI, Odoo is calculating
all the totals himself instead of getting them from the XML.

While it usually would not be an issue it can become one when taxes are
being rounded in the wrong way.

This will change that and make sure that we are always using the same
taxes than the XML.

Task id #2289153

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
