### PR TITLE
[FIX] account_edi_ubl: remove wrong move creation when importing xml

### DIFF
--- a/addons/account_edi_ubl/models/account_edi_format.py
+++ b/addons/account_edi_ubl/models/account_edi_format.py
@@ -16,6 +16,22 @@ _logger = logging.getLogger(__name__)
 class AccountEdiFormat(models.Model):
     _inherit = 'account.edi.format'
 
+    def _create_invoice_from_ubl(self, tree):
+        invoice = self.env['account.move']
+        journal = invoice._get_default_journal()
+
+        move_type = 'out_invoice' if journal.type == 'sale' else 'in_invoice'
+        element = tree.find('.//{*}InvoiceTypeCode')
+        if element is not None and element.text == '381':
+            move_type = 'in_refund' if move_type == 'in_invoice' else 'out_refund'
+
+        invoice = invoice.with_context(default_move_type=move_type, default_journal_id=journal.id)
+        return self._import_ubl(tree, invoice)
+
+    def _update_invoice_from_ubl(self, tree, invoice):
+        invoice = invoice.with_context(default_move_type=invoice.move_type, default_journal_id=invoice.journal_id.id)
+        return self._import_ubl(tree, invoice)
+
     def _import_ubl(self, tree, invoice):
         """ Decodes an UBL invoice into an invoice.
 
@@ -37,20 +53,9 @@ class AccountEdiFormat(models.Model):
             return namespaces
 
         namespaces = _get_ubl_namespaces()
-        if not invoice:
-            invoice = self.env['account.move'].create({})
 
-        elements = tree.xpath('//cbc:InvoiceTypeCode', namespaces=namespaces)
-        if elements:
-            type_code = elements[0].text
-            move_type = 'in_refund' if type_code == '381' else 'in_invoice'
-        else:
-            move_type = 'in_invoice'
+        with Form(invoice.with_context(account_predictive_bills_disable_prediction=True)) as invoice_form:
 
-        default_journal = invoice.with_context(default_move_type=move_type)._get_default_journal()
-
-        with Form(invoice.with_context(default_move_type=move_type, default_journal_id=default_journal.id,
-                                       account_predictive_bills_disable_prediction=True)) as invoice_form:
             # Reference
             elements = tree.xpath('//cbc:ID', namespaces=namespaces)
             if elements:

--- a/addons/l10n_be_edi/models/account_edi_format.py
+++ b/addons/l10n_be_edi/models/account_edi_format.py
@@ -14,13 +14,13 @@ class AccountEdiFormat(models.Model):
     def _create_invoice_from_xml_tree(self, filename, tree):
         self.ensure_one()
         if self._is_efff(filename, tree):
-            return self._import_ubl(tree, self.env['account.move'])
+            return self._create_invoice_from_ubl(tree)
         return super()._create_invoice_from_xml_tree(filename, tree)
 
     def _update_invoice_from_xml_tree(self, filename, tree, invoice):
         self.ensure_one()
         if self._is_efff(filename, tree):
-            return self._import_ubl(tree, invoice)
+            return self._update_invoice_from_ubl(tree, invoice)
         return super()._update_invoice_from_xml_tree(filename, tree, invoice)
 
     def _is_compatible_with_journal(self, journal):


### PR DESCRIPTION
The move was created before its type was determined and the type was not taken into account. This could cause an issue when this method was called directly if 'default_move_type' was not set in the context (the move would therefore be an entry). Also, the subsequent check to see if the invoice is a refund was not taken into account.
Thankfully, this shadowed another bug: when determining the type of the invoice, the context was ignored, and therefore if the file was imported as an invoice, the type determined was 'in_invoice' instead of 'out_invoice', this didn't cause any problem since the type was ignored. This commit fixes that also.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
