### PR TITLE
[FIX] web: inconsistent hover cursor on some stat button

### DIFF
--- a/addons/web/static/src/scss/form_view.scss
+++ b/addons/web/static/src/scss/form_view.scss
@@ -428,6 +428,12 @@ $o-form-label-margin-right: 0px;
                 }
             }
 
+            &:not(:disabled) {
+                > .o_stat_info .o_field_widget, > span .o_field_widget {
+                    cursor: pointer;
+                }
+            }
+
             &:not(:hover) .o_stat_info > .o_hover {
                 display: none !important;
             }


### PR DESCRIPTION
Currently, the hover property inconsistent with some content of
the stat button. It happens because the content of the stat button
contains the 'o_quick_editable' class in read-only mode which has
the property cursor: default.

so, this commit fixes the issue by overriding the CSS of the
stat button in the read-only mode.

TaskID-2479807