### PR TITLE
[FIX] sale_stock: auto width of incoterm block in sale report

### DIFF
--- a/addons/sale_stock/report/sale_order_report_templates.xml
+++ b/addons/sale_stock/report/sale_order_report_templates.xml
@@ -2,9 +2,9 @@
 <odoo>
     <template id="report_saleorder_document_inherit_sale_stock" inherit_id="sale.report_saleorder_document">
         <xpath expr="//div[@name='expiration_date']" position="after">
-            <div class="col-3" t-if="doc.incoterm" groups="sale_stock.group_display_incoterm">
+            <div class="col-auto col-3 mw-100 mb-2" t-if="doc.incoterm" groups="sale_stock.group_display_incoterm">
                 <strong>Incoterm:</strong>
-                <p t-field="doc.incoterm.code"/>
+                <p class="m-0" t-field="doc.incoterm.code"/>
             </div>
         </xpath>
     </template>


### PR DESCRIPTION
Before this commit, the class col-auto was missing from the element
representing the incoterm code on sales orders' reports.
When more than four fields were shown at once in the containing table,
the columns' width was no longer equal.