### PR TITLE
[REF] *: rename assets 'glob' to 'path'

### DIFF
--- a/addons/web/tests/test_serving_base.py
+++ b/addons/web/tests/test_serving_base.py
@@ -111,7 +111,7 @@ class TestStaticInheritanceCommon(BaseCase):
 
     # Private methods
     def _get_module_names(self):
-        return ','.join([glob[1] for glob in self.asset_paths])
+        return ','.join([asset_path[1] for asset_path in self.asset_paths])
 
     def _set_patchers(self):
         def _patched_for_get_asset_paths(*args, **kwargs):

--- a/addons/web_editor/data/editor_assets.xml
+++ b/addons/web_editor/data/editor_assets.xml
@@ -4,7 +4,7 @@
         <record id="web_editor.13_0_color_system_support_primary_variables_scss" model="ir.asset">
             <field name="name">13 0 color system support primary variables SCSS</field>
             <field name="bundle">web._assets_primary_variables</field>
-            <field name="glob">web_editor/static/src/scss/13_0_color_system_support_primary_variables.scss</field>
+            <field name="path">web_editor/static/src/scss/13_0_color_system_support_primary_variables.scss</field>
             <field name="active" eval="False"/>
         </record>
     </data>

--- a/addons/web_editor/models/assets.py
+++ b/addons/web_editor/models/assets.py
@@ -185,7 +185,7 @@ class Assets(models.AbstractModel):
             # Create an asset with the new attachment
             IrAsset = self.env['ir.asset']
             new_asset = {
-                'glob': custom_url,
+                'path': custom_url,
                 'target': url,
                 'directive': 'replace',
                 **self._save_asset_hook(),
@@ -229,7 +229,7 @@ class Assets(models.AbstractModel):
             ir.asset()
         """
         url = custom_url[1:] if custom_url.startswith(('/', '\\')) else custom_url
-        return self.env['ir.asset'].search([('glob', 'like', url)])
+        return self.env['ir.asset'].search([('path', 'like', url)])
 
     def _save_asset_hook(self):
         """

--- a/addons/website/data/ir_asset.xml
+++ b/addons/website/data/ir_asset.xml
@@ -6,28 +6,28 @@
             <field name="name">User custom bootstrap overridden SCSS</field>
             <field name="bundle">web._assets_frontend_helpers</field>
             <field name="directive">prepend</field>
-            <field name="glob">website/static/src/scss/user_custom_bootstrap_overridden.scss</field>
+            <field name="path">website/static/src/scss/user_custom_bootstrap_overridden.scss</field>
             <field name="sequence" eval="99"/>
         </record>
 
         <record id="website.user_custom_rules_scss" model="ir.asset">
             <field name="name">User custom rules SCSS</field>
             <field name="bundle">web.assets_frontend</field>
-            <field name="glob">website/static/src/scss/user_custom_rules.scss</field>
+            <field name="path">website/static/src/scss/user_custom_rules.scss</field>
             <field name="sequence" eval="99"/>
         </record>
 
         <record id="website.bs3_for_12_0_scss" model="ir.asset">
             <field name="name">Bs3 for 12 0 SCSS</field>
             <field name="bundle">web.assets_frontend</field>
-            <field name="glob">website/static/src/scss/compatibility/bs3_for_12_0.scss</field>
+            <field name="path">website/static/src/scss/compatibility/bs3_for_12_0.scss</field>
             <field name="active" eval="False"/>
         </record>
 
         <record id="website.configurator_tour" model="ir.asset">
             <field name="name">website.configurator_tour</field>
             <field name="bundle">website.assets_editor</field>
-            <field name="glob">website/static/src/js/tours/configurator_tour.js</field>
+            <field name="path">website/static/src/js/tours/configurator_tour.js</field>
             <field name="active" eval="False"/>
         </record>
 

--- a/addons/website/models/theme_models.py
+++ b/addons/website/models/theme_models.py
@@ -26,7 +26,7 @@ class ThemeAsset(models.Model):
         (REMOVE_DIRECTIVE, 'Remove'),
         (REPLACE_DIRECTIVE, 'Replace'),
         (INCLUDE_DIRECTIVE, 'Include')], default=APPEND_DIRECTIVE)
-    glob = fields.Char(required=True)
+    path = fields.Char(string='Path (or glob pattern)', required=True)
     target = fields.Char()
     active = fields.Boolean(default=True)
     sequence = fields.Integer(default=DEFAULT_SEQUENCE, required=True)
@@ -39,7 +39,7 @@ class ThemeAsset(models.Model):
             'key': self.key,
             'bundle': self.bundle,
             'directive': self.directive,
-            'glob': self.glob,
+            'path': self.path,
             'target': self.target,
             'active': self.active,
             'sequence': self.sequence,

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -157,7 +157,7 @@ class TestUi(odoo.tests.HttpCase):
         self.env['ir.asset'].create({
             'name': 'EditorExtension',
             'bundle': 'website.assets_wysiwyg',
-            'glob': custom_url,
+            'path': custom_url,
             'website_id': new_website.id,
         })
 

--- a/addons/website/views/snippets/s_alert.xml
+++ b/addons/website/views/snippets/s_alert.xml
@@ -42,7 +42,7 @@
 <record id="website.s_alert_000_scss" model="ir.asset">
     <field name="name">Alert 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_alert/000.scss</field>
+    <field name="path">website/static/src/snippets/s_alert/000.scss</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_badge.xml
+++ b/addons/website/views/snippets/s_badge.xml
@@ -21,13 +21,13 @@
 <record id="website.s_badge_000_variables_scss" model="ir.asset">
     <field name="name">Badge 000 variables SCSS</field>
     <field name="bundle">web._assets_primary_variables</field>
-    <field name="glob">website/static/src/snippets/s_badge/000_variables.scss</field>
+    <field name="path">website/static/src/snippets/s_badge/000_variables.scss</field>
 </record>
 
 <record id="website.s_badge_000_scss" model="ir.asset">
     <field name="name">Badge 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_badge/000.scss</field>
+    <field name="path">website/static/src/snippets/s_badge/000.scss</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_blockquote.xml
+++ b/addons/website/views/snippets/s_blockquote.xml
@@ -53,7 +53,7 @@
 <record id="website.s_blockquote_000_scss" model="ir.asset">
     <field name="name">Blockquote 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_blockquote/000.scss</field>
+    <field name="path">website/static/src/snippets/s_blockquote/000.scss</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_btn.xml
+++ b/addons/website/views/snippets/s_btn.xml
@@ -4,7 +4,7 @@
 <record id="website.s_btn_000_scss" model="ir.asset">
     <field name="name">Btn 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_btn/000.scss</field>
+    <field name="path">website/static/src/snippets/s_btn/000.scss</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_card.xml
+++ b/addons/website/views/snippets/s_card.xml
@@ -16,7 +16,7 @@
 <record id="website.s_card_000_scss" model="ir.asset">
     <field name="name">Card 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_card/000.scss</field>
+    <field name="path">website/static/src/snippets/s_card/000.scss</field>
 </record>
 
 

--- a/addons/website/views/snippets/s_chart.xml
+++ b/addons/website/views/snippets/s_chart.xml
@@ -69,7 +69,7 @@
 <record id="website.s_chart_000_js" model="ir.asset">
     <field name="name">Chart 000 JS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_chart/000.js</field>
+    <field name="path">website/static/src/snippets/s_chart/000.js</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_color_blocks_2.xml
+++ b/addons/website/views/snippets/s_color_blocks_2.xml
@@ -25,7 +25,7 @@
 <record id="website.s_color_blocks_2_000_scss" model="ir.asset">
     <field name="name">Color blocks 2 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_color_blocks_2/000.scss</field>
+    <field name="path">website/static/src/snippets/s_color_blocks_2/000.scss</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_company_team.xml
+++ b/addons/website/views/snippets/s_company_team.xml
@@ -61,7 +61,7 @@
 <record id="website.s_company_team_000_scss" model="ir.asset">
     <field name="name">Company team 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_company_team/000.scss</field>
+    <field name="path">website/static/src/snippets/s_company_team/000.scss</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_comparisons.xml
+++ b/addons/website/views/snippets/s_comparisons.xml
@@ -82,7 +82,7 @@
 <record id="website.s_comparisons_000_scss" model="ir.asset">
     <field name="name">Comparisons 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_comparisons/000.scss</field>
+    <field name="path">website/static/src/snippets/s_comparisons/000.scss</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_countdown.xml
+++ b/addons/website/views/snippets/s_countdown.xml
@@ -70,7 +70,7 @@
 <record id="website.s_countdown_000_js" model="ir.asset">
     <field name="name">Countdown 000 JS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_countdown/000.js</field>
+    <field name="path">website/static/src/snippets/s_countdown/000.js</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_dynamic_snippet.xml
+++ b/addons/website/views/snippets/s_dynamic_snippet.xml
@@ -55,13 +55,13 @@
 <record id="website.s_dynamic_snippet_000_scss" model="ir.asset">
     <field name="name">Dynamic snippet 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_dynamic_snippet/000.scss</field>
+    <field name="path">website/static/src/snippets/s_dynamic_snippet/000.scss</field>
 </record>
 
 <record id="website.s_dynamic_snippet_000_js" model="ir.asset">
     <field name="name">Dynamic snippet 000 JS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_dynamic_snippet/000.js</field>
+    <field name="path">website/static/src/snippets/s_dynamic_snippet/000.js</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_dynamic_snippet_carousel.xml
+++ b/addons/website/views/snippets/s_dynamic_snippet_carousel.xml
@@ -28,13 +28,13 @@
 <record id="website.s_dynamic_snippet_carousel_000_scss" model="ir.asset">
     <field name="name">Dynamic snippet carousel 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_dynamic_snippet_carousel/000.scss</field>
+    <field name="path">website/static/src/snippets/s_dynamic_snippet_carousel/000.scss</field>
 </record>
 
 <record id="website.s_dynamic_snippet_carousel_000_js" model="ir.asset">
     <field name="name">Dynamic snippet carousel 000 JS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_dynamic_snippet_carousel/000.js</field>
+    <field name="path">website/static/src/snippets/s_dynamic_snippet_carousel/000.js</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_facebook_page.xml
+++ b/addons/website/views/snippets/s_facebook_page.xml
@@ -25,7 +25,7 @@
 <record id="website.s_facebook_page_000_js" model="ir.asset">
     <field name="name">Facebook page 000 JS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_facebook_page/000.js</field>
+    <field name="path">website/static/src/snippets/s_facebook_page/000.js</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_faq_collapse.xml
+++ b/addons/website/views/snippets/s_faq_collapse.xml
@@ -38,7 +38,7 @@
 <record id="website.s_faq_collapse_000_scss" model="ir.asset">
     <field name="name">Faq collapse 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_faq_collapse/000.scss</field>
+    <field name="path">website/static/src/snippets/s_faq_collapse/000.scss</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_features_grid.xml
+++ b/addons/website/views/snippets/s_features_grid.xml
@@ -71,7 +71,7 @@
 <record id="website.s_features_grid_000_scss" model="ir.asset">
     <field name="name">Features grid 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_features_grid/000.scss</field>
+    <field name="path">website/static/src/snippets/s_features_grid/000.scss</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_google_map.xml
+++ b/addons/website/views/snippets/s_google_map.xml
@@ -47,13 +47,13 @@
 <record id="website.s_google_map_000_scss" model="ir.asset">
     <field name="name">Google map 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_google_map/000.scss</field>
+    <field name="path">website/static/src/snippets/s_google_map/000.scss</field>
 </record>
 
 <record id="website.s_google_map_000_js" model="ir.asset">
     <field name="name">Google map 000 JS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_google_map/000.js</field>
+    <field name="path">website/static/src/snippets/s_google_map/000.js</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_hr.xml
+++ b/addons/website/views/snippets/s_hr.xml
@@ -32,7 +32,7 @@
 <record id="website.s_hr_000_scss" model="ir.asset">
     <field name="name">Hr 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_hr/000.scss</field>
+    <field name="path">website/static/src/snippets/s_hr/000.scss</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_image_gallery.xml
+++ b/addons/website/views/snippets/s_image_gallery.xml
@@ -133,20 +133,20 @@
 <record id="website.s_image_gallery_000_js" model="ir.asset">
     <field name="name">Image gallery 000 JS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_image_gallery/000.js</field>
+    <field name="path">website/static/src/snippets/s_image_gallery/000.js</field>
 </record>
 
 <record id="website.s_image_gallery_000_scss" model="ir.asset">
     <field name="name">Image gallery 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_image_gallery/000.scss</field>
+    <field name="path">website/static/src/snippets/s_image_gallery/000.scss</field>
     <field name="active" eval="False"/>
 </record>
 
 <record id="website.s_image_gallery_001_scss" model="ir.asset">
     <field name="name">Image gallery 001 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_image_gallery/001.scss</field>
+    <field name="path">website/static/src/snippets/s_image_gallery/001.scss</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_map.xml
+++ b/addons/website/views/snippets/s_map.xml
@@ -63,7 +63,7 @@
 <record id="website.s_map_000_scss" model="ir.asset">
     <field name="name">Map 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_map/000.scss</field>
+    <field name="path">website/static/src/snippets/s_map/000.scss</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_masonry_block.xml
+++ b/addons/website/views/snippets/s_masonry_block.xml
@@ -38,20 +38,20 @@
 <record id="website.s_masonry_block_000_scss" model="ir.asset">
     <field name="name">Masonry block 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_masonry_block/000.scss</field>
+    <field name="path">website/static/src/snippets/s_masonry_block/000.scss</field>
     <field name="active" eval="False"/>
 </record>
 
 <record id="website.s_masonry_block_001_scss" model="ir.asset">
     <field name="name">Masonry block 001 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_masonry_block/001.scss</field>
+    <field name="path">website/static/src/snippets/s_masonry_block/001.scss</field>
 </record>
 
 <record id="website.s_masonry_block_000_variables_scss" model="ir.asset">
     <field name="name">Masonry block 000 variables SCSS</field>
     <field name="bundle">web._assets_primary_variables</field>
-    <field name="glob">website/static/src/snippets/s_masonry_block/000_variables.scss</field>
+    <field name="path">website/static/src/snippets/s_masonry_block/000_variables.scss</field>
     <field name="active" eval="False"/>
 </record>
 

--- a/addons/website/views/snippets/s_media_list.xml
+++ b/addons/website/views/snippets/s_media_list.xml
@@ -97,14 +97,14 @@
 <record id="website.s_media_list_000_scss" model="ir.asset">
     <field name="name">Media list 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_media_list/000.scss</field>
+    <field name="path">website/static/src/snippets/s_media_list/000.scss</field>
     <field name="active" eval="False"/>
 </record>
 
 <record id="website.s_media_list_001_scss" model="ir.asset">
     <field name="name">Media list 001 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_media_list/001.scss</field>
+    <field name="path">website/static/src/snippets/s_media_list/001.scss</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_popup.xml
+++ b/addons/website/views/snippets/s_popup.xml
@@ -71,20 +71,20 @@
 <record id="website.s_popup_000_scss" model="ir.asset">
     <field name="name">Popup 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_popup/000.scss</field>
+    <field name="path">website/static/src/snippets/s_popup/000.scss</field>
     <field name="active" eval="False"/>
 </record>
 
 <record id="website.s_popup_000_js" model="ir.asset">
     <field name="name">Popup 000 JS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_popup/000.js</field>
+    <field name="path">website/static/src/snippets/s_popup/000.js</field>
 </record>
 
 <record id="website.s_popup_001_scss" model="ir.asset">
     <field name="name">Popup 001 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_popup/001.scss</field>
+    <field name="path">website/static/src/snippets/s_popup/001.scss</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_process_steps.xml
+++ b/addons/website/views/snippets/s_process_steps.xml
@@ -57,7 +57,7 @@
 <record id="website.s_process_steps_000_scss" model="ir.asset">
     <field name="name">Process steps 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_process_steps/000.scss</field>
+    <field name="path">website/static/src/snippets/s_process_steps/000.scss</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_product_catalog.xml
+++ b/addons/website/views/snippets/s_product_catalog.xml
@@ -77,7 +77,7 @@
 <record id="website.s_product_catalog_001_scss" model="ir.asset">
     <field name="name">Product catalog 001 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_product_catalog/001.scss</field>
+    <field name="path">website/static/src/snippets/s_product_catalog/001.scss</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_product_list.xml
+++ b/addons/website/views/snippets/s_product_list.xml
@@ -61,13 +61,13 @@
 <record id="website.s_product_list_000_variables_scss" model="ir.asset">
     <field name="name">Product list 000 variables SCSS</field>
     <field name="bundle">web._assets_primary_variables</field>
-    <field name="glob">website/static/src/snippets/s_product_list/000_variables.scss</field>
+    <field name="path">website/static/src/snippets/s_product_list/000_variables.scss</field>
 </record>
 
 <record id="website.s_product_list_000_scss" model="ir.asset">
     <field name="name">Product list 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_product_list/000.scss</field>
+    <field name="path">website/static/src/snippets/s_product_list/000.scss</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_quotes_carousel.xml
+++ b/addons/website/views/snippets/s_quotes_carousel.xml
@@ -74,14 +74,14 @@
 <record id="website.s_quotes_carousel_000_scss" model="ir.asset">
     <field name="name">Quotes carousel 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_quotes_carousel/000.scss</field>
+    <field name="path">website/static/src/snippets/s_quotes_carousel/000.scss</field>
     <field name="active" eval="False"/>
 </record>
 
 <record id="website.s_quotes_carousel_001_scss" model="ir.asset">
     <field name="name">Quotes carousel 001 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_quotes_carousel/001.scss</field>
+    <field name="path">website/static/src/snippets/s_quotes_carousel/001.scss</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_rating.xml
+++ b/addons/website/views/snippets/s_rating.xml
@@ -59,14 +59,14 @@
 <record id="website.s_rating_000_scss" model="ir.asset">
     <field name="name">Rating 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_rating/000.scss</field>
+    <field name="path">website/static/src/snippets/s_rating/000.scss</field>
     <field name="active" eval="False"/>
 </record>
 
 <record id="website.s_rating_001_scss" model="ir.asset">
     <field name="name">Rating 001 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_rating/001.scss</field>
+    <field name="path">website/static/src/snippets/s_rating/001.scss</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_references.xml
+++ b/addons/website/views/snippets/s_references.xml
@@ -33,7 +33,7 @@
 <record id="website.s_references_000_scss" model="ir.asset">
     <field name="name">References 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_references/000.scss</field>
+    <field name="path">website/static/src/snippets/s_references/000.scss</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_share.xml
+++ b/addons/website/views/snippets/s_share.xml
@@ -53,13 +53,13 @@
 <record id="website.s_share_000_scss" model="ir.asset">
     <field name="name">Share 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_share/000.scss</field>
+    <field name="path">website/static/src/snippets/s_share/000.scss</field>
 </record>
 
 <record id="website.s_share_000_js" model="ir.asset">
     <field name="name">Share 000 JS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_share/000.js</field>
+    <field name="path">website/static/src/snippets/s_share/000.js</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_showcase.xml
+++ b/addons/website/views/snippets/s_showcase.xml
@@ -65,21 +65,21 @@
 <record id="website.s_showcase_000_scss" model="ir.asset">
     <field name="name">Showcase 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_showcase/000.scss</field>
+    <field name="path">website/static/src/snippets/s_showcase/000.scss</field>
     <field name="active" eval="False"/>
 </record>
 
 <record id="website.s_showcase_001_scss" model="ir.asset">
     <field name="name">Showcase 001 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_showcase/001.scss</field>
+    <field name="path">website/static/src/snippets/s_showcase/001.scss</field>
     <field name="active" eval="False"/>
 </record>
 
 <record id="website.s_showcase_002_scss" model="ir.asset">
     <field name="name">Showcase 002 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_showcase/002.scss</field>
+    <field name="path">website/static/src/snippets/s_showcase/002.scss</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_table_of_content.xml
+++ b/addons/website/views/snippets/s_table_of_content.xml
@@ -64,13 +64,13 @@
 <record id="website.s_table_of_content_000_scss" model="ir.asset">
     <field name="name">Table of content 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_table_of_content/000.scss</field>
+    <field name="path">website/static/src/snippets/s_table_of_content/000.scss</field>
 </record>
 
 <record id="website.s_table_of_content_000_js" model="ir.asset">
     <field name="name">Table of content 000 JS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_table_of_content/000.js</field>
+    <field name="path">website/static/src/snippets/s_table_of_content/000.js</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_tabs.xml
+++ b/addons/website/views/snippets/s_tabs.xml
@@ -79,7 +79,7 @@
 <record id="website.s_tabs_001_scss" model="ir.asset">
     <field name="name">Tabs 001 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_tabs/001.scss</field>
+    <field name="path">website/static/src/snippets/s_tabs/001.scss</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_text_highlight.xml
+++ b/addons/website/views/snippets/s_text_highlight.xml
@@ -13,7 +13,7 @@
 <record id="website.s_text_highlight_000_scss" model="ir.asset">
     <field name="name">Text highlight 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_text_highlight/000.scss</field>
+    <field name="path">website/static/src/snippets/s_text_highlight/000.scss</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_three_columns.xml
+++ b/addons/website/views/snippets/s_three_columns.xml
@@ -40,7 +40,7 @@
 <record id="website.s_three_columns_000_scss" model="ir.asset">
     <field name="name">Three columns 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_three_columns/000.scss</field>
+    <field name="path">website/static/src/snippets/s_three_columns/000.scss</field>
     <field name="active" eval="False"/>
     </record>
 

--- a/addons/website/views/snippets/s_timeline.xml
+++ b/addons/website/views/snippets/s_timeline.xml
@@ -67,7 +67,7 @@
 <record id="website.s_timeline_000_scss" model="ir.asset">
     <field name="name">Timeline 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_timeline/000.scss</field>
+    <field name="path">website/static/src/snippets/s_timeline/000.scss</field>
 </record>
 
 </odoo>

--- a/addons/website/views/snippets/s_title.xml
+++ b/addons/website/views/snippets/s_title.xml
@@ -12,7 +12,7 @@
 <record id="website.s_title_000_scss" model="ir.asset">
     <field name="name">Title 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website/static/src/snippets/s_title/000.scss</field>
+    <field name="path">website/static/src/snippets/s_title/000.scss</field>
     <field name="active" eval="False"/>
     </record>
 

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -1968,14 +1968,14 @@
 <record id="website.ripple_effect_scss" model="ir.asset">
     <field name="name">Ripple effect SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">/website/static/src/scss/options/ripple_effect.scss</field>
+    <field name="path">/website/static/src/scss/options/ripple_effect.scss</field>
     <field name="active" eval="False"/>
 </record>
 
 <record id="website.ripple_effect_js" model="ir.asset">
     <field name="name">Ripple effect JS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">/website/static/src/js/content/ripple_effect.js</field>
+    <field name="path">/website/static/src/js/content/ripple_effect.js</field>
     <field name="active" eval="False"/>
 </record>
 

--- a/addons/website_blog/data/ir_asset.xml
+++ b/addons/website_blog/data/ir_asset.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data>
-    
+
             <record id="website_blog.s_latest_posts_000_scss" model="ir.asset">
                 <field name="name">Latest posts 000 SCSS</field>
                 <field name="bundle">web.assets_frontend</field>
-                <field name="glob">website_blog/static/src/snippets/s_latest_posts/000.scss</field>
+                <field name="path">website_blog/static/src/snippets/s_latest_posts/000.scss</field>
                 <field name="active" eval="False"/>
                 </record>
 

--- a/addons/website_blog/views/snippets/s_blog_posts.xml
+++ b/addons/website_blog/views/snippets/s_blog_posts.xml
@@ -135,13 +135,13 @@
 <record id="website_blog.s_blog_posts_000_scss" model="ir.asset">
     <field name="name">Blog posts 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website_blog/static/src/snippets/s_blog_posts/000.scss</field>
+    <field name="path">website_blog/static/src/snippets/s_blog_posts/000.scss</field>
 </record>
 
 <record id="website_blog.s_blog_posts_000_js" model="ir.asset">
     <field name="name">Blog posts 000 JS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website_blog/static/src/snippets/s_blog_posts/000.js</field>
+    <field name="path">website_blog/static/src/snippets/s_blog_posts/000.js</field>
 </record>
 
 </odoo>

--- a/addons/website_form/data/ir_asset.xml
+++ b/addons/website_form/data/ir_asset.xml
@@ -5,7 +5,7 @@
         <record id="website_form.s_website_form_000_scss" model="ir.asset">
             <field name="name">Website form 000 SCSS</field>
             <field name="bundle">web.assets_frontend</field>
-            <field name="glob">website_form/static/src/snippets/s_website_form/000.scss</field>
+            <field name="path">website_form/static/src/snippets/s_website_form/000.scss</field>
             <field name="active" eval="False"/>
         </record>
 

--- a/addons/website_form/views/snippets/s_website_form.xml
+++ b/addons/website_form/views/snippets/s_website_form.xml
@@ -161,20 +161,20 @@
 <record id="website_form.s_website_form_000_scss" model="ir.asset">
     <field name="name">Website form 000 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website_form/static/src/snippets/s_website_form/000.scss</field>
+    <field name="path">website_form/static/src/snippets/s_website_form/000.scss</field>
     <field name="active" eval="False"/>
 </record>
 
 <record id="website_form.s_website_form_001_scss" model="ir.asset">
     <field name="name">Website form 001 SCSS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website_form/static/src/snippets/s_website_form/001.scss</field>
+    <field name="path">website_form/static/src/snippets/s_website_form/001.scss</field>
 </record>
 
 <record id="website_form.s_website_form_000_js" model="ir.asset">
     <field name="name">Website form 000 JS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website_form/static/src/snippets/s_website_form/000.js</field>
+    <field name="path">website_form/static/src/snippets/s_website_form/000.js</field>
 </record>
 
 </odoo>

--- a/addons/website_mail_channel/views/snippets/s_channel.xml
+++ b/addons/website_mail_channel/views/snippets/s_channel.xml
@@ -41,7 +41,7 @@
 <record id="website_mail_channel.s_channel_000_js" model="ir.asset">
     <field name="name">Channel 000 JS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website_mail_channel/static/src/snippets/s_channel/000.js</field>
+    <field name="path">website_mail_channel/static/src/snippets/s_channel/000.js</field>
 </record>
 
 </odoo>

--- a/addons/website_sale/views/snippets/s_dynamic_snippet_products.xml
+++ b/addons/website_sale/views/snippets/s_dynamic_snippet_products.xml
@@ -30,7 +30,7 @@
     <record id="website_sale.s_dynamic_snippet_products_000_js" model="ir.asset">
         <field name="name">Dynamic snippet products 000 JS</field>
         <field name="bundle">web.assets_frontend</field>
-        <field name="glob">website_sale/static/src/snippets/s_dynamic_snippet_products/000.js</field>
+        <field name="path">website_sale/static/src/snippets/s_dynamic_snippet_products/000.js</field>
     </record>
 
 </odoo>

--- a/addons/website_sale/views/snippets/s_products_searchbar.xml
+++ b/addons/website_sale/views/snippets/s_products_searchbar.xml
@@ -48,7 +48,7 @@
 <record id="website_sale.s_products_searchbar_000_js" model="ir.asset">
     <field name="name">Products searchbar 000 JS</field>
     <field name="bundle">web.assets_frontend</field>
-    <field name="glob">website_sale/static/src/snippets/s_products_searchbar/000.js</field>
+    <field name="path">website_sale/static/src/snippets/s_products_searchbar/000.js</field>
 </record>
 
 </odoo>

--- a/odoo/addons/base/views/ir_asset_views.xml
+++ b/odoo/addons/base/views/ir_asset_views.xml
@@ -15,7 +15,7 @@
                         </group>
                         <group>
                             <field name="target" attrs="{ 'invisible': [('directive', '!=', 'replace')] }"/>
-                            <field name="glob"/>
+                            <field name="path"/>
                         </group>
                     </group>
                 </sheet>
@@ -43,7 +43,7 @@
                 <field name="bundle"/>
                 <field name="directive"/>
                 <field name="sequence"/>
-                <field name="glob"/>
+                <field name="path"/>
                 <filter string="Active" name="active" domain="[('active', '=', True)]"/>
             </search>
         </field>

--- a/odoo/addons/test_assetsbundle/data/ir_asset.xml
+++ b/odoo/addons/test_assetsbundle/data/ir_asset.xml
@@ -4,7 +4,7 @@
         <record id="test_assetsbundle.test_jsfile[!4]_js" model="ir.asset">
             <field name="name">Test jsfile[!4] JS</field>
             <field name="bundle">test_assetsbundle.bundle1</field>
-            <field name="glob">test_assetsbundle/static/src/js/test_jsfile[!4].js</field>
+            <field name="path">test_assetsbundle/static/src/js/test_jsfile[!4].js</field>
         </record>
     </data>
 </odoo>

--- a/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
+++ b/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
@@ -251,7 +251,7 @@ class TestJavascriptAssetsBundle(FileTouchable):
         self.env['ir.asset'].create({
             'name': 'test bundle inheritance',
             'bundle': self.jsbundle_name,
-            'glob': 'test_assetsbundle/static/src/js/test_jsfile4.js',
+            'path': 'test_assetsbundle/static/src/js/test_jsfile4.js',
         })
 
         bundle1 = self._get_asset(self.jsbundle_name)
@@ -370,7 +370,7 @@ class TestJavascriptAssetsBundle(FileTouchable):
         self.env['ir.asset'].create({
             'name': 'test bundle inheritance',
             'bundle': self.cssbundle_name,
-            'glob': 'test_assetsbundle/static/src/css/test_cssfile2.css',
+            'path': 'test_assetsbundle/static/src/css/test_cssfile2.css',
         })
 
         bundle1 = self._get_asset(self.cssbundle_name)
@@ -562,7 +562,7 @@ class TestJavascriptAssetsBundle(FileTouchable):
         self.env['ir.asset'].create({
             'name': 'test bundle inheritance',
             'bundle': self.cssbundle_name,
-            'glob': 'test_assetsbundle/static/src/css/test_cssfile3.css',
+            'path': 'test_assetsbundle/static/src/css/test_cssfile3.css',
         })
 
         ltr_bundle1 = self._get_asset(self.cssbundle_name)
@@ -732,7 +732,7 @@ class TestAssetsBundleInBrowser(HttpCase):
         self.env['ir.asset'].create({
             'name': 'lol',
             'bundle': 'test_assetsbundle.bundle1',
-            'glob': custom_url,
+            'path': custom_url,
         })
         self.browser_js(
             "/test_assetsbundle/js",
@@ -907,7 +907,7 @@ class TestAssetsManifest(AddonManifestPatched):
         self.env['ir.asset'].create({
             'name': 'test_jsfile4',
             'bundle': 'test_assetsbundle.manifest4',
-            'glob': 'test_assetsbundle/static/src/js/test_jsfile1.js',
+            'path': 'test_assetsbundle/static/src/js/test_jsfile1.js',
         })
         view._render()
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.manifest4.min.js')], order='create_date DESC', limit=1)
@@ -928,7 +928,7 @@ class TestAssetsManifest(AddonManifestPatched):
         self.env['ir.asset'].create({
             'name': 'test_jsfile4',
             'bundle': 'test_assetsbundle.irasset1',
-            'glob': 'test_assetsbundle/static/src/js/test_jsfile1.js',
+            'path': 'test_assetsbundle/static/src/js/test_jsfile1.js',
         })
         view._render()
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.irasset1.min.js')], order='create_date DESC', limit=1)
@@ -948,7 +948,7 @@ class TestAssetsManifest(AddonManifestPatched):
             'bundle': 'test_assetsbundle.manifest1',
             'directive': 'replace',
             'target': 'test_assetsbundle/static/src/js/test_jsfile1.js',
-            'glob': 'http://external.link/external.js',
+            'path': 'http://external.link/external.js',
         })
         rendered = view._render()
         html_tree = lxml.etree.fromstring(rendered)
@@ -978,7 +978,7 @@ class TestAssetsManifest(AddonManifestPatched):
             'name': 'test_jsfile4',
             'bundle': 'test_assetsbundle.manifest4',
             'directive': 'replace',
-            'glob': 'test_assetsbundle/static/src/js/test_jsfile1.js',
+            'path': 'test_assetsbundle/static/src/js/test_jsfile1.js',
             'target': 'test_assetsbundle/static/src/js/test_jsfile3.js',
         })
         view._render()
@@ -998,14 +998,14 @@ class TestAssetsManifest(AddonManifestPatched):
             'name': 'test_jsfile4',
             'directive': 'prepend',
             'bundle': 'test_assetsbundle.manifest4',
-            'glob': 'test_assetsbundle/static/src/js/test_jsfile4.js',
+            'path': 'test_assetsbundle/static/src/js/test_jsfile4.js',
         })
         # asset is now: js_file4 ; js_file3
         self.env['ir.asset'].create({
             'name': 'test_jsfile4',
             'bundle': 'test_assetsbundle.manifest4',
             'directive': 'replace',
-            'glob': 'test_assetsbundle/static/src/js/test_jsfile[12].js',
+            'path': 'test_assetsbundle/static/src/js/test_jsfile[12].js',
             'target': 'test_assetsbundle/static/src/js/test_jsfile[45].js',
         })
         # asset is now: js_file1 ; js_file2 ; js_file3
@@ -1033,7 +1033,7 @@ class TestAssetsManifest(AddonManifestPatched):
             'name': 'test_jsfile4',
             'bundle': 'test_assetsbundle.manifest5',
             'directive': 'remove',
-            'glob': 'test_assetsbundle/static/src/js/test_jsfile2.js',
+            'path': 'test_assetsbundle/static/src/js/test_jsfile2.js',
         })
         view._render()
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.manifest5')], order='create_date DESC', limit=1)
@@ -1056,7 +1056,7 @@ class TestAssetsManifest(AddonManifestPatched):
         self.env['ir.asset'].create({
             'name': 'test_jsfile4',
             'bundle': 'test_assetsbundle.remove_error',
-            'glob': '/test_assetsbundle/static/src/js/test_jsfile1.js',
+            'path': '/test_assetsbundle/static/src/js/test_jsfile1.js',
         })
 
         view = self.make_asset_view('test_assetsbundle.remove_error')
@@ -1064,7 +1064,7 @@ class TestAssetsManifest(AddonManifestPatched):
             'name': 'test_jsfile4',
             'bundle': 'test_assetsbundle.remove_error',
             'directive': 'remove',
-            'glob': 'test_assetsbundle/static/src/js/test_doesntexist.js',
+            'path': 'test_assetsbundle/static/src/js/test_doesntexist.js',
         })
         with self.assertRaises(Exception) as cm:
             view._render()
@@ -1078,7 +1078,7 @@ class TestAssetsManifest(AddonManifestPatched):
             'name': 'test_jsfile4',
             'bundle': 'test_assetsbundle.manifest2',
             'directive': 'remove',
-            'glob': 'test_assetsbundle/static/src/**/*',
+            'path': 'test_assetsbundle/static/src/**/*',
         })
         view._render()
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.manifest2.js')], order='create_date DESC', limit=1)
@@ -1091,7 +1091,7 @@ class TestAssetsManifest(AddonManifestPatched):
             'name': 'test_jsfile4',
             'directive': 'prepend',
             'bundle': 'test_assetsbundle.manifest4',
-            'glob': 'test_assetsbundle/static/src/js/test_jsfile1.js',
+            'path': 'test_assetsbundle/static/src/js/test_jsfile1.js',
         })
         view._render()
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.manifest4')], order='create_date DESC', limit=1)
@@ -1113,7 +1113,7 @@ class TestAssetsManifest(AddonManifestPatched):
             'name': 'test_jsfile4',
             'directive': 'include',
             'bundle': 'test_assetsbundle.irasset_include1',
-            'glob': 'test_assetsbundle.manifest6',
+            'path': 'test_assetsbundle.manifest6',
         })
         view._render()
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.irasset_include1')], order='create_date DESC', limit=1)
@@ -1145,13 +1145,13 @@ class TestAssetsManifest(AddonManifestPatched):
             'name': 'test_jsfile4',
             'directive': 'include',
             'bundle': 'test_assetsbundle.irasset_include1',
-            'glob': 'test_assetsbundle.irasset_include2',
+            'path': 'test_assetsbundle.irasset_include2',
         })
         self.env['ir.asset'].create({
             'name': 'test_jsfile4',
             'directive': 'include',
             'bundle': 'test_assetsbundle.irasset_include2',
-            'glob': 'test_assetsbundle.irasset_include1',
+            'path': 'test_assetsbundle.irasset_include1',
         })
 
         with self.assertRaises(QWebException) as cm:
@@ -1168,30 +1168,30 @@ class TestAssetsManifest(AddonManifestPatched):
             'name': 'test_jsfile4',
             'directive': 'include',
             'bundle': 'test_assetsbundle.irasset_include1',
-            'glob': 'test_assetsbundle.irasset_include2',
+            'path': 'test_assetsbundle.irasset_include2',
         })
         self.env['ir.asset'].create({
             'name': 'test_jsfile4',
             'directive': 'include',
             'bundle': 'test_assetsbundle.irasset_include2',
-            'glob': 'test_assetsbundle.irasset_include3',
+            'path': 'test_assetsbundle.irasset_include3',
         })
         self.env['ir.asset'].create({
             'name': 'test_jsfile4',
             'directive': 'include',
             'bundle': 'test_assetsbundle.irasset_include2',
-            'glob': 'test_assetsbundle.irasset_include4',
+            'path': 'test_assetsbundle.irasset_include4',
         })
         self.env['ir.asset'].create({
             'name': 'test_jsfile4',
             'directive': 'include',
             'bundle': 'test_assetsbundle.irasset_include4',
-            'glob': 'test_assetsbundle.irasset_include3',
+            'path': 'test_assetsbundle.irasset_include3',
         })
         self.env['ir.asset'].create({
             'name': 'test_jsfile4',
             'bundle': 'test_assetsbundle.irasset_include3',
-            'glob': 'test_assetsbundle/static/src/js/test_jsfile1.js',
+            'path': 'test_assetsbundle/static/src/js/test_jsfile1.js',
         })
         view._render()
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.irasset_include1')], order='create_date DESC', limit=1)
@@ -1372,12 +1372,12 @@ class TestAssetsManifest(AddonManifestPatched):
         self.env['ir.asset'].create({
             'name': '1',
             'bundle': 'test_assetsbundle.irasset2',
-            'glob': 'http://external.css/externalstyle.css',
+            'path': 'http://external.css/externalstyle.css',
         })
         self.env['ir.asset'].create({
             'name': '2',
             'bundle': 'test_assetsbundle.irasset2',
-            'glob': 'test_assetsbundle/static/src/css/test_cssfile1.css',
+            'path': 'test_assetsbundle/static/src/css/test_cssfile1.css',
         })
         view = self.make_asset_view('test_assetsbundle.irasset2', {
             't-js': 'false',
@@ -1399,12 +1399,12 @@ class TestAssetsManifest(AddonManifestPatched):
         self.env['ir.asset'].create({
             'name': '1',
             'bundle': 'test_assetsbundle.irasset2',
-            'glob': 'http://external.css/externalstyle.css',
+            'path': 'http://external.css/externalstyle.css',
         })
         self.env['ir.asset'].create({
             'name': '2',
             'bundle': 'test_assetsbundle.irasset2',
-            'glob': 'test_assetsbundle/static/src/scss/test_file1.scss',
+            'path': 'test_assetsbundle/static/src/scss/test_file1.scss',
         })
         view = self.make_asset_view('test_assetsbundle.irasset2', {
             't-js': 'false',
@@ -1561,7 +1561,7 @@ class TestAssetsManifest(AddonManifestPatched):
         self.env['ir.asset'].create({
             'name': '1',
             'bundle': 'test_assetsbundle.bundle4',
-            'glob': '/test_assetsbundle/static/src/js/test_jsfile4.js',
+            'path': '/test_assetsbundle/static/src/js/test_jsfile4.js',
             'target': '/test_assetsbundle/static/src/js/test_jsfile3.js',
             'directive': 'before',
         })
@@ -1590,7 +1590,7 @@ class TestAssetsManifest(AddonManifestPatched):
         self.env['ir.asset'].create({
             'name': '1',
             'bundle': 'test_assetsbundle.bundle4',
-            'glob': '/test_assetsbundle/static/src/js/test_jsfile4.js',
+            'path': '/test_assetsbundle/static/src/js/test_jsfile4.js',
             'target': '/test_assetsbundle/static/src/js/test_jsfile2.js',
             'directive': 'after',
         })
@@ -1619,14 +1619,14 @@ class TestAssetsManifest(AddonManifestPatched):
         self.env['ir.asset'].create({
             'name': '1',
             'bundle': 'test_assetsbundle.bundle4',
-            'glob': '/test_assetsbundle/static/src/js/test_jsfile4.js',
+            'path': '/test_assetsbundle/static/src/js/test_jsfile4.js',
             'target': '/test_assetsbundle/static/src/css/test_cssfile1.css',
             'directive': 'after',
         })
         self.env['ir.asset'].create({
             'name': '1',
             'bundle': 'test_assetsbundle.bundle4',
-            'glob': '/test_assetsbundle/static/src/css/test_cssfile3.css',
+            'path': '/test_assetsbundle/static/src/css/test_cssfile3.css',
             'target': '/test_assetsbundle/static/src/js/test_jsfile2.js',
             'directive': 'before',
         })
@@ -1681,12 +1681,12 @@ class TestAssetsManifest(AddonManifestPatched):
         self.env['ir.asset'].create({
             'name': '1',
             'bundle': 'test_assetsbundle.wrong_path',
-            'glob': '/test_assetsbundle/static/src/js/test_jsfile4.js',
+            'path': '/test_assetsbundle/static/src/js/test_jsfile4.js',
         })
         self.env['ir.asset'].create({
             'name': '1',
             'bundle': 'test_assetsbundle.wrong_path',
-            'glob': '/test_assetsbundle/static/src/js/test_jsfile1.js',
+            'path': '/test_assetsbundle/static/src/js/test_jsfile1.js',
             'target': '/test_assetsbundle/static/src/js/doesnt_exist.js',
             'directive': 'after',
         })
@@ -1701,7 +1701,7 @@ class TestAssetsManifest(AddonManifestPatched):
         self.env['ir.asset'].create({
             'name': '1',
             'bundle': 'test_assetsbundle.manifest4',
-            'glob': '/test_assetsbundle/static/src/*/**',
+            'path': '/test_assetsbundle/static/src/*/**',
             'target': '/test_assetsbundle/static/src/js/test_jsfile3.js',
             'directive': 'after',
         })
@@ -1730,7 +1730,7 @@ class TestAssetsManifest(AddonManifestPatched):
         self.env['ir.asset'].create({
             'name': '1',
             'bundle': 'test_assetsbundle.manifest4',
-            'glob': '/test_assetsbundle/static/src/js/test_jsfile[124].js',
+            'path': '/test_assetsbundle/static/src/js/test_jsfile[124].js',
             'target': '/test_assetsbundle/static/src/js/test_jsfile3.js',
             'directive': 'before',
         })
@@ -1765,7 +1765,7 @@ class TestAssetsManifest(AddonManifestPatched):
         self.env['ir.asset'].create({
             'name': '1',
             'bundle': 'test_assetsbundle.irassetsec',
-            'glob': '/test_assetsbundle/%s' % path_to_dummy,
+            'path': '/test_assetsbundle/%s' % path_to_dummy,
         })
         view = self.make_asset_view('test_assetsbundle.irassetsec')
         view._render()
@@ -1782,7 +1782,7 @@ class TestAssetsManifest(AddonManifestPatched):
         self.env['ir.asset'].create({
             'name': '1',
             'bundle': 'test_assetsbundle.irassetsec',
-            'glob': '/test_assetsbundle/%s' % path_to_dummy,
+            'path': '/test_assetsbundle/%s' % path_to_dummy,
         })
 
         files = self.env['ir.asset']._get_asset_paths('test_assetsbundle.irassetsec', addons=self.installed_modules, xml=False)
@@ -1797,7 +1797,7 @@ class TestAssetsManifest(AddonManifestPatched):
         self.env['ir.asset'].create({
             'name': '1',
             'bundle': 'test_assetsbundle.irassetsec',
-            'glob': '/notinstalled_module/somejsfile.js',
+            'path': '/notinstalled_module/somejsfile.js',
         })
         view = self.make_asset_view('test_assetsbundle.irassetsec')
         with self.assertRaises(QWebException) as cm:
@@ -1809,7 +1809,7 @@ class TestAssetsManifest(AddonManifestPatched):
         self.env['ir.asset'].create({
             'name': '1',
             'bundle': 'test_assetsbundle.irassetsec',
-            'glob': '/notinstalled_module/somejsfile.js',
+            'path': '/notinstalled_module/somejsfile.js',
         })
         self.make_asset_view('test_assetsbundle.irassetsec')
         attach = self.env['ir.attachment'].search([('name', 'ilike', 'test_assetsbundle.irassetsec')], order='create_date DESC', limit=1)
@@ -1820,7 +1820,7 @@ class TestAssetsManifest(AddonManifestPatched):
         self.env['ir.asset'].create({
             'name': '1',
             'bundle': 'test_assetsbundle.irassetsec',
-            'glob': '/test_assetsbundle/__manifest__.py',
+            'path': '/test_assetsbundle/__manifest__.py',
         })
         view = self.make_asset_view('test_assetsbundle.irassetsec')
         view._render()
@@ -1832,7 +1832,7 @@ class TestAssetsManifest(AddonManifestPatched):
         self.env['ir.asset'].create({
             'name': '1',
             'bundle': 'test_assetsbundle.irassetsec',
-            'glob': '/test_assetsbundle/data/ir_asset.xml',
+            'path': '/test_assetsbundle/data/ir_asset.xml',
         })
         files = self.env['ir.asset']._get_asset_paths('test_assetsbundle.irassetsec', addons=self.installed_modules, xml=False)
         self.assertFalse(files)
@@ -1841,7 +1841,7 @@ class TestAssetsManifest(AddonManifestPatched):
         self.env['ir.asset'].create({
             'name': '1',
             'bundle': 'test_assetsbundle.irassetsec',
-            'glob': '/test_assetsbundle/static/accessible.xml',
+            'path': '/test_assetsbundle/static/accessible.xml',
         })
         files = self.env['ir.asset']._get_asset_paths('test_assetsbundle.irassetsec', addons=self.installed_modules, xml=False)
         self.assertEqual(len(files), 1)
@@ -1866,7 +1866,7 @@ class TestAssetsManifest(AddonManifestPatched):
         self.env['ir.asset'].create({
             'name': '1',
             'bundle': 'test_assetsbundle.irasset_custom_attach',
-            'glob': 'test_assetsbundle/my_style_attach.scss',
+            'path': 'test_assetsbundle/my_style_attach.scss',
         })
         view = self.make_asset_view('test_assetsbundle.irasset_custom_attach', {'t-css': True})
         view._render()


### PR DESCRIPTION
Backport of odoo/odoo#68695

Rationale:
The majority of cases where an ir.asset is manually declared
outside of manifest files is to specifically add a single asset file.
This means developers are specifying a single asset *path*, and not a
glob expression. In this context, it seems better to name the filepath
field `path`, and document that it can be specified with a glob
expression when (seldom) needed, rather than making the exception appear
to be the norm - possibly puzzling many developers (What's a glob and
why do I need one?)

The doc is updated as well, and some spell-checking and wording
improvements were done too.

This required some adaptations to the existing `ir.asset` declarations:
- odoo/enterprise#17544
- odoo/design-themes#460