### PR TITLE
[FIX] stock: inventory adjustement for user

### DIFF
--- a/addons/stock/tests/test_warehouse.py
+++ b/addons/stock/tests/test_warehouse.py
@@ -2,7 +2,7 @@
 
 from odoo.addons.stock.tests.common2 import TestStockCommon
 from odoo.tests import Form
-from odoo.exceptions import AccessError
+from odoo.exceptions import UserError
 from odoo.tools import mute_logger
 
 
@@ -83,15 +83,8 @@ class TestWarehouse(TestStockCommon):
             'new_quantity': 50.0,
         })
         # User has no right on quant, must raise an AccessError
-        with self.assertRaises(AccessError):
+        with self.assertRaises(UserError):
             inventory_wizard.change_product_qty()
-        # Check quantity wasn't updated
-        self.assertEqual(self.product_1.virtual_available, 0.0)
-        self.assertEqual(self.product_1.qty_available, 0.0)
-
-        # Check associated quants: 0 quant expected
-        quant = self.env['stock.quant'].search([('id', 'not in', self.existing_quants.ids)])
-        self.assertEqual(len(quant), 0)
 
     def test_basic_move(self):
         product = self.product_3.with_user(self.user_stock_manager)

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -359,7 +359,7 @@
                 <field name="inventory_date" optional="show"/>
                 <field name="user_id" string="User" optional="show"/>
                 <field name='company_id' groups="base.group_multi_company" optional="hide"/>
-                <button name="action_apply_inventory" type="object" string="Apply" class="btn btn-link" icon="fa-save" attrs="{'invisible': [('inventory_diff_quantity', '=', 0), ('inventory_quantity', '=', 0), ('quantity', '!=', 0)]}"/>
+                <button name="action_apply_inventory" groups="stock.group_stock_manager" type="object" string="Apply" class="btn btn-link" icon="fa-save" attrs="{'invisible': [('inventory_diff_quantity', '=', 0), ('inventory_quantity', '=', 0), ('quantity', '!=', 0)]}"/>
                 <button name="action_set_inventory_quantity" type="object" string="Set" class="btn btn-link" icon="fa-bullseye" attrs="{'invisible': ['|',  '|', ('quantity', '=', 0.0), ('inventory_diff_quantity', '!=', 0), ('inventory_quantity', '!=', 0)]}"/>
                 <button name="action_inventory_history" type="object" class="btn btn-link" icon="fa-history" string="History"/>
                 <button name="action_set_inventory_quantity_to_zero" type="object" string="Reset" class="btn" icon="fa-times" attrs="{'invisible': [('inventory_diff_quantity', '=', 0), ('inventory_quantity', '=', 0), ('quantity', '!=', 0)]}"/>


### PR DESCRIPTION
Fix the access for stock user to stock.quant.
Since the inventory adjustement feature has been moved on
the stock.quant. The user should be able to write on them to
make their count. However we kept that a stock user can't validate
an inventory nor modify quantities on product

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
