### PR TITLE
[FIX] web_editor: re-implement focus method

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/odoo-editor.js
+++ b/addons/web_editor/static/lib/odoo-editor/odoo-editor.js
@@ -3073,6 +3073,20 @@ var exportVariable = (function (exports) {
             this.dispatchEvent(new Event('historyRevert'));
         }
 
+        /**
+         * Place the cursor on the last known cursor position from the history steps.
+         *
+         * @returns {boolean}
+         */
+        resetCursorOnLastHistoryCursor() {
+            const lastHistoryStep = this._historySteps[this._historySteps.length - 1];
+            if (lastHistoryStep && lastHistoryStep.cursor && lastHistoryStep.cursor.anchorNode) {
+                this.historySetCursor(lastHistoryStep);
+                return true;
+            }
+            return false;
+        }
+
         historySetCursor(step) {
             if (step.cursor && step.cursor.anchorNode) {
                 const anchorNode = this.idFind(step.cursor.anchorNode);
@@ -3388,11 +3402,11 @@ var exportVariable = (function (exports) {
         }
 
         _insertHTML(data) {
-            this._insert(data, false);
+            return this._insert(data, false);
         }
 
         _insertText(data) {
-            this._insert(data);
+            return this._insert(data);
         }
 
         /**

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -396,6 +396,25 @@ const Wysiwyg = Widget.extend({
         this.odooEditor.historyRedo();
     },
     /**
+     * Focus inside the editor.
+     *
+     * Set cursor to the editor latest position before blur or to the last editable node, ready to type.
+     */
+    focus: function () {
+        if(!this.odooEditor.resetCursorOnLastHistoryCursor()) {
+            // If the editor don't have an history step to focus to,
+            // We place the cursor after the end of the editor exiting content.
+            const range = document.createRange();
+            const elementToTarget = this.$editable[0].lastElementChild ? this.$editable[0].lastElementChild : this.$editable[0];
+            range.selectNodeContents(elementToTarget);
+            range.collapse();
+
+            const selection = this.odooEditor.document.getSelection();
+            selection.removeAllRanges();
+            selection.addRange(range);
+        }
+    },
+    /**
      * Start or resume the Odoo field changes muation observers.
      *
      * Necessary to keep all copies of a given field at the same value throughout the page.


### PR DESCRIPTION
Focus is sometimes called on the Wysiwyg class in Note.
When the user use TAB to select the next field.

Implementation was missing.

Related Odoo task : https://www.odoo.com/web#id=2499663&action=333&active_id=1695&model=project.task&view_type=form&cids=1&menu_id=4720

:arrow_right:  Build of the editor lib

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
