### PR TITLE
[FIX] base: Traceback with address layout in reports

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -20647,6 +20647,12 @@ msgid "The internal user in charge of this contact."
 msgstr ""
 
 #. module: base
+#: code:addons/base/models/res_country.py:106
+#, python-format
+msgid "The layout contains an invalid format key"
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_model__inherited_model_ids
 msgid "The list of models that extends the current model."
 msgstr ""


### PR DESCRIPTION
What are the steps to reproduce your issue ?

    1. Go to Contacts > Configuration > Localization > Countries > Select a country
    2. Edit the 'Layout in reports' (enable debug mode) and add an invalid field
    3. Create a Quotation and search for a customer from the country you edited.

What is currently happening ?

    Traceback is raised and you can't select the customer anymore

Why is this happening ?

    Because the key is not defined.

How to fix the bug ?

    Handle KeyError to detect if the user put an undefined key
    Handle ValueError to detect if the user put an invalid format key

Behavior with this commit:

https://user-images.githubusercontent.com/77889661/113974009-8400bd00-983d-11eb-8f8f-e363d9b35c88.mp4


opw-2447078


