### PR TITLE
[FIX] base: Catastrophic Backtracking in js_transpiler

### DIFF
--- a/odoo/addons/test_assetsbundle/tests/test_js_transpiler.py
+++ b/odoo/addons/test_assetsbundle/tests/test_js_transpiler.py
@@ -328,6 +328,18 @@ return __exports;
         input_content = """export {a, b};
 
 export {a as aa, b, c as cc};
+export {a, aReallyVeryLongNameWithSomeExtra}
+export {
+        a,
+        aReallyVeryLongNameWithSomeExtra,
+        }
+export {
+        a,
+        aReallyVeryLongNameWithSomeExtra
+        }
+
+
+export {a, aReallyVeryLongNameWithSomeExtra /* a comment must not cause catastrophic backtracking, even if not supported */};
 
 export {c, d} from "@tests/Dialog";
 export {e} from "../src/Dialog";
@@ -344,11 +356,23 @@ let __exports = {};
 Object.assign(__exports, {a,  b});
 
 Object.assign(__exports, {aa: a,  b, cc:  c});
+Object.assign(__exports, {a,  aReallyVeryLongNameWithSomeExtra})
+Object.assign(__exports, {
+        a, 
+        aReallyVeryLongNameWithSomeExtra, 
+        })
+Object.assign(__exports, {
+        a, 
+        aReallyVeryLongNameWithSomeExtra
+        })
 
-{const {c,  d} = require("@tests/Dialog");Object.assign(__exports, {c,  d})};
+
+export {a, aReallyVeryLongNameWithSomeExtra /* a comment must not cause catastrophic backtracking, even if not supported */};
+
+{const {c, d} = require("@tests/Dialog");Object.assign(__exports, {c,  d})};
 {const {e} = require("@test_assetsbundle/Dialog");Object.assign(__exports, {e})};
 
-{const {c,  d,  e} = require("@tests/Dialog");Object.assign(__exports, {cc: c,  d, ee:  e})};
+{const {c, d, e} = require("@tests/Dialog");Object.assign(__exports, {cc: c,  d, ee:  e})};
 
 Object.assign(__exports, require("@tests/Dialog"));
 

--- a/odoo/tools/js_transpiler.py
+++ b/odoo/tools/js_transpiler.py
@@ -227,7 +227,7 @@ EXPORT_OBJECT_RE = re.compile(r"""
     ^
     (?P<space>\s*)                      # space and empty line
     export\s*                           # export
-    (?P<object>{(\s*\w+\s*,?\s*)*}\s*)  # { a, b, c as x, ... }
+    (?P<object>{[\w\s,]+})              # { a, b, c as x, ... }
     """, re.MULTILINE | re.VERBOSE)
 
 
@@ -253,7 +253,7 @@ EXPORT_FROM_RE = re.compile(r"""
     ^
     (?P<space>\s*)                      # space and empty line
     export\s*                           # export
-    (?P<object>{(\s*\w+\s*,?\s*)*})\s*  # { a, b, c as x, ... }
+    (?P<object>{[\w\s,]+})\s*           # { a, b, c as x, ... }
     from\s*                             # from
     (?P<path>(?P<quote>["'`])([^"'`]+)(?P=quote))   # "file path" ("some/path.js")
     """, re.MULTILINE | re.VERBOSE)
@@ -271,7 +271,7 @@ def convert_from_export(content):
         { a, b, c } = {require("some/path.js"); Object.assign(__exports, { a, b, x: c });}
     """
     def repl(matchobj):
-        object_clean = "{" + ", ".join([remove_as(val) for val in matchobj["object"][1:-1].split(",")]) + "}"
+        object_clean = "{" + ",".join([remove_as(val) for val in matchobj["object"][1:-1].split(",")]) + "}"
         object_process = "{" + ", ".join([convert_as(val) for val in matchobj["object"][1:-1].split(",")]) + "}"
         return "%(space)s{const %(object_clean)s = require(%(path)s);Object.assign(__exports, %(object_process)s)}" % {
             'object_clean': object_clean,


### PR DESCRIPTION
This commit is to fix two problems when transpiling an @odoo-module file.

1. When a file exports an object with a long name, the regex EXPORT_FROM_RE will cause catastrophic backtracking. The regex will take a long time to resolve.
Example:
```js
    export {a, aReallyVeryLongNameElement};
```

2.  When a file exports an object without ending the line with ';'. The regex EXPORT_OBJECT_RE will remove spaces and line breaks that follow this kind of export.
Example:
Input:
```js
    export {a}

    xxx
```

Output:
```js
    Object.assign(__export, {a})xxx
```

Output after this commit:
```js
    Object.assign(__export, {a})

    xxx
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
