### PR TITLE
[FIX] Resolve cron issue resulting in HR Presence State Display not being updated

### DIFF
--- a/addons/hr_presence/__manifest__.py
+++ b/addons/hr_presence/__manifest__.py
@@ -24,6 +24,7 @@ Allows to contact directly the employee in case of unjustified absence.
         'views/hr_employee_views.xml',
         'data/sms_data.xml',
         'data/mail_data.xml',
+        'data/ir_cron.xml',
     ],
     'demo': [],
     'installable': True,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This PR addresses issue #68761 for version 14.0. The issue describes a bug that results in a field not being automatically updated.

Current behavior before PR:

HR Presence State Display field not automatically updated unless officer manually does some actions.

Desired behavior after PR is merged:

HR Presence State Display field will be automatically updated and visible for employees.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
