### PR TITLE
[FIX] website: hide the cookie bar when entering edit mode 

### DIFF
--- a/addons/website/static/src/snippets/s_popup/000.js
+++ b/addons/website/static/src/snippets/s_popup/000.js
@@ -28,6 +28,7 @@ const PopupWidget = publicWidget.Widget.extend({
     destroy: function () {
         this._super.apply(this, arguments);
         $(document).off('mouseleave.open_popup');
+        this.$target.find('.modal').modal('hide');
         clearTimeout(this.timeout);
     },
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The cookie bar alter the behaviour of the web_editor, messing the cookie bar up

Current behavior before PR:
When a user enables the cookie bar, the drop zone for snippets becomes the cookie bar and every snippets a user drops will end up in the cookie bar until he hides it. The cookie bar doesn't treat snippets nicely.

Desired behavior after PR is merged:
When the users enables the editor the cookie bar is hidden.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
