### PR TITLE
Inaccessible module of the documentation exercise

### DIFF
--- a/doc/howtos/backend/exercise-model-inheritance
+++ b/doc/howtos/backend/exercise-model-inheritance
@@ -15,7 +15,7 @@ Index: addons/openacademy/__manifest__.py
 --- addons.orig/openacademy/__manifest__.py	2014-08-26 17:26:01.227783353 +0200
 +++ addons/openacademy/__manifest__.py	2014-08-26 17:26:01.223783354 +0200
 @@ -28,6 +28,7 @@
-         # 'security/ir.model.access.csv',
+         'security/ir.model.access.csv',
          'templates.xml',
          'views/openacademy.xml',
 +        'views/partner.xml',


### PR DESCRIPTION
When I searched on the internet there were more people in my same situation, but I notated this little mistake in the documentation.

Description of the issue/feature this PR addresses:
During my auto-training with the documentation, I had trouble seeing the module in the main menu.

Current behavior before PR:
The module of the documentation exercise is not accessible following the documentation.

Desired behavior after PR is merged:
The module of the documentation exercise will be accessible following the documentation.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
