### PR TITLE
[IMP] website_sale_stock: facilite inheritance _cart_update behavior

### DIFF
--- a/addons/website_sale_stock/models/sale_order.py
+++ b/addons/website_sale_stock/models/sale_order.py
@@ -12,8 +12,11 @@ class SaleOrder(models.Model):
 
     def _cart_update(self, product_id=None, line_id=None, add_qty=0, set_qty=0, **kwargs):
         values = super(SaleOrder, self)._cart_update(product_id, line_id, add_qty, set_qty, **kwargs)
-        line_id = values.get('line_id')
+        values = self._cart_lines_stock_update(values, **kwargs)
+        return values
 
+    def _cart_lines_stock_update(self, values, **kwargs):
+        line_id = values.get('line_id')
         for line in self.order_line:
             if line.product_id.type == 'product' and line.product_id.inventory_availability in ['always', 'threshold']:
                 cart_qty = sum(self.order_line.filtered(lambda p: p.product_id.id == line.product_id.id).mapped('product_uom_qty'))


### PR DESCRIPTION
It is currently impossible to modify the _cart_update behavoiur from website_sale_stock

The sale.order method _cart_update() updates the lines on the e-commerce shop
cart, some modules override the method adding new features, the module
website_sale_stock is one of them.

The specific behavior of _cart_update() in the module website_sale_stock allows
to delete from the sale order the products whose demand is greater than the stock.

If the specific behavior of the module website_sale_stock is needed to be
expanded or totally changed, that is not possible because the method _cart_update()
should be always super called, even if the website_sale_stock code for
_cart_update will be totally changed.

To allow inheriting just the specific behavior of website_sale_stock without
affecting other modules. This commit creates a new method _cart_lines_stock_update()
which have the important behavior for this module and will allow to be
easier to inherit it.

OPW#2500355

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
