### PR TITLE
[FIX] event: ignore fields which have a default value

### DIFF
--- a/addons/event/i18n/event.pot
+++ b/addons/event/i18n/event.pot
@@ -1503,6 +1503,12 @@ msgid "Online events like webinars do not require a specific location\n"
 msgstr ""
 
 #. module: event
+#: code:addons/event/models/event.py:386
+#, python-format
+msgid "Only event users or managers are allowed to create or update registrations."
+msgstr "Only event users or managers are allowed to create or update registrations."
+
+#. module: event
 #: model:ir.model.fields,help:event.field_event_type_is_online
 msgid "Online events like webinars do not require a specific location and are hosted online."
 msgstr ""

--- a/addons/event/models/event.py
+++ b/addons/event/models/event.py
@@ -394,7 +394,11 @@ class EventRegistration(models.Model):
             'partner_id': partner_id.id,
             'event_id': event_id and event_id.id or False,
         }
-        data.update({key: value for key, value in registration.items() if key in self._fields})
+        data.update({
+            key: value for key, value in registration.items()
+            if key in self._fields and key not in data and not self._fields[key].default
+        })
+
         return data
 
     @api.one

--- a/addons/event/models/event.py
+++ b/addons/event/models/event.py
@@ -380,6 +380,14 @@ class EventRegistration(models.Model):
         return registration
 
     @api.model
+    def check_access_rights(self, operation, raise_exception=True):
+        if not self.env.user._is_admin() and not self.user_has_groups('event.group_event_user'):
+            if raise_exception:
+                raise AccessError(_('Only event users or managers are allowed to create or update registrations.'))
+            return False
+        return super(EventRegistration, self).check_access_rights(operation, raise_exception=raise_exception)
+
+    @api.model
     def _prepare_attendee_values(self, registration):
         """ Method preparing the values to create new attendees based on a
         sales order line. It takes some registration data (dict-based) that are

--- a/addons/website_event/models/event.py
+++ b/addons/website_event/models/event.py
@@ -32,7 +32,7 @@ class Event(models.Model):
             email = self.env.user.partner_id.email
             for event in self:
                 domain = ['&', '|', ('email', '=', email), ('partner_id', '=', self.env.user.partner_id.id), ('event_id', '=', event.id)]
-                event.is_participating = self.env['event.registration'].search_count(domain)
+                event.is_participating = self.env['event.registration'].sudo().search_count(domain)
 
     @api.multi
     @api.depends('name')


### PR DESCRIPTION
Purpose
=======

When creating an attendee, some fields may be added in the parameters.
We want the defaults values to have the priority on those parameters
(e.g. barcode code).

Task-2169118
