### PR TITLE
[FIX] calendar: solve undeterministic bug on event acceptance

### DIFF
--- a/addons/calendar/tests/test_calendar_controller.py
+++ b/addons/calendar/tests/test_calendar_controller.py
@@ -27,21 +27,23 @@ class TestCalendarController(HttpCase):
 
     def test_accept_meeting_unauthenticated(self):
         self.event.write({"partner_ids": [(4, self.other_user.partner_id.id)]})
-        token = self.event.attendee_ids[1].access_token
+        attendee = self.event.attendee_ids.filtered(lambda att: att.partner_id.id == self.other_user.partner_id.id)
+        token = attendee.access_token
         url = "/calendar/meeting/accept?token=%s&id=%d" % (token, self.event.id)
         res = self.url_open(url)
 
         self.assertEqual(res.status_code, 200, "Response should = OK")
-        self.event.attendee_ids[1].invalidate_cache()
-        self.assertEqual(self.event.attendee_ids[1].state, "accepted", "Attendee should have accepted")
+        attendee.invalidate_cache()
+        self.assertEqual(attendee.state, "accepted", "Attendee should have accepted")
 
     def test_accept_meeting_authenticated(self):
         self.event.write({"partner_ids": [(4, self.other_user.partner_id.id)]})
-        token = self.event.attendee_ids[1].access_token
+        attendee = self.event.attendee_ids.filtered(lambda att: att.partner_id.id == self.other_user.partner_id.id)
+        token = attendee.access_token
         url = "/calendar/meeting/accept?token=%s&id=%d" % (token, self.event.id)
         self.authenticate("test_user_2", "P@ssw0rd!")
         res = self.url_open(url)
 
         self.assertEqual(res.status_code, 200, "Response should = OK")
-        self.event.attendee_ids[1].invalidate_cache()
-        self.assertEqual(self.event.attendee_ids[1].state, "accepted", "Attendee should have accepted")
+        attendee.invalidate_cache()
+        self.assertEqual(attendee.state, "accepted", "Attendee should have accepted")


### PR DESCRIPTION
Before this fix, the runbot would fails randomly during the nightly multi-build in test_accept_meeting_unauthenticated and test_accept_meeting_authenticated.

```py
odoo.addons.calendar.tests.test_calendar_controller:36

FAIL: TestCalendarController.test_accept_meeting_unauthenticated
Traceback (most recent call last):
  File "/data/build/odoo/addons/calendar/tests/test_calendar_controller.py", line 36, in test_accept_meeting_unauthenticated
    self.assertEqual(self.event.attendee_ids[1].state, "accepted", "Attendee should have accepted")
AssertionError: 'needsAction' != 'accepted'
- needsAction
+ accepted
 : Attendee should have accepted

```

Similar traceback in test_accept_meeting_authenticated.

This commit tries to check if the redirection is causing the issue or if the write occurs before.

taskid: 2497816


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
