### PR TITLE
[FIX] website: don't show advanced tree hierarchy if not debug

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -332,7 +332,7 @@ class Website(Home):
             domain += ['|', ('name', 'ilike', search), ('url', 'ilike', search)]
 
         pages = Page.search(domain, order=sort_order)
-        if sortby != 'url' or not request.env.user.has_group('website.group_multi_website'):
+        if sortby != 'url' or not request.session.debug:
             pages = pages.filtered(pages._is_most_specific_page)
         pages_count = len(pages)
 

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2382,11 +2382,11 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
     <t t-set='final_page' t-value="(next_page and page.url != next_page.url) or not next_page or specific_page"/>
     <tr t-att-style='not final_page and "color:#999"'>
         <td>
-            <t groups="website.group_multi_website">
+            <t t-if="debug">
                 <i t-if='specific_page and prev_page and prev_page.url == page.url and not prev_page.website_id' class="fa fa-level-up fa-rotate-90 ml32 mr4"/>
-                <i t-else="1" class="fa fa-globe mr4" t-att-style="'visibility:hidden;' if specific_page else ''"/>
+                <i t-else="1" class="fa fa-globe mr4" title="Websites-shared page" t-att-style="'visibility:hidden;' if specific_page else ''"/>
             </t>
-            <i t-if="page.is_homepage" class="fa fa-home" title="Home"/> <span t-esc="page.name"/>
+            <i t-if="page.is_homepage" class="fa fa-home" title="Homepage"/> <span t-esc="page.name"/>
         </td>
         <td>
             <a t-if='final_page' t-att-href="page.url"><t t-esc="page.url"/></a>


### PR DESCRIPTION
The page manager shows an advanced structure if the user has multi website
enabled. It will show specific pages as a child of its generic one.
It is useful to directly understand and figure which pages are 'overiden'.

But it doesn't really makes sense for an end user, which doesn't know there is
actually generic and/or specific pages.

It makes more sense to show that behavior only in debug and not in multi
websites.
