### PR TITLE
[FIX] account: resequence journal entry in purchase journal

### DIFF
--- a/addons/account/wizard/account_resequence.py
+++ b/addons/account/wizard/account_resequence.py
@@ -30,7 +30,12 @@ class ReSequenceWizard(models.TransientModel):
             active_move_ids = self.env['account.move'].browse(self.env.context['active_ids'])
         if len(active_move_ids.journal_id) > 1:
             raise UserError(_('You can only resequence items from the same journal'))
-        if active_move_ids.journal_id.refund_sequence and len(set(active_move_ids.mapped('move_type')) - {'out_receipt', 'in_receipt'}) > 1:
+        move_types = set(active_move_ids.mapped('move_type'))
+        if (
+            active_move_ids.journal_id.refund_sequence
+            and ('in_refund' in move_types or 'out_refund' in move_types)
+            and len(move_types) > 1
+        ):
             raise UserError(_('The sequences of this journal are different for Invoices and Refunds but you selected some of both types.'))
         values['move_ids'] = [(6, 0, active_move_ids.ids)]
         return values


### PR DESCRIPTION
The resequence wizard should consider that the sequence is shared for
invoices, journal entries and receipts; only refunds have a separate
sequence.
You could have journal entries in the purchase journal for expense
reports for instance. In that case, we want to be able to resequence all
of it at once.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
