### PR TITLE
[FIX] web_studio: trackback in reports

### DIFF
--- a/addons/product/report/product_pricelist_report.py
+++ b/addons/product/report/product_pricelist_report.py
@@ -9,6 +9,9 @@ class report_product_pricelist(models.AbstractModel):
     _description = 'Pricelist Report'
 
     def _get_report_values(self, docids, data):
+        if 'active_ids' not in data:
+            return self._get_report_data(False, False, False, False, 'pdf')
+
         product_ids = [int(i) for i in data['active_ids'].split(',')]
         pricelist_id = data['pricelist_id'] and int(data['pricelist_id']) or None
         quantities = [int(i) for i in data['quantities'].split(',')] or [1]
@@ -26,6 +29,14 @@ class report_product_pricelist(models.AbstractModel):
 
     def _get_report_data(self, active_model, active_ids, pricelist_id, quantities, report_type='html'):
         products = []
+        if not active_model:
+            return {
+                'pricelist': self.env['product.pricelist'],
+                'products': products,
+                'quantities': quantities,
+                'is_product_tmpl': False,
+                'is_html_type': report_type == 'html',
+            }
         is_product_tmpl = active_model == 'product.template'
 
         ProductClass = self.env['product.template'] if is_product_tmpl else self.env['product.product']

--- a/addons/product/report/product_pricelist_report.py
+++ b/addons/product/report/product_pricelist_report.py
@@ -10,7 +10,13 @@ class report_product_pricelist(models.AbstractModel):
 
     def _get_report_values(self, docids, data):
         if 'active_ids' not in data:
-            return self._get_report_data(False, False, False, False, 'pdf')
+            return {
+                'pricelist': self.env['product.pricelist'],
+                'products': [],
+                'quantities': [],
+                'is_product_tmpl': False,
+                'is_html_type': False,
+            }
 
         product_ids = [int(i) for i in data['active_ids'].split(',')]
         pricelist_id = data['pricelist_id'] and int(data['pricelist_id']) or None
@@ -29,14 +35,6 @@ class report_product_pricelist(models.AbstractModel):
 
     def _get_report_data(self, active_model, active_ids, pricelist_id, quantities, report_type='html'):
         products = []
-        if not active_model:
-            return {
-                'pricelist': self.env['product.pricelist'],
-                'products': products,
-                'quantities': quantities,
-                'is_product_tmpl': False,
-                'is_html_type': report_type == 'html',
-            }
         is_product_tmpl = active_model == 'product.template'
 
         ProductClass = self.env['product.template'] if is_product_tmpl else self.env['product.product']

--- a/addons/stock/report/report_stock_rule.py
+++ b/addons/stock/report/report_stock_rule.py
@@ -14,7 +14,7 @@ class ReportStockRule(models.AbstractModel):
         if 'product_id' not in data:
             return {
                 'docs': self.env['product.product'],
-                'locations': [],
+                'locations': self.env['stock.location'],
                 'header_lines': {},
                 'route_lines': [],
             }

--- a/addons/stock/report/report_stock_rule.py
+++ b/addons/stock/report/report_stock_rule.py
@@ -11,6 +11,14 @@ class ReportStockRule(models.AbstractModel):
 
     @api.model
     def _get_report_values(self, docids, data=None):
+        if 'product_id' not in data:
+            return {
+                'docs': self.env['product.product'],
+                'locations': [],
+                'header_lines': {},
+                'route_lines': [],
+            }
+
         product = self.env['product.product'].browse(data['product_id'])
         warehouses = self.env['stock.warehouse'].browse(data['warehouse_ids'])
 


### PR DESCRIPTION
currently,
when we try to edit reports 281.50 PDF(contacts), PRODUCT ROUTES REPORT
(inventory-> product), PRICELIST(inventory->product variant), 281.45 PDF
(payroll), INDIVIDUAL ACCOUNT(payroll) it give trace back.

after this commit,
when we try to edit reports 281.50 PDF(contacts), PRODUCT ROUTES REPORT
(inventory-> product), PRICELIST(inventory->product variant),
281.45 PDF(payroll), INDIVIDUAL ACCOUNT(payroll) it does not give trace back.
this was happening because when we try to edit this reports no record is
selected and xml try to print the value that were not passed. to solve this
issue , explicitly pass those value to false or empty object.

task-2329486

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
