### PR TITLE
[FIX] website: make configurator IAP call failures silent

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -18,7 +18,7 @@ from odoo.addons.http_routing.models.ir_http import slugify, _guess_mimetype, ur
 from odoo.addons.website.models.ir_http import sitemap_qs2dom
 from odoo.addons.portal.controllers.portal import pager
 from odoo.addons.iap.tools import iap_tools
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, AccessError
 from odoo.http import request
 from odoo.modules.module import get_resource_path
 from odoo.osv.expression import FALSE_DOMAIN
@@ -268,7 +268,11 @@ class Website(models.Model):
         r['logo'] = False
         if company_id.logo and company_id.logo != company_id._get_logo():
             r['logo'] = company_id.logo.decode('utf-8')
-        r['industries'] = self._website_api_rpc('/api/website/1/configurator/industries', {'lang': self.env.user.lang})['industries']
+        try:
+            result = self._website_api_rpc('/api/website/1/configurator/industries', {'lang': self.env.user.lang})
+            r['industries'] = result['industries']
+        except AccessError as e:
+            logger.warning(e.args[0])
         return r
 
     @api.model

--- a/addons/website/static/src/components/configurator/configurator.js
+++ b/addons/website/static/src/components/configurator/configurator.js
@@ -388,14 +388,10 @@ const actions = {
 async function getInitialState() {
 
     // Load values from python and iap
-    try {
-        var results = await rpc.query({
-            model: 'website',
-            method: 'configurator_init',
-        });
-    } catch (_e) {
-        return {};
-    }
+    var results = await rpc.query({
+        model: 'website',
+        method: 'configurator_init',
+    });
     const r = {
         features: {},
         industries: results.industries,


### PR DESCRIPTION
On initialization, the website configurator makes a
call to an external service (api_website) hosted on
iap-services.odoo.com to retrieve a list of industries.
This call might fail if the external service is done.
This potential failure is now correctly handled:

On '/api/website/1/configurator/industries' call
failure, the configurator is silently skipped and the
user is redirected to the view website.theme_view_kanban

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
