### PR TITLE
[IMP] website_event_track: rework track proposition mail template

### DIFF
--- a/addons/website_event_track/data/mail_data.xml
+++ b/addons/website_event_track/data/mail_data.xml
@@ -4,7 +4,6 @@
     <record id="mt_event_track" model="mail.message.subtype">
         <field name="name">New Track</field>
         <field name="res_model">event.event</field>
-        <field name="description">New Track Created</field>
         <field name="default" eval="False"/>
     </record>
 

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -392,8 +392,10 @@ class Track(models.Model):
         for track in tracks:
             track.event_id.message_post_with_view(
                 'website_event_track.event_track_template_new',
-                values={'track': track},
-                subject=track.name,
+                values={
+                    'track': track,
+                    'is_html_empty': is_html_empty,
+                },
                 subtype_id=self.env.ref('website_event_track.mt_event_track').id,
             )
             track._synchronize_with_stage(track.stage_id)

--- a/addons/website_event_track/views/mail_templates.xml
+++ b/addons/website_event_track/views/mail_templates.xml
@@ -3,13 +3,29 @@
 
 <!-- Chatter templates -->
 <template id="event_track_template_new">
-    <p>New track proposal <a href="#" t-att-data-oe-model="track._name" t-att-data-oe-id="track.id"> <t t-esc="track.name"/></a></p>
+    <p>
+        <span>New track proposal</span>
+        <a href="#" t-att-data-oe-model="track._name" t-att-data-oe-id="track.id" t-esc="track.name"/>
+    </p>
     <ul>
-        <li><b>Proposed By</b>: <t t-esc="track.partner_name or track.partner_email"/></li>
-        <li><b>Mail</b>: <a t-attf-href="mailto:#{track.partner_email}"><t t-esc="track.partner_email"/></a></li>
-        <li><b>Phone</b>: <t t-esc="track.partner_phone"/></li>
-        <li><b>Speaker Biography</b>: <div t-field="track.partner_biography"/></li>
-        <li><b>Talk Introduction</b>: <div t-field="track.description"/></li>
+        <!-- "contact" information (the ones from partner_id) take precedence over public information -->
+        <t t-set="speaker_name" t-value="track.partner_id.name or track.partner_name or track.partner_email" />
+        <li t-if="speaker_name">
+            <b>Proposed By</b>: <span t-esc="speaker_name"/>
+        </li>
+        <t t-set="speaker_email" t-value="track.contact_email or track.partner_email" />
+        <li t-if="speaker_email">
+            <b>Mail</b>: <a t-attf-href="mailto:#{speaker_email}" t-esc="speaker_email"></a>
+        </li>
+        <li t-if="track.contact_phone or track.partner_phone">
+            <b>Phone</b>: <span t-esc="track.contact_phone or track.partner_phone"/>
+        </li>
+        <li t-if="not is_html_empty(track.partner_biography)">
+            <b>Speaker Biography</b>: <div t-field="track.partner_biography"/>
+        </li>
+        <li t-if="not is_html_empty(track.description)">
+            <b>Talk Introduction</b>: <div t-field="track.description"/>
+        </li>
     </ul>
 </template>
 


### PR DESCRIPTION
This commit slightly reworks the "event_track_template_new" template to format
it a little better and get rid of unnecessary blank sections.

The "subject" param was removed from the "message_post_with_view" call as we
don't want the chatter to contain the name of the track twice.
Indeed, since #61570, the "subject" is displayed in the chatter if it differs
from the thread name (which is the case here).
This causes a small regression for emails that will state "Re: EventName" in
their subject instead of the track name, but it's deemed acceptable to have a
nicer chatter message.

We also remove the description of the "mt_event_track" mail.message.subtype as
it's only used with a custom template and is redundant with that template's
content.

Task-2496444