### PR TITLE
[14.0][FIX] TypeError: Object of type date is not JSON serializable upon login

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -646,10 +646,16 @@ class Users(models.Model):
         # use read() to not read other fields: this must work while modifying
         # the schema of models res.users or res.partner
         values = user.read(list(name_to_key), load=False)[0]
-        return frozendict({
-            key: values[name]
-            for name, key in name_to_key.items()
-        })
+        tmpdict = {}
+        # Convert date and datetime fields to string to avoid error
+        # TypeError: Object of type date is not JSON serializable
+        for name, key in name_to_key.items():
+            if isinstance(values[name], datetime.datetime):
+                values[name] = fields.Datetime.to_string(values[name])
+            elif isinstance(values[name], datetime.date):
+                values[name] = fields.Date.to_string(values[name])
+            tmpdict[key] = values[name]
+        return frozendict(tmpdict)
 
     @api.model
     def action_get(self):


### PR DESCRIPTION
Scenario of the bug:
When you have a fields.Date or fields.Datetime on res.users with a name that
starts with 'context_' and this field has a value, the user won't be
able to login into odoo:

```
Traceback (most recent call last):
[...]
  File "/home/odoo/erp/odoo/odoo/http.py", line 315, in _handle_exception
    raise exception.with_traceback(None) from new_cause
odoo.addons.base.models.qweb.QWebException: Object of type date is not JSON serializable
Traceback (most recent call last):
  File "/home/odoo/erp/odoo/odoo/addons/base/models/qweb.py", line 331, in _compiled_fn
    return compiled(self, append, new, options, log)
  File "<template>", line 1, in template_web_webclient_bootstrap_114
  File "<template>", line 2, in body_call_content_112
  File "<template>", line 1, in set_111
  File "/home/odoo/erp/odoo/odoo/tools/json.py", line 49, in dumps
    json_.dumps(*args, **kwargs),
  File "/usr/lib/python3.8/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/python3.8/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.8/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib/python3.8/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type date is not JSON serializable

Error to render compiling AST
TypeError: Object of type date is not JSON serializable
Template: web.webclient_bootstrap
Path: /t/t/t[1]/script/t
Node: <t t-raw="json.dumps(session_info)"/>;
                    odoo.reloadMenus = () =&gt; fetch(`/web/webclient/load_menus/${odoo.session_info.cache_hashes.load_menus}`).then(res =&gt; res.json());
                    odoo.loadMenusPromise = odoo.reloadMenus(); - - -
```

This is caused by the method context_get() on res.users that copies
in a frozendict the values of the fields whose name start with 'context_'
and that frozendict is later converted to JSON in the web client. Link to code: https://github.com/odoo/odoo/blob/14.0/odoo/addons/base/models/res_users.py#L638

This fix will convert date and datetime objects to string in the result of context_get()

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
