### PR TITLE
[FIX] base_address_extended: add complete address to contact

### DIFF
--- a/addons/base_address_extended/models/base_address_extended.py
+++ b/addons/base_address_extended/models/base_address_extended.py
@@ -33,9 +33,9 @@ class Partner(models.Model):
     street_number2 = fields.Char('Door', compute='_split_street', help="Door Number",
                                  inverse='_set_street', store=True)
 
-    def _formatting_address_fields(self):
-        """Returns the list of address fields usable to format addresses."""
-        return super(Partner, self)._formatting_address_fields() + self.get_street_fields()
+    def _address_fields(self):
+        """Returns the list of address fields that are synced from the parent."""
+        return super(Partner, self)._address_fields() + self.get_street_fields()
 
     def get_street_fields(self):
         """Returns the fields that can be used in a street format.
@@ -78,7 +78,8 @@ class Partner(models.Model):
 
             # add trailing chars in street_format
             street_value += street_format[previous_pos:]
-            partner.street = street_value
+            if partner.street != street_value:
+                partner.street = street_value
 
     def _split_street_with_params(self, street_raw, street_format):
         street_fields = self.get_street_fields()


### PR DESCRIPTION
Issue

	- Install "Contact" and "base_address_extended" modules
	- Create new partner X:
	- Set it as company
	- Fill all address fields
	- Add a "Contact & Addresses"
	- Add a name Y, set it as "contact" and save.
	- Open partner Y

	Address is missing House and Door values.

Cause

	base_address_extended module add 3 street fields
	that are not added to field considered as address_fields.

Solution

	Overide _address_fields (instead of _formatting_address_fields)
	and add extended street fields.

	Also, when calling `_set_street`,  if street_value,
	after recomputing it from `street_format`, is
	already the same as `partner.street`, then no need
	re-write it. (In addition to performance, it is also
	to avoid recomputing extended street_fields a second time).

As the issue was a side-effect of an optimisation (odoo#31876),
benchmarks were performed to ensure no significant performance regression was introduced.
With an input file composed half of companies and half of related contacts,
the performance impact seems minor at worst (less than 5% runtime, no change in queries count):

before fix:
```
nb records	queries		ms (min)

1000		37132		87749.52 (1 Min 27 s)
2000		74146		177770.39 (2 Min 57 s)
20000		740343(?+1)	1802148.42 (30 Min 2 s)
```
after fix:
```
nb records	queries		ms (min)

1000		37132		92962.22 (1 Min 32 s)
2000		74146		192642.4 (3 Min 12 s)
20000		740342		1887695.68 (31 Min 27 s)
```

test file sample:
```csv
"External ID","Name","Is a company","Related company/External ID","Address type","Customer","Supplier","Street Name","ZIP","City","State","Country","House","Door"
"__export__.res_partner_0_company","Test 0 company","1","","","1","0","Rue Van dam0","","","","Netherlands","0","AA"
...
"__export__.res_partner_0_contact","Test 0 contact","0","__export__.res_partner_0_company","Contact","1","0","","","","","","",""
...
```
opw-2491092