### PR TITLE
[FIX] website_form: fix duplicate field gdi

### DIFF
--- a/addons/website_form/static/src/snippets/s_website_form/options.js
+++ b/addons/website_form/static/src/snippets/s_website_form/options.js
@@ -821,6 +821,27 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
         // We need to reload the existing type list.
         this.rerender = true;
     },
+    /**
+     * Prevents id duplication
+     * 
+     * @override
+     */
+    onClone: function () {
+        const currentInput = this.$target[0].querySelector('[id]:not(div)');
+        let copiedField = document.querySelectorAll(`#${CSS.escape(currentInput.id)}`)[1];
+        while (!copiedField.classList.contains('s_website_form_field')) {
+            copiedField = copiedField.parentElement;
+        }
+        const inputInTheCopiedField = copiedField.querySelectorAll('[id]:not(div)');
+        inputInTheCopiedField.forEach(element => {
+            const newId = Math.random().toString(36).substring(2, 15); //Big unique ID
+            const labelOfElement = copiedField.querySelector(`label[for="${element.id}"]`);
+            if (labelOfElement) {
+                labelOfElement.setAttribute('for', newId);
+            }
+            element.id = newId;
+        });
+    },
 
     //----------------------------------------------------------------------
     // Options


### PR DESCRIPTION
### New PR => https://github.com/odoo/odoo/pull/69019
When a user creates a form, he can duplicate a field.
As long as he hasn't modified this field, both fields (the original and the copy have the same ID)


--
Task 2485093


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
