### PR TITLE
[FIX] web_editor: fix default shapes not reacting to palette changes

### DIFF
--- a/addons/website/static/tests/tours/default_shape_gets_palette_colors.js
+++ b/addons/website/static/tests/tours/default_shape_gets_palette_colors.js
@@ -1,0 +1,31 @@
+odoo.define("website.tour.default_shape_gets_palette_colors", function (require) {
+"use strict";
+
+var tour = require("web_tour.tour");
+const wTourUtils = require('website.tour_utils');
+
+tour.register("default_shape_gets_palette_colors", {
+    test: true,
+    url: "/?enable_editor=1",
+}, [
+    wTourUtils.dragNDrop({
+        id: 's_text_image',
+        name: 'Text - Image',
+    }),
+    wTourUtils.clickOnSnippet({
+        id: 's_text_image',
+        name: 'Text - Image',
+    }),
+    wTourUtils.changeOption('ColoredLevelBackground', 'Shape'),
+    {
+        content: "Check that shape does not have a background-image in its inline style",
+        trigger: '#wrap .s_text_image .o_we_shape',
+        run: () => {
+            const shape = $('#wrap .s_text_image .o_we_shape')[0];
+            if (shape.style.backgroundImage) {
+                console.error("error The default shape has a background-image in its inline style (should rely on the class)");
+            }
+        },
+    },
+]);
+});

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -10,3 +10,6 @@ class TestSnippets(odoo.tests.HttpCase):
 
     def test_01_empty_parents_autoremove(self):
         self.start_tour("/?enable_editor=1", "snippet_empty_parent_autoremove", login='admin')
+    
+    def test_02_default_shape_gets_palette_colors(self):
+        self.start_tour("/?enable_editor=1", "default_shape_gets_palette_colors", login='admin')


### PR DESCRIPTION
Previously, when toggling on background shapes, they always had the
default colours. In 1e30bce81eb8deb732747f8964ebd7fcd78c802c we made it
so that when you toggle on a shape on a section, it would automatically
reuse the colors of the surrounding shapes if any.

Unfortunately, when the "implicit" colors were also the default colors,
they were still marked on the shape, and it got an explicit background
image that would no longer react to changes in the palette.

This was caused by the fact that the call to _getDefaultColors returns
an empty object when the section doesn't already have a shape-container,
this was not a problem before since we were not passing in any colors
when creating the initial shape previously, the the aforementioned
change made it so that we did.

This commit fixes the issue by creating the shape-container before
calling the method that will set the colors on the shape, this way
getDefaultColors works as expected, and the colors are not marked on the
section when they are the default ones, restoring the ability of the
shape colors to adapt to the palette

task-2500607

Co-authored-by: Tom De Caluwé <tdc@odoo.com>