### PR TITLE
Inaccessible models of the documentation exercise

### DIFF
--- a/doc/howtos/backend/exercise-session
+++ b/doc/howtos/backend/exercise-session
@@ -56,3 +56,12 @@ Index: addons/openacademy/views/openacademy.xml
 +                  action="session_list_action"/>
 +
  </odoo>
+Index: addons/openacademy/security/ir.model.access.csv
+===================================================================
+--- addons.orig/openacademy/security/ir.model.access.csv
++++ addons/openacademy/security/ir.model.access.csv
+@@ -1,2 +1,3 @@
+ id,name,model_id/id,group_id/id,perm_read,perm_write,perm_create,perm_unlink
+-access_openacademy_openacademy,openacademy.openacademy,model_openacademy_openacademy,,1,0,0,0
++course_read_all,course all,model_openacademy_course,,1,0,0,0
++session_read_all,session all,model_openacademy_session,,1,0,0,0


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
During my auto-learning with the documentation, I had trouble seeing modules in the module.

Current behavior before PR:
The models in the module of the documentation exercise is not accessible following the documentation.

Desired behavior after PR is merged:
The models in the module of the documentation exercise will be accessible following the documentation.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
