### PR TITLE
[FIX] web: prevents error on duplicating browser tab

### DIFF
--- a/addons/web/static/src/js/chrome/action_manager_act_window.js
+++ b/addons/web/static/src/js/chrome/action_manager_act_window.js
@@ -75,7 +75,7 @@ ActionManager.include({
                     // jQuery's BBQ plugin does some parsing on values that are valid integers
                     // which means that if there's only one item, it will do parseInt() on it,
                     // otherwise it will keep the comma seperated list as string
-                    context.active_ids = state.active_ids.split(',').map(function (id) {
+                    context.active_ids = state.active_ids.toString().split(',').map(function (id) {
                         return parseInt(id, 10) || id;
                     });
                 } else if (state.active_id) {

--- a/addons/web/static/tests/chrome/action_manager_tests.js
+++ b/addons/web/static/tests/chrome/action_manager_tests.js
@@ -1167,6 +1167,26 @@ QUnit.module('ActionManager', {
         actionManager.destroy();
     });
 
+    QUnit.test('state with integer active_ids should not crash', function (assert) {
+        assert.expect(0);
+
+        var actionManager = createActionManager({
+            actions: this.actions,
+            mockRPC: function (route, args) {
+                if (route === '/web/action/run') {
+                    return $.when();
+                }
+                return this._super.apply(this, arguments);
+            },
+        });
+        actionManager.loadState({
+            action: 2,
+            active_ids: 3,
+        });
+
+        actionManager.destroy();
+    });
+
     QUnit.module('Concurrency management');
 
     QUnit.test('drop previous actions if possible', function (assert) {


### PR DESCRIPTION
In eg. 13.0 when refreshing sales analysis action of a product, we would
get an error because we have a single active_ids which is not expected
by the code.

With this commit, we use .toString() on the jQuery BBQ parsed active_ids
as it was done before 32b8cec refactoring (january 2018).

The added test with the fix fails with an error:

  TypeError: state.active_ids.split is not a function
  at Class.loadState (/web/static/src/js/chrome/action_manager_act_window.js)

opw-2471982
