### PR TITLE
[FIX] web_editor: fix scss typo

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -114,7 +114,7 @@ $o-we-zindex: $o-we-overlay-zindex + 1 !default;
     }
 
     // Specific elements
-    #colorInputButtonGroup label:last-of-type() .btn {
+    #colorInputButtonGroup label:last-of-type .btn {
         margin: 0 1px 0 -1px;
     }
     .tablepicker {


### PR DESCRIPTION
last-of-type pseudo class does not need parentheses [0].

This typo throws an exception only with recent versions of libsass.

[0] https://developer.mozilla.org/en-US/docs/Web/CSS/:last-of-type
