### PR TITLE
[IMP] stock_picking_batch: manage batches better

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -140,9 +140,9 @@ class StockPickingBatch(models.Model):
         return res
 
     @api.ondelete(at_uninstall=False)
-    def _unlink_if_draft(self):
-        if any(batch.state != 'draft' for batch in self):
-            raise UserError(_("You can only delete draft batch transfers."))
+    def _unlink_if_not_done(self):
+        if any(batch.state == 'done' for batch in self):
+            raise UserError(_("You cannot delete Done batch transfers."))
 
     def onchange(self, values, field_name, field_onchange):
         """Override onchange to NOT to update all scheduled_date on pickings when
@@ -171,6 +171,7 @@ class StockPickingBatch(models.Model):
     def action_cancel(self):
         self.ensure_one()
         self.state = 'cancel'
+        self.picking_ids = False
         return True
 
     def action_print(self):

--- a/addons/stock_picking_batch/tests/test_batch_picking.py
+++ b/addons/stock_picking_batch/tests/test_batch_picking.py
@@ -3,6 +3,7 @@
 
 from datetime import datetime, timedelta
 
+from odoo.exceptions import UserError
 from odoo.tests import Form
 from odoo.tests.common import TransactionCase
 
@@ -137,10 +138,9 @@ class TestBatchPicking(TransactionCase):
         # self.assertEqual(self.batch.scheduled_date, self.picking_client_3.scheduled_date)
         # self.batch.write({'picking_ids': [(3, self.picking_client_3.id)]})
 
-
-        # remove all pickings and batch scheduled date should default to none
-        self.batch.write({'picking_ids': [(3, self.picking_client_1.id)]})
-        self.batch.write({'picking_ids': [(3, self.picking_client_2.id)]})
+        # cancelling batch should auto-remove all pickings => scheduled_date should default to none
+        self.batch.action_cancel()
+        self.assertEqual(len(self.batch.picking_ids), 0)
         self.assertEqual(self.batch.scheduled_date, False)
 
     def test_simple_batch_with_manual_qty_done(self):
@@ -172,6 +172,10 @@ class TestBatchPicking(TransactionCase):
         # ensure that quantity for picking has been moved
         self.assertFalse(sum(quant_A.mapped('quantity')))
         self.assertFalse(sum(quant_B.mapped('quantity')))
+
+        # ensure that batch cannot be deleted now that it is done
+        with self.assertRaises(UserError):
+            self.batch.unlink()
 
     def test_simple_batch_with_wizard(self):
         """ Test a simple batch picking with all quantity for picking available.


### PR DESCRIPTION
This commit loosens 2 things:
1. A batch can now be deleted for all statuses except 'done'
2. Cancelled batches will now remove links to any pickings assigned to
   it (so they can be more easily reassigned in barcode app)

Task: 2486993

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
