### PR TITLE
[FIX] point_of_sale: resolve stock naming issue in orders

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -901,7 +901,7 @@ class PosOrder(models.Model):
 
             for line in order.lines.filtered(lambda l: l.product_id.type in ['product', 'consu'] and not float_is_zero(l.qty, precision_rounding=l.product_id.uom_id.rounding)):
                 moves |= Move.create({
-                    'name': line.name,
+                    'name': line.product_id.description if line.product_id.description else line.product_id.name,
                     'product_uom': line.product_id.uom_id.id,
                     'picking_id': order_picking.id if line.qty >= 0 else return_picking.id,
                     'picking_type_id': picking_type.id if line.qty >= 0 else return_pick_type.id,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This PR fixes manual stock picking name so that its name makes more sense. This PR addresses issue #67047

Current behavior before PR:

See #67047. Essentially boils down to the name of a product containing a reference to the POS order instead of an actual description or name.

Desired behavior after PR is merged:

The product description or product name is shown instead of the POS reference.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
