### PR TITLE
[FIX] base: KeyError when removing a model

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1202,11 +1202,16 @@ class IrModelSelection(models.Model):
                               'preferably through a custom addon!'))
 
         for selection in self:
-            if selection.field_id.store and \
-                    not self.env[selection.field_id.model]._abstract:
+            try:
+                model = self.env[selection.field_id.model]
+            except KeyError:
+                model = None
+            if selection.field_id.store \
+                    and model is not None \
+                    and not model._abstract:
                 # replace the value by NULL in the field's corresponding column
                 query = 'UPDATE "{table}" SET "{field}"=NULL WHERE "{field}"=%s'.format(
-                    table=self.env[selection.field_id.model]._table,
+                    table=model._table,
                     field=selection.field_id.name,
                 )
                 self.env.cr.execute(query, [selection.value])


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
In case a model becomes unavailable (eg: it is removed from a module's code and the module is then updated), such model won't be present in the registry. Therefore, when the `ir.model.selection`'s `unlink()` method tries to retrieve the model from the env, Odoo crashes (the model was removed => it was never initialized in the registry => a `KeyError` is raised).

**Current behavior before PR:**
A `KeyError` is raised when updating a module where a model was removed and such model had at least one `Selection` field.

**Desired behavior after PR is merged:**
The module update goes as planned.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
