### PR TITLE
[FIX] web: no bounce button form field/label click

### DIFF
--- a/addons/web/static/src/js/views/form/form_controller.js
+++ b/addons/web/static/src/js/views/form/form_controller.js
@@ -478,7 +478,10 @@ var FormController = BasicController.extend({
      * @override
      */
     _shouldBounceOnClick(element) {
-        return this.mode === 'readonly' && !!element.closest('.oe_title, .o_inner_group');
+        return this.mode === 'readonly' &&
+            !!element.closest('.oe_title, .o_inner_group') &&
+            !element.classList.contains("o_form_label") &&
+            !element.classList.contains("o_quick_editable");
     },
 
     //--------------------------------------------------------------------------

--- a/addons/web/static/tests/views/form_tests.js
+++ b/addons/web/static/tests/views/form_tests.js
@@ -11118,6 +11118,38 @@ QUnit.module('Views', {
         form.destroy();
     });
 
+    QUnit.test('Quick Edition: do not bounce edit button when click on field or label', async function (assert) {
+        assert.expect(2);
+
+        const MULTI_CLICK_TIME = 50;
+
+        const form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: `
+                <form>
+                    <group>
+                        <field name="display_name"/>
+                    </group>
+                </form>`,
+            formMultiClickTime: MULTI_CLICK_TIME,
+            res_id: 1,
+        });
+
+        await testUtils.dom.click(form.$('.o_field_widget'));
+        assert.containsNone(form, 'button.o_catch_attention:visible');
+        await concurrency.delay(MULTI_CLICK_TIME);
+
+        await testUtils.form.clickDiscard(form);
+
+        await testUtils.dom.click(form.$('.o_form_label'));
+        assert.containsNone(form, 'button.o_catch_attention:visible');
+        await concurrency.delay(MULTI_CLICK_TIME);
+
+        form.destroy();
+    });
+
     QUnit.test("attach callbacks with long processing in __renderView", async function (assert) {
         /**
          * The main use case of this test is discuss, in which the FormRenderer


### PR DESCRIPTION
Since commit [1], a delay was added to "debounce" the quick edit to
check if the user did a click or a select.
Because of this delay, the edit button now bounces when clicking on
a field or label.

In this commit, we check if the user clicks on a "quick editable"
field or a label to prevent bouncing.

[1] https://github.com/odoo/odoo/commit/2939ea4dd4736e659cc3e4df2226a3b08ac8ec48
