### PR TITLE
[MERGE] (website_)event: improve communication and frontend management

### DIFF
--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -235,7 +235,7 @@ class EventRegistration(models.Model):
             default_model='event.registration',
             default_res_id=self.id,
             default_use_template=bool(template),
-            default_template_ref='mail.template,%i' % template.id,
+            default_template_id=template.id,
             default_composition_mode='comment',
             custom_layout="mail.mail_notification_light",
         )

--- a/addons/event/models/event_tag.py
+++ b/addons/event/models/event_tag.py
@@ -29,6 +29,3 @@ class EventTag(models.Model):
     color = fields.Integer(
         string='Color Index', default=lambda self: self._default_color(),
         help='Tag color. No color means no display in kanban or front-end, to distinguish internal tags from public categorization tags.')
-
-    def name_get(self):
-        return [(tag.id, "%s: %s" % (tag.category_id.name, tag.name)) for tag in self]

--- a/addons/event_sms/tests/test_sms_schedule.py
+++ b/addons/event_sms/tests/test_sms_schedule.py
@@ -29,6 +29,7 @@ class TestSMSSchedule(TestEventCommon, SMSCase):
 
         cls.event_0.write({
             'event_mail_ids': [
+                (5, 0),
                 (0, 0, {  # right at subscription
                     'interval_unit': 'now',
                     'interval_type': 'after_sub',

--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -152,7 +152,7 @@ class WebsiteEventController(http.Controller):
             'current_type': current_type,
             'event_ids': events,  # event_ids used in website_event_track so we keep name as it is
             'dates': dates,
-            'categories': request.env['event.tag.category'].search([]),
+            'categories': request.env['event.tag.category'].search([('is_published', '=', True)]),
             'countries': countries,
             'pager': pager,
             'searches': searches,

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -24,7 +24,11 @@ class Event(models.Model):
 
     def _default_cover_properties(self):
         res = super()._default_cover_properties()
-        res['opacity'] = '0.4'
+        res.update({
+            'background-image': "url('/website_event/static/src/img/event_cover_4.jpg')",
+            'opacity': '0.4',
+            'resize_class': 'cover_auto'
+        })
         return res
 
     # description

--- a/addons/website_event/static/src/js/website_event.editor.js
+++ b/addons/website_event/static/src/js/website_event.editor.js
@@ -2,10 +2,256 @@ odoo.define('website_event.editor', function (require) {
 "use strict";
 
 var core = require('web.core');
-var wUtils = require('website.utils');
+var Dialog = require('web.Dialog');
+var time = require('web.time');
 var WebsiteNewMenu = require('website.newMenu');
-
 var _t = core._t;
+
+var EventCreateDialog = Dialog.extend({
+    xmlDependencies: Dialog.prototype.xmlDependencies.concat(['/website_event/static/src/xml/event_create.xml']),
+    template: 'website_event.event_create_dialog',
+    events: _.extend({}, Dialog.prototype.events, {
+        'change select[name="event_location"]': '_onLocationChanged',
+        'click .input-group-append': '_onDatetimeClicked',
+    }),
+    cssLibs: [
+        '/web/static/lib/daterangepicker/daterangepicker.css',
+    ],
+    jsLibs: [
+        '/web/static/lib/daterangepicker/daterangepicker.js',
+        '/web/static/src/legacy/js/libs/daterangepicker.js',
+    ],
+    
+
+    /**
+     * @override
+     * @param {Object} parent
+     * @param {Object} options
+     */
+    init: function (parent, options) {
+        options = _.defaults(options || {}, {
+            title: _t("New Event"),
+            size: 'medium',
+            buttons: [
+                {
+                    text: _t("Create"),
+                    classes: 'btn-primary',
+                    click: this._onClickCreate.bind(this),
+                },
+                {
+                    text: _t("Discard"),
+                    close: true
+                },
+            ]
+        });
+        this.eventStart = moment();
+        this.eventEnd = moment().add(1, "d");
+        this._super(parent, options);
+    },
+
+    /**
+     * @override
+     */
+    start: function () {
+        var self = this;
+        return this._super.apply(this, arguments).then(() => {
+            // stat / end datetimes widgets
+            self.$('input.daterange-input').each(function () {
+                self._initDateRangePicker($(this));
+            });
+            // address select2 configuration
+            self.$('input.o_wevent_js_address_id').select2(self._getSelect2AddressConfig());
+        });
+    },
+
+    /**
+     * @param {*} errors
+     */
+    _display_errors: function (errors) {
+        this.$("p.text-danger").toggleClass('d-none', true);
+        for (let i = 0; i < errors.length; i++) {
+            this.$("#" + errors[i] + " p.text-danger").toggleClass('d-none', false);
+        }
+    },
+
+    _getSelect2AddressConfig: function () {
+        var self = this;
+        return {
+            allowClear: true,
+            formatNoMatches: false,
+            multiple: false,
+            selection_data: false,
+            width: '100%',
+
+            createSearchChoice: function (name, data) {
+                var addedPartner = $(this.opts.element).select2('data');
+                if (_.filter(_.union(addedPartner, data), function (partner) {
+                    return partner.text.toLowerCase().localeCompare(name.toLowerCase()) === 0;
+                }).length === 0) {
+                    return {
+                        create: true,
+                        id: _.uniqueId('address_'),
+                        name: name,
+                        text: _.str.sprintf(_t('Create "%s"'), name),
+                    };
+                }
+            },
+            fill_data: function (query, data) {
+                var that = this;
+                var partners = {results: []};
+                _.each(data, function (partner) {
+                    var contact_address = partner.contact_address.replace(/[\n]+/g, '').trim();
+                    if (contact_address && that.matcher(query.term, contact_address)) {
+                        partners.results.push({
+                            id: partner.id,
+                            text: contact_address,
+                        });
+                    }
+                });
+                query.callback(partners);
+            },
+            formatSelection: function (data) {
+                if (data.name) {
+                    data.text = data.name;
+                }
+                return data.text;
+            },
+            query: function (query) {
+                var that = this;
+                // fetch data only once and store it
+                if (!this.selection_data) {
+                    self._rpc({
+                        model: 'res.partner',
+                        method: 'search_read',
+                        fields: ['contact_address'],
+                        domain: [],
+                    }).then(function (data) {
+                        that.fill_data(query, data);
+                        that.selection_data = data;
+                    });
+                } else {
+                    this.fill_data(query, this.selection_data);
+                }
+            }
+        }
+    },
+
+    _getSelect2AddressValues: function () {
+        var select2Value = this.$('input.o_wevent_js_address_id').select2('data');
+        if (select2Value) {
+            if (select2Value.create) {
+                return [0, {'name': select2Value.name}];
+            } else {
+                return [select2Value.id, {}];
+            }
+        }
+        return [];
+    },
+
+    /**
+     *
+     * @param {*} $dateGroup
+     */
+    _initDateRangePicker: function ($dateGroup) {
+        var minDate = moment().subtract(1, "d");
+        var maxDate = moment().add(200, "y");
+        var self = this;
+        var textDirection = _t.database.parameters.direction;
+
+        $dateGroup.daterangepicker({
+            // dates
+            endDate: this.eventEnd,
+            maxDate: maxDate,
+            minDate: minDate,
+            startDate: this.eventStart,
+            // display
+            locale: {
+                direction: textDirection,
+                format: time.getLangDatetimeFormat().replace(':ss', ''),
+                separator: ' 🠖 ',
+                applyLabel: _t('Apply'),
+                cancelLabel: _t('Cancel'),
+                weekLabel: 'W',
+                customRangeLabel: _t('Custom Range'),
+                daysOfWeek: moment.weekdaysMin(),
+                monthNames: moment.monthsShort(),
+                firstDay: moment.localeData().firstDayOfWeek()
+            },
+            opens: 'left',
+            timePicker: true,
+            timePicker24Hour: true,
+            viewDate: moment(new Date()).hours(minDate.hours()).minutes(minDate.minutes()).seconds(minDate.seconds()).milliseconds(minDate.milliseconds()),
+        }, function (start, end, label) {
+            self.eventStart = start;
+            self.eventEnd = end;
+        });
+    },
+    /**
+     * @private
+     */
+    _prepareFormValues: function () {
+        return {
+            address_values: this._getSelect2AddressValues(),
+            event_start: this.eventStart,
+            event_end: this.eventEnd,
+            location: this.$('select[name=event_location]').val(),
+            name: this.$('input[name=name]').val().trim(),
+        };
+    },
+    /**
+     * @private
+     * @param {*} values
+     */
+    _validateForm: function (values) {
+        var errors = [];
+        if (!values.name){
+            errors.push('name');
+        }
+        if (values.location === 'on_site' && !values.address_values.length) {
+            errors.push('address');
+        }
+        if (!values.event_start || !values.event_end) {
+            errors.push('event_dates');
+        }
+        return errors;
+    },
+
+    /**
+     * @private
+     */
+    _submitForm: function () {
+        var self = this;
+        var eventValues = this._prepareFormValues();
+        var errors = this._validateForm(eventValues)
+        console.log(eventValues, errors);
+        if (errors.length) {
+            this._display_errors(errors);
+            return;
+        }
+        return this._rpc({
+            route: '/event/add_event',
+            params: eventValues,
+        }).then((url) => {
+            window.location.href = url;
+            return new Promise(function () {});
+        });
+    },
+
+    /**
+     * @private
+     */
+    _onClickCreate: function () {
+        return this._submitForm();
+    },
+
+    /**
+     * @private
+     * @param {*} ev
+     */
+    _onLocationChanged: function (ev) {
+        this.$('.show_visibility_address').toggleClass('d-none', ev.target.value === 'online');
+    },
+});
 
 WebsiteNewMenu.include({
     actions: _.extend({}, WebsiteNewMenu.prototype.actions || {}, {
@@ -25,25 +271,12 @@ WebsiteNewMenu.include({
      */
     _createNewEvent: function () {
         var self = this;
-        return wUtils.prompt({
-            id: "editor_new_event",
-            window_title: _t("New Event"),
-            input: _t("Event Name"),
-        }).then(function (result) {
-            var eventName = result.val;
-            if (!eventName) {
-                return;
-            }
-            return self._rpc({
-                route: '/event/add_event',
-                params: {
-                    event_name: eventName,
-                },
-            }).then(function (url) {
-                window.location.href = url;
-                return new Promise(function () {});
-            });
+        var def = new Promise(function (resolve) {
+            var dialog = new EventCreateDialog(self, {});
+            dialog.open();
+            dialog.on('closed', self, resolve);
         });
+        return def;
     },
 });
 });

--- a/addons/website_event/static/src/xml/event_create.xml
+++ b/addons/website_event/static/src/xml/event_create.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="website_event.event_create_dialog">
+        <form id="editor_new_event" style="overflow:visible;">
+            <div class="form-group row" id="name">
+                <label for="name" class="col-md-2 col-form-label">Event Name</label>
+                <div class="col-md-10">
+                    <input type="text" name="name" class="form-control" required="required"/>
+                </div>
+                <p class="text-danger mt-1 mb-0 col-md-8 d-none">Please fill in this field</p>
+            </div>
+            <div class="form-group row">
+                <label class="col-form-label col-md-2" for="event_location">Location</label>
+                <div class="col-md-10">
+                    <select class="form-control" id="event_location" name="event_location">
+                        <option value="online">Online</option>
+                        <option value="on_site">On Site</option>
+                    </select>
+                </div>
+            </div>
+            <div class="form-group row d-none show_visibility_address" id="address">
+                <label class="col-form-label col-md-2" for="address_id">Venue</label>
+                <div class="col-md-10">
+                    <input type="text" class="form-control o_wevent_js_address_id" name="address_id" placeholder="Select Venue"/>
+                </div>
+                <p class="text-danger mt-1 mb-0 col-md-8 d-none">Please fill in this field</p>
+            </div>
+            <div class="form-group row d-flex justify-content-between align-items-center" id="event_dates">
+                <label class="col-form-label col-md-2" for="event_start_end">Start 🠖 End</label>
+                <div class="col-md-10 s_website_form_datetime input-group date o_wevent_form_datetime" data-target-input="nearest">
+                    <input type="text" name="event_start_end" class="form-control daterange-input bg-transparent text-dark rounded-0 p-1"/>
+                </div>
+                <p class="text-danger mt-1 col-md-8 d-none">Please fill in this field</p>
+            </div>
+        </form>
+    </t>
+</templates>

--- a/addons/website_event/static/tests/tours/website_event.js
+++ b/addons/website_event/static/tests/tours/website_event.js
@@ -4,6 +4,7 @@ odoo.define("website_event.tour", function (require) {
     const {_t} = require("web.core");
     const {Markup} = require('web.utils');
     var tour = require("web_tour.tour");
+    var time = require('web.time');
 
     tour.register("website_event_tour", {
         test: true,
@@ -17,11 +18,16 @@ odoo.define("website_event.tour", function (require) {
         content: _t("Click here to create a new event."),
         position: "bottom",
     }, {
-        trigger: '.modal-dialog #editor_new_event input[type=text]',
+        trigger: '.modal-dialog #editor_new_event input[name=name]',
         content: Markup(_t("Create a name for your new event and click <em>\"Continue\"</em>. e.g: Technical Training")),
+        run: 'text Technical Training',
         position: "left",
     }, {
-        trigger: '.modal-footer button.btn-primary.btn-continue',
+        trigger: '.modal-dialog #editor_new_event input[name=event_start_end]',
+        content: _t("Pick a Start date for your event"),
+        run: 'text ' + moment().format(time.getLangDatetimeFormat()) + ' - ' + moment().add(1, "d").format(time.getLangDatetimeFormat()),
+    }, {
+        trigger: '.modal-footer button.btn-primary',
         extra_trigger: '#editor_new_event input[type=text][value!=""]',
         content: Markup(_t("Click <em>Continue</em> to create the event.")),
         position: "right",

--- a/addons/website_event/views/event_tag_category_views.xml
+++ b/addons/website_event/views/event_tag_category_views.xml
@@ -17,7 +17,7 @@
         <field name="model">event.tag.category</field>
         <field name="inherit_id" ref="event.event_tag_category_view_tree"/>
         <field name="arch" type="xml">
-            <field name="tag_ids" position="before">
+            <field name="tag_ids" position="after">
                 <field name="is_published" string="Show on Website"/>
             </field>
         </field>

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -47,7 +47,25 @@
         <div class="container">
             <div class="d-flex flex-column flex-sm-row justify-content-between w-100">
                 <span class="navbar-brand h4 my-0 mr-auto">Events</span>
-                <ul class="o_wevent_index_topbar_filters nav"/>
+                <ul class="o_wevent_index_topbar_filters nav">
+                    <t t-foreach="categories" t-as="category">
+                        <li t-if="category.is_published and category.tag_ids and any(tag.color for tag in category.tag_ids)" class="nav-item dropdown mr-2 my-1">
+                            <a href="#" role="button" class="btn dropdown-toggle" data-toggle="dropdown">
+                                <i class="fa fa-folder-open"/>
+                                <t t-esc="category.name"/>
+                            </a>
+                            <div class="dropdown-menu">
+                                <t t-foreach="category.tag_ids" t-as="tag">
+                                    <a t-if="tag.color"
+                                        t-att-href="'/event?%s' % keep_query('*', tags=str((search_tags - tag).ids if tag in search_tags else (tag | search_tags).ids))"
+                                        t-attf-class="dropdown-item d-flex align-items-center justify-content-between #{'active' if tag in search_tags else ''}">
+                                        <t t-esc="tag.name"/>
+                                    </a>
+                                </t>
+                            </div>
+                        </li>
+                    </t>
+                </ul>
                 <div class="d-flex align-items-center flex-wrap pl-sm-3 pr-0">
                     <t t-call="website_event.events_search_box">
                         <t t-set="_searches" t-value="searches"/>
@@ -91,28 +109,6 @@
                 </t>
             </div>
         </li>
-    </xpath>
-</template>
-
-<template id="event_category_tag" inherit_id="website_event.index_topbar" active="False" customize_show="True" name="Filter by Tags">
-    <xpath expr="//ul[hasclass('o_wevent_index_topbar_filters')]" position="inside">
-        <t t-foreach="categories" t-as="category">
-            <li t-if="category.is_published and category.tag_ids and any(tag.color for tag in category.tag_ids)" class="nav-item dropdown mr-2 my-1">
-                <a href="#" role="button" class="btn dropdown-toggle" data-toggle="dropdown">
-                    <i class="fa fa-folder-open"/>
-                    <t t-esc="category.name"/>
-                </a>
-                <div class="dropdown-menu">
-                    <t t-foreach="category.tag_ids" t-as="tag">
-                        <a t-if="tag.color"
-                            t-att-href="'/event?%s' % keep_query('*', tags=str((search_tags - tag).ids if tag in search_tags else (tag | search_tags).ids))"
-                            t-attf-class="dropdown-item d-flex align-items-center justify-content-between #{'active' if tag in search_tags else ''}">
-                            <t t-esc="tag.name"/>
-                        </a>
-                    </t>
-                </div>
-            </li>
-        </t>
     </xpath>
 </template>
 

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -316,7 +316,7 @@
 </template>
 
 <!-- Index - Sidebar - Snippet - Country Events -->
-<template id="index_sidebar_country_event" inherit_id="website_event.index_sidebar" active="True" customize_show="True" name="Country Events" priority="70">
+<template id="index_sidebar_country_event" inherit_id="website_event.index_sidebar" active="False" customize_show="True" name="Country Events" priority="70">
     <xpath expr="//div[@id='o_wevent_index_sidebar']" position="inside">
         <div class="o_wevent_sidebar_block">
             <t t-snippet-call="website_event.s_country_events"/>

--- a/addons/website_event/views/event_templates_page.xml
+++ b/addons/website_event/views/event_templates_page.xml
@@ -20,8 +20,8 @@
                                     <i class="fa fa-folder-open text-primary mr-2"/><span t-field="event.event_type_id"/>
                                 </a>
                             </li>
-                            <li class="nav-item mr-3">
-                                <a t-if="event.country_id" t-attf-href="/event?country=#{event.country_id.id}" class="nav-link">
+                            <li t-if="event.country_id" class="nav-item mr-3">
+                                <a t-attf-href="/event?country=#{event.country_id.id}" class="nav-link">
                                     <i class="fa fa-map-marker text-primary mr-2"/><span t-field="event.country_id"/>
                                 </a>
                             </li>

--- a/addons/website_event_sale/controllers/main.py
+++ b/addons/website_event_sale/controllers/main.py
@@ -55,14 +55,17 @@ class WebsiteEventSaleController(WebsiteEventController):
 
         return res
 
-    def _add_event(self, event_name="New Event", context=None, **kwargs):
+    def _prepare_event_values(self, name, event_start, event_end, address_values=None):
+        values = super(WebsiteEventSaleController, self)._prepare_event_values(name, event_start, event_end, address_values)
         product = request.env.ref('event_sale.product_product_event', raise_if_not_found=False)
         if product:
-            context = dict(context or {}, default_event_ticket_ids=[[0, 0, {
-                'name': _('Registration'),
-                'product_id': product.id,
-                'end_sale_datetime': False,
-                'seats_max': 1000,
-                'price': 0,
-            }]])
-        return super(WebsiteEventSaleController, self)._add_event(event_name, context, **kwargs)
+            values.update({
+                'event_ticket_ids': [[0, 0, {
+                    'name': _('Registration'),
+                    'product_id': product.id,
+                    'end_sale_datetime': False,
+                    'seats_max': 1000,
+                    'price': 0,
+                }]]
+            })
+        return values


### PR DESCRIPTION
This merge improves event and website_event in various ways:

  * set default event_mail_ids on event.event (one registration, two
    reminders) as communication is considered as default behavior;
  * improve event creation flow on the frontend by adding fields;
  * improve customization on website_event;
  * remove name_get in event tags to avoid redundancy in tag category tree
    view and remove noise;
  * improve cover image of an event (Especially to improve the editor UX);
  * various display or testing related fixes;

Task-2488019