### PR TITLE
[FIX] web_editor: constant pseudo-classes should not be "called"

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -114,7 +114,7 @@ $o-we-zindex: $o-we-overlay-zindex + 1 !default;
     }
 
     // Specific elements
-    #colorInputButtonGroup label:last-of-type() .btn {
+    #colorInputButtonGroup label:last-of-type .btn {
         margin: 0 1px 0 -1px;
     }
     .tablepicker {


### PR DESCRIPTION
In recent versions of libsass, this triggers an error "Custom property
values may not be empty" (sass/libsass#3118) which breaks pages.
