### PR TITLE
Inaccessible module of the documentation exercise

### DIFF
--- a/doc/howtos/backend/exercise-basic-action
+++ b/doc/howtos/backend/exercise-basic-action
@@ -6,7 +6,7 @@ Index: addons/openacademy/__manifest__.py
 +++ addons/openacademy/__manifest__.py	2014-08-26 17:25:53.511783468 +0200
 @@ -27,6 +27,7 @@
      'data': [
-         # 'security/ir.model.access.csv',
+         'security/ir.model.access.csv',
          'templates.xml',
 +        'views/openacademy.xml',
      ],


### PR DESCRIPTION
When I searched on the internet there were more people in my same situation, but I notated this little mistake in the documentation.

Description of the issue/feature this PR addresses:
During my auto-training with the documentation, I had trouble seeing the module in the main menu.

Current behavior before PR:
The module of the documentation exercise is not accessible following the documentation.

Desired behavior after PR is merged:
The module of the documentation exercise will be accessible following the documentation.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
