### PR TITLE
[IMP] website: Show Scroll in case of full height

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -2757,6 +2757,20 @@ options.registry.ScrollButton = options.Class.extend({
     //--------------------------------------------------------------------------
 
     /**
+     * @see this.selectClass for parameters
+     */
+    async showScrollButton(previewMode, widgetValue, params) {
+        if (widgetValue) {
+            this.$button.show();
+        } else {
+            if (previewMode) {
+                this.$button.hide();
+            } else {
+                this.$button.detach();
+            }
+        }
+    },
+    /**
      * Toggles the scroll down button.
      */
     toggleButton: function (previewMode, widgetValue, params) {

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -1004,20 +1004,19 @@
         </we-button-group>
     </div>
 
-    <!-- Min height of section -->
-    <div data-option-name="minHeight" data-selector="section" data-exclude="[data-snippet] .row > div *">
-        <we-button-group string="Height">
-            <we-button data-name="minheight_auto_opt" data-select-class="" title="Fit content">Auto</we-button>
-            <we-button data-select-class="o_half_screen_height" title="Half screen">50%</we-button>
-            <we-button data-select-class="o_full_screen_height" title="Full screen">100%</we-button>
-        </we-button-group>
-    </div>
-
     <!-- Scroll to next section button (only for full height) -->
     <div data-js="ScrollButton" data-selector="section" data-exclude="[data-snippet] .row > div *">
-        <we-checkbox string="Scroll down button"
+        <!-- Min height of section -->
+        <we-button-group string="Height" data-show-scroll-button="">
+            <we-button data-name="minheight_auto_opt" data-select-class="" title="Fit content">Auto</we-button>
+            <we-button data-select-class="o_half_screen_height" title="Half screen">50%</we-button>
+            <we-button data-select-class="o_full_screen_height" title="Full screen" data-name="full_height_opt" data-show-scroll-button="true">100%</we-button>
+        </we-button-group>
+
+        <we-checkbox string="⌙ Scroll down button"
                      data-toggle-button="true"
                      data-no-preview="true"
+                     data-dependencies="full_height_opt"
                      data-name="scroll_button_opt"/>
         <!-- &emsp; -->
         <we-row string=" ⌙ Colors">


### PR DESCRIPTION
- Show "scroll down button" only when height is 100%.
- Make the "scroll down button" a child of "height" option.

task-2471323



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
