### PR TITLE
[FIX] point_of_sale: blurred company logo on ticket

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -520,7 +520,7 @@ exports.PosModel = Backbone.Model.extend({
                     reject();
                 };
                 self.company_logo.crossOrigin = "anonymous";
-                self.company_logo.src = '/web/binary/company_logo' + '?dbname=' + session.db + '&company=' + self.company.id + '&_' + Math.random();
+                self.company_logo.src = "/web/image?model=res.company&id=" + self.company.id + "&field=logo";
             });
         },
     }, {


### PR DESCRIPTION
The `/web/binary/company_logo` controller returns an image with a
maximum of 180px wide, while the point of sale data loader tries to
resize such image to 300px wide. The result is an image with blurry
edges.

A better option is to use the standard `/web/image` controller that
recovers the original image from the proper attachment. This is a tiny
overhead since it's done just once when session is loaded.

A visual example:

![image](https://user-images.githubusercontent.com/5040182/113590836-711a9c80-9633-11eb-807a-a2a64762cdc5.png)


cc @Tecnativa TT27220


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
