### PR TITLE
[FIX] stock: Dot added to the tracking link

### DIFF
--- a/addons/stock/data/mail_template_data.xml
+++ b/addons/stock/data/mail_template_data.xml
@@ -20,7 +20,7 @@
                         <br/><a href="${line[1]}" target="_blank">${line[0]}</a>
                     % endfor
                 %else:
-                    <a href="${object.carrier_tracking_url}" target="_blank">${object.carrier_tracking_ref}</a>.
+                    <a href="${object.carrier_tracking_url}" target="_blank">${object.carrier_tracking_ref}</a>
                 %endif
             %else:
                 ${object.carrier_tracking_ref}.


### PR DESCRIPTION
The dot made the link unreachable when a copy/paste was made.

opw:2453460