### PR TITLE
[WIP] hr_holidays: Leaves for partial time are wrongly counted

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -594,7 +594,10 @@ class HolidaysRequest(models.Model):
         """ Returns a float equals to the timedelta between two dates given as string."""
         if employee_id:
             employee = self.env['hr.employee'].browse(employee_id)
-            return employee._get_work_days_data_batch(date_from, date_to)[employee.id]
+            result = employee._get_work_days_data_batch(date_from, date_to)[employee.id]
+            if self.request_unit_half:
+                result['days'] = 0.5
+            return result
 
         today_hours = self.env.company.resource_calendar_id.get_work_hours_count(
             datetime.combine(date_from.date(), time.min),
@@ -602,8 +605,8 @@ class HolidaysRequest(models.Model):
             False)
 
         hours = self.env.company.resource_calendar_id.get_work_hours_count(date_from, date_to)
-
-        return {'days': hours / (today_hours or HOURS_PER_DAY), 'hours': hours}
+        days = hours / (today_hours or HOURS_PER_DAY) if not self.request_unit_half else 0.5
+        return {'days': days, 'hours': hours}
 
     def _adjust_date_based_on_tz(self, leave_date, hour):
         """ request_date_{from,to} are local to the user's tz but hour_{from,to} are in UTC.

--- a/addons/hr_holidays/tests/test_automatic_leave_dates.py
+++ b/addons/hr_holidays/tests/test_automatic_leave_dates.py
@@ -33,8 +33,8 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
             leave_form.request_unit_half = True
             leave_form.request_date_from_period = 'am'
 
-            self.assertEqual(leave_form.number_of_days_display, 0)
-            self.assertEqual(leave_form.number_of_hours_text, '0 Hours')
+            self.assertEqual(leave_form.number_of_days_display, 0.5)
+            self.assertEqual(leave_form.number_of_hours_text, '4 Hours')
 
     def test_single_attendance_on_morning_and_afternoon(self):
         calendar = self.env['resource.calendar'].create({
@@ -140,13 +140,13 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
             # Ask for morning
             leave_form.request_date_from_period = 'am'
 
-            self.assertEqual(leave_form.number_of_days_display, 1)
+            self.assertEqual(leave_form.number_of_days_display, 0.5)
             self.assertEqual(leave_form.number_of_hours_text, '8 Hours')
 
             # Ask for afternoon
             leave_form.request_date_from_period = 'pm'
 
-            self.assertEqual(leave_form.number_of_days_display, 1)
+            self.assertEqual(leave_form.number_of_days_display, 0.5)
             self.assertEqual(leave_form.number_of_hours_text, '8 Hours')
 
     def test_attendance_next_day(self):
@@ -173,8 +173,8 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
             leave_form.request_date_from_period = 'am'
 
 
-            self.assertEqual(leave_form.number_of_days_display, 0)
-            self.assertEqual(leave_form.number_of_hours_text, '0 Hours')
+            self.assertEqual(leave_form.number_of_days_display, 0.5)
+            self.assertEqual(leave_form.number_of_hours_text, '4 Hours')
             self.assertEqual(leave_form.date_from, datetime(2019, 9, 2, 6, 0, 0))
             self.assertEqual(leave_form.date_to, datetime(2019, 9, 2, 10, 0, 0))
 
@@ -202,8 +202,8 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
             leave_form.request_date_from_period = 'am'
 
 
-            self.assertEqual(leave_form.number_of_days_display, 0)
-            self.assertEqual(leave_form.number_of_hours_text, '0 Hours')
+            self.assertEqual(leave_form.number_of_days_display, 0.5)
+            self.assertEqual(leave_form.number_of_hours_text, '4 Hours')
             self.assertEqual(leave_form.date_from, datetime(2019, 9, 3, 6, 0, 0))
             self.assertEqual(leave_form.date_to, datetime(2019, 9, 3, 10, 0, 0))
 
@@ -241,7 +241,7 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
             leave_form.request_unit_half = True
             leave_form.request_date_from_period = 'am'
 
-            self.assertEqual(leave_form.number_of_days_display, 1)
+            self.assertEqual(leave_form.number_of_days_display, 0.5)
             self.assertEqual(leave_form.number_of_hours_text, '2 Hours')
             self.assertEqual(leave_form.date_from, datetime(2019, 9, 2, 8, 0, 0))
             self.assertEqual(leave_form.date_to, datetime(2019, 9, 2, 10, 0, 0))
@@ -254,7 +254,7 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
             leave_form.request_unit_half = True
             leave_form.request_date_from_period = 'am'
 
-            self.assertEqual(leave_form.number_of_days_display, 1)
+            self.assertEqual(leave_form.number_of_days_display, 0.5)
             self.assertEqual(leave_form.number_of_hours_text, '4 Hours')
             self.assertEqual(leave_form.date_from, datetime(2019, 9, 9, 6, 0, 0))
             self.assertEqual(leave_form.date_to, datetime(2019, 9, 9, 10, 0, 0))
@@ -285,7 +285,7 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
             leave_form.request_unit_half = True
             leave_form.request_date_from_period = 'am'
 
-            self.assertEqual(leave_form.number_of_days_display, 0)
-            self.assertEqual(leave_form.number_of_hours_text, '0 Hours')
+            self.assertEqual(leave_form.number_of_days_display, 0.5)
+            self.assertEqual(leave_form.number_of_hours_text, '4 Hours')
             self.assertEqual(leave_form.date_from, datetime(2019, 9, 2, 6, 0, 0))
             self.assertEqual(leave_form.date_to, datetime(2019, 9, 2, 10, 0, 0))


### PR DESCRIPTION
Steps to reproduce the bug:

- Let's consider an employee E that doesn't work on Monday morning
- Create a half day leave request LR for E on a Monday afternoon
- Save

Bug:

The duration of LR was counted as one day instead of 0.5

opw:2491784