### PR TITLE
[FIX] web: fix boolean labels

### DIFF
--- a/addons/web/static/src/js/views/graph/graph_renderer.js
+++ b/addons/web/static/src/js/views/graph/graph_renderer.js
@@ -527,6 +527,8 @@ return AbstractRenderer.extend({
     _sanitizeLabel: function (datapt) {
         datapt.labels = datapt.labels.map(function(label) {
             if (label === undefined) return _t("Undefined");
+            if (label === true) return _t("True");
+            if (label === false) return _t("False");
             return label;
         });
     },

--- a/addons/web/static/tests/views/graph_tests.js
+++ b/addons/web/static/tests/views/graph_tests.js
@@ -206,7 +206,7 @@ QUnit.module('Views', {
             "should contain a text element with product xphone on X axis");
         assert.strictEqual(graph.$('.nv-x text:contains(xpad)').length, 1,
             "should contain a text element with product xpad on X axis");
-        assert.strictEqual(graph.$('text:contains(true)').length, 1,
+        assert.strictEqual(graph.$('text:contains("True")').length, 1,
             "should have an entry for each value of field 'bar' in the legend");
 
         graph.destroy();


### PR DESCRIPTION
Open Website sale dashboard
The pie chart "Conversion Rate" labels display true/false which is not
meaningful for the user.
This occur because the labels are not taken into consideration for
boolean fields

opw-2454547

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
