### PR TITLE
Make "New Request Allocation" translatable

### DIFF
--- a/addons/hr_holidays/static/src/js/time_off_calendar.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar.js
@@ -99,7 +99,7 @@ odoo.define('hr_holidays.dashboard.view_custo', function(require) {
             this.do_action({
                 type: 'ir.actions.act_window',
                 res_model: 'hr.leave.allocation',
-                name: 'New Allocation Request',
+                name: _t('New Allocation Request'),
                 views: [[false,'form']],
                 context: {'form_view_ref': 'hr_holidays.hr_leave_allocation_view_form_dashboard'},
                 target: 'new',


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
"New Allocation Request" string was not able to be translated
Current behavior before PR:
Not able to find as untranslated terms
Desired behavior after PR is merged:
tested, it is now translatable



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
