### PR TITLE
[FIX] web_editor: fix traceback when selection is null

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2999,7 +2999,7 @@ var SnippetsMenu = Widget.extend({
     _checkEditorToolbarVisibility: function (e) {
         const $toolbarContainer = $('#o_we_editor_toolbar_container');
         const docSelection = document.getSelection();
-        const $currentSelectionTarget = docSelection.rangeCount > 0 ? $(docSelection.getRangeAt(0).commonAncestorContainer) : $();
+        const $currentSelectionTarget = docSelection && docSelection.rangeCount > 0 ? $(docSelection.getRangeAt(0).commonAncestorContainer) : $();
         // Do not  toggle visibility if the target is inside the toolbar ( eg. during link edition).
         if ($currentSelectionTarget.parents('#toolbar').length ||
             (e && $(e.target).parents('#toolbar').length)
@@ -3008,7 +3008,7 @@ var SnippetsMenu = Widget.extend({
         }
 
         const selection = this.options.wysiwyg.odooEditor.document.getSelection();
-        const range = selection.rangeCount && selection.getRangeAt(0);
+        const range = selection && selection.rangeCount && selection.getRangeAt(0);
         if (!range ||
             !$(range.commonAncestorContainer).parents('#wrapwrap').length ||
             $(range.commonAncestorContainer).parent('[data-oe-model]:not([data-oe-type="html"]):not([data-oe-field="arch"])').length


### PR DESCRIPTION
Note : This should be fix properly by calling destroy on the editor. So this is more of a quick and dirty fix, in before the detroy fix.(see [this task](https://www.odoo.com/web#id=2468804&action=333&active_id=1695&model=project.task&view_type=form&cids=1&menu_id=4720) for the destroy fix )


Odoo task : https://www.odoo.com/web#id=2497783&action=333&active_id=1695&model=project.task&view_type=form&cids=1&menu_id=4720

Bug report from LNA :
> Stack of tracebacks
Secret traceback level? https://youtu.be/EZ9-M6aAdlU https://pastebin.com/PSvQB5WS
To replicate: https://youtu.be/Om4mh5I9k5g




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
