### PR TITLE
[FIX] website_event_track: put partner_biography back on track proposal

### DIFF
--- a/addons/website_event_track/controllers/event_track.py
+++ b/addons/website_event_track/controllers/event_track.py
@@ -440,6 +440,7 @@ class EventTrackController(http.Controller):
             'event_id': event.id,
             'tag_ids': [(6, 0, valid_tag_indices)],
             'description': plaintext2html(post['description']),
+            'partner_biography': plaintext2html(post['partner_biography']),
             'user_id': False,
             'image': base64.b64encode(post['image'].read()) if post.get('image') else False,
         })

--- a/addons/website_event_track/views/event_track_templates_proposal.xml
+++ b/addons/website_event_track/views/event_track_templates_proposal.xml
@@ -92,6 +92,10 @@
                                         <label class="col-form-label col-sm-auto" for="partner_function" style="width: 200px">Job Title</label>
                                         <div class="col-sm"><input name="partner_function" type="text" class="form-control"/></div>
                                     </div>
+                                    <div class="row form-group">
+                                        <label class="col-form-label col-sm-auto" for="partner_biography" style="width: 200px" >Biography</label>
+                                        <div class="col-sm"><textarea name="partner_biography" class="form-control"/></div>
+                                    </div>
                                 </div>
                                 <t t-call="website_event_track.event_track_proposal_contact_details"/>   
                                 <div class="form-group o_form_buttons">


### PR DESCRIPTION
Small oversight of #60847 where the "partner_biography" field was mistakenly
removed from the frontend track proposal form.

This commit simply re-introduces the field back into the form and saves it when
submitting the event.track proposal.

Task-2500455

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
