### PR TITLE
add icons to boolean_toggle widget

### DIFF
--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -2771,6 +2771,27 @@ var BooleanToggle = FieldBoolean.extend({
     },
 
     //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * Adds the icon fa-check-circle if value is true else adds icon
+     * fa-times-circle
+     *
+     * @override
+     */
+    async _render() {
+        await this._super(...arguments);
+        const classToApply = this.value ? 'fa-check-circle' : 'fa-times-circle';
+        if (this.el.querySelector('i')) {
+            this.el.querySelector('i').remove();
+        }
+        const i = document.createElement("i");
+        i.setAttribute('class', `fa ${classToApply}`);
+        this.el.querySelector('label').appendChild(i);
+    },
+
+    //--------------------------------------------------------------------------
     // Handlers
     //--------------------------------------------------------------------------
 
@@ -2780,9 +2801,10 @@ var BooleanToggle = FieldBoolean.extend({
      * @private
      * @param {MouseEvent} event
      */
-    _onClick: function (event) {
+    _onClick: async function (event) {
         event.stopPropagation();
-        this._setValue(!this.value);
+        await this._setValue(!this.value);
+        this._render();
     },
 });
 

--- a/addons/web/static/src/scss/webclient.scss
+++ b/addons/web/static/src/scss/webclient.scss
@@ -27,12 +27,25 @@
 div.o_boolean_toggle.custom-control.custom-checkbox {
     $line-height-computed: $line-height-base * $font-size-base;
     $slider-width: $line-height-computed * 1.5;
-    $circle-width: $line-height-computed * 0.6;
+    $font-size: $font-size-base * 1.2;
 
     display: inline-block;
     padding-left: $slider-width + 0.25rem;
 
     > label.custom-control-label {
+        > i {
+            color: white;
+            cursor: pointer;
+            font-size: $font-size;
+            position: absolute;
+            top: 2px;
+            &.fa-times-circle {
+                right: 15px;
+            }
+            &.fa-check-circle {
+                right: 7px;
+            }
+        }
         &::before, &::after {
             content: "";
             top: 0;
@@ -45,21 +58,12 @@ div.o_boolean_toggle.custom-control.custom-checkbox {
             border-radius: 100px;
             outline: none !important;
         }
-        &::after {
-            transform: translate($line-height-computed * 0.2, $line-height-computed * 0.2);
-            width: ceil($circle-width / 1rem * $o-root-font-size);
-            height: ceil($circle-width / 1rem * $o-root-font-size);
-            border-radius: 100px;
-            background-color: $white;
-            cursor: pointer;
-        }
     }
     > input.custom-control-input:checked + label.custom-control-label {
         &::before {
             background-color: $o-brand-primary !important;
         }
         &::after {
-            transform: translate($slider-width - $circle-width - $line-height-computed * 0.2, $line-height-computed * 0.2);
             background-image: none;
         }
     }

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -393,7 +393,7 @@ QUnit.module('basic_fields', {
     QUnit.module('FieldBooleanToggle');
 
     QUnit.test('use boolean toggle widget in form view', async function (assert) {
-        assert.expect(1);
+        assert.expect(3);
 
         var form = await createView({
             View: FormView,
@@ -404,6 +404,13 @@ QUnit.module('basic_fields', {
         });
 
         assert.containsOnce(form, ".custom-checkbox.o_boolean_toggle", "Boolean toggle widget applied to boolean field");
+        assert.containsOnce(form, ".custom-checkbox.o_boolean_toggle .fa-check-circle",
+            "Boolean toggle should have fa-check-circle icon");
+
+        await testUtils.dom.click(form.$('.o_field_widget[name=bar]'));
+        assert.containsOnce(form, ".custom-checkbox.o_boolean_toggle .fa-times-circle",
+            "Boolean toggle should have fa-times-circle icon");
+
         form.destroy();
     });
 


### PR DESCRIPTION
PURPOSE
Make the boolean toggle widget more readable and self-explanatory.

SPEC
On the boolean_toggle widget:
    add a green fa-check icon in the 'switch' when set to True
    add a grey fa-times icon when set to False

TASK 2488999


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
