### PR TITLE
[FIX] (test_)mail: update status of failure notification instantly

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1171,10 +1171,16 @@ class Message(models.Model):
                     continue
                 else:
                     messages |= message
+        messages_per_partner = defaultdict(lambda: self.env['mail.message'])
+        for message in messages:
+            if not self.env.user._is_public():
+                messages_per_partner[self.env.user.partner_id] |= message
+            if message.author_id and not any(user._is_public() for user in message.author_id.with_context(active_test=False).user_ids):
+                messages_per_partner[message.author_id] |= message
         updates = [[
-            (self._cr.dbname, 'res.partner', author.id),
-            {'type': 'message_notification_update', 'elements': self.env['mail.message'].concat(*author_messages)._message_notification_format()}
-        ] for author, author_messages in groupby(messages.sorted('author_id'), itemgetter('author_id'))]
+            (self._cr.dbname, 'res.partner', partner.id),
+            {'type': 'message_notification_update', 'elements': messages._message_notification_format()}
+        ] for partner, messages in messages_per_partner.items()]
         self.env['bus.bus'].sendmany(updates)
 
     # ------------------------------------------------------

--- a/addons/test_mail/tests/test_message_management.py
+++ b/addons/test_mail/tests/test_message_management.py
@@ -43,7 +43,11 @@ class TestMailResend(TestMailCommon):
 
         # three more failure sent on bus, one for each mail in failure and one for resend
         self._reset_bus()
-        with self.mock_mail_gateway(), self.assertBus([(self.cr.dbname, 'res.partner', self.partner_admin.id)] * 3):
+        expected_bus_notifications = [
+            (self.cr.dbname, 'res.partner', self.partner_admin.id),
+            (self.cr.dbname, 'res.partner', self.env.user.partner_id.id),
+        ]
+        with self.mock_mail_gateway(), self.assertBus(expected_bus_notifications * 3):
             wizard.resend_mail_action()
         done_msgs, done_notifs = self.assertMailNotifications(message, [
             {'content': '', 'message_type': 'notification',
@@ -56,7 +60,7 @@ class TestMailResend(TestMailCommon):
 
         # two more failure update sent on bus, one for failed mail and one for resend
         self._reset_bus()
-        with self.mock_mail_gateway(), self.assertBus([(self.cr.dbname, 'res.partner', self.partner_admin.id)] * 2):
+        with self.mock_mail_gateway(), self.assertBus(expected_bus_notifications * 2):
             self.env['mail.resend.message'].with_context({'mail_message_to_resend': message.id}).create({}).resend_mail_action()
         done_msgs, done_notifs = self.assertMailNotifications(message, [
             {'content': '', 'message_type': 'notification',
@@ -69,7 +73,7 @@ class TestMailResend(TestMailCommon):
 
         # A success update should be sent on bus once the email has no more failure
         self._reset_bus()
-        with self.mock_mail_gateway(), self.assertBus([(self.cr.dbname, 'res.partner', self.partner_admin.id)]):
+        with self.mock_mail_gateway(), self.assertBus(expected_bus_notifications):
             self.env['mail.resend.message'].with_context({'mail_message_to_resend': message.id}).create({}).resend_mail_action()
         self.assertMailNotifications(message, [
             {'content': '', 'message_type': 'notification',
@@ -109,7 +113,11 @@ class TestMailResend(TestMailCommon):
         wizard = self.env['mail.resend.message'].with_context({'mail_message_to_resend': message.id}).create({})
         # one update for cancell
         self._reset_bus()
-        with self.mock_mail_gateway(), self.assertBus([(self.cr.dbname, 'res.partner', self.partner_admin.id)] * 1):
+        expected_bus_notifications = [
+            (self.cr.dbname, 'res.partner', self.partner_admin.id),
+            (self.cr.dbname, 'res.partner', self.env.user.partner_id.id),
+        ]
+        with self.mock_mail_gateway(), self.assertBus(expected_bus_notifications):
             wizard.cancel_mail_action()
 
         self.assertMailNotifications(message, [

--- a/addons/test_mail_full/tests/test_sms_performance.py
+++ b/addons/test_mail_full/tests/test_sms_performance.py
@@ -51,7 +51,7 @@ class TestSMSPerformance(BaseMailPerformance, sms_common.SMSCase):
     def test_message_sms_record_1_partner(self):
         record = self.test_record.with_user(self.env.user)
         pids = self.customer.ids
-        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=23):  # test_mail_enterprise: 18
+        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=24):  # test_mail_enterprise: 19
             messages = record._message_sms(
                 body='Performance Test',
                 partner_ids=pids,
@@ -66,7 +66,7 @@ class TestSMSPerformance(BaseMailPerformance, sms_common.SMSCase):
     def test_message_sms_record_10_partners(self):
         record = self.test_record.with_user(self.env.user)
         pids = self.partners.ids
-        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=41):
+        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=42):
             messages = record._message_sms(
                 body='Performance Test',
                 partner_ids=pids,
@@ -80,7 +80,7 @@ class TestSMSPerformance(BaseMailPerformance, sms_common.SMSCase):
     @warmup
     def test_message_sms_record_default(self):
         record = self.test_record.with_user(self.env.user)
-        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=26):
+        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=27):
             messages = record._message_sms(
                 body='Performance Test',
             )


### PR DESCRIPTION
**Current behavior before PR:**

Currently, failure notifications are sent to the author of the message that the
failure is concerning.

However, if another user than the author is resolving the failure, he is not
receiving any notification without refresh the page, so it appears as if nothing
happened even though the failure was indeed resolved
(either message resent, or failure ignored).

**Desired behavior after PR is merged:**

When another user than the author update the status of the failure notification
(message resent or failure ignored). the statues of the failure notification
update instantly, no refresh needed to show the updated status.

**LINKS:**
Task-2178257


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
