### PR TITLE
[FIX] stock_valuation_layer: auto_join product_id to avoid bloating q…

### DIFF
--- a/addons/stock_account/models/stock_valuation_layer.py
+++ b/addons/stock_account/models/stock_valuation_layer.py
@@ -15,7 +15,7 @@ class StockValuationLayer(models.Model):
 
     active = fields.Boolean(related='product_id.active')
     company_id = fields.Many2one('res.company', 'Company', readonly=True, required=True)
-    product_id = fields.Many2one('product.product', 'Product', readonly=True, required=True, check_company=True)
+    product_id = fields.Many2one('product.product', 'Product', readonly=True, required=True, check_company=True, auto_join=True)
     categ_id = fields.Many2one('product.category', related='product_id.categ_id')
     product_tmpl_id = fields.Many2one('product.template', related='product_id.product_tmpl_id')
     quantity = fields.Float('Quantity', digits=0, help='Quantity', readonly=True)


### PR DESCRIPTION
…ueries

The active field of stock.valuation.layer is related to product_id.active.
Since product_id is a Many2one stored field without auto_join, when performing
`self.env['stock.valuation.layer'].search(domain)` without `active_test=False`, the domain
expression will be extended with `[('product_id.active', '=', 1)]`. Evaluating this expression
in `expression.parse(self) L.912` will inject all the active product_ids found in the database.

This makes it quite slow for psql to parse the select queries when the number of active
products in a database is big, as the where condition is a series of AND. 
To avoid that, add `auto_join=True` for the `product_id` Many2one.

#### Speedup
 
Reported speedup of `web_read_group` of `Inventory > Reporting > Inventory Report` for the same company_id

| Number of active products | current timing | timing with auto_join |
| :--------------------------: | :--------------: | :--------------------: | 
| 1.000                                 | 8s                    | 1.2s
| 20.000                               | 15s                  | 1.2s                          |
| 100.000                             | 40s                  |            1.2s               |
| 500.000                             | 2min30s          |            1.3s               |

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
