### PR TITLE
[FIX] base: Report which PDFs can't be read before merging

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -17902,6 +17902,17 @@ msgid "Odoo helps you easily track all activities related to a vendor."
 msgstr ""
 
 #. module: base
+#: code:addons/base/models/ir_actions_report.py:0
+#, python-format
+msgid ""
+"Odoo is unable to merge the PDFs attached to the following records:\n"
+"%s\n\n"
+"Please exclude them from the selection to continue. It's possible to "
+"still retrieve those PDFs by selecting each of the affected records "
+"individually, which will avoid merging."
+msgstr ""
+
+#. module: base
 #: model:ir.module.module,shortdesc:base.module_odoo_referral
 msgid "Odoo referral program"
 msgstr ""

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -658,6 +658,30 @@ class IrActionsReport(models.Model):
         close_streams(streams)
         return result
 
+    def _get_unreadable_pdfs(self, streams):
+        unreadable_streams = []
+
+        writer = PdfFileWriter()
+        for stream in streams:
+            try:
+                reader = PdfFileReader(stream)
+                writer.appendPagesFromReader(reader)
+            except utils.PdfReadError:
+                unreadable_streams.append(stream)
+
+        return unreadable_streams
+
+    def _raise_on_unreadable_pdfs(self, streams, stream_record):
+        unreadable_pdfs = self._get_unreadable_pdfs(streams)
+        if unreadable_pdfs:
+            records = [stream_record[s].name for s in unreadable_pdfs if s in stream_record]
+            raise UserError(_(
+                "Odoo is unable to merge the PDFs attached to the following records:\n"
+                "%s\n\n"
+                "Please exclude them from the selection to continue. It's possible to "
+                "still retrieve those PDFs by selecting each of the affected records "
+                "individually, which will avoid merging.") % "\n".join(records))
+
     def _merge_pdfs(self, streams):
         writer = PdfFileWriter()
         for stream in streams:
@@ -706,6 +730,8 @@ class IrActionsReport(models.Model):
             return self.with_context(context).render_qweb_html(res_ids, data=data)[0]
 
         save_in_attachment = OrderedDict()
+        # Maps the streams in `save_in_attachment` back to the records they came from
+        stream_record = dict()
         if res_ids:
             # Dispatch the records by ones having an attachment and ones requesting a call to
             # wkhtmltopdf.
@@ -716,7 +742,9 @@ class IrActionsReport(models.Model):
                 for record_id in record_ids:
                     attachment = self.retrieve_attachment(record_id)
                     if attachment:
-                        save_in_attachment[record_id.id] = self._retrieve_stream_from_attachment(attachment)
+                        stream = self._retrieve_stream_from_attachment(attachment)
+                        save_in_attachment[record_id.id] = stream
+                        stream_record[stream] = record_id
                     if not self.attachment_use or not attachment:
                         wk_record_ids += record_id
             else:
@@ -728,6 +756,7 @@ class IrActionsReport(models.Model):
         # - The report is not fully present in attachments.
         if save_in_attachment and not res_ids:
             _logger.info('The PDF report has been generated from attachments.')
+            self._raise_on_unreadable_pdfs(save_in_attachment.values(), stream_record)
             return self._post_pdf(save_in_attachment), 'pdf'
 
         if self.get_wkhtmltopdf_state() == 'install':
@@ -758,6 +787,7 @@ class IrActionsReport(models.Model):
         )
         if res_ids:
             _logger.info('The PDF report has been generated for model: %s, records %s.' % (self.model, str(res_ids)))
+            self._raise_on_unreadable_pdfs(save_in_attachment.values(), stream_record)
             return self._post_pdf(save_in_attachment, pdf_content=pdf_content, res_ids=html_ids), 'pdf'
         return pdf_content, 'pdf'
 


### PR DESCRIPTION
PyPDF2 can't read some PDFs due to bugs, lack of fault-tolerance and not
supporting some encryption schemes. When invoices are uploaded directly
through the Invoices / Accounting app, that will fail for those files
because it will try to read part of them. When invoices are uploaded
through the Documents app, they're not read, which means the customer
can end up in a situation where read and merge operations (like when
printing a selection of original vendor bills) will fail.

The structural solution for this is to replace PyPDF2 with a more capable
library, like pikepdf: https://github.com/odoo/odoo/pull/64356 .

This change is too impactful for stable, and there are compatibility
concerns as well.

A possible workaround is merging the PDFs we can and bundling the rest
together in a zip file. This is possible on the level of just
_merge_pdfs ([example](https://gist.github.com/raf-odoo/8fbb9e16d4f6c9b5797cc2f8601fa6d9)) but the PDF extension and mimetype are pretty hard-coded
and the changes required to switch them to ZIP based on what happens in
_merge_pdfs seem too impactful.

Instead, this fix detects as early as possible if the PDFs can't be
read and reports it to the user. The excluded PDFs can still be
downloaded individually. In this way the user has a workaround
and does not need to resort to trial and error to figure out which PDFs
are causing the problem.

Related tickets: 2359929, 2389679