### PR TITLE
[FIX] web: ignore recursiveCallMounted on not yet rendered children

### DIFF
--- a/addons/web/static/src/js/owl_compatibility.js
+++ b/addons/web/static/src/js/owl_compatibility.js
@@ -375,6 +375,17 @@ odoo.define('web.OwlCompatibility', function () {
          */
         on_attach_callback() {
             function recursiveCallMounted(component) {
+                if (
+                    component.__owl__.status !== 2 /* RENDERED */ &&
+                    component.__owl__.status !== 3 /* MOUNTED */ &&
+                    component.__owl__.status !== 4 /* UNMOUNTED */
+                ) {
+                    // Avoid calling mounted on a component that is not even
+                    // rendered. Doing otherwise will lead to a crash if a
+                    // specific mounted callback is legitimately relying on the
+                    // component being mounted.
+                    return;
+                }
                 for (const key in component.__owl__.children) {
                     recursiveCallMounted(component.__owl__.children[key]);
                 }


### PR DESCRIPTION
This should hopefully fix the race condition that is described in the related
task. The issue is that our mounted callbacks are legitimately relying on the
component to be actually rendered.

task-2481713

---

Example of original issue: https://runbot.odoo.com/runbot/build/6647176
Proof of `recursiveCallMounted` being called with `status === 1` https://runbot.odoo.com/runbot/build/7007672