### PR TITLE
 [FIX] mrp: Kit Operations on parent MO without operations

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -457,6 +457,8 @@ class MrpWorkorder(models.Model):
                     })
 
             for workorders in workorders_by_bom.values():
+                if not workorders:
+                    continue
                 if workorders[0].state == 'pending':
                     workorders[0].state = 'ready'
                 for workorder in workorders:


### PR DESCRIPTION
Usecase to reproduce:
- BOM PROD 1 -> No operation -> KIT COMP 1
- BOM KIT COMP 1 -> at lease one operation

Create a MO and confirm it -> Traceback.

It happens because workorders_by_bom[production.bom_id] will try to
find the bom related to production order. However they don't exist but
it will create the entry [BOM PROD 1] = mrp.workorder()

The [0] will be call on each values of the list afterward and raise
the traceback

opw-2477269