### PR TITLE
[IMP] crm,*_crm: handle merging of leads and opportunities

### DIFF
--- a/addons/crm/__manifest__.py
+++ b/addons/crm/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'CRM',
-    'version': '1.5',
+    'version': '1.6',
     'category': 'Sales/CRM',
     'sequence': 15,
     'summary': 'Track leads and close opportunities',

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -225,7 +225,8 @@ class Lead(models.Model):
         'crm.lost.reason', string='Lost Reason',
         index=True, ondelete='restrict', tracking=True)
     # Statistics
-    meeting_count = fields.Integer('# Meetings', compute='_compute_meeting_count')
+    calendar_event_ids = fields.One2many('calendar.event', 'opportunity_id', string='Meetings')
+    calendar_event_count = fields.Integer('# Meetings', compute='_compute_calendar_event_count')
     duplicate_lead_ids = fields.Many2many("crm.lead", compute="_compute_potential_lead_duplicates", string="Potential Duplicate Lead", context={"active_test": False})
     duplicate_lead_count = fields.Integer(compute="_compute_potential_lead_duplicates", string="Potential Duplicate Lead Count")
     # UX
@@ -504,7 +505,7 @@ class Lead(models.Model):
         for lead in self:
             lead.recurring_revenue_monthly_prorated = (lead.recurring_revenue_monthly or 0.0) * (lead.probability or 0) / 100.0
 
-    def _compute_meeting_count(self):
+    def _compute_calendar_event_count(self):
         if self.ids:
             meeting_data = self.env['calendar.event'].sudo().read_group([
                 ('opportunity_id', 'in', self.ids)
@@ -513,7 +514,7 @@ class Lead(models.Model):
         else:
             mapped_data = dict()
         for lead in self:
-            lead.meeting_count = mapped_data.get(lead.id, 0)
+            lead.calendar_event_count = mapped_data.get(lead.id, 0)
 
     @api.depends('email_from', 'partner_id', 'contact_name', 'partner_name')
     def _compute_potential_lead_duplicates(self):
@@ -1310,62 +1311,6 @@ class Lead(models.Model):
         message_body = "\n\n".join(message_bodies)
         return self.message_post(body=message_body, subject=subject)
 
-    def _merge_opportunity_history(self, opportunities):
-        """ Move mail.message from the given opportunities to the current one. `self` is the
-            crm.lead record destination for message of `opportunities`.
-
-        :param opportunities: see ``_merge_dependences``
-        """
-        self.ensure_one()
-        for opportunity in opportunities:
-            for message in opportunity.message_ids:
-                if message.subject:
-                    subject = _("From %(source_name)s : %(source_subject)s", source_name=opportunity.name, source_subject=message.subject)
-                else:
-                    subject = _("From %(source_name)s", source_name=opportunity.name)
-                message.write({
-                    'res_id': self.id,
-                    'subject': subject,
-                })
-        return True
-
-    def _merge_opportunity_attachments(self, opportunities):
-        """ Move attachments of given opportunities to the current one `self`, and rename
-            the attachments having same name than native ones.
-
-        :param opportunities: see ``_merge_dependences``
-        """
-        self.ensure_one()
-
-        # return attachments of opportunity
-        def _get_attachments(opportunity_id):
-            return self.env['ir.attachment'].search([('res_model', '=', self._name), ('res_id', '=', opportunity_id)])
-
-        first_attachments = _get_attachments(self.id)
-        # counter of all attachments to move. Used to make sure the name is different for all attachments
-        count = 1
-        for opportunity in opportunities:
-            attachments = _get_attachments(opportunity.id)
-            for attachment in attachments:
-                values = {'res_id': self.id}
-                for attachment_in_first in first_attachments:
-                    if attachment.name == attachment_in_first.name:
-                        values['name'] = "%s (%s)" % (attachment.name, count)
-                count += 1
-                attachment.write(values)
-        return True
-
-    def _merge_dependences(self, opportunities):
-        """ Merge dependences (messages, attachments, ...). These dependences will be
-            transfered to `self`, the most important lead.
-
-        :param opportunities : recordset of opportunities to transfer. Does not
-          include `self` which is the target crm.lead being the result of the merge.
-        """
-        self.ensure_one()
-        self._merge_opportunity_history(opportunities)
-        self._merge_opportunity_attachments(opportunities)
-
     def merge_opportunity(self, user_id=False, team_id=False, auto_unlink=True):
         """ Merge opportunities in one. Different cases of merge:
                 - merge leads together = 1 new lead
@@ -1438,6 +1383,88 @@ class Lead(models.Model):
 
     def _merge_get_fields(self):
         return list(CRM_LEAD_FIELDS_TO_MERGE) + list(self._merge_get_fields_specific().keys())
+
+    def _merge_dependences(self, opportunities):
+        """ Merge dependences (messages, attachments,activities, calendar events,
+        ...). These dependences will be transfered to `self` considered as the
+        master lead.
+
+        :param opportunities : recordset of opportunities to transfer. Does not
+          include `self` which is the target crm.lead being the result of the
+          merge;
+        """
+        self.ensure_one()
+        self._merge_dependences_history(opportunities)
+        self._merge_dependences_attachments(opportunities)
+        self._merge_dependences_calendar_events(opportunities)
+
+    def _merge_dependences_history(self, opportunities):
+        """ Move history from the given opportunities to the current one. `self`
+        is the crm.lead record destination for message of `opportunities`.
+
+        This method moves
+          * messages
+          * activities
+
+        :param opportunities: see ``_merge_dependences``
+        """
+        self.ensure_one()
+        for opportunity in opportunities:
+            for message in opportunity.message_ids:
+                if message.subject:
+                    subject = _("From %(source_name)s : %(source_subject)s", source_name=opportunity.name, source_subject=message.subject)
+                else:
+                    subject = _("From %(source_name)s", source_name=opportunity.name)
+                message.write({
+                    'res_id': self.id,
+                    'subject': subject,
+                })
+
+        opportunities.activity_ids.write({
+            'res_id': self.id,
+        })
+
+        return True
+
+    def _merge_dependences_attachments(self, opportunities):
+        """ Move attachments of given opportunities to the current one `self`, and rename
+            the attachments having same name than native ones.
+
+        :param opportunities: see ``_merge_dependences``
+        """
+        self.ensure_one()
+
+        all_attachments = self.env['ir.attachment'].search([
+            ('res_model', '=', self._name),
+            ('res_id', 'in', opportunities.ids)
+        ])
+
+        for opportunity in opportunities:
+            attachments = all_attachments.filtered(lambda attach: attach.res_id == opportunity.id)
+            for attachment in attachments:
+                attachment.write({
+                    'res_id': self.id,
+                    'name': _("%(attach_name)s (from %(lead_name)s)",
+                              attach_name=attachment.name,
+                              lead_name=opportunity.name[:20]
+                             )
+                })
+        return True
+
+    def _merge_dependences_calendar_events(self, opportunities):
+        """ Move calender.event from the given opportunities to the current one. `self` is the
+            crm.lead record destination for event of `opportunities`.
+        :param opportunities: see ``merge_dependences``
+        """
+        self.ensure_one()
+        meetings = self.env['calendar.event'].search([('opportunity_id', 'in', opportunities.ids)])
+        return meetings.write({
+            'res_id': self.id,
+            'opportunity_id': self.id,
+        })
+
+    # CONVERT
+    # ----------------------------------------------------------------------
 
     def _convert_opportunity_data(self, customer, team_id=False):
         """ Extract the data from a lead to create the opportunity

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -30,9 +30,9 @@
                                 context="{'partner_id': partner_id}"
                                 attrs="{'invisible': [('type', '=', 'lead')]}">
                                 <div class="o_stat_info">
-                                    <field name="meeting_count" class="o_stat_value"/>
-                                    <span class="o_stat_text" attrs="{'invisible': [('meeting_count', '&lt;', 2)]}"> Meetings</span>
-                                    <span class="o_stat_text" attrs="{'invisible': [('meeting_count', '&gt;', 1)]}"> Meeting</span>
+                                    <field name="calendar_event_count" class="o_stat_value"/>
+                                    <span class="o_stat_text" attrs="{'invisible': [('calendar_event_count', '&lt;', 2)]}"> Meetings</span>
+                                    <span class="o_stat_text" attrs="{'invisible': [('calendar_event_count', '&gt;', 1)]}"> Meeting</span>
                                 </div>
                             </button>
                             <button name="action_show_potential_duplicates" type="object"

--- a/addons/crm/views/res_partner_views.xml
+++ b/addons/crm/views/res_partner_views.xml
@@ -11,7 +11,6 @@
             <field name="arch" type="xml">
                 <field name="mobile" position="after">
                     <field name="opportunity_count"/>
-                    <field name="meeting_count"/>
                 </field>
                 <xpath expr="//span[hasclass('oe_kanban_partner_links')]" position="inside">
                     <span class="badge badge-pill" t-if="record.opportunity_count.value>0"><i class="fa fa-fw fa-star" aria-label="Favorites" role="img" title="Favorites"/><t t-esc="record.opportunity_count.value"/></span>

--- a/addons/event_crm/models/crm_lead.py
+++ b/addons/event_crm/models/crm_lead.py
@@ -22,3 +22,11 @@ class Lead(models.Model):
     def _compute_registration_count(self):
         for record in self:
             record.registration_count = len(record.registration_ids)
+
+    def _merge_dependences(self, opportunities):
+        super(Lead, self)._merge_dependences(opportunities)
+
+        # merge registrations as sudo, as crm people may not have access to event rights
+        self.sudo().write({
+            'registration_ids': [(4, registration.id) for registration in opportunities.sudo().registration_ids]
+        })

--- a/addons/event_crm/tests/__init__.py
+++ b/addons/event_crm/tests/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_event_crm_flow
+from . import test_crm_lead_merge

--- a/addons/event_crm/tests/test_crm_lead_merge.py
+++ b/addons/event_crm/tests/test_crm_lead_merge.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.crm.tests.test_crm_lead_merge import TestLeadMergeCommon
+from odoo.addons.event_crm.tests.common import TestEventCrmCommon
+from odoo.tests.common import tagged, users
+
+
+@tagged('lead_manage')
+class TestLeadCrmMerge(TestLeadMergeCommon, TestEventCrmCommon):
+
+    @users('user_sales_manager')
+    def test_merge_method_dependencies(self):
+        """ Test if dependences for leads are not lost while merging leads. In
+        this test leads are ordered as
+
+        lead_w_contact -----------lead---seq=30
+        lead_w_email -------------lead---seq=3
+        lead_1 -------------------lead---seq=1
+        lead_w_partner_company ---lead---seq=1----------------registrations
+        lead_w_partner -----------lead---seq=False
+        """
+        TestLeadMergeCommon.merge_fields.append('registration_ids')
+
+        registration = self.env['event.registration'].sudo().create({
+            'partner_id': self.event_customer.id,
+            'event_id': self.event_0.id,
+            'lead_ids': [(4, self.lead_w_partner_company.id)],
+        })
+        self.assertEqual(self.lead_w_partner_company.registration_ids, registration)
+
+        leads = self.env['crm.lead'].browse(self.leads.ids)._sort_by_confidence_level(reverse=True)
+        with self.assertLeadMerged(self.lead_w_contact, leads,
+                                   name=self.lead_w_contact.name,
+                                   registration_ids=registration
+                                   ):
+            leads._merge_opportunity(auto_unlink=False, max_length=None)

--- a/addons/sale_crm/models/crm_lead.py
+++ b/addons/sale_crm/models/crm_lead.py
@@ -83,3 +83,9 @@ class CrmLead(models.Model):
             action['views'] = [(self.env.ref('sale.view_order_form').id, 'form')]
             action['res_id'] = orders.id
         return action
+
+    def _merge_get_fields_specific(self):
+        fields_info = super(CrmLead, self)._merge_get_fields_specific()
+        # add all the orders from all lead to merge
+        fields_info['order_ids'] = lambda fname, leads: [(4, order.id) for order in leads.order_ids]
+        return fields_info

--- a/addons/sale_crm/tests/__init__.py
+++ b/addons/sale_crm/tests/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_crm_lead_convert_quotation
+from . import test_crm_lead_merge

--- a/addons/sale_crm/tests/test_crm_lead_merge.py
+++ b/addons/sale_crm/tests/test_crm_lead_merge.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.crm.tests.test_crm_lead_merge import TestLeadMergeCommon
+from odoo.tests.common import tagged, users
+
+
+@tagged('lead_manage')
+class TestLeadSaleMerge(TestLeadMergeCommon):
+
+    @users('user_sales_manager')
+    def test_merge_method_dependencies(self):
+        """ Test if dependences for leads are not lost while merging leads. In
+        this test leads are ordered as
+
+        lead_w_contact -----------lead---seq=30
+        lead_w_email -------------lead---seq=3
+        lead_1 -------------------lead---seq=1
+        lead_w_partner_company ---lead---seq=1----------------orders
+        lead_w_partner -----------lead---seq=False------------orders
+        """
+        TestLeadMergeCommon.merge_fields.append('order_ids')
+
+        orders = self.env['sale.order'].sudo().create([
+            {'partner_id': self.contact_1.id,
+             'opportunity_id': self.lead_w_partner_company.id,
+            },
+            {'partner_id': self.contact_1.id,
+             'opportunity_id': self.lead_w_partner.id,
+            }
+        ])
+        self.assertEqual(self.lead_w_partner_company.order_ids, orders[0])
+        self.assertEqual(self.lead_w_partner.order_ids, orders[1])
+
+        leads = self.env['crm.lead'].browse(self.leads.ids)._sort_by_confidence_level(reverse=True)
+        with self.assertLeadMerged(self.lead_w_contact, leads,
+                                   name=self.lead_w_contact.name,
+                                   order_ids=orders
+                                   ):
+            leads._merge_opportunity(auto_unlink=False, max_length=None)

--- a/addons/website_crm/tests/__init__.py
+++ b/addons/website_crm/tests/__init__.py
@@ -3,3 +3,4 @@
 
 from . import test_website_crm
 from . import test_website_visitor
+from . import test_crm_lead_merge

--- a/addons/website_crm/tests/test_crm_lead_merge.py
+++ b/addons/website_crm/tests/test_crm_lead_merge.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.crm.tests.test_crm_lead_merge import TestLeadMergeCommon
+from odoo.tests.common import tagged, users
+
+
+@tagged('lead_manage')
+class TestLeadVisitorMerge(TestLeadMergeCommon):
+
+    @users('user_sales_manager')
+    def test_merge_method_dependencies(self):
+        """ Test if dependences for leads are not lost while merging leads. In
+        this test leads are ordered as
+
+        lead_w_contact -----------lead---seq=30
+        lead_w_email -------------lead---seq=3
+        lead_1 -------------------lead---seq=1
+        lead_w_partner_company ---lead---seq=1----------------visitor
+        lead_w_partner -----------lead---seq=False------------visitor
+        """
+        TestLeadMergeCommon.merge_fields.append('visitor_ids')
+
+        visitors = self.env['website.visitor'].sudo().create([
+            {'name': 'Visitor 1',
+             'lead_ids': [(4, self.lead_w_partner_company.id)],
+            },
+            {'name': 'Visitor 2',
+             'lead_ids': [(4, self.lead_w_partner.id)],
+            }
+        ])
+        self.assertEqual(self.lead_w_partner_company.visitor_ids, visitors[0])
+        self.assertEqual(self.lead_w_partner.visitor_ids, visitors[1])
+
+        leads = self.env['crm.lead'].browse(self.leads.ids)._sort_by_confidence_level(reverse=True)
+        with self.assertLeadMerged(self.lead_w_contact, leads,
+                                   name=self.lead_w_contact.name,
+                                   visitor_ids=visitors
+                                   ):
+            leads._merge_opportunity(auto_unlink=False, max_length=None)


### PR DESCRIPTION
PURPOSE
In CRM, when  we merge different leads many documents seem lost in wild 
like following,

1. Meetings
2. Activities
3. Sale orders
4. Attendees

The purpose of this commit is to prevent the loss of such documents during 
merging leads.

SPECIFICATIONS

Currently, we have a list of fields set to be considered for merging leads. 
We merge the  separate leads into the main lead  that always renders the same 
information as in the leads but we are getting only part of that information. 

For that, we have added those extra fields to be merged,  to these fields like 'Attendees' 
and 'Sale Orders' following how already 'Website Visitors' are added.

For adding Activities and Meetings we followed the procedure like merging
 'Dependences'

Also,  we have added test cases to ensure the working of these fields including the 
existing field for 'Visitors'.

This is the goal of this commit.

LINKS

PR #68884
Task 2457941