### PR TITLE
[FIX] mass_mailing: Remove underlining for all hyperlinks in mass mailing e-mail template

### DIFF
--- a/addons/mass_mailing/static/src/css/basic_theme_readonly.css
+++ b/addons/mass_mailing/static/src/css/basic_theme_readonly.css
@@ -5,3 +5,13 @@
 #wrapwrap .o_layout.o_basic_theme {
     font-family: -apple-system, "HelveticaNeue", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
 }
+
+/* We don't want all links in the mass mail template to be underlined by default. This removes underlining for
+   most compatible browsers.
+*/
+a:link, a:visited {
+    text-decoration: none;
+}
+a:hover {
+    text-decoration: underline;
+}


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
When we save the mailing record all links are underlined. This is due to the browser's default user agent stylesheet, and is inconsistent behaviour.

**Current behavior before PR:**
When we save the mailing record all links are underlined regardless of their state. 

**Desired behavior after PR is merged:**
When we save the mailing record no links are underlined by default, only when hovering over them.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
