### PR TITLE
[FIX] stock: small immediate transfer fixes

### DIFF
--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -233,7 +233,7 @@
                     <button name="action_assign" attrs="{'invisible': [('show_check_availability', '=', False)]}" string="Check Availability" type="object" class="oe_highlight" groups="base.group_user"/>
                     <button name="button_validate" attrs="{'invisible': ['|', ('state', 'in', ('waiting','confirmed')), ('show_validate', '=', False)]}" string="Validate" type="object" class="oe_highlight" groups="stock.group_stock_user"/>
                     <button name="button_validate" attrs="{'invisible': ['|', ('state', 'not in', ('waiting', 'confirmed')), ('show_validate', '=', False)]}" string="Validate" type="object" groups="stock.group_stock_user" class="o_btn_validate"/>
-                    <button name="action_set_quantities_to_reservation" attrs="{'invisible': [('show_validate', '=', False)]}" string="Set quantities" type="object" groups="stock.group_stock_user" class="o_btn_validate"/>
+                    <button name="action_set_quantities_to_reservation" attrs="{'invisible': ['|', ('show_validate', '=', False), ('immediate_transfer', '=', True)]}" string="Set quantities" type="object" groups="stock.group_stock_user" class="o_btn_validate"/>
                     <widget name="signature" string="Sign" highlight="1"
                             attrs="{'invisible': ['|', '|', ('id', '=', False), ('picking_type_code', '!=', 'outgoing'), ('state', '!=', 'done')]}"
                             full_name="partner_id" groups="stock.group_stock_sign_delivery"/>


### PR DESCRIPTION
This PR does 2 things:

1. Hides the "Set Quantities" button when doing an immediate transfer (there are no quantities to reserve => does not make sense)

2. Makes it so multi-step receipts that are started by an immediate transfer have its quantities done correctly transferred to its internal transfers. Steps to reproduce:
-- activate routes setting + multi-step incoming shipments (2 or 3, doesn't matter)
-- create an immediate transfer receipt
-- add a done quantity (optional: validate)
-- open corresponding 2nd step internal transfer
Expected result: amount done in immediate transfer receipt will be demand of internal transfer
Actual result: demand (and all other values) will be 0

Task: 2492994

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
