### PR TITLE
[FIX] web_editor: broken color dropdown in studio report

### DIFF
--- a/addons/web_editor/static/src/js/editor/rte.summernote.js
+++ b/addons/web_editor/static/src/js/editor/rte.summernote.js
@@ -88,7 +88,7 @@ renderer.createPalette = function ($container, options) {
             if (manualOpening) {
                 return true;
             }
-            mutex.exec(() => {
+            return mutex.exec(() => {
                 const oldColorpicker = colorpicker;
                 const hookEl = oldColorpicker ? oldColorpicker.el : elem;
 
@@ -118,7 +118,6 @@ renderer.createPalette = function ($container, options) {
                     manualOpening = false;
                 });
             });
-            return false;
         });
     });
 };

--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -62,6 +62,11 @@ $o-we-zindex: $o-we-overlay-zindex + 1 !default;
 .note-popover .popover {
     z-index: $o-we-overlay-zindex;
 }
+
+#web_editor-toolbars .note-popover .popover .popover-body .dropdown-menu {
+    transform: none !important;
+}
+
 .note-popover .popover .popover-body,
 .panel-heading.note-toolbar {
     padding-bottom: 0;
@@ -125,7 +130,6 @@ $o-we-zindex: $o-we-overlay-zindex + 1 !default;
         outline: none !important;
     }
     .dropdown-menu {
-        transform: none !important;
         margin-top: $o-we-dropdown-spacing;
         padding: 0;
         margin-top: $o-we-toolbar-height;

--- a/addons/web_editor/static/tests/field_html_tests.js
+++ b/addons/web_editor/static/tests/field_html_tests.js
@@ -165,7 +165,7 @@ QUnit.module('web_editor', {}, function () {
         });
 
         QUnit.test('colorpicker', async function (assert) {
-            assert.expect(6);
+            assert.expect(7);
 
             var form = await testUtils.createView({
                 View: FormView,
@@ -207,6 +207,10 @@ QUnit.module('web_editor', {}, function () {
             await openColorpicker('.note-toolbar .note-back-color-preview');
             assert.ok($field.find('.note-back-color-preview').hasClass('show'),
                 "should display the color picker");
+
+            var dropdownMenu = $field.find(".note-back-color-preview .dropdown-menu");
+            assert.ok(dropdownMenu[0].style.cssText.includes('position: absolute'),
+                'dropdown should contain inline css with correct property');
 
             await testUtils.dom.click($field.find('.note-toolbar .note-back-color-preview .o_we_color_btn[style="background-color:#00FFFF;"]'));
 


### PR DESCRIPTION
Before this commit, the color dropdown appears outside of
the report sidebar in the studio. It happens because clicking
on the dropdown calls the 'show.bs.dropdown' which returns
the results false and because of this, the dropdown-menu
class doesn't get the proper CSS property

After this commit, the color dropdown will appear inside the
report sidebar in the studio.

TaskID-2457224