### PR TITLE
[FIX] web_editor: have a default icon for media align toolbar button

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -995,6 +995,9 @@ const Wysiwyg = Widget.extend({
         ));
         if (commandState && !resetAlignment) {
             $paragraphDropdownButton.addClass(newClass);
+        } else {
+            // Ensure we always display an icon in the align toolbar button.
+            $paragraphDropdownButton.addClass('fa-align-justify');
         }
     },
     _updateFaResizeButtons: function () {


### PR DESCRIPTION
Odoo task : https://www.odoo.com/web#id=2497783&action=333&active_id=1695&model=project.task&view_type=form&cids=1&menu_id=4720

bug report from LNA:
> Missing icon? https://tinyurl.com/yzbmffx3

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
