### PR TITLE
[FIX] base_vat: patch orm limitation

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -148,13 +148,26 @@ class ResPartner(models.Model):
             if not partner.vat:
                 continue
             #check with country code as prefix of the TIN
-            vat_country, vat_number = self._split_vat(partner.vat)
-            if not check_func(vat_country, vat_number):
-                #if fails, check with country code from country
-                country_code = partner.commercial_partner_id.country_id.code
-                if not  country_code or not check_func(country_code.lower(), partner.vat):
-                    msg = partner._construct_constraint_msg(country_code.lower() if country_code else None)
-                    raise ValidationError(msg)
+            failed_check = False
+            vat_country_code, vat_number = self._split_vat(partner.vat)
+            vat_guessed_country = self.env['res.country'].search([('code', '=', vat_country_code.upper())])
+            if vat_guessed_country:
+                failed_check = not check_func(vat_country_code, vat_number)
+
+            #if fails, check with country code from country
+            partner_country_code = partner.commercial_partner_id.country_id.code
+            if (not vat_guessed_country or failed_check) and partner_country_code:
+                failed_check = not check_func(partner_country_code.lower(), partner.vat)
+
+            # We allow any number if it doesn't start with a country code and the partner has no country.
+            # This is necessary to support an ORM limitation: setting vat and country_id together on a company
+            # triggers two distinct write on res.partner, one for each field, both triggering this constraint.
+            # If vat is set before country_id, the constraint must not break.
+
+            if failed_check:
+                country_code = partner_country_code or vat_country_code
+                msg = partner._construct_constraint_msg(country_code.lower() if country_code else None)
+                raise ValidationError(msg)
 
     def _construct_constraint_msg(self, country_code):
         self.ensure_one()
@@ -176,7 +189,7 @@ class ResPartner(models.Model):
         '''
         # A new VAT number format in Switzerland has been introduced between 2011 and 2013
         # https://www.estv.admin.ch/estv/fr/home/mehrwertsteuer/fachinformationen/steuerpflicht/unternehmens-identifikationsnummer--uid-.html
-        # The old format "TVA 123456" is not valid since 2014 
+        # The old format "TVA 123456" is not valid since 2014
         # Accepted format are: (spaces are ignored)
         #     CHE#########MWST
         #     CHE#########TVA

--- a/addons/base_vat/tests/test_validate_ruc.py
+++ b/addons/base_vat/tests/test_validate_ruc.py
@@ -81,6 +81,6 @@ class TestStructure(common.TransactionCase):
         with self.assertRaises(ValidationError):
             test_partner.write({'vat': '42', 'country_id': self.env.ref('base.be').id})
 
-        # If no country can be guessed: VAT number cannot be validated
-        with self.assertRaises(ValidationError):
-            test_partner.write({'vat': '0477472701', 'country_id': None})
+        # If no country can be guessed: VAT number should always be considered valid
+        # (for technical reasons due to ORM and res.company making related fields towards res.partner for country_id and vat)
+        test_partner.write({'vat': '0477472701', 'country_id': None})


### PR DESCRIPTION
https://github.com/odoo/odoo/pull/68253 fixed a bug in check_vat that caused it not to run any check when called on a partner with no country.

However, doing this caused another issue because of an ORM limitation: when writing vat and country_id with a single write() on the res.company, two distinct write are triggered on the related res.partner, one for each field. Both those write trigger the check_vat constraint.

Depending on the order in which the keys of the dictionnary passed to res.company's write were ordered, country_id could or could not be written before vat. If vat was written first and did not start with a country code, the write() on res.partner failed the constraint, because country_id wasn't set yet. This was wrong, but used to pass as there was no country_id on the partner, before https://github.com/odoo/odoo/pull/68253 fixed that.

To circumvent the issue, we now allow entering any vat number without performing any check if it does not start with a country code and no country_id is set on the partner.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
