### PR TITLE
[FIX] l10n_in: GST Credit to Wrong GST Number

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -104,7 +104,7 @@ class AccountMove(models.Model):
             elif self.journal_id.type == 'purchase':
                 move.l10n_in_state_id = company_unit_partner.state_id
 
-            shipping_partner = move._l10n_in_get_shipping_partner()
+            shipping_partner = move.partner_id
             # In case of shipping address does not have GSTN then also check customer(partner_id) GSTN
             # This happens when Bill-to Ship-to transaction where shipping(Ship-to) address is unregistered and customer(Bill-to) is registred.
             move.l10n_in_gstin = move._l10n_in_get_shipping_partner_gstin(shipping_partner) or move.partner_id.vat


### PR DESCRIPTION
Before this commit, Currently system giving GST credit to the person receiving
delivery of goods. This can be seen from GSTR 1 Reports.

After this commit, GST credit should be given to a person (GST number) who is
actually buying goods.