### PR TITLE
[FIX] project: kanban select in selectionMode


### DIFF
--- a/addons/project/static/src/js/project_kanban.js
+++ b/addons/project/static/src/js/project_kanban.js
@@ -18,7 +18,8 @@ KanbanRecord.include({
      */
      // YTI TODO: Should be transformed into a extend and specific to project
     _openRecord: function () {
-        if (this.modelName === 'project.project' && this.$(".o_project_kanban_boxes a").length) {
+        if (this.selectionMode !== true && this.modelName === 'project.project' &&
+            this.$(".o_project_kanban_boxes a").length) {
             this.$('.o_project_kanban_boxes a').first().click();
         } else {
             this._super.apply(this, arguments);


### PR DESCRIPTION

The custom code for project.project kanban view prevented the kanban to
works in selectionMode (eg. kanban view to select a many2one record in
mobile).

opw-2490912
