### PR TITLE
[IMP] hr_timesheet, project: back2basic improvements

### DIFF
--- a/addons/hr_timesheet/views/project_views.xml
+++ b/addons/hr_timesheet/views/project_views.xml
@@ -322,5 +322,9 @@
             </field>
         </record>
 
+        <record id="project.open_view_project_all" model="ir.actions.act_window">
+            <field name="domain">[('is_internal_project', '=', False)]</field>
+        </record>
+
     </data>
 </odoo>

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -692,7 +692,7 @@ class Task(models.Model):
     kanban_state = fields.Selection([
         ('normal', 'In Progress'),
         ('done', 'Ready'),
-        ('blocked', 'Blocked')], string='Kanban State',
+        ('blocked', 'Blocked')], string='Status',
         copy=False, default='normal', required=True)
     kanban_state_label = fields.Char(compute='_compute_kanban_state_label', string='Kanban State Label', tracking=True)
     create_date = fields.Datetime("Created On", readonly=True, index=True)

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -439,7 +439,7 @@
                     <field name="name" string="Name" class="font-weight-bold"/>
                     <field name="user_id" optional="show" string="Project Manager" widget="many2one_avatar_user"/>
                     <field name="partner_id" optional="show" string="Customer"/>
-                    <field name="analytic_account_id" optional="hide"/>
+                    <field name="analytic_account_id" optional="hide" groups="analytic.group_analytic_accounting"/>
                     <field name="privacy_visibility" optional="hide"/>
                     <field name="label_tasks" optional="hide"/>
                     <field name="company_id" optional="show"  groups="base.group_multi_company"/>

--- a/addons/project_timesheet_holidays/__init__.py
+++ b/addons/project_timesheet_holidays/__init__.py
@@ -15,6 +15,6 @@ def post_init(cr, registry):
     for hr_leave_type in env['hr.leave.type'].search([('timesheet_generate', '=', True), ('timesheet_project_id', '=', False)]):
         company = hr_leave_type.company_id or env.company
         hr_leave_type.write({
-            'timesheet_project_id': company.leave_timesheet_project_id.id,
+            'timesheet_project_id': company.internal_project_id.id,
             'timesheet_task_id': company.leave_timesheet_task_id.id,
         })

--- a/addons/project_timesheet_holidays/models/hr_holidays.py
+++ b/addons/project_timesheet_holidays/models/hr_holidays.py
@@ -10,7 +10,7 @@ class HolidaysType(models.Model):
 
     def _default_project_id(self):
         company = self.company_id if self.company_id else self.env.company
-        return company.leave_timesheet_project_id.id
+        return company.internal_project_id.id
 
     def _default_task_id(self):
         company = self.company_id if self.company_id else self.env.company

--- a/addons/project_timesheet_holidays/models/res_config_settings.py
+++ b/addons/project_timesheet_holidays/models/res_config_settings.py
@@ -7,19 +7,19 @@ from odoo import api, fields, models
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
-    leave_timesheet_project_id = fields.Many2one(
-        related='company_id.leave_timesheet_project_id', required=True, string="Internal Project",
+    internal_project_id = fields.Many2one(
+        related='company_id.internal_project_id', required=True, string="Internal Project",
         domain="[('company_id', '=', company_id)]", readonly=False)
     leave_timesheet_task_id = fields.Many2one(
         related='company_id.leave_timesheet_task_id', string="Time Off Task", readonly=False,
-        domain="[('company_id', '=', company_id), ('project_id', '=?', leave_timesheet_project_id)]")
+        domain="[('company_id', '=', company_id), ('project_id', '=?', internal_project_id)]")
 
-    @api.onchange('leave_timesheet_project_id')
+    @api.onchange('internal_project_id')
     def _onchange_timesheet_project_id(self):
-        if self.leave_timesheet_project_id != self.leave_timesheet_task_id.project_id:
+        if self.internal_project_id != self.leave_timesheet_task_id.project_id:
             self.leave_timesheet_task_id = False
 
     @api.onchange('leave_timesheet_task_id')
     def _onchange_timesheet_task_id(self):
         if self.leave_timesheet_task_id:
-            self.leave_timesheet_project_id = self.leave_timesheet_task_id.project_id
+            self.internal_project_id = self.leave_timesheet_task_id.project_id

--- a/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
+++ b/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
@@ -20,7 +20,7 @@ class TestTimesheetHolidaysCreate(common.TransactionCase):
         })
 
         company = self.env.company
-        self.assertEqual(status.timesheet_project_id, company.leave_timesheet_project_id, 'The default project linked to the status should be the same as the company')
+        self.assertEqual(status.timesheet_project_id, company.internal_project_id, 'The default project linked to the status should be the same as the company')
         self.assertEqual(status.timesheet_task_id, company.leave_timesheet_task_id, 'The default task linked to the status should be the same as the company')
 
     def test_company_create(self):
@@ -33,7 +33,7 @@ class TestTimesheetHolidaysCreate(common.TransactionCase):
         Company = Company.with_user(user)
         Company = Company.with_company(main_company)
         company = Company.create({'name': "Wall Company"})
-        self.assertEqual(company.leave_timesheet_project_id.sudo().company_id, company, "It should have created a project for the company")
+        self.assertEqual(company.internal_project_id.sudo().company_id, company, "It should have created a project for the company")
 
 class TestTimesheetHolidays(TestCommonTimesheet):
 
@@ -48,7 +48,7 @@ class TestTimesheetHolidays(TestCommonTimesheet):
         self.leave_end_datetime = self.leave_start_datetime + relativedelta(days=3)
 
         # all company have those internal project/task (created by default)
-        self.internal_project = self.env.company.leave_timesheet_project_id
+        self.internal_project = self.env.company.internal_project_id
         self.internal_task_leaves = self.env.company.leave_timesheet_task_id
 
         self.hr_leave_type_with_ts = self.env['hr.leave.type'].create({

--- a/addons/project_timesheet_holidays/views/res_config_settings_views.xml
+++ b/addons/project_timesheet_holidays/views/res_config_settings_views.xml
@@ -10,12 +10,12 @@
                 <div attrs="{'invisible': [('module_project_timesheet_holidays','=',False)]}">
                     <div class="row mt16">
                         <div class="w-100">
-                            <label string="Project" for="leave_timesheet_project_id" class="col-3 col-lg-3 o_light_label"/>
-                            <field name="leave_timesheet_project_id" context="{'active_test': False}" class="oe_inline"/>
+                            <label string="Project" for="internal_project_id" class="col-3 col-lg-3 o_light_label"/>
+                            <field name="internal_project_id" context="{'active_test': False}" class="oe_inline"/>
                         </div>
                         <div class="w-100">
                             <label string="Task" for="leave_timesheet_task_id" class="col-3 col-lg-3 o_light_label"/>
-                            <field name="leave_timesheet_task_id" context="{'active_test': False, 'default_project_id': leave_timesheet_project_id}" class="oe_inline"/>
+                            <field name="leave_timesheet_task_id" context="{'active_test': False, 'default_project_id': internal_project_id}" class="oe_inline"/>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Currently,

* In the project module -> Tasks, there is a column named "Kanban
  state" which is confusing where anywhere else we speak about task status.
* In the project dashboard, when starting the Project app from scratch with
  timesheet app configured, the only data shown is the internal project that is
  not very meaningful regarding project management.
* In project module -> configuration -> Project list view column "analytic
  account" is suggested as a hidden column when the accounting app or timesheet
  app are not configured. At the same time, the analytic account field is not
  shown in the project form view and cannot be updated.

So in this commit did the below changes:

* Renamed the "Kanban state" column to "Status".
* Project app do not show internal project when the timesheet app is configured.
  Instead, it shows sample data as there is no project.
* Made both view aligned (project list view and project form view) for timesheet
  and analytic account app. Column "analytic account" will be hidden only when
  analytic accounting app is configured.

Task ID: 2451722

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
