### PR TITLE
[FIX] point_of_sale: Fix wifi firmware for IoT

### DIFF
--- a/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
+++ b/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
@@ -20,6 +20,8 @@ echo "export LC_ALL=en_US.UTF-8" >> ~/.bashrc
 locale-gen
 source ~/.bashrc
 
+# upgrade firmware-brcm80211 broke access point on rpi4
+apt-mark hold firmware-brcm80211
 apt-get update && apt-get -y upgrade
 # Do not be too fast to upgrade to more recent firmware and kernel than 4.38
 # Firmware 4.44 seems to prevent the LED mechanism from working

--- a/addons/point_of_sale/tools/posbox/posbox_create_image.sh
+++ b/addons/point_of_sale/tools/posbox/posbox_create_image.sh
@@ -33,11 +33,11 @@ VERSION_IOTBOX=21.03
 REPO=https://github.com/odoo/odoo.git
 
 if ! file_exists *raspios*.img ; then
-    wget 'http://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-01-12/2021-01-11-raspios-buster-armhf-lite.zip' -O raspios.img.zip
+    wget 'http://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2020-02-07/2020-02-05-raspbian-buster-lite.zip' -O raspios.img.zip
     unzip raspios.img.zip
 fi
 
-RASPIOS=$(echo *raspios*.img)
+RASPIOS=$(echo *raspbian*.img)
 rsync -avh --progress "${RASPIOS}" iotbox.img
 
 CLONE_DIR="${OVERWRITE_FILES_BEFORE_INIT_DIR}/home/pi/odoo"


### PR DESCRIPTION
With the new OS RaspiOS the firmware for the wifi card are unstable.
We need to keep a specific version of firmware-brcm80211 to keep
a stable and usable wifi connection.

So we fallback on a previous version of Buster and hold the
version of the package firmware-brcm80211 before the upgrade when
we build the box.

id: 2499855

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
