### PR TITLE
[FIX] Tools: Improve error message about wrong addons path

### DIFF
--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -556,7 +556,7 @@ class configmanager(object):
             path = path.strip()
             res = os.path.abspath(os.path.expanduser(path))
             if not os.path.isdir(res):
-                raise optparse.OptionValueError("option %s: no such directory: %r" % (opt, path))
+                raise optparse.OptionValueError("option %s: no such directory: %r" % (opt, res))
             if not self._is_addons_path(res):
                 raise optparse.OptionValueError("option %s: the path %r is not a valid addons directory" % (opt, path))
             ad_paths.append(res)


### PR DESCRIPTION
Show full path to not found addons folder to ease debugging.
Right now if you misconfigure the addons path, the error message only shows the configured folder name, without the full path.
Showing a full path in the error makes debugging much easier, especially when using relative addons paths like: '../my-addons'.

Often users try to call `odoo-bin` from different folder then the one where `odoo-bin` is located (assumming that relative paths will be resolved relatively to odoo-bin location and not the current working directory).

Showing full path will help them debug and spot the error.

Current behavior before PR:

error: option --addons-path: no such directory: '../non-existing'

Desired behavior after PR is merged:

error: option --addons-path: no such directory: '/home/user/Odoo/non-existing'



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
