### PR TITLE
[FIX] account: Impossible to create account type

### DIFF
--- a/addons/account/views/account_view.xml
+++ b/addons/account/views/account_view.xml
@@ -317,7 +317,7 @@
                                     </group>
                                     <group string="Control-Access" groups="account.group_account_manager">
                                         <div class="text-muted" colspan="2">Keep empty for no control</div>
-                                        <field name="type_control_ids" widget="many2many_tags"/>
+                                        <field name="type_control_ids" widget="many2many_tags" options="{'no_create': True}"/>
                                         <field name="account_control_ids" widget="many2many_tags"/>
                                         <field name="restrict_mode_hash_table" groups="account.group_account_user"/>
                                     </group>


### PR DESCRIPTION
Steps to reproduce the bug:

- Go to Accounting>Journals and create new record
- In advanced settings tab, use 'Allowed Account Types' field to create a new one

Bug:

Form for account type does not have required internal_group

Introduced by https://github.com/odoo/odoo/commit/5aeec0c3dcd8aa20293167073f3f4f5cec323b74

opw:2497616