### PR TITLE
[FIX] portal: fix ACL issue during the revocation of the portal group

### DIFF
--- a/addons/portal/wizard/portal_wizard.py
+++ b/addons/portal/wizard/portal_wizard.py
@@ -167,7 +167,7 @@ class PortalWizardUser(models.TransientModel):
             self.partner_id.write({'email': self.email})
 
         # Remove the sign up token, so it can not be used
-        self.partner_id.signup_token = False
+        self.partner_id.sudo().signup_token = False
 
         user_sudo = self.user_id.sudo()
 


### PR DESCRIPTION
Bug
===
1. Login as Demo user (no admin access right)
2. Grant the portal access to a partner
3. Revoke the access

An access error is raised.

Task 2501250