### PR TITLE
Module of the documentation exercise is inaccessible

### DIFF
--- a/doc/howtos/backend/exercise-creation
+++ b/doc/howtos/backend/exercise-creation
@@ -32,7 +32,7 @@ Index: addons/openacademy/__manifest__.py
 +
 +    # always loaded
 +    'data': [
-+        # 'security/ir.model.access.csv',
++        'security/ir.model.access.csv',
 +        'templates.xml',
 +    ],
 +    # only loaded in demonstration mode


### PR DESCRIPTION
When I searched on the internet there were more people in my same situation, but I notated this little mistake in the documentation.

Description of the issue/feature this PR addresses:
During my auto-training with the documentation, I had trouble seeing the module in the main menu.

Current behavior before PR:
The module of the documentation exercise is not accessible following the documentation.

Desired behavior after PR is merged:
The module of the documentation exercise will be accessible following the documentation.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
