### PR TITLE
[FIX] crm: dot not sync the phone / email from False to an empty string

### DIFF
--- a/addons/crm/tests/common.py
+++ b/addons/crm/tests/common.py
@@ -152,12 +152,12 @@ class TestCrmCommon(TestSalesCommon, MailCase):
             'philip.j.fry@test.example.com',
             'turanga.leela@test.example.com',
         ]
-        cls.test_pĥone_data = [
+        cls.test_phone_data = [
             '+1 202 555 0122',  # formatted US number
             '202 555 0999',  # local US number
             '202 555 0888',  # local US number
         ]
-        cls.test_pĥone_data_sanitized = [
+        cls.test_phone_data_sanitized = [
             '+12025550122',
             '+12025550999',
             '+12025550888',
@@ -176,7 +176,7 @@ class TestCrmCommon(TestSalesCommon, MailCase):
         cls.contact_1 = cls.env['res.partner'].create({
             'name': 'Philip J Fry',
             'email': cls.test_email_data[1],
-            'mobile': cls.test_pĥone_data[0],
+            'mobile': cls.test_phone_data[0],
             'title': cls.env.ref('base.res_partner_title_mister').id,
             'function': 'Delivery Boy',
             'phone': False,
@@ -190,8 +190,8 @@ class TestCrmCommon(TestSalesCommon, MailCase):
         cls.contact_2 = cls.env['res.partner'].create({
             'name': 'Turanga Leela',
             'email': cls.test_email_data[2],
-            'mobile': cls.test_pĥone_data[1],
-            'phone': cls.test_pĥone_data[2],
+            'mobile': cls.test_phone_data[1],
+            'phone': cls.test_phone_data[2],
             'parent_id': False,
             'is_company': False,
             'street': 'Cookieville Minimum-Security Orphanarium',

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -168,8 +168,8 @@
                                         type="object" context="{'default_email': email_from}" groups="base.group_user"
                                         attrs="{'invisible': [('is_blacklisted', '=', False)]}"/>
                                     <field name="email_from" string="Email" widget="email"/>
-                                    <span class="fa fa-exclamation-triangle text-warning" 
-                                        title="By saving this change, the customer email will also be updated." 
+                                    <span class="fa fa-exclamation-triangle text-warning oe_edit_only"
+                                        title="By saving this change, the customer email will also be updated."
                                         attrs="{'invisible': [('partner_email_update', '=', False)]}"/>
                                 </div>
                                 <label for="phone" class="oe_inline"/>
@@ -179,8 +179,8 @@
                                         type="object" context="{'default_phone': phone}" groups="base.group_user"
                                         attrs="{'invisible': [('phone_blacklisted', '=', False)]}"/>
                                     <field name="phone" widget="phone"/>
-                                    <span class="fa fa-exclamation-triangle text-warning" 
-                                        title="By saving this change, the customer phone number will also be updated." 
+                                    <span class="fa fa-exclamation-triangle text-warning oe_edit_only"
+                                        title="By saving this change, the customer phone number will also be updated."
                                         attrs="{'invisible': [('partner_phone_update', '=', False)]}"/>
                                 </div>
                             </group>
@@ -203,8 +203,8 @@
                                         type="object" context="{'default_email': email_from}" groups="base.group_user"
                                         attrs="{'invisible': [('is_blacklisted', '=', False)]}"/>
                                     <field name="email_from" id="email_from_group_lead_info" string="Email" widget="email"/>
-                                    <span class="fa fa-exclamation-triangle text-warning" 
-                                        title="By saving this change, the customer email will also be updated." 
+                                    <span class="fa fa-exclamation-triangle text-warning oe_edit_only"
+                                        title="By saving this change, the customer email will also be updated."
                                         attrs="{'invisible': [('partner_email_update', '=', False)]}"/>
                                 </div>
                                 <field name="email_cc" groups="base.group_no_one"/>
@@ -216,8 +216,8 @@
                                         type="object" context="{'default_phone': phone}" groups="base.group_user"
                                         attrs="{'invisible': [('phone_blacklisted', '=', False)]}"/>
                                     <field name="phone" id="phone_group_lead_info" widget="phone"/>
-                                    <span class="fa fa-exclamation-triangle text-warning" 
-                                        title="By saving this change, the customer phone number will also be updated." 
+                                    <span class="fa fa-exclamation-triangle text-warning oe_edit_only"
+                                        title="By saving this change, the customer phone number will also be updated."
                                         attrs="{'invisible': [('partner_phone_update', '=', False)]}"/>
                                 </div>
                                 <label for="mobile" class="oe_inline"/>


### PR DESCRIPTION
Bug 1
=====
1. Create a new database from the database selector
2. Do not select a country for your company
3. Install CRM
4. Create a new opportunity and select your company
5. The sync "warning" will be displayed, and it should not

The reason for that is the phone of the company is an empty string,
and the phone of the lead is False. So we try to sync them and we show
the warning message even if for the user, nothing will happen.

Bug 2
=====
If we change the format of the email / phone on the partner, it should not
change the email / phone on the lead.

Currently it does that only for "from the lead to the partner" but not for
"from the partner to the lead".

Task 2499659

Task 2499659