### PR TITLE
[IMP] l10n_latam_invoice_document: remove fields and compute methods

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1640,10 +1640,10 @@ class AccountMove(models.Model):
                 move.tax_totals_json = None
                 continue
 
-            tax_lines_data, amount_untaxed = move._prepare_tax_lines_data_for_totals_from_invoice()
+            tax_lines_data = move._prepare_tax_lines_data_for_totals_from_invoice()
 
             move.tax_totals_json = json.dumps({
-                **self._get_tax_totals(move.partner_id, tax_lines_data, move.amount_total, amount_untaxed, move.currency_id),
+                **self._get_tax_totals(move.partner_id, tax_lines_data, move.amount_total, move.amount_untaxed, move.currency_id),
                 'allow_tax_edition': move.is_purchase_document(include_receipts=False) and move.state == 'draft',
             })
 
@@ -1660,15 +1660,11 @@ class AccountMove(models.Model):
         """
         self.ensure_one()
 
-        taxes_filtered = tax_line_id_filter or tax_ids_filter
-        filtered_amount_untaxed = self.amount_total
-
         tax_line_id_filter = tax_line_id_filter or (lambda aml, tax: True)
         tax_ids_filter = tax_ids_filter or (lambda aml, tax: True)
 
         balance_multiplicator = -1 if self.is_inbound() else 1
         tax_lines_data = []
-
 
         for line in self.line_ids:
             if line.tax_line_id and tax_line_id_filter(line, line.tax_line_id):
@@ -1677,7 +1673,6 @@ class AccountMove(models.Model):
                     'tax_amount': line.amount_currency * balance_multiplicator,
                     'tax': line.tax_line_id,
                 })
-                filtered_amount_untaxed -= line.amount_currency * balance_multiplicator
 
             if line.tax_ids:
                 for base_tax in line.tax_ids.flatten_taxes_hierarchy():
@@ -1689,12 +1684,7 @@ class AccountMove(models.Model):
                             'tax_affecting_base': line.tax_line_id,
                         })
 
-        if taxes_filtered:
-            amount_untaxed = self.currency_id.round(filtered_amount_untaxed)
-        else:
-            amount_untaxed = self.amount_untaxed
-
-        return tax_lines_data, amount_untaxed
+        return tax_lines_data
 
     @api.model
     def _prepare_tax_lines_data_for_totals_from_object(self, object_lines, tax_results_function):

--- a/addons/l10n_ar/models/__init__.py
+++ b/addons/l10n_ar/models/__init__.py
@@ -15,3 +15,4 @@ from . import res_partner_bank
 from . import uom_uom
 from . import account_chart_template
 from . import account_move
+from . import account_move_line

--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import models, fields, api, _
 from odoo.exceptions import UserError, RedirectWarning, ValidationError
-from odoo.tools.misc import formatLang
 from dateutil.relativedelta import relativedelta
 import logging
 _logger = logging.getLogger(__name__)
@@ -294,73 +293,14 @@ class AccountMove(models.Model):
             return 'l10n_ar.report_invoice_document'
         return super()._get_name_invoice_report()
 
-    def _l10n_ar_amount_and_taxes(self):
+    def _prepare_tax_lines_data_for_totals_from_invoice(self, tax_line_id_filter=None, tax_ids_filter=None):
+        if self.company_id.account_fiscal_country_id.code == 'AR' and self._l10n_ar_include_vat() and (
+                'commit_assetsbundle' in self.env.context or not self.env.context.get('params', {}).get('view_type') == 'form'):
+            tax_ids_filter = (lambda aml, tax: not bool(tax.tax_group_id.l10n_ar_vat_afip_code))
+            tax_line_id_filter = (lambda aml, tax: not bool(tax.tax_group_id.l10n_ar_vat_afip_code))
+        return super()._prepare_tax_lines_data_for_totals_from_invoice(
+            tax_line_id_filter=tax_line_id_filter, tax_ids_filter=tax_ids_filter)
+
+    def _l10n_ar_include_vat(self):
         self.ensure_one()
-        res = {}
-        if self.is_invoice():
-            tax_lines = self.line_ids.filtered('tax_line_id')
-            included_taxes = self.l10n_latam_document_type_id and \
-                self.l10n_latam_document_type_id._filter_taxes_included(tax_lines.mapped('tax_line_id'))
-            if not included_taxes:
-                amount_untaxed = self.amount_untaxed
-                not_included_invoice_taxes = tax_lines
-            else:
-                included_invoice_taxes = tax_lines.filtered(lambda x: x.tax_line_id in included_taxes)
-                not_included_invoice_taxes = tax_lines - included_invoice_taxes
-                sign = -1 if self.is_inbound() else 1
-                amount_untaxed = self.amount_untaxed + sign * sum(included_invoice_taxes.mapped('balance'))
-            res['amount_untaxed'] = amount_untaxed
-            res['tax_lines'] = not_included_invoice_taxes
-        else:
-            res['amount_untaxed'] = False
-            res['tax_lines'] = self.env['account.move.line']
-
-        return res
-
-    def _compute_invoice_taxes_by_group(self):
-        report_or_portal_view = 'commit_assetsbundle' in self.env.context or \
-            not self.env.context.get('params', {}).get('view_type') == 'form'
-        if not report_or_portal_view:
-            return super()._compute_invoice_taxes_by_group()
-
-        move_with_doc_type = self.filtered('l10n_latam_document_type_id')
-        for move in move_with_doc_type:
-            lang_env = move.with_context(lang=move.partner_id.lang).env
-            tax_lines = move._l10n_ar_amount_and_taxes()['tax_lines']
-            tax_balance_multiplicator = -1 if move.is_inbound(True) else 1
-            res = {}
-            # There are as many tax line as there are repartition lines
-            done_taxes = set()
-            for line in tax_lines:
-                res.setdefault(line.tax_line_id.tax_group_id, {'base': 0.0, 'amount': 0.0})
-                res[line.tax_line_id.tax_group_id]['amount'] += tax_balance_multiplicator * (line.amount_currency if line.currency_id else line.balance)
-                tax_key_add_base = tuple(move._get_tax_key_for_group_add_base(line))
-                if tax_key_add_base not in done_taxes:
-                    if line.currency_id and line.company_currency_id and line.currency_id != line.company_currency_id:
-                        amount = line.company_currency_id._convert(line.tax_base_amount, line.currency_id, line.company_id, line.date or fields.Date.today())
-                    else:
-                        amount = line.tax_base_amount
-                    res[line.tax_line_id.tax_group_id]['base'] += amount
-                    # The base should be added ONCE
-                    done_taxes.add(tax_key_add_base)
-
-            # At this point we only want to keep the taxes with a zero amount since they do not
-            # generate a tax line.
-            zero_taxes = set()
-            for line in move.line_ids:
-                for tax in line._l10n_ar_prices_and_taxes()['taxes'].flatten_taxes_hierarchy():
-                    if tax.tax_group_id not in res or tax.id in zero_taxes:
-                        res.setdefault(tax.tax_group_id, {'base': 0.0, 'amount': 0.0})
-                        res[tax.tax_group_id]['base'] += tax_balance_multiplicator * (line.amount_currency if line.currency_id else line.balance)
-                        zero_taxes.add(tax.id)
-
-            res = sorted(res.items(), key=lambda l: l[0].sequence)
-            move.amount_by_group = [(
-                group.name, amounts['amount'],
-                amounts['base'],
-                formatLang(lang_env, amounts['amount'], currency_obj=move.currency_id),
-                formatLang(lang_env, amounts['base'], currency_obj=move.currency_id),
-                len(res),
-                group.id
-            ) for group, amounts in res]
-        super(AccountMove, self - move_with_doc_type)._compute_invoice_taxes_by_group()
+        return self.l10n_latam_document_type_id.l10n_ar_letter in ['B', 'C', 'X', 'R']

--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -1,8 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import models, fields, api, _
 from odoo.exceptions import UserError, RedirectWarning, ValidationError
+from odoo.tools.misc import formatLang
 from dateutil.relativedelta import relativedelta
-from lxml import etree
 import logging
 _logger = logging.getLogger(__name__)
 
@@ -293,3 +293,73 @@ class AccountMove(models.Model):
         if self.l10n_latam_use_documents and self.company_id.account_fiscal_country_id.code == 'AR':
             return 'l10n_ar.report_invoice_document'
         return super()._get_name_invoice_report()
+
+    def _l10n_ar_amount_and_taxes(self):
+        self.ensure_one()
+        res = {}
+        if self.is_invoice():
+            tax_lines = self.line_ids.filtered('tax_line_id')
+            included_taxes = self.l10n_latam_document_type_id and \
+                self.l10n_latam_document_type_id._filter_taxes_included(tax_lines.mapped('tax_line_id'))
+            if not included_taxes:
+                l10n_latam_amount_untaxed = self.amount_untaxed
+                not_included_invoice_taxes = tax_lines
+            else:
+                included_invoice_taxes = tax_lines.filtered(lambda x: x.tax_line_id in included_taxes)
+                not_included_invoice_taxes = tax_lines - included_invoice_taxes
+                sign = -1 if self.is_inbound() else 1
+                l10n_latam_amount_untaxed = self.amount_untaxed + sign * sum(included_invoice_taxes.mapped('balance'))
+            res['l10n_latam_amount_untaxed'] = l10n_latam_amount_untaxed
+            res['l10n_latam_tax_ids'] = not_included_invoice_taxes
+        else:
+            res['l10n_latam_amount_untaxed'] = False
+            res['l10n_latam_tax_ids'] = [(5, 0)]
+        return res
+
+    def _compute_invoice_taxes_by_group(self):
+        report_or_portal_view = 'commit_assetsbundle' in self.env.context or \
+            not self.env.context.get('params', {}).get('view_type') == 'form'
+        if not report_or_portal_view:
+            return super()._compute_invoice_taxes_by_group()
+
+        move_with_doc_type = self.filtered('l10n_latam_document_type_id')
+        for move in move_with_doc_type:
+            lang_env = move.with_context(lang=move.partner_id.lang).env
+            tax_lines = move._l10n_ar_amount_and_taxes()['l10n_latam_tax_ids']
+            tax_balance_multiplicator = -1 if move.is_inbound(True) else 1
+            res = {}
+            # There are as many tax line as there are repartition lines
+            done_taxes = set()
+            for line in tax_lines:
+                res.setdefault(line.tax_line_id.tax_group_id, {'base': 0.0, 'amount': 0.0})
+                res[line.tax_line_id.tax_group_id]['amount'] += tax_balance_multiplicator * (line.amount_currency if line.currency_id else line.balance)
+                tax_key_add_base = tuple(move._get_tax_key_for_group_add_base(line))
+                if tax_key_add_base not in done_taxes:
+                    if line.currency_id and line.company_currency_id and line.currency_id != line.company_currency_id:
+                        amount = line.company_currency_id._convert(line.tax_base_amount, line.currency_id, line.company_id, line.date or fields.Date.today())
+                    else:
+                        amount = line.tax_base_amount
+                    res[line.tax_line_id.tax_group_id]['base'] += amount
+                    # The base should be added ONCE
+                    done_taxes.add(tax_key_add_base)
+
+            # At this point we only want to keep the taxes with a zero amount since they do not
+            # generate a tax line.
+            zero_taxes = set()
+            for line in move.line_ids:
+                for tax in line._l10n_ar_prices_and_taxes()['l10n_latam_tax_ids'].flatten_taxes_hierarchy():
+                    if tax.tax_group_id not in res or tax.id in zero_taxes:
+                        res.setdefault(tax.tax_group_id, {'base': 0.0, 'amount': 0.0})
+                        res[tax.tax_group_id]['base'] += tax_balance_multiplicator * (line.amount_currency if line.currency_id else line.balance)
+                        zero_taxes.add(tax.id)
+
+            res = sorted(res.items(), key=lambda l: l[0].sequence)
+            move.amount_by_group = [(
+                group.name, amounts['amount'],
+                amounts['base'],
+                formatLang(lang_env, amounts['amount'], currency_obj=move.currency_id),
+                formatLang(lang_env, amounts['base'], currency_obj=move.currency_id),
+                len(res),
+                group.id
+            ) for group, amounts in res]
+        super(AccountMove, self - move_with_doc_type)._compute_invoice_taxes_by_group()

--- a/addons/l10n_ar/models/account_move_line.py
+++ b/addons/l10n_ar/models/account_move_line.py
@@ -9,17 +9,13 @@ class AccountMoveLine(models.Model):
     def _l10n_ar_prices_and_taxes(self):
         self.ensure_one()
         invoice = self.move_id
-        included_taxes = \
-            invoice.l10n_latam_document_type_id and invoice.l10n_latam_document_type_id._filter_taxes_included(
-                self.tax_ids)
+        included_taxes = self.tax_ids.filtered('tax_group_id.l10n_ar_vat_afip_code') if self.move_id._l10n_ar_include_vat() else self.tax_ids
         if not included_taxes:
             price_unit = self.tax_ids.with_context(round=False).compute_all(
                 self.price_unit, invoice.currency_id, 1.0, self.product_id, invoice.partner_id)
             price_unit = price_unit['total_excluded']
-            not_included_taxes = self.tax_ids
             price_subtotal = self.price_subtotal
         else:
-            not_included_taxes = self.tax_ids - included_taxes
             price_unit = included_taxes.compute_all(
                 self.price_unit, invoice.currency_id, 1.0, self.product_id, invoice.partner_id)['total_included']
             price = self.price_unit * (1 - (self.discount or 0.0) / 100.0)
@@ -28,8 +24,7 @@ class AccountMoveLine(models.Model):
         price_net = price_unit * (1 - (self.discount or 0.0) / 100.0)
 
         return {
-            'taxes': not_included_taxes,
             'price_unit': price_unit,
             'price_subtotal': price_subtotal,
-            'price_net': price_net
+            'price_net': price_net,
         }

--- a/addons/l10n_ar/models/account_move_line.py
+++ b/addons/l10n_ar/models/account_move_line.py
@@ -1,0 +1,35 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+
+class AccountMoveLine(models.Model):
+
+    _inherit = 'account.move.line'
+
+    def _l10n_ar_prices_and_taxes(self):
+        self.ensure_one()
+        invoice = self.move_id
+        included_taxes = \
+            invoice.l10n_latam_document_type_id and invoice.l10n_latam_document_type_id._filter_taxes_included(
+                self.tax_ids)
+        if not included_taxes:
+            price_unit = self.tax_ids.with_context(round=False).compute_all(
+                self.price_unit, invoice.currency_id, 1.0, self.product_id, invoice.partner_id)
+            l10n_latam_price_unit = price_unit['total_excluded']
+            not_included_taxes = self.tax_ids
+            l10n_latam_price_subtotal = self.price_subtotal
+        else:
+            not_included_taxes = self.tax_ids - included_taxes
+            l10n_latam_price_unit = included_taxes.compute_all(
+                self.price_unit, invoice.currency_id, 1.0, self.product_id, invoice.partner_id)['total_included']
+            price = self.price_unit * (1 - (self.discount or 0.0) / 100.0)
+            l10n_latam_price_subtotal = included_taxes.compute_all(
+                price, invoice.currency_id, self.quantity, self.product_id, invoice.partner_id)['total_included']
+        l10n_latam_price_net = l10n_latam_price_unit * (1 - (self.discount or 0.0) / 100.0)
+
+        return {
+            'l10n_latam_tax_ids': not_included_taxes,
+            'l10n_latam_price_unit': l10n_latam_price_unit,
+            'l10n_latam_price_subtotal': l10n_latam_price_subtotal,
+            'l10n_latam_price_net': l10n_latam_price_net
+        }

--- a/addons/l10n_ar/models/account_move_line.py
+++ b/addons/l10n_ar/models/account_move_line.py
@@ -15,21 +15,21 @@ class AccountMoveLine(models.Model):
         if not included_taxes:
             price_unit = self.tax_ids.with_context(round=False).compute_all(
                 self.price_unit, invoice.currency_id, 1.0, self.product_id, invoice.partner_id)
-            l10n_latam_price_unit = price_unit['total_excluded']
+            price_unit = price_unit['total_excluded']
             not_included_taxes = self.tax_ids
-            l10n_latam_price_subtotal = self.price_subtotal
+            price_subtotal = self.price_subtotal
         else:
             not_included_taxes = self.tax_ids - included_taxes
-            l10n_latam_price_unit = included_taxes.compute_all(
+            price_unit = included_taxes.compute_all(
                 self.price_unit, invoice.currency_id, 1.0, self.product_id, invoice.partner_id)['total_included']
             price = self.price_unit * (1 - (self.discount or 0.0) / 100.0)
-            l10n_latam_price_subtotal = included_taxes.compute_all(
+            price_subtotal = included_taxes.compute_all(
                 price, invoice.currency_id, self.quantity, self.product_id, invoice.partner_id)['total_included']
-        l10n_latam_price_net = l10n_latam_price_unit * (1 - (self.discount or 0.0) / 100.0)
+        price_net = price_unit * (1 - (self.discount or 0.0) / 100.0)
 
         return {
-            'l10n_latam_tax_ids': not_included_taxes,
-            'l10n_latam_price_unit': l10n_latam_price_unit,
-            'l10n_latam_price_subtotal': l10n_latam_price_subtotal,
-            'l10n_latam_price_net': l10n_latam_price_net
+            'taxes': not_included_taxes,
+            'price_unit': price_unit,
+            'price_subtotal': price_subtotal,
+            'price_net': price_net
         }

--- a/addons/l10n_ar/models/l10n_latam_document_type.py
+++ b/addons/l10n_ar/models/l10n_latam_document_type.py
@@ -31,12 +31,6 @@ class L10nLatamDocumentType(models.Model):
             ('X', 'X'),
             ('I', 'I'),  # used for mapping of imports
         ]
-    def _filter_taxes_included(self, taxes):
-        """ In argentina we include taxes depending on document letter """
-        self.ensure_one()
-        if self.country_id.code == "AR" and self.l10n_ar_letter in ['B', 'C', 'X', 'R']:
-            return taxes.filtered(lambda x: x.tax_group_id.l10n_ar_vat_afip_code)
-        return super()._filter_taxes_included(taxes)
 
     def _format_document_number(self, document_number):
         """ Make validation of Import Dispatch Number

--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -114,29 +114,38 @@
         </td>
 
         <!-- use latam prices (to include/exclude VAT) -->
+        <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" position="before">
+            <t t-set="l10n_ar_values" t-value="line._l10n_ar_prices_and_taxes()"/>
+        </t>
         <xpath expr="//span[@t-field='line.price_unit']" position="attributes">
-            <attribute name="t-field">line.l10n_latam_price_unit</attribute>
+            <attribute name="t-field"></attribute>
+            <attribute name="t-esc">l10n_ar_values['l10n_latam_price_unit']</attribute>
+            <attribute name="t-options">{"widget": "monetary", "display_currency": o.currency_id}</attribute>
         </xpath>
         <xpath expr="//span[@id='line_tax_ids']" position="attributes">
-            <attribute name="t-esc">', '.join(map(lambda x: (x.description or x.name), line.l10n_latam_tax_ids))</attribute>
+            <attribute name="t-esc">', '.join(map(lambda x: (x.description or x.name), l10n_ar_values['l10n_latam_tax_ids']))</attribute>
         </xpath>
         <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" position="attributes">
-            <attribute name="t-value">current_subtotal + line.l10n_latam_price_subtotal</attribute>
+            <attribute name="t-value">current_subtotal + l10n_ar_values['l10n_latam_price_subtotal']</attribute>
         </t>
         <!-- if b2c we still wants the latam subtotal -->
         <t t-set="current_subtotal" t-value="current_subtotal + line.price_total" position="attributes">
-            <attribute name="t-value">current_subtotal + line.l10n_latam_price_subtotal</attribute>
+            <attribute name="t-value">current_subtotal + l10n_ar_values['l10n_latam_price_subtotal']</attribute>
         </t>
         <!-- label amount for subtotal column on b2b and b2c -->
         <xpath expr="//th[@name='th_subtotal']/span[@groups='account.group_show_line_subtotals_tax_included']" position="replace">
             <span groups="account.group_show_line_subtotals_tax_included">Amount</span>
         </xpath>
         <span t-field="line.price_subtotal" position="attributes">
-            <attribute name="t-field">line.l10n_latam_price_subtotal</attribute>
+            <attribute name="t-field"></attribute>
+            <attribute name="t-esc">l10n_ar_values['l10n_latam_price_subtotal']</attribute>
+            <attribute name="t-options">{"widget": "monetary", "display_currency": o.currency_id}</attribute>
         </span>
         <!-- if b2c we still wants the latam subtotal -->
         <span t-field="line.price_total" position="attributes">
-            <attribute name="t-field">line.l10n_latam_price_subtotal</attribute>
+            <attribute name="t-field"></attribute>
+            <attribute name="t-esc">l10n_ar_values['l10n_latam_price_subtotal']</attribute>
+            <attribute name="t-options">{"widget": "monetary", "display_currency": o.currency_id}</attribute>
         </span>
 
         <t t-set="tax_totals" position="attributes">
@@ -157,7 +166,7 @@
             <attribute name="t-if">o.tax_totals_json</attribute>
         </xpath>
         <span id="line_tax_ids" position="attributes">
-            <attribute name="t-esc">', '.join(map(lambda x: (x.description or x.name), line.l10n_latam_tax_ids.filtered(lambda x: x.tax_group_id.l10n_ar_vat_afip_code)))</attribute>
+            <attribute name="t-esc">', '.join(map(lambda x: (x.description or x.name), l10n_ar_values['l10n_latam_tax_ids'].filtered(lambda x: x.tax_group_id.l10n_ar_vat_afip_code)))</attribute>
         </span>
 
         <!-- remove payment reference that is not used in Argentina -->

--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -122,9 +122,6 @@
             <attribute name="t-esc">l10n_ar_values['price_unit']</attribute>
             <attribute name="t-options">{"widget": "monetary", "display_currency": o.currency_id}</attribute>
         </xpath>
-        <xpath expr="//span[@id='line_tax_ids']" position="attributes">
-            <attribute name="t-esc">', '.join(map(lambda x: (x.description or x.name), l10n_ar_values['taxes']))</attribute>
-        </xpath>
         <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" position="attributes">
             <attribute name="t-value">current_subtotal + l10n_ar_values['price_subtotal']</attribute>
         </t>
@@ -148,25 +145,20 @@
             <attribute name="t-options">{"widget": "monetary", "display_currency": o.currency_id}</attribute>
         </span>
 
-        <t t-set="tax_totals" position="attributes">
-            <attribute name="t-value">o._get_tax_totals_for_latam_invoice_report()</attribute>
-        </t>
-
         <!-- use column vat instead of taxes and only if vat discriminated -->
         <xpath expr="//th[@name='th_taxes']/span" position="replace">
             <span>% VAT</span>
         </xpath>
 
-        <xpath expr="//th[@name='th_taxes']" position="attributes">
-            <attribute name="t-if">o.tax_totals_json</attribute>
-        </xpath>
-
         <!-- use column vat instead of taxes and only list vat taxes-->
+        <xpath expr="//th[@name='th_taxes']" position="attributes">
+            <attribute name="t-if">not o._l10n_ar_include_vat()</attribute>
+        </xpath>
         <xpath expr="//span[@id='line_tax_ids']/.." position="attributes">
-            <attribute name="t-if">o.tax_totals_json</attribute>
+            <attribute name="t-if">not o._l10n_ar_include_vat()</attribute>
         </xpath>
         <span id="line_tax_ids" position="attributes">
-            <attribute name="t-esc">', '.join(map(lambda x: (x.description or x.name), l10n_ar_values['taxes'].filtered(lambda x: x.tax_group_id.l10n_ar_vat_afip_code)))</attribute>
+            <attribute name="t-esc">', '.join(map(lambda x: (x.description or x.name), line.tax_ids.filtered(lambda x: x.tax_group_id.l10n_ar_vat_afip_code)))</attribute>
         </span>
 
         <!-- remove payment reference that is not used in Argentina -->

--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -119,18 +119,18 @@
         </t>
         <xpath expr="//span[@t-field='line.price_unit']" position="attributes">
             <attribute name="t-field"></attribute>
-            <attribute name="t-esc">l10n_ar_values['l10n_latam_price_unit']</attribute>
+            <attribute name="t-esc">l10n_ar_values['price_unit']</attribute>
             <attribute name="t-options">{"widget": "monetary", "display_currency": o.currency_id}</attribute>
         </xpath>
         <xpath expr="//span[@id='line_tax_ids']" position="attributes">
-            <attribute name="t-esc">', '.join(map(lambda x: (x.description or x.name), l10n_ar_values['l10n_latam_tax_ids']))</attribute>
+            <attribute name="t-esc">', '.join(map(lambda x: (x.description or x.name), l10n_ar_values['taxes']))</attribute>
         </xpath>
         <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" position="attributes">
-            <attribute name="t-value">current_subtotal + l10n_ar_values['l10n_latam_price_subtotal']</attribute>
+            <attribute name="t-value">current_subtotal + l10n_ar_values['price_subtotal']</attribute>
         </t>
         <!-- if b2c we still wants the latam subtotal -->
         <t t-set="current_subtotal" t-value="current_subtotal + line.price_total" position="attributes">
-            <attribute name="t-value">current_subtotal + l10n_ar_values['l10n_latam_price_subtotal']</attribute>
+            <attribute name="t-value">current_subtotal + l10n_ar_values['price_subtotal']</attribute>
         </t>
         <!-- label amount for subtotal column on b2b and b2c -->
         <xpath expr="//th[@name='th_subtotal']/span[@groups='account.group_show_line_subtotals_tax_included']" position="replace">
@@ -138,13 +138,13 @@
         </xpath>
         <span t-field="line.price_subtotal" position="attributes">
             <attribute name="t-field"></attribute>
-            <attribute name="t-esc">l10n_ar_values['l10n_latam_price_subtotal']</attribute>
+            <attribute name="t-esc">l10n_ar_values['price_subtotal']</attribute>
             <attribute name="t-options">{"widget": "monetary", "display_currency": o.currency_id}</attribute>
         </span>
         <!-- if b2c we still wants the latam subtotal -->
         <span t-field="line.price_total" position="attributes">
             <attribute name="t-field"></attribute>
-            <attribute name="t-esc">l10n_ar_values['l10n_latam_price_subtotal']</attribute>
+            <attribute name="t-esc">l10n_ar_values['price_subtotal']</attribute>
             <attribute name="t-options">{"widget": "monetary", "display_currency": o.currency_id}</attribute>
         </span>
 
@@ -166,7 +166,7 @@
             <attribute name="t-if">o.tax_totals_json</attribute>
         </xpath>
         <span id="line_tax_ids" position="attributes">
-            <attribute name="t-esc">', '.join(map(lambda x: (x.description or x.name), l10n_ar_values['l10n_latam_tax_ids'].filtered(lambda x: x.tax_group_id.l10n_ar_vat_afip_code)))</attribute>
+            <attribute name="t-esc">', '.join(map(lambda x: (x.description or x.name), l10n_ar_values['taxes'].filtered(lambda x: x.tax_group_id.l10n_ar_vat_afip_code)))</attribute>
         </span>
 
         <!-- remove payment reference that is not used in Argentina -->

--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -145,6 +145,10 @@
             <attribute name="t-options">{"widget": "monetary", "display_currency": o.currency_id}</attribute>
         </span>
 
+        <t t-set="tax_totals" position="attributes">
+            <attribute name="t-value">o._l10n_ar_get_invoice_totals_for_report()</attribute>
+        </t>
+
         <!-- use column vat instead of taxes and only if vat discriminated -->
         <xpath expr="//th[@name='th_taxes']/span" position="replace">
             <span>% VAT</span>

--- a/addons/l10n_cl/models/__init__.py
+++ b/addons/l10n_cl/models/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import account_chart_template
 from . import account_move
+from . import account_move_line
 from . import account_tax
 from . import l10n_latam_document_type
 from . import res_company

--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -124,13 +124,24 @@ class AccountMove(models.Model):
             return 'l10n_cl.report_invoice_document'
         return super()._get_name_invoice_report()
 
-    def _prepare_tax_lines_data_for_totals_from_invoice(self, tax_line_id_filter=None, tax_ids_filter=None):
-        if self.company_id.account_fiscal_country_id.code == 'CL' and self._l10n_cl_include_sii() and (
-                'commit_assetsbundle' in self.env.context or not self.env.context.get('params', {}).get('view_type') == 'form'):
+    def _l10n_cl_get_invoice_totals_for_report(self):
+        self.ensure_one()
+        tax_ids_filter = tax_line_id_filter = None
+        include_sii = self._l10n_cl_include_sii()
+
+        if include_sii:
             tax_ids_filter = (lambda aml, tax: bool(tax.l10n_cl_sii_code != 14))
             tax_line_id_filter = (lambda aml, tax: bool(tax.l10n_cl_sii_code != 14))
-        return super()._prepare_tax_lines_data_for_totals_from_invoice(
-            tax_line_id_filter=tax_line_id_filter, tax_ids_filter=tax_ids_filter)
+
+        tax_lines_data = self._prepare_tax_lines_data_for_totals_from_invoice(
+            tax_ids_filter=tax_ids_filter, tax_line_id_filter=tax_line_id_filter)
+
+        if include_sii:
+            amount_untaxed = self.currency_id.round(
+                self.amount_total - sum([x['tax_amount'] for x in tax_lines_data if 'tax_amount' in x]))
+        else:
+            amount_untaxed = self.amount_untaxed
+        return self._get_tax_totals(self.partner_id, tax_lines_data, self.amount_total, amount_untaxed, self.currency_id)
 
     def _l10n_cl_include_sii(self):
         self.ensure_one()

--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -3,6 +3,7 @@
 from odoo.exceptions import ValidationError
 from odoo import models, fields, api, _
 from odoo.osv import expression
+from odoo.tools.misc import formatLang
 
 SII_VAT = '60805000-0'
 
@@ -124,3 +125,73 @@ class AccountMove(models.Model):
         if self.l10n_latam_use_documents and self.company_id.account_fiscal_country_id.code == 'CL':
             return 'l10n_cl.report_invoice_document'
         return super()._get_name_invoice_report()
+
+    def _l10n_cl_amount_and_taxes(self):
+        self.ensure_one()
+        res = {}
+        if self.is_invoice():
+            tax_lines = self.line_ids.filtered('tax_line_id')
+            included_taxes = self.l10n_latam_document_type_id and \
+                self.l10n_latam_document_type_id._filter_taxes_included(tax_lines.mapped('tax_line_id'))
+            if not included_taxes:
+                l10n_latam_amount_untaxed = self.amount_untaxed
+                not_included_invoice_taxes = tax_lines
+            else:
+                included_invoice_taxes = tax_lines.filtered(lambda x: x.tax_line_id in included_taxes)
+                not_included_invoice_taxes = tax_lines - included_invoice_taxes
+                sign = -1 if self.is_inbound() else 1
+                l10n_latam_amount_untaxed = self.amount_untaxed + sign * sum(included_invoice_taxes.mapped('balance'))
+            res['l10n_latam_amount_untaxed'] = l10n_latam_amount_untaxed
+            res['l10n_latam_tax_ids'] = not_included_invoice_taxes
+        else:
+            res['l10n_latam_amount_untaxed'] = False
+            res['l10n_latam_tax_ids'] = [(5, 0)]
+        return res
+
+    def _compute_invoice_taxes_by_group(self):
+        report_or_portal_view = 'commit_assetsbundle' in self.env.context or \
+            not self.env.context.get('params', {}).get('view_type') == 'form'
+        if not report_or_portal_view:
+            return super()._compute_invoice_taxes_by_group()
+
+        move_with_doc_type = self.filtered('l10n_latam_document_type_id')
+        for move in move_with_doc_type:
+            lang_env = move.with_context(lang=move.partner_id.lang).env
+            tax_lines = move._l10n_cl_amount_and_taxes()['l10n_latam_tax_ids']
+            tax_balance_multiplicator = -1 if move.is_inbound(True) else 1
+            res = {}
+            # There are as many tax line as there are repartition lines
+            done_taxes = set()
+            for line in tax_lines:
+                res.setdefault(line.tax_line_id.tax_group_id, {'base': 0.0, 'amount': 0.0})
+                res[line.tax_line_id.tax_group_id]['amount'] += tax_balance_multiplicator * (line.amount_currency if line.currency_id else line.balance)
+                tax_key_add_base = tuple(move._get_tax_key_for_group_add_base(line))
+                if tax_key_add_base not in done_taxes:
+                    if line.currency_id and line.company_currency_id and line.currency_id != line.company_currency_id:
+                        amount = line.company_currency_id._convert(line.tax_base_amount, line.currency_id, line.company_id, line.date or fields.Date.today())
+                    else:
+                        amount = line.tax_base_amount
+                    res[line.tax_line_id.tax_group_id]['base'] += amount
+                    # The base should be added ONCE
+                    done_taxes.add(tax_key_add_base)
+
+            # At this point we only want to keep the taxes with a zero amount since they do not
+            # generate a tax line.
+            zero_taxes = set()
+            for line in move.line_ids:
+                for tax in line._l10n_cl_prices_and_taxes()['l10n_latam_tax_ids'].flatten_taxes_hierarchy():
+                    if tax.tax_group_id not in res or tax.id in zero_taxes:
+                        res.setdefault(tax.tax_group_id, {'base': 0.0, 'amount': 0.0})
+                        res[tax.tax_group_id]['base'] += tax_balance_multiplicator * (line.amount_currency if line.currency_id else line.balance)
+                        zero_taxes.add(tax.id)
+
+            res = sorted(res.items(), key=lambda l: l[0].sequence)
+            move.amount_by_group = [(
+                group.name, amounts['amount'],
+                amounts['base'],
+                formatLang(lang_env, amounts['amount'], currency_obj=move.currency_id),
+                formatLang(lang_env, amounts['base'], currency_obj=move.currency_id),
+                len(res),
+                group.id
+            ) for group, amounts in res]
+        super(AccountMove, self - move_with_doc_type)._compute_invoice_taxes_by_group()

--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -43,7 +43,6 @@ class AccountMove(models.Model):
             domain += [('code', 'in', [])]
         return domain
 
-
     def _check_document_types_post(self):
         for rec in self.filtered(
                 lambda r: r.company_id.account_fiscal_country_id.code == "CL" and
@@ -134,18 +133,18 @@ class AccountMove(models.Model):
             included_taxes = self.l10n_latam_document_type_id and \
                 self.l10n_latam_document_type_id._filter_taxes_included(tax_lines.mapped('tax_line_id'))
             if not included_taxes:
-                l10n_latam_amount_untaxed = self.amount_untaxed
+                amount_untaxed = self.amount_untaxed
                 not_included_invoice_taxes = tax_lines
             else:
                 included_invoice_taxes = tax_lines.filtered(lambda x: x.tax_line_id in included_taxes)
                 not_included_invoice_taxes = tax_lines - included_invoice_taxes
                 sign = -1 if self.is_inbound() else 1
-                l10n_latam_amount_untaxed = self.amount_untaxed + sign * sum(included_invoice_taxes.mapped('balance'))
-            res['l10n_latam_amount_untaxed'] = l10n_latam_amount_untaxed
-            res['l10n_latam_tax_ids'] = not_included_invoice_taxes
+                amount_untaxed = self.amount_untaxed + sign * sum(included_invoice_taxes.mapped('balance'))
+            res['amount_untaxed'] = amount_untaxed
+            res['tax_lines'] = not_included_invoice_taxes
         else:
-            res['l10n_latam_amount_untaxed'] = False
-            res['l10n_latam_tax_ids'] = [(5, 0)]
+            res['amount_untaxed'] = False
+            res['tax_lines'] = self.env['account.move.line']
         return res
 
     def _compute_invoice_taxes_by_group(self):
@@ -157,7 +156,7 @@ class AccountMove(models.Model):
         move_with_doc_type = self.filtered('l10n_latam_document_type_id')
         for move in move_with_doc_type:
             lang_env = move.with_context(lang=move.partner_id.lang).env
-            tax_lines = move._l10n_cl_amount_and_taxes()['l10n_latam_tax_ids']
+            tax_lines = move._l10n_cl_amount_and_taxes()['tax_lines']
             tax_balance_multiplicator = -1 if move.is_inbound(True) else 1
             res = {}
             # There are as many tax line as there are repartition lines
@@ -179,7 +178,7 @@ class AccountMove(models.Model):
             # generate a tax line.
             zero_taxes = set()
             for line in move.line_ids:
-                for tax in line._l10n_cl_prices_and_taxes()['l10n_latam_tax_ids'].flatten_taxes_hierarchy():
+                for tax in line._l10n_cl_prices_and_taxes()['taxes'].flatten_taxes_hierarchy():
                     if tax.tax_group_id not in res or tax.id in zero_taxes:
                         res.setdefault(tax.tax_group_id, {'base': 0.0, 'amount': 0.0})
                         res[tax.tax_group_id]['base'] += tax_balance_multiplicator * (line.amount_currency if line.currency_id else line.balance)

--- a/addons/l10n_cl/models/account_move_line.py
+++ b/addons/l10n_cl/models/account_move_line.py
@@ -10,17 +10,13 @@ class AccountMoveLine(models.Model):
     def _l10n_cl_prices_and_taxes(self):
         self.ensure_one()
         invoice = self.move_id
-        included_taxes = \
-            invoice.l10n_latam_document_type_id and invoice.l10n_latam_document_type_id._filter_taxes_included(
-                self.tax_ids)
+        included_taxes = self.tax_ids.filtered(lambda x: x.l10n_cl_sii_code == 14) if self.move_id._l10n_cl_include_sii() else self.tax_ids
         if not included_taxes:
             price_unit = self.tax_ids.with_context(round=False).compute_all(
                 self.price_unit, invoice.currency_id, 1.0, self.product_id, invoice.partner_id)
             price_unit = price_unit['total_excluded']
-            not_included_taxes = self.tax_ids
             price_subtotal = self.price_subtotal
         else:
-            not_included_taxes = self.tax_ids - included_taxes
             price_unit = included_taxes.compute_all(
                 self.price_unit, invoice.currency_id, 1.0, self.product_id, invoice.partner_id)['total_included']
             price = self.price_unit * (1 - (self.discount or 0.0) / 100.0)
@@ -29,7 +25,6 @@ class AccountMoveLine(models.Model):
         price_net = price_unit * (1 - (self.discount or 0.0) / 100.0)
 
         return {
-            'taxes': not_included_taxes,
             'price_unit': price_unit,
             'price_subtotal': price_subtotal,
             'price_net': price_net

--- a/addons/l10n_cl/models/account_move_line.py
+++ b/addons/l10n_cl/models/account_move_line.py
@@ -16,21 +16,21 @@ class AccountMoveLine(models.Model):
         if not included_taxes:
             price_unit = self.tax_ids.with_context(round=False).compute_all(
                 self.price_unit, invoice.currency_id, 1.0, self.product_id, invoice.partner_id)
-            l10n_latam_price_unit = price_unit['total_excluded']
+            price_unit = price_unit['total_excluded']
             not_included_taxes = self.tax_ids
-            l10n_latam_price_subtotal = self.price_subtotal
+            price_subtotal = self.price_subtotal
         else:
             not_included_taxes = self.tax_ids - included_taxes
-            l10n_latam_price_unit = included_taxes.compute_all(
+            price_unit = included_taxes.compute_all(
                 self.price_unit, invoice.currency_id, 1.0, self.product_id, invoice.partner_id)['total_included']
             price = self.price_unit * (1 - (self.discount or 0.0) / 100.0)
-            l10n_latam_price_subtotal = included_taxes.compute_all(
+            price_subtotal = included_taxes.compute_all(
                 price, invoice.currency_id, self.quantity, self.product_id, invoice.partner_id)['total_included']
-        l10n_latam_price_net = l10n_latam_price_unit * (1 - (self.discount or 0.0) / 100.0)
+        price_net = price_unit * (1 - (self.discount or 0.0) / 100.0)
 
         return {
-            'l10n_latam_tax_ids': not_included_taxes,
-            'l10n_latam_price_unit': l10n_latam_price_unit,
-            'l10n_latam_price_subtotal': l10n_latam_price_subtotal,
-            'l10n_latam_price_net': l10n_latam_price_net
+            'taxes': not_included_taxes,
+            'price_unit': price_unit,
+            'price_subtotal': price_subtotal,
+            'price_net': price_net
         }

--- a/addons/l10n_cl/models/account_move_line.py
+++ b/addons/l10n_cl/models/account_move_line.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+
+class AccountMoveLine(models.Model):
+
+    _inherit = 'account.move.line'
+
+    def _l10n_cl_prices_and_taxes(self):
+        self.ensure_one()
+        invoice = self.move_id
+        included_taxes = \
+            invoice.l10n_latam_document_type_id and invoice.l10n_latam_document_type_id._filter_taxes_included(
+                self.tax_ids)
+        if not included_taxes:
+            price_unit = self.tax_ids.with_context(round=False).compute_all(
+                self.price_unit, invoice.currency_id, 1.0, self.product_id, invoice.partner_id)
+            l10n_latam_price_unit = price_unit['total_excluded']
+            not_included_taxes = self.tax_ids
+            l10n_latam_price_subtotal = self.price_subtotal
+        else:
+            not_included_taxes = self.tax_ids - included_taxes
+            l10n_latam_price_unit = included_taxes.compute_all(
+                self.price_unit, invoice.currency_id, 1.0, self.product_id, invoice.partner_id)['total_included']
+            price = self.price_unit * (1 - (self.discount or 0.0) / 100.0)
+            l10n_latam_price_subtotal = included_taxes.compute_all(
+                price, invoice.currency_id, self.quantity, self.product_id, invoice.partner_id)['total_included']
+        l10n_latam_price_net = l10n_latam_price_unit * (1 - (self.discount or 0.0) / 100.0)
+
+        return {
+            'l10n_latam_tax_ids': not_included_taxes,
+            'l10n_latam_price_unit': l10n_latam_price_unit,
+            'l10n_latam_price_subtotal': l10n_latam_price_subtotal,
+            'l10n_latam_price_net': l10n_latam_price_net
+        }

--- a/addons/l10n_cl/models/l10n_latam_document_type.py
+++ b/addons/l10n_cl/models/l10n_latam_document_type.py
@@ -28,10 +28,3 @@ class L10nLatamDocumentType(models.Model):
             return False
 
         return document_number.zfill(6)
-
-    def _filter_taxes_included(self, taxes):
-        """ In Chile we include taxes depending on document type """
-        self.ensure_one()
-        if self.country_id.code == "CL" and self.code in ['39', '41', '110', '111', '112', '34']:
-            return taxes.filtered(lambda x: x.l10n_cl_sii_code == 14)
-        return super()._filter_taxes_included(taxes)

--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -138,8 +138,14 @@
 
         <xpath expr="//h2" position="replace"/>
 
+        <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" position="before">
+            <t t-set="l10n_cl_values" t-value="line._l10n_cl_prices_and_taxes()"/>
+        </t>
+
         <xpath expr="//span[@t-field='line.price_unit']" position="attributes">
-            <attribute name="t-field">line.l10n_latam_price_unit</attribute>
+            <attribute name="t-field"></attribute>
+            <attribute name="t-esc">line.price_unit</attribute>
+            <attribute name="t-options">{"widget": "monetary", "display_currency": o.currency_id}</attribute>
         </xpath>
 
         <xpath expr="//span[@id='line_tax_ids']" position="attributes">
@@ -147,7 +153,7 @@
         </xpath>
 
         <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" position="attributes">
-            <attribute name="t-value">current_subtotal + line.l10n_latam_price_subtotal</attribute>
+            <attribute name="t-value">current_subtotal + l10n_cl_values['l10n_latam_price_subtotal']</attribute>
         </t>
 
         <xpath expr="//th[@name='th_subtotal']/span[@groups='account.group_show_line_subtotals_tax_included']" position="replace">
@@ -155,7 +161,9 @@
         </xpath>
 
         <span t-field="line.price_subtotal" position="attributes">
-            <attribute name="t-field">line.l10n_latam_price_subtotal</attribute>
+            <attribute name="t-field"></attribute>
+            <attribute name="t-esc">current_subtotal + l10n_cl_values['l10n_latam_price_subtotal']</attribute>
+            <attribute name="t-options">{"widget": "monetary", "display_currency": o.currency_id}</attribute>
         </span>
 
         <t t-set="tax_totals" position="attributes">

--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -166,9 +166,6 @@
             <attribute name="t-options">{"widget": "monetary", "display_currency": o.currency_id}</attribute>
         </span>
 
-        <t t-set="tax_totals" position="attributes">
-            <attribute name="t-value">o._get_tax_totals_for_latam_invoice_report()</attribute>
-        </t>
 
         <xpath expr="//th[@name='th_taxes']" position="replace"/>
         <xpath expr="//span[@id='line_tax_ids']/.." position="replace"/>

--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -166,6 +166,9 @@
             <attribute name="t-options">{"widget": "monetary", "display_currency": o.currency_id}</attribute>
         </span>
 
+        <t t-set="tax_totals" position="attributes">
+            <attribute name="t-value">o._l10n_cl_get_invoice_totals_for_report()</attribute>
+        </t>
 
         <xpath expr="//th[@name='th_taxes']" position="replace"/>
         <xpath expr="//span[@id='line_tax_ids']/.." position="replace"/>

--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -149,11 +149,11 @@
         </xpath>
 
         <xpath expr="//span[@id='line_tax_ids']" position="attributes">
-            <attribute name="t-esc">', '.join(map(lambda x: (x.description or x.name), line.l10n_latam_tax_ids))</attribute>
+            <attribute name="t-esc">', '.join(map(lambda x: (x.description or x.name), line.tax_lines))</attribute>
         </xpath>
 
         <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" position="attributes">
-            <attribute name="t-value">current_subtotal + l10n_cl_values['l10n_latam_price_subtotal']</attribute>
+            <attribute name="t-value">current_subtotal + l10n_cl_values['price_subtotal']</attribute>
         </t>
 
         <xpath expr="//th[@name='th_subtotal']/span[@groups='account.group_show_line_subtotals_tax_included']" position="replace">
@@ -162,7 +162,7 @@
 
         <span t-field="line.price_subtotal" position="attributes">
             <attribute name="t-field"></attribute>
-            <attribute name="t-esc">current_subtotal + l10n_cl_values['l10n_latam_price_subtotal']</attribute>
+            <attribute name="t-esc">current_subtotal + l10n_cl_values['price_subtotal']</attribute>
             <attribute name="t-options">{"widget": "monetary", "display_currency": o.currency_id}</attribute>
         </span>
 

--- a/addons/l10n_latam_invoice_document/models/account_move.py
+++ b/addons/l10n_latam_invoice_document/models/account_move.py
@@ -2,8 +2,6 @@
 
 from odoo import models, fields, api, _
 from odoo.exceptions import UserError, ValidationError
-import json
-import re
 from odoo.tools.sql import column_exists, create_column
 
 
@@ -231,9 +229,3 @@ class AccountMove(models.Model):
             ]
             if rec.search(domain):
                 raise ValidationError(_('Vendor bill number must be unique per vendor and company.'))
-
-    def _get_tax_totals_for_latam_invoice_report(self):
-        self.ensure_one()
-        tax_totals = json.loads(self.tax_totals_json)
-        tax_totals['amount_untaxed'] = self.l10n_latam_amount_untaxed
-        return tax_totals

--- a/addons/l10n_latam_invoice_document/models/account_move.py
+++ b/addons/l10n_latam_invoice_document/models/account_move.py
@@ -4,7 +4,6 @@ from odoo import models, fields, api, _
 from odoo.exceptions import UserError, ValidationError
 import json
 import re
-from odoo.tools.misc import formatLang
 from odoo.tools.sql import column_exists, create_column
 
 
@@ -44,8 +43,6 @@ class AccountMove(models.Model):
             create_column(self.env.cr, "account_move", "l10n_latam_document_type_id", "int4")
         return super()._auto_init()
 
-    l10n_latam_amount_untaxed = fields.Monetary(compute='_compute_l10n_latam_amount_and_taxes')
-    l10n_latam_tax_ids = fields.One2many(compute="_compute_l10n_latam_amount_and_taxes", comodel_name='account.move.line')
     l10n_latam_available_document_type_ids = fields.Many2many('l10n_latam.document.type', compute='_compute_l10n_latam_available_document_types')
     l10n_latam_document_type_id = fields.Many2one(
         'l10n_latam.document.type', string='Document Type', readonly=False, auto_join=True, index=True,
@@ -129,31 +126,6 @@ class AccountMove(models.Model):
             return ""
 
         return super(AccountMove, self)._get_starting_sequence()
-
-    def _compute_l10n_latam_amount_and_taxes(self):
-        recs_invoice = self.filtered(lambda x: x.is_invoice())
-        for invoice in recs_invoice:
-            tax_lines = invoice.line_ids.filtered('tax_line_id')
-            currencies = invoice.line_ids.filtered(lambda x: x.currency_id == invoice.currency_id).mapped('currency_id')
-            included_taxes = invoice.l10n_latam_document_type_id and \
-                invoice.l10n_latam_document_type_id._filter_taxes_included(tax_lines.mapped('tax_line_id'))
-            if not included_taxes:
-                l10n_latam_amount_untaxed = invoice.amount_untaxed
-                not_included_invoice_taxes = tax_lines
-            else:
-                included_invoice_taxes = tax_lines.filtered(lambda x: x.tax_line_id in included_taxes)
-                not_included_invoice_taxes = tax_lines - included_invoice_taxes
-                if invoice.is_inbound():
-                    sign = -1
-                else:
-                    sign = 1
-                amount = 'amount_currency' if len(currencies) == 1 else 'balance'
-                l10n_latam_amount_untaxed = invoice.amount_untaxed + sign * sum(included_invoice_taxes.mapped(amount))
-            invoice.l10n_latam_amount_untaxed = l10n_latam_amount_untaxed
-            invoice.l10n_latam_tax_ids = not_included_invoice_taxes
-        remaining = self - recs_invoice
-        remaining.l10n_latam_amount_untaxed = False
-        remaining.l10n_latam_tax_ids = [(5, 0)]
 
     def _post(self, soft=True):
         for rec in self.filtered(lambda x: x.l10n_latam_use_documents and (not x.name or x.name == '/')):

--- a/addons/l10n_latam_invoice_document/models/account_move_line.py
+++ b/addons/l10n_latam_invoice_document/models/account_move_line.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models, api, fields
+from odoo import models, fields
 from odoo.tools.sql import column_exists, create_column
 
 
@@ -17,39 +17,3 @@ class AccountMoveLine(models.Model):
 
     l10n_latam_document_type_id = fields.Many2one(
         related='move_id.l10n_latam_document_type_id', auto_join=True, store=True, index=True)
-    l10n_latam_price_unit = fields.Float(compute='compute_l10n_latam_prices_and_taxes', digits='Product Price')
-    l10n_latam_price_subtotal = fields.Monetary(compute='compute_l10n_latam_prices_and_taxes')
-    l10n_latam_price_net = fields.Float(compute='compute_l10n_latam_prices_and_taxes', digits='Product Price')
-    l10n_latam_tax_ids = fields.One2many(compute="compute_l10n_latam_prices_and_taxes", comodel_name='account.tax')
-
-    @api.depends('price_unit', 'price_subtotal', 'move_id.l10n_latam_document_type_id')
-    def compute_l10n_latam_prices_and_taxes(self):
-        for line in self:
-            invoice = line.move_id
-            included_taxes = \
-                invoice.l10n_latam_document_type_id and invoice.l10n_latam_document_type_id._filter_taxes_included(
-                    line.tax_ids)
-            # For the unit price, we need the number rounded based on the product price precision.
-            # The method compute_all uses the accuracy of the currency so, we multiply and divide for 10^(decimal accuracy of product price) to get the price correctly rounded.
-            price_digits = 10**self.env['decimal.precision'].precision_get('Product Price')
-            if not included_taxes:
-                price_unit = line.tax_ids.with_context(round=False, force_sign=invoice._get_tax_force_sign()).compute_all(
-                    line.price_unit * price_digits, invoice.currency_id, 1.0, line.product_id, invoice.partner_id)
-                l10n_latam_price_unit = price_unit['total_excluded'] / price_digits
-                l10n_latam_price_subtotal = line.price_subtotal
-                not_included_taxes = line.tax_ids
-                l10n_latam_price_net = l10n_latam_price_unit * (1 - (line.discount or 0.0) / 100.0)
-            else:
-                not_included_taxes = line.tax_ids - included_taxes
-                l10n_latam_price_unit = included_taxes.with_context(force_sign=invoice._get_tax_force_sign()).compute_all(
-                    line.price_unit * price_digits, invoice.currency_id, 1.0, line.product_id, invoice.partner_id)['total_included'] / price_digits
-                l10n_latam_price_net = l10n_latam_price_unit * (1 - (line.discount or 0.0) / 100.0)
-                price = line.price_unit * (1 - (line.discount or 0.0) / 100.0)
-                l10n_latam_price_subtotal = included_taxes.with_context(force_sign=invoice._get_tax_force_sign()).compute_all(
-                    price, invoice.currency_id, line.quantity, line.product_id,
-                    invoice.partner_id)['total_included']
-
-            line.l10n_latam_price_subtotal = l10n_latam_price_subtotal
-            line.l10n_latam_price_unit = l10n_latam_price_unit
-            line.l10n_latam_price_net = l10n_latam_price_net
-            line.l10n_latam_tax_ids = not_included_taxes

--- a/addons/l10n_latam_invoice_document/models/l10n_latam_document_type.py
+++ b/addons/l10n_latam_invoice_document/models/l10n_latam_document_type.py
@@ -51,11 +51,3 @@ class L10nLatamDocumentType(models.Model):
         else:
             domain = ['|', ('name', 'ilike', name), ('code', 'ilike', name)]
         return self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
-
-    def _filter_taxes_included(self, taxes):
-        # TODO BORRAR
-        """ This method is to be inherited by different localizations and must return filter the given taxes recordset
-        returning the taxes to be included on reports of this document type. All taxes are going to be discriminated
-        except the one returned by this method. """
-        self.ensure_one()
-        return self.env['account.tax']

--- a/addons/l10n_latam_invoice_document/models/l10n_latam_document_type.py
+++ b/addons/l10n_latam_invoice_document/models/l10n_latam_document_type.py
@@ -53,6 +53,7 @@ class L10nLatamDocumentType(models.Model):
         return self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
 
     def _filter_taxes_included(self, taxes):
+        # TODO BORRAR
         """ This method is to be inherited by different localizations and must return filter the given taxes recordset
         returning the taxes to be included on reports of this document type. All taxes are going to be discriminated
         except the one returned by this method. """


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Fields removed from l10n_latam:
 * l10n_latam_amount_untaxed
 * l10n_latam_tax_ids
 * l10n_latam_price_unit
 * l10n_latam_price_subtotal
 * l10n_latam_price_net

Methods removed from l10n_latam:
 * compute_l10n_latam_prices_and_taxes
 * compute_l10n_latam_amount_and_taxes
 * _compute_invoice_taxes_by_group

Move the removed methods to l10n_ar and l10n_cl and now it returns
a dictionary with the removed fields as the keys.

Also, adapt the invoices reports to get the required values from the new methods for each localization.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
